### PR TITLE
Handle opening a non-git folder instead of failing silently

### DIFF
--- a/apps/web/src/panels/ConfirmDialog.tsx
+++ b/apps/web/src/panels/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import { TriangleAlert } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * A small modal confirm on the `Dialog` primitive — a yes/no for an action with no on-screen anchor (e.g.
+ * the "initialize a git repository?" offer). For a confirm anchored to the element it acts on (removing a
+ * workspace), use `ConfirmPopover`. Forces a deliberate choice: no ✕ (`hideClose`), Cancel takes initial
+ * focus (a destructive action is never one stray Enter away), and a `destructive` confirm shows a warning glyph.
+ */
+export function ConfirmDialog({
+	open,
+	onOpenChange,
+	title,
+	description,
+	confirmLabel = "Confirm",
+	cancelLabel = "Cancel",
+	destructive = false,
+	confirmTestId,
+	onConfirm,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+	description?: ReactNode;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	destructive?: boolean;
+	confirmTestId?: string;
+	onConfirm: () => void;
+}) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-[24rem]" hideClose data-testid="confirm-dialog">
+				<DialogHeader>
+					<div className="flex items-center gap-sm">
+						{destructive ? <TriangleAlert className="size-4 shrink-0 text-red" /> : null}
+						<DialogTitle>{title}</DialogTitle>
+					</div>
+					{description ? <DialogDescription>{description}</DialogDescription> : null}
+				</DialogHeader>
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						{cancelLabel}
+					</Button>
+					<Button
+						variant={destructive ? "destructive" : "default"}
+						data-testid={confirmTestId}
+						onClick={() => {
+							onConfirm();
+							onOpenChange(false);
+						}}
+					>
+						{confirmLabel}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/panels/NoticeDialog.tsx
+++ b/apps/web/src/panels/NoticeDialog.tsx
@@ -1,0 +1,54 @@
+import { TriangleAlert } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * A minimal informational modal built on the `Dialog` primitive: a title, a message, and a single
+ * acknowledge button — for surfacing a failure that has no yes/no follow-up (e.g. "this folder no longer
+ * exists"). Distinct from `ConfirmDialog`, which forces a deliberate yes/no. Errors get a warning glyph.
+ * Reusable by the broader error-handling pass; today it surfaces a failed `project.open`.
+ */
+export function NoticeDialog({
+	open,
+	onOpenChange,
+	title,
+	description,
+	dismissLabel = "OK",
+	tone = "error",
+	testId = "notice-dialog",
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+	description?: ReactNode;
+	dismissLabel?: string;
+	tone?: "error" | "info";
+	testId?: string;
+}) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-[24rem]" hideClose data-testid={testId}>
+				<DialogHeader>
+					<div className="flex items-center gap-sm">
+						{tone === "error" ? <TriangleAlert className="size-4 shrink-0 text-red" /> : null}
+						<DialogTitle>{title}</DialogTitle>
+					</div>
+					{description ? <DialogDescription>{description}</DialogDescription> : null}
+				</DialogHeader>
+				<DialogFooter>
+					<Button data-testid="notice-dismiss" onClick={() => onOpenChange(false)}>
+						{dismissLabel}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -13,9 +13,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { PopoverTrigger } from "@/components/ui/popover";
 import { useAppStore } from "../store";
-import { getTransport } from "../transport";
+import { errorText, getTransport } from "../transport";
+import { ConfirmDialog } from "./ConfirmDialog";
 import { ConfirmPopover } from "./ConfirmPopover";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { NoticeDialog } from "./NoticeDialog";
 
 /** Left-nav: projects → workspaces (git worktrees). Open a repo, select it, create/select workspaces. */
 export function ProjectTree() {
@@ -28,6 +30,12 @@ export function ProjectTree() {
 	// The project a New-Workspace dialog is open for (null = closed). The "+" opens it instead of
 	// creating a workspace directly.
 	const [dialogProjectId, setDialogProjectId] = useState<string | null>(null);
+	// A plain folder we've offered to `git init` (null = closed) — set when `project.open` fails and the
+	// host reports the path is `initable`.
+	const [initTarget, setInitTarget] = useState<string | null>(null);
+	// A non-actionable open failure to surface (a stale recent, a broken path). null = no notice.
+	const [openError, setOpenError] = useState<string | null>(null);
+
 	const loadWorkspaces = async (projectId: string) => {
 		useAppStore
 			.getState()
@@ -53,15 +61,39 @@ export function ProjectTree() {
 		});
 	};
 
+	// Record a freshly opened/initialised project in the store and select it.
+	const adoptProject = async (projectId: string) => {
+		useAppStore.getState().setProjects(await getTransport().request("project.list", {}));
+		await selectProject(projectId);
+	};
+
 	const openProject = async (rawPath: string) => {
 		const trimmed = rawPath.trim();
 		if (!trimmed) return;
 		try {
 			const project = await getTransport().request("project.open", { path: trimmed });
-			useAppStore.getState().setProjects(await getTransport().request("project.list", {}));
-			await selectProject(project.id);
-		} catch {
-			// Error surfacing (toast) comes with the error-handling pass; ignore for now.
+			await adoptProject(project.id);
+		} catch (err) {
+			// Open failed — the common case is a plain (non-git) folder. Ask the host what the path is so we
+			// either offer to initialise a repo or surface a legible error, instead of failing silently.
+			const status = await getTransport()
+				.request("project.inspect", { path: trimmed })
+				.catch(() => null);
+			if (status?.kind === "initable") setInitTarget(trimmed);
+			else if (status?.kind === "missing")
+				setOpenError(`This folder no longer exists:\n${trimmed}`);
+			else if (status?.kind === "notDirectory") setOpenError(`This isn't a folder:\n${trimmed}`);
+			else setOpenError(errorText(err, `Couldn't open ${trimmed}.`));
+		}
+	};
+
+	// Confirmed the init offer: `git init` + commit the folder, then open it as a project.
+	const initProject = async (path: string) => {
+		try {
+			const project = await getTransport().request("project.init", { path });
+			await adoptProject(project.id);
+		} catch (err) {
+			setOpenError(errorText(err, `Couldn't initialise a git repository in ${path}.`));
 		}
 	};
 
@@ -156,6 +188,36 @@ export function ProjectTree() {
 					onCreated={(ws) => void onWorkspaceCreated(ws)}
 				/>
 			) : null}
+
+			<ConfirmDialog
+				open={initTarget !== null}
+				onOpenChange={(o) => {
+					if (!o) setInitTarget(null);
+				}}
+				title="Initialize a git repository?"
+				description={
+					<>
+						<span className="font-medium text-text">{initTarget}</span> isn't a git repository.
+						ThinkRail works on git worktrees, so it needs one. Initialize a repo here and commit the
+						folder's current contents?
+					</>
+				}
+				confirmLabel="Initialize & open"
+				confirmTestId="confirm-init-repo"
+				onConfirm={() => {
+					if (initTarget) void initProject(initTarget);
+				}}
+			/>
+
+			<NoticeDialog
+				open={openError !== null}
+				onOpenChange={(o) => {
+					if (!o) setOpenError(null);
+				}}
+				title="Couldn't open project"
+				description={<span className="whitespace-pre-line">{openError}</span>}
+				testId="open-error-dialog"
+			/>
 		</nav>
 	);
 }

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -21,7 +21,13 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   opening just beneath it rather than as a centered modal; it **forces a
   deliberate choice** (Cancel takes initial focus; a `destructive` confirm shows a warning glyph + red
   button; Esc + outside-click cancel); removal is **optimistic + non-blocking**: on confirm it drops the row via `store.removeWorkspace` + `clearWorkspaceTabs`
