### PR TITLE
spec: workflow-system meta-layer for pi-thinkrail-workflow

### DIFF
--- a/packages/pi-thinkrail-workflow/SPEC.md
+++ b/packages/pi-thinkrail-workflow/SPEC.md
@@ -2,17 +2,18 @@
 id: module-thinkrail-workflow
 type: module-design
 status: active
-title: pi-thinkrail-workflow — workflow skills (brainstorming, project-setup)
+title: pi-thinkrail-workflow — the workflow system (workflow skills + meta-layer)
 parent: architecture
 depends-on: [module-spec-graph]
-tags: [pi-extension, workflow, brainstorming, project-setup, skill]
+tags: [pi-extension, workflow, brainstorming, project-setup, skill, workflow-system]
 ---
 
 ## Responsibility
 
-`pi-thinkrail-workflow` is a pi extension that ships **process/workflow skills** — skills that codify how
-the agent should *run a piece of work*, as opposed to `pi-spec-graph` (what the spec model is) or
-`pi-visualize` (a rendering tool). It ships two skills:
+`pi-thinkrail-workflow` is a pi extension that ships ThinkRail's **workflow system**: a family of
+**process/workflow skills** — skills that codify how the agent should *run a piece of work* — governed
+by the meta-layer in "The workflow system" below. (Contrast: `pi-spec-graph` defines what the spec
+model is; `pi-visualize` is a rendering tool.) It ships two skills today:
 
 - **`brainstorming`** — turns a raw feature request into a validated design, captured as a spec-graph
   `task-spec`, before any implementation starts, mirroring the discipline this repo already applies to
@@ -25,9 +26,124 @@ the agent should *run a piece of work*, as opposed to `pi-spec-graph` (what the 
   personal-vs-public routing, MVP-first elicitation) is preserved; anything with no equivalent (a
   progress-tracker/summary-box visualization, a ticket/board hand-off) is dropped in favour of plain text.
 
