### PR TITLE
fix(web): review multi-question answers before submit

### DIFF
--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -23,8 +23,8 @@ import { resultText } from "./toolHelpers";
 // "bare" tool card (see the tool registry `chrome`), so it's a full-width, always-open panel rather than a
 // folded card. Styled after the app's inline prompt-card spec: the question IS the card header, options are
 // radio/checkbox rows (the recommended one badged) closed by a mandatory native "Other" row (same
-// radio/checkbox indicator, inline free-text field), a footer with a mode hint + Skip/Submit, and compact,
-// borderless "record" states once resolved. Presentational: reads the questions
+// radio/checkbox indicator, inline free-text field), a footer with a mode hint + Skip/Next/Submit, and
+// compact, borderless "record" states once resolved. Presentational: reads the questions
 // from the tool-call `args`, replies through the `ChatActions` context (provided by `ChatView`) — never the
 // store/transport directly, so it stays reusable.
 
@@ -204,8 +204,9 @@ export function AskUserQuestionCard({
 	const state = stateFor(idx);
 	if (!q) return <WaitingCard>Preparing questions…</WaitingCard>;
 
-	const onLastQuestion = idx === questions.length - 1;
-	const showContinue = multi && !onReview && !onLastQuestion;
+	// A multi-question questionnaire always advances through its synthetic review step; only that step
+	// submits. Single-question cards retain their direct Submit action.
+	const showContinue = multi && !onReview;
 	const canSubmit =
 		!!actions && (onReview || !multi ? answers.length > 0 : answeredIndices.has(idx));
 
@@ -282,7 +283,7 @@ export function AskUserQuestionCard({
 								<button
 									type="button"
 									data-testid="ask-continue"
-									onClick={() => setTab(tab + 1)}
+									onClick={() => setTab(Math.min(tab + 1, reviewTab))}
 									className="rounded-[var(--radius-md)] bg-primary px-md py-1.5 font-medium text-on-accent text-sm hover:opacity-90"
 								>
 									Next →

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -23,9 +23,12 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 - **`AskUserQuestionCard`** — the inline questionnaire for the host-owned `ask_user_question` tool
   (capability + rationale: the server's `agent/askUserQuestion` SPEC). Registered `"bare"`: it owns its
   full-width frame, never folds, and answers through the `ChatActions` context (correlated by
-  `toolCallId`). Two behaviors worth their invariants:
+  `toolCallId`). Behaviors worth their invariants:
   - **Controls never stream** — while args stream it shows a stable composing placeholder and the
     complete questionnaire reveals atomically at message end (rationale in the component's jsdoc).
+  - **Multi-question completion is review-gated** — every question page advances with **Next**, including
+    the final question; only the synthetic **Review & submit** page exposes **Submit**. A single question
+    keeps its direct **Submit** action.
   - **Per-call UI state survives virtualization** — a module-level cache keyed by `toolCallId` (dropped
     on resolve), since react-virtuoso unmounts off-screen rows. This is the pattern the activity fold's
     expansion state reuses.

--- a/e2e/ask-user-question.live.spec.ts
+++ b/e2e/ask-user-question.live.spec.ts
@@ -179,7 +179,7 @@ test("skip: declining resolves the tool as a skipped record", { tag: "@agent" },
 	await expect(skipped).toContainText("skipped");
 });
 
-test("multi-question: tab through, review, and submit a batch", { tag: "@agent" }, async ({
+test("multi-question: Next reaches review before submitting the batch", { tag: "@agent" }, async ({
 	page,
 }) => {
 	test.setTimeout(180_000);
@@ -195,16 +195,22 @@ test("multi-question: tab through, review, and submit a batch", { tag: "@agent" 
 	const tabs = card.getByTestId("ask-tab");
 	await expect(tabs).toHaveCount(3);
 
-	// Answer each question tab (all but the last "Review & submit" chip) by picking its first option.
+	// Follow the sequential path: every real question — including the final one — advances with Next.
 	for (let i = 0; i < 2; i++) {
-		await tabs.nth(i).click();
+		await expect(tabs.nth(i)).toHaveAttribute("data-active", "true");
 		await card.getByTestId("ask-option").first().click();
+		await expect(card.getByTestId("ask-submit")).toHaveCount(0);
+		await card.getByTestId("ask-continue").click();
 	}
-	// Every question answered → both tab chips flip to their "answered" marker.
+
+	// Final-question Next must activate review rather than submitting directly.
+	await expect(tabs.nth(2)).toHaveAttribute("data-active", "true");
+	await expect(card).toContainText("Review your answers");
+	await expect(card.getByTestId("ask-continue")).toHaveCount(0);
+	await expect(card.getByTestId("ask-submit")).toBeEnabled();
+	// Every question answered → both question chips carry their answered marker.
 	await expect(card.locator('[data-testid="ask-tab"][data-answered="true"]')).toHaveCount(2);
 
-	// Review, then submit the batch.
-	await tabs.nth(2).click();
 	await card.getByTestId("ask-submit").click();
 	const record = answeredRecord(page);
 	await expect(record).toBeVisible({ timeout: 60_000 });


### PR DESCRIPTION
## Summary

- route the final question's **Next** action to the existing **Review & submit** step
- expose **Submit** only from review for multi-question questionnaires while preserving direct submit for a single question
- document the interaction invariant and cover the sequential path with the live-agent e2e test

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run e2e` — 28 passed
- `bunx playwright test e2e/ask-user-question.live.spec.ts --grep "multi-question: Next reaches review"` — 1 passed
- `spec_validate`
