### PR TITLE
[Web] Stop a failed lazy chunk from blanking the whole UI

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -35,21 +35,24 @@ convention; their boundary is held by convention + spec. Sibling edges live here
 | `panels` | layout-agnostic, store-driven feature views | no | [panels/SPEC.md](src/panels/SPEC.md) |
 | `chat` | pi conversation UI primitives: content-block renderers + the tool-renderer registry | no | [chat/SPEC.md](src/chat/SPEC.md) |
 | `shell` | the responsive frame + composition of panels | no | [shell/SPEC.md](src/shell/SPEC.md) |
+| `components` | the app's single `ErrorBoundary` primitive (contains the `ui/` sub-module) | no | [components/SPEC.md](src/components/SPEC.md) |
 | `components/ui` | shadcn primitives, themed with our tokens | no | [components/ui/SPEC.md](src/components/ui/SPEC.md) |
 | `lib` | `cn()` (clsx + tailwind-merge) | yes | [lib/SPEC.md](src/lib/SPEC.md) |
 
 Leaf utilities without their own spec: `constants/` (branding), `utils/` (font scaling), `styles/` (the
-CSS token theme contract — see Styling & theming). `main.tsx` is the entry/composition root.
+CSS token theme contract — see Styling & theming). `main.tsx` is the entry/composition root — it wraps
+`<Shell />` in `components/ErrorBoundary` as the last-resort boundary (a crash escaping every region
+shows a reload screen, not a blank root).
 
 ### Dependency graph
 
-- `shell` → `panels`, `store`, `transport`, `components/ui`, `constants`
-- `panels` → `store`, `transport`, `components/ui`, `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector` — these are shiki-free, so the eager import stays split-safe)
+- `shell` → `panels`, `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`
+- `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` — `CenterTabs`'s per-tab boundary), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector` — these are shiki-free, so the eager import stays split-safe)
 - `chat` → `contracts` (pi message types, **type-only**), `components/ui`, `lib`; `store` + `transport` (**`ChatView` only** — the renderers are store-free)
 - `store` → `transport` (**type-only** — `ConnectionStatus`), `chat` (**type-only** — `ChatTurn`/`ToolResultState`), `contracts`
 - `transport` → `contracts`, `store` (welcome routing; the `store → transport` back-edge is type-only, so
   the runtime graph is acyclic)
