### PR TITLE
fix: use `central` for the CLI + auth-kind value (#63)

### DIFF
--- a/apps/web/src/panels/JetBrainsAiCard.tsx
+++ b/apps/web/src/panels/JetBrainsAiCard.tsx
@@ -20,8 +20,8 @@ type ConnectResult =
 
 /**
  * The JetBrains AI option in the Providers settings: route Claude + GPT through the local `jbcentral` proxy
- * using your JetBrains subscription. A small state machine over the host's jbcentral CLI —
- * connected (Disconnect) / ready (Connect) / not signed in (in-app `jbcentral login` + retry) / not installed
+ * using your JetBrains subscription. A small state machine over the host's central CLI —
+ * connected (Disconnect) / ready (Connect) / not signed in (in-app `central login` + retry) / not installed
  * (install guidance + Recheck). `wired`/`installed` come from the `provider.status` the pane already fetched
  * (the source of truth); `result` layers on only the last connect attempt's outcome; `onChanged` re-reads
  * status after a mutation.
@@ -90,7 +90,7 @@ export function JetBrainsAiCard({
 		}
 	}, [onChanged]);
 
-	// Gate concurrent spawns — without this, rapid clicks launch multiple `jbcentral login` processes.
+	// Gate concurrent spawns — without this, rapid clicks launch multiple `central login` processes.
 	const signIn = useCallback(async () => {
 		if (signingIn) return;
 		setSigningIn(true);

--- a/apps/web/src/panels/ProvidersSettings.tsx
+++ b/apps/web/src/panels/ProvidersSettings.tsx
@@ -9,7 +9,7 @@ import { JetBrainsAiCard } from "./JetBrainsAiCard";
 
 /** Human label per auth kind (a configured provider's source suffix). */
 const KIND_LABEL: Record<ProviderAuthKind, string> = {
-	jbcentral: "JetBrains AI proxy",
+	central: "JetBrains AI proxy",
 	oauth: "OAuth subscription",
 	"api-key": "API key",
 	env: "environment",
@@ -299,7 +299,7 @@ function ConnectedCard({
 					{provider.detail ? ` · ${provider.detail}` : ""}
 				</span>
 			</div>
-			{/* Only auth.json credentials are removable here — env / jbcentral / models.json auth can't be
+			{/* Only auth.json credentials are removable here — env / central / models.json auth can't be
 			    unset by the host, so it shows a "Managed" tag instead of a Sign-out that would silently no-op. */}
 			{provider.canLogout ? (
 				<Button

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -82,7 +82,7 @@ prompt hero (still editable; empty by default), a base-branch
   **store-driven two-pane shell** (left section rail + scrollable content pane; mobile collapses the rail to
   a horizontal segmented strip): `settingsOpen`/`settingsSection` live in the store so the gear AND the
   Welcome banner can open it deep-linked to a section. Live sections: **`ProvidersSettings`** (the in-app
-  provider-auth surface — Connected cards each with a **Sign-out only when `canLogout`** (env / jbcentral /
+  provider-auth surface — Connected cards each with a **Sign-out only when `canLogout`** (env / central /
   models.json auth shows a "Managed" tag instead, since the host can't unset it); a **"Sign in with a
   subscription"** block of `canOAuth` providers → `provider.loginStart` → the store-driven `auth/LoginDialog`
   (open the URL or paste the code, `provider.loginReply`); an **"Add an API key"** group of single-key
@@ -90,7 +90,7 @@ prompt hero (still editable; empty by default), a base-branch
   the **`JetBrainsAiCard`** — route Claude+GPT through your JetBrains subscription (the jbcentral proxy) — a
   state machine over `jbcentralWired`/`jbcentralInstalled` + `jbcentralInstall` (all from the same status
   read) + `provider.jbcentral*`:
-  Connected (Disconnect) / ready (Connect) / not signed in (in-app `jbcentral login` + Retry) / not installed
+  Connected (Disconnect) / ready (Connect) / not signed in (in-app `central login` + Retry) / not installed
   (the host's per-OS copyable install command — from `jbcentralInstall`, for the *host's* OS, never the
   browser's — + Recheck); each mutation re-reads `provider.status`) and **`GithubSettings`** (the "Local GitHub" block — `github.authStatus()`
   Connected + login / Not connected + Refresh). Dimmed "General"/"Appearance" nav items ("Soon") signal the

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -128,7 +128,7 @@ test("clicking Sign in (Settings) opens the in-app login dialog, and Cancel dism
 	await expect(dialog).toHaveCount(0);
 });
 
-test("Settings → Providers offers JetBrains AI, guiding install when the jbcentral CLI is missing", async ({
+test("Settings → Providers offers JetBrains AI, guiding install when the central CLI is missing", async ({
 	page,
 }) => {
 	await openAppFresh(page);
@@ -139,7 +139,7 @@ test("Settings → Providers offers JetBrains AI, guiding install when the jbcen
 	await expect(card).toBeVisible();
 	await expect(card).toContainText("JetBrains AI");
 
-	// The card's state depends on the host's jbcentral CLI (the e2e host has none → install guidance;
+	// The card's state depends on the host's central CLI (the e2e host has none → install guidance;
 	// a dev machine with it wired/ready shows Disconnect/Connect). Accept whichever is truthful.
 	if ((await card.getAttribute("data-installed")) === "false") {
 		await expect(page.getByTestId("jetbrains-needs-install")).toBeVisible();

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -72,14 +72,14 @@ runtime exports being the WS method/channel constants and the protocol version. 
   again), `Session` (chat tab),
   `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types; **`ProviderStatus`/`ProviderStatusReport`**
   — the auth-provider status rows the Welcome strip renders (per-provider `configured` + auth `kind`:
-  oauth / api-key / env / jbcentral / other — never credential values; plus `canOAuth`/`canApiKey`/`canLogout`,
+  oauth / api-key / env / central / other — never credential values; plus `canOAuth`/`canApiKey`/`canLogout`,
   which gate the strip's in-app Sign-in / Sign-out affordances — `canLogout` is true only for a removable
-  auth.json credential, false for env / jbcentral / models.json auth the host can't unset); the **in-app login wire** — **`LoginFrame`** (the streamed
+  auth.json credential, false for env / central / models.json auth the host can't unset); the **in-app login wire** — **`LoginFrame`** (the streamed
   flow updates: `authUrl` / `deviceCode` / `select` / `prompt` / `progress` / `success` / `error`, which
   **accumulate** client-side, never a credential value), **`LoginPush`** (the `provider.login` frame,
   `{ loginId, providerId, frame }`) and **`LoginReply`** (`{ loginId, value }` — the browser's answer to a
   `select`/`prompt`); the JetBrains AI wire — **`ProviderStatusReport.jbcentralInstalled`** (is the
-  `jbcentral` CLI on the host) alongside `jbcentralWired` and **`jbcentralInstall`** (**`JbcentralInstall`**:
+  `central` CLI on the host) alongside `jbcentralWired` and **`jbcentralInstall`** (**`JbcentralInstall`**:
   the host's per-OS `{platform, shell, command}` install one-liner — for the *host's* OS, not the browser's,
   so a remote/phone client still shows the command for the machine running the host), and
   **`JbcentralConnectResult`** (the in-app connect state machine: `connected` / `needs-install` /
@@ -98,7 +98,7 @@ runtime exports being the WS method/channel constants and the protocol version. 
   not sit on the request nor block the WS pump) / **`loginReply`** — answers a live `select`/`prompt`,
   correlated by `loginId` / **`loginCancel`** / **`setApiKey`** (single key → auth.json) / **`logout`** /
   the **JetBrains AI** trio **`jbcentralConnect`** (wire Claude+GPT via the jbcentral proxy → a
-  `JbcentralConnectResult`) / **`jbcentralDisconnect`** / **`jbcentralLogin`** (launch `jbcentral login`)) /
+  `JbcentralConnectResult`) / **`jbcentralDisconnect`** / **`jbcentralLogin`** (launch `central login`)) /
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -117,7 +117,7 @@ export interface BranchList {
 
 /** Local `gh` CLI auth status (read-only, shelled server-side) for the New-Workspace + Settings surfaces. */
 /** How a model provider is authenticated — drives the status row's label, never carries secrets. */
-export type ProviderAuthKind = "oauth" | "api-key" | "env" | "jbcentral" | "other";
+export type ProviderAuthKind = "oauth" | "api-key" | "env" | "central" | "other";
 
 /** One model provider's auth status, as the host reports it (read-only; no credential values). */
 export interface ProviderStatus {
@@ -127,7 +127,7 @@ export interface ProviderStatus {
 	name: string;
 	/** Whether the provider is usable (any auth form: stored, env var, models.json, proxy). */
 	configured: boolean;
-	/** The auth source kind, when configured. `jbcentral` = routed through the JetBrains Central proxy. */
+	/** The auth source kind, when configured. `central` = routed through the JetBrains Central proxy. */
 	kind?: ProviderAuthKind;
 	/** Optional human hint for the source (e.g. the env var name, or `models.json`). */
 	detail?: string;
@@ -135,7 +135,7 @@ export interface ProviderStatus {
 	canOAuth?: boolean;
 	/** In-app single-key API-key entry is available (`provider.setApiKey`) — false for multi-field creds. */
 	canApiKey?: boolean;
-	/** The provider has a removable `auth.json` credential (`provider.logout`) — false for env / jbcentral /
+	/** The provider has a removable `auth.json` credential (`provider.logout`) — false for env / central /
 	 * models.json auth, which the host can't unset (so the strip shows no Sign-out for those). */
 	canLogout?: boolean;
 }
@@ -161,7 +161,7 @@ export interface ProviderStatusReport {
 	providers: ProviderStatus[];
 	/** Whether any provider's effective baseUrl routes through the jbcentral proxy (JetBrains AI is wired). */
 	jbcentralWired: boolean;
-	/** Whether the `jbcentral` CLI is installed on the host (drives the in-app JetBrains AI card's state). */
+	/** Whether the `central` CLI is installed on the host (drives the in-app JetBrains AI card's state). */
 	jbcentralInstalled: boolean;
 	/** The host's per-OS install command for the JetBrains Central CLI — rendered by the card when not
 	 * installed (reflects the host's OS, not the browser's). */

--- a/packages/server/src/auth/SPEC.md
+++ b/packages/server/src/auth/SPEC.md
@@ -21,7 +21,7 @@ parse `auth.json` / `models.json` ourselves and never surface a credential value
 - **Owns:**
   - `providerStatus` — `getProviderStatus()` → the wire `ProviderStatusReport`: per-provider `configured`
     (pi's `hasAuth`-family truth, so env-var auth counts) + auth `kind` (oauth / api-key / env /
-    **jbcentral** / other) + display name + the in-app-login capability flags **`canOAuth`/`canApiKey`**,
+    **central** / other) + display name + the in-app-login capability flags **`canOAuth`/`canApiKey`**,
     configured-first. It **revalidates on every read** (`authStorage.reload()` + `modelRegistry.refresh()`)
     so a `pi` `/login` (or a terminal `central` re-wire) — or an in-app mutation below — shows up
     on the next read without a host restart (accepted micro-risk: refreshing the shared registry concurrent
@@ -39,7 +39,7 @@ parse `auth.json` / `models.json` ourselves and never surface a credential value
       re-derive pi's private `isApiKeyLoginProvider` predicate, which isn't a package export (deep TUI
       import only) — **drift note:** re-check them on pi bumps against pi's provider-display-names map.
       `canLogout` = the id has a stored **auth.json** credential (`credentialProviders`) — the only auth the
-      host can remove; env / jbcentral (models.json) / models.json-keyed auth report `false` (Sign-out would
+      host can remove; env / central (models.json) / models.json-keyed auth report `false` (Sign-out would
       no-op, so the strip hides it).
   - `providerLogin` — the in-app credential **writes**, session-less (a login runs on the Welcome screen
     before any session exists), so a `loginId`-keyed sibling of `agent/webUiContext`:
@@ -60,7 +60,7 @@ parse `auth.json` / `models.json` ourselves and never surface a credential value
     (which owns the protocol) and adding the one live-runtime step the standalone CLI can't:
     `connectJbcentral()` (`wireJbcentral` → on success `modelRegistry.refresh()` → a `JbcentralConnectResult`:
     connected / needs-install / needs-login / error), `disconnectJbcentral()` (`unwireJbcentral` + refresh),
-    `jbcentralLogin()` (best-effort `jbcentral login` browser launch). `providerStatus` also surfaces
+    `jbcentralLogin()` (best-effort `central login` browser launch). `providerStatus` also surfaces
     `jbcentralInstalled` (via `isJbcentralInstalled`) **and `jbcentralInstall`** (the host's per-OS install
     one-liner, via `jbcentralInstall(process.platform)`) so the card knows its state — and shows the right
     command for the host's OS — from the one status read.

--- a/packages/server/src/auth/jbcentral.ts
+++ b/packages/server/src/auth/jbcentral.ts
@@ -12,7 +12,7 @@ import {
 } from "@thinkrail/shared/jbcentral";
 import { getPiRuntime } from "../agent";
 
-/** Whether the `jbcentral` CLI is on the host's PATH (cheap, side-effect-free). */
+/** Whether the `central` CLI is on the host's PATH (cheap, side-effect-free). */
 export function jbcentralInstalled(): boolean {
 	return isJbcentralInstalled();
 }
@@ -42,7 +42,7 @@ export async function disconnectJbcentral(): Promise<void> {
 	getPiRuntime().modelRegistry.refresh();
 }
 
-/** Best-effort launch of `jbcentral login` (its browser sign-in) on the host. */
+/** Best-effort launch of `central login` (its browser sign-in) on the host. */
 export function jbcentralLogin(): { launched: boolean } {
 	return { launched: launchJbcentralLogin().launched };
 }

--- a/packages/server/src/auth/providerStatus.test.ts
+++ b/packages/server/src/auth/providerStatus.test.ts
@@ -53,7 +53,7 @@ describe("buildProviderReport", () => {
 		);
 	});
 
-	test("jbcentral-wired provider reports kind jbcentral and flips jbcentralWired", () => {
+	test("jbcentral-wired provider reports kind central and flips jbcentralWired", () => {
 		const report = buildProviderReport(
 			sources({
 				modelProviders: new Map([
@@ -68,7 +68,7 @@ describe("buildProviderReport", () => {
 		);
 		expect(report.jbcentralWired).toBe(true);
 		expect(report.providers).toEqual([
-			{ id: "anthropic", name: "Anthropic", configured: true, kind: "jbcentral", canApiKey: true },
+			{ id: "anthropic", name: "Anthropic", configured: true, kind: "central", canApiKey: true },
 			{ id: "google", name: "Google", configured: false, canApiKey: true },
 		]);
 	});

--- a/packages/server/src/auth/providerStatus.ts
+++ b/packages/server/src/auth/providerStatus.ts
@@ -50,7 +50,7 @@ export interface ProviderStatusSources {
 	displayName: (id: string) => string;
 	/** Any auth form at all (stored / runtime / env) — the fallback truth for model-less providers. */
 	hasAuth: (id: string) => boolean;
-	/** Whether the `jbcentral` CLI is on PATH — surfaced so the JetBrains AI card knows its state. */
+	/** Whether the `central` CLI is on PATH — surfaced so the JetBrains AI card knows its state. */
 	jbcentralInstalled: boolean;
 	/** The host's per-OS install command for the JetBrains Central CLI — carried to the card so it renders
 	 * the right command (for the *host's* OS) when the CLI isn't installed. */
@@ -63,7 +63,7 @@ function resolveKind(
 	credentialType: "oauth" | "api_key" | undefined,
 	source: string | undefined,
 ): ProviderAuthKind {
-	if (viaJbcentral) return "jbcentral";
+	if (viaJbcentral) return "central";
 	if (credentialType === "oauth") return "oauth";
 	if (credentialType === "api_key") return "api-key";
 	switch (source) {
@@ -84,7 +84,7 @@ function resolveDetail(
 	source?: string,
 	label?: string,
 ): string | undefined {
-	if (kind === "jbcentral") return undefined; // the kind's label says it all
+	if (kind === "central") return undefined; // the kind's label says it all
 	if (label) return label;
 	if (source === "models_json_key") return "models.json";
 	if (source === "models_json_command") return "models.json (command)";
@@ -95,7 +95,7 @@ function resolveDetail(
 export function buildProviderReport(sources: ProviderStatusSources): ProviderStatusReport {
 	const oauthIds = new Set(sources.oauthProviders.map((p) => p.id));
 	const oauthName = new Map(sources.oauthProviders.map((p) => [p.id, p.name]));
-	// Only providers with a stored auth.json credential are removable in-app; env / jbcentral (models.json) /
+	// Only providers with a stored auth.json credential are removable in-app; env / central (models.json) /
 	// models.json-keyed auth can't be unset by `authStorage.logout`, so Sign-out is hidden for them.
 	const removable = new Set(sources.credentialProviders);
 	// Every loginable thing is a row: model providers + stored credentials + OAuth providers (so the

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -255,7 +255,7 @@ const handlers: Record<string, Handler> = {
 		return { ok: true } as const;
 	},
 	// JetBrains AI (jbcentral proxy): connect/disconnect write models.json + refresh the registry; login
-	// launches `jbcentral login` (browser) on the host.
+	// launches `central login` (browser) on the host.
 	"provider.jbcentralConnect": () => connectJbcentral(),
 	"provider.jbcentralDisconnect": async () => {
 		await disconnectJbcentral();

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -39,9 +39,9 @@ Exposed through explicit subpath exports, not a barrel.
   they can't silently diverge (a co-located drift test asserts `buildProxyUrls` output satisfies
   `isJbcentralProxyUrl`). **Read:** `isJbcentralProxyUrl(url)` (loopback host + `/wire/` path) — how the
   server's provider-status report detects a wired provider. **Write:** `wireJbcentral(env)` (probe the proxy
-  secret via `jbcentral proxy start`, resolve the port, override anthropic/openai `baseUrl` in `models.json`
+  secret via `central proxy start`, resolve the port, override anthropic/openai `baseUrl` in `models.json`
   → a `WireOutcome`: `connected` / `needs-install` / `needs-login` / `error`), `unwireJbcentral(env)` (undo),
-  `isJbcentralInstalled()` (`Bun.which`), `launchJbcentralLogin()` (best-effort spawn of `jbcentral login`),
+  `isJbcentralInstalled()` (`Bun.which`), `launchJbcentralLogin()` (best-effort spawn of `central login`),
   plus the pure transforms + probe. **Install guidance is per-OS and single-sourced:** `jbcentralInstall(platform)`
   returns the `{platform, shell, command}` one-liner (macOS/Linux → `install.sh` curl pipe; Windows →
   `install.ps1` PowerShell) off the `central/` S3 path (post-rebrand, not the old `jbcentral/`); the server
@@ -61,10 +61,10 @@ Exposed through explicit subpath exports, not a barrel.
 
 ## Get right (jbcentral)
 
-- **Detect + invoke jbcentral by absolute path (`resolveJbcentralBin`), never by bare command.** Two traps,
+- **Detect + invoke central by absolute path (`resolveJbcentralBin`), never by bare command.** Two traps,
   both of which caused an "installed but the in-app Recheck does nothing" bug: (1) `Bun.which(cmd)` with no
   options reads the PATH **snapshotted at process start**, not the live `process.env.PATH` — so we pass
-  `process.env.PATH` explicitly; (2) the installer drops `jbcentral` in `~/.local/bin` and does **not** add
+  `process.env.PATH` explicitly; (2) the installer drops `central` in `~/.local/bin` and does **not** add
   that to PATH (it only prints a hint) — so we fall back to that location. `probeJbcentralSecret` /
   `launchJbcentralLogin` then run the resolved absolute path, so wiring/login work even when it's off PATH.
 - **Back up `models.json` to `.bak` only once** (when no `.bak` exists) — a connect→disconnect→connect cycle

--- a/packages/shared/src/jbcentral.test.ts
+++ b/packages/shared/src/jbcentral.test.ts
@@ -155,7 +155,7 @@ describe("resolveJbcentralBin (install detection)", () => {
 		expect(isJbcentralInstalled()).toBe(true);
 	});
 
-	test("still finds the legacy `jbcentral` name when that's all that's present", () => {
+	test("ignores the legacy `jbcentral` name — only `central` is supported", () => {
 		tmp = mkdtempSync(join(tmpdir(), "jbc-home-"));
 		const binDir = join(tmp, ".local", "bin");
 		mkdirSync(binDir, { recursive: true });
@@ -165,7 +165,8 @@ describe("resolveJbcentralBin (install detection)", () => {
 
 		process.env.PATH = "";
 		process.env.HOME = tmp;
-		expect(resolveJbcentralBin()).toBe(bin);
+		expect(resolveJbcentralBin()).toBeNull();
+		expect(isJbcentralInstalled()).toBe(false);
 	});
 
 	test("null when the CLI is neither on PATH nor in ~/.local/bin", () => {

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -1,4 +1,4 @@
-// The JetBrains Central CLI (`jbcentral`) proxy integration — the single home for its wire, pinned here so
+// The JetBrains Central CLI (`central`) proxy integration — the single home for its wire, pinned here so
 // the **write** side (build the proxy `baseUrl`s + override `models.json`) and the **read** side
 // (`isJbcentralProxyUrl`, how the server detects a wired provider) can never silently diverge. The server's
 // in-app "Connect JetBrains AI" flow is a thin caller over `wireJbcentral`/`unwireJbcentral`, adding only its
@@ -197,7 +197,7 @@ export type SecretProbe =
 
 /**
  * Ensure the proxy daemon is running and return its persistent secret. An empty secret means the user isn't
- * signed into JetBrains AI (`jbcentral login`); a non-zero exit is a hard error (surfaced verbatim).
+ * signed into JetBrains AI (`central login`); a non-zero exit is a hard error (surfaced verbatim).
  */
 export async function probeJbcentralSecret(): Promise<SecretProbe> {
 	const bin = resolveJbcentralBin();
@@ -239,7 +239,7 @@ export async function wireJbcentral(env: ParseEnv): Promise<WireOutcome> {
 	if (!probe.ok) {
 		if (probe.reason === "not-installed") return { outcome: "needs-install" };
 		if (probe.reason === "not-logged-in") return { outcome: "needs-login" };
-		return { outcome: "error", message: probe.message || "jbcentral proxy start failed" };
+		return { outcome: "error", message: probe.message || "central proxy start failed" };
 	}
 	let port: number;
 	try {
@@ -270,12 +270,12 @@ export async function unwireJbcentral(env: ParseEnv): Promise<void> {
 }
 
 /**
- * Best-effort launch of `jbcentral login` (its browser sign-in) as a detached child — non-blocking. Returns
- * whether it started; if `jbcentral` needs a TTY and refuses, the caller falls back to terminal guidance.
+ * Best-effort launch of `central login` (its browser sign-in) as a detached child — non-blocking. Returns
+ * whether it started; if `central` needs a TTY and refuses, the caller falls back to terminal guidance.
  */
 export function launchJbcentralLogin(): { launched: boolean; message?: string } {
 	const bin = resolveJbcentralBin();
-	if (!bin) return { launched: false, message: "jbcentral is not installed" };
+	if (!bin) return { launched: false, message: "central is not installed" };
 	try {
 		// Invoke by absolute path (it may be off PATH, e.g. ~/.local/bin); `.unref()` so the browser sign-in
 		// child doesn't keep the host's event loop alive (it outlives this call).

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -129,34 +129,31 @@ export function jbcentralInstall(platform: NodeJS.Platform): JbcentralInstall {
 }
 
 /**
- * Candidate binary names, in preference order. The CLI rebranded **jbcentral → central** (v1.x): a fresh
- * install ships only `central`, with `jbcentral` created merely as a legacy-compat symlink when upgrading.
+ * The JetBrains Central CLI binary name. The tool is `central` only — the legacy `jbcentral` name (and any
+ * `ln -s central jbcentral` symlink) is intentionally **not** supported.
  */
-const JBCENTRAL_BINS = ["central", "jbcentral"] as const;
+const CENTRAL_BIN = "central";
 
 /**
  * Resolve the JetBrains Central CLI binary to an absolute path, or `null` if it isn't installed. Subtleties
  * this exists for (each caused the "installed but Recheck does nothing" bug):
- *   1. the tool is now named `central`, not `jbcentral` (see above) — check both.
- *   2. `Bun.which(cmd)` with no options reads the PATH **snapshotted at process start**, not the live
+ *   1. `Bun.which(cmd)` with no options reads the PATH **snapshotted at process start**, not the live
  *      `process.env.PATH` — so we pass `process.env.PATH` explicitly (honors a re-resolved login PATH).
- *   3. the installer drops it in `~/.local/bin` and does NOT add that to PATH (it only prints a hint) — so
+ *   2. the installer drops it in `~/.local/bin` and does NOT add that to PATH (it only prints a hint) — so
  *      we fall back to that well-known location.
  * Invoking by this absolute path also means the proxy/login calls work even when it's off PATH.
  */
 export function resolveJbcentralBin(): string | null {
 	const path = process.env.PATH ?? "";
 	const home = process.env.HOME ?? homedir();
-	for (const name of JBCENTRAL_BINS) {
-		const onPath = Bun.which(name, { PATH: path });
-		if (onPath) return onPath;
-		const local = join(home, ".local", "bin", name);
-		if (existsSync(local)) return local;
-	}
+	const onPath = Bun.which(CENTRAL_BIN, { PATH: path });
+	if (onPath) return onPath;
+	const local = join(home, ".local", "bin", CENTRAL_BIN);
+	if (existsSync(local)) return local;
 	return null;
 }
 
-/** Whether the JetBrains Central CLI is installed (`central`/`jbcentral` on the live PATH or `~/.local/bin`). */
+/** Whether the JetBrains Central CLI (`central`) is installed (on the live PATH or `~/.local/bin`). */
 export function isJbcentralInstalled(): boolean {
 	return resolveJbcentralBin() !== null;
 }


### PR DESCRIPTION
(rename only binary and references to it; all other parts kept to be jbcentral-based names)

`jbcentral` CLI was renamed to `central`.

- Resolve/launch the **`central` bin only** — dropped the legacy `jbcentral` fallback, so no `ln -s central jbcentral` symlink is needed.
- Auth-kind value `"jbcentral"` → `"central"` (contracts union, server derivation, web label key, test).
- Executable/command mentions → `central` (error strings, comments, specs, e2e titles).
- Kept as `jbcentral` by design: wire methods, types, internal symbols, filenames.

Runtime binary resolution already preferred `central` (de4031d); this makes it `central`-only.

Verified: check:deps · lint · typecheck 8/8 · unit tests · e2e no-agent 38/38.

Closes #63