### PR TITLE
fix: propagate workspace lifecycle (create/rename/remove) to every client (#77)

### DIFF
--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -3,8 +3,8 @@ import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Trash2 } from "luci
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
-import { useAppStore } from "../store";
-import { getTransport } from "../transport";
+import { toast, useAppStore } from "../store";
+import { errorText, getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmPopover } from "./ConfirmPopover";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
@@ -66,16 +66,14 @@ export function ProjectTree() {
 		await loadWorkspaces(workspace.projectId);
 	};
 
-	// Optimistic removal: drop the row + its tabs now, then fire the request without blocking the UI (the
-	// host acks fast and reclaims the worktree in the background). A failed delete reconciles by re-listing.
-	const removeWorkspace = (projectId: string, workspaceId: string) => {
-		const store = useAppStore.getState();
-		store.removeWorkspace(projectId, workspaceId);
-		store.clearWorkspaceTabs(workspaceId);
-		if (activeWorkspaceId === workspaceId) store.setActiveWorkspace(null);
+	// Event-driven removal: just fire the request — no per-client optimism. The host tears the worktree
+	// down and broadcasts `workspace.removed`, which every client (including this one) reacts to via
+	// `applyWorkspaceRemoved`. A rejected request means no event will come, so surface it as an error toast
+	// (the row simply stays).
+	const removeWorkspace = (workspaceId: string) => {
 		void getTransport()
 			.request("workspace.remove", { id: workspaceId })
-			.catch(() => void loadWorkspaces(projectId));
+			.catch((err) => toast.error(errorText(err, "Failed to remove workspace")));
 	};
 
 	return (
@@ -124,7 +122,7 @@ export function ProjectTree() {
 												workspace={ws}
 												isActive={activeWorkspaceId === ws.id}
 												onSelect={() => useAppStore.getState().setActiveWorkspace(ws.id)}
-												onRemove={() => removeWorkspace(project.id, ws.id)}
+												onRemove={() => removeWorkspace(ws.id)}
 											/>
 										))
 									)}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -20,8 +20,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   **anchored to that Remove button** (`align="end"`, so its right border lines up with the button's) and
   opening just beneath it rather than as a centered modal; it **forces a
   deliberate choice** (Cancel takes initial focus; a `destructive` confirm shows a warning glyph + red
-  button; Esc + outside-click cancel); removal is **optimistic + non-blocking**: on confirm it drops the row via `store.removeWorkspace` + `clearWorkspaceTabs`
-  and fires `workspace.remove` without awaiting, reconciling a failure by re-listing).
+  button; Esc + outside-click cancel); removal is **event-driven** (no per-client optimism): on confirm it
+  just fires `workspace.remove` and lets every client — including this one — react to the host's
+  `workspace.removed` push via the store's `applyWorkspaceRemoved`; a rejected request (no event will come)
+  surfaces an error toast, leaving the row in place).
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -16,13 +16,21 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
 
 ## Boundary
 
-- **Owns:** `appStore.ts` — connection/projects/workspaces state + setters (**`updateWorkspace(ws)`**
-  folds a server-pushed `workspace.updated` snapshot in: merge by `id` into `workspaces[ws.projectId]`,
-  spreading over the existing record so the computed `diffStats` badge survives the push (the snapshot
-  is the persisted record, which has none); a project never fetched or an id absent from its list is a
-  **no-op** — the next `workspace.list` reconciles); **`removeWorkspace(projectId, id)`** drops a workspace
-  from its project's list — the **optimistic** remove drops the row before the host finishes reclaiming
-  the worktree (unknown project/id is a no-op); `tabsByWorkspace` /
+- **Owns:** `appStore.ts` — connection/projects/workspaces state + setters, incl. the **workspace
+  lifecycle reactions** every client runs identically on the `workspace.created`/`updated`/`removed`
+  pushes (no per-client optimism — the backend is authoritative): **`addWorkspace(ws)`** upserts a
+  `workspace.created` snapshot by `id` (no-op if the project isn't listed yet — reconciles on its next
+  `workspace.list` rather than seeding a partial one-row list; else add-if-absent / merge-if-present,
+  idempotent with the creating client's own post-create re-list); **`updateWorkspace(ws)`** folds a
+  `workspace.updated` snapshot in: merge by `id` into `workspaces[ws.projectId]`, spreading over the
+  existing record so the computed `diffStats` badge survives the push (the snapshot is the persisted
+  record, which has none); a project never fetched or an id absent from its list is a **no-op** — the next
+  `workspace.list` reconciles; **`applyWorkspaceRemoved(projectId, id)`** is the **entire** removal
+  reaction (`removeWorkspace` drops the row + `clearWorkspaceTabs` drops its tabs/terminals/chat runtimes,
+  and **if it was this client's active workspace** → `setActiveWorkspace(null)` (shell falls back to the
+  project Welcome) + a neutral toast that reads right for both the initiator and an observer); the
+  primitive **`removeWorkspace(projectId, id)`** just drops the row (unknown project/id is a no-op);
+  `tabsByWorkspace` /
   `activeTabByWorkspace` (`openTab`/`closeTab`/`setActiveTab`/`clearWorkspaceTabs`, plus
   **`setFileTabView(id, view)`** — a markdown `FileTab`'s `view` (`"rendered"`|`"source"`) lives on the tab
   so the rendered↔source choice survives tab switches; absent = rendered); `terminalsByWorkspace`

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -505,6 +505,67 @@ test("removeWorkspace optimistically drops the row, leaving siblings; unknown pr
 	expect(useAppStore.getState().workspaces.p2).toBeUndefined();
 });
 
