### PR TITLE
feat(chat): explain why an ask_user_question option is recommended

### DIFF
--- a/apps/web/src/chat/tools/AskUserQuestionCard.test.ts
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.test.ts
@@ -5,6 +5,7 @@ import {
 	deriveRecapState,
 	parseQuestions,
 	readAskResult,
+	readRecommendation,
 	splitRecommended,
 } from "./AskUserQuestionCard";
 
@@ -226,6 +227,42 @@ describe("splitRecommended", () => {
 	});
 	it("leaves a plain label untouched", () => {
 		expect(splitRecommended("MySQL")).toEqual({ text: "MySQL", recommended: false });
+	});
+});
+
+describe("readRecommendation", () => {
+	it("suffix only → recommended, no reason", () => {
+		expect(readRecommendation({ label: "Postgres (Recommended)" })).toEqual({
+			text: "Postgres",
+			recommended: true,
+			reason: undefined,
+		});
+	});
+	it("suffix + reason → recommended with a trimmed reason", () => {
+		expect(
+			readRecommendation({ label: "Postgres (Recommended)", recommendedReason: "  scales best  " }),
+		).toEqual({ text: "Postgres", recommended: true, reason: "scales best" });
+	});
+	it("reason WITHOUT the suffix still implies recommended (defensive)", () => {
+		expect(readRecommendation({ label: "Postgres", recommendedReason: "scales best" })).toEqual({
+			text: "Postgres",
+			recommended: true,
+			reason: "scales best",
+		});
+	});
+	it("neither → not recommended", () => {
+		expect(readRecommendation({ label: "MySQL" })).toEqual({
+			text: "MySQL",
+			recommended: false,
+			reason: undefined,
+		});
+	});
+	it("a whitespace-only reason is ignored (no icon, suffix decides)", () => {
+		expect(readRecommendation({ label: "MySQL", recommendedReason: "   " })).toEqual({
+			text: "MySQL",
+			recommended: false,
+			reason: undefined,
+		});
 	});
 });
 

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -682,12 +682,13 @@ function OtherOptionRow({
 }
 
 const RECOMMENDED_PILL =
-	"inline-flex items-center gap-0.5 rounded-full bg-primary/15 px-xs py-0 font-medium text-[11px] text-primary";
+	"inline-flex items-center rounded-full bg-primary/15 px-xs py-0 font-medium text-[11px] text-primary";
 
 /**
- * The "Recommended" pill next to an agent-recommended option. When the agent gave a `reason`, the pill
- * grows a (?) affordance revealing *why* — a Popover styled as a tooltip, opening on hover (desktop) AND
- * tap (mobile-first: Radix Tooltip never opens on touch, so Popover is the base).
+ * The "Recommended" pill next to an agent-recommended option. When the agent gave a `reason`, a (?)
+ * affordance sits *beside* the pill (spaced out, in the body font color) revealing *why* — a Popover
+ * styled as a tooltip, opening on hover (desktop) AND tap (mobile-first: Radix Tooltip never opens on
+ * touch, so Popover is the base).
  */
 function RecommendedBadge({ reason }: { reason?: string | undefined }) {
 	if (!reason) {
@@ -700,8 +701,8 @@ function RecommendedBadgeWithReason({ reason }: { reason: string }) {
 	const [open, setOpen] = useState(false);
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
-			<span className={RECOMMENDED_PILL}>
-				Recommended
+			<span className="inline-flex items-center gap-1.5">
+				<span className={RECOMMENDED_PILL}>Recommended</span>
 				<PopoverTrigger asChild>
 					{/* A non-focusable <span>, not a nested <button> (the row is already a <button>): keyboard/AT
 					    reach the reason via the sr-only text in OptionRow. Tapping must NOT select the option. */}
@@ -711,7 +712,7 @@ function RecommendedBadgeWithReason({ reason }: { reason: string }) {
 						onClick={(e) => e.stopPropagation()}
 						onPointerEnter={() => setOpen(true)}
 						onPointerLeave={() => setOpen(false)}
-						className="inline-flex cursor-help text-primary/70 hover:text-primary"
+						className="inline-flex cursor-help text-text transition-opacity hover:opacity-70"
 					>
 						<CircleHelp className="size-3" />
 					</span>

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -7,14 +7,12 @@ import type {
 import {
 	Check,
 	CircleDot,
-	CircleHelp,
 	ListChecks,
 	MessageCircleQuestion,
 	Pencil,
 	SkipForward,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib";
 import { useChatActions } from "../ChatActions";
 import { Markdown } from "../Markdown";
@@ -498,8 +496,8 @@ function QuestionBody({
 	return (
 		<div className="flex flex-col gap-md">
 			<div className="flex items-start gap-sm">
-				<MessageCircleQuestion className="mt-0.5 size-4 shrink-0 text-muted" />
-				<p data-testid="ask-question-text" className="font-semibold text-md text-text">
+				<MessageCircleQuestion className="mt-0.5 size-5 shrink-0 text-muted" />
+				<p data-testid="ask-question-text" className="font-semibold text-lg text-text">
 					{question.question}
 				</p>
 			</div>
@@ -599,21 +597,26 @@ function OptionRow({
 			data-selected={selected}
 			onClick={onClick}
 			className={cn(
-				"flex items-start gap-sm rounded-[var(--radius-md)] border px-md py-sm text-left transition-colors",
+				"flex items-start gap-sm rounded-[var(--radius-md)] border px-md py-md text-left transition-colors",
 				selected ? "border-primary bg-primary/10" : "border-border2 hover:bg-hover",
 			)}
 		>
 			<Indicator selected={selected} multi={multi} />
 			<span className="flex min-w-0 flex-col gap-0.5">
 				<span className="flex items-center gap-xs">
-					<span data-testid="ask-option-label" className="font-medium text-sm text-text">
+					<span data-testid="ask-option-label" className="font-medium text-md text-text">
 						{text}
 					</span>
-					{recommended ? <RecommendedBadge reason={reason} /> : null}
-					{/* Keyboard/screen-reader users read the reason here, not from the floating panel. */}
-					{reason ? <span className="sr-only">Recommended because: {reason}</span> : null}
+					{recommended ? <RecommendedBadge /> : null}
 				</span>
-				{description ? <span className="text-muted text-xs">{description}</span> : null}
+				{description ? <span className="text-muted text-sm">{description}</span> : null}
+				{/* The recommendation rationale, inline (not a popover): shown up front for a recommended
+				    option so it reads on touch too, and AT reads it as ordinary visible text. */}
+				{reason ? (
+					<span data-testid="ask-recommended-reason" className="mt-0.5 text-muted text-sm">
+						<span className="font-medium text-primary">Why:</span> {reason}
+					</span>
+				) : null}
 			</span>
 		</button>
 	);
@@ -647,7 +650,7 @@ function OtherOptionRow({
 			data-testid="ask-custom-row"
 			data-selected={active}
 			className={cn(
-				"flex cursor-text items-center gap-sm rounded-[var(--radius-md)] border px-md py-sm transition-colors",
+				"flex cursor-text items-center gap-sm rounded-[var(--radius-md)] border px-md py-md transition-colors",
 				active ? "border-primary bg-primary/10" : "border-border2 hover:bg-hover",
 			)}
 		>
@@ -668,68 +671,29 @@ function OtherOptionRow({
 			) : (
 				<Indicator selected={active} multi={false} className="mt-0" />
 			)}
-			<span className="font-medium text-sm text-text">Other</span>
+			<span className="font-medium text-md text-text">Other</span>
 			<input
 				data-testid="ask-custom"
 				value={text}
 				placeholder="type your own answer…"
 				onFocus={onActivate}
 				onChange={(e) => onText(e.target.value)}
-				className="min-w-0 flex-1 border-none bg-transparent text-sm text-text outline-none placeholder:text-hint"
+				className="min-w-0 flex-1 border-none bg-transparent text-md text-text outline-none placeholder:text-hint"
 			/>
 		</label>
 	);
 }
 
 const RECOMMENDED_PILL =
-	"inline-flex items-center rounded-full bg-primary/15 px-xs py-0 font-medium text-[11px] text-primary";
+	"inline-flex items-center rounded-full bg-primary/15 px-2 py-0.5 font-medium text-[11px] text-primary";
 
 /**
- * The "Recommended" pill next to an agent-recommended option. When the agent gave a `reason`, a (?)
- * affordance sits *beside* the pill (spaced out, in the muted question-icon color) revealing *why* — a Popover
- * styled as a tooltip, opening on hover (desktop) AND tap (mobile-first: Radix Tooltip never opens on
- * touch, so Popover is the base).
+ * The "Recommended" pill next to an agent-recommended option. The rationale is rendered inline in
+ * `OptionRow` (a `Why:` block below the description), not behind this pill — so it's visible up front
+ * and works on touch (a popover/tooltip never opens reliably on touch).
  */
-function RecommendedBadge({ reason }: { reason?: string | undefined }) {
-	if (!reason) {
-		return <span className={RECOMMENDED_PILL}>Recommended</span>;
-	}
-	return <RecommendedBadgeWithReason reason={reason} />;
-}
-
-function RecommendedBadgeWithReason({ reason }: { reason: string }) {
-	const [open, setOpen] = useState(false);
-	return (
-		<Popover open={open} onOpenChange={setOpen}>
-			<span className="inline-flex items-center gap-1.5">
-				<span className={RECOMMENDED_PILL}>Recommended</span>
-				<PopoverTrigger asChild>
-					{/* A non-focusable <span>, not a nested <button> (the row is already a <button>): keyboard/AT
-					    reach the reason via the sr-only text in OptionRow. Tapping must NOT select the option. */}
-					<span
-						data-testid="ask-recommended-why"
-						aria-hidden="true"
-						onClick={(e) => e.stopPropagation()}
-						onPointerEnter={() => setOpen(true)}
-						onPointerLeave={() => setOpen(false)}
-						className="inline-flex cursor-help text-muted hover:text-text"
-					>
-						<CircleHelp className="size-3" />
-					</span>
-				</PopoverTrigger>
-			</span>
-			<PopoverContent
-				side="top"
-				data-testid="ask-recommended-reason"
-				onOpenAutoFocus={(e) => e.preventDefault()}
-				onPointerEnter={() => setOpen(true)}
-				onPointerLeave={() => setOpen(false)}
-				className="max-w-[16rem] px-sm py-xs text-text text-xs leading-snug"
-			>
-				{reason}
-			</PopoverContent>
-		</Popover>
-	);
+function RecommendedBadge() {
+	return <span className={RECOMMENDED_PILL}>Recommended</span>;
 }
 
 /** A radio (single) or checkbox (multi) marker: an accent ring/box, filled when selected. */
@@ -793,8 +757,8 @@ function ReviewView({
 	return (
 		<div className="flex flex-col gap-sm">
 			<div className="flex items-start gap-sm">
-				<MessageCircleQuestion className="mt-0.5 size-4 shrink-0 text-muted" />
-				<p className="font-semibold text-md text-text">Review your answers</p>
+				<MessageCircleQuestion className="mt-0.5 size-5 shrink-0 text-muted" />
+				<p className="font-semibold text-lg text-text">Review your answers</p>
 			</div>
 			<ul className="flex flex-col gap-md">
 				{questions.map((q, i) => (

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -686,7 +686,7 @@ const RECOMMENDED_PILL =
 
 /**
  * The "Recommended" pill next to an agent-recommended option. When the agent gave a `reason`, a (?)
- * affordance sits *beside* the pill (spaced out, in the body font color) revealing *why* — a Popover
+ * affordance sits *beside* the pill (spaced out, in the muted question-icon color) revealing *why* — a Popover
  * styled as a tooltip, opening on hover (desktop) AND tap (mobile-first: Radix Tooltip never opens on
  * touch, so Popover is the base).
  */
@@ -712,7 +712,7 @@ function RecommendedBadgeWithReason({ reason }: { reason: string }) {
 						onClick={(e) => e.stopPropagation()}
 						onPointerEnter={() => setOpen(true)}
 						onPointerLeave={() => setOpen(false)}
-						className="inline-flex cursor-help text-text transition-opacity hover:opacity-70"
+						className="inline-flex cursor-help text-muted hover:text-text"
 					>
 						<CircleHelp className="size-3" />
 					</span>

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -7,12 +7,14 @@ import type {
 import {
 	Check,
 	CircleDot,
+	CircleHelp,
 	ListChecks,
 	MessageCircleQuestion,
 	Pencil,
 	SkipForward,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib";
 import { useChatActions } from "../ChatActions";
 import { Markdown } from "../Markdown";
@@ -42,6 +44,24 @@ export function splitRecommended(label: string): { text: string; recommended: bo
 	return m
 		? { text: label.slice(0, m.index).trim(), recommended: true }
 		: { text: label, recommended: false };
+}
+
+/**
+ * Read an option's recommendation: its display text, whether it's recommended, and the optional "why".
+ * A non-empty `recommendedReason` **implies** recommended (defensive — a model that authors a reason but
+ * forgets the "(Recommended)" suffix must not silently lose the badge). Pure.
+ */
+export function readRecommendation(option: {
+	label: string;
+	recommendedReason?: string | undefined;
+}): {
+	text: string;
+	recommended: boolean;
+	reason?: string | undefined;
+} {
+	const { text, recommended } = splitRecommended(option.label);
+	const reason = option.recommendedReason?.trim() || undefined;
+	return { text, recommended: recommended || !!reason, reason };
 }
 
 /** Per-question local UI state. */
@@ -494,6 +514,7 @@ function QuestionBody({
 								<OptionRow
 									label={opt.label}
 									description={opt.description}
+									recommendedReason={opt.recommendedReason}
 									selected={selected}
 									multi={!!question.multiSelect}
 									onClick={() =>
@@ -558,17 +579,19 @@ function QuestionBody({
 function OptionRow({
 	label,
 	description,
+	recommendedReason,
 	selected,
 	multi,
 	onClick,
 }: {
 	label: string;
 	description: string;
+	recommendedReason?: string | undefined;
 	selected: boolean;
 	multi: boolean;
 	onClick: () => void;
 }) {
-	const { text, recommended } = splitRecommended(label);
+	const { text, recommended, reason } = readRecommendation({ label, recommendedReason });
 	return (
 		<button
 			type="button"
@@ -586,7 +609,9 @@ function OptionRow({
 					<span data-testid="ask-option-label" className="font-medium text-sm text-text">
 						{text}
 					</span>
-					{recommended ? <RecommendedBadge /> : null}
+					{recommended ? <RecommendedBadge reason={reason} /> : null}
+					{/* Keyboard/screen-reader users read the reason here, not from the floating panel. */}
+					{reason ? <span className="sr-only">Recommended because: {reason}</span> : null}
 				</span>
 				{description ? <span className="text-muted text-xs">{description}</span> : null}
 			</span>
@@ -656,12 +681,53 @@ function OtherOptionRow({
 	);
 }
 
-/** The "Recommended" pill next to an agent-recommended option. */
-function RecommendedBadge() {
+const RECOMMENDED_PILL =
+	"inline-flex items-center gap-0.5 rounded-full bg-primary/15 px-xs py-0 font-medium text-[11px] text-primary";
+
+/**
+ * The "Recommended" pill next to an agent-recommended option. When the agent gave a `reason`, the pill
+ * grows a (?) affordance revealing *why* — a Popover styled as a tooltip, opening on hover (desktop) AND
+ * tap (mobile-first: Radix Tooltip never opens on touch, so Popover is the base).
+ */
+function RecommendedBadge({ reason }: { reason?: string | undefined }) {
+	if (!reason) {
+		return <span className={RECOMMENDED_PILL}>Recommended</span>;
+	}
+	return <RecommendedBadgeWithReason reason={reason} />;
+}
+
+function RecommendedBadgeWithReason({ reason }: { reason: string }) {
+	const [open, setOpen] = useState(false);
 	return (
-		<span className="inline-flex items-center rounded-full bg-primary/15 px-xs py-0 font-medium text-[11px] text-primary">
-			Recommended
-		</span>
+		<Popover open={open} onOpenChange={setOpen}>
+			<span className={RECOMMENDED_PILL}>
+				Recommended
+				<PopoverTrigger asChild>
+					{/* A non-focusable <span>, not a nested <button> (the row is already a <button>): keyboard/AT
+					    reach the reason via the sr-only text in OptionRow. Tapping must NOT select the option. */}
+					<span
+						data-testid="ask-recommended-why"
+						aria-hidden="true"
+						onClick={(e) => e.stopPropagation()}
+						onPointerEnter={() => setOpen(true)}
+						onPointerLeave={() => setOpen(false)}
+						className="inline-flex cursor-help text-primary/70 hover:text-primary"
+					>
+						<CircleHelp className="size-3" />
+					</span>
+				</PopoverTrigger>
+			</span>
+			<PopoverContent
+				side="top"
+				data-testid="ask-recommended-reason"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onPointerEnter={() => setOpen(true)}
+				onPointerLeave={() => setOpen(false)}
+				className="max-w-[16rem] px-sm py-xs text-text text-xs leading-snug"
+			>
+				{reason}
+			</PopoverContent>
+		</Popover>
 	);
 }
 

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -610,8 +610,8 @@ function OptionRow({
 					{recommended ? <RecommendedBadge /> : null}
 				</span>
 				{description ? <span className="text-muted text-sm">{description}</span> : null}
-				{/* The recommendation rationale, inline (not a popover): shown up front for a recommended
-				    option so it reads on touch too, and AT reads it as ordinary visible text. */}
+				{/* The recommendation rationale, shown inline up front for a recommended option so it
+				    reads on touch, and AT reads it as ordinary visible text. */}
 				{reason ? (
 					<span data-testid="ask-recommended-reason" className="mt-0.5 text-muted text-sm">
 						<span className="font-medium text-primary">Why:</span> {reason}
@@ -688,9 +688,9 @@ const RECOMMENDED_PILL =
 	"inline-flex items-center rounded-full bg-primary/15 px-2 py-0.5 font-medium text-[11px] text-primary";
 
 /**
- * The "Recommended" pill next to an agent-recommended option. The rationale is rendered inline in
- * `OptionRow` (a `Why:` block below the description), not behind this pill — so it's visible up front
- * and works on touch (a popover/tooltip never opens reliably on touch).
+ * The "Recommended" pill next to an agent-recommended option — a plain label. Its rationale renders
+ * inline in `OptionRow` (a `Why:` block below the description) so it's visible up front and on touch,
+ * where a tooltip/popover never opens reliably.
  */
 function RecommendedBadge() {
 	return <span className={RECOMMENDED_PILL}>Recommended</span>;

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -36,11 +36,11 @@ registration runs once when the chat module mounts. Unregistered tools fall back
     expansion state reuses.
   - Awaiting an answer, the card carries a subtle primary-tinted accent ring (the "needs you" accent).
   - **Recommended-reason affordance** — a recommended option (label suffix `(Recommended)` **or** a
-    non-empty `recommendedReason` — a reason *implies* recommended, defensively) shows a (?) glyph on
-    its badge revealing *why*. Mobile-first, so it's a Popover styled as a tooltip (opens on hover **and**
-    tap — Radix Tooltip never opens on touch); tapping it must not select the option (`stopPropagation`),
-    and the reason is mirrored as `sr-only` text in the row for keyboard/AT. **Active card only** — the
-    resolved record is unchanged.
+    non-empty `recommendedReason` — a reason *implies* recommended, defensively) renders its rationale
+    **inline** as a `Why: …` block inside the option card (below the description; `Why:` in the accent
+    color). Shown up front for every recommended option, not gated on selection: more discoverable than
+    a tooltip and, being ordinary visible text, it reads on touch and for AT without a popover.
+    **Active card only** — the resolved record shows selections only, no rationale.
 - **`visualize/`** — `VisualizationCard` dispatches on `args.type` to `DiagramCard` (mermaid → themed
   SVG via the **lazy-loaded** `mermaid`, source fallback on parse error) and `ComparisonCard` (option
   cards with pros/cons + `recommended` highlight); shared `MermaidView` re-renders on `[data-theme]`

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -35,6 +35,12 @@ registration runs once when the chat module mounts. Unregistered tools fall back
     on resolve), since react-virtuoso unmounts off-screen rows. This is the pattern the activity fold's
     expansion state reuses.
   - Awaiting an answer, the card carries a subtle primary-tinted accent ring (the "needs you" accent).
+  - **Recommended-reason affordance** — a recommended option (label suffix `(Recommended)` **or** a
+    non-empty `recommendedReason` — a reason *implies* recommended, defensively) shows a (?) glyph on
+    its badge revealing *why*. Mobile-first, so it's a Popover styled as a tooltip (opens on hover **and**
+    tap — Radix Tooltip never opens on touch); tapping it must not select the option (`stopPropagation`),
+    and the reason is mirrored as `sr-only` text in the row for keyboard/AT. **Active card only** — the
+    resolved record is unchanged.
 - **`visualize/`** — `VisualizationCard` dispatches on `args.type` to `DiagramCard` (mermaid → themed
   SVG via the **lazy-loaded** `mermaid`, source fallback on parse error) and `ComparisonCard` (option
   cards with pros/cons + `recommended` highlight); shared `MermaidView` re-renders on `[data-theme]`

--- a/e2e/ask-user-question.live.spec.ts
+++ b/e2e/ask-user-question.live.spec.ts
@@ -75,6 +75,31 @@ test("single-select: Submit is gated, an answer resolves the tool, the record re
 	).toBeVisible({ timeout: 60_000 });
 });
 
+test("recommended option: the (?) affordance reveals why it was recommended", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(150_000);
+	await ask(
+		page,
+		`Call the ask_user_question tool with EXACTLY ONE single-select question (multiSelect false) offering 3 short options with descriptions and no previews. RECOMMEND one option: make it FIRST, append "(Recommended)" to its label, and set its recommendedReason to a short sentence explaining why. ${ONLY_TOOL}`,
+	);
+
+	const card = activeCard(page);
+	await expect(card).toBeVisible({ timeout: 90_000 });
+
+	// The recommended option carries the (?) affordance; the reason panel is hidden until activated.
+	const why = card.getByTestId("ask-recommended-why").first();
+	await expect(why).toBeVisible();
+	await expect(page.getByTestId("ask-recommended-reason")).toHaveCount(0);
+
+	// Activating it reveals a non-empty reason — and does NOT select the option (stopPropagation).
+	await why.click();
+	const reason = page.getByTestId("ask-recommended-reason");
+	await expect(reason).toBeVisible();
+	await expect(reason).not.toBeEmpty();
+	await expect(card.locator('[data-testid="ask-option"][data-selected="true"]')).toHaveCount(0);
+});
+
 test("multi-select: several options can be checked and submitted", { tag: "@agent" }, async ({
 	page,
 }) => {

--- a/e2e/ask-user-question.live.spec.ts
+++ b/e2e/ask-user-question.live.spec.ts
@@ -75,7 +75,7 @@ test("single-select: Submit is gated, an answer resolves the tool, the record re
 	).toBeVisible({ timeout: 60_000 });
 });
 
-test("recommended option: the (?) affordance reveals why it was recommended", {
+test("recommended option: its rationale is shown inline (no interaction needed)", {
 	tag: "@agent",
 }, async ({ page }) => {
 	test.setTimeout(150_000);
@@ -87,16 +87,13 @@ test("recommended option: the (?) affordance reveals why it was recommended", {
 	const card = activeCard(page);
 	await expect(card).toBeVisible({ timeout: 90_000 });
 
-	// The recommended option carries the (?) affordance; the reason panel is hidden until activated.
-	const why = card.getByTestId("ask-recommended-why").first();
-	await expect(why).toBeVisible();
-	await expect(page.getByTestId("ask-recommended-reason")).toHaveCount(0);
-
-	// Activating it reveals a non-empty reason — and does NOT select the option (stopPropagation).
-	await why.click();
-	const reason = page.getByTestId("ask-recommended-reason");
+	// The recommended option's rationale is rendered inline — visible up front, no click, no popover.
+	const reason = card.getByTestId("ask-recommended-reason").first();
 	await expect(reason).toBeVisible();
+	await expect(reason).toContainText("Why:");
 	await expect(reason).not.toBeEmpty();
+
+	// And merely surfacing the rationale must not have selected anything.
 	await expect(card.locator('[data-testid="ask-option"][data-selected="true"]')).toHaveCount(0);
 });
 

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -56,8 +56,9 @@ runtime exports being the WS method/channel constants and the protocol version. 
   - the **extension-UI frames** **`ExtUiRequest`** / **`ExtUiResponse`** — our wire shape for pi's in-process
     `uiContext` calls (`select`/`confirm`/`input`/`editor` round-trip; `notify`/`setStatus`/`setWidget`/
     `setTitle`/`dismiss` are fire-and-forget), carried on the `pi.extensionUi` channel.
-  - the **`ask_user_question`** wire types — **`AskUserQuestionArgs`** (`AskUserQuestionItem` + `AskUserQuestionOption`:
-    the questions the agent authors, what the tool card reads from the `toolCall` block) and
+  - the **`ask_user_question`** wire types — **`AskUserQuestionArgs`** (`AskUserQuestionItem` + `AskUserQuestionOption`
+    — the latter carries an optional `recommendedReason` the card reveals behind the Recommended badge's
+    (?) affordance: the questions the agent authors, what the tool card reads from the `toolCall` block) and
     **`AskUserQuestionResult`** (`AskUserQuestionAnswer[]` + `cancelled`: the browser's reply). The capability
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
     rationale); the tool blocks while the chat renders the questionnaire **inline** and replies via

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -57,8 +57,8 @@ runtime exports being the WS method/channel constants and the protocol version. 
     `uiContext` calls (`select`/`confirm`/`input`/`editor` round-trip; `notify`/`setStatus`/`setWidget`/
     `setTitle`/`dismiss` are fire-and-forget), carried on the `pi.extensionUi` channel.
   - the **`ask_user_question`** wire types — **`AskUserQuestionArgs`** (`AskUserQuestionItem` + `AskUserQuestionOption`
-    — the latter carries an optional `recommendedReason` the card reveals behind the Recommended badge's
-    (?) affordance: the questions the agent authors, what the tool card reads from the `toolCall` block) and
+    — the latter carries an optional `recommendedReason` the card renders inline as a `Why:` line under the
+    option: the questions the agent authors, what the tool card reads from the `toolCall` block) and
     **`AskUserQuestionResult`** (`AskUserQuestionAnswer[]` + `cancelled`: the browser's reply). The capability
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
     rationale); the tool blocks while the chat renders the questionnaire **inline** and replies via

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -174,6 +174,11 @@ export interface AskUserQuestionOption {
 	description: string;
 	/** Optional markdown preview shown beside the option (code, ASCII diagram, config). Single-select only. */
 	preview?: string;
+	/**
+	 * Why the agent recommends this option — revealed behind the Recommended badge's (?) affordance.
+	 * Meaningful only on the recommended option; optional + back-compatible (absent → no icon).
+	 */
+	recommendedReason?: string;
 }
 
 /** One question in the questionnaire. */

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -175,8 +175,8 @@ export interface AskUserQuestionOption {
 	/** Optional markdown preview shown beside the option (code, ASCII diagram, config). Single-select only. */
 	preview?: string;
 	/**
-	 * Why the agent recommends this option — revealed behind the Recommended badge's (?) affordance.
-	 * Meaningful only on the recommended option; optional + back-compatible (absent → no icon).
+	 * Why the agent recommends this option — rendered inline as a `Why:` line under the option's description.
+	 * Meaningful only on the recommended option; optional + back-compatible (absent → no rationale shown).
 	 */
 	recommendedReason?: string;
 }

--- a/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
@@ -19,7 +19,7 @@ degrade when answers don't come. Process skills name this concept at the steps t
 ## Options
 
 - Recommended option first, label suffixed "(Recommended)", plus a one-line `recommendedReason` saying
-  why you recommend it over the alternatives (revealed behind the badge's (?) affordance).
+  why you recommend it over the alternatives (shown inline under the option as a `Why:` line).
 - Every option: a concise label (1–5 words, ≤ 60 chars) + a description carrying the trade-off or
   consequence of choosing it. Tailor options to the work at hand — never generic placeholders.
 - Never author your own "Other", free-text, or escape options — the tool adds a free-text row to

--- a/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
@@ -18,7 +18,8 @@ degrade when answers don't come. Process skills name this concept at the steps t
 
 ## Options
 
-- Recommended option first, label suffixed "(Recommended)".
+- Recommended option first, label suffixed "(Recommended)", plus a one-line `recommendedReason` saying
+  why you recommend it over the alternatives (revealed behind the badge's (?) affordance).
 - Every option: a concise label (1–5 words, ≤ 60 chars) + a description carrying the trade-off or
   consequence of choosing it. Tailor options to the work at hand — never generic placeholders.
 - Never author your own "Other", free-text, or escape options — the tool adds a free-text row to

--- a/packages/server/src/agent/askUserQuestion.test.ts
+++ b/packages/server/src/agent/askUserQuestion.test.ts
@@ -50,6 +50,22 @@ test("validateQuestionnaire accepts a well-formed questionnaire", () => {
 	expect(validateQuestionnaire(args()).ok).toBe(true);
 });
 
+test("the optional recommendedReason field is accepted on an option (no new validation gate)", () => {
+	const withReason: AskUserQuestionArgs = {
+		questions: [
+			{
+				question: "Which library?",
+				header: "Lib",
+				options: [
+					{ label: "date-fns (Recommended)", description: "small", recommendedReason: "lightest" },
+					{ label: "luxon", description: "rich" },
+				],
+			},
+		],
+	};
+	expect(validateQuestionnaire(withReason).ok).toBe(true);
+});
+
 test("validateQuestionnaire rejects empty, too-few-options, dupes, and reserved labels", () => {
 	const one = (options: { label: string; description: string }[]): AskUserQuestionArgs => ({
 		questions: [{ question: "q", header: "h", options }],

--- a/packages/server/src/agent/askUserQuestion.ts
+++ b/packages/server/src/agent/askUserQuestion.ts
@@ -25,6 +25,7 @@ export const MIN_OPTIONS = 2;
 export const MAX_OPTIONS = 4;
 export const MAX_HEADER_LENGTH = 16;
 export const MAX_LABEL_LENGTH = 60;
+export const MAX_RECOMMENDED_REASON_LENGTH = 160;
 
 /**
  * Labels reserved for affordances the card provides itself (the free-text row, the Skip escape, the
@@ -50,8 +51,8 @@ const OptionSchema = Type.Object({
 	),
 	recommendedReason: Type.Optional(
 		Type.String({
-			description:
-				"Why you recommend this option — 1-2 sentences revealed behind a (?) on the Recommended badge. Set only on the option whose label carries '(Recommended)'.",
+			maxLength: MAX_RECOMMENDED_REASON_LENGTH,
+			description: `MAX ${MAX_RECOMMENDED_REASON_LENGTH} CHARACTERS. Why you recommend this option — one short sentence, rendered inline as a 'Why:' line under the option. Set only on the option whose label carries '(Recommended)'.`,
 		}),
 	),
 });
@@ -97,7 +98,7 @@ const DESCRIPTION = `Ask the user one or more structured, multiple-choice questi
 The questions render inline in the chat as an interactive card (tabs when there are several). Notes:
 - Every question also gets an "Other" option with a free-text field, and the user can always Skip the whole questionnaire (you are told they declined) — do NOT author "Other"-style, free-text, or escape options yourself (reserved labels are rejected).
 - Set multiSelect: true when several answers are valid; the user may combine checked options with their own typed answer.
-- If you recommend one option, make it FIRST, append "(Recommended)" to its label, and set its recommendedReason to a short (1-2 sentence) explanation of why you recommend it over the alternatives.
+- If you recommend one option, make it FIRST, append "(Recommended)" to its label, and set its recommendedReason to one short sentence on why you recommend it over the alternatives (shown inline under the option).
 - Use options[].preview (markdown) for concrete artifacts to compare side-by-side (code, ASCII mockups, configs). Single-select only.
 - Group all clarifying questions into ONE call — do not chain calls back-to-back.
 - The user may answer only some questions; unanswered ones are reported as declined.`;
@@ -105,7 +106,7 @@ The questions render inline in the chat as an interactive card (tabs when there 
 const PROMPT_GUIDELINES = [
 	`Call ask_user_question whenever the request is ambiguous and a concrete decision is needed — up to ${MAX_QUESTIONS} questions per call, ${MIN_OPTIONS}-${MAX_OPTIONS} options each.`,
 	"Every option needs a concise label (1-5 words) and a description of what it means / its trade-off.",
-	'Recommend by putting the option first with "(Recommended)" appended and setting its recommendedReason to why you recommend it over the alternatives; the user can always type a custom answer or skip the questionnaire.',
+	'Recommend by putting the option first with "(Recommended)" appended and setting its recommendedReason to one short sentence (shown inline under the option) on why you recommend it over the alternatives; the user can always type a custom answer or skip the questionnaire.',
 ];
 
 const ERROR_NO_UI = "Error: UI not available (running in non-interactive mode)";

--- a/packages/server/src/agent/askUserQuestion.ts
+++ b/packages/server/src/agent/askUserQuestion.ts
@@ -48,6 +48,12 @@ const OptionSchema = Type.Object({
 				"Optional markdown preview shown beside this option (mockups, code snippets, diagrams, configs). Single-select only.",
 		}),
 	),
+	recommendedReason: Type.Optional(
+		Type.String({
+			description:
+				"Why you recommend this option — 1-2 sentences revealed behind a (?) on the Recommended badge. Set only on the option whose label carries '(Recommended)'.",
+		}),
+	),
 });
 
 const QuestionSchema = Type.Object({
@@ -91,7 +97,7 @@ const DESCRIPTION = `Ask the user one or more structured, multiple-choice questi
 The questions render inline in the chat as an interactive card (tabs when there are several). Notes:
 - Every question also gets an "Other" option with a free-text field, and the user can always Skip the whole questionnaire (you are told they declined) — do NOT author "Other"-style, free-text, or escape options yourself (reserved labels are rejected).
 - Set multiSelect: true when several answers are valid; the user may combine checked options with their own typed answer.
-- If you recommend one option, make it FIRST and append "(Recommended)" to its label.
+- If you recommend one option, make it FIRST, append "(Recommended)" to its label, and set its recommendedReason to a short (1-2 sentence) explanation of why you recommend it over the alternatives.
 - Use options[].preview (markdown) for concrete artifacts to compare side-by-side (code, ASCII mockups, configs). Single-select only.
 - Group all clarifying questions into ONE call — do not chain calls back-to-back.
 - The user may answer only some questions; unanswered ones are reported as declined.`;
@@ -99,7 +105,7 @@ The questions render inline in the chat as an interactive card (tabs when there 
 const PROMPT_GUIDELINES = [
 	`Call ask_user_question whenever the request is ambiguous and a concrete decision is needed — up to ${MAX_QUESTIONS} questions per call, ${MIN_OPTIONS}-${MAX_OPTIONS} options each.`,
 	"Every option needs a concise label (1-5 words) and a description of what it means / its trade-off.",
-	'Recommend by putting the option first with "(Recommended)" appended; the user can always type a custom answer or skip the questionnaire.',
+	'Recommend by putting the option first with "(Recommended)" appended and setting its recommendedReason to why you recommend it over the alternatives; the user can always type a custom answer or skip the questionnaire.',
 ];
 
 const ERROR_NO_UI = "Error: UI not available (running in non-interactive mode)";


### PR DESCRIPTION
## What & why

When the agent marks an `ask_user_question` option as **Recommended**, the card now shows *why* — the rationale renders **inline as a `Why:` line** under the option. Previously "Recommended" was just a label with no rationale.

## Changes

- **Contract** (`packages/contracts/src/piProtocol.ts`): optional `recommendedReason?: string` on `AskUserQuestionOption` — back-compatible (absent → no rationale shown; old transcripts unaffected). Not echoed back in the answer envelope (agent-authored).
- **Capability** (`packages/server/src/agent/askUserQuestion.ts`): `recommendedReason` added to the TypeBox `OptionSchema`, capped at `MAX_RECOMMENDED_REASON_LENGTH` (160 chars, "one short sentence") now that it's always on screen; the tool description + prompt guidelines tell the model to fill it when it recommends. No new gate in `validateQuestionnaire`.
- **UI** (`apps/web/src/chat/tools/AskUserQuestionCard.tsx`):
  - new pure `readRecommendation()` helper — a non-empty reason **implies** recommended (defensive: a model that writes a reason but forgets the `(Recommended)` suffix must not silently lose the badge).
  - the reason renders **inline** as a `Why:` line beneath the option's description — visible up front, so it reads on touch and AT sees it as ordinary text (no popover/tooltip, which never opens reliably on touch).
  - **Active card only** — the resolved record is unchanged.
- **Scope**: `ask_user_question` only (the `visualize` ComparisonCard is out of scope).

## Tests

- Web unit: `readRecommendation` cases (suffix only / reason only / both / neither / whitespace).
- Server unit: schema accepts the new field (no new validation gate).
- E2E (`@agent`): a case asserts the recommended option's reason is visible inline up front — no click, no popover, and asserting it doesn't select the option.

## Specs

Design was brainstormed & user-confirmed, then promoted into durable specs and the task-spec retired:
- `packages/contracts/SPEC.md`, `apps/web/src/chat/tools/SPEC.md`
- `packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md` (the "Recommended option first" norm now asks for a one-line `recommendedReason`).

## Verification

Fast gates (`check:deps` · `lint` · `typecheck`) ✓ · web build ✓ · web + server unit ✓, all run locally after rebasing onto `main`. No-agent e2e + binary smoke run in CI. The feature's own end-to-end coverage is the `@agent` spec (`bun run e2e:agent`; needs a provider authenticated).

## Note

The reason only appears when the model actually populates `recommendedReason`. Prompt guidance now asks for it; reliability is a prompt-tuning follow-up once observed in practice.

> **Screenshots below are stale** — they show the earlier `(?)`-popover revision. The shipped design renders the rationale inline as a `Why:` line under the option (a fresh capture needs an `@agent` run against an authenticated provider).

<img width="795" height="363" alt="Screenshot 2026-07-15 at 18 07 02" src="https://github.com/user-attachments/assets/330f0498-bf4a-46fc-9fe6-c2ce0b2047f8" />
<img width="801" height="344" alt="Screenshot 2026-07-15 at 18 07 06" src="https://github.com/user-attachments/assets/b7d344da-8e6f-4203-8283-7887d15e382b" />
