### PR TITLE
feat: theme support — Light, IntelliJ Darcula + Gruvbox, server-synced in Settings

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -40,15 +40,17 @@ convention; their boundary is held by convention + spec. Sibling edges live here
 | `components/ui` | shadcn primitives, themed with our tokens | no | [components/ui/SPEC.md](src/components/ui/SPEC.md) |
 | `lib` | `cn()` (clsx + tailwind-merge) | yes | [lib/SPEC.md](src/lib/SPEC.md) |
 
-Leaf utilities without their own spec: `constants/` (branding), `utils/` (font scaling), `styles/` (the
-CSS token theme contract — see Styling & theming). `main.tsx` is the entry/composition root — it wraps
-`<Shell />` in `components/ErrorBoundary` as the last-resort boundary (a crash escaping every region
-shows a reload screen, not a blank root).
+Leaf utilities without their own spec: `constants/` (branding), `utils/` (font scaling + `theme` — the
+`applyTheme(id)` `[data-theme]` swap, the `THEMES` picker list, and the localStorage first-paint hint),
+`styles/` (the CSS token theme contract — see Styling & theming). `main.tsx` is the entry/composition
+root — it applies the font scale + the cached theme hint pre-React, then wraps `<Shell />` in
+`components/ErrorBoundary` as the last-resort boundary (a crash escaping every region shows a reload
+screen, not a blank root).
 
 ### Dependency graph
 
-- `shell` → `panels`, `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`
-- `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` — `CenterTabs`'s per-tab boundary), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector` — these are shiki-free, so the eager import stays split-safe), `auth` (`ProvidersSettings` mounts `auth/LoginDialog`)
+- `shell` → `panels`, `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`, `utils` (`theme` — the single owner of the `applyTheme` DOM effect, driven by `store.theme`)
+- `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` — `CenterTabs`'s per-tab boundary), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector` — these are shiki-free, so the eager import stays split-safe), `auth` (`ProvidersSettings` mounts `auth/LoginDialog`), `utils` (`AppearanceSettings`'s theme picker uses `theme`'s `THEMES`)
 - `chat` → `contracts` (pi message types, **type-only**), `components/ui`, `lib`; `store` + `transport` (**`ChatView` only** — the renderers are store-free)
 - `auth` → `components/ui` (the dialog is store/transport-free — the panel integrates it; the state types need no imports)
 - `store` → `transport` (**type-only** — `ConnectionStatus`), `chat` (**type-only** — `ChatTurn`/`ToolResultState`), `auth` (**type-only** — `LoginState`; the `foldLoginFrame` reducer lives in `store`, like `reduceExtUi`), `contracts`
@@ -71,9 +73,19 @@ The module set: `transport` / `store` / branded `shell`; `ProjectTree`; `FileTre
   `style` objects, never raw hex.** Responsive (`md:` …) and states (`hover:` / `focus-visible:`) come
   from Tailwind (inline styles can't express them, and the responsive shell needs them).
 - **`src/styles/tokens.css` is the theme contract.** A *theme* is one set of CSS custom properties; a
-  theme swap = changing the token block via `[data-theme="…"]` on `<html>` (`applyTheme(id)`) — nothing
-  in components changes. `@theme inline` keeps utilities pointing at the live `var(--token)`, so the swap
-  re-themes everything. V1 ships one dark theme, structured for N (pibun's theme engine, lifted at V2).
+  theme swap = changing the token block via `[data-theme="…"]` on `<html>` (`utils/theme` `applyTheme(id)`)
+  — nothing in components changes. `@theme inline` keeps utilities pointing at the live `var(--token)`, so
+  the swap re-themes everything. **Ships three themes** — **Dark** (default, under `:root`), **Light**, and
+  classic IntelliJ **Darcula** (`[data-theme="light"|"darcula"]` blocks override only the semantic
+  surface/text/status tokens + `color-scheme`; accent tints, type scale, spacing, radii, fonts stay shared
+  in `:root`). The choice is **server-synced** (`AppConfig.theme`, host-owned): it arrives in
+  `server.welcome`, is set from the store's `theme` (fed by transport), applied by the shell's one theme
+  effect, and cached in `localStorage` only as a **first-paint hint** (`main.tsx` applies it pre-React so
+  the initial paint matches, before the welcome reconciles it). Changed via `settings.update`, converged on
+  the `settings.changed` broadcast. Code surfaces that own their own theming track the swap: **xterm** and
+  **Monaco** observe `[data-theme]` (Monaco also picks its `vs`/`vs-dark` base from it); **shiki** renders
+  dual (dark+light) palettes as CSS vars, flipped by `[data-theme="light"] .shiki`; **mermaid** re-derives
+  from the tokens. Structured for N (pibun's theme engine, lifted at V2).
 - Token names that collide with Tailwind namespaces (`--font-mono`, `--font-accent`, `--radius-*`) are
   used as token arbitrary values (`font-[var(--font-accent)]`), not `@theme` mappings.
 - **Icons: `lucide-react`. Components: shadcn/ui** (Radix primitives), copy-in under `src/components/ui/`

--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -75,10 +75,12 @@ The module set: `transport` / `store` / branded `shell`; `ProjectTree`; `FileTre
 - **`src/styles/tokens.css` is the theme contract.** A *theme* is one set of CSS custom properties; a
   theme swap = changing the token block via `[data-theme="…"]` on `<html>` (`utils/theme` `applyTheme(id)`)
   — nothing in components changes. `@theme inline` keeps utilities pointing at the live `var(--token)`, so
-  the swap re-themes everything. **Ships three themes** — **Dark** (default, under `:root`), **Light**, and
-  classic IntelliJ **Darcula** (`[data-theme="light"|"darcula"]` blocks override only the semantic
-  surface/text/status tokens + `color-scheme`; accent tints, type scale, spacing, radii, fonts stay shared
-  in `:root`). The choice is **server-synced** (`AppConfig.theme`, host-owned): it arrives in
+  the swap re-themes everything. **Ships four themes** — **Dark** (default, under `:root`), **Light**,
+  classic IntelliJ **Darcula**, and **Gruvbox** (the vim classic — warm retro darks; the one theme that
+  swaps the interactive accent to gruvbox orange with dark-on-accent text, so a `[data-theme]` block MAY
+  override the accent family when the palette demands it). Theme blocks override only the semantic
+  surface/text/status tokens + `color-scheme` (+ `--ansi-*`/`--code-*`/accent where the theme calls for
+  it); type scale, spacing, radii, fonts stay shared in `:root`. The choice is **server-synced** (`AppConfig.theme`, host-owned): it arrives in
   `server.welcome`, is set from the store's `theme` (fed by transport), applied by the shell's one theme
   effect, and cached in `localStorage` only as a **first-paint hint** (`main.tsx` applies it pre-React so
   the initial paint matches, before the welcome reconciles it). Changed via `settings.update`, converged on