-This package is the seed of a growing family. Future workflow skills (e.g. a thinkrail-implement or
-bug-fix equivalent) are added as sibling `skills/<name>/` sub-modules; a new tool goes under a `tools/`
-sub-module if one is ever needed. Nothing about the layout changes to add the next skill.
+This package is the seed of a growing family. Future workflow skills are added as sibling
+`skills/<name>/` sub-modules per meta-rule 12 below; a new tool goes under a `tools/` sub-module if one
+is ever needed. Nothing about the layout — or the system's shape — changes to add the next skill.
+
+## The workflow system (meta-layer)
+
+The rules that govern every workflow skill in this package. Decided in [[task-workflow-system]]
+(researched against obra/superpowers, gsd-build/gsd-2, Anthropic's skill-authoring guidance, and
+JetBrains/thinkrail-v1 — whose workflows are an *example* of a possible future complex workflow, not a
+template).
+
+### Concept model
+
+- **Workflow** — a repeatable way of running a piece of work, codified as one or more skills.
+- **Workflow skill** — one skill = one phase *or one branch* of a workflow; short, imperative,
+  workflow-focused, with heavy reference material in sibling files read on demand.
+- **Handoff** — the explicit, by-name transition at the end of a workflow skill, or a declared
+  terminal state.
+- **Gate** — a hard discipline point (e.g. "no implementation before the design is approved"),
+  written with anti-rationalization notes, not soft advice.
+- **Artifacts** — *durable*: spec-graph nodes (task-spec working docs, promoted module SPECs);
+  *ephemeral*: per-workflow working files (resume state, scratch plans) with a cleanup contract.
+
+### Skill roles & handoff contracts
+
+Every workflow skill takes exactly one of **two roles**; everything richer is a *pattern* built from
+them.
+
+| Role | Body contains | Ends by |
+|---|---|---|
+| **Router** | classification rules + handoffs only | naming what runs next |
+| **Worker** | one phase's steps | a handoff — fixed successor, back to its caller, or a terminal state |
+
+The **root router** is the single always-on entry; branch skills may route further (fractal routing).
+
+**Patterns** (vocabulary, not roles — no instances yet; for complex work):
+
+- **Composer** — a *stateful router*: agrees a per-task pipeline with the user, records it in the
+  task-spec's **Pipeline section** (checkboxes = plan + frontier + history), and walks it, adjusting as
+  findings land; the workers it launches hand back to it. Its between-stage checking discipline is its
+  own design, not a system rule. The family may hold several composers drawing on a shared pool of
+  stages.
+- **Stage** — any worker reached from a pipeline: upstream artifacts in, one artifact out, hands back
+  to its caller. The same worker can also run standalone (fixed-successor/terminal handoff) —
+  stage-ness is how a worker is *used*, not what it *is*.
+
+No runtime machinery: pipeline state is task-spec content; stage transitions are ordinary handoffs.
+
+```mermaid
+flowchart LR
+  rule([before_agent_start rule]) --> router[root router]
+  router --> ps[project-setup]
+  router --> bs[brainstorming]
+  router -. future .-> comp[composer — stateful router]
+  comp -->|launch| st[stage workers]
+  st -->|hand back| comp
+```
+
+### Meta-rules
+
+**Structure**
+1. One phase/branch per skill. When a workflow needs a conditional fork, each branch becomes its own
+   skill and the *choice rules stay in the skill before the fork*.
+2. Routers route; workers work. A router contains classification rules + handoffs only — never a
+   branch's steps. A worker skill embeds no routing beyond its own terminal handoff.
+3. Skills are concise and workflow-focused: target < ~150 lines of body; push reference detail into
+   sibling files named in the step that needs them (progressive disclosure).
+
+**Discovery & entry**
+4. One always-on entry: the `before_agent_start` rule points at the root router. Other skills are
+   reached by routing/handoff; a skill may *also* carry a narrow self-trigger `description` (as
+   `project-setup` does) when its trigger is unmistakable.
+5. `description` = triggering conditions only ("Use when …"), never a summary of the workflow's steps
+   — a step-summary tempts the agent to follow the description and skip the body.
+
+**Chaining**
+6. Explicit handoffs: every workflow skill ends by naming its successor skill or its terminal state.
+   Cross-reference skills by name; never inline another skill's steps, never force-load files.
+7. Say each thing once: a rule or step lives in exactly one skill; others point at it.
+
+**Artifacts**
+8. Durable output goes to the spec graph: decisions accrete in the task-spec and are promoted into
+   module SPECs. No parallel durable plan/state format.
+9. A workflow *may* declare ephemeral working files (resume/continue state, scratch plans) when it
+   needs to stop/resume or pass info between phases. Contract: the skill names the file's location and
+   shape, the file is consumed/deleted when the work lands, and it never becomes the record — anything
+   durable is promoted to specs before cleanup.
+
+**Scaling**
+10. Scale by route and composition, not by prose: the router sends simple work down short paths;
+    optional phases carry explicit "when to use / when to skip" criteria; complex work composes a
+    per-task pipeline of stage workers. Depth lives in the route taken.
+11. Gates where discipline matters, matching the form to the failure: prohibitions + red-flags for
+    discipline violations; positive recipes for output shape.
+
+**Maintenance**
+12. Adding a workflow = add `skills/<name>/` + one routing line in the root router + one row in the
+    family table below. Nothing else changes shape.
+13. The spec leads: system-shaping changes update this SPEC.md first; the authoring skill carries only
+    the actionable checklist and points here for rationale.
+14. Verify by use: a new or changed skill isn't done until a real request has been observed flowing
+    through it.
+
+### Workflow family
+
+| Skill | Role | Status |
+|---|---|---|
+| `brainstorming` | design workflow (feature/change → validated task-spec) | active; fate under review — routed as-is |
+| `project-setup` | project inception (empty workspace → goal-and-requirements) | active |
+| `choosing-a-workflow` | root router — classification + routing | decided, not yet built |
+| `writing-workflow-skills` | authoring checklist for adding workflows | decided, not yet built |
+
+The family is open and grows from real use; candidates (research/spike, refactor, bug-fix, a composing
+skill in the composer pattern, with its stage workers) each get their own task-spec when they earn
+their place. Until
+`choosing-a-workflow` lands, the `before_agent_start` rule keeps pointing at `brainstorming`; the
+decided entry model (rule → root router) takes effect when the router is built
+([[task-workflow-system]] tracks this).
 
 ## Boundary
 
