### PR TITLE
fix(web): include questions in AskUserQuestion review

### DIFF
--- a/apps/web/src/chat/tools/AskUserQuestionCard.test.ts
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import type { AskUserQuestionItem } from "@thinkrail/contracts";
+import type { AskUserQuestionAnswer, AskUserQuestionItem } from "@thinkrail/contracts";
 import {
 	deriveAnswer,
+	deriveRecapState,
 	parseQuestions,
 	readAskResult,
 	splitRecommended,
@@ -147,6 +148,68 @@ describe("deriveAnswer", () => {
 			selected: ["A"],
 		});
 		expect(deriveAnswer(q({ multiSelect: true }), 0, state({ multi: ["Gone"] }))).toBeNull();
+	});
+});
+
+describe("deriveRecapState", () => {
+	const base = { questionIndex: 0, question: "Which?" };
+
+	it("shows every option for an unanswered review but not for a resolved skipped record", () => {
+		expect(deriveRecapState(undefined, "review")).toEqual({
+			selectedLabels: [],
+			customAnswer: null,
+			showOptions: true,
+		});
+		expect(deriveRecapState(undefined, "resolved")).toEqual({
+			selectedLabels: [],
+			customAnswer: null,
+			showOptions: false,
+		});
+	});
+
+	it("marks a single authored option selected in both recap variants", () => {
+		const answer: AskUserQuestionAnswer = {
+			...base,
+			kind: "option",
+			answer: "A",
+		};
+		const expected = { selectedLabels: ["A"], customAnswer: null, showOptions: true };
+		expect(deriveRecapState(answer, "review")).toEqual(expected);
+		expect(deriveRecapState(answer, "resolved")).toEqual(expected);
+	});
+
+	it("keeps multi selections and additive custom text in both recap variants", () => {
+		const answer: AskUserQuestionAnswer = {
+			...base,
+			kind: "multi",
+			answer: "extra",
+			selected: ["A", "B"],
+		};
+		const expected = {
+			selectedLabels: ["A", "B"],
+			customAnswer: "extra",
+			showOptions: true,
+		};
+		expect(deriveRecapState(answer, "review")).toEqual(expected);
+		expect(deriveRecapState(answer, "resolved")).toEqual(expected);
+	});
+
+	it("shows authored options around a custom answer only during review", () => {
+		const answer: AskUserQuestionAnswer = {
+			...base,
+			kind: "custom",
+			answer: "mine",
+		};
+		expect(deriveRecapState(answer, "review")).toEqual({
+			selectedLabels: [],
+			customAnswer: "mine",
+			showOptions: true,
+		});
+		expect(deriveRecapState(answer, "resolved")).toEqual({
+			selectedLabels: [],
+			customAnswer: "mine",
+			showOptions: false,
+		});
 	});
 });
 

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -119,6 +119,32 @@ export function readAskResult(raw: unknown): AskUserQuestionResult | null {
 	return isResult(raw) ? raw : null;
 }
 
