### PR TITLE
chore: upgrade pi 0.80.3 → 0.80.6, adopt `max` thinking level

### DIFF
--- a/apps/web/src/chat/ThinkingSelector.tsx
+++ b/apps/web/src/chat/ThinkingSelector.tsx
@@ -3,11 +3,11 @@ import { Check, ChevronDown } from "lucide-react";
 import { useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
-/** The honest effort knob pi exposes: the six thinking levels. pi clamps any the model can't do. */
-const LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+/** The honest effort knob pi exposes: the seven thinking levels. pi clamps any the model can't do. */
+const LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 /**
- * The per-session effort picker (cheap win #1): a pill opening a list of the six thinking levels — the
+ * The per-session effort picker (cheap win #1): a pill opening a list of the seven thinking levels — the
  * same trigger+popover shape as the model picker. Props-driven, no store — shared by the chat header and
  * the New-Workspace dialog.
  */

--- a/bun.lock
+++ b/bun.lock
@@ -166,9 +166,9 @@
     "@biomejs/biome",
   ],
   "catalog": {
-    "@earendil-works/pi-agent-core": "0.80.3",
-    "@earendil-works/pi-ai": "0.80.3",
-    "@earendil-works/pi-coding-agent": "0.80.3",
+    "@earendil-works/pi-agent-core": "0.80.6",
+    "@earendil-works/pi-ai": "0.80.6",
+    "@earendil-works/pi-coding-agent": "0.80.6",
     "@types/bun": "1.3.14",
     "typebox": "1.1.38",
     "typescript": "6.0.3",
@@ -252,13 +252,13 @@
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.3", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.6", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.6", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.3", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.3", "@earendil-works/pi-ai": "^0.80.3", "@earendil-works/pi-tui": "^0.80.3", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.6", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.6", "@earendil-works/pi-ai": "^0.80.6", "@earendil-works/pi-tui": "^0.80.6", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.6", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -42,7 +42,7 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	// pill reflects the choice.
 	const effort = dialog.getByTestId("thinking-selector");
 	await effort.click();
-	await expect(page.getByTestId("thinking-option")).toHaveCount(6);
+	await expect(page.getByTestId("thinking-option")).toHaveCount(7);
 	await page.locator('[data-testid="thinking-option"][data-level="minimal"]').click();
 	await expect(effort).toContainText("minimal");
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 			"packages/*"
 		],
 		"catalog": {
-			"@earendil-works/pi-agent-core": "0.80.3",
-			"@earendil-works/pi-ai": "0.80.3",
-			"@earendil-works/pi-coding-agent": "0.80.3",
+			"@earendil-works/pi-agent-core": "0.80.6",
+			"@earendil-works/pi-ai": "0.80.6",
+			"@earendil-works/pi-coding-agent": "0.80.6",
 			"@types/bun": "1.3.14",
 			"typebox": "1.1.38",
 			"typescript": "6.0.3"

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -84,7 +84,7 @@ runtime exports being the WS method/channel constants and the protocol version. 
 
 ## Get right
 
-- **Type-only, from the package roots, always** (verified vs 0.80.3: type-only imports are erased by
+- **Type-only, from the package roots, always** (verified vs 0.80.6: type-only imports are erased by
   `verbatimModuleSyntax`, so the web bundle stays provider-free; the pi-ai provider/API subpaths
   statically import the Node SDKs — never touch them). The `/base` entries existed only in 0.79.8–0.79.9.
 - `Model` is generic — expose as `Model<any>`.


### PR DESCRIPTION
## Summary

Upgrades the in-process `pi` engine from **0.80.3 → 0.80.6** and adopts the one new feature relevant to a thin host: the opt-in **`max` thinking level**.

**Dependency bump** (single source of truth — the root catalog): `@earendil-works/pi-agent-core`, `pi-ai`, `pi-coding-agent` → `0.80.6`.

**Feature adopted — `max` thinking level (0.80.6):** the `ThinkingLevel` type now ends in `… | "max"`. Our `ThinkingSelector` hardcodes the list, so:
- `apps/web/src/chat/ThinkingSelector.tsx` — `LEVELS` now includes `"max"` (7 levels).
- `e2e/new-workspace.spec.ts` — `thinking-option` count `6 → 7`.
- `packages/contracts/SPEC.md` — "verified vs 0.80.3" → "0.80.6".

**Everything else in 0.80.4/0.80.6 needed no code:**
- *Inherited automatically:* GPT-5.6 / Copilot Claude Sonnet 5 models, zstd Codex transport, input-based pricing tiers (pi owns cost — we render `SessionStats`).
- *CLI/TUI-only or N/A to a thin in-process host:* `showCacheMissNotices`, `pi config -l`, `~` shellPath expansion, `/login <provider>`, TUI theme `thinkingMax` (we theme via our own token utilities).
- *Optional extension hooks not currently needed:* `agent_settled`, `before_provider_headers`, `InlineExtension`, entry renderers, `InMemory`/`Jsonl` session-storage exports, `get_entries`/`get_tree` RPC (we're in-process).

## Related issues

_None._

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test` (104 unit)
- [x] E2E suite passes for app-affecting changes — `bun run e2e` (24 no-agent) **and** `bun run e2e:agent` (34, against the real 0.80.6 runtime); web bundle gate stays provider-free
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