@@ -145,8 +261,10 @@ e2e spec is a reasonable follow-up once a skill's wording stabilizes — not req
 - A vanilla-pi-portable brainstorming or project-setup skill (would require replacing `ask_user_question`
   with a lowest-common-denominator question mechanism — not worth it for a thinkrail-only host
   feature).
-- Building out the rest of the skill family (thinkrail-implement, bug-fix, etc.) now — this spec only
-  covers `brainstorming` and `project-setup`; the structure is ready for more, they are not designed here.
+- Building out the rest of the skill family now — the meta-layer is in force and the structure is
+  ready, but future workflows are designed one task-spec at a time when they earn their place.
+- Any runtime/engine layer for workflows (YAML pipelines, DAG tools, stage sessions) — this system is
+  skills-only; pipeline state lives in task-spec content, not machinery.
 - Reimplementing old thinkrail's `claude-plugin` **ticket/board engineering workflow** (its
   ticket-orchestrator, ticket-implement, bug-fix, spec-review, etc. skills — used by the thinkrail team to
   build thinkrail itself) as a pi package. That is dev-tooling for a different, ticket-based product and

--- a/packages/pi-thinkrail-workflow/TASK-workflow-system.md
+++ b/packages/pi-thinkrail-workflow/TASK-workflow-system.md
@@ -1,0 +1,76 @@
+---
+id: task-workflow-system
+type: task-spec
+status: active
+title: Workflow system — meta-concepts and meta-rules for the skill-based workflow family
+parent: module-thinkrail-workflow
+references: [module-spec-graph]
+---
+
+## Purpose
+
+Grow `pi-thinkrail-workflow` from two ad-hoc skills (`brainstorming`, `project-setup`) into a
+**workflow system**: a family of skills that lets the agent run work naturally — simple tasks, complex
+tasks, bug fixes, new projects — with the spec graph as the artifact layer. This task designed the
+system's **meta-layer** (concepts, rules, roles, routing/entry model) and tracks the remaining build
+work. The meta-layer itself is promoted and lives in [[module-thinkrail-workflow]]'s SPEC.md ("The
+workflow system") — that section is authoritative; nothing is restated here.
+
+## Request (as understood)
+
+- Flexible: adapts to simple vs. complex work rather than forcing one heavy process.
+- A system of *skills* — easily extendable; adding a workflow must not change the system's shape.
+- Branching rule (user-stated): each branch is its own skill; the skill before the fork holds the
+  choice rules.
+- Skills concise and workflow-focused; spec graph integrated as ground truth.
+- Meta-concepts/meta-rules first; align before building.
+
+## Decisions (consolidated; rationale in SPEC.md where promoted)
+
+1. **Scope:** meta-layer + root router + authoring skill. Wider family designed later, one task-spec
+   each. Retrofit of existing skills postponed (routed as-is).
+2. **Entry model:** `before_agent_start` rule → root router **`choosing-a-workflow`** (repoint happens
+   when the router lands; until then the rule keeps pointing at `brainstorming`).
+3. **Meta-rules home:** SPEC.md (durable rationale) + **`writing-workflow-skills`** (actionable
+   authoring checklist, points at SPEC.md).
+4. **Artifacts:** durable = spec graph only; ephemeral per-workflow working files allowed with a
+   declare-and-clean-up contract; pipeline state = a Pipeline section *inside* the task-spec.
+5. **Roles:** collapsed from an initial 4 (router/worker/stage/composer) to **2 roles + handoff
+   modes**; composer and stage are *patterns*, which dissolved the standalone-vs-stage dual-use
+   question (the same worker can serve both ways).
+6. **Composition** is a first-class meta-concept for complex work, but no machinery now; between-stage
+   checking is each composer's own design, deliberately **not** a system rule.
+7. **thinkrail-v1 workflows are not copied** — the user flagged them as broken/inflexible; they serve
+   as an *example* of one possible future complex workflow. The family stays open and grows from real
+   use; endorsed candidates: research/spike, refactor, bug-fix.
+8. **Presentation:** meta-layer written as slim glossary + roles/contracts table + mermaid topology;
+   meta-rules stay a numbered list (stable `meta-rule N` references).
+9. **Final review:** user approved **spec promotion only**; the two skills + rule repoint are held for
+   a later session.
+
+## Research (digest; clones at `/tmp/thinkrail-research/`)
+
+- **obra/superpowers** — gateway skill + explicit named handoffs between workflow skills; `description`
+  = triggers only (never step summaries); token budgets; hard gates with anti-rationalization tables;
+  "match the form to the failure".
+- **gsd-build/gsd-2** (built on pi) — router-pattern skills (`SKILL.md` routes; `workflows/`,
+  `references/`, `templates/` on demand); optional phases with explicit skip criteria; verification
+  ladder. Its `.gsd/` artifact tree is a *contrast* — our artifact layer is the spec graph.
+- **Anthropic guidance** — progressive disclosure; name/description as the discovery surface.
+- **JetBrains/thinkrail-v1** — per-ticket composed stage pipelines (orchestrator + small stage skills,
+  pipeline adjusted between stages; mandatory spec-diff stage; bug = spec/code discrepancy). Source of
+  the composition concept; explicitly an example, not a template.
+
+## Remaining work (held for a later session)
+
+1. `skills/choosing-a-workflow/` — the root router (concise; routes to today's family only).
+2. `skills/writing-workflow-skills/` — the authoring checklist.
+3. Repoint the `before_agent_start` rule in `index.ts` at the router (byte-stable, pointer-only).
+4. Verify by use (meta-rule 14): a real request through the router; walk the authoring skill once.
+
+## Postponed (explicitly out of this task)
+
+- Fate of `brainstorming` (keep/reshape/replace) and the quick-path boundary (mechanical asks
+  bypassing design work).
+- Designing any future workflow (research/spike, refactor, bug-fix, composer/stage workers).
+- Any runtime/engine layer (YAML pipelines, DAG tools) — skills only.


### PR DESCRIPTION
## What

**Spec-only PR** — design review requested, no code/skills yet.

Promotes the design of ThinkRail's **workflow system** (a growing family of workflow skills) into `packages/pi-thinkrail-workflow/SPEC.md`, plus the working task-spec with the full decision record.

## The meta-layer (SPEC.md → "The workflow system")

- **Concept model** — workflow · workflow skill (one phase/branch each) · handoff (fixed successor / back-to-caller / terminal) · gate · artifacts (durable = spec graph; ephemeral = declared per-workflow files with a cleanup contract).
- **2 skill roles** — *Router* (classification rules + handoffs only) and *Worker* (one phase's steps). *Composer* (stateful router walking a per-task pipeline recorded in the task-spec) and *stage* (a worker as used in a pipeline) are **patterns, not roles** — so the same worker can run standalone or as a stage.
- **14 meta-rules** — incl. branch = own skill with choice rules staying in the skill before the fork; `description` = triggers only; scale by *route and composition*, not by prose; adding a workflow = skill dir + one router row + one family-table row.
- **Entry model (decided, not yet built)** — `before_agent_start` rule → root router `choosing-a-workflow`; authoring checklist in `writing-workflow-skills`. Until they land, the rule keeps pointing at `brainstorming`.

## Research basis

obra/superpowers (named handoffs, description discipline, gates), gsd-build/gsd-2 (router pattern, skip criteria — notably built on pi), Anthropic skill-authoring guidance, and JetBrains/thinkrail-v1 (composed stage pipelines — an *example* for the composition concept, deliberately not copied).

## Review focus

- Do the 2 roles + patterns hold up? (collapsed from an initial 4 during design)
- Are the 14 meta-rules the right set — anything missing/overreaching?
- Artifact contract: spec graph durable, ephemeral files declare-and-clean-up, pipeline state inside the task-spec.

## Out of scope (held/postponed, tracked in TASK-workflow-system.md)

Building the two skills + rule repoint · fate of `brainstorming` / quick-path boundary · designing future workflows (research/spike, refactor, bug-fix) · any runtime engine layer.