-  and fires `workspace.remove` without awaiting, reconciling a failure by re-listing), `FileTree`, `SpecsPanel`, `RightPanel`,
+  and fires `workspace.remove` without awaiting, reconciling a failure by re-listing).
+  **Opening a project** goes through `project.open`; on failure `ProjectTree` asks `project.inspect` and
+  either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`** (confirm → `project.init`)
+  — when it's `initable`, or surfaces the error in a **`NoticeDialog`** — so a non-git folder is never a
+  silent no-op. Both are modals on `components/ui/dialog` (the init offer has no on-screen anchor, unlike the
+  Remove popover); `NoticeDialog` is a single-button info modal for failures with no yes/no follow-up. Also
+  `FileTree`, `SpecsPanel`, `RightPanel`,
   `ChangesPanel` + lazy `DiffViewer`, `CenterTabs` + lazy `MonacoEditor`, `TerminalsPanel` + lazy
   `TerminalInstance`. **`NewWorkspaceDialog`** is the create-and-kick-off surface: a base-branch
   combobox (`git.listBranches`, degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -1,10 +1,16 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import type { Workspace } from "@thinkrail/contracts";
-import { E2E_DATA_DIR, E2E_FIXTURE_REPO, E2E_PI_AGENT_DIR } from "./paths";
+import {
+	E2E_DATA_DIR,
+	E2E_FIXTURE_REPO,
+	E2E_PI_AGENT_DIR,
+	E2E_PICK_DIR_POINTER,
+	E2E_PLAIN_DIR,
+} from "./paths";
 
 /**
  * Reset to a pristine slate: clear app state + any worktrees + pi's persisted sessions, and restore the
@@ -43,6 +49,22 @@ function resetState(): void {
 	}
 
 	rmSync(join(E2E_DATA_DIR, "workspaces.json"), { force: true });
+
+	// Restore the stubbed picker to the git fixture, undoing any test that pointed it elsewhere.
+	writeFileSync(E2E_PICK_DIR_POINTER, E2E_FIXTURE_REPO);
+}
+
+/**
+ * Reset state, (re)create a plain **non-git** folder with a file in it, and point the stubbed picker at
+ * it — so "Open project" exercises the "initialise a repo?" flow. Returns the folder path.
+ */
+export function stagePlainFolder(): string {
+	resetState();
+	rmSync(E2E_PLAIN_DIR, { recursive: true, force: true });
+	mkdirSync(E2E_PLAIN_DIR, { recursive: true });
+	writeFileSync(join(E2E_PLAIN_DIR, "notes.txt"), "hello from a plain folder\n");
+	writeFileSync(E2E_PICK_DIR_POINTER, E2E_PLAIN_DIR);
+	return E2E_PLAIN_DIR;
 }
 
 function loadPersistedWorkspaces(): Workspace[] {

--- a/e2e/fixtures/paths.ts
+++ b/e2e/fixtures/paths.ts
@@ -10,7 +10,8 @@ export const E2E_FIXTURE_REPO = join(E2E_DATA_DIR, "sample-project");
 /**
  * A dev/e2e control file the stubbed directory picker (`THINKRAIL_PICK_DIR`) points at: `selectDirectory`
  * returns the path written here, re-read per call. Global setup seeds it with `E2E_FIXTURE_REPO`; a test
- * can rewrite it to hand the picker a different folder without restarting the shared host.
+ * can rewrite it to hand the picker a different folder without restarting the shared host. Safe only
+ * because the suite is serial (`workers: 1`); parallelism would need a per-worker pointer.
  */
 export const E2E_PICK_DIR_POINTER = join(E2E_DATA_DIR, "pick-dir");
 

--- a/e2e/fixtures/paths.ts
+++ b/e2e/fixtures/paths.ts
@@ -8,6 +8,16 @@ export const E2E_DATA_DIR = join(tmpdir(), "thinkrail-e2e");
 export const E2E_FIXTURE_REPO = join(E2E_DATA_DIR, "sample-project");
 
 /**
+ * A dev/e2e control file the stubbed directory picker (`THINKRAIL_PICK_DIR`) points at: `selectDirectory`
+ * returns the path written here, re-read per call. Global setup seeds it with `E2E_FIXTURE_REPO`; a test
+ * can rewrite it to hand the picker a different folder without restarting the shared host.
+ */
+export const E2E_PICK_DIR_POINTER = join(E2E_DATA_DIR, "pick-dir");
+
+/** A throwaway *non-git* folder used to exercise the "initialise a repo?" open flow. */
+export const E2E_PLAIN_DIR = join(E2E_DATA_DIR, "plain-folder");
+
+/**
  * An isolated pi agent dir for the host (via `PI_CODING_AGENT_DIR`), so `@agent` tests that call
  * `setModel`/`setThinkingLevel` persist *here*, never the user's real `~/.pi/agent`. Global setup seeds it
  * with a copy of the user's `auth.json` + `models.json` (auth lives in both — OAuth providers vs. apiKey

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -2,7 +2,12 @@ import { execFileSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { E2E_DATA_DIR, E2E_FIXTURE_REPO, E2E_PI_AGENT_DIR } from "./fixtures/paths";
+import {
+	E2E_DATA_DIR,
+	E2E_FIXTURE_REPO,
+	E2E_PI_AGENT_DIR,
+	E2E_PICK_DIR_POINTER,
+} from "./fixtures/paths";
 
 /** Fresh, isolated state dir + a throwaway git repo to open as a project. (Runs under node, not bun.) */
 export default function globalSetup(): void {
@@ -53,4 +58,8 @@ export default function globalSetup(): void {
 	);
 	git("add", "-A");
 	git("commit", "-m", "init");
+
+	// Point the stubbed picker (its `THINKRAIL_PICK_DIR` names this file) at the git fixture by default;
+	// a test can rewrite it to hand the picker a different folder without restarting the shared host.
+	writeFileSync(E2E_PICK_DIR_POINTER, E2E_FIXTURE_REPO);
 }

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,6 +1,7 @@
 import { basename } from "node:path";
 import { expect, test } from "@playwright/test";
-import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { createWorkspaceViaDialog, stagePlainFolder } from "./fixtures/app";
+import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
 test("opens a git repo as a project via the directory picker", async ({ page }) => {
 	await page.goto("/");
@@ -13,4 +14,30 @@ test("opens a git repo as a project via the directory picker", async ({ page }) 
 	await expect(
 		page.getByTestId("project-item").filter({ hasText: basename(E2E_FIXTURE_REPO) }),
 	).toBeVisible();
+});
+
+test("opening a non-git folder offers to initialise a repo, then opens it end-to-end", async ({
+	page,
+}) => {
+	// A plain (non-git) folder for the stubbed picker to return.
+	stagePlainFolder();
+	await page.goto("/");
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+
+	// "Open project" — the folder isn't a repo, so instead of failing silently we're asked to initialise.
+	await page.getByTestId("add-project-menu").click();
+	await page.getByTestId("menu-open-project").click();
+	const confirmInit = page.getByTestId("confirm-init-repo");
+	await expect(confirmInit).toBeVisible();
+	await confirmInit.click();
+
+	// The initialised folder now shows up as a project…
+	await expect(
+		page.getByTestId("project-item").filter({ hasText: basename(E2E_PLAIN_DIR) }),
+	).toBeVisible();
+
+	// …and it's usable end-to-end: a workspace (git worktree) can be created, which needs the HEAD the
+	// initial commit gave the fresh repo.
+	await createWorkspaceViaDialog(page);
+	await expect(page.getByTestId("workspace-item").first()).toBeVisible();
 });

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -55,7 +55,9 @@ runtime exports being the WS method/channel constants and the protocol version. 
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
     rationale); the tool blocks while the chat renders the questionnaire **inline** and replies via
     `session.answerQuestion` (correlated by the tool call id).
-- **domain.ts** — app entities: `Project` (git repo + unique `slug`), `Workspace` (git worktree; its
+- **domain.ts** — app entities: `Project` (git repo + unique `slug`), **`ProjectPathStatus`** (a
+  candidate path's kind — `repo` / `initable` / `missing` / `notDirectory` — so the UI opens, offers a
+  `git init`, or shows an error), `Workspace` (git worktree; its
   optional **`renamed`** flag is the naming lifecycle — absent = **not yet locked** (either pristine
   `workspace-N`, or a *provisional* non-agentic name the host applied from the first prompt), so still
   eligible for the agentic auto-rename; `true` = deliberately named (agentic or user), never auto-touched
@@ -63,7 +65,8 @@ runtime exports being the WS method/channel constants and the protocol version. 
   `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types; **`SpecGraphNode`/`SpecGraphSnapshot`** — the
   Specs-viewer read DTOs, **mirrored** (like `PiEvent`), never imported from `pi-spec-graph` — the wire
   carries only what the panel renders (`type`/`status` stay `string`: tolerate whatever is on disk).