+interface RecapState {
+	selectedLabels: string[];
+	customAnswer: string | null;
+	showOptions: boolean;
+}
+
+/** Derive the shared review/resolved recap model from one structured answer. Pure. */
+export function deriveRecapState(
+	answer: AskUserQuestionAnswer | undefined,
+	variant: "review" | "resolved",
+): RecapState {
+	const selectedLabels =
+		answer?.kind === "multi"
+			? (answer.selected ?? [])
+			: answer?.kind === "option" && answer.answer
+				? [answer.answer]
+				: [];
+	const customAnswer =
+		answer && (answer.kind === "custom" || answer.kind === "multi") ? answer.answer : null;
+	return {
+		selectedLabels,
+		customAnswer,
+		showOptions: variant === "review" || (!!answer && answer.kind !== "custom"),
+	};
+}
+
 // ---- the card ----
 
 /**
@@ -453,7 +479,9 @@ function QuestionBody({
 		<div className="flex flex-col gap-md">
 			<div className="flex items-start gap-sm">
 				<MessageCircleQuestion className="mt-0.5 size-4 shrink-0 text-muted" />
-				<p className="font-semibold text-md text-text">{question.question}</p>
+				<p data-testid="ask-question-text" className="font-semibold text-md text-text">
+					{question.question}
+				</p>
 			</div>
 			<div className={cn("grid gap-sm", anyPreview && "md:grid-cols-2")}>
 				<div className="flex flex-col gap-sm">
@@ -555,7 +583,9 @@ function OptionRow({
 			<Indicator selected={selected} multi={multi} />
 			<span className="flex min-w-0 flex-col gap-0.5">
 				<span className="flex items-center gap-xs">
-					<span className="font-medium text-sm text-text">{text}</span>
+					<span data-testid="ask-option-label" className="font-medium text-sm text-text">
+						{text}
+					</span>
 					{recommended ? <RecommendedBadge /> : null}
 				</span>
 				{description ? <span className="text-muted text-xs">{description}</span> : null}
@@ -699,18 +729,13 @@ function ReviewView({
 				<MessageCircleQuestion className="mt-0.5 size-4 shrink-0 text-muted" />
 				<p className="font-semibold text-md text-text">Review your answers</p>
 			</div>
-			<ul className="flex flex-col gap-sm">
-				{questions.map((q, i) => {
-					const a = byIndex.get(i);
-					return (
-						<li key={q.question} className="flex flex-col">
-							<span className="text-hint text-xs">{q.header || `Q${i + 1}`}</span>
-							<span className="text-sm text-text">
-								{a ? summarizeAnswer(a) : <span className="text-hint italic">Not answered</span>}
-							</span>
-						</li>
-					);
-				})}
+			<ul className="flex flex-col gap-md">
+				{questions.map((q, i) => (
+					<li key={q.question} data-testid="ask-review-item" className="flex flex-col gap-xs">
+						<span className="text-hint text-xs">{q.header || `Q${i + 1}`}</span>
+						<QuestionRecap question={q} answer={byIndex.get(i)} variant="review" />
+					</li>
+				))}
 			</ul>
 			{unanswered.length > 0 ? (
 				<button
@@ -752,7 +777,7 @@ function ResolvedRecord({
 			className="flex flex-col gap-md"
 		>
 			{questions.map((q, i) => (
-				<RecordRow key={q.question} question={q} answer={byIndex.get(i)} />
+				<QuestionRecap key={q.question} question={q} answer={byIndex.get(i)} variant="resolved" />
 			))}
 			{questions.length === 0 ? (
 				<div className="text-muted text-xs">{rawText || "Answered."}</div>
@@ -761,65 +786,97 @@ function ResolvedRecord({
 	);
 }
 
-function RecordRow({
+/** Shared question + answer recap, with fuller context on the pre-submit review page. */
+function QuestionRecap({
 	question,
 	answer,
+	variant,
 }: {
 	question: AskUserQuestionItem;
 	answer: AskUserQuestionAnswer | undefined;
+	variant: "review" | "resolved";
 }) {
-	const selected = new Set(
-		answer?.kind === "multi" ? (answer.selected ?? []) : answer?.answer ? [answer.answer] : [],
-	);
+	const reviewing = variant === "review";
+	const { selectedLabels, customAnswer, showOptions } = deriveRecapState(answer, variant);
+	const selected = new Set(selectedLabels);
+
 	return (
 		<div className="flex flex-col gap-xs">
 			<div className="flex items-start gap-sm">
 				<MessageCircleQuestion className="mt-0.5 size-3.5 shrink-0 text-hint" />
-				<p className="text-muted text-sm">{question.question}</p>
+				<p
+					data-testid={reviewing ? "ask-review-question" : undefined}
+					className={cn("text-sm", reviewing ? "font-medium text-text" : "text-muted")}
+				>
+					{question.question}
+				</p>
 			</div>
-			{!answer ? (
+			{showOptions ? (
+				<>
+					<ul className="flex flex-col gap-0.5 pl-[calc(0.875rem+var(--spacing-sm))]">
+						{question.options.map((opt) => {
+							const isSel = selected.has(opt.label);
+							return (
+								<li
+									key={opt.label}
+									data-testid={reviewing ? "ask-review-option" : "ask-record-option"}
+									data-selected={isSel}
+									className={cn(
+										"flex items-center gap-xs text-sm",
+										isSel ? "text-text" : "text-hint",
+									)}
+								>
+									{isSel ? (
+										<Check aria-hidden="true" className="size-3.5 shrink-0 text-green" />
+									) : (
+										<span
+											aria-hidden="true"
+											className="size-3 shrink-0 rounded-full border border-border2"
+										/>
+									)}
+									<span data-testid="ask-selection-status" className="sr-only">
+										{isSel ? "Selected: " : "Not selected: "}
+									</span>
+									<span>{splitRecommended(opt.label).text}</span>
+								</li>
+							);
+						})}
+						{/* A custom answer follows the authored options: additive for multi-select, exclusive for
+						    single-select review. Keeping it inside the list aligns it with the option rows. */}
+						{customAnswer ? (
+							<li
+								data-testid={reviewing ? "ask-review-custom" : "ask-record-custom"}
+								className="flex items-center gap-xs text-sm text-text"
+							>
+								<Check aria-hidden="true" className="size-3.5 shrink-0 text-green" />
+								<span data-testid="ask-selection-status" className="sr-only">
+									Selected custom answer:{" "}
+								</span>
+								<span>“{customAnswer}”</span>
+							</li>
+						) : null}
+					</ul>
+					{!answer ? (
+						<div
+							data-testid="ask-review-unanswered"
+							className="flex items-center gap-xs pl-[calc(0.875rem+var(--spacing-sm))] text-hint text-xs italic"
+						>
+							<SkipForward className="size-3 shrink-0" /> Not answered
+						</div>
+					) : null}
+				</>
+			) : !answer ? (
 				<div className="flex items-center gap-xs pl-[calc(0.875rem+var(--spacing-sm))] text-hint text-xs italic">
 					<SkipForward className="size-3 shrink-0" /> No answer (skipped).
 				</div>
-			) : answer.kind === "custom" ? (
+			) : (
 				<div className="flex items-center gap-xs border-border2 border-l-2 pl-sm">
-					<Check className="size-3.5 shrink-0 text-green" />
+					<Check aria-hidden="true" className="size-3.5 shrink-0 text-green" />
+					<span data-testid="ask-selection-status" className="sr-only">
+						Selected custom answer:{" "}
+					</span>
 					<span className="text-sm text-text">“{answer.answer}”</span>
 				</div>
-			) : (
-				<ul className="flex flex-col gap-0.5 pl-[calc(0.875rem+var(--spacing-sm))]">
-					{question.options.map((opt) => {
-						const isSel = selected.has(opt.label);
-						return (
-							<li
-								key={opt.label}
-								data-testid="ask-record-option"
-								data-selected={isSel}
-								className={cn(
-									"flex items-center gap-xs text-sm",
-									isSel ? "text-text" : "text-hint",
-								)}
-							>
-								{isSel ? (
-									<Check className="size-3.5 shrink-0 text-green" />
-								) : (
-									<span className="size-3 shrink-0 rounded-full border border-border2" />
-								)}
-								{splitRecommended(opt.label).text}
-							</li>
-						);
-					})}
-					{/* A multi answer's free text (typed in addition to the checks) is the list's final row —
-						    inside the <ul> so it aligns exactly with the option rows above it. */}
-					{answer.kind === "multi" && answer.answer ? (
-						<li
-							data-testid="ask-record-custom"
-							className="flex items-center gap-xs text-sm text-text"
-						>
-							<Check className="size-3.5 shrink-0 text-green" />“{answer.answer}”
-						</li>
-					) : null}
-				</ul>
 			)}
 			{answer?.notes ? (
 				<div className="pl-[calc(0.875rem+var(--spacing-sm))] text-hint text-xs">
@@ -828,13 +885,4 @@ function RecordRow({
 			) : null}
 		</div>
 	);
-}
-
-/** One answer as a short human string for the review panel (a multi answer's free text is quoted). */
-function summarizeAnswer(a: AskUserQuestionAnswer): string {
-	const value =
-		a.kind === "multi"
-			? [...(a.selected ?? []), ...(a.answer ? [`“${a.answer}”`] : [])].join(", ")
-			: (a.answer ?? "(no answer)");
-	return a.notes ? `${value} — ${a.notes}` : value;
 }

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -27,8 +27,10 @@ registration runs once when the chat module mounts. Unregistered tools fall back
   - **Controls never stream** — while args stream it shows a stable composing placeholder and the
     complete questionnaire reveals atomically at message end (rationale in the component's jsdoc).
   - **Multi-question completion is review-gated** — every question page advances with **Next**, including
-    the final question; only the synthetic **Review & submit** page exposes **Submit**. A single question
-    keeps its direct **Submit** action.
+    the final question; only the synthetic **Review & submit** page exposes **Submit**. Its review entries
+    show the full original question plus every option with selected markers (and custom answer / note), so
+    the submission can be checked in context. Selection status is also exposed as screen-reader text —
+    never by icon/color alone. A single question keeps its direct **Submit** action.
   - **Per-call UI state survives virtualization** — a module-level cache keyed by `toolCallId` (dropped
     on resolve), since react-virtuoso unmounts off-screen rows. This is the pattern the activity fold's
     expansion state reuses.

--- a/e2e/ask-user-question.live.spec.ts
+++ b/e2e/ask-user-question.live.spec.ts
@@ -135,8 +135,11 @@ test("multi-select: the free-text row is mandatory and additive — checks + typ
 	await expect(
 		record.locator('[data-testid="ask-record-option"][data-selected="true"]'),
 	).toHaveCount(2);
-	// …and the record echoes the additional typed answer.
+	// …and the record echoes the additional typed answer, announced as selected to assistive tech.
 	await expect(record).toContainText("my-extra-e2e-answer");
+	await expect(
+		record.getByTestId("ask-record-custom").getByTestId("ask-selection-status"),
+	).toHaveText("Selected custom answer:");
 });
 
 test("freeform: a typed answer via 'Type your own answer' resolves the tool", {
@@ -196,8 +199,15 @@ test("multi-question: Next reaches review before submitting the batch", { tag: "
 	await expect(tabs).toHaveCount(3);
 
 	// Follow the sequential path: every real question — including the final one — advances with Next.
+	// Capture the agent-authored text so the review can be checked against the exact questions/options.
+	const questionTexts: string[] = [];
+	const optionLabels: string[][] = [];
 	for (let i = 0; i < 2; i++) {
 		await expect(tabs.nth(i)).toHaveAttribute("data-active", "true");
+		questionTexts.push((await card.getByTestId("ask-question-text").innerText()).trim());
+		optionLabels.push(
+			(await card.getByTestId("ask-option-label").allTextContents()).map((label) => label.trim()),
+		);
 		await card.getByTestId("ask-option").first().click();
 		await expect(card.getByTestId("ask-submit")).toHaveCount(0);
 		await card.getByTestId("ask-continue").click();
@@ -208,6 +218,26 @@ test("multi-question: Next reaches review before submitting the batch", { tag: "
 	await expect(card).toContainText("Review your answers");
 	await expect(card.getByTestId("ask-continue")).toHaveCount(0);
 	await expect(card.getByTestId("ask-submit")).toBeEnabled();
+	// Each review item carries the full original question, every option, and the selected answer.
+	const reviewItems = card.getByTestId("ask-review-item");
+	await expect(reviewItems).toHaveCount(2);
+	for (let i = 0; i < 2; i++) {
+		const item = reviewItems.nth(i);
+		await expect(item.getByTestId("ask-review-question")).toHaveText(questionTexts[i] ?? "");
+		const reviewOptions = item.getByTestId("ask-review-option");
+		const labels = optionLabels[i] ?? [];
+		await expect(reviewOptions).toHaveCount(labels.length);
+		for (let j = 0; j < labels.length; j++) {
+			const option = reviewOptions.nth(j);
+			await expect(option).toContainText(labels[j] ?? "");
+			await expect(option.getByTestId("ask-selection-status")).toHaveText(
+				j === 0 ? "Selected:" : "Not selected:",
+			);
+		}
+		await expect(
+			item.locator('[data-testid="ask-review-option"][data-selected="true"]'),
+		).toContainText(labels[0] ?? "");
+	}
 	// Every question answered → both question chips carry their answered marker.
 	await expect(card.locator('[data-testid="ask-tab"][data-answered="true"]')).toHaveCount(2);
 


### PR DESCRIPTION
## Summary

- Make the multi-question **Review & submit** page self-contained by showing each original question and a full option recap with selected markers.
- Preserve answer derivation and submission behavior while supporting option, multi-select, custom, note, and unanswered states.
- Expose **Selected** / **Not selected** status to screen readers instead of relying on icon or color alone.
- Add deterministic recap-state unit coverage and strengthen the real-agent E2E assertions.

## Related issues

N/A.

## Testing

- `bun run check:deps`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run e2e` — 38 passed
- Focused `@agent` AskUserQuestion scenarios — 2 passed
- Spec graph validation

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, plus focused real-agent coverage)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

<img width="833" height="406" alt="Screenshot 2026-07-15 at 16 04 41" src="https://github.com/user-attachments/assets/55d7f01e-5db7-4790-8732-cf1431f83b59" />