+// ---- addWorkspace: the workspace.created push upserts by id ----------------------------------------
+
+test("addWorkspace upserts into a fetched list (append if absent, merge if present)", () => {
+	const other = pushedWorkspace({ id: "other", name: "workspace-2", branch: "workspace-2" });
+	useAppStore.setState({ workspaces: { p1: [other] } });
+
+	useAppStore.getState().addWorkspace(pushedWorkspace()); // id w1 — new row appended
+	expect(useAppStore.getState().workspaces.p1?.map((w) => w.id)).toEqual(["other", "w1"]);
+
+	// Re-applying the same id merges in place (idempotent with the creator's own post-create re-list).
+	useAppStore.getState().addWorkspace(pushedWorkspace({ name: "renamed-later" }));
+	const list = useAppStore.getState().workspaces.p1;
+	expect(list).toHaveLength(2);
+	expect(list?.find((w) => w.id === "w1")?.name).toBe("renamed-later");
+});
+
+test("addWorkspace is a no-op for a project whose list was never fetched", () => {
+	useAppStore.setState({ workspaces: {} });
+	useAppStore.getState().addWorkspace(pushedWorkspace());
+	expect(useAppStore.getState().workspaces).toEqual({});
+});
+
+// ---- applyWorkspaceRemoved: the workspace.removed reaction, run by every client --------------------
+
+test("applyWorkspaceRemoved drops the row, clears its tabs, and returns the active client to Welcome + toast", () => {
+	useAppStore.setState({
+		workspaces: { p1: [pushedWorkspace()] },
+		activeWorkspaceId: "w1",
+		tabsByWorkspace: {
+			w1: [{ kind: "file", id: "w1:a", workspaceId: "w1", name: "a", path: "a", content: "" }],
+		},
+		activeTabByWorkspace: { w1: "w1:a" },
+		toasts: [],
+	});
+
+	useAppStore.getState().applyWorkspaceRemoved("p1", "w1");
+
+	const s = useAppStore.getState();
+	expect(s.workspaces.p1).toEqual([]);
+	expect(s.tabsByWorkspace.w1).toBeUndefined(); // clearWorkspaceTabs dropped its tabs
+	expect(s.activeWorkspaceId).toBeNull(); // shell falls back to the project Welcome
+	expect(s.toasts).toHaveLength(1);
+	expect(s.toasts[0]?.message).toContain("add-login-flow"); // the removed workspace's name
+});
+
+test("applyWorkspaceRemoved on a non-active workspace drops the row silently (no toast, active untouched)", () => {
+	const keep = pushedWorkspace({ id: "other", name: "workspace-2", branch: "workspace-2" });
+	useAppStore.setState({
+		workspaces: { p1: [pushedWorkspace(), keep] },
+		activeWorkspaceId: "other",
+		toasts: [],
+	});
+
+	useAppStore.getState().applyWorkspaceRemoved("p1", "w1");
+
+	const s = useAppStore.getState();
+	expect(s.workspaces.p1?.map((w) => w.id)).toEqual(["other"]);
+	expect(s.activeWorkspaceId).toBe("other"); // a background removal doesn't move the client
+	expect(s.toasts).toHaveLength(0);
+});
+
 // --- in-app login (flat, session-less) -------------------------------------------------------------
 
 test("beginLogin opens a fresh active login; frames accumulate (url + paste prompt coexist)", () => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -354,14 +354,29 @@ interface AppState {
 	setProjects: (projects: Project[]) => void;
 	setWorkspaces: (projectId: string, workspaces: Workspace[]) => void;
 	/**
+	 * Fold a server-pushed `workspace.created` snapshot in (**upsert** by id). A project never fetched is a
+	 * **no-op** — a client that hasn't opened the project reconciles on its next `workspace.list` rather
+	 * than being handed a partial one-row list (a wrong count); otherwise add if absent / merge if present
+	 * (idempotent with the creating client's own post-create re-list).
+	 */
+	addWorkspace: (workspace: Workspace) => void;
+	/**
 	 * Fold a server-pushed `workspace.updated` snapshot in (e.g. the auto-rename): merge by id into the
 	 * project's list. A project never fetched, or an id absent from its list, is a no-op — the next
 	 * `workspace.list` reconciles.
 	 */
 	updateWorkspace: (workspace: Workspace) => void;
-	/** Optimistically drop a workspace from its project's list (the remove flow drops the row before
-	 * the host finishes tearing the worktree down). A missing project/id is a no-op. */
+	/** Drop a workspace from its project's list (a missing project/id is a no-op). The primitive behind
+	 * `applyWorkspaceRemoved`; not called directly by the remove flow (that reacts to the push). */
 	removeWorkspace: (projectId: string, workspaceId: string) => void;
+	/**
+	 * React to a server-pushed `workspace.removed` — the **entire** removal reaction, run identically by
+	 * every client (including the one that initiated the remove, so there's no per-client optimism): drop
+	 * the row + clear its tabs/terminals/chat runtimes (`clearWorkspaceTabs`), and **if it was this
+	 * client's active workspace** return to the project Welcome (`setActiveWorkspace(null)`) and raise a
+	 * neutral toast (reads correctly for both the initiator and an observer).
+	 */
+	applyWorkspaceRemoved: (projectId: string, workspaceId: string) => void;
 	selectProject: (projectId: string) => void;
 	setActiveWorkspace: (id: string | null) => void;
 	openTab: (tab: EditorTab) => void;
@@ -533,6 +548,21 @@ export const useAppStore = create<AppState>((set, get) => ({
 	setProjects: (projects) => set({ projects }),
 	setWorkspaces: (projectId, workspaces) =>
 		set((s) => ({ workspaces: { ...s.workspaces, [projectId]: workspaces } })),
+	addWorkspace: (workspace) =>
+		set((s) => {
+			const list = s.workspaces[workspace.projectId];
+			// Unlisted project → no-op: reconcile on its next `workspace.list` rather than seed a partial
+			// one-row list. Otherwise upsert by id (merge if somehow already present).
+			if (!list) return {};
+			return {
+				workspaces: {
+					...s.workspaces,
+					[workspace.projectId]: list.some((w) => w.id === workspace.id)
+						? list.map((w) => (w.id === workspace.id ? { ...w, ...workspace } : w))
+						: [...list, workspace],
+				},
+			};
+		}),
 	updateWorkspace: (workspace) =>
 		set((s) => {
 			const list = s.workspaces[workspace.projectId];
@@ -556,6 +586,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 				workspaces: { ...s.workspaces, [projectId]: list.filter((w) => w.id !== workspaceId) },
 			};
 		}),
+	applyWorkspaceRemoved: (projectId, workspaceId) => {
+		const s = get();
+		const wasActive = s.activeWorkspaceId === workspaceId;
+		const name = s.workspaces[projectId]?.find((w) => w.id === workspaceId)?.name;
+		s.removeWorkspace(projectId, workspaceId);
+		s.clearWorkspaceTabs(workspaceId); // drops the row's tabs + terminals + chat runtimes
+		if (wasActive) {
+			s.setActiveWorkspace(null); // the shell falls back to the project Welcome
+			toast.info(`Workspace "${name ?? "?"}" was removed`);
+		}
+	},
 	selectProject: (selectedProjectId) => set({ selectedProjectId }),
 	setActiveWorkspace: (activeWorkspaceId) => set({ activeWorkspaceId }),
 	openTab: (tab) =>

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -18,14 +18,16 @@ The single WebSocket client to the host, and its app-wide singleton.
   replay, reconnect/backoff; `inferUrl` defaults to same-origin; **`httpBase()`** derives the host's HTTP origin
   from the WS `url` — for building host HTTP URLs like the `/files/<workspaceId>/<path>` worktree-file
   endpoint the markdown viewer points relative `<img>`s at, targeting the same host the transport dials); `wireTransport.ts` (`initTransport`/
-  `getTransport` singleton; routes the `server.welcome`, `pi.event`, `pi.extensionUi`, **and
-  `workspace.updated`** pushes into the store — `pi.event` via `handlePiEvent(event, sessionId)`,
-  `pi.extensionUi` via `applyExtUi(request)`, `workspace.updated` via `updateWorkspace(workspace)`;
-  all subscriptions happen once at init, never in component effects);
+  `getTransport` singleton; routes the `server.welcome`, `pi.event`, `pi.extensionUi`, **and the
+  `workspace.created`/`updated`/`removed` lifecycle trio** into the store — `pi.event` via
+  `handlePiEvent(event, sessionId)`, `pi.extensionUi` via `applyExtUi(request)`, `workspace.created` via
+  `addWorkspace(workspace)`, `workspace.updated` via `updateWorkspace(workspace)`, `workspace.removed` via
+  `applyWorkspaceRemoved(projectId, id)`; all subscriptions happen once at init, never in component effects);
   `errorText.ts` (**`errorText(err, fallback?)`** — normalizes a rejected `request` (the host's error
   string / a timeout / a thrown non-Error) into a short, display-ready line for an error turn/notice).
 - **Public surface (barrel):** `initTransport`, `getTransport`, `errorText`, `ConnectionStatus`, `TransportOptions`.
 - **Allowed deps:** `contracts` (method maps, `WS_CHANNELS`, `Project` for welcome, `SessionEventPayload`
-  for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.updated`); `store`
+  for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.created`/`updated`,
+  `WorkspaceRemoved` for `workspace.removed`); `store`
   (welcome + event routing — a runtime edge owned by the parent graph); the browser `WebSocket`.
 - **Forbidden:** `server`/`shared`/any `pi` package; importing `panels`/`shell`.

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -4,6 +4,7 @@ import type {
 	ServerWelcome,
 	SessionEventPayload,
 	Workspace,
+	WorkspaceRemoved,
 } from "@thinkrail/contracts";
 import { WS_CHANNELS } from "@thinkrail/contracts";
 import { useAppStore } from "../store";
@@ -42,8 +43,19 @@ export function initTransport(): WsTransport {
 		useAppStore.getState().applyLoginFrame(data as LoginPush);
 	});
 
+	// The workspace lifecycle trio — every client (including the initiator) converges by reacting to these,
+	// never a per-client optimistic mutation. `created`/`updated` carry the full snapshot; `removed` the ids.
+	transport.subscribe(WS_CHANNELS.workspaceCreated, (data) => {
+		useAppStore.getState().addWorkspace(data as Workspace);
+	});
+
 	transport.subscribe(WS_CHANNELS.workspaceUpdated, (data) => {
 		useAppStore.getState().updateWorkspace(data as Workspace);
+	});
+
+	transport.subscribe(WS_CHANNELS.workspaceRemoved, (data) => {
+		const { projectId, id } = data as WorkspaceRemoved;
+		useAppStore.getState().applyWorkspaceRemoved(projectId, id);
 	});
 
 	transport.connect();

--- a/e2e/workspace-lifecycle.spec.ts
+++ b/e2e/workspace-lifecycle.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+
+// Two tabs on ONE host, no agent. Registry membership is backend-owned shared domain state (architecture
+// #9), so a create/remove in one tab streams to the other via the workspace lifecycle pushes — every
+// client (including the initiator) reacts identically, with no per-client optimism. Regression cover for
+// issue #77: a workspace removed in one tab used to linger as a broken "zombie" row in the others.
+
+test("workspace removal propagates — no zombie row in a second tab", async ({ page, context }) => {
+	// Tab A: open the project + create a workspace (it becomes A's active workspace).
+	await openFixtureProject(page);
+	const created = await createWorkspaceViaDialog(page);
+	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+
+	// Tab B: a second tab on the same host — expand the project (loads the list) + activate the workspace.
+	const page2 = await context.newPage();
+	await page2.goto("/");
+	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page2.getByTestId("project-expand").first().click();
+	await expect(page2.getByTestId("workspace-item")).toHaveCount(1);
+	await page2.getByTestId("workspace-item").first().click();
+	await expect(page2.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+
+	// Tab A: remove the workspace (confirm-popover → confirm).
+	await page.getByTestId("workspace-item").first().hover();
+	await page.getByTestId("workspace-item").first().getByTestId("workspace-remove").click();
+	await page.getByTestId("confirm-remove").click();
+	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+
+	// Tab B converges purely by reacting to the `workspace.removed` push: the row disappears (no zombie),
+	// and — since it was B's active workspace — B returns to the Welcome screen with a neutral toast.
+	await expect(page2.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(page2.getByTestId("welcome")).toBeVisible();
+	await expect(page2.getByTestId("toast").filter({ hasText: created.name })).toBeVisible();
+});
+
+test("workspace creation propagates to a second tab's rail", async ({ page, context }) => {
+	// Tab A: open the project (no workspaces yet).
+	await openFixtureProject(page);
+
+	// Tab B: expand the project so its (empty) list is loaded — the precondition for folding in `created`.
+	const page2 = await context.newPage();
+	await page2.goto("/");
+	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page2.getByTestId("project-expand").first().click();
+	await expect(page2.getByTestId("workspace-item")).toHaveCount(0);
+
+	// Tab A: create a workspace.
+	await createWorkspaceViaDialog(page);
+	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+
+	// Tab B sees it appear via the `workspace.created` push — no manual re-list, no focus stolen.
+	await expect(page2.getByTestId("workspace-item")).toHaveCount(1);
+});

--- a/e2e/workspaces.spec.ts
+++ b/e2e/workspaces.spec.ts
@@ -19,8 +19,9 @@ test("creates, removes, and re-creates worktree workspaces (no branch collision)
 	// Worktrees live under a readable project-name dir, not the project id.
 	expect(worktrees).toContain("/worktrees/sample-project/");
 
-	// Remove it: the button opens a confirmation anchored to the row; confirming removes the row
-	// optimistically (instantly) AND the worktree is reclaimed from disk in the background (back to just `main`).
+	// Remove it: the button opens a confirmation anchored to the row; confirming fires `workspace.remove`,
+	// and the row disappears when the client reacts to the host's `workspace.removed` push (event-driven, not
+	// optimistic) AND the worktree is reclaimed from disk in the background (back to just `main`).
 	await items.first().hover();
 	await items.first().getByTestId("workspace-remove").click();
 	// The confirm is an accessible alertdialog named by its title (so screen readers announce it).

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -105,11 +105,13 @@ runtime exports being the WS method/channel constants and the protocol version. 
   read side)), `WS_CHANNELS` (`server.welcome` /
   `pi.event` / `pi.extensionUi` / **`provider.login`** — the session-less in-app login stream (a `LoginPush`
   per frame, keyed by `loginId`; the sibling of `pi.extensionUi`, since a login runs on the Welcome screen
-  before any session exists) / `terminal.data` / **`workspace.updated`** — a host-initiated workspace
-  mutation (the auto-rename — the instant naive pass and the agentic refine both push it) fanned out to
-  every client; `data` is the **full persisted `Workspace` snapshot** (idempotent under the transport's
-  last-value replay, so a naive-then-agentic pair merges by `id` — never a delta), keyed by `id` +
-  `projectId`), the `WsMethodMap` typed request/result map +
+  before any session exists) / `terminal.data` / the **workspace lifecycle trio** — **`workspace.created`**
+  / **`workspace.updated`** / **`workspace.removed`** — registry membership changes fanned out to every
+  client so it stays shared domain state (architecture #9), all emitted by the server's `workspaces`
+  publisher (never a per-client optimistic mutation). `created`/`updated` carry the **full persisted
+  `Workspace` snapshot** (idempotent under the transport's last-value replay, so e.g. the auto-rename's
+  naive-then-agentic pair merges by `id` — never a delta); `removed` carries a **`WorkspaceRemoved`** id
+  pair (`{ projectId, id }` — the record is already gone). The `WsMethodMap` typed request/result map +
   `WsParams`/`WsResult` helpers, and `PROTOCOL_VERSION`.
 
 ## Get right

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -29,7 +29,9 @@ import type {
 /** Bumped on any breaking wire change; sent in `server.welcome` so a stale UI can detect host drift. */
 // v4: model.* / session.create / session.setModel / SessionSummary now carry `WireModel` (pi's `Model`
 // minus the secret-bearing `baseUrl`/`headers`); the host re-resolves the real model by `{provider,id}`.
-export const PROTOCOL_VERSION = 4;
+// v5: workspace registry membership now streams to every client — `workspace.created` + `workspace.removed`
+// join the existing `workspace.updated` (the workspace lifecycle trio; see `WS_CHANNELS`).
+export const PROTOCOL_VERSION = 5;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -40,6 +42,16 @@ export interface ServerWelcome {
 	protocolVersion: number;
 	appVersion?: string;
 	projects: Project[];
+}
+
+/**
+ * The `workspace.removed` push payload. Only the ids: the workspace record is already gone by the time the
+ * event fires, and a client locates the row to drop by `projectId` + `id`. (`workspace.created`/`.updated`
+ * carry a bare `Workspace` snapshot instead.)
+ */
+export interface WorkspaceRemoved {
+	projectId: string;
+	id: string;
 }
 
 /** Request/response methods. `session.*` drives the pi engine. */
@@ -125,9 +137,15 @@ export const WS_CHANNELS = {
 	// the Welcome screen before any session exists, so this is the sibling of pi.extensionUi, not scoped to one.
 	providerLogin: "provider.login",
 	terminalData: "terminal.data",
-	// A host-initiated workspace mutation (the auto-rename), broadcast to every client. `data` is the
-	// full persisted `Workspace` snapshot — idempotent under last-value replay, never a delta.
+	// The workspace-registry lifecycle trio, broadcast to every client so registry membership is shared
+	// domain state (architecture #9), not per-client. All three are emitted by the `workspaces` module's
+	// injected publisher (host maps kind → channel); every client reacts identically (no per-client
+	// optimism). `created`/`updated` carry the full persisted `Workspace` snapshot (idempotent under
+	// last-value replay, never a delta — `updated` is the auto-rename); `removed` carries a `WorkspaceRemoved`
+	// id pair (the record is already gone).
+	workspaceCreated: "workspace.created",
 	workspaceUpdated: "workspace.updated",
+	workspaceRemoved: "workspace.removed",
 } as const;
 
 export type WsMethod = (typeof WS_METHODS)[keyof typeof WS_METHODS];

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -68,7 +68,11 @@ the host from env via `bootHost` for dev/e2e.
 - `persistence`, `dialog`, `github` → (leaves)
 
 Rules: features never import `host`, and never each other except the edges above. The graph is acyclic.
-`agent`'s WS surface (`session.*` + `pi.event` forwarding) attaches to `host`.
+`agent`'s WS surface (`session.*` + `pi.event` forwarding) attaches to `host`. Features that push on their
+own never import `host` either: they expose a **publisher-injection seam** (`setTerminalPublisher`,
+`setSessionPublisher`, `setLoginPublisher`, and `workspaces`' `setWorkspacePublisher` for the
+`workspace.created`/`updated`/`removed` lifecycle trio) that `host` installs at `createServer` — so the
+channel wiring lives only in `host`.
 
 ## Get right
 

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -28,8 +28,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
   install SIGINT/SIGTERM handlers that `stop()` then exit); `handlers.ts` (the WS method→handler registry);
   `ackSend.ts` (the send-ack policy — see "Get right"); `autoRename.ts` (the **workspace auto-rename
   flow** — the composition of `agent` + `assist` + `workspaces` only the host may make, in **two passes**
-  the session-publisher closure in `createServer` tees fire-and-forget, both pushing **`workspace.updated`**
-  and both reading the session **transcript** via `getSessionMessages` (never `agent_end.messages` — that
+  the session-publisher closure in `createServer` tees fire-and-forget, both triggering a
+  `renameWorkspace` (which **self-emits `workspace.updated`** through the lifecycle publisher — the tee no
+  longer pushes) and both reading the session **transcript** via `getSessionMessages` (never `agent_end.messages` — that
   array is run-local and empty of the prompt on auto-retry continuations) then `extractFirstTurn` (assist
   skips killed error/aborted turns, so a retracted prompt never becomes the name); an injectable
   transcript reader is the unit-test seam:
@@ -64,6 +65,12 @@ channel fan-out, and the process-boot wrapper both launchers share.
     a failed background teardown is `console.warn`ed, never thrown into the void (nothing awaits it), like
     the auto-rename tee. **Archive keeps the branch but not the chat:** the git branch stays (code is
     recoverable), yet chat history is purged with the worktree — a deliberate scope choice, not a leak.
+- **Workspace lifecycle fan-out:** `createServer` installs the `workspaces` module's publisher
+  (`setWorkspacePublisher`), mapping each domain event `kind` → its `WS_CHANNELS.workspace*` channel
+  (`created`/`updated` → the full record; `removed` → `{ projectId, id }`) and `server.publish`ing it. This
+  is the **single** place workspace membership changes reach the wire — create/rename/archive all flow
+  through it, so every client (including the initiator) converges by reacting, never by per-client optimism.
+  The two new channels are `ws.subscribe`d in the WS `open` handler alongside `workspace.updated`.
 - **Public surface (barrel):** `createServer`, `CreateServerOptions`, `RunningServer`, `bootHost`,
   `BootHostOptions`, `BootedHost`.
 - **Allowed deps:** `contracts` (`PROTOCOL_VERSION`, `WS_CHANNELS`); `shared` (`freePort`, `shellEnv` — for
@@ -73,10 +80,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
 
 ## Get right
 
-- WS commands return values directly; only events + extension-UI + host-initiated workspace mutations
-  (`workspace.updated`, published from the auto-rename tee with the full persisted snapshot) use push
-  channels. Every push channel a client should hear must be `ws.subscribe`d in the WS `open` handler —
-  a publish on an unsubscribed topic reaches nobody, silently.
+- WS commands return values directly; only events + extension-UI + the workspace lifecycle trio
+  (`workspace.created`/`updated`/`removed`, published from the `workspaces` module's injected publisher)
+  use push channels. Every push channel a client should hear must be `ws.subscribe`d in the WS `open`
+  handler — a publish on an unsubscribed topic reaches nobody, silently.
 - The host is the single place features are wired together — features never reach back into it.
 - **A send (prompt/steer/followUp) is acked when ACCEPTED, not when the turn ends** (`ackSend`): pi's send
   methods resolve only at turn end, and a turn can outlive the client's request timeout (an

--- a/packages/server/src/host/autoRename.ts
+++ b/packages/server/src/host/autoRename.ts
@@ -110,7 +110,8 @@ function isPristine(workspaceId: string): boolean {
 
 /**
  * Auto-name `workspaceId` off the session's first turn, if it's still eligible. Resolves the updated
- * `Workspace` for the caller to push on `workspace.updated`, or `null` when nothing happened.
+ * `Workspace` (informational — the `workspace.updated` push is self-emitted by `renameWorkspace` via the
+ * lifecycle publisher), or `null` when nothing happened.
  */
 export async function maybeAutoRenameWorkspace(
 	sessionId: string,

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -1,5 +1,5 @@
 import { join, normalize } from "node:path";
-import type { ServerWelcome, Workspace } from "@thinkrail/contracts";
+import type { ServerWelcome } from "@thinkrail/contracts";
 import { PROTOCOL_VERSION, WS_CHANNELS } from "@thinkrail/contracts";
 import {
 	disposeAllSessions,
@@ -11,6 +11,7 @@ import { cancelAllLogins, setLoginPublisher } from "../auth";
 import { resolveWorktreeFile } from "../fs";
 import { listProjects, openProject } from "../projects";
 import { closeAllTerminals, setTerminalPublisher } from "../terminal";
+import { setWorkspacePublisher } from "../workspaces";
 import {
 	isPromptCommitted,
 	isSettledTurn,
@@ -64,7 +65,9 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				ws.subscribe(WS_CHANNELS.piEvent);
 				ws.subscribe(WS_CHANNELS.piExtensionUi);
 				ws.subscribe(WS_CHANNELS.providerLogin);
+				ws.subscribe(WS_CHANNELS.workspaceCreated);
 				ws.subscribe(WS_CHANNELS.workspaceUpdated);
+				ws.subscribe(WS_CHANNELS.workspaceRemoved);
 				const welcome: ServerWelcome = {
 					protocolVersion: PROTOCOL_VERSION,
 					projects: listProjects(),
@@ -97,21 +100,29 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		server.publish(channel, JSON.stringify({ channel, data }));
 	});
 
-	// Push a host-initiated workspace mutation (an auto-rename) to every subscribed client. The web store
-	// folds `workspace.updated` by id, so a naive-then-agentic pair is two idempotent updates (last wins).
-	const pushWorkspaceUpdated = (ws: Workspace | null): void => {
-		if (!ws) return;
-		server.publish(
-			WS_CHANNELS.workspaceUpdated,
-			JSON.stringify({ channel: WS_CHANNELS.workspaceUpdated, data: ws }),
-		);
-	};
+	// Fan the `workspaces` module's lifecycle events out to every subscribed client, mapping each domain
+	// `kind` to its `workspace.*` channel (the module stays channel-ignorant). `created`/`updated` send the
+	// full record snapshot (idempotent under the store's fold-by-id, so the auto-rename's naive-then-agentic
+	// pair is two updates, last wins); `removed` sends the `{ projectId, id }` pair. Every client — including
+	// the initiator — converges by reacting to these, never a per-client optimistic mutation.
+	setWorkspacePublisher((event) => {
+		const channel =
+			event.kind === "created"
+				? WS_CHANNELS.workspaceCreated
+				: event.kind === "updated"
+					? WS_CHANNELS.workspaceUpdated
+					: WS_CHANNELS.workspaceRemoved;
+		const data =
+			event.kind === "removed" ? { projectId: event.projectId, id: event.id } : event.workspace;
+		server.publish(channel, JSON.stringify({ channel, data }));
+	});
 
 	// Stream each in-process AgentSession's events to subscribed clients over the pi.event channel, and
 	// tee the best-effort workspace auto-rename off two points, fire-and-forget (`void` — the hooks never
 	// reject, and this closure's slot is sync by design): the **first prompt landing** (a user
 	// `message_end`, before the model responds) gets an instant non-agentic name, and a **settled turn**
-	// (agent_end, no retry) refines it with the agentic namer and locks it. Both push `workspace.updated`.
+	// (agent_end, no retry) refines it with the agentic namer and locks it. The `workspace.updated` push is
+	// self-emitted by `renameWorkspace` (via the lifecycle publisher above) — the tee just triggers it.
 	setSessionPublisher((payload) => {
 		server.publish(
 			WS_CHANNELS.piEvent,
@@ -119,14 +130,10 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		);
 		if (isPromptCommitted(payload.event)) {
 			const workspaceId = getSessionWorkspaceId(payload.sessionId);
-			if (workspaceId) {
-				void maybeNaiveNameWorkspace(payload.sessionId, workspaceId).then(pushWorkspaceUpdated);
-			}
+			if (workspaceId) void maybeNaiveNameWorkspace(payload.sessionId, workspaceId);
 		} else if (isSettledTurn(payload.event)) {
 			const workspaceId = getSessionWorkspaceId(payload.sessionId);
-			if (workspaceId) {
-				void maybeAutoRenameWorkspace(payload.sessionId, workspaceId).then(pushWorkspaceUpdated);
-			}
+			if (workspaceId) void maybeAutoRenameWorkspace(payload.sessionId, workspaceId);
 		}
 	});
 

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -43,7 +43,16 @@ chats.
   `listWorkspaces` immediately), `reclaimWorktree(ws)` (the slow half — `git worktree remove --force`,
   keeps the branch; hardened: rm + `prune` if git fails), and `removeWorkspace(id)` (the synchronous
   composition of the two, kept for callers/tests that want the whole archive in one call).
+- **Lifecycle events:** every membership mutation — `createWorkspace` (`created`), `renameWorkspace`
+  (`updated`, both the naive and agentic auto-rename passes since both go through it), `forgetWorkspace`
+  (`removed`) — emits a `WorkspaceLifecycleEvent` through an **injected publisher** (`setWorkspacePublisher`,
+  the same inversion `terminal`/`agent`/`auth` use; `null` in unit tests / the e2e reset → silent no-op).
+  The module stays ignorant of WS channels: it emits a domain event (`created`/`updated` carry the record,
+  `removed` carries `{ projectId, id }`) and the host maps `kind` → `workspace.*` channel. This makes the
+  module the **single source of workspace lifecycle pushes** (the auto-rename tee no longer pushes — rename
+  self-publishes), so registry membership stays shared domain state across every client (architecture #9).
 - **Public surface (barrel):** `createWorkspace`, `listWorkspaces`, `forgetWorkspace`, `reclaimWorktree`,
-  `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`.
+  `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`, `setWorkspacePublisher`,
+  `WorkspaceLifecycleEvent`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`; Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -9,6 +9,8 @@ import {
 	reclaimWorktree,
 	removeWorkspace,
 	renameWorkspace,
+	setWorkspacePublisher,
+	type WorkspaceLifecycleEvent,
 } from "./workspaces";
 
 function gitOut(cwd: string, ...args: string[]): string {
@@ -43,6 +45,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	setWorkspacePublisher(null); // never leak a test's lifecycle sink into the next
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
@@ -192,6 +195,31 @@ test("forgetWorkspace drops the record + returns it, but leaves the worktree for
 
 	// A second forget (double-archive) is a no-op returning null.
 	expect(forgetWorkspace(ws.id)).toBeNull();
+});
+
+test("membership mutations emit lifecycle events through the injected publisher", async () => {
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
+
+	const ws = await createWorkspace("p1"); // auto-named workspace-1
+	renameWorkspace(ws.id, "my feature"); // → branch my-feature
+	expect(forgetWorkspace(ws.id)).not.toBeNull();
+	expect(forgetWorkspace(ws.id)).toBeNull(); // unknown now → no further event
+
+	expect(events.map((e) => e.kind)).toEqual(["created", "updated", "removed"]);
+	expect(events[0]).toMatchObject({ kind: "created", workspace: { id: ws.id, projectId: "p1" } });
+	expect(events[1]).toMatchObject({
+		kind: "updated",
+		workspace: { id: ws.id, name: "my-feature" },
+	});
+	expect(events[2]).toEqual({ kind: "removed", projectId: "p1", id: ws.id });
+});
+
+test("a null publisher makes lifecycle emits silent no-ops", async () => {
+	setWorkspacePublisher(null);
+	const ws = await createWorkspace("p1");
+	expect(() => removeWorkspace(ws.id)).not.toThrow();
+	expect(listWorkspaces("p1")).toHaveLength(0);
 });
 
 test("removeWorkspace cleans up even when the worktree dir is already gone", async () => {

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -6,6 +6,32 @@ import { git, gitAsync } from "../git";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
 import { getProjects } from "../projects";
 
+/**
+ * A workspace-registry membership change, emitted on every create/rename/archive so the host can fan it
+ * out to every client (architecture #9 — registry membership is shared domain state). The module stays
+ * ignorant of WS channels: it emits a domain event; `createServer` maps `kind` → `workspace.*` channel.
+ * `created`/`updated` carry the full record; `removed` carries only the ids (the record is already gone).
+ */
+export type WorkspaceLifecycleEvent =
+	| { kind: "created"; workspace: Workspace }
+	| { kind: "updated"; workspace: Workspace }
+	| { kind: "removed"; projectId: string; id: string };
+
+type WorkspacePublisher = (event: WorkspaceLifecycleEvent) => void;
+
+// Injected by the host (the same publisher inversion `terminal`/`agent`/`auth` use). `null` in unit tests
+// / the e2e reset → emits are silent no-ops, so the pure record functions stay testable in isolation.
+let publishLifecycle: WorkspacePublisher | null = null;
+
+/** Install (or clear with `null`) the sink the workspace lifecycle events are fanned out through. */
+export function setWorkspacePublisher(fn: WorkspacePublisher | null): void {
+	publishLifecycle = fn;
+}
+
+function emit(event: WorkspaceLifecycleEvent): void {
+	publishLifecycle?.(event);
+}
+
 function toBranch(name: string): string {
 	return (
 		name
@@ -118,6 +144,7 @@ export async function createWorkspace(
 	};
 	all.push(workspace);
 	saveWorkspaces(all);
+	emit({ kind: "created", workspace });
 	return workspace;
 }
 
@@ -165,6 +192,7 @@ export function renameWorkspace(
 	target.branch = branch;
 	if (lock) target.renamed = true;
 	saveWorkspaces(all);
+	emit({ kind: "updated", workspace: target });
 	return target;
 }
 
@@ -185,6 +213,7 @@ export function forgetWorkspace(id: string): Workspace | null {
 	const ws = all.find((w) => w.id === id);
 	if (!ws) return null;
 	saveWorkspaces(all.filter((w) => w.id !== id));
+	emit({ kind: "removed", projectId: ws.projectId, id: ws.id });
 	return ws;
 }
 


### PR DESCRIPTION
Fixes #77.

## Problem

`workspace.remove` was **optimistic and client-local**: the removing tab dropped its own row and the host tore everything down but **pushed nothing**. Other tabs kept a **zombie** workspace — dead worktree (file/git/spec reads fail quietly), dead terminals, disposed chats — until a manual re-list. Symmetric gap for **create** (a workspace made in tab B never appeared in tab A). The only registry push was the auto-rename's `workspace.updated`.

Per `architecture.md` #8 (hydrate-then-stream) and #9 (domain state is backend-owned and shared across clients), registry membership changes must stream to every client.

## Approach — one reactive path for every client

The backend is authoritative: it broadcasts a lifecycle event and **every client — including the initiator — converges by reacting to it** (no per-client optimism). Membership is domain state (from the event); *activation* (which workspace a tab views, opening a chat) stays per-client view state, so creating in tab A never yanks tab B's focus.

```
Tab A ──workspace.remove──▶ Host ──forgetWorkspace──▶ workspaces module
                                       │ emit {kind: removed, projectId, id}
        ◀──workspace.removed────────── Host ──────────▶ Tab B
        (both react via applyWorkspaceRemoved: drop row, clear
         tabs/terminals/runtimes, if active → Welcome + toast)
```

## Changes

**contracts** — add `workspace.created` + `workspace.removed` channels (the lifecycle trio) + `WorkspaceRemoved` payload; `PROTOCOL_VERSION` 4 → 5.

**server** — the `workspaces` module gains a `setWorkspacePublisher` seam (same inversion `terminal`/`agent`/`auth` use) and emits a lifecycle event on every membership mutation (`createWorkspace`/`renameWorkspace`/`forgetWorkspace`) — making it the **single source** of workspace pushes. `createServer` installs the publisher (maps kind → channel) and subscribes the new topics; the auto-rename tee no longer pushes (rename self-publishes).

**web** — transport routes the new channels; store gains `addWorkspace` (upsert) and `applyWorkspaceRemoved` (the whole reaction: drop row + clear tabs/terminals/runtimes; if it was the active workspace → Welcome + a neutral toast). `ProjectTree` drops its optimistic remove and reacts to the event like every client.

**specs** — promoted into contracts / server host + workspaces / web transport + store + panels SPECs; `TASK-workspace-lifecycle.md` records the design.

## Notes / deliberate calls

- **Toast wording is neutral** (`Workspace "X" was removed`), not "removed in another window": the uniform reaction can't/shouldn't distinguish initiator from observer, so the message must read correctly for both.
- **`created`/`updated` no-op if the project isn't listed yet** (reconcile on the next `workspace.list`) — a client that never opened the project isn't handed a partial one-row list.
- The creating client keeps its own post-create re-list (its authoritative read); the `created` event drives *other* clients and is idempotent for the actor.

## Verification

- `bun run typecheck` + `bun run lint` + `bun run check:deps` — clean
- `bun run test` — green (new `workspaces` publisher tests + store `addWorkspace`/`applyWorkspaceRemoved` tests)
- `bun run e2e` — **all 40 no-agent specs pass**, incl. the new two-context `e2e/workspace-lifecycle.spec.ts` (remove → no zombie in tab B; create → appears in tab B)