-- `components/ui` → `lib`
+- `components` (`ErrorBoundary`) → none internal (React + `lucide-react` only, so any region can wrap in it); `components/ui` → `lib`
 - leaves (`lib`, `constants`, `utils`, `styles`) → none internal
 
 Rules: a panel never imports another panel sideways; nothing imports `shell` (it's the composition root).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "^4.3.1",
+		"@types/bun": "catalog:",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.2",

--- a/apps/web/src/components/ErrorBoundary.test.ts
+++ b/apps/web/src/components/ErrorBoundary.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { isChunkLoadError, keysEqual } from "./ErrorBoundary";
+
+test("classifies failed dynamic imports (stale Vite chunk / 504) as chunk-load errors", () => {
+	expect(
+		isChunkLoadError(
+			new Error("Failed to fetch dynamically imported module: http://localhost/src/panels/X.tsx"),
+		),
+	).toBe(true);
+	expect(isChunkLoadError(new Error("504 (Outdated Optimize Dep)"))).toBe(true);
+	expect(isChunkLoadError(new Error("error loading dynamically imported module"))).toBe(true);
+	expect(isChunkLoadError(new Error("Importing a module script failed."))).toBe(true);
+});
+
+test("treats ordinary render errors as non-chunk (in-place retry, not reload)", () => {
+	expect(isChunkLoadError(new Error("Cannot read properties of undefined (reading 'title')"))).toBe(
+		false,
+	);
+	expect(isChunkLoadError(new TypeError("x.localeCompare is not a function"))).toBe(false);
+});
+
+test("tolerates non-Error throwables", () => {
+	expect(isChunkLoadError("Failed to fetch dynamically imported module")).toBe(true);
+	expect(isChunkLoadError(null)).toBe(false);
+	expect(isChunkLoadError(undefined)).toBe(false);
+});
+
+// `keysEqual` gates auto-recovery: a caught error clears only when the resetKeys array changes
+// (wired to workspace/tab id), so a stale key must read as equal and a changed one as unequal.
+test("resetKeys recovery: equal keys keep the error, a changed key clears it", () => {
+	// A changed value in the array → not equal → boundary resets and re-renders children.
+	expect(keysEqual(["ws-1"], ["ws-2"])).toBe(false);
+	expect(keysEqual([1, "tab-a"], [1, "tab-b"])).toBe(false);
+	// Same values (even across distinct array instances) → equal → error stays until identity changes.
+	expect(keysEqual(["ws-1"], ["ws-1"])).toBe(true);
+	const same: readonly unknown[] = ["ws-1"];
+	expect(keysEqual(same, same)).toBe(true);
+});
+
+test("resetKeys recovery: undefined and length changes are handled", () => {
+	expect(keysEqual(undefined, undefined)).toBe(true); // no resetKeys on either side → never auto-resets
+	expect(keysEqual(undefined, ["ws-1"])).toBe(false);
+	expect(keysEqual(["ws-1"], undefined)).toBe(false);
+	expect(keysEqual([], [])).toBe(true);
+	expect(keysEqual(["ws-1"], ["ws-1", "ws-2"])).toBe(false);
+	// `Object.is` semantics: NaN equals NaN, +0 ≠ -0.
+	expect(keysEqual([Number.NaN], [Number.NaN])).toBe(true);
+	expect(keysEqual([0], [-0])).toBe(false);
+});

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,125 @@
+import { AlertTriangle, RefreshCw, RotateCcw } from "lucide-react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+// Our single boundary primitive: contains a panel's render/lazy-import crash to that region instead of unmounting the root (bare gray `--bg-dark`); a rejected lazy `import()` (stale Vite chunk → 504) throws through Suspense into here, and we steer that case to a reload.
+
+const CHUNK_ERROR_PATTERNS = [
+	"dynamically imported module", // "Failed to fetch dynamically imported module: …"
+	"importing a module script failed", // Safari
+	"error loading dynamically imported module",
+	"outdated optimize dep", // Vite dev: pre-bundled deps went stale
+];
+
+/** True when `error` is a failed dynamic `import()` (stale/unreachable chunk) — those recover from a reload, not a retry. Pure so it's unit-testable. */
+export function isChunkLoadError(error: unknown): boolean {
+	const message = (error instanceof Error ? error.message : String(error ?? "")).toLowerCase();
+	return CHUNK_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+type Props = {
+	children: ReactNode;
+	/** Short human name of the wrapped surface (e.g. "Terminals") — shown in the fallback + logs. */
+	label?: string;
+	/** When any value here changes, a caught error clears and children re-render — wire to the subtree's identity (workspace/tab id) so navigating away auto-recovers. */
+	resetKeys?: readonly unknown[];
+};
+
+type State = { error: Error | null };
+
+export class ErrorBoundary extends Component<Props, State> {
+	override state: State = { error: null };
+
+	static getDerivedStateFromError(error: Error): State {
+		return { error };
+	}
+
+	override componentDidCatch(error: Error, info: ErrorInfo): void {
+		// Keep the crash observable in the console for dev/debugging; the UI already degrades gracefully.
+		console.error(`[ErrorBoundary${this.props.label ? `: ${this.props.label}` : ""}]`, error, info);
+	}
+
+	override componentDidUpdate(prev: Props): void {
+		if (this.state.error && !keysEqual(prev.resetKeys, this.props.resetKeys)) {
+			this.reset();
+		}
+	}
+
+	reset = (): void => {
+		this.setState({ error: null });
+	};
+
+	override render(): ReactNode {
+		const { error } = this.state;
+		if (!error) return this.props.children;
+		return (
+			<PanelErrorFallback
+				label={this.props.label}
+				error={error}
+				reset={this.reset}
+				isChunkError={isChunkLoadError(error)}
+			/>
+		);
+	}
+}
+
+/** Shallow (`Object.is`) equality of two `resetKeys` arrays — a caught error clears only when this returns false. Pure so it's unit-testable. */
+export function keysEqual(
+	a: readonly unknown[] | undefined,
+	b: readonly unknown[] | undefined,
+): boolean {
+	if (a === b) return true;
+	if (!a || !b || a.length !== b.length) return false;
+	return a.every((value, i) => Object.is(value, b[i]));
+}
+
+/** Themed, self-contained fallback — token utilities only, so it wears any theme. */
+function PanelErrorFallback({
+	label,
+	error,
+	reset,
+	isChunkError,
+}: {
+	label: string | undefined;
+	error: Error;
+	reset: () => void;
+	isChunkError: boolean;
+}) {
+	return (
+		<div
+			data-testid="error-boundary-fallback"
+			role="alert"
+			className="flex h-full min-h-0 flex-col items-center justify-center gap-sm overflow-auto p-lg text-center"
+		>
+			<AlertTriangle className="size-6 text-red" />
+			<p className="text-sm font-medium text-text">
+				{label ? `The ${label} panel hit an error` : "Something went wrong"}
+			</p>
+			<p className="max-w-[28rem] text-xs text-hint">
+				{isChunkError
+					? "Failed to load part of the app (a stale or unreachable resource). Reloading usually fixes it."
+					: error.message || "An unexpected error occurred while rendering this view."}
+			</p>
+			<div className="mt-xs flex items-center gap-sm">
+				{isChunkError ? (
+					<button
+						type="button"
+						data-testid="error-reload"
+						onClick={() => window.location.reload()}
+						className="flex items-center gap-xs rounded-[var(--radius-md)] border border-border2 bg-elevated px-md py-xs text-sm text-text hover:bg-hover"
+					>
+						<RefreshCw className="size-4" /> Reload page
+					</button>
+				) : (
+					<button
+						type="button"
+						data-testid="error-retry"
+						onClick={reset}
+						className="flex items-center gap-xs rounded-[var(--radius-md)] border border-border2 bg-elevated px-md py-xs text-sm text-text hover:bg-hover"
+					>
+						<RotateCcw className="size-4" /> Try again
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/SPEC.md
+++ b/apps/web/src/components/SPEC.md
@@ -1,0 +1,41 @@
+---
+id: submodule-web-components
+type: submodule-design
+status: active
+title: components — ErrorBoundary primitive (+ ui/)
+parent: module-web
+tags: [v1, ui, resilience]
+---
+
+## Responsibility
+
+The app's single **error-boundary primitive** — the one thing that keeps a panel's render crash or a
+failed lazy chunk from unmounting the React root. Also houses the `ui/` sub-module (shadcn primitives),
+which has its own spec.
+
+## Boundary
+
+- **Owns:** `ErrorBoundary.tsx` — a class boundary (`getDerivedStateFromError`) that renders a themed,
+  self-contained fallback instead of propagating a throw to the root. It:
+  - resets a caught error when any `resetKeys` value changes (wire to the subtree's identity —
+    workspace/tab id — so navigating away auto-recovers);
+  - classifies failed dynamic `import()`s via the pure, unit-tested **`isChunkLoadError`** (stale Vite
+    chunk / 504 / Safari "module script failed") and steers those to a page **reload** (re-fetches the
+    chunk) rather than an in-place retry;
+  - logs the crash to the console (`componentDidCatch`) — the UI already degrades gracefully.
+- **Public surface:** `ErrorBoundary`, `isChunkLoadError` — imported directly via
+  `@/components/ErrorBoundary` (no barrel). The `ui/` primitives are their own sub-module
+  ([components/ui/SPEC.md](ui/SPEC.md)).
+- **Allowed deps:** React, `lucide-react`. **Nothing else internal** — kept dependency-light on purpose so
+  *any* region (shell, panels, `main.tsx`) can wrap in it without creating a cycle.
+- **Forbidden:** `store`/`transport`/`panels`/`shell`/`chat`/`contracts`; `server`/`shared`/`pi`; inline
+  `style` objects or raw hex (fallback is themed with token utilities only).
+
+## Get right
+
+- **Scope of protection:** React boundaries catch **render + lazy-import** throws only — **not** errors in
+  event handlers, effects, or rejected promises (e.g. `transport.request`). Those surface through
+  `transport`'s `errorText()` as an error turn/notice, not here. The shell's "panels can't blank the app"
+  guarantee is about render/lazy-load; async failures are a separate path.
+- Where the boundary is mounted (each region + the last-resort root wrap) is owned by `shell/SPEC.md` and
+  the parent dependency graph in `apps/web/SPEC.md`, not repeated here.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import "./index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Shell } from "./shell/Shell";
 import { initTransport } from "./transport";
 import { applyFontScale } from "./utils/fontScale";
@@ -12,7 +13,10 @@ const root = document.getElementById("root");
 if (root) {
 	createRoot(root).render(
 		<StrictMode>
-			<Shell />
+			{/* Last-resort boundary: a crash escaping every panel boundary shows a reload screen, not a gray unmounted root. */}
+			<ErrorBoundary label="app">
+				<Shell />
+			</ErrorBoundary>
 		</StrictMode>,
 	);
 }

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -1,5 +1,6 @@
 import { History, MessageSquarePlus, RotateCcw, X } from "lucide-react";
 import { lazy, Suspense, useEffect } from "react";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -240,21 +241,24 @@ export function CenterTabs() {
 			</div>
 			<div data-testid="editor-pane" className="min-h-0 flex-1">
 				{active ? (
-					<Suspense
-						fallback={
-							<div className="flex h-full items-center justify-center text-hint">Loading…</div>
-						}
-					>
-						{active.kind === "chat" ? (
-							<ChatView
-								key={active.id}
-								sessionId={active.sessionId}
-								workspaceId={active.workspaceId}
-							/>
-						) : (
-							<FilePane key={active.id} tab={active} />
-						)}
-					</Suspense>
+					// Per-tab boundary: a tab's crash/failed lazy-load stays contained; switching tabs (new `active.id`) resets it.
+					<ErrorBoundary label={active.kind === "chat" ? "chat" : "editor"} resetKeys={[active.id]}>
+						<Suspense
+							fallback={
+								<div className="flex h-full items-center justify-center text-hint">Loading…</div>
+							}
+						>
+							{active.kind === "chat" ? (
+								<ChatView
+									key={active.id}
+									sessionId={active.sessionId}
+									workspaceId={active.workspaceId}
+								/>
+							) : (
+								<FilePane key={active.id} tab={active} />
+							)}
+						</Suspense>
+					</ErrorBoundary>
 				) : (
 					placeholder
 				)}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -136,5 +136,8 @@ prompt hero (still editable; empty by default), a base-branch
   (built from `transport.httpBase()`). A cross-file link's `#fragment` is not yet followed (opens the
   file only).
 - Heavy deps (Monaco / shiki / xterm) load via `React.lazy(() => import())` to stay out of the eager bundle.
+  A lazy chunk that fails to load (or a render throw) is contained by the `components/ErrorBoundary` the
+  **shell** wraps each region in (see `shell/SPEC.md`), so a single panel degrades instead of blanking the
+  app; panels themselves don't own the boundary.
 - Streaming invariant (when chat lands): `text_delta`/`thinking_delta` **APPEND**;
   `tool_execution_update.partialResult` **REPLACE**.

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -23,5 +23,17 @@ later, the mobile single-view-with-switcher).
   layout's saved sizes.
 - **Public surface:** `Shell`.
 - **Allowed deps:** `panels`, `store` (status), `transport` (`ConnectionStatus` type), `components/ui`
-  (resizable), `constants` (branding).
+  (resizable), `components/ErrorBoundary`, `constants` (branding).
 - **Forbidden:** `server`/`shared`/`pi`; being imported by `panels`/`store`/`transport`.
+
+## Error resilience (why panels can't blank the app)
+
+Panels render (and lazily import) untrusted-shaped data; a throw during render or a failed lazy chunk
+(e.g. a stale Vite dep → 504) would otherwise propagate to the React root and unmount the **whole**
+tree, leaving the bare gray `--bg-dark` background. So the shell wraps each independently-mounted
+region — **center (`CenterTabs`)**, **right (`RightPanel`)**, **terminals (`TerminalsPanel`)** — in its
+own `components/ErrorBoundary`, keyed with `resetKeys={[activeWorkspaceId]}` so switching workspace
+clears a stuck error. A **last-resort boundary wraps `<Shell />` in `main.tsx`**. `CenterTabs` adds a
+per-tab boundary (`resetKeys={[active.id]}`) so one bad tab keeps the tab strip usable. The boundary
+detects failed dynamic imports (`isChunkLoadError`) and steers those to a page **reload** (re-fetches
+the chunk) rather than an in-place retry. Each region degrades independently — never the whole app.

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -1,5 +1,6 @@
 import { Settings } from "lucide-react";
 import { useState } from "react";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable";
 import { PRODUCT_NAME } from "../constants/branding";
 import { CenterTabs } from "../panels/CenterTabs";
@@ -25,7 +26,8 @@ const STATUS_DOT: Record<ConnectionStatus, string> = {
 
 export function Shell() {
 	const status = useAppStore((s) => s.status);
-	const hasActiveWorkspace = useAppStore((s) => s.activeWorkspaceId != null);
+	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
+	const hasActiveWorkspace = activeWorkspaceId != null;
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	return (
 		<div data-testid="shell" className="grid h-full grid-rows-[auto_1fr]">
@@ -69,7 +71,9 @@ export function Shell() {
 					<ResizableHandle direction="horizontal" data-testid="resize-left" />
 					<ResizablePanel id="center" order={2} defaultSize={52} minSize={28}>
 						<main data-testid="center-tabs" className="h-full min-h-0 bg-surface-content">
-							<CenterTabs />
+							<ErrorBoundary label="Editor" resetKeys={[activeWorkspaceId]}>
+								<CenterTabs />
+							</ErrorBoundary>
 						</main>
 					</ResizablePanel>
 					<ResizableHandle direction="horizontal" data-testid="resize-right" />
@@ -77,13 +81,17 @@ export function Shell() {
 						<ResizablePanelGroup direction="vertical" autoSaveId="thinkrail-right">
 							<ResizablePanel id="right-files" order={1} defaultSize={60} minSize={20}>
 								<div data-testid="right-panel" className="h-full min-h-0 bg-surface-content">
-									<RightPanel />
+									<ErrorBoundary label="Files" resetKeys={[activeWorkspaceId]}>
+										<RightPanel />
+									</ErrorBoundary>
 								</div>
 							</ResizablePanel>
 							<ResizableHandle direction="vertical" data-testid="resize-terminals" />
 							<ResizablePanel id="right-terminals" order={2} defaultSize={40} minSize={15}>
 								<div className="h-full min-h-0 bg-surface-content">
-									<TerminalsPanel />
+									<ErrorBoundary label="Terminals" resetKeys={[activeWorkspaceId]}>
+										<TerminalsPanel />
+									</ErrorBoundary>
 								</div>
 							</ResizablePanel>
 						</ResizablePanelGroup>

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": true,
-		"includes": ["**", "!designs"]
+		"includes": ["**", "!designs", "!**/.claude"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.1",
+        "@types/bun": "catalog:",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",

--- a/e2e/error-boundary.spec.ts
+++ b/e2e/error-boundary.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+
+// A failed lazy chunk must degrade the ONE panel, not blank the app. We simulate a stale/unreachable
+// chunk by aborting the editor's dynamic-import request at the network layer (no prod fault-injection
+// code) — the rejected `import()` throws through Suspense into the per-tab ErrorBoundary, which
+// classifies it as a chunk-load error and offers a page reload.
+test("a failed editor chunk shows the boundary's reload fallback and keeps the shell alive", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+
+	// Abort the lazily-loaded Monaco chunk (Vite default name: `assets/MonacoEditor-<hash>.js`).
+	await page.route(/MonacoEditor.*\.js(\?.*)?$/, (route) => route.abort());
+
+	await page.getByTestId("tab-files").click();
+	const notes = page.getByTestId("file-node").filter({ hasText: "notes.txt" });
+	await expect(notes).toBeVisible();
+	// Plain text → straight to the Monaco editor path, whose chunk we just blocked.
+	await notes.dblclick();
+
+	// The boundary catches it and, because it's a chunk-load failure, offers a reload (not a retry).
+	const fallback = page.getByTestId("error-boundary-fallback");
+	await expect(fallback).toBeVisible();
+	await expect(fallback).toContainText("editor");
+	await expect(page.getByTestId("error-reload")).toBeVisible();
+	await expect(page.getByTestId("error-retry")).toHaveCount(0);
+
+	// Containment: the crash stayed inside the center pane — the tab strip and the rest of the shell live.
+	await expect(page.getByTestId("editor-tab").filter({ hasText: "notes.txt" })).toBeVisible();
+	await expect(page.getByTestId("shell")).toBeVisible();
+	await expect(page.getByTestId("right-panel")).toBeVisible();
+});


### PR DESCRIPTION
Problem: A panel's render error or a failed lazy chunk load (e.g. a stale Vite chunk returning a 504) propagated all the way to the React root, unmounting the entire tree and leaving the user staring at a blank gray background — one bad panel took down the whole UI, with no way to recover short of a manual reload.  