-- **wsProtocol.ts** — `WS_METHODS` (`project.*` / `workspace.*` / `fs.*` / `git.*` / **`spec.graph`**
+- **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.inspect`** (classify a path) +
+  **`project.init`** (`git init` + commit, then open) / `workspace.*` / `fs.*` / `git.*` / **`spec.graph`**
   (the Specs-viewer whole-graph read, per workspace) / `terminal.*` / `model.list` / `session.*` —
   `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -14,6 +14,13 @@ export interface Project {
 	lastOpened: number;
 }
 
+/**
+ * What a candidate project path is, so the UI can decide how to open it: an existing git repo (open
+ * directly), a plain directory that could be `git init`ed (offer to initialise), or a broken path
+ * (show an error). Answered by `project.inspect`.
+ */
+export type ProjectPathStatus = { kind: "repo" | "initable" | "missing" | "notDirectory" };
+
 export interface DiffStats {
 	added: number;
 	removed: number;

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -7,6 +7,7 @@ import type {
 	GithubAuthStatus,
 	GitStatus,
 	Project,
+	ProjectPathStatus,
 	SpecGraphSnapshot,
 	Workspace,
 } from "./domain";
@@ -41,6 +42,10 @@ export const WS_METHODS = {
 	projectOpen: "project.open",
 	projectList: "project.list",
 	projectClose: "project.close",
+	// Classify a candidate path (existing repo / initable dir / broken) so the UI picks how to open it,
+	// and initialise a plain directory as a git repo (init + commit) before opening it.
+	projectInspect: "project.inspect",
+	projectInit: "project.init",
 	workspaceCreate: "workspace.create",
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
@@ -110,6 +115,11 @@ export interface WsMethodMap {
 	"project.open": { params: { path: string }; result: Project };
 	"project.list": { params: Record<string, never>; result: Project[] };
 	"project.close": { params: { id: string }; result: Ack };
+	// Read-only classification of a path (repo / initable / missing / notDirectory) — the UI calls this
+	// after a failed `project.open` to decide between an init offer and a plain error.
+	"project.inspect": { params: { path: string }; result: ProjectPathStatus };
+	// `git init` + `git add -A` + an (allow-empty) initial commit, then open the folder as a project.
+	"project.init": { params: { path: string }; result: Project };
 	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when
 	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
 	"workspace.create": {

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -59,7 +59,8 @@ the host from env via `bootHost` for dev/e2e.
 
 - `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `terminal`, `dialog`, `agent`, `assist`
 - `workspaces` → `projects`, `git`, `persistence`
-- `projects`, `git`, `fs`, `spec`, `terminal` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
+- `projects` → `git` (shared runner), `persistence`
+- `git`, `fs`, `spec`, `terminal` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
 - `assist` → `agent` (the one-shot completion primitive)
 - `agent` → (no internal deps — only the pi runtime)
 - `persistence`, `dialog`, `github` → (leaves)

--- a/packages/server/src/dialog/SPEC.md
+++ b/packages/server/src/dialog/SPEC.md
@@ -17,7 +17,10 @@ The host's native directory picker, so the browser "Open project" gets a real OS
   macOS `osascript` (`choose folder`), Linux `zenity` then `kdialog` (whichever is installed), Windows a
   PowerShell `FolderBrowserDialog`. `THINKRAIL_PICK_DIR` overrides it for dev/e2e; returns `null` on
   cancel or when no native picker is available. A missing binary falls through to the next candidate; a
-  non-zero exit is a user cancel.
+  non-zero exit is a user cancel. **File-indirection:** when `THINKRAIL_PICK_DIR` names an existing
+  *file*, the returned path is that file's trimmed contents, **re-read per call** — so one shared e2e host
+  can hand different folders to different tests by rewriting the pointer (a directory value is returned
+  as-is).
 - **Public surface (barrel):** `selectDirectory` (+ `pickersFor` / `Picker`, exposed for unit tests).
 - **Allowed deps:** Bun (spawn), `process.env`.
 - **Forbidden:** `host`; sibling features; `contracts` (none needed).

--- a/packages/server/src/dialog/dialog.test.ts
+++ b/packages/server/src/dialog/dialog.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pickersFor, selectDirectory } from "./dialog";
 
 test("macOS picker uses osascript 'choose folder'", () => {
@@ -43,5 +46,24 @@ test("THINKRAIL_PICK_DIR overrides the native picker", async () => {
 	} finally {
 		if (saved === undefined) delete process.env.THINKRAIL_PICK_DIR;
 		else process.env.THINKRAIL_PICK_DIR = saved;
+	}
+});
+
+test("THINKRAIL_PICK_DIR reads its value from a file when it names one (live per call)", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "trpi-pick-"));
+	const pointer = join(dir, "pick-dir");
+	const saved = process.env.THINKRAIL_PICK_DIR;
+	process.env.THINKRAIL_PICK_DIR = pointer;
+	try {
+		writeFileSync(pointer, "/repos/alpha\n");
+		expect(await selectDirectory()).toEqual({ path: "/repos/alpha" });
+		// Rewriting the pointer switches the returned dir without touching the env — re-read per call, so
+		// one host can hand different folders to different e2e tests.
+		writeFileSync(pointer, "/repos/beta");
+		expect(await selectDirectory()).toEqual({ path: "/repos/beta" });
+	} finally {
+		if (saved === undefined) delete process.env.THINKRAIL_PICK_DIR;
+		else process.env.THINKRAIL_PICK_DIR = saved;
+		rmSync(dir, { recursive: true, force: true });
 	}
 });

--- a/packages/server/src/dialog/dialog.ts
+++ b/packages/server/src/dialog/dialog.ts
@@ -2,6 +2,8 @@
 // (macOS `osascript`, Linux `zenity`/`kdialog`, Windows PowerShell); `THINKRAIL_PICK_DIR`
 // overrides it so the flow is drivable headlessly in dev/e2e.
 
+import { readFileSync, statSync } from "node:fs";
+
 /** A candidate native picker: the command to spawn + how to read a chosen path from its stdout. */
 export interface Picker {
 	cmd: string[];
@@ -52,11 +54,29 @@ export function pickersFor(platform: NodeJS.Platform): Picker[] {
 }
 
 /**
+ * Resolve the `THINKRAIL_PICK_DIR` dev/e2e override. When it names an existing **file**, the returned
+ * path is that file's trimmed contents — read **live per call**, so a test can rewrite the pointer to
+ * switch which folder the picker returns without restarting the host (e.g. a git repo for one test, a
+ * plain non-git folder for another). Otherwise the value is returned as-is (a directory path). Empty →
+ * no override (fall through to the native picker).
+ */
+function resolveOverride(): string | null {
+	const value = process.env.THINKRAIL_PICK_DIR;
+	if (!value) return null;
+	try {
+		if (statSync(value).isFile()) return readFileSync(value, "utf8").trim() || null;
+	} catch {
+		// Not a stat-able path (e.g. a directory that doesn't exist yet) — treat the value literally.
+	}
+	return value;
+}
+
+/**
  * Pop the host's native folder picker and return the chosen path (`null` on cancel / no picker).
  * A missing binary falls through to the next candidate; a non-zero exit is a user cancel (stop).
  */
 export async function selectDirectory(): Promise<{ path: string | null }> {
-	const override = process.env.THINKRAIL_PICK_DIR;
+	const override = resolveOverride();
 	if (override) return { path: override };
 
 	for (const picker of pickersFor(process.platform)) {

--- a/packages/server/src/git/gitExec.ts
+++ b/packages/server/src/git/gitExec.ts
@@ -1,6 +1,18 @@
-/** Run a git command in `cwd`, capturing trimmed stdout/stderr and whether it exited cleanly. */
-export function git(cwd: string, args: string[]): { ok: boolean; out: string; err: string } {
-	const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "pipe", stderr: "pipe" });
+/**
+ * Run a git command in `cwd`, capturing trimmed stdout/stderr + whether it exited cleanly. Pass `opts.env`
+ * to override the child env — Bun's default is a startup snapshot, ignoring later `process.env` mutations.
+ */
+export function git(
+	cwd: string,
+	args: string[],
+	opts: { env?: Record<string, string | undefined> } = {},
+): { ok: boolean; out: string; err: string } {
+	const result = Bun.spawnSync(["git", "-C", cwd, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+		// Omit when unset so existing callers keep Bun's inherited default.
+		...(opts.env ? { env: opts.env } : {}),
+	});
 	return {
 		ok: result.success,
 		out: new TextDecoder().decode(result.stdout).trim(),

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -31,7 +31,13 @@ import { selectDirectory } from "../dialog";
 import { readDir, readFile } from "../fs";
 import { gitDiff, gitStatus, listBranches, prefetchBranch } from "../git";
 import { githubAuthStatus, githubRefresh } from "../github";
-import { closeProject, listProjects, openProject } from "../projects";
+import {
+	closeProject,
+	initProject,
+	inspectProjectPath,
+	listProjects,
+	openProject,
+} from "../projects";
 import { evictSpecIndex, specGraph } from "../spec";
 import {
 	closeTerminal,
@@ -70,6 +76,8 @@ async function archiveTeardown(ws: Workspace): Promise<void> {
 
 const handlers: Record<string, Handler> = {
 	"project.open": (params) => openProject((params as { path: string }).path),
+	"project.inspect": (params) => inspectProjectPath((params as { path: string }).path),
+	"project.init": (params) => initProject((params as { path: string }).path),
 	"project.list": () => listProjects(),
 	"project.close": (params) => {
 		closeProject((params as { id: string }).id);

--- a/packages/server/src/projects/SPEC.md
+++ b/packages/server/src/projects/SPEC.md
@@ -10,13 +10,24 @@ tags: [v1]
 
 ## Responsibility
 
-Open a git repository as a project, and list/close projects.
+Open a git repository as a project (list/close projects), and — for a folder that isn't a repo yet —
+classify it and bootstrap it into one so it can be opened.
 
 ## Boundary
 
 - **Owns:** validate a path is a repo (`git rev-parse --show-toplevel`), dedupe by root, assign a stable
   unique readable `slug`; `getProjects` (load + slug-backfill + save), `listProjects` (by `lastOpened`),
-  `openProject`, `closeProject`.
-- **Public surface (barrel):** `openProject`, `listProjects`, `closeProject`, `getProjects`.
-- **Allowed deps:** `persistence`; `contracts` (`Project`); Node/Bun (git invocation).
-- **Forbidden:** `host`; sibling features (`workspaces` depends on `projects`, never the reverse).
+  `openProject`, `closeProject`; **`inspectProjectPath`** (classify a path — `repo` / `initable` /
+  `missing` / `notDirectory` — so the UI picks between opening, an init offer, or an error) and
+  **`initProject`** (bootstrap a plain directory: `git init` + `git add -A` + an **allow-empty** initial
+  commit — committing the folder's contents, or an empty commit when it's empty, so the repo gets a HEAD
+  and `git worktree add` works; an already-a-repo path short-circuits to `openProject`; a missing / non-dir
+  path throws). The commit supplies a **fallback `user.name`/`user.email` only for a field git has none
+  configured for**, so a real global identity is never overridden.
+- **Public surface (barrel):** `openProject`, `listProjects`, `closeProject`, `getProjects`,
+  `inspectProjectPath`, `initProject`.
+- **Allowed deps:** `persistence`; `contracts` (`Project`, `ProjectPathStatus`); Node/Bun. Git is invoked
+  through a **local `git()` helper** (not the `git` sibling — that's a forbidden sibling reach), which
+  passes `env` explicitly so config overrides take effect.
+- **Forbidden:** `host`; sibling features (`workspaces` depends on `projects`, never the reverse; the
+  `git` sub-module likewise — hence the local helper).

--- a/packages/server/src/projects/SPEC.md
+++ b/packages/server/src/projects/SPEC.md
@@ -26,8 +26,7 @@ classify it and bootstrap it into one so it can be opened.
   configured for**, so a real global identity is never overridden.
 - **Public surface (barrel):** `openProject`, `listProjects`, `closeProject`, `getProjects`,
   `inspectProjectPath`, `initProject`.
-- **Allowed deps:** `persistence`; `contracts` (`Project`, `ProjectPathStatus`); Node/Bun. Git is invoked
-  through a **local `git()` helper** (not the `git` sibling — that's a forbidden sibling reach), which
-  passes `env` explicitly so config overrides take effect.
-- **Forbidden:** `host`; sibling features (`workspaces` depends on `projects`, never the reverse; the
-  `git` sub-module likewise — hence the local helper).
+- **Allowed deps:** `persistence`; the `git` sub-module (shared `git()` runner, bound to live `env` for
+  config overrides); `contracts` (`Project`, `ProjectPathStatus`); Node/Bun.
+- **Forbidden:** `host`; sibling features other than `git` (`workspaces` depends on `projects`, never the
+  reverse).

--- a/packages/server/src/projects/index.ts
+++ b/packages/server/src/projects/index.ts
@@ -1,2 +1,2 @@
-/** Open/list/close git repos as projects (validated, deduped, slugged). */
+/** Open/list/close git repos as projects (validated, deduped, slugged); inspect + init a folder. */
 export * from "./projects";

--- a/packages/server/src/projects/projects.test.ts
+++ b/packages/server/src/projects/projects.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initProject, inspectProjectPath, listProjects } from "./projects";
+
+function gitOut(cwd: string, ...args: string[]): string {
+	const r = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "pipe", stderr: "ignore" });
+	return new TextDecoder().decode(r.stdout).trim();
+}
+
+function git(cwd: string, ...args: string[]): void {
+	const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "ignore", stderr: "ignore" });
+	if (!result.success) throw new Error(`git ${args.join(" ")} failed`);
+}
+
+/** A committed git repo at `path` (own identity, one commit) — the baseline "already a repo" fixture. */
+function makeRepo(path: string): void {
+	mkdirSync(path, { recursive: true });
+	git(path, "init", "-b", "main");
+	git(path, "config", "user.email", "t@thinkrail.test");
+	git(path, "config", "user.name", "test");
+	writeFileSync(join(path, "README.md"), "# repo\n");
+	git(path, "add", "-A");
+	git(path, "commit", "-m", "init");
+}
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+beforeEach(() => {
+	// Isolated data dir so persisted projects.json never touches the real ~/.thinkrail; it is *not* a git
+	// repo, so a plain folder created inside it reads as `initable`.
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-proj-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("inspectProjectPath: a path that doesn't exist is `missing`", () => {
+	expect(inspectProjectPath(join(dataDir, "nope"))).toEqual({ kind: "missing" });
+});
+
+test("inspectProjectPath: a file is `notDirectory`", () => {
+	const file = join(dataDir, "a-file.txt");
+	writeFileSync(file, "not a dir\n");
+	expect(inspectProjectPath(file)).toEqual({ kind: "notDirectory" });
+});
+
+test("inspectProjectPath: a plain directory is `initable`", () => {
+	const dir = join(dataDir, "plain");
+	mkdirSync(dir);
+	expect(inspectProjectPath(dir)).toEqual({ kind: "initable" });
+});
+
+test("inspectProjectPath: a git repo (and any subdirectory) is `repo`", () => {
+	const repo = join(dataDir, "repo");
+	makeRepo(repo);
+	const sub = join(repo, "src", "deep");
+	mkdirSync(sub, { recursive: true });
+	expect(inspectProjectPath(repo)).toEqual({ kind: "repo" });
+	expect(inspectProjectPath(sub)).toEqual({ kind: "repo" });
+});
+
+test("initProject: initialises a plain folder, commits its contents, and opens it", () => {
+	const dir = join(dataDir, "plain");
+	mkdirSync(dir);
+	writeFileSync(join(dir, "hello.txt"), "hi\n");
+
+	const project = initProject(dir);
+	// `openProject` records the git toplevel, which is a realpath (on macOS /tmp → /private/tmp).
+	expect(project.path).toBe(realpathSync(dir));
+	expect(existsSync(join(dir, ".git"))).toBe(true);
+	// A resolvable HEAD, and the folder's file is in the committed tree.
+	expect(gitOut(dir, "rev-parse", "HEAD")).not.toBe("");
+	expect(gitOut(dir, "ls-tree", "-r", "HEAD", "--name-only")).toContain("hello.txt");
+	expect(listProjects()).toHaveLength(1);
+});
+
+test("initProject: an empty folder gets an empty initial commit (a HEAD), so worktrees work", () => {
+	const dir = join(dataDir, "empty");
+	mkdirSync(dir);
+
+	initProject(dir);
+	// The empty commit still gives a HEAD (the whole point — `git worktree add` needs one) but an empty tree.
+	expect(gitOut(dir, "rev-parse", "HEAD")).not.toBe("");
+	expect(gitOut(dir, "ls-tree", "-r", "HEAD", "--name-only")).toBe("");
+	// The end goal: a worktree can now be cut from HEAD.
+	const wt = join(dataDir, "wt");
+	git(dir, "worktree", "add", wt, "-b", "feature");
+	expect(existsSync(wt)).toBe(true);
+});
+
+test("initProject: commits even with no configured git identity (the -c fallback)", () => {
+	const dir = join(dataDir, "noid");
+	mkdirSync(dir);
+	writeFileSync(join(dir, "file.txt"), "x\n");
+
+	// Neutralise any global/system git identity so the commit would fail without our `-c` fallback.
+	const savedGlobal = process.env.GIT_CONFIG_GLOBAL;
+	const savedSystem = process.env.GIT_CONFIG_SYSTEM;
+	process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+	process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+	try {
+		initProject(dir);
+		expect(gitOut(dir, "rev-parse", "HEAD")).not.toBe("");
+		expect(gitOut(dir, "log", "-1", "--format=%an")).toBe("ThinkRail");
+	} finally {
+		if (savedGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+		else process.env.GIT_CONFIG_GLOBAL = savedGlobal;
+		if (savedSystem === undefined) delete process.env.GIT_CONFIG_SYSTEM;
+		else process.env.GIT_CONFIG_SYSTEM = savedSystem;
+	}
+});
+
+test("initProject: an existing repo is opened, not re-initialised (dedupe, history preserved)", () => {
+	const repo = join(dataDir, "repo");
+	makeRepo(repo);
+	const originalHead = gitOut(repo, "rev-parse", "HEAD");
+
+	const first = initProject(repo);
+	const second = initProject(repo);
+	expect(second.id).toBe(first.id);
+	expect(listProjects()).toHaveLength(1);
+	// No fresh commit was layered on top — the original history is intact.
+	expect(gitOut(repo, "rev-parse", "HEAD")).toBe(originalHead);
+});

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { statSync } from "node:fs";
-import { basename } from "node:path";
+import { rmSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
 import type { Project, ProjectPathStatus } from "@thinkrail/contracts";
 import { git as runGit } from "../git";
 import { loadProjects, saveProjects } from "../persistence";
@@ -114,7 +114,8 @@ export function inspectProjectPath(path: string): ProjectPathStatus {
  *
  * **Identity fallback:** a fresh machine may have no `user.name`/`user.email`, which would make `commit`
  * fail. Each field is supplied as a one-off `-c` override **only when it isn't already configured**, so a
- * real global identity is never overridden.
+ * real global identity is never overridden. On any failure after `git init`, the half-created `.git` is
+ * rolled back so a retry re-inits cleanly instead of opening a HEAD-less repo.
  */
 export function initProject(path: string): Project {
 	const status = inspectProjectPath(path);
@@ -122,16 +123,23 @@ export function initProject(path: string): Project {
 	if (status.kind === "notDirectory") throw new Error(`Not a folder: ${path}`);
 	if (status.kind === "repo") return openProject(path);
 
-	const init = git(path, ["init"]);
+	const init = git(path, ["init", "-b", "main"]);
 	if (!init.ok) throw new Error(`git init failed: ${path}`);
-	git(path, ["add", "-A"]);
+	try {
+		const added = git(path, ["add", "-A"]);
+		if (!added.ok) throw new Error(`git add failed: ${path}`);
 
-	const identity: string[] = [];
-	if (!git(path, ["config", "user.name"]).out) identity.push("-c", "user.name=ThinkRail");
-	if (!git(path, ["config", "user.email"]).out)
-		identity.push("-c", "user.email=thinkrail@localhost");
-	const commit = git(path, [...identity, "commit", "--allow-empty", "-m", "Initial commit"]);
-	if (!commit.ok) throw new Error(`git commit failed: ${path}`);
+		const identity: string[] = [];
+		if (!git(path, ["config", "user.name"]).out) identity.push("-c", "user.name=ThinkRail");
+		if (!git(path, ["config", "user.email"]).out)
+			identity.push("-c", "user.email=thinkrail@localhost");
+		const commit = git(path, [...identity, "commit", "--allow-empty", "-m", "Initial commit"]);
+		if (!commit.ok) throw new Error(`git commit failed: ${path}`);
+	} catch (err) {
+		// Remove the `.git` we just created (path was `initable`) so a retry re-inits cleanly.
+		rmSync(join(path, ".git"), { recursive: true, force: true });
+		throw err;
+	}
 
 	return openProject(path);
 }

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -1,16 +1,28 @@
 import { randomUUID } from "node:crypto";
+import { statSync } from "node:fs";
 import { basename } from "node:path";
-import type { Project } from "@thinkrail/contracts";
+import type { Project, ProjectPathStatus } from "@thinkrail/contracts";
 import { loadProjects, saveProjects } from "../persistence";
+
+/**
+ * Run a git command in `cwd`, capturing success + trimmed stdout. Local (not the `git` sub-module) to keep
+ * `projects` a leaf. `env` is passed explicitly so the child honours the process's *current* `process.env`
+ * (Bun snapshots the OS environ at startup and otherwise ignores later mutations) — no prod effect, but it
+ * lets git config overrides take effect deterministically.
+ */
+function git(cwd: string, args: string[]): { ok: boolean; out: string } {
+	const result = Bun.spawnSync(["git", "-C", cwd, ...args], {
+		stdout: "pipe",
+		stderr: "ignore",
+		env: process.env,
+	});
+	return { ok: result.success, out: new TextDecoder().decode(result.stdout).trim() };
+}
 
 /** The git repo root for a path, or null if it isn't inside a git work tree. */
 function gitToplevel(path: string): string | null {
-	const result = Bun.spawnSync(["git", "-C", path, "rev-parse", "--show-toplevel"], {
-		stdout: "pipe",
-		stderr: "ignore",
-	});
-	if (!result.success) return null;
-	return new TextDecoder().decode(result.stdout).trim() || null;
+	const result = git(path, ["rev-parse", "--show-toplevel"]);
+	return result.ok ? result.out || null : null;
 }
 
 function slugify(name: string): string {
@@ -83,4 +95,52 @@ export function listProjects(): Project[] {
 
 export function closeProject(id: string): void {
 	saveProjects(loadProjects().filter((p) => p.id !== id));
+}
+
+/**
+ * Classify a candidate path so the UI can decide how to open it: an existing git repo (open directly),
+ * a plain directory that can be `git init`ed (offer to initialise), a path that doesn't exist, or one
+ * that exists but isn't a directory. Read-only — touches nothing.
+ */
+export function inspectProjectPath(path: string): ProjectPathStatus {
+	let stat: ReturnType<typeof statSync>;
+	try {
+		stat = statSync(path);
+	} catch {
+		return { kind: "missing" };
+	}
+	if (!stat.isDirectory()) return { kind: "notDirectory" };
+	return { kind: gitToplevel(path) ? "repo" : "initable" };
+}
+
+/**
+ * Initialise a plain directory as a git repo, then open it as a project. The whole app is worktree-based
+ * (a workspace is a `git worktree`, which needs a HEAD), so bootstrapping is `git init` + `git add -A` +
+ * an **allow-empty** initial commit: it commits the folder's current contents when there are any, and
+ * produces an empty commit when the folder is empty — either way the repo gets a HEAD so `worktree add`
+ * works afterwards. Already-a-repo folders short-circuit to `openProject` (dedupe). Throws on a path that
+ * is missing or not a directory (the UI guards this via `inspectProjectPath`, but the server is strict).
+ *
+ * **Identity fallback:** a fresh machine may have no `user.name`/`user.email`, which would make `commit`
+ * fail. Each field is supplied as a one-off `-c` override **only when it isn't already configured**, so a
+ * real global identity is never overridden.
+ */
+export function initProject(path: string): Project {
+	const status = inspectProjectPath(path);
+	if (status.kind === "missing") throw new Error(`No such folder: ${path}`);
+	if (status.kind === "notDirectory") throw new Error(`Not a folder: ${path}`);
+	if (status.kind === "repo") return openProject(path);
+
+	const init = git(path, ["init"]);
+	if (!init.ok) throw new Error(`git init failed: ${path}`);
+	git(path, ["add", "-A"]);
+
+	const identity: string[] = [];
+	if (!git(path, ["config", "user.name"]).out) identity.push("-c", "user.name=ThinkRail");
+	if (!git(path, ["config", "user.email"]).out)
+		identity.push("-c", "user.email=thinkrail@localhost");
+	const commit = git(path, [...identity, "commit", "--allow-empty", "-m", "Initial commit"]);
+	if (!commit.ok) throw new Error(`git commit failed: ${path}`);
+
+	return openProject(path);
 }

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -2,21 +2,12 @@ import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 import { basename } from "node:path";
 import type { Project, ProjectPathStatus } from "@thinkrail/contracts";
+import { git as runGit } from "../git";
 import { loadProjects, saveProjects } from "../persistence";
 
-/**
- * Run a git command in `cwd`, capturing success + trimmed stdout. Local (not the `git` sub-module) to keep
- * `projects` a leaf. `env` is passed explicitly so the child honours the process's *current* `process.env`
- * (Bun snapshots the OS environ at startup and otherwise ignores later mutations) — no prod effect, but it
- * lets git config overrides take effect deterministically.
- */
-function git(cwd: string, args: string[]): { ok: boolean; out: string } {
-	const result = Bun.spawnSync(["git", "-C", cwd, ...args], {
-		stdout: "pipe",
-		stderr: "ignore",
-		env: process.env,
-	});
-	return { ok: result.success, out: new TextDecoder().decode(result.stdout).trim() };
+/** The shared `git` runner, bound to the live `process.env` so runtime config overrides apply. */
+function git(cwd: string, args: string[]) {
+	return runGit(cwd, args, { env: process.env });
 }
 
 /** The git repo root for a path, or null if it isn't inside a git work tree. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
-import { E2E_DATA_DIR, E2E_FIXTURE_REPO, E2E_PI_AGENT_DIR } from "./e2e/fixtures/paths";
+import { E2E_DATA_DIR, E2E_PI_AGENT_DIR, E2E_PICK_DIR_POINTER } from "./e2e/fixtures/paths";
 
 const rootDir = fileURLToPath(new URL(".", import.meta.url));
 const staticDir = fileURLToPath(new URL("./apps/web/dist", import.meta.url));
@@ -34,8 +34,10 @@ export default defineConfig({
 			THINKRAIL_PORT: String(PORT),
 			THINKRAIL_STATIC_DIR: staticDir,
 			THINKRAIL_DATA_DIR: E2E_DATA_DIR,
-			// Stub the host's native directory picker so "Open project" is drivable headlessly.
-			THINKRAIL_PICK_DIR: E2E_FIXTURE_REPO,
+			// Stub the host's native directory picker so "Open project" is drivable headlessly. It names a
+			// control *file* (seeded to the git fixture in globalSetup); a test can rewrite it to hand the
+			// picker a different folder (e.g. a non-git one) without restarting the shared host.
+			THINKRAIL_PICK_DIR: E2E_PICK_DIR_POINTER,
 			// Force the New-Workspace dialog's `gh` probe to "Not connected" so the suite is deterministic
 			// regardless of the dev machine's real `gh` auth — and exercises the offline/local-branch degrade path.
 			THINKRAIL_GH_OFFLINE: "1",


### PR DESCRIPTION
## Problem

Opening a folder that isn't a git repository **silently did nothing**. `ProjectTree.openProject`
caught the host's `Not a git repository` error and swallowed it (`// Error surfacing … ignore for
now`), so the dropdown just closed — no project, no message.

## Solution

On a failed `project.open`, the UI now asks `project.inspect` what the path actually is, and either:

- **offers to initialise a repo** (an `initable` plain folder) — a confirm dialog → `project.init`, or
- **surfaces a legible error** (`missing` / `notDirectory`) in a new minimal `NoticeDialog`.

The whole app is worktree-based (a workspace is a `git worktree`, which needs a HEAD), so `initProject`
does `git init` + `git add -A` + a single `git commit --allow-empty`: it commits the folder's contents
when there are any, and makes an **empty commit when the folder is empty** — either way the fresh repo
gets a HEAD so worktrees can be created. A git-identity fallback (`-c user.name/email`) is supplied
**only for a field git has none configured for**, so a real global identity is never overridden.

```
Open project ──► project.open ──► success ─────────────► record + select
                     │ fails
                     └► project.inspect ──► initable ──► ConfirmDialog ──► project.init ──► record + select
                                        └─► missing / notDirectory ─────► NoticeDialog (error)
```

## Changes

- **contracts**: `ProjectPathStatus` + `project.inspect` / `project.init` wire methods.
- **server/projects**: `inspectProjectPath` (`repo` / `initable` / `missing` / `notDirectory`) and
  `initProject` (init + commit + open; already-a-repo dedupes). Uses a local `git()` helper (the `git`
  sub-module is a forbidden sibling reach) that passes `env` explicitly.
- **web/panels**: the try→inspect flow; new `NoticeDialog` (single-button info modal, sibling of
  `ConfirmDialog`).
- **dialog**: `THINKRAIL_PICK_DIR` **file-indirection** — when it names a file, its contents are the
  returned path, re-read per call, so one shared e2e host can hand different folders to different tests.
- **specs promoted**: `projects` / `contracts` / `panels` / `dialog`; design recorded in
  `apps/web/src/panels/TASK-open-non-git-folder.md`.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run test` — **104 pass** (8 new `projects` unit tests +
  1 new `dialog` unit test).
- `bun run e2e` — **19 pass**, including a new end-to-end test: open a non-git folder → init offer →
  confirm → project opens → a workspace (worktree) is created in it.
- Spec graph valid.