--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -82,10 +82,18 @@ The module set: `transport` / `store` / branded `shell`; `ProjectTree`; `FileTre
   `server.welcome`, is set from the store's `theme` (fed by transport), applied by the shell's one theme
   effect, and cached in `localStorage` only as a **first-paint hint** (`main.tsx` applies it pre-React so
   the initial paint matches, before the welcome reconciles it). Changed via `settings.update`, converged on
-  the `settings.changed` broadcast. Code surfaces that own their own theming track the swap: **xterm** and
-  **Monaco** observe `[data-theme]` (Monaco also picks its `vs`/`vs-dark` base from it); **shiki** renders
-  dual (dark+light) palettes as CSS vars, flipped by `[data-theme="light"] .shiki`; **mermaid** re-derives
-  from the tokens. Structured for N (pibun's theme engine, lifted at V2).
+  the `settings.changed` broadcast. The token vocabulary also carries the code surfaces: **`--ansi-*`**
+  (the 16 xterm colors — light overrides them, dark-tuned brights wash out on white) and optional
+  **`--code-*`** syntax colors (set by Darcula, whose identity is its syntax palette; unset elsewhere).
+  Code surfaces that own their own theming track the swap: **xterm** and **Monaco** observe
+  `[data-theme]` and rebuild from the tokens (Monaco also picks its `vs`/`vs-dark` base from it, and
+  derives token rules from `--code-*`); **shiki** renders the tri palette (dark+light+darcula, the
+  darcula registration in `lib/shikiTheme.ts`) as CSS vars, flipped by the `[data-theme]` rules in
+  `global.css`; **mermaid** re-derives from the tokens. **Reading color tokens from JS goes through
+  `lib.cssColorToHex`** — the built CSS is minified, so `getComputedStyle` can return any equivalent form
+  (`#fff`, `gray`), which strict consumers (Monaco, xterm) reject. Text/status token values hold a contrast floor (body ≥
+  4.5:1, `--muted` ≥ 4.5:1 on its worst surface, `--hint` ≥ 3:1 — see the note in `tokens.css`).
+  Structured for N (pibun's theme engine, lifted at V2).
 - Token names that collide with Tailwind namespaces (`--font-mono`, `--font-accent`, `--radius-*`) are
   used as token arbitrary values (`font-[var(--font-accent)]`), not `@theme` mappings.
 - **Icons: `lucide-react`. Components: shadcn/ui** (Radix primitives), copy-in under `src/components/ui/`

--- a/apps/web/src/lib/SPEC.md
+++ b/apps/web/src/lib/SPEC.md
@@ -15,7 +15,15 @@ Tiny UI helpers shared across components.
 
 - **Owns:** `utils.ts` → `cn()` (merge clsx output through tailwind-merge) + `isMarkdownPath()` (the
   `.md`/`.markdown` gate for the rendered-preview view) + `stripFrontmatter()` (drop a leading YAML `---`
-  block so the rendered view doesn't render spec metadata as a heading).
-- **Public surface (barrel):** `cn`, `isMarkdownPath`, `stripFrontmatter`.
-- **Allowed deps:** `clsx`, `tailwind-merge`.
+  block so the rendered view doesn't render spec metadata as a heading) + `cssColorToHex()` (canonicalize
+  a CSS color to hex — minified CSS serves `#fff`/`gray`-style equivalents, which strict consumers like
+  Monaco and xterm reject; `""` when unparseable). Also the shared
+  shiki pieces, **kept out of the barrel** so the eager `@/lib` import stays shiki-free: `highlighter.ts`
+  (the chat code-block highlighter — curated grammars, JS regex engine, tri-theme render) and
+  `shikiTheme.ts` (the `SHIKI_THEMES` tri-palette map + the custom `darcula` registration, shared with
+  `panels/DiffViewer`); both are imported per-file (`@/lib/highlighter`, `@/lib/shikiTheme`) from lazy
+  chunks only.
+- **Public surface (barrel):** `cn`, `isMarkdownPath`, `stripFrontmatter`, `cssColorToHex`.
+- **Allowed deps:** `clsx`, `tailwind-merge`; `shiki`/`@shikijs/*` (the per-file shiki modules only —
+  never reachable through the barrel).
 - **Forbidden:** every app-internal module — this is a leaf.

--- a/apps/web/src/lib/highlighter.ts
+++ b/apps/web/src/lib/highlighter.ts
@@ -43,6 +43,7 @@ function getHighlighter(): Promise<HighlighterCore> {
 		themes: [
 			import("@shikijs/themes/github-dark-default"),
 			import("@shikijs/themes/github-light-default"),
+			import("@shikijs/themes/gruvbox-dark-hard"),
 			DARCULA_SHIKI,
 		],
 		langs: [

--- a/apps/web/src/lib/highlighter.ts
+++ b/apps/web/src/lib/highlighter.ts
@@ -1,12 +1,12 @@
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import { DARCULA_SHIKI, SHIKI_THEMES } from "./shikiTheme";
 
 // Shared shiki highlighter for chat code blocks: the JS regex engine (no WASM), a curated language set,
-// and a DUAL theme (dark + light) — all behind dynamic imports so nothing loads until the first code block
-// renders. Matches the DiffViewer pattern; kept here so chat can highlight many languages. The dual theme
-// emits both palettes as CSS vars in one render; `[data-theme="light"] .shiki` (global.css) flips to the
-// light palette, so a theme swap needs no re-highlighting.
-const THEMES = { dark: "github-dark-default", light: "github-light-default" } as const;
+// and the TRI theme (dark + light + darcula, from `shikiTheme.ts`) — all behind dynamic imports so nothing
+// loads until the first code block renders. Matches the DiffViewer pattern; kept here so chat can highlight
+// many languages. One render emits every palette as CSS vars; the `[data-theme]` rules in global.css flip
+// between them, so a theme swap needs no re-highlighting.
 
 const CANONICAL = new Set([
 	"typescript",
@@ -43,6 +43,7 @@ function getHighlighter(): Promise<HighlighterCore> {
 		themes: [
 			import("@shikijs/themes/github-dark-default"),
 			import("@shikijs/themes/github-light-default"),
+			DARCULA_SHIKI,
 		],
 		langs: [
 			import("@shikijs/langs/typescript"),
@@ -70,7 +71,7 @@ export async function highlightCode(code: string, lang: string): Promise<string 
 	if (!CANONICAL.has(canonical)) return null;
 	try {
 		const hl = await getHighlighter();
-		return hl.codeToHtml(code, { lang: canonical, themes: THEMES, defaultColor: "dark" });
+		return hl.codeToHtml(code, { lang: canonical, themes: SHIKI_THEMES, defaultColor: "dark" });
 	} catch {
 		return null;
 	}

--- a/apps/web/src/lib/highlighter.ts
+++ b/apps/web/src/lib/highlighter.ts
@@ -1,10 +1,12 @@
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
-// Shared shiki highlighter for chat code blocks: the JS regex engine (no WASM), one theme, a curated
-// language set — all behind dynamic imports so nothing loads until the first code block renders. Matches
-// the DiffViewer pattern (which only needs `diff`); kept here so chat can highlight many languages.
-const THEME = "github-dark-default";
+// Shared shiki highlighter for chat code blocks: the JS regex engine (no WASM), a curated language set,
+// and a DUAL theme (dark + light) — all behind dynamic imports so nothing loads until the first code block
+// renders. Matches the DiffViewer pattern; kept here so chat can highlight many languages. The dual theme
+// emits both palettes as CSS vars in one render; `[data-theme="light"] .shiki` (global.css) flips to the
+// light palette, so a theme swap needs no re-highlighting.
+const THEMES = { dark: "github-dark-default", light: "github-light-default" } as const;
 
 const CANONICAL = new Set([
 	"typescript",
@@ -38,7 +40,10 @@ const ALIAS: Record<string, string> = {
 let highlighterPromise: Promise<HighlighterCore> | null = null;
 function getHighlighter(): Promise<HighlighterCore> {
 	highlighterPromise ??= createHighlighterCore({
-		themes: [import("@shikijs/themes/github-dark-default")],
+		themes: [
+			import("@shikijs/themes/github-dark-default"),
+			import("@shikijs/themes/github-light-default"),
+		],
 		langs: [
 			import("@shikijs/langs/typescript"),
 			import("@shikijs/langs/tsx"),
@@ -65,7 +70,7 @@ export async function highlightCode(code: string, lang: string): Promise<string 
 	if (!CANONICAL.has(canonical)) return null;
 	try {
 		const hl = await getHighlighter();
-		return hl.codeToHtml(code, { lang: canonical, theme: THEME });
+		return hl.codeToHtml(code, { lang: canonical, themes: THEMES, defaultColor: "dark" });
 	} catch {
 		return null;
 	}

--- a/apps/web/src/lib/shikiTheme.ts
+++ b/apps/web/src/lib/shikiTheme.ts
@@ -33,12 +33,14 @@ export const DARCULA_SHIKI: ThemeRegistration = {
 };
 
 /**
- * The tri-palette map for `codeToHtml({ themes })`: `dark` is the inline default color; `light` and
- * `darcula` are emitted as `--shiki-light` / `--shiki-darcula` CSS vars on every token, flipped by the
- * `[data-theme]` rules in `global.css` — a theme swap needs no re-highlighting.
+ * The palette map for `codeToHtml({ themes })`: `dark` is the inline default color; every other entry is
+ * emitted as a `--shiki-<name>` CSS var on every token, flipped by the `[data-theme]` rules in
+ * `global.css` — a theme swap needs no re-highlighting. `darcula` is the custom registration above;
+ * `gruvbox` uses the shiki-shipped `gruvbox-dark-hard` (matching the `#1d2021` content surface).
  */
 export const SHIKI_THEMES = {
 	dark: "github-dark-default",
 	light: "github-light-default",
 	darcula: "darcula",
+	gruvbox: "gruvbox-dark-hard",
 } as const;

--- a/apps/web/src/lib/shikiTheme.ts
+++ b/apps/web/src/lib/shikiTheme.ts
@@ -1,0 +1,44 @@
+import type { ThemeRegistration } from "shiki/core";
+
+/**
+ * The classic IntelliJ Darcula palette as a shiki theme — shiki ships no darcula, so we register our own
+ * (orange keywords, green strings, gray comments, blue numbers on the `#2b2b2b` editor). Kept per-file
+ * (not in the `lib` barrel) like `highlighter.ts`, so it only loads with the lazy shiki chunks.
+ */
+export const DARCULA_SHIKI: ThemeRegistration = {
+	name: "darcula",
+	type: "dark",
+	settings: [
+		{ settings: { foreground: "#a9b7c6", background: "#2b2b2b" } },
+		{ scope: ["comment"], settings: { foreground: "#808080" } },
+		{ scope: ["comment.block.documentation"], settings: { foreground: "#629755" } },
+		{ scope: ["string", "punctuation.definition.string"], settings: { foreground: "#6a8759" } },
+		{ scope: ["string.regexp"], settings: { foreground: "#6a8759" } },
+		{
+			scope: ["keyword", "storage.type", "storage.modifier", "constant.language"],
+			settings: { foreground: "#cc7832" },
+		},
+		{ scope: ["constant.numeric"], settings: { foreground: "#6897bb" } },
+		{ scope: ["entity.name.function", "support.function"], settings: { foreground: "#ffc66d" } },
+		{ scope: ["entity.name.tag"], settings: { foreground: "#e8bf6a" } },
+		{ scope: ["entity.other.attribute-name"], settings: { foreground: "#bababa" } },
+		{ scope: ["support.type.property-name.json"], settings: { foreground: "#9876aa" } },
+		{ scope: ["markup.inserted"], settings: { foreground: "#6a8759" } },
+		{ scope: ["markup.deleted"], settings: { foreground: "#d25252" } },
+		{
+			scope: ["meta.diff.header", "meta.diff.range", "meta.diff.index"],
+			settings: { foreground: "#6897bb" },
+		},
+	],
+};
+
+/**
+ * The tri-palette map for `codeToHtml({ themes })`: `dark` is the inline default color; `light` and
+ * `darcula` are emitted as `--shiki-light` / `--shiki-darcula` CSS vars on every token, flipped by the
+ * `[data-theme]` rules in `global.css` — a theme swap needs no re-highlighting.
+ */
+export const SHIKI_THEMES = {
+	dark: "github-dark-default",
+	light: "github-light-default",
+	darcula: "darcula",
+} as const;

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isMarkdownPath, stripFrontmatter } from "./utils";
+import { cssColorToHex, isMarkdownPath, stripFrontmatter } from "./utils";
 
 test("isMarkdownPath matches .md/.markdown case-insensitively, nothing else", () => {
 	expect(isMarkdownPath("README.md")).toBe(true);
@@ -25,4 +25,20 @@ test("stripFrontmatter leaves content without frontmatter untouched", () => {
 	expect(stripFrontmatter("# Heading\n\nbody")).toBe("# Heading\n\nbody");
 	// A `---` that isn't the very first line is a thematic break, not frontmatter.
 	expect(stripFrontmatter("intro\n---\nid: x\n---\n")).toBe("intro\n---\nid: x\n---\n");
+});
+
+test("cssColorToHex expands short hex and passes full hex through", () => {
+	expect(cssColorToHex("#fff")).toBe("#ffffff");
+	expect(cssColorToHex("#FfF")).toBe("#FFffFF"); // case-preserving; hex is case-insensitive anyway
+	expect(cssColorToHex("#abc4")).toBe("#aabbcc44");
+	expect(cssColorToHex("#ffffff")).toBe("#ffffff");
+	expect(cssColorToHex("#a9b7c6")).toBe("#a9b7c6");
+	expect(cssColorToHex(" #2b2b2b ")).toBe("#2b2b2b");
+});
+
+test("cssColorToHex reads unparseable values as unset", () => {
+	// Non-hex forms (`gray`, `rgb(…)`) canonicalize through a canvas — DOM-only, covered by the theme
+	// e2e spec. Under bun (no DOM) they fall back to "" (unset), same as genuinely invalid input.
+	expect(cssColorToHex("")).toBe("");
+	expect(cssColorToHex("not-a-color")).toBe("");
 });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -11,6 +11,42 @@ export function isMarkdownPath(path: string): boolean {
 	return /\.(md|markdown)$/i.test(path);
 }
 
+let colorCanvas: CanvasRenderingContext2D | null | undefined;
+
+function canvasNormalize(color: string): string {
+	if (typeof document === "undefined") return "";
+	colorCanvas ??= document.createElement("canvas").getContext("2d");
+	if (!colorCanvas) return "";
+	// An invalid assignment leaves fillStyle unchanged, so two different priors agreeing means `color`
+	// really parsed (and a canvas serializes it canonically: `#rrggbb`, or `rgba()` when it has alpha).
+	colorCanvas.fillStyle = "#000000";
+	colorCanvas.fillStyle = color;
+	const first = colorCanvas.fillStyle;
+	colorCanvas.fillStyle = "#ffffff";
+	colorCanvas.fillStyle = color;
+	return first === colorCanvas.fillStyle ? first : "";
+}
+
+/**
+ * Canonicalize a CSS color to hex (`#rrggbb`/`#rrggbbaa`), or `""` when it can't be parsed. The built CSS
+ * is minified, so a token read via `getComputedStyle` can come back in ANY equivalent form (`#fff`,
+ * `gray`, `rgb(…)`) — and strict consumers (Monaco's theme colors, xterm's palette) only accept hex.
+ * Non-hex forms round-trip through a canvas, which serializes solid colors to `#rrggbb` and alpha colors
+ * to `rgba()` (converted here).
+ */
+export function cssColorToHex(color: string): string {
+	const value = color.trim();
+	const short = /^#([0-9a-f]{3,4})$/i.exec(value)?.[1];
+	if (short) return `#${[...short].map((c) => c + c).join("")}`;
+	if (/^#([0-9a-f]{6}|[0-9a-f]{8})$/i.test(value)) return value;
+	const parsed = canvasNormalize(value);
+	if (parsed.startsWith("#")) return parsed;
+	const [, r, g, b, a] = /^rgba\((\d+), (\d+), (\d+), ([\d.]+)\)$/.exec(parsed) ?? [];
+	const channels = [Number(r), Number(g), Number(b), Math.round(Number(a) * 255)];
+	if (channels.some((c) => !Number.isFinite(c))) return "";
+	return `#${channels.map((c) => c.toString(16).padStart(2, "0")).join("")}`;
+}
+
 /**
  * Drop a leading YAML frontmatter block (a `---` line, its body, and a closing `---`/`...` line) so the
  * rendered markdown view doesn't turn spec metadata into a stray heading — the conventional behavior for

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,8 +5,12 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Shell } from "./shell/Shell";
 import { initTransport } from "./transport";
 import { applyFontScale } from "./utils/fontScale";
+import { applyTheme, readThemeHint } from "./utils/theme";
 
 applyFontScale();
+// Apply the cached theme before React mounts so the first paint matches; `server.welcome` reconciles it
+// against the host's source-of-truth config a moment later.
+applyTheme(readThemeHint());
 initTransport();
 
 const root = document.getElementById("root");

--- a/apps/web/src/panels/AppearanceSettings.tsx
+++ b/apps/web/src/panels/AppearanceSettings.tsx
@@ -1,0 +1,58 @@
+import type { ThemeId } from "@thinkrail/contracts";
+import { Check } from "lucide-react";
+import { cn } from "@/lib";
+import { toast, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+import { THEMES } from "@/utils/theme";
+
+/**
+ * The "Appearance" settings section: the theme picker. Server-synced — clicking a theme fires
+ * `settings.update` and the UI converges when the host's `settings.changed` broadcast folds into the store
+ * (no optimistic apply), the same pattern as the workspace lifecycle. The active theme is read from the
+ * store (fed by `server.welcome` / `settings.changed`); a rejected update surfaces a toast.
+ */
+export function AppearanceSettings() {
+	const theme = useAppStore((s) => s.theme);
+
+	const select = (id: ThemeId) => {
+		if (id === theme) return;
+		getTransport()
+			.request("settings.update", { config: { theme: id } })
+			.catch(() => toast.error("Couldn't change theme"));
+	};
+
+	return (
+		<section data-testid="settings-appearance" className="flex flex-col gap-sm">
+			<div className="flex flex-col gap-xs">
+				<h3 className="font-medium text-md text-text">Theme</h3>
+				<p className="text-hint text-xs">
+					Choose the app theme. Your choice is saved on the host and follows you across devices.
+				</p>
+			</div>
+			<div className="flex flex-col gap-xs">
+				{THEMES.map(({ id, label }) => {
+					const active = id === theme;
+					return (
+						<button
+							key={id}
+							type="button"
+							aria-pressed={active}
+							data-testid={`theme-option-${id}`}
+							data-active={active}
+							onClick={() => select(id)}
+							className={cn(
+								"flex items-center gap-sm rounded-[var(--radius-md)] border px-md py-sm text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+								active
+									? "border-[var(--primary-40)] bg-[var(--primary-10)] text-text"
+									: "border-border2 text-muted hover:bg-hover hover:text-text",
+							)}
+						>
+							<span className="flex-1 font-medium">{label}</span>
+							{active ? <Check className="size-4 shrink-0 text-primary" /> : null}
+						</button>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/panels/DiffViewer.tsx
+++ b/apps/web/src/panels/DiffViewer.tsx
@@ -2,13 +2,18 @@ import { useEffect, useState } from "react";
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
-const THEME = "github-dark-default";
+// Dual theme (dark + light) so a theme swap needs no re-highlight: one render emits both palettes as CSS
+// vars and `[data-theme="light"] .shiki` (global.css) flips to the light one. Dark + Darcula use the default.
+const THEMES = { dark: "github-dark-default", light: "github-light-default" } as const;
 
-// One shared highlighter: only the `diff` grammar + one theme, on the JS regex engine (no WASM).
+// One shared highlighter: only the `diff` grammar, on the JS regex engine (no WASM).
 let highlighter: Promise<HighlighterCore> | null = null;
 function getHighlighter(): Promise<HighlighterCore> {
 	highlighter ??= createHighlighterCore({
-		themes: [import("@shikijs/themes/github-dark-default")],
+		themes: [
+			import("@shikijs/themes/github-dark-default"),
+			import("@shikijs/themes/github-light-default"),
+		],
 		langs: [import("@shikijs/langs/diff")],
 		engine: createJavaScriptRegexEngine(),
 	});
@@ -22,7 +27,7 @@ export default function DiffViewer({ diff }: { diff: string }) {
 	useEffect(() => {
 		let cancelled = false;
 		getHighlighter()
-			.then((hl) => hl.codeToHtml(diff, { lang: "diff", theme: THEME }))
+			.then((hl) => hl.codeToHtml(diff, { lang: "diff", themes: THEMES, defaultColor: "dark" }))
 			.then((h) => {
 				if (!cancelled) setHtml(h);
 			})

--- a/apps/web/src/panels/DiffViewer.tsx
+++ b/apps/web/src/panels/DiffViewer.tsx
@@ -13,6 +13,7 @@ function getHighlighter(): Promise<HighlighterCore> {
 		themes: [
 			import("@shikijs/themes/github-dark-default"),
 			import("@shikijs/themes/github-light-default"),
+			import("@shikijs/themes/gruvbox-dark-hard"),
 			DARCULA_SHIKI,
 		],
 		langs: [import("@shikijs/langs/diff")],

--- a/apps/web/src/panels/DiffViewer.tsx
+++ b/apps/web/src/panels/DiffViewer.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import { DARCULA_SHIKI, SHIKI_THEMES } from "@/lib/shikiTheme";
 
-// Dual theme (dark + light) so a theme swap needs no re-highlight: one render emits both palettes as CSS
-// vars and `[data-theme="light"] .shiki` (global.css) flips to the light one. Dark + Darcula use the default.
-const THEMES = { dark: "github-dark-default", light: "github-light-default" } as const;
+// Tri theme (dark + light + darcula, from `lib/shikiTheme.ts`) so a theme swap needs no re-highlight: one
+// render emits every palette as CSS vars and the `[data-theme]` rules in global.css flip between them.
 
 // One shared highlighter: only the `diff` grammar, on the JS regex engine (no WASM).
 let highlighter: Promise<HighlighterCore> | null = null;
@@ -13,6 +13,7 @@ function getHighlighter(): Promise<HighlighterCore> {
 		themes: [
 			import("@shikijs/themes/github-dark-default"),
 			import("@shikijs/themes/github-light-default"),
+			DARCULA_SHIKI,
 		],
 		langs: [import("@shikijs/langs/diff")],
 		engine: createJavaScriptRegexEngine(),
@@ -27,7 +28,9 @@ export default function DiffViewer({ diff }: { diff: string }) {
 	useEffect(() => {
 		let cancelled = false;
 		getHighlighter()
-			.then((hl) => hl.codeToHtml(diff, { lang: "diff", themes: THEMES, defaultColor: "dark" }))
+			.then((hl) =>
+				hl.codeToHtml(diff, { lang: "diff", themes: SHIKI_THEMES, defaultColor: "dark" }),
+			)
 			.then((h) => {
 				if (!cancelled) setHtml(h);
 			})

--- a/apps/web/src/panels/MonacoEditor.tsx
+++ b/apps/web/src/panels/MonacoEditor.tsx
@@ -1,4 +1,9 @@
-import MonacoReact, { type BeforeMount, loader } from "@monaco-editor/react";
+import MonacoReact, {
+	type BeforeMount,
+	loader,
+	type Monaco,
+	type OnMount,
+} from "@monaco-editor/react";
 import type { Environment } from "monaco-editor";
 import * as monaco from "monaco-editor";
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
@@ -6,6 +11,7 @@ import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+import { useEffect, useRef } from "react";
 
 declare global {
 	interface Window {
@@ -35,7 +41,9 @@ function token(name: string): string {
 	return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
-const defineThinkrailTheme: BeforeMount = (m) => {
+/** Define (or redefine) the thinkrail Monaco theme from the live CSS tokens, picking the light/dark base
+ * from the active `[data-theme]`. Called before mount and again on every theme swap. */
+function defineThinkrailTheme(m: Monaco): void {
 	const colors: Record<string, string> = {};
 	const set = (key: string, value: string) => {
 		if (value) colors[key] = value;
@@ -45,18 +53,40 @@ const defineThinkrailTheme: BeforeMount = (m) => {
 	set("editorLineNumber.foreground", token("--hint"));
 	set("editorCursor.foreground", token("--primary"));
 	set("editor.selectionBackground", token("--sel"));
-	m.editor.defineTheme(THEME, { base: "vs-dark", inherit: true, rules: [], colors });
-};
+	const base = document.documentElement.dataset.theme === "light" ? "vs" : "vs-dark";
+	m.editor.defineTheme(THEME, { base, inherit: true, rules: [], colors });
+}
+
+const beforeMount: BeforeMount = (m) => defineThinkrailTheme(m);
 
 /** Read-only file viewer; language is inferred from `path`. Editing + save land with `fs.writeFile`. */
 export default function MonacoEditor({ path, content }: { path: string; content: string }) {
+	const observerRef = useRef<MutationObserver | null>(null);
+
+	// Re-theme Monaco on a `[data-theme]` swap: its chrome + light/dark base are read once at define time, so
+	// without this the editor would keep the theme it mounted with. Mirrors TerminalInstance's observer.
+	const onMount: OnMount = (_editor, m) => {
+		const observer = new MutationObserver(() => {
+			defineThinkrailTheme(m);
+			m.editor.setTheme(THEME);
+		});
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["data-theme"],
+		});
+		observerRef.current = observer;
+	};
+
+	useEffect(() => () => observerRef.current?.disconnect(), []);
+
 	return (
 		<MonacoReact
 			height="100%"
 			path={path}
 			value={content}
 			theme={THEME}
-			beforeMount={defineThinkrailTheme}
+			beforeMount={beforeMount}
+			onMount={onMount}
 			loading={
 				<div className="flex h-full items-center justify-center text-hint">Loading editor…</div>
 			}

--- a/apps/web/src/panels/MonacoEditor.tsx
+++ b/apps/web/src/panels/MonacoEditor.tsx
@@ -12,6 +12,7 @@ import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 import { useEffect, useRef } from "react";
+import { cssColorToHex } from "@/lib";
 
 declare global {
 	interface Window {
@@ -36,13 +37,31 @@ loader.config({ monaco });
 
 const THEME = "thinkrail";
 
-/** Read a CSS custom property off the document root, so Monaco's chrome tracks the active theme tokens. */
+/** Read a CSS custom property off the document root, so Monaco's chrome tracks the active theme tokens.
+ * Canonicalized to hex: the built CSS is minified (`#ffffff` → `#fff`, `#808080` → `gray`), and Monaco
+ * accepts only hex — an unparseable value reads as unset (`""`) and is dropped by the callers. */
 function token(name: string): string {
-	return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+	return cssColorToHex(getComputedStyle(document.documentElement).getPropertyValue(name).trim());
 }
 
-/** Define (or redefine) the thinkrail Monaco theme from the live CSS tokens, picking the light/dark base
- * from the active `[data-theme]`. Called before mount and again on every theme swap. */
+/** Monaco token name → the `--code-*` syntax token a theme may set (only Darcula does today). */
+const SYNTAX_TOKENS: [string, string][] = [
+	["keyword", "--code-keyword"],
+	["string", "--code-string"],
+	["comment", "--code-comment"],
+	["comment.doc", "--code-comment-doc"],
+	["number", "--code-number"],
+	["regexp", "--code-regexp"],
+	["annotation", "--code-annotation"],
+	["tag", "--code-tag"],
+	["attribute.name", "--code-attribute-name"],
+	["attribute.value", "--code-attribute-value"],
+	["string.key.json", "--code-json-key"],
+];
+
+/** Define (or redefine) the thinkrail Monaco theme from the live CSS tokens: chrome colors from the
+ * surface tokens, the light/dark base from the active `[data-theme]`, and syntax rules from whichever
+ * `--code-*` tokens the theme sets. Called before mount and again on every theme swap. */
 function defineThinkrailTheme(m: Monaco): void {
 	const colors: Record<string, string> = {};
 	const set = (key: string, value: string) => {
@@ -53,8 +72,17 @@ function defineThinkrailTheme(m: Monaco): void {
 	set("editorLineNumber.foreground", token("--hint"));
 	set("editorCursor.foreground", token("--primary"));
 	set("editor.selectionBackground", token("--sel"));
+	const rules = SYNTAX_TOKENS.flatMap(([monacoToken, name]) => {
+		const color = token(name);
+		return color ? [{ token: monacoToken, foreground: color.replace("#", "") }] : [];
+	});
 	const base = document.documentElement.dataset.theme === "light" ? "vs" : "vs-dark";
-	m.editor.defineTheme(THEME, { base, inherit: true, rules: [], colors });
+	try {
+		m.editor.defineTheme(THEME, { base, inherit: true, rules, colors });
+	} catch {
+		// A token value Monaco can't parse must degrade to the base palette, never crash the panel.
+		m.editor.defineTheme(THEME, { base, inherit: true, rules: [], colors: {} });
+	}
 }
 
 const beforeMount: BeforeMount = (m) => defineThinkrailTheme(m);

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -190,6 +190,15 @@ prompt hero (still editable; empty by default), a base-branch
   **external** link opens a new tab, and a **relative image** rewrites to the host **`/files/…`** route
   (built from `transport.httpBase()`). A cross-file link's `#fragment` is not yet followed (opens the
   file only).
+- **Code surfaces re-theme from the tokens, resiliently.** `MonacoEditor` defines the `thinkrail` theme
+  from the live tokens (chrome from the surface tokens, `vs`/`vs-dark` base from `[data-theme]`, syntax
+  rules from whichever `--code-*` a theme sets — Darcula today) and redefines it via a `[data-theme]`
+  MutationObserver; token reads are **canonicalized to hex** (`lib.cssColorToHex` — minified CSS serves
+  equivalents like `#fff`/`gray`, which Monaco rejects; unparseable → dropped, never passed through) and
+  the define **degrades to the base palette instead of throwing** (a bad
+  token value must never crash the editor panel). `TerminalInstance` builds the xterm theme the same way,
+  including the **16 `--ansi-*` slots** (so shell colors stay legible per theme), re-read on the same
+  observer. `DiffViewer` renders shiki's tri palette (`lib/shikiTheme`) once; the swap is pure CSS.
 - Heavy deps (Monaco / shiki / xterm) load via `React.lazy(() => import())` to stay out of the eager bundle.
   A lazy chunk that fails to load (or a render throw) is contained by the `components/ErrorBoundary` the
   **shell** wraps each region in (see `shell/SPEC.md`), so a single panel degrades instead of blanking the

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -94,10 +94,13 @@ prompt hero (still editable; empty by default), a base-branch
   read) + `provider.jbcentral*`:
   Connected (Disconnect) / ready (Connect) / not signed in (in-app `central login` + Retry) / not installed
   (the host's per-OS copyable install command — from `jbcentralInstall`, for the *host's* OS, never the
-  browser's — + Recheck); each mutation re-reads `provider.status`) and **`GithubSettings`** (the "Local GitHub" block — `github.authStatus()`
-  Connected + login / Not connected + Refresh). Dimmed "General"/"Appearance" nav items ("Soon") signal the
-  shell is built to grow. `ProvidersSettings` is the **integration piece** (store + transport); the
-  `LoginDialog` stays presentational (`auth` module).
+  browser's — + Recheck); each mutation re-reads `provider.status`) **`GithubSettings`** (the "Local GitHub" block — `github.authStatus()`
+  Connected + login / Not connected + Refresh); and **`AppearanceSettings`** (the **theme picker** — a
+  labelled list of `utils/theme`'s `THEMES`, the active one from `store.theme` marked; clicking one fires
+  `settings.update` and the UI **converges on the `settings.changed` broadcast** (no optimistic apply), a
+  rejected update raising a toast). A single dimmed "General" nav item ("Soon") still signals the shell is
+  built to grow. `ProvidersSettings`/`AppearanceSettings` are the **integration pieces** (store + transport);
+  the `LoginDialog` stays presentational (`auth` module).
   Panels compose their own sub-panels
   (e.g. `RightPanel`→`FileTree`/`ChangesPanel`, `CenterTabs`→`FilePane`→`MonacoEditor`) — an internal hierarchy.
   `CenterTabs` closing a chat tab routes to `store.closeChatToHistory` (keeps the session alive) and shows a
@@ -118,7 +121,7 @@ prompt hero (still editable; empty by default), a base-branch
   one set or the other on the active-workspace branch.)
 - **Allowed deps:** `store`, `transport`, `components/ui` (incl. `popover`/`command`/`textarea` for the
   dialog), `chat` (`ModelSelector`/`ThinkingSelector`, reused by `NewWorkspaceDialog`; `Markdown`,
-  reused by `MarkdownPreview`), `lib`,
+  reused by `MarkdownPreview`), `lib`, `utils` (`theme`'s `THEMES`, for `AppearanceSettings`),
   `contracts`; `lucide-react`; and the heavy libs each lazy panel owns (`monaco-editor`, `shiki`,
   `@xterm/*`) loaded via `import()`.
 - **Forbidden:** `server`/`shared`/`pi`; importing `shell`; reaching across unrelated panels.

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -1,20 +1,19 @@
 import { GitBranch, KeyRound, type LucideIcon, Palette, SlidersHorizontal } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib";
-import { type SettingsSection, useAppStore } from "@/store";
+import { SettingsSection, useAppStore } from "@/store";
+import { AppearanceSettings } from "./AppearanceSettings";
 import { GithubSettings } from "./GithubSettings";
 import { ProvidersSettings } from "./ProvidersSettings";
 
 /** The live settings sections, in nav order. */
 const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
-	{ id: "providers", label: "Providers", icon: KeyRound },
-	{ id: "github", label: "GitHub", icon: GitBranch },
+	{ id: SettingsSection.Providers, label: "Providers", icon: KeyRound },
+	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
+	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
 ];
 /** Placeholder sections — shown dimmed so the shell reads as built-to-grow (not yet wired). */
-const SOON: { label: string; icon: LucideIcon }[] = [
-	{ label: "General", icon: SlidersHorizontal },
-	{ label: "Appearance", icon: Palette },
-];
+const SOON: { label: string; icon: LucideIcon }[] = [{ label: "General", icon: SlidersHorizontal }];
 
 /**
  * App settings — a two-pane shell (left section rail + scrollable content pane) so it grows past today's two
@@ -81,7 +80,13 @@ export function SettingsDialog() {
 					</nav>
 
 					<div className="min-h-0 flex-1 overflow-y-auto p-lg">
-						{section === "providers" ? <ProvidersSettings /> : <GithubSettings />}
+						{section === SettingsSection.Providers ? (
+							<ProvidersSettings />
+						) : section === SettingsSection.Github ? (
+							<GithubSettings />
+						) : (
+							<AppearanceSettings />
+						)}
 					</div>
 				</div>
 			</DialogContent>

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -5,23 +5,55 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { type ITheme, Terminal as XTerm } from "@xterm/xterm";
 import { useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
+import { cssColorToHex } from "@/lib";
 import { getTransport } from "../transport";
 
 function cssVar(name: string): string | undefined {
 	return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || undefined;
 }
 
+/** A color token, canonicalized to hex — minified CSS can serve any equivalent form (`#fff`, `gray`),
+ * and xterm's parser takes hex/rgb only. Unparseable reads as unset → xterm's default for that slot. */
+function cssColorVar(name: string): string | undefined {
+	return cssColorToHex(cssVar(name) ?? "") || undefined;
+}
+
+/** The 16 ANSI slots, each fed by its `--ansi-*` token — so shell colors stay legible per theme (the
+ * light theme swaps in a light-tuned palette; xterm's dark-tuned defaults wash out on white). */
+const ANSI_TOKENS = [
+	["black", "--ansi-black"],
+	["red", "--ansi-red"],
+	["green", "--ansi-green"],
+	["yellow", "--ansi-yellow"],
+	["blue", "--ansi-blue"],
+	["magenta", "--ansi-magenta"],
+	["cyan", "--ansi-cyan"],
+	["white", "--ansi-white"],
+	["brightBlack", "--ansi-bright-black"],
+	["brightRed", "--ansi-bright-red"],
+	["brightGreen", "--ansi-bright-green"],
+	["brightYellow", "--ansi-bright-yellow"],
+	["brightBlue", "--ansi-bright-blue"],
+	["brightMagenta", "--ansi-bright-magenta"],
+	["brightCyan", "--ansi-bright-cyan"],
+	["brightWhite", "--ansi-bright-white"],
+] as const;
+
 /** xterm theme from the live CSS tokens (no raw hex; falls back to xterm defaults if a token is unset). */
 function readTheme(): ITheme {
 	const theme: ITheme = {};
-	const bg = cssVar("--surface-content");
+	const bg = cssColorVar("--surface-content");
 	if (bg) theme.background = bg;
-	const fg = cssVar("--text");
+	const fg = cssColorVar("--text");
 	if (fg) theme.foreground = fg;
-	const cursor = cssVar("--primary");
+	const cursor = cssColorVar("--primary");
 	if (cursor) theme.cursor = cursor;
-	const sel = cssVar("--sel");
+	const sel = cssColorVar("--sel");
 	if (sel) theme.selectionBackground = sel;
+	for (const [slot, name] of ANSI_TOKENS) {
+		const color = cssColorVar(name);
+		if (color) theme[slot] = color;
+	}
 	return theme;
 }
 

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -22,10 +22,13 @@ later, the mobile single-view-with-switcher).
   resizable, `resize-left` preserved) beside the `panels/WelcomePanel`; the center/right/terminal surface
   is not mounted. The welcome-state group uses its own `autoSaveId` so it doesn't clobber the 3-column
   layout's saved sizes. Mounts the `panels/Toaster` once (outside both layout branches) so notifications
-  show over either state.
+  show over either state. **Owns the theme DOM side-effect** — the single place that applies the store's
+  (host-owned) `theme`: a `useEffect` on `store.theme` calls `utils/theme` `applyTheme(theme)` +
+  `writeThemeHint(theme)` (the localStorage first-paint cache). The value flows store ← transport (welcome /
+  `settings.changed`); the shell just performs the swap, so no other component touches `[data-theme]`.
 - **Public surface:** `Shell`.
-- **Allowed deps:** `panels`, `store` (status), `transport` (`ConnectionStatus` type), `components/ui`
-  (resizable), `components/ErrorBoundary`, `constants` (branding).
+- **Allowed deps:** `panels`, `store` (status + theme), `transport` (`ConnectionStatus` type), `components/ui`
+  (resizable), `components/ErrorBoundary`, `constants` (branding), `utils` (`theme`'s `applyTheme`/`writeThemeHint`).
 - **Forbidden:** `server`/`shared`/`pi`; being imported by `panels`/`store`/`transport`.
 
 ## Error resilience (why panels can't blank the app)

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -1,4 +1,5 @@
 import { Settings } from "lucide-react";
+import { useEffect } from "react";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable";
 import { PRODUCT_NAME } from "../constants/branding";
@@ -11,6 +12,7 @@ import { Toaster } from "../panels/Toaster";
 import { WelcomePanel } from "../panels/WelcomePanel";
 import { useAppStore } from "../store";
 import type { ConnectionStatus } from "../transport";
+import { applyTheme, writeThemeHint } from "../utils/theme";
 
 const STATUS_LABEL: Record<ConnectionStatus, string> = {
 	connected: "Connected",
@@ -28,6 +30,13 @@ export function Shell() {
 	const status = useAppStore((s) => s.status);
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 	const hasActiveWorkspace = activeWorkspaceId != null;
+	// The single owner of the theme DOM side-effect: apply the store's (host-owned) theme + cache it as the
+	// next load's first-paint hint. The store is fed by transport (welcome / settings.changed).
+	const theme = useAppStore((s) => s.theme);
+	useEffect(() => {
+		applyTheme(theme);
+		writeThemeHint(theme);
+	}, [theme]);
 	return (
 		<div data-testid="shell" className="grid h-full grid-rows-[auto_1fr]">
 			<header className="flex items-center justify-between border-b border-border2 bg-bg-dark px-lg py-sm">

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -65,9 +65,14 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `provider.login` frame (creating `activeLogin` if the frame arrived first; ignoring frames for a different
   live login), **`clearLoginInput()`** drops the live input the instant a reply is sent (no double-submit),
   and **`clearLogin()`** dismisses it. The **settings surface** state — **`settingsOpen`** +
-  **`settingsSection`** (`"providers"|"github"`) with **`openSettings(section?)`** (deep-links to a section,
-  defaults to Providers) / **`closeSettings()`** / **`setSettingsSection()`** — lives here so the top-bar gear
-  AND the Welcome provider warning open Settings to a section without prop-drilling through the shell. The
+  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`) with
+  **`openSettings(section?)`** (deep-links to a section, defaults to Providers) / **`closeSettings()`** /
+  **`setSettingsSection()`** — lives here so the top-bar gear AND the Welcome provider warning open Settings
+  to a section without prop-drilling through the shell. The **theme** state — **`theme: ThemeId`** (the
+  host-owned active theme) with **`applyConfig(config)`** (folds the server-synced `AppConfig` in from
+  `server.welcome` / the `settings.changed` broadcast) — lives here too; it's a **pure value only** (the
+  `applyTheme` DOM side-effect is the shell's, keyed off `theme`), and defaults to `Theme.Dark` until the
+  welcome arrives. The
   **toast queue** — **`toasts: Toast[]`** (oldest-first) with **`pushToast(toast) → id`** / **`dismissToast(id)`**
   and the ergonomic **`toast.error/success/info(message, title?)`** helper (wraps `pushToast` so a non-React
   call site — a `.catch` in a fire-and-forget wire call — can fire one) — lives here so any surface can raise
@@ -92,7 +97,8 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `EditorTab` (`FileTab`/`ChatTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` + `EMPTY_RUNTIME`
   (ChatView's pre-creation fallback), `reduceSessionEvent`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/
-  `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`; `PiEvent`/`LoginFrame`, **type-only**); `chat`
+  `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`/`AppConfig`/`ThemeId`; the
+  `Theme` value for the default; `PiEvent`/`LoginFrame`, **type-only**); `chat`
   (`ChatTurn`/`ToolResultState`, **type-only**); `auth` (`LoginState`, **type-only**); `transport`
   (`ConnectionStatus`, **type-only**); `zustand`.
 - **Forbidden:** `server`/`shared`/`pi`; importing `panels`/`shell` or transport runtime.

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -769,3 +769,11 @@ test("the toast helper enqueues by variant and omits an absent title", () => {
 	]);
 	expect(useAppStore.getState().toasts[0]).not.toHaveProperty("title");
 });
+
+test("applyConfig folds the server-synced app config in (theme is host-owned, a pure value)", () => {
+	// The DOM swap is the shell's; the store just holds the value the UI reads.
+	useAppStore.getState().applyConfig({ theme: "darcula" });
+	expect(useAppStore.getState().theme).toBe("darcula");
+	useAppStore.getState().applyConfig({ theme: "light" });
+	expect(useAppStore.getState().theme).toBe("light");
+});

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1,4 +1,5 @@
 import type {
+	AppConfig,
 	ExtUiRequest,
 	LoginFrame,
 	LoginPush,
@@ -7,11 +8,13 @@ import type {
 	SessionStats,
 	SessionSummary,
 	SlashCommandInfo,
+	ThemeId,
 	ThinkingLevel,
 	WireModel,
 	Workspace,
 	WorkspaceFsChangedPayload,
 } from "@thinkrail/contracts";
+import { Theme } from "@thinkrail/contracts";
 import { create } from "zustand";
 import type { LoginState } from "../auth";
 import type { ChatTurn, ExtUiDialogRequest, ToolResultState } from "../chat/types";
@@ -40,8 +43,16 @@ export interface ChatTab {
 }
 export type EditorTab = FileTab | ChatTab;
 
-/** A section of the settings dialog. Extensible — the two live sections today are providers + github. */
-export type SettingsSection = "providers" | "github";
+/**
+ * A section of the settings dialog (a const-object "enum", the codebase convention). Extensible — the live
+ * sections are providers, github, and appearance (the theme picker).
+ */
+export const SettingsSection = {
+	Providers: "providers",
+	Github: "github",
+	Appearance: "appearance",
+} as const;
+export type SettingsSection = (typeof SettingsSection)[keyof typeof SettingsSection];
 
 /** A transient notification. `error` persists until dismissed; `success`/`info` auto-dismiss (the Toaster
  * owns the timer). `title` is optional — a bare `message` is the common case. */
@@ -357,6 +368,9 @@ interface AppState {
 	 * provider warning) can open it to a section without prop-drilling through the shell. */
 	settingsOpen: boolean;
 	settingsSection: SettingsSection;
+	/** The active UI theme (host-owned; `applyConfig` sets it from `server.welcome` / `settings.changed`).
+	 * The DOM side-effect (`applyTheme`) is the shell's job — this holds the value the UI reads. */
+	theme: ThemeId;
 	/** Transient notifications, oldest-first (the Toaster renders + times them out). At-most a handful live
 	 * at once; a failed wire call that has no better home (no chat tab to host an error turn) lands here. */
 	toasts: Toast[];
@@ -462,6 +476,8 @@ interface AppState {
 	openSettings: (section?: SettingsSection) => void;
 	closeSettings: () => void;
 	setSettingsSection: (section: SettingsSection) => void;
+	/** Fold the server-synced app config in (from `server.welcome` / the `settings.changed` broadcast). */
+	applyConfig: (config: AppConfig) => void;
 	/** Ask the right panel to open `path`'s diff in its Changes view (deep-link from chat). */
 	requestChangesView: (workspaceId: string, path: string) => void;
 	/** Enqueue a toast; returns its id so a caller can dismiss it early. An identical live toast (same
@@ -558,7 +574,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 	fsChangesByWorkspace: {},
 	activeLogin: null,
 	settingsOpen: false,
-	settingsSection: "providers",
+	settingsSection: SettingsSection.Providers,
+	theme: Theme.Dark,
 	toasts: [],
 	setStatus: (status) => set({ status }),
 	setWelcome: (protocolVersion) => set({ protocolVersion }),
@@ -967,9 +984,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 			return { activeLogin: rest };
 		}),
 	clearLogin: () => set({ activeLogin: null }),
-	openSettings: (section = "providers") => set({ settingsOpen: true, settingsSection: section }),
+	openSettings: (section = SettingsSection.Providers) =>
+		set({ settingsOpen: true, settingsSection: section }),
 	closeSettings: () => set({ settingsOpen: false }),
 	setSettingsSection: (section) => set({ settingsSection: section }),
+	applyConfig: (config) => set({ theme: config.theme }),
 	requestChangesView: (workspaceId, path) => set({ changesRequest: { workspaceId, path } }),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -23,10 +23,10 @@ body {
 }
 
 /*
- * Shiki multi-theme swap. `highlightCode` / `DiffViewer` render with `themes: { dark, light, darcula }`
- * (see `lib/shikiTheme.ts`) + `defaultColor: "dark"`, so the base inline `color` is the dark palette and
- * each token also carries `--shiki-light` / `--shiki-darcula` variables. Dark uses the default; Light and
- * Darcula swap via the rules below — a pure-CSS flip, no re-highlighting. Backgrounds stay owned by the
+ * Shiki multi-theme swap. `highlightCode` / `DiffViewer` render with the `SHIKI_THEMES` map (see
+ * `lib/shikiTheme.ts`) + `defaultColor: "dark"`, so the base inline `color` is the dark palette and each
+ * token also carries a `--shiki-<name>` variable per other theme. Dark uses the default; every other
+ * theme swaps via its rule below — a pure-CSS flip, no re-highlighting. Backgrounds stay owned by the
  * token surfaces the code containers set (`--bg-dark` / transparent), so only the text color is swapped here.
  */
 [data-theme="light"] .shiki,
@@ -40,6 +40,12 @@ body {
 [data-theme="darcula"] .shiki span {
 	/* biome-ignore lint/complexity/noImportantStyles: same inline-style override as the light rule above. */
 	color: var(--shiki-darcula) !important;
+}
+
+[data-theme="gruvbox"] .shiki,
+[data-theme="gruvbox"] .shiki span {
+	/* biome-ignore lint/complexity/noImportantStyles: same inline-style override as the light rule above. */
+	color: var(--shiki-gruvbox) !important;
 }
 
 a {

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -23,17 +23,23 @@ body {
 }
 
 /*
- * Shiki dual-theme swap. `highlightCode` / `DiffViewer` render with `themes: { dark, light }` +
- * `defaultColor: "dark"`, so the base inline `color` is the dark palette and each token also carries a
- * `--shiki-light` variable. Dark + Darcula use the default; only the Light theme swaps to the light
- * palette — a pure-CSS flip, no re-highlighting. Backgrounds stay owned by the token surfaces the code
- * containers set (`--bg-dark` / transparent), so only the text color is swapped here.
+ * Shiki multi-theme swap. `highlightCode` / `DiffViewer` render with `themes: { dark, light, darcula }`
+ * (see `lib/shikiTheme.ts`) + `defaultColor: "dark"`, so the base inline `color` is the dark palette and
+ * each token also carries `--shiki-light` / `--shiki-darcula` variables. Dark uses the default; Light and
+ * Darcula swap via the rules below — a pure-CSS flip, no re-highlighting. Backgrounds stay owned by the
+ * token surfaces the code containers set (`--bg-dark` / transparent), so only the text color is swapped here.
  */
 [data-theme="light"] .shiki,
 [data-theme="light"] .shiki span {
 	/* biome-ignore lint/complexity/noImportantStyles: shiki writes the token color inline on every span; a
-	   stylesheet rule can only override an inline style with !important. This is shiki's own dual-theme recipe. */
+	   stylesheet rule can only override an inline style with !important. This is shiki's own multi-theme recipe. */
 	color: var(--shiki-light) !important;
+}
+
+[data-theme="darcula"] .shiki,
+[data-theme="darcula"] .shiki span {
+	/* biome-ignore lint/complexity/noImportantStyles: same inline-style override as the light rule above. */
+	color: var(--shiki-darcula) !important;
 }
 
 a {

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -19,7 +19,21 @@ body {
 }
 
 ::selection {
-	background: #2c2947;
+	background: var(--selection-bg);
+}
+
+/*
+ * Shiki dual-theme swap. `highlightCode` / `DiffViewer` render with `themes: { dark, light }` +
+ * `defaultColor: "dark"`, so the base inline `color` is the dark palette and each token also carries a
+ * `--shiki-light` variable. Dark + Darcula use the default; only the Light theme swaps to the light
+ * palette — a pure-CSS flip, no re-highlighting. Backgrounds stay owned by the token surfaces the code
+ * containers set (`--bg-dark` / transparent), so only the text color is swapped here.
+ */
+[data-theme="light"] .shiki,
+[data-theme="light"] .shiki span {
+	/* biome-ignore lint/complexity/noImportantStyles: shiki writes the token color inline on every span; a
+	   stylesheet rule can only override an inline style with !important. This is shiki's own dual-theme recipe. */
+	color: var(--shiki-light) !important;
 }
 
 a {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -87,14 +87,38 @@
 	--font: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 	--font-mono: "JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code", monospace;
 	--font-accent: "Cabinet Grotesk", sans-serif;
+	/* Terminal ANSI palette (the 16 xterm colors, VS Code Dark+ values) — read by TerminalInstance so
+	   shell output stays legible per theme; a light theme MUST override these (the dark-tuned brights
+	   wash out on white). */
+	--ansi-black: #000000;
+	--ansi-red: #cd3131;
+	--ansi-green: #0dbc79;
+	--ansi-yellow: #e5e510;
+	--ansi-blue: #2472c8;
+	--ansi-magenta: #bc3fbc;
+	--ansi-cyan: #11a8cd;
+	--ansi-white: #e5e5e5;
+	--ansi-bright-black: #666666;
+	--ansi-bright-red: #f14c4c;
+	--ansi-bright-green: #23d18b;
+	--ansi-bright-yellow: #f5f543;
+	--ansi-bright-blue: #3b8eea;
+	--ansi-bright-magenta: #d670d6;
+	--ansi-bright-cyan: #29b8db;
+	--ansi-bright-white: #e5e5e5;
 }
 
 /*
  * Additional themes. Each overrides only the SEMANTIC surface/text/status tokens + `color-scheme` (and the
- * one-off `--selection-bg`); the brand accent tints, type scale, spacing, radii, and fonts stay shared in
- * `:root`. `applyTheme(id)` sets `[data-theme=id]` on <html>; picking "dark" matches neither block below and
- * falls back to the `:root` defaults. Because `@theme inline` binds every utility to the live `var(--token)`,
- * swapping the block re-themes the whole UI with no component changes.
+ * one-off `--selection-bg`, plus `--ansi-*` where the default terminal palette wouldn't read, and optional
+ * `--code-*` syntax colors for Monaco); the brand accent tints, type scale, spacing, radii, and fonts stay
+ * shared in `:root`. `applyTheme(id)` sets `[data-theme=id]` on <html>; picking "dark" matches neither block
+ * below and falls back to the `:root` defaults. Because `@theme inline` binds every utility to the live
+ * `var(--token)`, swapping the block re-themes the whole UI with no component changes.
+ *
+ * Contrast floor: body text ≥ 4.5:1 (WCAG AA) on the surfaces it sits on; `--muted` ≥ 4.5:1 on its
+ * worst surface; `--hint` is tertiary by design but stays ≥ 3:1. Check with a quick script before
+ * changing any text/status value.
  */
 
 /* Light — white editor surface, light tool windows, a deeper on-brand violet for legible white-on-accent. */
@@ -104,11 +128,11 @@
 	/* Deeper violet (the #6B57FF brand violet) so `text-on-accent` (white) passes contrast on light. */
 	--primary: #6b57ff;
 	--secondary: #d6d8e0;
-	/* Status colors darkened for contrast against light surfaces. */
-	--blue: #2f7ed8;
-	--green: #2ea043;
-	--red: #e5484d;
-	--gold: #b6890b;
+	/* Status colors darkened to ≥ 4.5:1 on white — they double as text (diff badges, "M" markers, links). */
+	--blue: #2265cf;
+	--green: #1a7f37;
+	--red: #d02533;
+	--gold: #946300;
 
 	--bg: #f2f3f5;
 	--bg-dark: #ffffff;
@@ -122,7 +146,7 @@
 	--text: #1a1a1e;
 	--text-40: rgba(26, 26, 30, 0.4);
 	--muted: #5a5f6a;
-	--hint: #8a8f99;
+	--hint: #667085;
 	--sel: #cfe0fb;
 	--selection-bg: rgba(107, 87, 255, 0.22);
 	/* Two-tone: light tool windows (sidebar) around the white editor/content. */
@@ -137,6 +161,21 @@
 	--shadow-lg: 0 8px 28px rgba(0, 0, 0, 0.14);
 	--shadow-xl: 0 24px 64px rgba(0, 0, 0, 0.18);
 	--shadow-up: 0 -2px 8px rgba(0, 0, 0, 0.1);
+
+	/* Terminal ANSI palette for light surfaces (VS Code Light+ values) — the dark brights wash out on white. */
+	--ansi-green: #00bc00;
+	--ansi-yellow: #949800;
+	--ansi-blue: #0451a5;
+	--ansi-magenta: #bc05bc;
+	--ansi-cyan: #0598bc;
+	--ansi-white: #555555;
+	--ansi-bright-red: #cd3131;
+	--ansi-bright-green: #14ce14;
+	--ansi-bright-yellow: #b5ba00;
+	--ansi-bright-blue: #0451a5;
+	--ansi-bright-magenta: #bc05bc;
+	--ansi-bright-cyan: #0598bc;
+	--ansi-bright-white: #a5a5a5;
 }
 
 /* Darcula — the famous IntelliJ palette: #3c3f41 tool windows around a #2b2b2b editor, #a9b7c6 foreground,
@@ -155,11 +194,28 @@
 	--border2: #4b4f52;
 	--text: #a9b7c6;
 	--text-40: rgba(169, 183, 198, 0.4);
-	--muted: #808a94;
-	--hint: #6a6f78;
+	/* Muted/hint sit in the Darcula blue-gray family but lifted for the lighter #3c3f41 tool windows
+	   (muted ≥ 4.5:1 there; the originals bottomed out near 3:1). */
+	--muted: #9fabb5;
+	--hint: #8b959e;
 	--sel: #214283;
 	--selection-bg: #214283;
 	/* Two-tone: lighter tool windows (sidebar) around the darker editor (content). */
 	--surface-sidebar: var(--bg);
 	--surface-content: var(--bg-dark);
+
+	/* Darcula's signature syntax palette — Monaco builds its token rules from whichever `--code-*` are
+	   set (unset in other themes → the vs/vs-dark base defaults apply). shiki's copy of this palette
+	   lives in `lib/shikiTheme.ts`. */
+	--code-keyword: #cc7832;
+	--code-string: #6a8759;
+	--code-comment: #808080;
+	--code-comment-doc: #629755;
+	--code-number: #6897bb;
+	--code-regexp: #6a8759;
+	--code-annotation: #bbb529;
+	--code-tag: #e8bf6a;
+	--code-attribute-name: #bababa;
+	--code-attribute-value: #a5c261;
+	--code-json-key: #9876aa;
 }

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -110,11 +110,13 @@
 
 /*
  * Additional themes. Each overrides only the SEMANTIC surface/text/status tokens + `color-scheme` (and the
- * one-off `--selection-bg`, plus `--ansi-*` where the default terminal palette wouldn't read, and optional
- * `--code-*` syntax colors for Monaco); the brand accent tints, type scale, spacing, radii, and fonts stay
- * shared in `:root`. `applyTheme(id)` sets `[data-theme=id]` on <html>; picking "dark" matches neither block
- * below and falls back to the `:root` defaults. Because `@theme inline` binds every utility to the live
- * `var(--token)`, swapping the block re-themes the whole UI with no component changes.
+ * one-off `--selection-bg`, plus `--ansi-*` where the default terminal palette wouldn't read, optional
+ * `--code-*` syntax colors for Monaco, and — when the palette demands it, as gruvbox's does — the accent
+ * family); type scale, spacing, radii, and fonts stay shared in `:root`. `applyTheme(id)` sets
+ * `[data-theme=id]` on <html>; picking "dark" matches no block below and falls back to the `:root`
+ * defaults (which is also what an older client does for a theme id it doesn't know). Because
+ * `@theme inline` binds every utility to the live `var(--token)`, swapping the block re-themes the whole
+ * UI with no component changes.
  *
  * Contrast floor: body text ≥ 4.5:1 (WCAG AA) on the surfaces it sits on; `--muted` ≥ 4.5:1 on its
  * worst surface; `--hint` is tertiary by design but stays ≥ 3:1. Check with a quick script before
@@ -218,4 +220,83 @@
 	--code-attribute-name: #bababa;
 	--code-attribute-value: #a5c261;
 	--code-json-key: #9876aa;
+}
+
+/* Gruvbox — the vim / tiling-WM classic (morhetz's "retro groove"): warm hard-contrast darks (#1d2021
+   editor inside #282828 tool windows), amber #ebdbb2 text — and, uniquely among the themes, the signature
+   GRUVBOX ORANGE as the interactive accent with dark-on-accent text (violet fights this palette; a theme
+   made for rice deserves the real thing). */
+[data-theme="gruvbox"] {
+	color-scheme: dark;
+
+	/* Accent: gruvbox bright orange; text ON the accent is the hard dark (6.5:1), not white (2.2:1). */
+	--primary: #fe8019;
+	--primary-10: rgba(254, 128, 25, 0.1);
+	--primary-20: rgba(254, 128, 25, 0.2);
+	--primary-40: rgba(254, 128, 25, 0.4);
+	--primary-60: rgba(254, 128, 25, 0.6);
+	--primary-80: rgba(254, 128, 25, 0.8);
+	--secondary: #504945;
+	--on-accent: #1d2021;
+	--on-accent-16: rgba(29, 32, 33, 0.16);
+	/* Status: the gruvbox brights — designed as text on these darks (all ≥ 4.5:1 on the editor bg). */
+	--blue: #83a598;
+	--green: #b8bb26;
+	--green-tint: rgba(184, 187, 38, 0.12);
+	--red: #fb4934;
+	--gold: #fabd2f;
+	--gold-tint: rgba(250, 189, 47, 0.12);
+	/* Chat user bubble follows the accent here — a violet bubble would be the one cold thing on screen. */
+	--bubble-user-bg: rgba(254, 128, 25, 0.1);
+	--bubble-user-border: rgba(254, 128, 25, 0.3);
+
+	--bg: #282828;
+	--bg-dark: #1d2021;
+	--bg-input: #3c3836;
+	--input-bg: #3c3836;
+	--panel: rgba(29, 32, 33, 0.8);
+	--elevated: #3c3836;
+	--hover: #504945;
+	--border: #3c3836;
+	--border2: #504945;
+	--text: #ebdbb2;
+	--text-40: rgba(235, 219, 178, 0.4);
+	--muted: #a89984;
+	--hint: #928374;
+	--sel: #504945;
+	--selection-bg: #504945;
+	/* Two-tone: warm tool windows (sidebar) around the hard-contrast editor (content). */
+	--surface-sidebar: var(--bg);
+	--surface-content: var(--bg-dark);
+
+	/* Terminal ANSI: gruvbox's canonical 16-color palette. */
+	--ansi-black: #282828;
+	--ansi-red: #cc241d;
+	--ansi-green: #98971a;
+	--ansi-yellow: #d79921;
+	--ansi-blue: #458588;
+	--ansi-magenta: #b16286;
+	--ansi-cyan: #689d6a;
+	--ansi-white: #a89984;
+	--ansi-bright-black: #928374;
+	--ansi-bright-red: #fb4934;
+	--ansi-bright-green: #b8bb26;
+	--ansi-bright-yellow: #fabd2f;
+	--ansi-bright-blue: #83a598;
+	--ansi-bright-magenta: #d3869b;
+	--ansi-bright-cyan: #8ec07c;
+	--ansi-bright-white: #ebdbb2;
+
+	/* Gruvbox vim syntax (Monaco rules; shiki uses the shipped `gruvbox-dark-hard`). */
+	--code-keyword: #fb4934;
+	--code-string: #b8bb26;
+	--code-comment: #928374;
+	--code-comment-doc: #928374;
+	--code-number: #d3869b;
+	--code-regexp: #fe8019;
+	--code-annotation: #fabd2f;
+	--code-tag: #8ec07c;
+	--code-attribute-name: #fabd2f;
+	--code-attribute-value: #b8bb26;
+	--code-json-key: #83a598;
 }

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -26,6 +26,7 @@
 	--on-accent-16: rgba(255, 255, 255, 0.16);
 	--sunken: rgba(0, 0, 0, 0.12);
 	--overlay: rgba(0, 0, 0, 0.5);
+	--selection-bg: #2c2947;
 	--shadow-xs: 0 1px 3px rgba(0, 0, 0, 0.18);
 	--shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
 	--shadow-md: 0 4px 16px rgba(0, 0, 0, 0.35);
@@ -86,4 +87,79 @@
 	--font: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 	--font-mono: "JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code", monospace;
 	--font-accent: "Cabinet Grotesk", sans-serif;
+}
+
+/*
+ * Additional themes. Each overrides only the SEMANTIC surface/text/status tokens + `color-scheme` (and the
+ * one-off `--selection-bg`); the brand accent tints, type scale, spacing, radii, and fonts stay shared in
+ * `:root`. `applyTheme(id)` sets `[data-theme=id]` on <html>; picking "dark" matches neither block below and
+ * falls back to the `:root` defaults. Because `@theme inline` binds every utility to the live `var(--token)`,
+ * swapping the block re-themes the whole UI with no component changes.
+ */
+
+/* Light — white editor surface, light tool windows, a deeper on-brand violet for legible white-on-accent. */
+[data-theme="light"] {
+	color-scheme: light;
+
+	/* Deeper violet (the #6B57FF brand violet) so `text-on-accent` (white) passes contrast on light. */
+	--primary: #6b57ff;
+	--secondary: #d6d8e0;
+	/* Status colors darkened for contrast against light surfaces. */
+	--blue: #2f7ed8;
+	--green: #2ea043;
+	--red: #e5484d;
+	--gold: #b6890b;
+
+	--bg: #f2f3f5;
+	--bg-dark: #ffffff;
+	--bg-input: #ffffff;
+	--input-bg: #ffffff;
+	--panel: rgba(255, 255, 255, 0.85);
+	--elevated: #ffffff;
+	--hover: #e9eaee;
+	--border: #dcdfe4;
+	--border2: #c7ccd6;
+	--text: #1a1a1e;
+	--text-40: rgba(26, 26, 30, 0.4);
+	--muted: #5a5f6a;
+	--hint: #8a8f99;
+	--sel: #cfe0fb;
+	--selection-bg: rgba(107, 87, 255, 0.22);
+	/* Two-tone: light tool windows (sidebar) around the white editor/content. */
+	--surface-sidebar: var(--bg);
+	--surface-content: var(--bg-dark);
+
+	/* Softer elevation — the dark shadow alphas read as heavy on light. */
+	--sunken: rgba(0, 0, 0, 0.05);
+	--shadow-xs: 0 1px 3px rgba(0, 0, 0, 0.08);
+	--shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.1);
+	--shadow-md: 0 4px 16px rgba(0, 0, 0, 0.12);
+	--shadow-lg: 0 8px 28px rgba(0, 0, 0, 0.14);
+	--shadow-xl: 0 24px 64px rgba(0, 0, 0, 0.18);
+	--shadow-up: 0 -2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Darcula — the famous IntelliJ palette: #3c3f41 tool windows around a #2b2b2b editor, #a9b7c6 foreground,
+   blue selection. ThinkRail's violet stays the interactive accent (per the theme decision). */
+[data-theme="darcula"] {
+	color-scheme: dark;
+
+	--bg: #3c3f41;
+	--bg-dark: #2b2b2b;
+	--bg-input: #45494a;
+	--input-bg: #45494a;
+	--panel: rgba(43, 43, 43, 0.8);
+	--elevated: #3c3f41;
+	--hover: #4c5052;
+	--border: #323232;
+	--border2: #4b4f52;
+	--text: #a9b7c6;
+	--text-40: rgba(169, 183, 198, 0.4);
+	--muted: #808a94;
+	--hint: #6a6f78;
+	--sel: #214283;
+	--selection-bg: #214283;
+	/* Two-tone: lighter tool windows (sidebar) around the darker editor (content). */
+	--surface-sidebar: var(--bg);
+	--surface-content: var(--bg-dark);
 }

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -23,12 +23,15 @@ The single WebSocket client to the host, and its app-wide singleton.
   `pi.event` via `handlePiEvent(event, sessionId)`, `pi.extensionUi` via `applyExtUi(request)`,
   `workspace.created` via `addWorkspace(workspace)`, `workspace.updated` via `updateWorkspace(workspace)`,
   `workspace.removed` via `applyWorkspaceRemoved(projectId, id)`, `workspace.fsChanged` via
-  `noteFsChanged(payload)`; all subscriptions happen once at init, never in component effects);
+  `noteFsChanged(payload)`, and **`settings.changed`** (+ the `config` field in `server.welcome`) via
+  `applyConfig(config)` — the server-synced app config (theme, …), applied on connect + on every broadcast
+  so clients converge; all subscriptions happen once at init, never in component effects);
   `errorText.ts` (**`errorText(err, fallback?)`** — normalizes a rejected `request` (the host's error
   string / a timeout / a thrown non-Error) into a short, display-ready line for an error turn/notice).
 - **Public surface (barrel):** `initTransport`, `getTransport`, `errorText`, `ConnectionStatus`, `TransportOptions`.
 - **Allowed deps:** `contracts` (method maps, `WS_CHANNELS`, `Project` for welcome, `SessionEventPayload`
   for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.created`/`updated`,
-  `WorkspaceRemoved` for `workspace.removed`, `WorkspaceFsChangedPayload` for `workspace.fsChanged`); `store`
+  `WorkspaceRemoved` for `workspace.removed`, `WorkspaceFsChangedPayload` for `workspace.fsChanged`,
+  `AppConfig` for `server.welcome`'s config + `settings.changed`); `store`
   (welcome + event routing — a runtime edge owned by the parent graph); the browser `WebSocket`.
 - **Forbidden:** `server`/`shared`/any `pi` package; importing `panels`/`shell`.

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -1,4 +1,5 @@
 import type {
+	AppConfig,
 	ExtUiRequest,
 	LoginPush,
 	ServerWelcome,
@@ -28,6 +29,11 @@ export function initTransport(): WsTransport {
 		}
 		if (Array.isArray(welcome.projects)) {
 			useAppStore.getState().setProjects(welcome.projects);
+		}
+		// The host's source-of-truth app config (theme, …), applied on connect. Reconciles the pre-React
+		// paint hint; the shell's theme effect performs the DOM swap.
+		if (welcome.config) {
+			useAppStore.getState().applyConfig(welcome.config);
 		}
 	});
 
@@ -61,6 +67,12 @@ export function initTransport(): WsTransport {
 
 	transport.subscribe(WS_CHANNELS.workspaceFsChanged, (data) => {
 		useAppStore.getState().noteFsChanged(data as WorkspaceFsChangedPayload);
+	});
+
+	// A server-synced settings change (theme, …) — every client converges on this broadcast, including the
+	// one that made the change (no optimistic apply).
+	transport.subscribe(WS_CHANNELS.settingsChanged, (data) => {
+		useAppStore.getState().applyConfig(data as AppConfig);
 	});
 
 	transport.connect();

--- a/apps/web/src/utils/theme.ts
+++ b/apps/web/src/utils/theme.ts
@@ -1,0 +1,51 @@
+// The theme swap: sets `data-theme` on <html>, which flips the token block in `styles/tokens.css` (every
+// Tailwind utility resolves to the live `var(--token)`, so nothing in components changes). The host owns
+// the theme (server-synced `AppConfig`); this module only applies it + caches a first-paint hint.
+import { THEME_IDS, Theme, type ThemeId } from "@thinkrail/contracts";
+import { STORAGE_PREFIX } from "../constants/branding";
+
+export const DEFAULT_THEME: ThemeId = Theme.Dark;
+
+const LABELS: Record<ThemeId, string> = {
+	[Theme.Dark]: "Dark",
+	[Theme.Light]: "Light",
+	[Theme.Darcula]: "Darcula",
+};
+
+/** The pickable themes, in display order — the Appearance settings section's source. */
+export const THEMES: { id: ThemeId; label: string }[] = THEME_IDS.map((id) => ({
+	id,
+	label: LABELS[id],
+}));
+
+// A render cache only (NOT the setting store — the host is the source of truth): applied pre-React so the
+// very first paint matches, before `server.welcome` arrives, avoiding a flash of the wrong theme.
+const HINT_KEY = `${STORAGE_PREFIX}theme`;
+
+function isThemeId(v: unknown): v is ThemeId {
+	return typeof v === "string" && (THEME_IDS as readonly string[]).includes(v);
+}
+
+/** Apply a theme by setting `data-theme` on <html>; `color-scheme` rides the CSS token block. */
+export function applyTheme(id: ThemeId): void {
+	document.documentElement.dataset.theme = id;
+}
+
+/** The cached first-paint theme (or the default when unset/invalid/localStorage is unavailable). */
+export function readThemeHint(): ThemeId {
+	try {
+		const v = localStorage.getItem(HINT_KEY);
+		return isThemeId(v) ? v : DEFAULT_THEME;
+	} catch {
+		return DEFAULT_THEME;
+	}
+}
+
+/** Cache the applied theme for the next load's first paint. Best-effort — a storage failure is ignored. */
+export function writeThemeHint(id: ThemeId): void {
+	try {
+		localStorage.setItem(HINT_KEY, id);
+	} catch {
+		return;
+	}
+}

--- a/apps/web/src/utils/theme.ts
+++ b/apps/web/src/utils/theme.ts
@@ -10,6 +10,7 @@ const LABELS: Record<ThemeId, string> = {
 	[Theme.Dark]: "Dark",
 	[Theme.Light]: "Light",
 	[Theme.Darcula]: "Darcula",
+	[Theme.Gruvbox]: "Gruvbox",
 };
 
 /** The pickable themes, in display order — the Appearance settings section's source. */

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -79,6 +79,10 @@ test("Monaco opens files and re-themes under every theme", async ({ page }) => {
 	await expect(editor).toHaveCSS("background-color", "rgb(43, 43, 43)");
 	await expect(page.getByTestId("error-boundary-fallback")).toHaveCount(0);
 
+	await pickTheme(page, "gruvbox");
+	await expect(editor).toHaveCSS("background-color", "rgb(29, 32, 33)");
+	await expect(page.getByTestId("error-boundary-fallback")).toHaveCount(0);
+
 	// Back to Dark — also restores the suite's default state for the other specs.
 	await pickTheme(page, "dark");
 	await expect(editor).toHaveCSS("background-color", "rgb(23, 23, 25)");

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 
 // The Appearance settings section: the theme picker. Themes are SERVER-SYNCED (config.json on the host,
 // delivered in server.welcome), so a pick survives a reload. This test leaves the host back on Dark so the
@@ -42,4 +43,44 @@ test("appearance section switches the theme and persists it across a reload", as
 	await page.getByTestId("settings-nav-appearance").click();
 	await page.getByTestId("theme-option-dark").click();
 	await expect(html).toHaveAttribute("data-theme", "dark");
+});
+
+async function pickTheme(page: Page, theme: string): Promise<void> {
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-appearance").click();
+	await page.getByTestId(`theme-option-${theme}`).click();
+	await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+	await page.keyboard.press("Escape");
+	await expect(page.getByTestId("settings-dialog")).toBeHidden();
+}
+
+// Monaco rebuilds its theme from the CSS tokens — and the BUILT stylesheet is minified, so a token can
+// come back as short hex (`#ffffff` → `#fff`), which Monaco rejects. This suite runs against the built
+// app, so opening a real file under each theme guards that whole token → Monaco path: an unopenable file
+// (the editor ErrorBoundary) or an editor that silently keeps the previous palette both fail here.
+test("Monaco opens files and re-themes under every theme", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+
+	// Mount the editor UNDER Light — the regression case: `--surface-content` resolves to `#fff` from
+	// minified CSS, which used to throw in defineTheme and crash the panel before first paint.
+	await pickTheme(page, "light");
+	await page.getByTestId("tab-files").click();
+	const notes = page.getByTestId("file-node").filter({ hasText: "notes.txt" });
+	await expect(notes).toBeVisible();
+	await notes.dblclick();
+	await expect(page.getByTestId("editor-pane")).toContainText("plain-text-fixture");
+	await expect(page.getByTestId("error-boundary-fallback")).toHaveCount(0);
+	const editor = page.locator(".monaco-editor").first();
+	await expect(editor).toHaveCSS("background-color", "rgb(255, 255, 255)");
+
+	// Swap with the editor open — the data-theme observer must redefine + reapply, not keep the old palette.
+	await pickTheme(page, "darcula");
+	await expect(editor).toHaveCSS("background-color", "rgb(43, 43, 43)");
+	await expect(page.getByTestId("error-boundary-fallback")).toHaveCount(0);
+
+	// Back to Dark — also restores the suite's default state for the other specs.
+	await pickTheme(page, "dark");
+	await expect(editor).toHaveCSS("background-color", "rgb(23, 23, 25)");
+	await expect(page.getByTestId("editor-pane")).toContainText("plain-text-fixture");
 });

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+// The Appearance settings section: the theme picker. Themes are SERVER-SYNCED (config.json on the host,
+// delivered in server.welcome), so a pick survives a reload. This test leaves the host back on Dark so the
+// shared e2e data dir stays in its default state for other specs.
+test("appearance section switches the theme and persists it across a reload", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+
+	const html = page.locator("html");
+	// Fresh data dir → DEFAULT_CONFIG → Dark.
+	await expect(html).toHaveAttribute("data-theme", "dark");
+
+	await page.getByTestId("open-settings").click();
+	const dialog = page.getByTestId("settings-dialog");
+	await expect(dialog).toBeVisible();
+	await page.getByTestId("settings-nav-appearance").click();
+	await expect(dialog).toContainText("Theme");
+
+	// Dark is the active option to start.
+	await expect(page.getByTestId("theme-option-dark")).toHaveAttribute("data-active", "true");
+
+	// Pick Light → the swap applies (converged on the settings.changed broadcast) and the option marks active.
+	await page.getByTestId("theme-option-light").click();
+	await expect(html).toHaveAttribute("data-theme", "light");
+	await expect(page.getByTestId("theme-option-light")).toHaveAttribute("data-active", "true");
+
+	// Pick Darcula → applies live too.
+	await page.getByTestId("theme-option-darcula").click();
+	await expect(html).toHaveAttribute("data-theme", "darcula");
+
+	await page.keyboard.press("Escape");
+	await expect(dialog).toBeHidden();
+
+	// Server-synced: a reload comes back on Darcula (from server.welcome's config, not a fresh default).
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(html).toHaveAttribute("data-theme", "darcula");
+
+	// Leave the host back on Dark so the shared data dir stays default for the other specs.
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-appearance").click();
+	await page.getByTestId("theme-option-dark").click();
+	await expect(html).toHaveAttribute("data-theme", "dark");
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -11,15 +11,17 @@ tags: [v1, wire]
 ## Responsibility
 
 The browser↔host wire spine: the single source of truth for the protocol. Types-only, with the only
-runtime exports being the WS method/channel constants and the protocol version. The one package
-`apps/web` may depend on — which is what lets the UI ship independently of the host.
+runtime exports being the WS method/channel constants, the protocol version, and the small theme/config
+value-sets (`Theme` / `THEME_IDS` / `DEFAULT_CONFIG`). The one package `apps/web` may depend on — which is
+what lets the UI ship independently of the host.
 
 ## Boundary
 
 - **Owns:** the wire — entity types, the `pi` event/message types (re-exported), the WS method & channel
   registries, and the protocol version.
-- **Public surface (`index.ts`):** `export type *` of `piProtocol` + `domain`; `export *` (value) of
-  `wsProtocol` (`WS_METHODS`, `WS_CHANNELS`, the typed maps, `PROTOCOL_VERSION`).
+- **Public surface (`index.ts`):** `export type *` of `piProtocol` + `domain`; the value re-exports
+  `Theme` / `THEME_IDS` / `DEFAULT_CONFIG` from `domain`; `export *` (value) of `wsProtocol`
+  (`WS_METHODS`, `WS_CHANNELS`, the typed maps, `PROTOCOL_VERSION`).
 - **Allowed deps:** none at runtime. **Type-only** devDeps on `@earendil-works/pi-ai` +
   `@earendil-works/pi-agent-core`, imported **from their package roots** (type-only → erased at build).
 - **Forbidden:** any *value* import of a `pi` package; **any** import (even `type`) of
@@ -86,6 +88,10 @@ runtime exports being the WS method/channel constants and the protocol version. 
   **`JbcentralConnectResult`** (the in-app connect state machine: `connected` / `needs-install` /
   `needs-login` / `error` (+`message`); the `needs-install` command comes from `jbcentralInstall`, not a
   hint on this result));
+  the **theme/config value-set** — **`Theme`** (a const-object "enum": `Dark`/`Light`/`Darcula`), its derived
+  **`ThemeId`** type + runtime-iterable **`THEME_IDS`** (the picker source), and the server-synced
+  **`AppConfig`** (`{ theme }` — an extensible bag) with its **`DEFAULT_CONFIG`** fallback (persisted host-side
+  as `config.json`, delivered in `server.welcome`, mutated via `settings.update`);
   **`SpecGraphNode`/`SpecGraphSnapshot`** — the
   Specs-viewer read DTOs, **mirrored** (like `PiEvent`), never imported from `pi-spec-graph` — the wire
   carries only what the panel renders (`type`/`status` stay `string`: tolerate whatever is on disk).
@@ -103,8 +109,10 @@ runtime exports being the WS method/channel constants and the protocol version. 
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
-  read side)), `WS_CHANNELS` (`server.welcome` /
-  `pi.event` / `pi.extensionUi` / **`provider.login`** — the session-less in-app login stream (a `LoginPush`
+  read side) / **`settings.update`** (merge + persist a partial `AppConfig`, returns the merged config)),
+  `WS_CHANNELS` (`server.welcome` — which carries the initial `config: AppConfig` alongside `projects` /
+  `pi.event` / `pi.extensionUi` / **`settings.changed`** (the full `AppConfig`, broadcast so every client
+  converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`
   per frame, keyed by `loginId`; the sibling of `pi.extensionUi`, since a login runs on the Welcome screen
   before any session exists) / `terminal.data` / the **workspace lifecycle trio** — **`workspace.created`**
   / **`workspace.updated`** / **`workspace.removed`** — registry membership changes fanned out to every

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -88,7 +88,8 @@ what lets the UI ship independently of the host.
   **`JbcentralConnectResult`** (the in-app connect state machine: `connected` / `needs-install` /
   `needs-login` / `error` (+`message`); the `needs-install` command comes from `jbcentralInstall`, not a
   hint on this result));
-  the **theme/config value-set** — **`Theme`** (a const-object "enum": `Dark`/`Light`/`Darcula`), its derived
+  the **theme/config value-set** — **`Theme`** (a const-object "enum": `Dark`/`Light`/`Darcula`/`Gruvbox`;
+  adding a value is wire-compatible — an older client falls back to Dark's `:root` tokens), its derived
   **`ThemeId`** type + runtime-iterable **`THEME_IDS`** (the picker source), and the server-synced
   **`AppConfig`** (`{ theme }` — an extensible bag) with its **`DEFAULT_CONFIG`** fallback (persisted host-side
   as `config.json`, delivered in `server.welcome`, mutated via `settings.update`);

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -231,12 +231,15 @@ export interface GithubAuthStatus {
  * The selectable UI themes. A const-object "enum" (the codebase's `WS_METHODS`/`WS_CHANNELS` convention):
  * enum ergonomics (`Theme.Dark`) + a runtime-iterable value list (`THEME_IDS`, the picker source), while the
  * values stay plain strings so they cross JSON/the wire with no casts. `Dark` is the default ThinkRail dark;
- * `Light` and `Darcula` (classic IntelliJ surfaces, ThinkRail violet accent) are the additions.
+ * `Light`, `Darcula` (classic IntelliJ surfaces, ThinkRail violet accent), and `Gruvbox` (the vim classic —
+ * warm retro darks, orange accent) are the additions. A client that doesn't know a theme id falls back to
+ * Dark's `:root` tokens, so adding a value here is wire-compatible.
  */
 export const Theme = {
 	Dark: "dark",
 	Light: "light",
 	Darcula: "darcula",
+	Gruvbox: "gruvbox",
 } as const;
 export type ThemeId = (typeof Theme)[keyof typeof Theme];
 export const THEME_IDS: readonly ThemeId[] = Object.values(Theme);

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -226,3 +226,29 @@ export interface GithubAuthStatus {
 	/** The token's OAuth scopes, when reported by `gh auth status`. */
 	scopes?: string[];
 }
+
+/**
+ * The selectable UI themes. A const-object "enum" (the codebase's `WS_METHODS`/`WS_CHANNELS` convention):
+ * enum ergonomics (`Theme.Dark`) + a runtime-iterable value list (`THEME_IDS`, the picker source), while the
+ * values stay plain strings so they cross JSON/the wire with no casts. `Dark` is the default ThinkRail dark;
+ * `Light` and `Darcula` (classic IntelliJ surfaces, ThinkRail violet accent) are the additions.
+ */
+export const Theme = {
+	Dark: "dark",
+	Light: "light",
+	Darcula: "darcula",
+} as const;
+export type ThemeId = (typeof Theme)[keyof typeof Theme];
+export const THEME_IDS: readonly ThemeId[] = Object.values(Theme);
+
+/**
+ * Server-synced app settings — OUR config, persisted host-side as `config.json` under the data dir and
+ * delivered to every client in `server.welcome`. A small, extensible bag (theme is the first member);
+ * mutate a subset via `settings.update`, converge on the `settings.changed` broadcast.
+ */
+export interface AppConfig {
+	theme: ThemeId;
+}
+
+/** The config a fresh host (no `config.json` yet) falls back to. */
+export const DEFAULT_CONFIG: AppConfig = { theme: Theme.Dark };

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,7 @@
-// The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol).
+// The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol) and
+// the theme/config value-sets (domain: `Theme`, `THEME_IDS`, `DEFAULT_CONFIG`).
 
 export type * from "./domain";
+export { DEFAULT_CONFIG, THEME_IDS, Theme } from "./domain";
 export type * from "./piProtocol";
 export * from "./wsProtocol";

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -1,6 +1,7 @@
 // The browser↔host API — ours, not pi's. Methods are request/response; channels are server→client push.
 
 import type {
+	AppConfig,
 	BranchList,
 	DiffStats,
 	FileNode,
@@ -33,7 +34,10 @@ import type {
 // join the existing `workspace.updated` (the workspace lifecycle trio; see `WS_CHANNELS`).
 // v6: the worktree change notifier — `workspace.fsChanged` streams debounced fs-invalidation nudges so
 // clients re-read files/specs/git state instead of polling.
-export const PROTOCOL_VERSION = 6;
+// v7: server-synced app settings — `server.welcome` now carries `config: AppConfig` (the initial theme
+// travels with the handshake), `settings.update` persists a partial, and `settings.changed` broadcasts
+// the new config to every client so they converge (the same shared-state pattern as the workspace trio).
+export const PROTOCOL_VERSION = 7;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -44,6 +48,8 @@ export interface ServerWelcome {
 	protocolVersion: number;
 	appVersion?: string;
 	projects: Project[];
+	/** The server-synced app settings (theme, …) — applied on connect so the initial paint matches. */
+	config: AppConfig;
 }
 
 /**
@@ -128,6 +134,9 @@ export const WS_METHODS = {
 	providerJbcentralConnect: "provider.jbcentralConnect",
 	providerJbcentralDisconnect: "provider.jbcentralDisconnect",
 	providerJbcentralLogin: "provider.jbcentralLogin",
+	// Persist a partial change to the server-synced app settings (e.g. the theme). The host merges, saves
+	// `config.json`, and broadcasts `settings.changed` — the caller converges on that push, not optimism.
+	settingsUpdate: "settings.update",
 } as const;
 
 /** Server→client push channels. */
@@ -151,6 +160,9 @@ export const WS_CHANNELS = {
 	// The worktree change notifier (a `WorkspaceFsChangedPayload` per frame), broadcast to every client.
 	// A debounced invalidation nudge, not data — receivers re-read via the read methods they already use.
 	workspaceFsChanged: "workspace.fsChanged",
+	// The server-synced app settings changed (carries the full `AppConfig`), broadcast to every client so
+	// they converge — the initiator applies on this push too, never optimistically.
+	settingsChanged: "settings.changed",
 } as const;
 
 export type WsMethod = (typeof WS_METHODS)[keyof typeof WS_METHODS];
@@ -261,6 +273,9 @@ export interface WsMethodMap {
 	"provider.jbcentralDisconnect": { params: Record<string, never>; result: Ack };
 	// Launch `jbcentral login` (its browser sign-in) on the host, best-effort.
 	"provider.jbcentralLogin": { params: Record<string, never>; result: { launched: boolean } };
+	// Merge a partial into the server-synced app settings, persist it, and broadcast `settings.changed`.
+	// Returns the merged, persisted `AppConfig`.
+	"settings.update": { params: { config: Partial<AppConfig> }; result: AppConfig };
 }
 
 export type WsMethodName = keyof WsMethodMap;

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -43,7 +43,8 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | module | owns | spec |
 | --- | --- | --- |
 | `host` | `Bun.serve` HTTP+WS, static SPA, the WS dispatch registry, channel publish | [host/SPEC.md](src/host/SPEC.md) |
-| `persistence` | JSON app state under the data dir (projects + workspaces) | [persistence/SPEC.md](src/persistence/SPEC.md) |
+| `persistence` | JSON app state under the data dir (projects + workspaces + app config) | [persistence/SPEC.md](src/persistence/SPEC.md) |
+| `settings` | the server-synced app config (theme, …): read/merge/persist + broadcast seam | [settings/SPEC.md](src/settings/SPEC.md) |
 | `projects` | open/list/close git repos as projects (validate, dedupe, slug) | [projects/SPEC.md](src/projects/SPEC.md) |
 | `workspaces` | workspaces = `git worktree`s on their own branch | [workspaces/SPEC.md](src/workspaces/SPEC.md) |
 | `git` | the `git(cwd, args)` runner + worktree status/diff vs base + branch list | [git/SPEC.md](src/git/SPEC.md) |
@@ -64,10 +65,10 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`
+- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`
 - `workspaces` → `projects`, `git`, `persistence`
 - `projects` → `git` (shared runner), `persistence`
-- `git`, `fs`, `spec`, `watch`, `terminal` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
+- `git`, `fs`, `spec`, `watch`, `terminal`, `settings` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
 - `assist` → `agent` (the one-shot completion primitive)
 - `auth` → `agent` (`getPiRuntime` — the shared `AuthStorage` + `ModelRegistry`; one-way, `agent` never imports `auth`)
 - `agent` → (no internal deps — only the pi runtime)
@@ -76,9 +77,9 @@ the host from env via `bootHost` for dev/e2e.
 Rules: features never import `host`, and never each other except the edges above. The graph is acyclic.
 `agent`'s WS surface (`session.*` + `pi.event` forwarding) attaches to `host`. Features that push on their
 own never import `host` either: they expose a **publisher-injection seam** (`setTerminalPublisher`,
-`setSessionPublisher`, `setLoginPublisher`, and `workspaces`' `setWorkspacePublisher` for the
-`workspace.created`/`updated`/`removed` lifecycle trio) that `host` installs at `createServer` — so the
-channel wiring lives only in `host`.
+`setSessionPublisher`, `setLoginPublisher`, `workspaces`' `setWorkspacePublisher` for the
+`workspace.created`/`updated`/`removed` lifecycle trio, and `settings`' `setSettingsPublisher` for
+`settings.changed`) that `host` installs at `createServer` — so the channel wiring lives only in `host`.
 
 ## Get right
 

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -1,4 +1,5 @@
 import type {
+	AppConfig,
 	AskUserQuestionResult,
 	ExtUiResponse,
 	ImageContent,
@@ -50,6 +51,7 @@ import {
 	listProjects,
 	openProject,
 } from "../projects";
+import { updateConfig } from "../settings";
 import { evictSpecIndex, projectHasSpecs, specGraph } from "../spec";
 import {
 	closeTerminal,
@@ -283,6 +285,9 @@ const handlers: Record<string, Handler> = {
 		return { ok: true } as const;
 	},
 	"provider.jbcentralLogin": () => jbcentralLogin(),
+	// Merge + persist a partial into the server-synced app config (theme, …); the broadcast is fired by
+	// `updateConfig`'s injected publisher (wired in `createServer`), so every client converges.
+	"settings.update": (params) => updateConfig((params as { config: Partial<AppConfig> }).config),
 };
 
 /** Route a WS request to its handler. Throws on unknown method (→ a `{ ok:false }` WS response). */

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -10,6 +10,7 @@ import {
 import { cancelAllLogins, setLoginPublisher } from "../auth";
 import { resolveWorktreeFile } from "../fs";
 import { listProjects, openProject } from "../projects";
+import { getConfig, setSettingsPublisher } from "../settings";
 import { closeAllTerminals, setTerminalPublisher } from "../terminal";
 import { setWatchPublisher, stopAllWatches } from "../watch";
 import { setWorkspacePublisher } from "../workspaces";
@@ -70,9 +71,11 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				ws.subscribe(WS_CHANNELS.workspaceUpdated);
 				ws.subscribe(WS_CHANNELS.workspaceRemoved);
 				ws.subscribe(WS_CHANNELS.workspaceFsChanged);
+				ws.subscribe(WS_CHANNELS.settingsChanged);
 				const welcome: ServerWelcome = {
 					protocolVersion: PROTOCOL_VERSION,
 					projects: listProjects(),
+					config: getConfig(),
 					...(appVersion ? { appVersion } : {}),
 				};
 				ws.send(JSON.stringify({ channel: WS_CHANNELS.serverWelcome, data: welcome }));
@@ -125,6 +128,15 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		server.publish(
 			WS_CHANNELS.workspaceFsChanged,
 			JSON.stringify({ channel: WS_CHANNELS.workspaceFsChanged, data: payload }),
+		);
+	});
+
+	// Broadcast a server-synced settings change (the full `AppConfig`) to every client so they converge —
+	// the initiator applies on this push too, never optimistically (the workspace-lifecycle pattern).
+	setSettingsPublisher((config) => {
+		server.publish(
+			WS_CHANNELS.settingsChanged,
+			JSON.stringify({ channel: WS_CHANNELS.settingsChanged, data: config }),
 		);
 	});
 

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -10,12 +10,16 @@ tags: [v1]
 
 ## Responsibility
 
-Durable app state — projects and workspaces — as JSON under the data dir.
+Durable app state — projects, workspaces, and the server-synced app config — as JSON under the data dir.
 
 ## Boundary
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
-  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces` (tab-indented JSON).
-- **Public surface (barrel):** `dataDir`, `loadProjects`, `saveProjects`, `loadWorkspaces`, `saveWorkspaces`.
-- **Allowed deps:** `contracts` (`Project`/`Workspace` types); Node `fs`/`os`/`path`.
+  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, and `loadConfig`/`saveConfig`
+  (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly) — all
+  tab-indented JSON.
+- **Public surface (barrel):** `dataDir`, `loadProjects`, `saveProjects`, `loadWorkspaces`,
+  `saveWorkspaces`, `loadConfig`, `saveConfig`.
+- **Allowed deps:** `contracts` (`Project`/`Workspace`/`AppConfig` types + `DEFAULT_CONFIG`); Node
+  `fs`/`os`/`path`.
 - **Forbidden:** importing any sibling module or `host` — this is a leaf others depend on.

--- a/packages/server/src/persistence/index.ts
+++ b/packages/server/src/persistence/index.ts
@@ -1,2 +1,2 @@
-/** JSON app state under `~/.thinkrail` (or `THINKRAIL_DATA_DIR`): projects + workspaces. */
+/** JSON app state under `~/.thinkrail` (or `THINKRAIL_DATA_DIR`): projects + workspaces + app config. */
 export * from "./persistence";

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -3,7 +3,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { Project, Workspace } from "@thinkrail/contracts";
+import { type AppConfig, DEFAULT_CONFIG, type Project, type Workspace } from "@thinkrail/contracts";
 
 export function dataDir(): string {
 	return process.env.THINKRAIL_DATA_DIR ?? join(homedir(), ".thinkrail");
@@ -36,4 +36,13 @@ export function loadWorkspaces(): Workspace[] {
 
 export function saveWorkspaces(workspaces: Workspace[]): void {
 	writeJson("workspaces.json", workspaces);
+}
+
+/** OUR server-synced app settings. Missing/corrupt file, or missing keys, fall back to `DEFAULT_CONFIG`. */
+export function loadConfig(): AppConfig {
+	return { ...DEFAULT_CONFIG, ...readJson<Partial<AppConfig>>("config.json", {}) };
+}
+
+export function saveConfig(config: AppConfig): void {
+	writeJson("config.json", config);
 }

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -1,0 +1,31 @@
+---
+id: submodule-server-settings
+type: submodule-design
+status: active
+title: settings — server-synced app config
+parent: module-server
+depends-on: [module-contracts]
+tags: [v1]
+---
+
+## Responsibility
+
+The server-synced app config — OUR settings (theme today), an extensible `AppConfig` bag. Reads/merges/
+persists it and fans changes out to every client, so a preference set on one client follows the user to
+the others (architecture #9: shared domain state).
+
+## Boundary
+
+- **Owns:** the cached current `AppConfig` (lazy-loaded, so the per-connect `getConfig()` for
+  `server.welcome` doesn't hit disk each time); `getConfig()`, `updateConfig(partial)` (merge → persist →
+  broadcast), the `setSettingsPublisher` seam, and `resetConfigCache()` (the e2e reset).
+- **Public surface (barrel):** `getConfig`, `updateConfig`, `setSettingsPublisher`, `resetConfigCache`.
+- **Allowed deps:** `persistence` (`loadConfig`/`saveConfig`), `contracts` (`AppConfig`).
+- **Forbidden:** importing `host` or any other sibling; owning WS channels — it emits a domain value
+  through the injected publisher; `host` maps it onto `settings.changed`.
+
+## Get right
+
+- **Converge on the broadcast, no per-client optimism.** `updateConfig` persists then publishes; the
+  initiating client applies on the `settings.changed` push like everyone else (the workspace-lifecycle
+  pattern). `getConfig()` is the same value `server.welcome` seeds on connect.

--- a/packages/server/src/settings/index.ts
+++ b/packages/server/src/settings/index.ts
@@ -1,0 +1,2 @@
+/** The server-synced app config (theme, …): read/merge/persist + the `settings.changed` publisher seam. */
+export * from "./settings";

--- a/packages/server/src/settings/settings.test.ts
+++ b/packages/server/src/settings/settings.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG, Theme } from "@thinkrail/contracts";
+import { getConfig, resetConfigCache, setSettingsPublisher, updateConfig } from "./settings";
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-settings-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	resetConfigCache(); // never carry a prior test's cache into this fresh data dir
+});
+
+afterEach(() => {
+	setSettingsPublisher(null); // never leak a test's publisher into the next
+	resetConfigCache();
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("getConfig falls back to DEFAULT_CONFIG when no config.json exists", () => {
+	expect(getConfig()).toEqual(DEFAULT_CONFIG);
+});
+
+test("updateConfig merges, persists to config.json, and returns the merged config", () => {
+	const next = updateConfig({ theme: Theme.Darcula });
+	expect(next.theme).toBe(Theme.Darcula);
+	// Persisted to disk.
+	const onDisk = JSON.parse(readFileSync(join(dataDir, "config.json"), "utf8"));
+	expect(onDisk.theme).toBe(Theme.Darcula);
+	// Cached: a re-read reflects it without touching disk again.
+	expect(getConfig().theme).toBe(Theme.Darcula);
+});
+
+test("updateConfig broadcasts the new config through the injected publisher", () => {
+	const seen: string[] = [];
+	setSettingsPublisher((c) => seen.push(c.theme));
+	updateConfig({ theme: Theme.Light });
+	expect(seen).toEqual([Theme.Light]);
+});
+
+test("a null publisher makes updates silent no-ops (still persisted)", () => {
+	setSettingsPublisher(null);
+	expect(() => updateConfig({ theme: Theme.Light })).not.toThrow();
+	expect(existsSync(join(dataDir, "config.json"))).toBe(true);
+});
+
+test("loadConfig degrades a partial/corrupt file over DEFAULT_CONFIG", () => {
+	writeFileSync(join(dataDir, "config.json"), "{ not json");
+	resetConfigCache();
+	expect(getConfig()).toEqual(DEFAULT_CONFIG);
+});

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -1,0 +1,39 @@
+// The server-synced app config (OUR settings, not the agent's) — theme today, an extensible bag. Reads
+// `config.json` via `persistence`, merges a partial on update, and fans the new config out through an
+// injected publisher (the same inversion `workspaces`/`terminal`/`agent`/`auth` use), so the WS-channel
+// wiring stays in `host`.
+import type { AppConfig } from "@thinkrail/contracts";
+import { loadConfig, saveConfig } from "../persistence";
+
+type SettingsPublisher = (config: AppConfig) => void;
+
+// Injected by the host; `null` in unit tests / the e2e reset → the broadcast is a silent no-op.
+let publishSettings: SettingsPublisher | null = null;
+
+/** Install (or clear with `null`) the sink `settings.changed` is fanned out through. */
+export function setSettingsPublisher(fn: SettingsPublisher | null): void {
+	publishSettings = fn;
+}
+
+// Lazily loaded + cached, so `getConfig()` (called for every `server.welcome`) doesn't hit disk each time.
+let cached: AppConfig | null = null;
+
+/** The current app config (cached; loaded from `config.json` on first read, merged over `DEFAULT_CONFIG`). */
+export function getConfig(): AppConfig {
+	cached ??= loadConfig();
+	return cached;
+}
+
+/** Merge a partial into the config, persist it, broadcast the new config, and return it. */
+export function updateConfig(partial: Partial<AppConfig>): AppConfig {
+	const next: AppConfig = { ...getConfig(), ...partial };
+	cached = next;
+	saveConfig(next);
+	publishSettings?.(next);
+	return next;
+}
+
+/** Drop the in-memory cache — the e2e reset seam, so a fresh data dir isn't shadowed by a stale config. */
+export function resetConfigCache(): void {
+	cached = null;
+}


### PR DESCRIPTION
## What

Adds user-selectable UI themes, chosen in **Settings → Appearance** and **persisted host-side** so the choice follows the user across devices/browsers dialing the same host.

- **Dark** — the existing ThinkRail dark (default, unchanged for current users)
- **Light** — new
- **Darcula** — the classic IntelliJ palette (`#3c3f41` tool windows around a `#2b2b2b` editor, `#a9b7c6` foreground, blue selection, authentic syntax colors in Monaco + shiki) with ThinkRail's violet kept as the interactive accent
- **Gruvbox** — the vim / tiling-WM classic (morhetz's "retro groove"): `#1d2021` editor inside `#282828` tool windows, amber `#ebdbb2` text, the canonical gruvbox 16-color terminal palette, gruvbox vim syntax colors — and, uniquely, the signature **gruvbox orange as the interactive accent** with dark-on-accent text (violet fights this palette)

## Screenshots

<!-- 2 per theme: *-1-ide (editor + diff + terminal) and *-2-settings (Appearance picker) -->

## How

**Settings persistence (new)** — a `config.json` under `~/.thinkrail`, following the `projects.json`/`workspaces.json` pattern:
- `contracts`: `Theme` const-object enum + `ThemeId`/`THEME_IDS`, `AppConfig`, `DEFAULT_CONFIG` (plain-string values → cross JSON/the wire with no casts; adding a theme id is wire-compatible — an older client falls back to Dark's `:root` tokens)
- `persistence`: `loadConfig`/`saveConfig`
- new **`settings` host module**: `getConfig`/`updateConfig` + a publisher seam
- wire (**PROTOCOL_VERSION 6→7**): `server.welcome` carries `config`, `settings.update` persists a partial, `settings.changed` broadcasts the merged config so every client converges (same no-per-client-optimism pattern as the workspace lifecycle)

**Theme mechanism (web)** — the `[data-theme]` swap the spec already described:
- `tokens.css` gains per-theme blocks overriding the semantic surface/text/status tokens + `color-scheme` (plus, where a theme calls for it, the accent family); `@theme inline` re-themes every utility for free
- the token vocabulary carries the code surfaces too: **`--ansi-*`** (the 16 xterm colors — Light and Gruvbox ship their own palettes; dark-tuned brights wash out on white) and optional **`--code-*`** syntax colors (Darcula + Gruvbox set them; other themes get the Monaco base palette)
- `utils/theme.applyTheme` + a **localStorage first-paint hint** (avoids a flash before `server.welcome`; the host stays the source of truth), `store.theme` fed by transport, and the Shell owns the single DOM effect
- new **Appearance** settings section with the theme picker

**Code surfaces track the swap:** Monaco picks `vs`/`vs-dark`, observes `data-theme`, and rebuilds chrome + syntax rules from the tokens; shiki renders all palettes in one pass (dark/light/darcula/gruvbox — darcula is a custom registration in `lib/shikiTheme.ts`, gruvbox is shiki-shipped) flipped by pure-CSS `[data-theme]` rules, no re-highlighting; xterm rebuilds its theme incl. the ANSI palette on the same observer; mermaid already followed the tokens.

## Hardening (found by a UX/theme review of the first cut)

- **Minified-CSS token reads**: the built CSS serves colors in any equivalent form (`#ffffff`→`#fff`, `#808080`→`gray`), which Monaco/xterm reject — under Light this crashed the editor panel on any file open. All JS token reads now go through **`lib.cssColorToHex`** (canvas-canonicalized; unparseable → treated as unset), and Monaco's define degrades to the base palette instead of throwing. Regression-covered by e2e against the *built* bundle.
- **Contrast floors** (documented in `tokens.css`): body ≥ 4.5:1, `--muted` ≥ 4.5:1 on its worst resting surface, `--hint` ≥ 3:1. Darcula's muted/hint were lifted (3.0 → 4.5:1 on the `#3c3f41` sidebar); Light's hint + status colors darkened to ≥ 4.5:1 as text on white (they double as diff badges / "M" markers / links).
- **Terminal legibility**: xterm's dark-tuned default ANSI colors washed out on Light — the 16 slots are now themed per palette.

## Design note

The localStorage paint-hint is a **render cache only** — the host's `config.json` remains the source of truth for the server-synced setting.

## Tests / verification

- `typecheck` ✅ · `lint` ✅ · `check:deps` ✅ (husky pre-commit)
- unit: `settings` module tests, store `applyConfig`, `cssColorToHex` (full suite green)
- **e2e no-agent suite: 44/44 ✅**, incl. `e2e/theme.spec.ts`: switch + persist across reload, and **open a real file under every theme against the built (minified) CSS**, asserting Monaco actually re-themes (Light `#ffffff` → Darcula `#2b2b2b` → Gruvbox `#1d2021` → Dark) with no editor ErrorBoundary
- every palette verified live in the running app (measured rendered colors: Darcula `#cc7832` keywords / Gruvbox `#fb4934` keywords / shiki `--shiki-*` flips)

## SPECs

Updated across `contracts`, `persistence`, new `settings/SPEC.md`, `server`, `module-web` (styling & theming incl. the token vocabulary + contrast floors), `store`, `transport`, `panels` (code-surface re-theming), `lib`, `shell` — spec-graph validates clean.
