### PR TITLE
feat(chat): ask_user_question survives host restarts — ack + terminate redesign

### DIFF
--- a/apps/web/src/chat/ChatActions.tsx
+++ b/apps/web/src/chat/ChatActions.tsx
@@ -3,15 +3,16 @@ import { createContext, useContext } from "react";
 
 /**
  * The interaction seam for chat tool renderers that need to talk BACK to the agent (e.g. the inline
- * `ask_user_question` card answering a blocked tool call). Presentational renderers stay store/transport
+ * `ask_user_question` card sending its reply). Presentational renderers stay store/transport
  * free — they read these callbacks from context instead. `ChatView` (the app-integration layer) provides
  * the value, wired to the transport + this tab's `sessionId`; when no provider is present (a renderer used
  * standalone, e.g. an extracted `packages/chat-ui`), the context is `null` and the card renders read-only.
  */
 export interface ChatActions {
 	/**
-	 * Answer a blocked `ask_user_question` tool call, correlated by its tool call id. Rejects when the host
-	 * refuses the reply (unknown session, malformed result) so the card can un-latch its "sent" state.
+	 * Answer an awaiting `ask_user_question` questionnaire, correlated by its tool call id — the host
+	 * injects the reply as the next turn's `ask-user-answers` message. Rejects when the host refuses it
+	 * (unknown session/call, already answered, superseded) so the card can un-latch its "sent" state.
 	 */
 	answerQuestion: (toolCallId: string, result: AskUserQuestionResult) => Promise<void>;
 }

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { EMPTY_RUNTIME, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
+import { AskStatesContext, deriveAskStates } from "./askState";
 import { type ChatActions, ChatActionsContext } from "./ChatActions";
 import { ChatHeader } from "./ChatHeader";
 import { Composer, type MentionCandidate, type SubmitBehavior } from "./Composer";
@@ -205,9 +206,16 @@ export default function ChatView({
 		[workspaceId],
 	);
 
+	// The questionnaire cards' transcript-derived lifecycle (awaiting / answered / superseded) — provided
+	// as context so the presentational card stays store-free (see askState.ts).
+	const askStates = useMemo(
+		() => deriveAskStates(runtime.turns, runtime.askAnswers),
+		[runtime.turns, runtime.askAnswers],
+	);
+
 	// Interactive tool renderers reach the agent through this context (kept out of the presentational
-	// renderers). Currently: the inline `ask_user_question` card answering its blocked tool call. The
-	// promise is handed to the caller — the card owns the failure UX (it un-latches its "sent" state).
+	// renderers). Currently: the inline `ask_user_question` card sending its reply. The promise is handed
+	// to the caller — the card owns the failure UX (it un-latches its "sent" state).
 	const chatActions = useMemo<ChatActions>(
 		() => ({
 			answerQuestion: (toolCallId: string, result: AskUserQuestionResult) =>
@@ -231,72 +239,74 @@ export default function ChatView({
 
 	return (
 		<ChatActionsContext.Provider value={chatActions}>
-			<div className="flex h-full min-h-0 flex-col bg-bg">
-				<ChatHeader stats={stats} statusEntries={Object.entries(extUiStatus)} />
-				<div
-					data-testid="chat-scroll"
-					className="relative flex min-h-0 flex-1 flex-col"
-					{...containerProps}
-				>
-					<Virtuoso<ChatRow, ChatListContext>
-						ref={virtuosoRef}
-						data={rows}
-						context={listContext}
-						components={CHAT_LIST_COMPONENTS}
-						className="min-h-0 flex-1"
-						followOutput={followOutput}
-						atBottomStateChange={handleAtBottom}
-						atBottomThreshold={50}
-						// Row ids are stable across streaming snapshots (rows.ts), so items never remount mid-stream.
-						computeItemKey={(_, row) => row.id}
-						itemContent={(_, row) => (
-							<div className="mx-auto max-w-3xl px-md py-xs">
-								<ChatTurnView
-									row={row}
-									workspaceRoot={workspaceRoot}
-									onOpenChanges={onOpenChanges}
-								/>
-							</div>
-						)}
+			<AskStatesContext.Provider value={askStates}>
+				<div className="flex h-full min-h-0 flex-col bg-bg">
+					<ChatHeader stats={stats} statusEntries={Object.entries(extUiStatus)} />
+					<div
+						data-testid="chat-scroll"
+						className="relative flex min-h-0 flex-1 flex-col"
+						{...containerProps}
+					>
+						<Virtuoso<ChatRow, ChatListContext>
+							ref={virtuosoRef}
+							data={rows}
+							context={listContext}
+							components={CHAT_LIST_COMPONENTS}
+							className="min-h-0 flex-1"
+							followOutput={followOutput}
+							atBottomStateChange={handleAtBottom}
+							atBottomThreshold={50}
+							// Row ids are stable across streaming snapshots (rows.ts), so items never remount mid-stream.
+							computeItemKey={(_, row) => row.id}
+							itemContent={(_, row) => (
+								<div className="mx-auto max-w-3xl px-md py-xs">
+									<ChatTurnView
+										row={row}
+										workspaceRoot={workspaceRoot}
+										onOpenChanges={onOpenChanges}
+									/>
+								</div>
+							)}
+						/>
+						{showScrollButton ? (
+							<button
+								type="button"
+								data-testid="scroll-to-bottom"
+								onClick={scrollToBottom}
+								className="-translate-x-1/2 absolute bottom-md left-1/2 flex items-center gap-xs rounded-[var(--radius-lg)] border border-border2 bg-elevated px-sm py-xs text-muted text-xs shadow-[var(--shadow-md)] hover:bg-hover hover:text-text"
+							>
+								<ArrowDown className="size-3" />
+								New messages
+							</button>
+						) : null}
+					</div>
+					{widgetEntries.length > 0 ? (
+						<div className="shrink-0 border-border2 border-t bg-elevated px-md py-xs text-muted text-xs">
+							{widgetEntries.map(([key, lines]) => (
+								<div key={key}>{lines.join(" ")}</div>
+							))}
+						</div>
+					) : null}
+					<Composer
+						value={draft}
+						onChange={(v) => useAppStore.getState().setChatDraft(sessionId, v)}
+						isStreaming={isStreaming}
+						commands={commands}
+						mentionCandidates={mentionCandidates}
+						models={models}
+						currentModel={currentModel}
+						thinkingLevel={thinkingLevel}
+						onMentionQuery={onMentionQuery}
+						onSelectModel={onSelectModel}
+						onSelectThinking={onSelectThinking}
+						onSubmit={onSubmit}
+						onAbort={onAbort}
 					/>
-					{showScrollButton ? (
-						<button
-							type="button"
-							data-testid="scroll-to-bottom"
-							onClick={scrollToBottom}
-							className="-translate-x-1/2 absolute bottom-md left-1/2 flex items-center gap-xs rounded-[var(--radius-lg)] border border-border2 bg-elevated px-sm py-xs text-muted text-xs shadow-[var(--shadow-md)] hover:bg-hover hover:text-text"
-						>
-							<ArrowDown className="size-3" />
-							New messages
-						</button>
+					{pendingExtUi ? (
+						<ExtUiDialog key={pendingExtUi.id} request={pendingExtUi} onReply={onExtUiReply} />
 					) : null}
 				</div>
-				{widgetEntries.length > 0 ? (
-					<div className="shrink-0 border-border2 border-t bg-elevated px-md py-xs text-muted text-xs">
-						{widgetEntries.map(([key, lines]) => (
-							<div key={key}>{lines.join(" ")}</div>
-						))}
-					</div>
-				) : null}
-				<Composer
-					value={draft}
-					onChange={(v) => useAppStore.getState().setChatDraft(sessionId, v)}
-					isStreaming={isStreaming}
-					commands={commands}
-					mentionCandidates={mentionCandidates}
-					models={models}
-					currentModel={currentModel}
-					thinkingLevel={thinkingLevel}
-					onMentionQuery={onMentionQuery}
-					onSelectModel={onSelectModel}
-					onSelectThinking={onSelectThinking}
-					onSubmit={onSubmit}
-					onAbort={onAbort}
-				/>
-				{pendingExtUi ? (
-					<ExtUiDialog key={pendingExtUi.id} request={pendingExtUi} onReply={onExtUiReply} />
-				) : null}
-			</div>
+			</AskStatesContext.Provider>
 		</ChatActionsContext.Provider>
 	);
 }

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -80,11 +80,18 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 
 - **`ChatActions`** — a React context (provided by `ChatView`, `null` standalone): how a renderer talks
   **back** to the agent without importing store/transport. Today: `answerQuestion(toolCallId, result)` —
-  it rejects when the host refuses, and the caller owns the failure UX.
-- **Hydration** (`hydrate.ts`) — the pure `messagesToRuntime(Message[])` converter (read-side counterpart
-  of the event reducer): rebuilds `{ turns, toolResults }` from a persisted transcript so a
-  reconnecting/second client renders identically to the live path (same `raw` result shape, same
-  error-turn surfacing for `stopReason: "error"`). No store/transport/shiki.
+  it rejects when the host refuses (unknown/answered/superseded call), and the caller owns the failure UX.
+- **`askState`** — the questionnaire lifecycle seam: the pure `deriveAskStates(turns, askAnswers)` +
+  `AskStatesContext`/`useAskState` (provided by `ChatView`, `null` standalone). The ask tool is **ack +
+  terminate** (its tool result is just an ack; the reply arrives later as an `ask-user-answers` message),
+  so "answered / superseded / awaiting" is a fact about the transcript, not a tool status — derived once
+  per runtime snapshot and consumed by the card via context, keeping it props-driven everywhere else.
+- **Hydration** (`hydrate.ts`) — the pure `messagesToRuntime(TranscriptMessage[])` converter (read-side
+  counterpart of the event reducer): rebuilds `{ turns, toolResults, askAnswers }` (a `HydratedRuntime`)
+  from a persisted transcript so a reconnecting/second client renders identically to the live path (same
+  `raw` result shape, same error-turn surfacing for `stopReason: "error"`). `custom` messages never
+  become turns: known ones (`ask-user-answers`) index into `askAnswers`; unknown customTypes are
+  ignored. No store/transport/shiki.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
   commands, image paste/drop), `ModelSelector` + `ThinkingSelector` (shared with `NewWorkspaceDialog`;
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`,
@@ -109,8 +116,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 - **Forbidden:** value-importing any `pi` package; a **presentational** renderer importing
   `store`/`transport` (only `ChatView` may — keep the renderers reusable).
 - **`ChatView`** is the one app-integration file: wires this session's runtime
-  (`store.sessions[sessionId]`), the transport calls, the `ChatActions` context, and the divider's
-  "files changed" → `requestChangesView` deep link. A **rejected** send (`prompt`/`steer`/`followUp`)
+  (`store.sessions[sessionId]`), the transport calls, the `ChatActions` + `AskStates` contexts, and the
+  divider's "files changed" → `requestChangesView` deep link. A **rejected** send (`prompt`/`steer`/`followUp`)
   lands in the chat via the store's `appendErrorTurn` — never swallowed; *streaming* faults arrive as pi
   events instead.
 
@@ -120,10 +127,10 @@ The `store` folds pi events into pi-canonical turns **per session**: the in-flig
 the latest `assistantMessageEvent.partial` snapshot (replaced each update — not hand-accumulated). A
 message's true terminal is **`message_end`**: the reducer adopts the final message (it carries
 `stopReason`, how renderers spot dead tool calls) and clears the turn's `streaming` flag **there** — not
-at `agent_end`, which for a tool-calling message arrives only after its tools ran (for
-`ask_user_question`, only after the user answers). Tool results are indexed by `toolCallId` in
-`toolResults`. The view re-derives rows each render (`deriveRows` is pure; `ChatView` memoizes) — stable
-row/step ids keep fold state across snapshots.
+at `agent_end`, which for a tool-calling message arrives only after its tools ran. Tool results are
+indexed by `toolCallId` in `toolResults`; `ask-user-answers` custom messages index into `askAnswers`
+(never the turn list — the questionnaire card is their rendering). The view re-derives rows each render
+(`deriveRows` is pure; `ChatView` memoizes) — stable row/step ids keep fold state across snapshots.
 
 **One live indicator, always.** pi splits a run into several assistant messages, so the reducer sweeps
 the `streaming` flag on new-message start and `agent_end` (at most one turn is ever flagged). The loader

--- a/apps/web/src/chat/askState.test.ts
+++ b/apps/web/src/chat/askState.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import type { AskUserQuestionResult, AssistantMessage, UserMessage } from "@thinkrail/contracts";
+import { deriveAskStates } from "./askState";
+import type { ChatTurn } from "./types";
+
+// The transcript-derived questionnaire lifecycle (see askState.ts): answered when an ask-user-answers
+// reply is indexed, superseded when a user turn follows an unanswered call, awaiting otherwise.
+
+const askTurn = (id: string, toolCallId: string): ChatTurn => ({
+	kind: "assistant",
+	id,
+	streaming: false,
+	message: {
+		role: "assistant",
+		content: [{ type: "toolCall", id: toolCallId, name: "ask_user_question", arguments: {} }],
+	} as unknown as AssistantMessage,
+});
+
+const userTurn = (id: string): ChatTurn => ({
+	kind: "user",
+	id,
+	message: { role: "user", content: "hi", timestamp: 0 } as UserMessage,
+});
+
+const reply: AskUserQuestionResult = { answers: [], cancelled: false };
+
+test("an ask call with neither reply nor later user turn is awaiting", () => {
+	const states = deriveAskStates([userTurn("u1"), askTurn("a1", "tc1")], {});
+	expect(states.tc1).toEqual({ superseded: false });
+});
+
+test("an indexed reply marks the call answered (never superseded, even with a later user turn)", () => {
+	const states = deriveAskStates([askTurn("a1", "tc1"), userTurn("u2")], { tc1: reply });
+	expect(states.tc1).toEqual({ answer: reply, superseded: false });
+});
+
+test("a user turn AFTER an unanswered call supersedes it; one before does not", () => {
+	const states = deriveAskStates(
+		[userTurn("u1"), askTurn("a1", "tc1"), userTurn("u2"), askTurn("a2", "tc2")],
+		{},
+	);
+	expect(states.tc1).toEqual({ superseded: true });
+	expect(states.tc2).toEqual({ superseded: false }); // the later ask is still open
+});
+
+test("non-ask tool calls derive no state", () => {
+	const turns: ChatTurn[] = [
+		{
+			kind: "assistant",
+			id: "a1",
+			streaming: false,
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "b1", name: "bash", arguments: {} }],
+			} as unknown as AssistantMessage,
+		},
+	];
+	expect(Object.keys(deriveAskStates(turns, {}))).toHaveLength(0);
+});

--- a/apps/web/src/chat/askState.ts
+++ b/apps/web/src/chat/askState.ts
@@ -1,0 +1,67 @@
+import type { AskUserQuestionResult } from "@thinkrail/contracts";
+import { createContext, useContext } from "react";
+import type { ChatTurn } from "./types";
+
+// The transcript-derived lifecycle of `ask_user_question` calls under the ack + terminate design: the
+// tool resolves instantly (its result is just an ack), so "answered or still open?" is NOT a tool status —
+// it's a fact about the conversation that follows the call. This module derives that fact once per
+// runtime snapshot; the questionnaire card consumes it via context (`ChatView` provides it), staying
+// store/transport-free like the other renderers.
+
+/** One questionnaire's transcript-derived state (see {@link deriveAskStates}). */
+export interface AskState {
+	/** The structured reply, when an `ask-user-answers` message for this call exists. */
+	answer?: AskUserQuestionResult;
+	/**
+	 * The user sent a free-form message after the questionnaire instead of answering it — the model was
+	 * told to treat that message as the reply, so the card is terminal (not answerable). Mirrors the
+	 * host-side verdict (`assessAnswerability`), which rejects answers to superseded calls.
+	 */
+	superseded: boolean;
+}
+
+/**
+ * Derive every `ask_user_question` call's state from the transcript: `answer` from the indexed
+ * `ask-user-answers` replies, `superseded` when a user turn follows the call without one. An answered
+ * call is never superseded (the reply exists — render it), and a call with neither is "awaiting":
+ * answerable now, after a reconnect, or after any number of host restarts. Pure.
+ */
+export function deriveAskStates(
+	turns: ChatTurn[],
+	askAnswers: Record<string, AskUserQuestionResult>,
+): Record<string, AskState> {
+	const callTurnIndex: Record<string, number> = {};
+	let lastUserIndex = -1;
+	for (let i = 0; i < turns.length; i++) {
+		const turn = turns[i];
+		if (!turn) continue;
+		if (turn.kind === "user") {
+			lastUserIndex = i;
+		} else if (turn.kind === "assistant") {
+			for (const block of turn.message.content) {
+				if (block.type === "toolCall" && block.name === "ask_user_question")
+					callTurnIndex[block.id] = i;
+			}
+		}
+	}
+	const states: Record<string, AskState> = {};
+	for (const [toolCallId, turnIndex] of Object.entries(callTurnIndex)) {
+		const answer = askAnswers[toolCallId];
+		states[toolCallId] = {
+			...(answer ? { answer } : {}),
+			superseded: !answer && lastUserIndex > turnIndex,
+		};
+	}
+	return states;
+}
+
+/**
+ * The per-chat ask states, provided by `ChatView` (derived from the session runtime). `null` when a
+ * renderer is used without one (standalone/extracted) — the card then treats every call as awaiting.
+ */
+export const AskStatesContext = createContext<Record<string, AskState> | null>(null);
+
+/** The transcript-derived state for one `ask_user_question` call, or `undefined` outside a provider. */
+export function useAskState(toolCallId: string): AskState | undefined {
+	return useContext(AskStatesContext)?.[toolCallId];
+}

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test";
-import type { Message } from "@thinkrail/contracts";
+import type { TranscriptMessage } from "@thinkrail/contracts";
+import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
 import { messagesToRuntime } from "./hydrate";
+
+type Message = TranscriptMessage;
 
 // Partial fixtures cast to Message — the converter reads only `role` (+ toolCallId/isError/content for
 // tool results) and passes user/assistant messages through verbatim.
@@ -65,10 +68,9 @@ test("a failed tool result maps to error status", () => {
 	expect(toolResults.x?.status).toBe("error");
 });
 
-test("a toolCall with no matching toolResult has no entry — a blocked interactive tool stays 'running'", () => {
-	// A pending `ask_user_question`: the assistant emitted the toolCall, but `execute` is still blocked so no
-	// toolResult message exists yet. On reconnect the card must re-render as still-pending — which it does
-	// because the absent `toolResults` entry makes ToolCard/ToolBlock default the status to "running".
+test("a toolCall with no matching toolResult has no entry — the call renders as still running", () => {
+	// The (sub-second) window between an assistant message ending and its tool results landing: the absent
+	// `toolResults` entry makes ToolCard/ToolBlock default the status to "running".
 	const { turns, toolResults } = messagesToRuntime([
 		{
 			role: "assistant",
@@ -81,9 +83,9 @@ test("a toolCall with no matching toolResult has no entry — a blocked interact
 	expect(toolResults.ask1).toBeUndefined();
 });
 
-test("a resolved toolResult keeps its structured `details` (the ask_user_question record on reconnect)", () => {
-	// hydrate mirrors the live `tool_execution_end` shape (`{ content, details }`) so the resolved
-	// questionnaire record survives a reconnect — the answers live in `details`.
+test("a resolved toolResult keeps its structured `details` (a legacy blocking-era ask record)", () => {
+	// hydrate mirrors the live `tool_execution_end` shape (`{ content, details }`) so a legacy resolved
+	// questionnaire record (answers in the tool result) survives a reconnect — the card's fallback path.
 	const details = {
 		answers: [{ questionIndex: 0, question: "Q?", kind: "option", answer: "A" }],
 		cancelled: false,
@@ -101,4 +103,41 @@ test("a resolved toolResult keeps its structured `details` (the ask_user_questio
 	] as unknown as Message[]);
 	expect(toolResults.ask2?.status).toBe("done");
 	expect((toolResults.ask2?.raw as { details: unknown }).details).toEqual(details);
+});
+
+test("an ask-user-answers custom message indexes into askAnswers and never becomes a turn", () => {
+	const result = {
+		answers: [{ questionIndex: 0, question: "Q?", kind: "option", answer: "A" }],
+		cancelled: false,
+	};
+	const { turns, askAnswers } = messagesToRuntime([
+		{
+			role: "assistant",
+			content: [{ type: "toolCall", id: "ask3", name: "ask_user_question", arguments: {} }],
+		},
+		{
+			role: "custom",
+			customType: ASK_USER_ANSWERS_CUSTOM_TYPE,
+			content: "User has answered your questions: …",
+			display: true,
+			details: { toolCallId: "ask3", result },
+			timestamp: 2,
+		},
+	] as unknown as Message[]);
+	expect(turns).toHaveLength(1); // the card is the answers' rendering — no separate bubble
+	expect(askAnswers.ask3).toEqual(result as never);
+});
+
+test("unknown custom messages are ignored entirely", () => {
+	const { turns, askAnswers } = messagesToRuntime([
+		{
+			role: "custom",
+			customType: "someone-elses-extension",
+			content: "hello",
+			display: true,
+			timestamp: 1,
+		},
+	] as unknown as Message[]);
+	expect(turns).toHaveLength(0);
+	expect(Object.keys(askAnswers)).toHaveLength(0);
 });

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -128,6 +128,28 @@ test("an ask-user-answers custom message indexes into askAnswers and never becom
 	expect(askAnswers.ask3).toEqual(result as never);
 });
 
+test("an answers message with malformed details is ignored — the guard validates shape, not just tag", () => {
+	const { askAnswers } = messagesToRuntime([
+		// right customType, but details missing / wrong-shaped — wire data is untrusted.
+		{
+			role: "custom",
+			customType: ASK_USER_ANSWERS_CUSTOM_TYPE,
+			content: "looks right, isn't",
+			display: true,
+			timestamp: 1,
+		},
+		{
+			role: "custom",
+			customType: ASK_USER_ANSWERS_CUSTOM_TYPE,
+			content: "still not right",
+			display: true,
+			details: { toolCallId: 42, result: { answers: "nope", cancelled: "nope" } },
+			timestamp: 2,
+		},
+	] as unknown as Message[]);
+	expect(Object.keys(askAnswers)).toHaveLength(0);
+});
+
 test("unknown custom messages are ignored entirely", () => {
 	const { turns, askAnswers } = messagesToRuntime([
 		{

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -1,5 +1,5 @@
 import type { AskUserAnswersDetails, TranscriptMessage } from "@thinkrail/contracts";
-import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
+import { isAskUserAnswersMessage } from "@thinkrail/contracts";
 import type { ChatTurn, ToolResultState } from "./types";
 
 /** The runtime slice a transcript hydrates: what `hydrateSession` seeds a fresh `SessionRuntime` with. */
@@ -45,9 +45,9 @@ export function messagesToRuntime(messages: TranscriptMessage[]): HydratedRuntim
 				status: message.isError ? "error" : "done",
 				raw: { content: message.content, details: message.details },
 			};
-		} else if (message.role === "custom" && message.customType === ASK_USER_ANSWERS_CUSTOM_TYPE) {
-			const details = message.details as AskUserAnswersDetails | undefined;
-			if (details?.toolCallId && details.result) askAnswers[details.toolCallId] = details.result;
+		} else if (isAskUserAnswersMessage(message)) {
+			// The shared guard validates the details shape (not just the tag) — a malformed reply is ignored.
+			askAnswers[message.details.toolCallId] = message.details.result;
 		}
 	}
 	return { turns, toolResults, askAnswers };

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -1,18 +1,27 @@
-import type { Message } from "@thinkrail/contracts";
+import type { AskUserAnswersDetails, TranscriptMessage } from "@thinkrail/contracts";
+import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
 import type { ChatTurn, ToolResultState } from "./types";
 
-/**
- * Fold a session's pi-canonical transcript (`session.getMessages`) into the runtime shape the renderers
- * consume — the read-side counterpart of the event reducer, used to hydrate a chat on connect. pi
- * messages carry no stable id, so we mint one per turn; tool results are indexed by `toolCallId` (which
- * pairs with the `toolCall` block's `id` inside the assistant turn, exactly as in the live path).
- */
-export function messagesToRuntime(messages: Message[]): {
+/** The runtime slice a transcript hydrates: what `hydrateSession` seeds a fresh `SessionRuntime` with. */
+export interface HydratedRuntime {
 	turns: ChatTurn[];
 	toolResults: Record<string, ToolResultState>;
-} {
+	/** `ask_user_question` replies keyed by tool call id (from `ask-user-answers` custom messages). */
+	askAnswers: Record<string, AskUserAnswersDetails["result"]>;
+}
+
+/**
+ * Fold a session's transcript (`session.getMessages`) into the runtime shape the renderers consume — the
+ * read-side counterpart of the event reducer, used to hydrate a chat on connect. pi messages carry no
+ * stable id, so we mint one per turn; tool results are indexed by `toolCallId` (which pairs with the
+ * `toolCall` block's id inside an assistant turn, exactly as in the live path). `custom` messages never
+ * become turns: the ones we know (`ask-user-answers`) index into `askAnswers` — the questionnaire card is
+ * their rendering — and unknown customTypes are ignored.
+ */
+export function messagesToRuntime(messages: TranscriptMessage[]): HydratedRuntime {
 	const turns: ChatTurn[] = [];
 	const toolResults: Record<string, ToolResultState> = {};
+	const askAnswers: HydratedRuntime["askAnswers"] = {};
 	for (const message of messages) {
 		if (message.role === "user") {
 			turns.push({ kind: "user", id: crypto.randomUUID(), message });
@@ -30,13 +39,16 @@ export function messagesToRuntime(messages: Message[]): {
 			}
 		} else if (message.role === "toolResult") {
 			// Mirror the live `tool_execution_end` result shape (`{ content, details }`) so renderers read the
-			// same value whether streamed or hydrated (e.g. the `ask_user_question` card's structured answers
-			// live in `details`, so they survive a reconnect).
+			// same value whether streamed or hydrated (e.g. the `ask_user_question` card reads its ack — or a
+			// legacy blocking-era result — from `details`).
 			toolResults[message.toolCallId] = {
 				status: message.isError ? "error" : "done",
 				raw: { content: message.content, details: message.details },
 			};
+		} else if (message.role === "custom" && message.customType === ASK_USER_ANSWERS_CUSTOM_TYPE) {
+			const details = message.details as AskUserAnswersDetails | undefined;
+			if (details?.toolCallId && details.result) askAnswers[details.toolCallId] = details.result;
 		}
 	}
-	return { turns, toolResults };
+	return { turns, toolResults, askAnswers };
 }

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib";
+import { useAskState } from "../askState";
 import { useChatActions } from "../ChatActions";
 import { Markdown } from "../Markdown";
 import type { ToolRenderProps } from "../toolRegistry";
@@ -24,9 +25,16 @@ import { resultText } from "./toolHelpers";
 // folded card. Styled after the app's inline prompt-card spec: the question IS the card header, options are
 // radio/checkbox rows (the recommended one badged) closed by a mandatory native "Other" row (same
 // radio/checkbox indicator, inline free-text field), a footer with a mode hint + Skip/Next/Submit, and
-// compact, borderless "record" states once resolved. Presentational: reads the questions
-// from the tool-call `args`, replies through the `ChatActions` context (provided by `ChatView`) — never the
-// store/transport directly, so it stays reusable.
+// compact, borderless "record" states once resolved.
+//
+// The tool is **ack + terminate** (its own result is just an ack; the turn ends), so the card's lifecycle
+// derives from the TRANSCRIPT, not the tool status: `useAskState` supplies the reply (an
+// `ask-user-answers` message pairs by tool call id) or the superseded verdict (a later free-form user
+// message closed the questionnaire). With neither, the card is "awaiting" — answerable now, after a
+// reconnect, or after any number of host restarts. Legacy transcripts (the blocking-era tool, validation
+// errors, restart-repaired declines) carry a final result in the tool result itself and render as the
+// same resolved record. Presentational: reads the questions from the tool-call `args`, replies through
+// the `ChatActions` context (provided by `ChatView`) — never the store/transport directly.
 
 // ---- pure helpers (exported for unit tests) ----
 
@@ -185,7 +193,14 @@ export function AskUserQuestionCard({
 	streaming,
 }: ToolRenderProps) {
 	const actions = useChatActions();
+	const ask = useAskState(toolCallId);
 	const questions = useMemo(() => parseQuestions(args), [args]);
+	// The reply, wherever it lives: the transcript's ask-user-answers message (ack + terminate design), or
+	// the tool result itself (legacy blocking-era transcripts, validation errors, restart-repaired declines).
+	const resolvedResult = ask?.answer ?? readAskResult(result);
+	// Awaiting = shown and unanswered: interactive until a reply or a superseding user message exists. A
+	// dead call (aborted/errored owning message → status "error") is terminal, never answerable.
+	const awaiting = !resolvedResult && !ask?.superseded && status !== "error";
 	// Keyed by question index rather than a positional array: the card can first mount while the tool
 	// call's `arguments` are still streaming in (0 questions), so an array sized at init would stay empty
 	// after the questions arrive. A sparse map defaults each question to a fresh state on demand instead.
@@ -198,9 +213,9 @@ export function AskUserQuestionCard({
 	);
 
 	useEffect(() => {
-		if (status === "running") cardStateCache.set(toolCallId, { states, tab, submitted });
+		if (awaiting) cardStateCache.set(toolCallId, { states, tab, submitted });
 		else cardStateCache.delete(toolCallId);
-	}, [toolCallId, status, states, tab, submitted]);
+	}, [toolCallId, awaiting, states, tab, submitted]);
 
 	const stateFor = (qi: number): QState => states[qi] ?? emptyQState();
 	const patch = (qi: number, next: Partial<QState>) =>
@@ -218,15 +233,17 @@ export function AskUserQuestionCard({
 		actions.answerQuestion(toolCallId, r).catch(() => setSubmitted(false));
 	};
 
-	// Resolved (or resolved on another client) → a compact, read-only record.
-	if (status !== "running") {
+	// Answered (here or on another client) / legacy-resolved → a compact, read-only record.
+	if (resolvedResult) {
 		return (
-			<ResolvedRecord
-				questions={questions}
-				result={readAskResult(result)}
-				rawText={resultText(result)}
-			/>
+			<ResolvedRecord questions={questions} result={resolvedResult} rawText={resultText(result)} />
 		);
+	}
+	// A later free-form user message replaced the answer — terminal, matching the host-side verdict.
+	if (ask?.superseded) return <SupersededRecord questions={questions} />;
+	// Dead call (the owning message aborted/errored — pi never ran it): a closed record, never a form.
+	if (status === "error") {
+		return <ResolvedRecord questions={questions} result={null} rawText={resultText(result)} />;
 	}
 	// Controls never stream: while the args arrive the card is a stable placeholder (a form whose labels
 	// mutate under the cursor reads as broken); the complete questionnaire reveals atomically at message end.
@@ -354,6 +371,31 @@ export function AskUserQuestionCard({
 /** "Agent is waiting for your input" — the small status line above the active card. */
 function WaitingLine() {
 	return <div className="text-muted text-xs">Agent is waiting for your input</div>;
+}
+
+/**
+ * The terminal record for a questionnaire the conversation moved past: the user replied with their own
+ * message instead of answering, so the model was told to treat that message as the reply. Read-only — a
+ * late answer would be rejected by the host (`assessAnswerability`) anyway.
+ */
+function SupersededRecord({ questions }: { questions: AskUserQuestionItem[] }) {
+	return (
+		<div
+			data-testid="ask-user-question"
+			data-tone="superseded"
+			className="flex flex-col gap-xs text-muted text-xs"
+		>
+			<div className="flex items-center gap-xs">
+				<SkipForward className="size-3.5 shrink-0" />
+				Superseded — you replied in chat instead of answering these.
+			</div>
+			{questions.map((q) => (
+				<div key={q.question} className="pl-[calc(0.875rem+var(--spacing-sm))] text-hint">
+					{q.question}
+				</div>
+			))}
+		</div>
+	);
 }
 
 /** The card frame used for the transient "answer sent" state (no interactive body). */

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -24,6 +24,14 @@ registration runs once when the chat module mounts. Unregistered tools fall back
   (capability + rationale: the server's `agent/askUserQuestion` SPEC). Registered `"bare"`: it owns its
   full-width frame, never folds, and answers through the `ChatActions` context (correlated by
   `toolCallId`). Behaviors worth their invariants:
+  - **The lifecycle derives from the transcript, not the tool status** (the tool is ack + terminate; its
+    own result is just the ack): `useAskState(toolCallId)` supplies the reply / superseded verdict, and
+    the card resolves in order — **answered/declined** (an `ask-user-answers` reply exists → the resolved
+    record; a legacy blocking-era result or a restart-repaired decline in the tool result renders the
+    same way), **superseded** (a later free-form user message replaced the answer → a terminal compact
+    record; the host rejects late answers, matching), **dead** (owning message aborted/errored → closed
+    record), else **awaiting** — interactive now, after a reconnect, or after any number of host
+    restarts.
   - **Controls never stream** — while args stream it shows a stable composing placeholder and the
     complete questionnaire reveals atomically at message end (rationale in the component's jsdoc).
   - **Multi-question completion is review-gated** — every question page advances with **Next**, including
@@ -32,8 +40,8 @@ registration runs once when the chat module mounts. Unregistered tools fall back
     the submission can be checked in context. Selection status is also exposed as screen-reader text —
     never by icon/color alone. A single question keeps its direct **Submit** action.
   - **Per-call UI state survives virtualization** — a module-level cache keyed by `toolCallId` (dropped
-    on resolve), since react-virtuoso unmounts off-screen rows. This is the pattern the activity fold's
-    expansion state reuses.
+    once no longer awaiting), since react-virtuoso unmounts off-screen rows. This is the pattern the
+    activity fold's expansion state reuses.
   - Awaiting an answer, the card carries a subtle primary-tinted accent ring (the "needs you" accent).
   - **Recommended-reason affordance** — a recommended option (label suffix `(Recommended)` **or** a
     non-empty `recommendedReason` — a reason *implies* recommended, defensively) renders its rationale
@@ -57,8 +65,9 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 
 - **Public surface:** the side-effect `register` import + the shared `CodeBlock`/`Collapsible`/
   `toolHelpers` for sibling renderers. No barrel (chat pulls shiki — per-file imports, as in the parent).
-- **Allowed deps:** parent chat primitives (`toolRegistry`, `Markdown`, `ChatActions`); `contracts`
-  (**type-only**); `components/ui`; `lib`; `lucide-react`; `mermaid` (**lazy, `visualize/` only**).
+- **Allowed deps:** parent chat primitives (`toolRegistry`, `Markdown`, `ChatActions`, `askState`);
+  `contracts` (type-only + the `ASK_USER_ANSWERS_CUSTOM_TYPE` constant); `components/ui`; `lib`;
+  `lucide-react`; `mermaid` (**lazy, `visualize/` only**).
 - **Forbidden:** value-importing any `pi` package; `store`/`transport` (renderers stay presentational —
   extraction-ready into a future `packages/chat-ui`).
 

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -110,8 +110,7 @@ export function CenterTabs() {
 							{ sessionId: summary.sessionId, workspaceId: activeWorkspaceId },
 						);
 						if (cancelled) return;
-						const { turns, toolResults } = messagesToRuntime(messages);
-						useAppStore.getState().hydrateSession(fresh, turns, toolResults);
+						useAppStore.getState().hydrateSession(fresh, messagesToRuntime(messages));
 					} catch {
 						// Skip a session that failed to load; the others still hydrate.
 					}
@@ -141,8 +140,7 @@ export function CenterTabs() {
 				sessionId,
 				workspaceId: activeWorkspaceId,
 			});
-			const { turns, toolResults } = messagesToRuntime(messages);
-			useAppStore.getState().hydrateSession(summary, turns, toolResults, true);
+			useAppStore.getState().hydrateSession(summary, messagesToRuntime(messages), true);
 		} catch (err) {
 			// The chat stays in history for a retry — but say why the click did nothing.
 			toast.error(errorText(err), "Couldn't reopen the chat");

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -36,7 +36,9 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   so the rendered↔source choice survives tab switches; absent = rendered); `terminalsByWorkspace`
   / `activeTerminalByWorkspace` (`addTerminal`/`closeTerminalTab`/`setActiveTerminalTab`); the
   **per-session chat state** — `sessions: Record<sessionId, SessionRuntime>`, where a `SessionRuntime` holds
-  one chat's `turns` (pi-canonical) / `toolResults` / `currentAssistantId` / `isStreaming` / `model` /
+  one chat's `turns` (pi-canonical) / `toolResults` / `askAnswers` (the `ask-user-answers` replies keyed
+  by tool call id — indexed by the reducer and hydration, never turned into bubbles) /
+  `currentAssistantId` / `isStreaming` / `model` /
   `thinkingLevel` / `stats` / `commands` / `draft` and its **extension-UI state** (`pendingExtUi` (typed by
   `chat`'s `ExtUiDialogRequest`) + `extUiQueue` (overlapping dialogs FIFO so none orphans its server
   promise) + `extUiStatus` / `extUiWidget`). `openChatSession` creates a runtime; `closeChatRuntime` /

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -172,6 +172,42 @@ test("message_end finalizes the turn the moment its message completes (not at ag
 	expect(rt("a")).toBe(before);
 });
 
+test("an ask-user-answers custom message_end indexes into askAnswers (never the turn list)", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+
+	const result = {
+		answers: [{ questionIndex: 0, question: "Q?", kind: "option", answer: "A" }],
+		cancelled: false,
+	};
+	store.handlePiEvent(
+		{
+			type: "message_end",
+			message: {
+				role: "custom",
+				customType: "ask-user-answers",
+				content: "User has answered your questions: …",
+				display: true,
+				details: { toolCallId: "ask1", result },
+			},
+		} as unknown as PiEvent,
+		"a",
+	);
+	expect(rt("a").askAnswers.ask1).toEqual(result as never);
+	expect(rt("a").turns.filter((t) => t.kind === "assistant" || t.kind === "user")).toHaveLength(0);
+
+	// Unknown customTypes are ignored without touching the runtime ref.
+	const before = rt("a");
+	store.handlePiEvent(
+		{
+			type: "message_end",
+			message: { role: "custom", customType: "other", content: "x", display: false },
+		} as unknown as PiEvent,
+		"a",
+	);
+	expect(rt("a")).toBe(before);
+});
+
 test("the tool lifecycle folds into toolResults (the status + raw the renderers read)", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");
@@ -367,17 +403,20 @@ test("hydrateSession rebuilds a runtime + tab on connect, and never clobbers a l
 		updatedAt: 0,
 		live: true,
 	};
-	store.hydrateSession(
-		summary,
-		[{ kind: "user", id: "u1", message: { role: "user", content: "hi", timestamp: 0 } }],
-		{},
-	);
+	store.hydrateSession(summary, {
+		turns: [{ kind: "user", id: "u1", message: { role: "user", content: "hi", timestamp: 0 } }],
+		toolResults: {},
+		askAnswers: {},
+	});
 	const st = useAppStore.getState();
 	expect(st.sessions.h1?.turns).toHaveLength(1);
 	expect(st.tabsByWorkspace.ws1?.some((t) => t.kind === "chat" && t.sessionId === "h1")).toBe(true);
 
 	// A second hydrate (e.g. stale list) must NOT overwrite the now-live runtime.
-	store.hydrateSession({ ...summary, messageCount: 99 }, [], {});
+	store.hydrateSession(
+		{ ...summary, messageCount: 99 },
+		{ turns: [], toolResults: {}, askAnswers: {} },
+	);
 	expect(useAppStore.getState().sessions.h1?.turns).toHaveLength(1);
 });
 
@@ -417,7 +456,7 @@ test("hydrateSession(activate) reopens a disk-only chat: builds it, focuses it, 
 		updatedAt: 1,
 		live: true,
 	};
-	store.hydrateSession(summary, [], {}, true);
+	store.hydrateSession(summary, { turns: [], toolResults: {}, askAnswers: {} }, true);
 
 	const st = useAppStore.getState();
 	expect(st.sessions.disk1).toBeDefined(); // runtime built from the re-opened session

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1,5 +1,7 @@
 import type {
 	AppConfig,
+	AskUserAnswersDetails,
+	AskUserQuestionResult,
 	ExtUiRequest,
 	LoginFrame,
 	LoginPush,
@@ -14,9 +16,10 @@ import type {
 	Workspace,
 	WorkspaceFsChangedPayload,
 } from "@thinkrail/contracts";
-import { Theme } from "@thinkrail/contracts";
+import { ASK_USER_ANSWERS_CUSTOM_TYPE, Theme } from "@thinkrail/contracts";
 import { create } from "zustand";
 import type { LoginState } from "../auth";
+import type { HydratedRuntime } from "../chat/hydrate";
 import type { ChatTurn, ExtUiDialogRequest, ToolResultState } from "../chat/types";
 import type { ConnectionStatus } from "../transport";
 
@@ -91,6 +94,8 @@ export interface SessionRuntime {
 	turns: ChatTurn[];
 	/** Live tool state keyed by toolCallId; paired with the toolCall block inside an assistant turn. */
 	toolResults: Record<string, ToolResultState>;
+	/** `ask_user_question` replies keyed by tool call id (from `ask-user-answers` custom messages). */
+	askAnswers: Record<string, AskUserQuestionResult>;
 	currentAssistantId: string | null;
 	isStreaming: boolean;
 	/** This chat's model + thinking level (display only; `pi` owns them). */
@@ -115,6 +120,7 @@ function newRuntime(model: WireModel | null, thinkingLevel: ThinkingLevel): Sess
 	return {
 		turns: [],
 		toolResults: {},
+		askAnswers: {},
 		currentAssistantId: null,
 		isStreaming: false,
 		model,
@@ -185,11 +191,35 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 			};
 		}
 		case "message_end": {
+			// An `ask-user-answers` custom message (the questionnaire reply the host injected) indexes into
+			// `askAnswers` — the questionnaire card is its rendering, it never becomes a turn. The `custom`
+			// role only exists with pi-coding-agent's module augmentation (Node-only), so it's read
+			// structurally here. Unknown customTypes are ignored.
+			const custom = event.message as unknown as {
+				role: string;
+				customType?: string;
+				details?: AskUserAnswersDetails;
+			};
+			if (custom.role === "custom") {
+				if (
+					custom.customType === ASK_USER_ANSWERS_CUSTOM_TYPE &&
+					custom.details?.toolCallId &&
+					custom.details.result
+				) {
+					return {
+						...rt,
+						askAnswers: {
+							...rt.askAnswers,
+							[custom.details.toolCallId]: custom.details.result,
+						},
+					};
+				}
+				return rt;
+			}
 			// The message's true terminal: pi forwards only *streaming* variants as `message_update` (the
 			// LLM-level done/error become this event), so without it the turn would stay flagged streaming
-			// until `agent_end` — seconds or minutes later when tools run (and never, for a tool blocked on
-			// user input like `ask_user_question`). Adopt the final message too: it carries `stopReason`,
-			// which the renderers use to spot dead (aborted/errored) tool calls.
+			// until `agent_end` — seconds or minutes later when tools run. Adopt the final message too: it
+			// carries `stopReason`, which the renderers use to spot dead (aborted/errored) tool calls.
 			if (event.message.role !== "assistant" || !rt.currentAssistantId) return rt;
 			const id = rt.currentAssistantId;
 			const turn: ChatTurn = { kind: "assistant", id, message: event.message, streaming: false };
@@ -440,12 +470,7 @@ interface AppState {
 	 * Drops the session from chat-history (it's open now). `activate` focuses the tab (a user-driven reopen);
 	 * otherwise it only takes focus if the workspace has none yet (auto-restore must not steal focus).
 	 */
-	hydrateSession: (
-		summary: SessionSummary,
-		turns: ChatTurn[],
-		toolResults: Record<string, ToolResultState>,
-		activate?: boolean,
-	) => void;
+	hydrateSession: (summary: SessionSummary, hydrated: HydratedRuntime, activate?: boolean) => void;
 	appendUserMessage: (sessionId: string, text: string) => void;
 	/**
 	 * Surface a failed send as a visible error turn. The turn-driving wire calls (`session.prompt`/`steer`/
@@ -854,14 +879,15 @@ export const useAppStore = create<AppState>((set, get) => ({
 				},
 			};
 		}),
-	hydrateSession: (summary, turns, toolResults, activate = false) =>
+	hydrateSession: (summary, hydrated, activate = false) =>
 		set((s) => {
 			if (s.sessions[summary.sessionId]) return {}; // a live/ahead runtime wins — never clobber it
 			const wsId = summary.workspaceId;
 			const runtime: SessionRuntime = {
 				...newRuntime(summary.model, summary.thinkingLevel),
-				turns,
-				toolResults,
+				turns: hydrated.turns,
+				toolResults: hydrated.toolResults,
+				askAnswers: hydrated.askAnswers,
 				isStreaming: summary.isStreaming,
 			};
 			const id = `${wsId}:${summary.sessionId}`;

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1,6 +1,5 @@
 import type {
 	AppConfig,
-	AskUserAnswersDetails,
 	AskUserQuestionResult,
 	ExtUiRequest,
 	LoginFrame,
@@ -16,7 +15,7 @@ import type {
 	Workspace,
 	WorkspaceFsChangedPayload,
 } from "@thinkrail/contracts";
-import { ASK_USER_ANSWERS_CUSTOM_TYPE, Theme } from "@thinkrail/contracts";
+import { isAskUserAnswersMessage, Theme } from "@thinkrail/contracts";
 import { create } from "zustand";
 import type { LoginState } from "../auth";
 import type { HydratedRuntime } from "../chat/hydrate";
@@ -192,29 +191,12 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 		}
 		case "message_end": {
 			// An `ask-user-answers` custom message (the questionnaire reply the host injected) indexes into
-			// `askAnswers` — the questionnaire card is its rendering, it never becomes a turn. The `custom`
-			// role only exists with pi-coding-agent's module augmentation (Node-only), so it's read
-			// structurally here. Unknown customTypes are ignored.
-			const custom = event.message as unknown as {
-				role: string;
-				customType?: string;
-				details?: AskUserAnswersDetails;
-			};
-			if (custom.role === "custom") {
-				if (
-					custom.customType === ASK_USER_ANSWERS_CUSTOM_TYPE &&
-					custom.details?.toolCallId &&
-					custom.details.result
-				) {
-					return {
-						...rt,
-						askAnswers: {
-							...rt.askAnswers,
-							[custom.details.toolCallId]: custom.details.result,
-						},
-					};
-				}
-				return rt;
+			// `askAnswers` — the questionnaire card is its rendering, it never becomes a turn. The shared
+			// guard validates the details shape, not just the tag; every other custom message falls through
+			// to the assistant-only logic below, which ignores it.
+			if (isAskUserAnswersMessage(event.message)) {
+				const { toolCallId, result } = event.message.details;
+				return { ...rt, askAnswers: { ...rt.askAnswers, [toolCallId]: result } };
 			}
 			// The message's true terminal: pi forwards only *streaming* variants as `message_update` (the
 			// LLM-level done/error become this event), so without it the turn would stay flagged streaming

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -1,0 +1,184 @@
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, openSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, type Page, test } from "@playwright/test";
+import { E2E_PI_AGENT_DIR } from "./fixtures/paths";
+
+// Tagged @agent: drives a real pi agent. THE restart test — the one scenario the shared-host suite
+// structurally cannot cover (Playwright's webServer owns that host for the whole run): a questionnaire is
+// open, the host process DIES (kill -9 — no graceful shutdown, the harshest path), a fresh host boots on
+// the same on-disk state, and the questionnaire is still answerable — the answer starts a new turn and
+// the agent replies. This is the end-to-end proof of the ack + terminate design (see the server
+// `agent/askUserQuestion` SPEC): nothing about a pending question lives in host memory, so a restart
+// costs nothing. Everything here is self-contained: a dedicated port, data dir, fixture repo, and pi
+// agent dir (copied from the suite's seeded one, so the same auth + pinned model apply); the shared host
+// on 24252 keeps running untouched.
+
+const PORT = 24254; // dev 24242, shared e2e host 24252 — this suite's private host lives here
+const BASE = `http://localhost:${PORT}`;
+const DATA_DIR = join(tmpdir(), "thinkrail-e2e-restart");
+const REPO = join(DATA_DIR, "sample-project");
+const AGENT_DIR = join(DATA_DIR, "pi-agent");
+const PICK_POINTER = join(DATA_DIR, "pick-dir");
+// Outside DATA_DIR so a failed run's teardown doesn't destroy the post-mortem trail.
+const HOST_LOG = join(tmpdir(), "thinkrail-e2e-restart-host.log");
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const staticDir = join(rootDir, "apps", "web", "dist");
+
+/** Fresh isolated state: a tiny git fixture repo + a pi agent dir cloned from the suite's seeded one. */
+function seedState(): void {
+	rmSync(DATA_DIR, { recursive: true, force: true });
+	rmSync(HOST_LOG, { force: true });
+	mkdirSync(REPO, { recursive: true });
+	const git = (...args: string[]) =>
+		execFileSync("git", ["-C", REPO, ...args], { stdio: "ignore" });
+	git("init", "-b", "main");
+	git("config", "user.email", "e2e@thinkrail.test");
+	git("config", "user.name", "ThinkRail E2E");
+	writeFileSync(join(REPO, "README.md"), "# restart fixture\n");
+	git("add", "-A");
+	git("commit", "-m", "init");
+
+	// Same auth + pinned default model as the shared suite (global setup seeded these from the user's).
+	mkdirSync(AGENT_DIR, { recursive: true });
+	for (const file of ["auth.json", "models.json", "settings.json"]) {
+		const src = join(E2E_PI_AGENT_DIR, file);
+		if (existsSync(src)) copyFileSync(src, join(AGENT_DIR, file));
+	}
+	writeFileSync(PICK_POINTER, REPO);
+}
+
+let host: ChildProcess | null = null;
+
+/** Boot the private host and wait for /health. The web app is already built (the shared webServer did). */
+async function startHost(): Promise<void> {
+	const log = openSync(HOST_LOG, "a"); // post-mortem trail for a failed boot (appended across restarts)
+	host = spawn("bun", ["packages/server/src/dev.ts"], {
+		cwd: rootDir,
+		stdio: ["ignore", log, log],
+		env: {
+			...process.env,
+			THINKRAIL_PORT: String(PORT),
+			THINKRAIL_STATIC_DIR: staticDir,
+			THINKRAIL_DATA_DIR: DATA_DIR,
+			THINKRAIL_PICK_DIR: PICK_POINTER,
+			THINKRAIL_GH_OFFLINE: "1",
+			PI_CODING_AGENT_DIR: AGENT_DIR,
+		},
+	});
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${BASE}/health`);
+			if (res.ok) return;
+		} catch {
+			// not up yet
+		}
+		await new Promise((r) => setTimeout(r, 250));
+	}
+	throw new Error(`private e2e host did not become healthy on :${PORT} (see ${HOST_LOG})`);
+}
+
+/** Kill the private host (default SIGKILL — the crash case) and wait for the process to exit. */
+async function stopHost(signal: NodeJS.Signals = "SIGKILL"): Promise<void> {
+	const proc = host;
+	host = null;
+	if (!proc || proc.exitCode !== null) return;
+	const exited = new Promise<void>((resolve) => proc.once("exit", () => resolve()));
+	proc.kill(signal);
+	await exited;
+}
+
+test.afterEach(async () => {
+	await stopHost();
+	rmSync(DATA_DIR, { recursive: true, force: true });
+});
+
+/** The interactive (awaiting) questionnaire card. */
+function activeCard(page: Page) {
+	return page.locator('[data-testid="ask-user-question"][data-tone="active"]').first();
+}
+
+test("a pending questionnaire survives a host kill -9: reboot, reopen, answer, agent resumes", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(300_000); // two host boots + two real agent turns
+	seedState();
+	await startHost();
+
+	// ---- before the restart: open a chat and get a questionnaire on screen ----
+	await page.goto(BASE);
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("add-project-menu").click();
+	await page.getByTestId("menu-open-project").click();
+	await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+	await page.getByTestId("add-workspace").first().click();
+	const dialog = page.getByTestId("new-workspace-dialog");
+	await expect(dialog).toBeVisible();
+	await page.getByTestId("create-workspace").click();
+	await expect(dialog).toBeHidden();
+	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1, {
+		timeout: 20_000,
+	});
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			"Call the ask_user_question tool with EXACTLY ONE single-select question (multiSelect false) offering 2 short options with descriptions and no previews. Call no other tool, and do nothing else besides asking. After I answer, reply with one short sentence.",
+		);
+	await page.getByTestId("chat-send").click();
+	await expect(activeCard(page)).toBeVisible({ timeout: 90_000 });
+	// Ack + terminate: the ask TURN is already over ("✓ Done"), so the ack tool result — everything the
+	// answer path needs — is durably on disk before we pull the plug.
+	await expect(
+		page.locator('[data-testid="chat-message"][data-role="system"]').filter({ hasText: "Done" }),
+	).toBeVisible({ timeout: 30_000 });
+
+	// ---- the restart: kill -9, then a fresh host on the same on-disk state ----
+	await stopHost("SIGKILL");
+	await expect(page.getByTestId("connection-status")).not.toHaveAttribute(
+		"data-status",
+		"connected",
+		{ timeout: 30_000 },
+	);
+	await startHost();
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+
+	// The project persisted but renders collapsed after a fresh load — select it to reveal its workspaces.
+	await page.getByTestId("project-item").first().click();
+	// The workspace persisted; its session is now DISK-ONLY (the live one died with the host), so it
+	// surfaces in chat history and re-opens through the hydration path.
+	await expect(page.getByTestId("workspace-item").first()).toBeVisible({ timeout: 15_000 });
+	await page.getByTestId("workspace-item").first().click();
+	await page.getByTestId("chat-history").click();
+	await page.getByTestId("closed-chat-item").first().click();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+
+	// The questionnaire is STILL ANSWERABLE — the awaiting state is pure transcript, no host memory.
+	const card = activeCard(page);
+	await expect(card).toBeVisible({ timeout: 30_000 });
+	await card.getByTestId("ask-option").first().click();
+	await card.getByTestId("ask-submit").click();
+
+	// The answer resolves the card into the answered record and STARTS A NEW TURN on the reborn host —
+	// the agent replies with the answer in context.
+	await expect(
+		page.locator('[data-testid="ask-user-question"][data-tone="answered"]').first(),
+	).toBeVisible({ timeout: 60_000 });
+	await expect(
+		page
+			.locator('[data-testid="chat-message"][data-role="system"]')
+			.filter({ hasText: "Done" })
+			.last(),
+	).toBeVisible({ timeout: 90_000 });
+	// A fresh assistant reply exists below the record (the resumed turn's output).
+	await expect(
+		page.locator('[data-testid="chat-message"][data-role="assistant"]').last(),
+	).toBeVisible();
+});

--- a/e2e/ask-user-question.live.spec.ts
+++ b/e2e/ask-user-question.live.spec.ts
@@ -4,13 +4,15 @@ import { openWorkspaceChat } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): these drive a REAL pi agent — the only way to exercise the
 // host-owned `ask_user_question` tool end to end, since the questionnaire is rendered from a real tool
-// call (there is no fake agent). They prove the whole inline path: the agent calls the tool → its
-// `execute` BLOCKS → our `AskUserQuestionCard` renders the questionnaire inline → the user answers/skips →
-// the reply (`session.answerQuestion`) resolves the blocked tool. The card's pure logic (parse/derive/
-// envelope/validation) is unit-tested separately (AskUserQuestionCard.test.ts, askUserQuestion.test.ts);
-// the blocked-tool hydration shape in chat/hydrate.test.ts. Prompts steer the model to a specific question
-// shape; assertions stay structural (data-testid / data-tone / data-selected) so they tolerate the exact
-// wording the model chooses.
+// call (there is no fake agent). They prove the whole inline path under the ack + terminate design: the
+// agent calls the tool → the tool acks and ENDS THE TURN (nothing blocks; the transcript stays valid
+// across restarts) → our `AskUserQuestionCard` renders the awaiting questionnaire inline → the user
+// answers/skips → the reply (`session.answerQuestion`) is injected as an `ask-user-answers` message that
+// starts the next turn, and the card flips to its resolved record. The card's pure logic (parse/derive/
+// envelope/validation/lifecycle) is unit-tested separately (AskUserQuestionCard.test.ts, askState.test.ts,
+// askUserQuestion.test.ts); the hydration shape in chat/hydrate.test.ts. Prompts steer the model to a
+// specific question shape; assertions stay structural (data-testid / data-tone / data-selected) so they
+// tolerate the exact wording the model chooses.
 
 /** Reset state, open the fixture project, create a workspace + chat, and send `prompt`. */
 async function ask(page: Page, prompt: string): Promise<void> {
@@ -19,7 +21,7 @@ async function ask(page: Page, prompt: string): Promise<void> {
 	await page.getByTestId("chat-send").click();
 }
 
-/** The interactive (pending) questionnaire card — visible while the tool call blocks on our answer. */
+/** The interactive (awaiting) questionnaire card — visible until it's answered or superseded. */
 function activeCard(page: Page): Locator {
 	return page.locator('[data-testid="ask-user-question"][data-tone="active"]').first();
 }
@@ -272,7 +274,28 @@ test("multi-question: Next reaches review before submitting the batch", { tag: "
 	).toHaveCount(2);
 });
 
-test("the blocked card survives closing and reopening the chat", { tag: "@agent" }, async ({
+test("typing a message instead of answering supersedes the questionnaire", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(150_000);
+	await ask(
+		page,
+		`Call the ask_user_question tool with one single-select question and 2 options. ${ONLY_TOOL} If I answer in chat instead, reply with one short sentence.`,
+	);
+	await expect(activeCard(page)).toBeVisible({ timeout: 90_000 });
+
+	// Reply in chat instead of using the card — the user's own words are the answer now.
+	await page.getByTestId("chat-input").fill("Just pick whichever option you prefer — go ahead.");
+	await page.getByTestId("chat-send").click();
+
+	// The card flips to its terminal superseded record (no longer answerable)…
+	await expect(
+		page.locator('[data-testid="ask-user-question"][data-tone="superseded"]').first(),
+	).toBeVisible({ timeout: 30_000 });
+	await expect(activeCard(page)).toHaveCount(0);
+});
+
+test("the awaiting card survives closing and reopening the chat", { tag: "@agent" }, async ({
 	page,
 }) => {
 	test.setTimeout(150_000);
@@ -282,18 +305,19 @@ test("the blocked card survives closing and reopening the chat", { tag: "@agent"
 	);
 
 	const before = activeCard(page);
-	// The active card appears only at message end, i.e. once the blocked tool call is durably in the
-	// transcript — so the reopen below deterministically exercises the hydration path.
+	// The active card appears only at message end, i.e. once the tool call is durably in the transcript —
+	// so the reopen below deterministically exercises the hydration path (the same path a host restart
+	// takes: the awaiting state is pure transcript, nothing pends in memory).
 	await expect(before).toBeVisible({ timeout: 90_000 });
 	await before.getByTestId("ask-option").first().click();
 	await expect(before.getByTestId("ask-submit")).toBeEnabled({ timeout: 30_000 });
 
-	// Close the chat tab — the session/runtime stay alive (the tool is still blocking on the host).
+	// Close the chat tab — the session stays live on the host; the questionnaire stays awaiting.
 	const chatTabs = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
 	await chatTabs.first().getByTestId("editor-tab-close").click();
 	await expect(chatTabs).toHaveCount(0);
 
-	// Reopen from chat history → the still-pending questionnaire re-renders, ready to answer.
+	// Reopen from chat history → the still-awaiting questionnaire re-renders, ready to answer.
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
 	await expect(chatTabs).toHaveCount(1);

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -66,8 +66,13 @@ what lets the UI ship independently of the host.
     **`AskUserQuestionResult`** (`AskUserQuestionAnswer[]` + `cancelled`: the browser's reply),
     **`AskUserQuestionAckDetails`** (the tool result's `details` under the **ack + terminate** design —
     the call resolves instantly; the turn ends) and **`AskUserAnswersDetails`** + the
-    **`ASK_USER_ANSWERS_CUSTOM_TYPE`** constant (in `wsProtocol`, the value-bearing half): the reply
-    travels as an `ask-user-answers` custom message the card pairs by `details.toolCallId`. The capability
+    **`ASK_USER_ANSWERS_CUSTOM_TYPE`** constant, **`AskUserAnswersMessage`** (the correctly-paired
+    tag↔details shape the host's builder is compile-held to) and the shared **`isAskUserAnswersMessage`**
+    guard (all in `wsProtocol`, the value-bearing half): the reply travels as an `ask-user-answers`
+    custom message the card pairs by `details.toolCallId`. `WireCustomMessage.customType` itself stays
+    `string` — the namespace is open (any pi extension can mint custom messages and they all cross the
+    wire), so strictness lives at the producer + the guard, which validates the details *shape* (wire
+    data is untrusted — another process, possibly another protocol version). The capability
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
     rationale); the chat renders the questionnaire **inline** and replies via `session.answerQuestion`
     (correlated by the tool call id; rejected loud when the call is unknown/answered/superseded).

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -53,18 +53,24 @@ what lets the UI ship independently of the host.
     skill catalog).
   - **`SessionSummary`** — a chat session as the host reports it for hydration (read side); `live`
     distinguishes an in-memory session (auto-restored) from a disk-only one (surfaced in chat-history,
-    re-opened on demand). `session.getMessages` returns `{ summary, messages }` (the transcript is the
-    pi-canonical `Message[]`; the summary reflects the now-live session after a disk re-open).
+    re-opened on demand). `session.getMessages` returns `{ summary, messages }` (the transcript is
+    **`TranscriptMessage[]`** — the pi-canonical `Message` union widened with **`WireCustomMessage`**, a
+    type-only mirror of pi-coding-agent's Node-only `CustomMessage`, so extension-injected messages like
+    the ask replies cross the wire; the summary reflects the now-live session after a disk re-open).
   - the **extension-UI frames** **`ExtUiRequest`** / **`ExtUiResponse`** — our wire shape for pi's in-process
     `uiContext` calls (`select`/`confirm`/`input`/`editor` round-trip; `notify`/`setStatus`/`setWidget`/
     `setTitle`/`dismiss` are fire-and-forget), carried on the `pi.extensionUi` channel.
   - the **`ask_user_question`** wire types — **`AskUserQuestionArgs`** (`AskUserQuestionItem` + `AskUserQuestionOption`
     — the latter carries an optional `recommendedReason` the card renders inline as a `Why:` line under the
-    option: the questions the agent authors, what the tool card reads from the `toolCall` block) and
-    **`AskUserQuestionResult`** (`AskUserQuestionAnswer[]` + `cancelled`: the browser's reply). The capability
+    option: the questions the agent authors, what the tool card reads from the `toolCall` block),
+    **`AskUserQuestionResult`** (`AskUserQuestionAnswer[]` + `cancelled`: the browser's reply),
+    **`AskUserQuestionAckDetails`** (the tool result's `details` under the **ack + terminate** design —
+    the call resolves instantly; the turn ends) and **`AskUserAnswersDetails`** + the
+    **`ASK_USER_ANSWERS_CUSTOM_TYPE`** constant (in `wsProtocol`, the value-bearing half): the reply
+    travels as an `ask-user-answers` custom message the card pairs by `details.toolCallId`. The capability
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
-    rationale); the tool blocks while the chat renders the questionnaire **inline** and replies via
-    `session.answerQuestion` (correlated by the tool call id).
+    rationale); the chat renders the questionnaire **inline** and replies via `session.answerQuestion`
+    (correlated by the tool call id; rejected loud when the call is unknown/answered/superseded).
 - **domain.ts** — app entities: `Project` (git repo + unique `slug`; "does it have specs?" is **not** a
   field — it's the lazy `project.hasSpecs` query, since it's a full-tree walk), **`ProjectPathStatus`** (a
   candidate path's kind — `repo` / `initable` / `missing` / `notDirectory` — so the UI opens, offers a

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -20,7 +20,7 @@ export type {
 } from "@earendil-works/pi-ai";
 
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { Model } from "@earendil-works/pi-ai";
+import type { ImageContent, Message, Model, TextContent } from "@earendil-works/pi-ai";
 
 /**
  * A model **as it crosses the wire**: an **allowlist** of exactly the fields the UI renders — identity
@@ -162,9 +162,11 @@ export interface ExtUiResponse {
 }
 
 // ---- ask_user_question — structured clarifying questions, rendered INLINE in the chat ----
-// The capability is a host-owned pi custom tool (server `agent/askUserQuestion`): the agent calls
-// `ask_user_question` with these args; the tool blocks while the browser renders the questionnaire card
-// and awaits an `AskUserQuestionResult` (correlated by the tool call's id).
+// The capability is a host-owned pi custom tool (server `agent/askUserQuestion`), designed "ack +
+// terminate": the tool returns an ACK immediately and ends the agent's turn, so nothing blocks and the
+// transcript stays valid across host restarts. The browser renders the questionnaire card from the tool
+// call's args; the user's reply (`session.answerQuestion`, correlated by the tool call's id) is delivered
+// to the session as an `ask-user-answers` custom message that starts the next turn.
 
 /** One selectable option in a question. */
 export interface AskUserQuestionOption {
@@ -216,8 +218,48 @@ export interface AskUserQuestionAnswer {
 	preview?: string;
 }
 
-/** The browser's reply to an `ask_user_question` tool call — resolves the awaiting tool `execute`. */
+/** The browser's reply to an `ask_user_question` tool call. */
 export interface AskUserQuestionResult {
 	answers: AskUserQuestionAnswer[];
 	cancelled: boolean;
 }
+
+/**
+ * The `ask_user_question` tool result's `details` under the ack + terminate design: the call itself
+ * resolves instantly with this marker (the turn ends; the model is told answers arrive as the next user
+ * message). The card treats an ack'd call with no later answers message as "awaiting" — still answerable,
+ * now or after any number of host restarts. Legacy transcripts (the old blocking tool) carry an
+ * `AskUserQuestionResult` here instead, which the card still renders as a resolved record.
+ */
+export interface AskUserQuestionAckDetails {
+	kind: "ack";
+}
+
+/**
+ * `details` of an `ask-user-answers` custom message (its `customType` constant lives in `wsProtocol`,
+ * the value-bearing half of this package): the reply, correlated to its tool call. The UI pairs it with
+ * the questionnaire card by `toolCallId` and never renders the message as its own bubble.
+ */
+export interface AskUserAnswersDetails {
+	toolCallId: string;
+	result: AskUserQuestionResult;
+}
+
+/**
+ * MIRROR of pi-coding-agent's `CustomMessage` (that package is Node-only, so the shape is re-declared
+ * type-only for the wire — keep in sync with @earendil-works/pi-coding-agent@0.80.3 core/messages.d.ts):
+ * an extension-injected transcript message (`sendCustomMessage`). Crosses the wire in
+ * `session.getMessages` and inside `message_start`/`message_end` events; the LLM sees it as a user
+ * message. The web renders only the `customType`s it knows (e.g. `ask-user-answers`) and ignores the rest.
+ */
+export interface WireCustomMessage<T = unknown> {
+	role: "custom";
+	customType: string;
+	content: string | (TextContent | ImageContent)[];
+	display: boolean;
+	details?: T;
+	timestamp: number;
+}
+
+/** A transcript message as `session.getMessages` reports it: pi-canonical + custom messages. */
+export type TranscriptMessage = Message | WireCustomMessage;

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -19,11 +19,11 @@ import type {
 	AskUserQuestionResult,
 	ExtUiResponse,
 	ImageContent,
-	Message,
 	SessionStats,
 	SessionSummary,
 	SlashCommandInfo,
 	ThinkingLevel,
+	TranscriptMessage,
 	WireModel,
 } from "./piProtocol";
 
@@ -37,7 +37,10 @@ import type {
 // v7: server-synced app settings — `server.welcome` now carries `config: AppConfig` (the initial theme
 // travels with the handshake), `settings.update` persists a partial, and `settings.changed` broadcasts
 // the new config to every client so they converge (the same shared-state pattern as the workspace trio).
-export const PROTOCOL_VERSION = 7;
+// v8: `ask_user_question` is ack + terminate — the tool no longer blocks; answers travel as
+// `ask-user-answers` custom messages, and `session.getMessages` now returns `TranscriptMessage[]`
+// (pi-canonical + `custom` role) so the questionnaire card can pair answers by tool call id.
+export const PROTOCOL_VERSION = 8;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -109,7 +112,8 @@ export const WS_METHODS = {
 	sessionGetCommands: "session.getCommands",
 	sessionExtUiReply: "session.extUiReply",
 	// Inline `ask_user_question` reply: the browser sends the questionnaire result, correlated by the tool
-	// call's id, to resolve the blocked tool `execute`.
+	// call's id; the host delivers it to the session as an `ask-user-answers` custom message, starting the
+	// next turn (or steering the current one).
 	sessionAnswerQuestion: "session.answerQuestion",
 	// Read side of the wire (hydrate-then-stream): a client lists a workspace's sessions and pulls a
 	// transcript to rebuild its view on connect.
@@ -167,6 +171,14 @@ export const WS_CHANNELS = {
 
 export type WsMethod = (typeof WS_METHODS)[keyof typeof WS_METHODS];
 export type WsChannel = (typeof WS_CHANNELS)[keyof typeof WS_CHANNELS];
+
+/**
+ * The `customType` of the transcript message that carries an `ask_user_question` reply back to the agent
+ * (host-injected via pi's `sendCustomMessage`, starting/steering a turn). Both ends key on it: the host
+ * builds these messages; the UI pairs them with the questionnaire card by `details.toolCallId`
+ * (`AskUserAnswersDetails`) and never renders them as their own bubble.
+ */
+export const ASK_USER_ANSWERS_CUSTOM_TYPE = "ask-user-answers";
 
 /** Wire result for methods that return nothing meaningful — the host coerces a void handler to this. */
 export interface Ack {
@@ -238,6 +250,8 @@ export interface WsMethodMap {
 	"session.getStats": { params: { sessionId: string }; result: SessionStats };
 	"session.getCommands": { params: { sessionId: string }; result: SlashCommandInfo[] };
 	"session.extUiReply": { params: { response: ExtUiResponse }; result: Ack };
+	// Rejects when the tool call is unknown, already answered, superseded by a later user message, or not
+	// an awaiting ask — so a stale card fails loud instead of silently parking an answer.
 	"session.answerQuestion": {
 		params: { sessionId: string; toolCallId: string; result: AskUserQuestionResult };
 		result: Ack;
@@ -247,7 +261,7 @@ export interface WsMethodMap {
 	// now-live model/thinking (a disk `SessionSummary` only carries placeholders).
 	"session.getMessages": {
 		params: { sessionId: string; workspaceId: string };
-		result: { summary: SessionSummary; messages: Message[] };
+		result: { summary: SessionSummary; messages: TranscriptMessage[] };
 	};
 	"model.list": { params: Record<string, never>; result: WireModel[] };
 	// The model/thinking a fresh session resolves to (settings default, else first available) — so the

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -16,6 +16,7 @@ import type {
 	Workspace,
 } from "./domain";
 import type {
+	AskUserAnswersDetails,
 	AskUserQuestionResult,
 	ExtUiResponse,
 	ImageContent,
@@ -24,6 +25,7 @@ import type {
 	SlashCommandInfo,
 	ThinkingLevel,
 	TranscriptMessage,
+	WireCustomMessage,
 	WireModel,
 } from "./piProtocol";
 
@@ -179,6 +181,37 @@ export type WsChannel = (typeof WS_CHANNELS)[keyof typeof WS_CHANNELS];
  * (`AskUserAnswersDetails`) and never renders them as their own bubble.
  */
 export const ASK_USER_ANSWERS_CUSTOM_TYPE = "ask-user-answers";
+
+/**
+ * A correctly-paired `ask-user-answers` message. `WireCustomMessage.customType` stays `string` (the
+ * namespace is open — any pi extension can mint custom messages, and they all cross the wire), so the
+ * strictness lives at the two points that matter instead: the host's builder is HELD to this type (a
+ * tag↔details mismatch is a compile error at the one place the message is minted), and
+ * {@link isAskUserAnswersMessage} narrows to it.
+ */
+export interface AskUserAnswersMessage extends WireCustomMessage<AskUserAnswersDetails> {
+	customType: typeof ASK_USER_ANSWERS_CUSTOM_TYPE;
+	details: AskUserAnswersDetails;
+}
+
+/**
+ * THE narrowing point for `ask-user-answers` messages, shared by every consumer (web hydration, the
+ * event reducer, the server's answerability check) instead of hand-rolled checks. Wire data is untrusted
+ * — another process, possibly another protocol version — so it validates the `details` shape, not just
+ * the tag: a malformed reply is ignored rather than trusted on its customType.
+ */
+export function isAskUserAnswersMessage(message: unknown): message is AskUserAnswersMessage {
+	if (!message || typeof message !== "object") return false;
+	const m = message as { role?: unknown; customType?: unknown; details?: unknown };
+	if (m.role !== "custom" || m.customType !== ASK_USER_ANSWERS_CUSTOM_TYPE) return false;
+	const details = m.details as Partial<AskUserAnswersDetails> | undefined;
+	return (
+		typeof details?.toolCallId === "string" &&
+		!!details.result &&
+		Array.isArray(details.result.answers) &&
+		typeof details.result.cancelled === "boolean"
+	);
+}
 
 /** Wire result for methods that return nothing meaningful — the host coerces a void handler to this. */
 export interface Ack {

--- a/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
@@ -13,6 +13,12 @@ degrade when answers don't come. Process skills name this concept at the steps t
 
 - One call = one **round**: up to 4 questions, 2–4 options each. Group everything the current step
   needs into a single round — never chain a second call straight after for a trivial follow-up.
+- **The call ends your turn.** The questionnaire is shown and your run stops; the answers arrive as the
+  next user message (a structured "User has answered your questions:" message). Don't keep working on
+  the blocked step after calling, and don't assume an answer until it arrives — whether that is seconds
+  later or days later.
+- If the user replies with a free-form message instead of answering the card, that reply **supersedes**
+  the round — treat it as their answer, and re-ask only what is still genuinely undecided.
 - Resolve the round, act on what you learned, and open a new round only when the answers raised a
   genuinely new question.
 

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -13,8 +13,8 @@ tags: [v1, pi]
 
 The in-process `pi` engine: a shared runtime (auth + model registry), the lifecycle of `AgentSession`s
 (one per chat tab, rooted in a workspace's worktree), the **extension-UI bridge** that turns pi's
-in-process `uiContext` dialog calls into WS frames, and the host-owned **`ask_user_question`** tool +
-its inline answer bridge.
+in-process `uiContext` dialog calls into WS frames, the host-owned **`ask_user_question`** tool + its
+answer-injection path, and the **restart repair** that keeps re-opened transcripts provider-valid.
 
 ## Boundary
 
@@ -42,8 +42,21 @@ its inline answer bridge.
     `listSessions(workspaceId, cwd)` (live sessions
     **unioned with on-disk** ones pi persisted under `cwd`, live winning on id → `SessionSummary[]` tagged
     `live`) + `getSessionMessages(sessionId, workspaceId, cwd)` (re-opens a disk session into the manager if
-    not live, then returns `{ summary, messages }` — the pi-canonical `Message` subset); the disk half is
-    what survives a host **restart**; `getSessionWorkspaceId(sessionId)` (the live session→workspace
+    not live, then returns `{ summary, messages }` — `TranscriptMessage[]`: the pi-canonical subset **plus
+    `custom` messages**, which carry the `ask-user-answers` replies the questionnaire card pairs by tool
+    call id); the disk half is what survives a host **restart** — and re-attaching runs
+    **`repairDanglingToolCalls` (the `sessionRepair` sibling) BEFORE `createAgentSession` seeds its
+    context**: a host death mid-tool leaves an assistant message with unpaired `toolCall`s, every provider
+    rejects such a context (the chat would brick), and appending behind a live session would desync its
+    in-memory state — so orphans are paired at the one choke point every post-restart session passes.
+    Generic orphans get pi's abort convention (`isError` "Operation aborted (host restarted…)"); an
+    old-format dangling ask gets the canonical decline + a re-ask hint (`details {answers:[],
+    cancelled:true}`), so its card hydrates as the normal skipped record;
+    **`answerQuestion(sessionId, toolCallId, result)`** — the `ask_user_question` reply path (see the
+    `askUserQuestion` bullet); **`settleSessionsForShutdown(timeoutMs)`** — the polite half of shutdown:
+    abort every streaming session and wait (bounded) so pi persists their "Operation aborted" tool results
+    before `process.exit` (the launcher's SIGINT/SIGTERM handler awaits it; whatever misses the window is
+    healed by the restart repair); `getSessionWorkspaceId(sessionId)` (the live session→workspace
     lookup the host's auto-rename hook keys on); `removeSession`/`disposeAllSessions`;
     **`removeWorkspaceSessions(workspaceId, cwd?)`** (the **archive teardown**: abort a streaming turn,
     `removeSession` every live session for the workspace, then delete pi's on-disk transcripts rooted at
@@ -64,32 +77,43 @@ its inline answer bridge.
     (server→client push seam), `resolveExtUi` (browser reply), `cancelExtUiForSession` (on dispose),
     `notifyExtUi`.
   - `askUserQuestion` — the host-owned **`ask_user_question`** pi custom tool (`createAskUserQuestionTool`,
-    registered on every session via the `askUserQuestionExtension` factory in `extensions`).
-    **Rejected alternative** (the one place this decision is recorded): bundling the community
-    `@juicesharp/rpiv-ask-user-question` extension. Its questionnaire UI is a live pi-tui component handed
-    to the host via `ctx.ui.custom(factory)` — *code, not data* — so it can't be serialized over the WS
-    bridge or hosted by a browser; the tool would block forever. Interception is technically possible
-    (stub the TUI in `webUiContext.custom`, capture the factory's `done` callback, synthesize its result)
-    but couples us to two fast-moving packages' private internals (the result shape `done` expects, the
-    TUI surface the factory touches) and still requires all the same browser-side work — so we own the
-    small LLM-facing contract instead (schema/validation/envelope mirror the rpiv tool's so the model
-    behaves the same). Ours renders **nothing** — its
-    `execute` guards on `ctx.hasUI`, runs the pure `validateQuestionnaire`, then **blocks** awaiting a
-    structured `AskUserQuestionResult` from the browser (keyed by the unique tool call id, cancelled on the
-    agent abort `signal`), and formats the LLM envelope with `buildQuestionnaireResponse` (a partial
-    submission lists its unanswered questions explicitly as declined). The reply arrives over
-    `session.answerQuestion` → `answerQuestion(sessionId, toolCallId, result)`; the WS handler vets the
-    session is live (`hasSession`) and the result shape before forwarding. **The reply can beat the tool:**
-    the inline card is interactive as soon as the tool call's args stream in, but `execute` (which registers
-    the pending entry) only runs once the assistant message completes — so an answer with no pending entry
-    is **held**, keyed by tool call id, and consumed when `awaitAnswer` registers (only if the session
-    matches; holds are bounded per session, oldest evicted). `cancelQuestionsForSession(sessionId)` (called
-    from `removeSession`/`disposeAllSessions`) settles any awaiting question as cancelled and drops the
-    session's held answers. The
-    questionnaire is rendered **inline** in chat by `apps/web`'s `AskUserQuestionCard` (joined by tool name).
-    Correlation is exact because `ctx.sessionManager.getSessionId()` **is** the `AgentSession.sessionId` we
-    key on. The LLM-facing contract (TypeBox schema, validation, envelope) is re-implemented here so we own
-    it and avoid the package's pi-tui/i18n peer deps.
+    registered on every session via the `askUserQuestionExtension` factory in `extensions`), designed
+    **ack + terminate** so a questionnaire survives host restarts: `execute` renders nothing and **awaits
+    nothing** — it guards on `ctx.hasUI`, runs the pure `validateQuestionnaire`, then immediately returns
+    the ack (`details {kind:"ack"}`) with **`terminate: true`**, ending the turn at the tool batch with no
+    further LLM call. Nothing pends in memory, the transcript is complete and provider-valid the moment
+    the ack lands, and the session is genuinely **idle** while the user thinks — restarts need no
+    question-specific handling at all. The reply arrives over `session.answerQuestion` → the manager's
+    `answerQuestion(sessionId, toolCallId, result)`: it vets the reply against the transcript with the
+    pure **`assessAnswerability`** (unknown call / already answered / `not_awaiting` legacy-final results /
+    **superseded** — a later free-form user message replaced the answer, so the card is terminal and a
+    stale answer **fails loud**, never parks), then injects **`buildAnswersMessage`** — an
+    **`ask-user-answers` custom message** (`ASK_USER_ANSWERS_CUSTOM_TYPE`, `details {toolCallId, result}`,
+    text = the same `buildQuestionnaireResponse` envelope the blocking design fed the model; a partial
+    submission lists its unanswered questions explicitly as declined) — via pi's public
+    `AgentSession.sendCustomMessage({triggerTurn: true})`, which starts a new turn when idle and steers
+    the current one when streaming. **Answering live and answering after a restart are the same code
+    path.** The questionnaire is rendered **inline** in chat by `apps/web`'s `AskUserQuestionCard`
+    (joined by tool name; lifecycle derived from the transcript — see the chat tools SPEC).
+    **Rejected alternatives** (the one place these decisions are recorded): (1) the original **blocking
+    design** — `execute` parked on an in-memory promise until the browser replied. A host restart
+    destroyed the pending promise and left a dangling `toolCall` in the transcript; providers reject
+    unpaired `tool_use`, so the chat **bricked** on every later prompt, and post-restart answers rotted in
+    a held-answers map. The shutdown handler's synchronous `process.exit` made this deterministic, and
+    questions block on human timescales — restarts during the window are the common case, not the edge.
+    (2) A **suspended-session** variant (write the real result at answer time; tolerate the dangle while
+    waiting) — needs two different answer mechanisms (resolve-blocked-promise live vs
+    heal-file-then-attach post-restart), keeps a deliberately-invalid on-disk state every consumer must
+    tiptoe around, and pi exposes no public turn-resume from a bare tool result anyway. (3) Bundling the
+    community `@juicesharp/rpiv-ask-user-question` extension — its questionnaire UI is a live pi-tui
+    component handed to the host via `ctx.ui.custom(factory)` (*code, not data*), unserializable over the
+    WS bridge; and like every blocking ask-extension it inherits the restart hole. The LLM-facing contract
+    (TypeBox schema, validation, envelope — mirroring rpiv's so the model behaves the same) stays
+    re-implemented here so we own it and avoid the package's pi-tui/i18n peer deps.
+  - `sessionRepair` — `repairDanglingToolCalls(sessionManager)`: the restart safety net (rationale under
+    the manager bullet above). Pure over pi's `SessionManager` (compaction-aware via
+    `buildSessionContext`; idempotent; appends at the leaf, where orphans sit by construction) —
+    unit-tested against `SessionManager.inMemory`.
   - `extensions` — `buildResourceLoader(cwd, settingsManager)`: a `DefaultResourceLoader` (pi's normal
     disk discovery) that also loads the four bundled extensions — **`pi-web-access`** (`web_search` +
     `fetch_content`), **`pi-visualize`** (`visualize`), **`pi-spec-graph`** (the `spec_*` tools + its
@@ -111,11 +135,12 @@ its inline answer bridge.
     `rpc` host can't render) **and** `askUserQuestionExtension` (registers the `ask_user_question` tool).
     Both session paths pass it as `resourceLoader`. `buildResourceLoader` stays internal; the seam +
     its types are on the barrel.
-- **Public surface (barrel):** the manager operations + `CreateSessionInput`/`CreateSessionResult` +
-  `SessionEventPayload`; `configurePiRuntime`/`getPiRuntime`; `completeOnce`/`pickModel` +
-  `OneShotRequest`/`OneShotResult`/`ModelTier`; the `webUiContext` seams; the
-  `askUserQuestion` bridge (`answerQuestion`/`cancelQuestionsForSession`) + its pure helpers
-  (`validateQuestionnaire`/`buildQuestionnaireResponse`); the compiled-binary extension seam
+- **Public surface (barrel):** the manager operations (incl. `answerQuestion` +
+  `settleSessionsForShutdown`) + `CreateSessionInput`/`CreateSessionResult` + `SessionEventPayload`;
+  `configurePiRuntime`/`getPiRuntime`; `completeOnce`/`pickModel` +
+  `OneShotRequest`/`OneShotResult`/`ModelTier`; the `webUiContext` seams; the `askUserQuestion` pure
+  helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
+  `buildAnswersMessage`); `repairDanglingToolCalls`; the compiled-binary extension seam
   (`setBundledExtensions` + `BundledExtensions`/`BundledExtensionFactory`).
 - **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (runtime — the
   `complete()` dispatch used by `oneshot`); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
@@ -130,6 +155,13 @@ its inline answer bridge.
 
 - `prompt()` throws while a session is streaming → `promptSession` falls back to `steer()`.
 - Errors arrive via the event stream + thrown methods, not a crash signal — wrap + forward.
+- **A re-opened disk session is repaired before it is seeded** (`repairDanglingToolCalls` between
+  `SessionManager.open` and `createAgentSession`) — never append to a session file behind a live
+  `AgentSession`, its in-memory context would desync.
+- **The ask tool never blocks and never holds state** — anything "pending" about a questionnaire must be
+  derivable from the transcript alone (that's what makes restarts free); reply validity is
+  `assessAnswerability`'s verdict, computed from `session.messages`, and rejections fail the WS request
+  loud.
 - Share one `authStorage`/`modelRegistry`; give each session its own `SessionManager`; `dispose()` on removal.
 - **A `pi` `Model` must never cross the wire raw** — its `baseUrl` carries the jbcentral proxy secret (and
   `headers` can carry auth). Every model-bearing frame (`model.list`/`model.default`, the `session.create`

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -6,8 +6,8 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 import type {
+	AskUserQuestionResult,
 	ImageContent,
-	Message,
 	Model,
 	PiEvent,
 	SessionEventPayload,
@@ -15,11 +15,13 @@ import type {
 	SessionSummary,
 	SlashCommandInfo,
 	ThinkingLevel,
+	TranscriptMessage,
 	WireModel,
 } from "@thinkrail/contracts";
-import { cancelQuestionsForSession } from "./askUserQuestion";
+import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import { buildResourceLoader } from "./extensions";
 import { getPiRuntime } from "./piRuntime";
+import { repairDanglingToolCalls } from "./sessionRepair";
 import { cancelExtUiForSession, createWebUiContext, notifyExtUi } from "./webUiContext";
 
 interface Entry {
@@ -244,11 +246,16 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 	if (sessions.has(sessionId)) return; // attached while we listed
 	const { authStorage, modelRegistry } = getPiRuntime();
 	const settingsManager = buildSessionSettings(cwd);
+	const sessionManager = SessionManager.open(info.path);
+	// Restart safety net: pair any tool call the last run left dangling (host died mid-tool) with a
+	// synthetic result BEFORE the session seeds its context — providers reject unpaired tool calls, and
+	// appending behind a live session would desync its in-memory state. See `sessionRepair`.
+	repairDanglingToolCalls(sessionManager);
 	const { session } = await createAgentSession({
 		cwd,
 		authStorage,
 		modelRegistry,
-		sessionManager: SessionManager.open(info.path),
+		sessionManager,
 		settingsManager,
 		resourceLoader: await buildResourceLoader(cwd, settingsManager),
 	});
@@ -268,7 +275,7 @@ export async function getSessionMessages(
 	sessionId: string,
 	workspaceId: string,
 	cwd: string,
-): Promise<{ summary: SessionSummary; messages: Message[] }> {
+): Promise<{ summary: SessionSummary; messages: TranscriptMessage[] }> {
 	let entry = sessions.get(sessionId);
 	// Scope the read to the requested workspace — a client can't pull a session from a different one.
 	if (entry && entry.workspaceId !== workspaceId) throw new Error(`Unknown session: ${sessionId}`);
@@ -277,9 +284,35 @@ export async function getSessionMessages(
 		entry = sessions.get(sessionId);
 		if (!entry) throw new Error(`Unknown session: ${sessionId}`);
 	}
-	const renderable = new Set(["user", "assistant", "toolResult"]);
-	const messages = entry.session.messages.filter((m) => renderable.has(m.role)) as Message[];
+	// `custom` rides along for the ask-user-answers pairing (the card reads `details.toolCallId`); the
+	// web renders only the customTypes it knows and ignores the rest.
+	const renderable = new Set(["user", "assistant", "toolResult", "custom"]);
+	const messages = entry.session.messages.filter((m) =>
+		renderable.has(m.role),
+	) as TranscriptMessage[];
 	return { summary: summaryOf(sessionId, entry), messages };
+}
+
+/**
+ * Deliver the browser's `ask_user_question` reply: vet it against the transcript (pure
+ * `assessAnswerability` — unknown/answered/superseded calls fail loud instead of parking an answer),
+ * then send the `ask-user-answers` custom message. `sendCustomMessage` starts a new turn when the
+ * session is idle (the normal ack+terminate case — also right after a restart re-open) and steers the
+ * current one when it is streaming (a fast submit while the ask turn is still winding down), so
+ * answering live and answering after a restart are the same code path. Resolves at turn end — the WS
+ * handler acks acceptance via `ackSend`, mirroring prompt/steer/followUp.
+ */
+export async function answerQuestion(
+	sessionId: string,
+	toolCallId: string,
+	result: AskUserQuestionResult,
+): Promise<void> {
+	const session = mustGet(sessionId);
+	const verdict = assessAnswerability(session.messages, toolCallId);
+	if (!verdict.ok) throw new Error(`${ANSWERABILITY_ERRORS[verdict.reason]}: ${toolCallId}`);
+	await session.sendCustomMessage(buildAnswersMessage(toolCallId, verdict.args, result), {
+		triggerTurn: true,
+	});
 }
 
 /** Send a turn. `prompt()` throws while streaming, so fall back to `steer()` then. */
@@ -421,7 +454,6 @@ export function removeSession(sessionId: string): void {
 	const entry = sessions.get(sessionId);
 	if (!entry) return;
 	cancelExtUiForSession(sessionId);
-	cancelQuestionsForSession(sessionId);
 	entry.unsubscribe();
 	entry.session.dispose();
 	sessions.delete(sessionId);
@@ -431,11 +463,26 @@ export function removeSession(sessionId: string): void {
 export function disposeAllSessions(): void {
 	for (const [sessionId, entry] of sessions) {
 		cancelExtUiForSession(sessionId);
-		cancelQuestionsForSession(sessionId);
 		entry.unsubscribe();
 		entry.session.dispose();
 	}
 	sessions.clear();
+}
+
+/**
+ * The polite half of shutdown: abort every streaming session and give pi a bounded window to settle —
+ * pi's abort path writes "Operation aborted" tool results through the normal loop, so transcripts land
+ * on disk already paired (no repair needed on the next boot). Bounded because shutdown must not hang on
+ * a wedged provider: whatever doesn't settle inside `timeoutMs` is left to the restart repair
+ * (`sessionRepair`). Callers dispose afterwards (`disposeAllSessions` via `server.stop()`).
+ */
+export async function settleSessionsForShutdown(timeoutMs = 2000): Promise<void> {
+	const streaming = [...sessions.values()].filter((entry) => entry.session.isStreaming);
+	if (streaming.length === 0) return;
+	await Promise.race([
+		Promise.allSettled(streaming.map((entry) => entry.session.abort())),
+		new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+	]);
 }
 
 /**

--- a/packages/server/src/agent/askUserQuestion.test.ts
+++ b/packages/server/src/agent/askUserQuestion.test.ts
@@ -1,11 +1,18 @@
 import { expect, test } from "bun:test";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { AskUserQuestionArgs, AskUserQuestionResult } from "@thinkrail/contracts";
+import type {
+	AgentMessage,
+	AskUserQuestionArgs,
+	AskUserQuestionResult,
+} from "@thinkrail/contracts";
+import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
 import {
-	answerQuestion,
+	ASK_ACK_TEXT,
+	assessAnswerability,
+	buildAnswersMessage,
 	buildQuestionnaireResponse,
-	cancelQuestionsForSession,
 	createAskUserQuestionTool,
+	isAckDetails,
 	validateQuestionnaire,
 } from "./askUserQuestion";
 
@@ -27,24 +34,53 @@ const args = (over: Partial<AskUserQuestionArgs> = {}): AskUserQuestionArgs => (
 const textOf = (r: { content: { type: string; text?: string }[] }): string =>
 	r.content.map((c) => c.text ?? "").join("");
 
-/** A minimal `ExtensionContext` for the tool: only `hasUI` + `sessionManager.getSessionId()` are read. */
-const ctx = (sessionId: string, hasUI = true): ExtensionContext =>
-	({ hasUI, sessionManager: { getSessionId: () => sessionId } }) as unknown as ExtensionContext;
+/** A minimal `ExtensionContext` for the tool: only `hasUI` is read (the ack design awaits nothing). */
+const ctx = (hasUI = true): ExtensionContext => ({ hasUI }) as unknown as ExtensionContext;
 
-const run = (
-	toolCallId: string,
-	sessionId: string,
-	signal?: AbortSignal,
-	hasUI = true,
-	params: AskUserQuestionArgs = args(),
-) =>
-	createAskUserQuestionTool().execute(
+const run = (hasUI = true, params: AskUserQuestionArgs = args()) =>
+	createAskUserQuestionTool().execute("tc-1", params as never, undefined, undefined, ctx(hasUI));
+
+// ---- transcript fixtures for the pure assessors (structural AgentMessage views) ----
+
+const askCall = (toolCallId: string, a: AskUserQuestionArgs = args()) =>
+	({
+		role: "assistant",
+		content: [{ type: "toolCall", id: toolCallId, name: "ask_user_question", arguments: a }],
+	}) as unknown as AgentMessage;
+
+const ackResult = (toolCallId: string) =>
+	({
+		role: "toolResult",
 		toolCallId,
-		params as never,
-		signal,
-		undefined,
-		ctx(sessionId, hasUI),
-	);
+		toolName: "ask_user_question",
+		content: [{ type: "text", text: ASK_ACK_TEXT }],
+		details: { kind: "ack" },
+		isError: false,
+	}) as unknown as AgentMessage;
+
+const finalResult = (toolCallId: string) =>
+	({
+		role: "toolResult",
+		toolCallId,
+		toolName: "ask_user_question",
+		content: [{ type: "text", text: "User declined to answer questions" }],
+		details: { answers: [], cancelled: true },
+		isError: false,
+	}) as unknown as AgentMessage;
+
+const answersMessage = (toolCallId: string) =>
+	({
+		role: "custom",
+		customType: ASK_USER_ANSWERS_CUSTOM_TYPE,
+		content: "User has answered your questions: …",
+		display: true,
+		details: { toolCallId, result: { answers: [], cancelled: false } },
+	}) as unknown as AgentMessage;
+
+const userMessage = (text = "actually, let me explain") =>
+	({ role: "user", content: [{ type: "text", text }] }) as unknown as AgentMessage;
+
+// ---- validation (unchanged contract) ----
 
 test("validateQuestionnaire accepts a well-formed questionnaire", () => {
 	expect(validateQuestionnaire(args()).ok).toBe(true);
@@ -89,6 +125,8 @@ test("validateQuestionnaire rejects empty, too-few-options, dupes, and reserved 
 		).ok,
 	).toBe(false);
 });
+
+// ---- the envelope (now the ask-user-answers message text; same wording as the blocking era) ----
 
 test("buildQuestionnaireResponse: cancelled → the canonical decline message", () => {
 	const r = buildQuestionnaireResponse({ answers: [], cancelled: true }, args());
@@ -157,96 +195,86 @@ test("buildQuestionnaireResponse: a multi answer's typed free text is marked as 
 	expect(r.content[0]?.text).toContain('user\'s own answer: "some-other-lib"');
 });
 
-test("execute blocks until answerQuestion resolves it, then formats the envelope", async () => {
-	const promise = run("tc-1", "s1");
-	answerQuestion("s1", "tc-1", {
-		cancelled: false,
-		answers: [{ questionIndex: 0, question: "Which library?", kind: "option", answer: "date-fns" }],
-	});
-	const r = await promise;
-	expect(textOf(r)).toContain('"Which library?"="date-fns"');
+// ---- the ack + terminate execute ----
+
+test("execute returns the ack immediately and ends the turn (terminate: true) — it never blocks", async () => {
+	const r = await run();
+	expect(textOf(r)).toBe(ASK_ACK_TEXT);
+	expect(isAckDetails(r.details)).toBe(true);
+	expect((r as { terminate?: boolean }).terminate).toBe(true);
 });
 
-test("an answer that arrives BEFORE execute is held and consumed on registration", async () => {
-	// The inline card is interactive while the assistant message still streams, so a fast submit can land
-	// before the tool call executes. The bridge must hold it — not drop it — or the tool blocks forever.
-	answerQuestion("s5", "tc-5", {
-		cancelled: false,
-		answers: [{ questionIndex: 0, question: "Which library?", kind: "option", answer: "luxon" }],
-	});
-	const r = await run("tc-5", "s5");
-	expect(textOf(r)).toContain('"Which library?"="luxon"');
-});
-
-test("cancelQuestionsForSession drops a held early answer (a disposed session's answer never leaks)", async () => {
-	answerQuestion("s6", "tc-6", {
-		cancelled: false,
-		answers: [{ questionIndex: 0, question: "Which library?", kind: "option", answer: "date-fns" }],
-	});
-	cancelQuestionsForSession("s6");
-	let resolvedEarly = false;
-	const promise = run("tc-6", "s6").then((r) => {
-		resolvedEarly = true;
-		return r;
-	});
-	await new Promise((r) => setTimeout(r, 0)); // a held answer settles via microtasks — a macrotask flushes them all
-	expect(resolvedEarly).toBe(false); // the dropped answer must NOT settle the fresh execute
-	answerQuestion("s6", "tc-6", { cancelled: true, answers: [] });
-	const r = await promise;
-	expect(r.details.cancelled).toBe(true);
-});
-
-test("cancelQuestionsForSession settles a blocked execute as declined", async () => {
-	const promise = run("tc-2", "s2");
-	cancelQuestionsForSession("s2");
-	const r = await promise;
-	expect(r.details.cancelled).toBe(true);
-});
-
-test("a held early answer for a DIFFERENT session is dropped, never delivered", async () => {
-	answerQuestion("s-other", "tc-7", {
-		cancelled: false,
-		answers: [{ questionIndex: 0, question: "Which library?", kind: "option", answer: "luxon" }],
-	});
-	let resolvedEarly = false;
-	const promise = run("tc-7", "s7").then((r) => {
-		resolvedEarly = true;
-		return r;
-	});
-	await new Promise((r) => setTimeout(r, 0));
-	expect(resolvedEarly).toBe(false); // the mismatched hold must not settle s7's execute
-	answerQuestion("s7", "tc-7", { cancelled: true, answers: [] });
-	expect((await promise).details.cancelled).toBe(true);
-});
-
-test("held early answers are bounded per session — the oldest is evicted", async () => {
-	for (let i = 0; i < 9; i++) answerQuestion("s8", `tc-8-${i}`, { cancelled: true, answers: [] });
-	// 9 holds > the cap of 8 → the first one was evicted, so its execute blocks…
-	let resolvedEarly = false;
-	const evicted = run("tc-8-0", "s8").then((r) => {
-		resolvedEarly = true;
-		return r;
-	});
-	await new Promise((r) => setTimeout(r, 0));
-	expect(resolvedEarly).toBe(false);
-	// …while the newest hold is still there and settles its execute immediately.
-	const kept = await run("tc-8-8", "s8");
-	expect(kept.details.cancelled).toBe(true);
-	answerQuestion("s8", "tc-8-0", { cancelled: true, answers: [] });
-	await evicted;
-	cancelQuestionsForSession("s8"); // drop the remaining holds so this test leaves no residue
-});
-
-test("execute declines when the agent abort signal fires", async () => {
-	const controller = new AbortController();
-	const promise = run("tc-3", "s3", controller.signal);
-	controller.abort();
-	const r = await promise;
-	expect(r.details.cancelled).toBe(true);
-});
-
-test("execute returns the no-UI error when hasUI is false (non-interactive host)", async () => {
-	const r = await run("tc-4", "s4", undefined, false);
+test("execute returns the no-UI error (non-terminating) when hasUI is false", async () => {
+	const r = await run(false);
 	expect(textOf(r)).toContain("UI not available");
-	expect(r.details.cancelled).toBe(true);
+	expect((r.details as AskUserQuestionResult).cancelled).toBe(true);
+	expect((r as { terminate?: boolean }).terminate).toBeUndefined();
+});
+
+test("execute returns a validation error (non-terminating) for a malformed questionnaire", async () => {
+	const r = await run(true, { questions: [] });
+	expect(textOf(r)).toContain("At least one question is required");
+	expect((r.details as AskUserQuestionResult).cancelled).toBe(true);
+	expect((r as { terminate?: boolean }).terminate).toBeUndefined();
+});
+
+// ---- assessAnswerability: the transcript-derived verdict behind session.answerQuestion ----
+
+test("assessAnswerability: an ack'd, unanswered call is answerable and yields its args", () => {
+	const verdict = assessAnswerability([askCall("tc"), ackResult("tc")], "tc");
+	expect(verdict.ok).toBe(true);
+	if (verdict.ok) expect(verdict.args.questions[0]?.question).toBe("Which library?");
+});
+
+test("assessAnswerability: an unknown tool call id is rejected", () => {
+	expect(assessAnswerability([askCall("tc"), ackResult("tc")], "nope")).toEqual({
+		ok: false,
+		reason: "unknown_call",
+	});
+});
+
+test("assessAnswerability: a second answer to the same call is rejected", () => {
+	const messages = [askCall("tc"), ackResult("tc"), answersMessage("tc")];
+	expect(assessAnswerability(messages, "tc")).toEqual({ ok: false, reason: "already_answered" });
+});
+
+test("assessAnswerability: a legacy/final tool result (not the ack) is not awaiting", () => {
+	const messages = [askCall("tc"), finalResult("tc")];
+	expect(assessAnswerability(messages, "tc")).toEqual({ ok: false, reason: "not_awaiting" });
+});
+
+test("assessAnswerability: a later free-form user message supersedes the questionnaire", () => {
+	const messages = [askCall("tc"), ackResult("tc"), userMessage()];
+	expect(assessAnswerability(messages, "tc")).toEqual({ ok: false, reason: "superseded" });
+});
+
+test("assessAnswerability: an answers message for ANOTHER call neither answers nor supersedes", () => {
+	const messages = [askCall("tc"), ackResult("tc"), askCall("tc2"), answersMessage("tc2")];
+	expect(assessAnswerability(messages, "tc").ok).toBe(true);
+});
+
+test("assessAnswerability: the tiny pre-ack window (call ended, result not yet) is answerable", () => {
+	// The card unlocks at message end; `execute` (which writes the ack) runs a beat later. An answer in
+	// that window must not be rejected — sendCustomMessage will steer it into the ending turn.
+	expect(assessAnswerability([askCall("tc")], "tc").ok).toBe(true);
+});
+
+// ---- the ask-user-answers payload ----
+
+test("buildAnswersMessage carries the envelope text + the correlated structured result", () => {
+	const result: AskUserQuestionResult = {
+		cancelled: false,
+		answers: [{ questionIndex: 0, question: "Which library?", kind: "option", answer: "luxon" }],
+	};
+	const msg = buildAnswersMessage("tc-9", args(), result);
+	expect(msg.customType).toBe(ASK_USER_ANSWERS_CUSTOM_TYPE);
+	expect(msg.content).toContain('"Which library?"="luxon"');
+	expect(msg.display).toBe(true);
+	expect(msg.details).toEqual({ toolCallId: "tc-9", result });
+});
+
+test("buildAnswersMessage: a skip travels as the canonical decline", () => {
+	const msg = buildAnswersMessage("tc-10", args(), { answers: [], cancelled: true });
+	expect(msg.content).toBe("User declined to answer questions");
+	expect(msg.details.result.cancelled).toBe(true);
 });

--- a/packages/server/src/agent/askUserQuestion.test.ts
+++ b/packages/server/src/agent/askUserQuestion.test.ts
@@ -253,6 +253,17 @@ test("assessAnswerability: an answers message for ANOTHER call neither answers n
 	expect(assessAnswerability(messages, "tc").ok).toBe(true);
 });
 
+test("assessAnswerability: a malformed answers message cannot mark a call answered (shared guard)", () => {
+	const malformed = {
+		role: "custom",
+		customType: ASK_USER_ANSWERS_CUSTOM_TYPE,
+		content: "tag right, shape wrong",
+		display: true,
+		details: { toolCallId: "tc", result: { answers: "nope" } }, // no cancelled, answers not an array
+	} as unknown as AgentMessage;
+	expect(assessAnswerability([askCall("tc"), ackResult("tc"), malformed], "tc").ok).toBe(true);
+});
+
 test("assessAnswerability: the tiny pre-ack window (call ended, result not yet) is answerable", () => {
 	// The card unlocks at message end; `execute` (which writes the ack) runs a beat later. An answer in
 	// that window must not be rejected — sendCustomMessage will steer it into the ending turn.

--- a/packages/server/src/agent/askUserQuestion.ts
+++ b/packages/server/src/agent/askUserQuestion.ts
@@ -1,11 +1,26 @@
 // The `ask_user_question` capability — a HOST-OWNED pi custom tool, registered via an extension factory
 // on every session. It lets the agent put structured, typed clarifying questions to the user instead of
-// guessing. The tool renders nothing itself: it validates, blocks, and awaits a structured
-// `AskUserQuestionResult` pushed back by the browser (`session.answerQuestion`, correlated by the tool
-// call id). The chat renders the questionnaire INLINE as a tool card (see
-// `apps/web/src/chat/tools/AskUserQuestionCard`): tabs per question, single/multi-select, per-option
-// markdown previews, a free-text row, Skip. The design rationale (why host-owned rather than a bundled
-// community extension) is recorded in this module's SPEC.md.
+// guessing. Designed **ack + terminate** so a pending questionnaire survives host restarts:
+//
+//   - `execute` renders nothing and WAITS FOR NOTHING: it validates, then immediately returns an ack
+//     ("questions are shown; answers arrive as the next user message") with `terminate: true`, ending the
+//     turn with no extra LLM call. The transcript is complete and provider-valid the moment the ack lands,
+//     and the session is genuinely idle while the user thinks — for seconds or for weeks, across any
+//     number of restarts.
+//   - The browser renders the questionnaire INLINE from the tool call's args (see
+//     `apps/web/src/chat/tools/AskUserQuestionCard`); the reply arrives over `session.answerQuestion` and
+//     is delivered by the session manager as an `ask-user-answers` CUSTOM MESSAGE (correlated by tool
+//     call id in its `details`) that starts the next turn — or steers the current one. Answering live and
+//     answering after a restart are the same code path.
+//   - A free-form user message sent instead of an answer SUPERSEDES the questionnaire (the ack told the
+//     model answers arrive as the next user message — whatever the user typed is that reply); the pure
+//     `assessAnswerability` below is what makes a late answer to a superseded/answered call fail loud.
+//
+// The earlier blocking design (execute parks on an in-memory promise until the browser replies) is gone:
+// a host restart destroyed the pending promise, left a dangling `toolCall` in the transcript (providers
+// reject unpaired tool_use — the chat bricked), and quietly swallowed post-restart answers. The design
+// rationale — including why this is host-owned rather than the community rpiv extension — is recorded in
+// this module's SPEC.md.
 
 import type {
 	ExtensionAPI,
@@ -13,10 +28,14 @@ import type {
 	ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type {
+	AgentMessage,
+	AskUserAnswersDetails,
+	AskUserQuestionAckDetails,
 	AskUserQuestionAnswer,
 	AskUserQuestionArgs,
 	AskUserQuestionResult,
 } from "@thinkrail/contracts";
+import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
 import { type Static, Type } from "typebox";
 
 // ---- limits (mirrors the rpiv contract so the model behaves the same) ----
@@ -95,7 +114,7 @@ const DESCRIPTION = `Ask the user one or more structured, multiple-choice questi
 1. The request is underspecified and you cannot proceed without a concrete decision.
 2. You need a user preference, requirement, or a direction/implementation choice.
 
-The questions render inline in the chat as an interactive card (tabs when there are several). Notes:
+Calling this tool ENDS YOUR TURN: the questions render inline in the chat as an interactive card (tabs when there are several), and the user's answers arrive as the NEXT USER MESSAGE (a structured "User has answered your questions:" message). Do not continue working on the blocked task after calling it, and do not assume an answer until that message arrives. If the user replies with a free-form message instead of using the card, treat that message as their reply and re-ask only what is still genuinely undecided. Notes:
 - Every question also gets an "Other" option with a free-text field, and the user can always Skip the whole questionnaire (you are told they declined) — do NOT author "Other"-style, free-text, or escape options yourself (reserved labels are rejected).
 - Set multiSelect: true when several answers are valid; the user may combine checked options with their own typed answer.
 - If you recommend one option, make it FIRST, append "(Recommended)" to its label, and set its recommendedReason to one short sentence on why you recommend it over the alternatives (shown inline under the option).
@@ -104,12 +123,19 @@ The questions render inline in the chat as an interactive card (tabs when there 
 - The user may answer only some questions; unanswered ones are reported as declined.`;
 
 const PROMPT_GUIDELINES = [
-	`Call ask_user_question whenever the request is ambiguous and a concrete decision is needed — up to ${MAX_QUESTIONS} questions per call, ${MIN_OPTIONS}-${MAX_OPTIONS} options each.`,
+	`Call ask_user_question whenever the request is ambiguous and a concrete decision is needed — up to ${MAX_QUESTIONS} questions per call, ${MIN_OPTIONS}-${MAX_OPTIONS} options each. The call ends your turn; the answers arrive as the next user message.`,
 	"Every option needs a concise label (1-5 words) and a description of what it means / its trade-off.",
 	'Recommend by putting the option first with "(Recommended)" appended and setting its recommendedReason to one short sentence (shown inline under the option) on why you recommend it over the alternatives; the user can always type a custom answer or skip the questionnaire.',
 ];
 
 const ERROR_NO_UI = "Error: UI not available (running in non-interactive mode)";
+
+/**
+ * The ack the model receives the instant the questionnaire is on screen. Paired with `terminate: true`,
+ * so the turn ends right here — no "I'll wait" filler completion, no blocked tool.
+ */
+export const ASK_ACK_TEXT =
+	"The questions are now shown to the user. This turn ends here; the user's answers (or their own free-form reply) will arrive as the next user message. Do not assume an answer until it arrives.";
 
 export interface ValidationResult {
 	ok: boolean;
@@ -155,17 +181,23 @@ export function validateQuestionnaire(args: AskUserQuestionArgs): ValidationResu
 	return { ok: true, message: "" };
 }
 
-const DECLINE_MESSAGE = "User declined to answer questions";
+/** The canonical "didn't answer" signal — also composed into the restart-repair decline (sessionRepair). */
+export const DECLINE_MESSAGE = "User declined to answer questions";
 const ENVELOPE_PREFIX = "User has answered your questions:";
 const ENVELOPE_SUFFIX = "You can now continue with the user's answers in mind.";
 
-/** The tool `execute` return shape (an `AgentToolResult<AskUserQuestionResult>`). */
-interface ToolResult {
+/** The tool `execute` return shape (an `AgentToolResult<…>`). */
+interface ToolResult<D> {
 	content: { type: "text"; text: string }[];
-	details: AskUserQuestionResult;
+	details: D;
+	/** pi's early-termination hint: every result in the batch setting it ends the turn after the batch. */
+	terminate?: boolean;
 }
 
-function toolResult(text: string, details: AskUserQuestionResult): ToolResult {
+function toolResult(
+	text: string,
+	details: AskUserQuestionResult,
+): ToolResult<AskUserQuestionResult> {
 	return { content: [{ type: "text", text }], details };
 }
 
@@ -185,15 +217,17 @@ function answerSegment(a: AskUserQuestionAnswer): string {
 }
 
 /**
- * Map an `AskUserQuestionResult` to the LLM-facing tool envelope. Cancelled / no-answers both fall to the
+ * Map an `AskUserQuestionResult` to the LLM-facing envelope. Cancelled / no-answers both fall to the
  * single canonical `DECLINE_MESSAGE` so the model sees one "didn't answer" signal regardless of why. A
  * partial submission lists its unanswered questions explicitly as declined — silence would read as "all
- * answered" and send the model guessing on the very questions it asked. Pure.
+ * answered" and send the model guessing on the very questions it asked. Pure. (Under ack + terminate the
+ * envelope travels as the `ask-user-answers` custom message's text, not as a tool result — same wording,
+ * so the model reads answers exactly as it did under the blocking design.)
  */
 export function buildQuestionnaireResponse(
 	result: AskUserQuestionResult,
 	args: AskUserQuestionArgs,
-): ToolResult {
+): ToolResult<AskUserQuestionResult> {
 	if (result.cancelled)
 		return toolResult(DECLINE_MESSAGE, { answers: result.answers, cancelled: true });
 	const segments: string[] = [];
@@ -213,118 +247,149 @@ export function buildQuestionnaireResponse(
 	);
 }
 
-// ---- the reply bridge: a blocked tool `execute` awaits the browser's answer, keyed by toolCallId ----
-interface PendingQuestion {
-	sessionId: string;
-	finish: (result: AskUserQuestionResult) => void;
+// ---- the answer path: pure transcript assessment + the custom-message payload ----
+
+/** Minimal structural views of the transcript messages the assessors walk (subset of `AgentMessage`). */
+interface ToolCallView {
+	type: string;
+	id?: string;
+	name?: string;
+	arguments?: unknown;
 }
-const pending = new Map<string, PendingQuestion>();
+interface MessageView {
+	role?: string;
+	content?: unknown;
+	customType?: string;
+	details?: unknown;
+	toolCallId?: string;
+}
+
+function toolCallsOf(message: MessageView): ToolCallView[] {
+	if (message.role !== "assistant" || !Array.isArray(message.content)) return [];
+	return (message.content as ToolCallView[]).filter((b) => b?.type === "toolCall");
+}
+
+function isAnswersFor(message: MessageView, toolCallId: string): boolean {
+	return (
+		message.role === "custom" &&
+		message.customType === ASK_USER_ANSWERS_CUSTOM_TYPE &&
+		!!message.details &&
+		(message.details as AskUserAnswersDetails).toolCallId === toolCallId
+	);
+}
+
+/** Whether a tool result's `details` is the ack marker (vs a legacy blocking-era final result). */
+export function isAckDetails(details: unknown): details is AskUserQuestionAckDetails {
+	return !!details && (details as AskUserQuestionAckDetails).kind === "ack";
+}
+
+export type Answerability =
+	| { ok: true; args: AskUserQuestionArgs }
+	| { ok: false; reason: "unknown_call" | "already_answered" | "not_awaiting" | "superseded" };
 
 /**
- * Answers that arrived while no tool call was awaiting them. The legitimate producer is the streaming
- * window: the inline card is interactive as soon as the tool call's arguments stream in, but `execute`
- * (which registers the `pending` entry) only runs once the assistant message completes — a fast submit
- * beats the registration and must be held until `awaitAnswer` consumes it. Answers that never get
- * consumed (a second client re-answering a settled call, a submit after abort, junk tool call ids) are
- * bounded: at most `MAX_HELD_PER_SESSION` per session, oldest evicted first, and a session's holds are
- * dropped when it is disposed.
+ * Can this `ask_user_question` call still take an answer? Pure, derived ENTIRELY from the transcript —
+ * the same verdict falls out live, after a reconnect, or after a host restart:
+ * - `unknown_call` — no such ask tool call in the transcript;
+ * - `already_answered` — an `ask-user-answers` message for it already exists (double-submit, second client);
+ * - `not_awaiting` — its tool result is a final result, not the ack (legacy blocking-era transcript, a
+ *   validation error, or a restart-repaired decline — all already resolved);
+ * - `superseded` — the user sent a free-form message after the questionnaire instead of answering it; the
+ *   conversation has moved on, and the model was told to treat that message as the reply.
  */
-interface EarlyAnswer {
-	sessionId: string;
-	result: AskUserQuestionResult;
-}
-const early = new Map<string, EarlyAnswer>();
-const MAX_HELD_PER_SESSION = 8;
-
-/**
- * Resolve the blocked `ask_user_question` tool call with the browser's answer, or hold the answer until
- * the tool call registers (see `early`). The WS handler has already vetted that the session is live.
- */
-export function answerQuestion(
-	sessionId: string,
+export function assessAnswerability(
+	messages: readonly AgentMessage[],
 	toolCallId: string,
-	result: AskUserQuestionResult,
-): void {
-	const entry = pending.get(toolCallId);
-	if (entry) {
-		entry.finish(result);
-		return;
-	}
-	early.set(toolCallId, { sessionId, result });
-	const mine = [...early.entries()].filter(([, held]) => held.sessionId === sessionId);
-	for (let i = 0; i < mine.length - MAX_HELD_PER_SESSION; i++) {
-		const oldest = mine[i];
-		if (oldest) early.delete(oldest[0]);
-	}
-}
-
-/** Settle every question awaiting on a session as cancelled — used when the session is disposed. */
-export function cancelQuestionsForSession(sessionId: string): void {
-	for (const entry of [...pending.values()]) {
-		if (entry.sessionId === sessionId) entry.finish({ answers: [], cancelled: true });
-	}
-	for (const [toolCallId, held] of [...early.entries()]) {
-		if (held.sessionId === sessionId) early.delete(toolCallId);
-	}
-}
-
-/** Await the browser's answer for one tool call; cancels on the agent abort signal so it never hangs. */
-function awaitAnswer(
-	toolCallId: string,
-	sessionId: string,
-	signal: AbortSignal | undefined,
-): Promise<AskUserQuestionResult> {
-	return new Promise((resolve) => {
-		const held = early.get(toolCallId);
-		if (held) {
-			early.delete(toolCallId);
-			// A hold whose session doesn't match this execution is bogus (stale or spoofed) — drop, don't deliver.
-			if (held.sessionId === sessionId) {
-				resolve(held.result);
-				return;
+): Answerability {
+	const views = messages as readonly MessageView[];
+	let callIndex = -1;
+	let args: AskUserQuestionArgs | null = null;
+	for (let i = 0; i < views.length; i++) {
+		const view = views[i];
+		if (!view) continue;
+		for (const block of toolCallsOf(view)) {
+			if (block.id === toolCallId && block.name === ASK_USER_QUESTION_TOOL_NAME) {
+				callIndex = i;
+				args = (block.arguments ?? { questions: [] }) as AskUserQuestionArgs;
 			}
 		}
-		let settled = false;
-		const finish = (result: AskUserQuestionResult): void => {
-			if (settled) return;
-			settled = true;
-			pending.delete(toolCallId);
-			signal?.removeEventListener("abort", onAbort);
-			resolve(result);
-		};
-		const onAbort = (): void => finish({ answers: [], cancelled: true });
-		pending.set(toolCallId, { sessionId, finish });
-		if (signal) {
-			if (signal.aborted) return finish({ answers: [], cancelled: true });
-			signal.addEventListener("abort", onAbort, { once: true });
-		}
-	});
+	}
+	if (callIndex < 0 || !args) return { ok: false, reason: "unknown_call" };
+
+	for (let i = callIndex + 1; i < views.length; i++) {
+		const view = views[i];
+		if (!view) continue;
+		if (isAnswersFor(view, toolCallId)) return { ok: false, reason: "already_answered" };
+		if (view.role === "toolResult" && view.toolCallId === toolCallId && !isAckDetails(view.details))
+			return { ok: false, reason: "not_awaiting" };
+		if (view.role === "user") return { ok: false, reason: "superseded" };
+	}
+	return { ok: true, args };
 }
 
-/** Build the `ask_user_question` tool definition. Stateless: correlation is by the (unique) tool call id. */
+/** The message a rejected answer surfaces to the client, per verdict. */
+export const ANSWERABILITY_ERRORS: Record<Extract<Answerability, { ok: false }>["reason"], string> =
+	{
+		unknown_call: "Unknown ask_user_question tool call",
+		already_answered: "This questionnaire was already answered",
+		not_awaiting: "This questionnaire is not awaiting an answer",
+		superseded: "This questionnaire was superseded by a later message",
+	};
+
+/**
+ * The `ask-user-answers` custom message for one reply — the payload `AgentSession.sendCustomMessage`
+ * delivers (starting a turn when idle, steering when streaming). `content` is the same LLM envelope the
+ * blocking tool used to return; `details` carries the structured result the questionnaire card renders,
+ * correlated by tool call id. `display: true` so a pi TUI opening the same transcript shows the reply.
+ */
+export function buildAnswersMessage(
+	toolCallId: string,
+	args: AskUserQuestionArgs,
+	result: AskUserQuestionResult,
+): {
+	customType: string;
+	content: string;
+	display: boolean;
+	details: AskUserAnswersDetails;
+} {
+	const envelope = buildQuestionnaireResponse(result, args);
+	return {
+		customType: ASK_USER_ANSWERS_CUSTOM_TYPE,
+		content: envelope.content.map((c) => c.text).join(""),
+		display: true,
+		details: { toolCallId, result },
+	};
+}
+
+export const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
+
+/**
+ * Build the `ask_user_question` tool definition. Stateless and instantaneous: validate, then ack +
+ * `terminate` (the turn ends at the tool batch, with no further LLM call). Only the no-UI guard and
+ * validation failures return a plain (non-terminating) result — the model should correct and continue.
+ */
 export function createAskUserQuestionTool(): ToolDefinition<
 	typeof AskUserQuestionSchema,
-	AskUserQuestionResult
+	AskUserQuestionAckDetails | AskUserQuestionResult
 > {
 	return {
-		name: "ask_user_question",
+		name: ASK_USER_QUESTION_TOOL_NAME,
 		label: "Ask User Question",
 		description: DESCRIPTION,
 		promptGuidelines: PROMPT_GUIDELINES,
 		parameters: AskUserQuestionSchema,
-		async execute(toolCallId, params, signal, _onUpdate, ctx: ExtensionContext) {
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx: ExtensionContext) {
 			const args = params as AskUserQuestionArgs;
 			if (!ctx.hasUI) return toolResult(ERROR_NO_UI, { answers: [], cancelled: true });
 
 			const validation = validateQuestionnaire(args);
 			if (!validation.ok) return toolResult(validation.message, { answers: [], cancelled: true });
 
-			// `ctx.sessionManager.getSessionId()` === the `AgentSession.sessionId` we key everything on
-			// (the session's `sessionId` getter delegates to this same manager), so per-session cancellation
-			// on dispose lines up exactly with our manager's key.
-			const sessionId = ctx.sessionManager.getSessionId();
-			const result = await awaitAnswer(toolCallId, sessionId, signal);
-			return buildQuestionnaireResponse(result, args);
+			return {
+				content: [{ type: "text", text: ASK_ACK_TEXT }],
+				details: { kind: "ack" } satisfies AskUserQuestionAckDetails,
+				terminate: true,
+			};
 		},
 	};
 }

--- a/packages/server/src/agent/askUserQuestion.ts
+++ b/packages/server/src/agent/askUserQuestion.ts
@@ -29,13 +29,13 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type {
 	AgentMessage,
-	AskUserAnswersDetails,
+	AskUserAnswersMessage,
 	AskUserQuestionAckDetails,
 	AskUserQuestionAnswer,
 	AskUserQuestionArgs,
 	AskUserQuestionResult,
 } from "@thinkrail/contracts";
-import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
+import { ASK_USER_ANSWERS_CUSTOM_TYPE, isAskUserAnswersMessage } from "@thinkrail/contracts";
 import { type Static, Type } from "typebox";
 
 // ---- limits (mirrors the rpiv contract so the model behaves the same) ----
@@ -259,7 +259,6 @@ interface ToolCallView {
 interface MessageView {
 	role?: string;
 	content?: unknown;
-	customType?: string;
 	details?: unknown;
 	toolCallId?: string;
 }
@@ -267,15 +266,6 @@ interface MessageView {
 function toolCallsOf(message: MessageView): ToolCallView[] {
 	if (message.role !== "assistant" || !Array.isArray(message.content)) return [];
 	return (message.content as ToolCallView[]).filter((b) => b?.type === "toolCall");
-}
-
-function isAnswersFor(message: MessageView, toolCallId: string): boolean {
-	return (
-		message.role === "custom" &&
-		message.customType === ASK_USER_ANSWERS_CUSTOM_TYPE &&
-		!!message.details &&
-		(message.details as AskUserAnswersDetails).toolCallId === toolCallId
-	);
 }
 
 /** Whether a tool result's `details` is the ack marker (vs a legacy blocking-era final result). */
@@ -319,7 +309,8 @@ export function assessAnswerability(
 	for (let i = callIndex + 1; i < views.length; i++) {
 		const view = views[i];
 		if (!view) continue;
-		if (isAnswersFor(view, toolCallId)) return { ok: false, reason: "already_answered" };
+		if (isAskUserAnswersMessage(view) && view.details.toolCallId === toolCallId)
+			return { ok: false, reason: "already_answered" };
 		if (view.role === "toolResult" && view.toolCallId === toolCallId && !isAckDetails(view.details))
 			return { ok: false, reason: "not_awaiting" };
 		if (view.role === "user") return { ok: false, reason: "superseded" };
@@ -341,17 +332,13 @@ export const ANSWERABILITY_ERRORS: Record<Extract<Answerability, { ok: false }>[
  * delivers (starting a turn when idle, steering when streaming). `content` is the same LLM envelope the
  * blocking tool used to return; `details` carries the structured result the questionnaire card renders,
  * correlated by tool call id. `display: true` so a pi TUI opening the same transcript shows the reply.
+ * Held to the contracts' `AskUserAnswersMessage` pairing, so a tag↔details mismatch cannot compile.
  */
 export function buildAnswersMessage(
 	toolCallId: string,
 	args: AskUserQuestionArgs,
 	result: AskUserQuestionResult,
-): {
-	customType: string;
-	content: string;
-	display: boolean;
-	details: AskUserAnswersDetails;
-} {
+): Pick<AskUserAnswersMessage, "customType" | "content" | "display" | "details"> {
 	const envelope = buildQuestionnaireResponse(result, args);
 	return {
 		customType: ASK_USER_ANSWERS_CUSTOM_TYPE,

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -9,4 +9,5 @@ export {
 } from "./extensions";
 export * from "./oneshot";
 export * from "./piRuntime";
+export * from "./sessionRepair";
 export * from "./webUiContext";

--- a/packages/server/src/agent/sessionRepair.test.ts
+++ b/packages/server/src/agent/sessionRepair.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import type { Message } from "@thinkrail/contracts";
+import { repairDanglingToolCalls } from "./sessionRepair";
+
+// The restart safety net: a transcript that died mid-tool (host crash/kill) ends with an assistant
+// message whose toolCalls have no toolResult — providers reject that context outright. The repair pairs
+// every orphan before the session re-attaches. Exercised against a real (in-memory) pi SessionManager so
+// the appended results round-trip through `buildSessionContext` exactly as a re-opened session would see.
+
+const assistantWithCalls = (
+	calls: { id: string; name: string; args?: Record<string, unknown> }[],
+): Message =>
+	({
+		role: "assistant",
+		content: calls.map((c) => ({
+			type: "toolCall",
+			id: c.id,
+			name: c.name,
+			arguments: c.args ?? {},
+		})),
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	}) as unknown as Message;
+
+const toolResult = (toolCallId: string, toolName: string): Message =>
+	({
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text: "ok" }],
+		isError: false,
+		timestamp: Date.now(),
+	}) as unknown as Message;
+
+const user = (text: string): Message =>
+	({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() }) as Message;
+
+test("a healthy transcript is untouched", () => {
+	const sm = SessionManager.inMemory("/tmp/repair-test");
+	sm.appendMessage(user("hi"));
+	sm.appendMessage(assistantWithCalls([{ id: "b1", name: "bash" }]));
+	sm.appendMessage(toolResult("b1", "bash"));
+	const before = sm.buildSessionContext().messages.length;
+	expect(repairDanglingToolCalls(sm)).toEqual([]);
+	expect(sm.buildSessionContext().messages.length).toBe(before);
+});
+
+test("a dangling generic tool call gets an error 'Operation aborted' result", () => {
+	const sm = SessionManager.inMemory("/tmp/repair-test");
+	sm.appendMessage(user("run it"));
+	sm.appendMessage(assistantWithCalls([{ id: "b1", name: "bash" }]));
+	expect(repairDanglingToolCalls(sm)).toEqual([{ toolCallId: "b1", toolName: "bash" }]);
+	const { messages } = sm.buildSessionContext();
+	const repaired = messages.find((m) => m.role === "toolResult");
+	expect(repaired).toBeDefined();
+	if (repaired?.role !== "toolResult") throw new Error("unreachable");
+	expect(repaired.toolCallId).toBe("b1");
+	expect(repaired.isError).toBe(true);
+	expect((repaired.content[0] as { text?: string }).text ?? "").toContain("host restarted");
+	// Idempotent: the orphan is paired now.
+	expect(repairDanglingToolCalls(sm)).toEqual([]);
+});
+
+test("a dangling ask_user_question (old blocking format) resolves as the canonical decline", () => {
+	const sm = SessionManager.inMemory("/tmp/repair-test");
+	sm.appendMessage(user("decide"));
+	sm.appendMessage(assistantWithCalls([{ id: "q1", name: "ask_user_question" }]));
+	expect(repairDanglingToolCalls(sm)).toEqual([
+		{ toolCallId: "q1", toolName: "ask_user_question" },
+	]);
+	const repaired = sm.buildSessionContext().messages.find((m) => m.role === "toolResult");
+	if (repaired?.role !== "toolResult") throw new Error("unreachable");
+	expect(repaired.isError).toBe(false); // a decline is a valid outcome, not a tool fault
+	expect(repaired.details).toEqual({ answers: [], cancelled: true });
+	const text = (repaired.content[0] as { text?: string }).text ?? "";
+	expect(text).toContain("User declined to answer questions");
+	expect(text).toContain("ask again if still relevant");
+});
+
+test("several orphans in one batch are all paired (mixed ask + generic)", () => {
+	const sm = SessionManager.inMemory("/tmp/repair-test");
+	sm.appendMessage(user("both"));
+	sm.appendMessage(
+		assistantWithCalls([
+			{ id: "b1", name: "bash" },
+			{ id: "q1", name: "ask_user_question" },
+		]),
+	);
+	const repaired = repairDanglingToolCalls(sm);
+	expect(repaired.map((r) => r.toolCallId).sort()).toEqual(["b1", "q1"]);
+	const results = sm.buildSessionContext().messages.filter((m) => m.role === "toolResult");
+	expect(results).toHaveLength(2);
+});
+
+test("only calls on the context path are considered — resulted calls never re-repair", () => {
+	const sm = SessionManager.inMemory("/tmp/repair-test");
+	sm.appendMessage(user("go"));
+	sm.appendMessage(assistantWithCalls([{ id: "b1", name: "bash" }]));
+	sm.appendMessage(toolResult("b1", "bash"));
+	sm.appendMessage(assistantWithCalls([{ id: "b2", name: "bash" }]));
+	expect(repairDanglingToolCalls(sm).map((r) => r.toolCallId)).toEqual(["b2"]);
+});

--- a/packages/server/src/agent/sessionRepair.ts
+++ b/packages/server/src/agent/sessionRepair.ts
@@ -1,0 +1,63 @@
+// Restart repair for pi transcripts: a host death mid-turn (crash, kill, a shutdown that couldn't wait)
+// leaves the persisted session ending in an assistant message whose `toolCall`s have no `toolResult` —
+// and every LLM provider rejects a context with unpaired tool calls, so the next prompt would 400 and the
+// chat would be bricked. `repairDanglingToolCalls` runs when a disk session is re-opened, BEFORE
+// `createAgentSession` seeds its in-memory context (appending behind a live session would desync it): it
+// pairs every orphaned call with a synthetic tool result, mirroring pi's own abort convention
+// ("Operation aborted" error results). `ask_user_question` orphans — only possible in transcripts from
+// the old blocking design, where the result was written at answer time — resolve as the canonical
+// decline instead, with a re-ask hint, so the model gracefully re-asks rather than treating the
+// questionnaire as failed.
+
+import type { SessionManager } from "@earendil-works/pi-coding-agent";
+import { ASK_USER_QUESTION_TOOL_NAME, DECLINE_MESSAGE } from "./askUserQuestion";
+
+/** One repaired (orphaned) call, for logs/tests. */
+export interface RepairedToolCall {
+	toolCallId: string;
+	toolName: string;
+}
+
+const ASK_REPAIR_TEXT = `${DECLINE_MESSAGE} (the host restarted before the user answered — ask again if still relevant)`;
+const GENERIC_REPAIR_TEXT =
+	"Operation aborted (the host restarted before this tool call completed)";
+
+/**
+ * Append a synthetic `toolResult` for every tool call on the session's current context path that has
+ * none. The context path (`buildSessionContext`) is compaction-aware — a call summarized away no longer
+ * reaches the provider, so only calls that would actually be sent get repaired. Orphans sit at the leaf
+ * by construction (the loop appends results right after their call in normal operation), so appending at
+ * the leaf pairs them where providers expect. Idempotent: a repaired call has a result and won't match
+ * again. Returns the repaired calls (empty for the overwhelmingly common healthy transcript).
+ */
+export function repairDanglingToolCalls(sessionManager: SessionManager): RepairedToolCall[] {
+	const { messages } = sessionManager.buildSessionContext();
+
+	const resulted = new Set<string>();
+	for (const message of messages) {
+		if (message.role === "toolResult") resulted.add(message.toolCallId);
+	}
+
+	const repaired: RepairedToolCall[] = [];
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const block of message.content) {
+			if (block.type !== "toolCall" || resulted.has(block.id)) continue;
+			const isAsk = block.name === ASK_USER_QUESTION_TOOL_NAME;
+			sessionManager.appendMessage({
+				role: "toolResult",
+				toolCallId: block.id,
+				toolName: block.name,
+				content: [{ type: "text", text: isAsk ? ASK_REPAIR_TEXT : GENERIC_REPAIR_TEXT }],
+				// The decline is a *valid* outcome the model was told to expect (isError would read as a tool
+				// fault); an interrupted bash/web_search is an error, matching pi's abort convention.
+				isError: !isAsk,
+				...(isAsk ? { details: { answers: [], cancelled: true } } : {}),
+				timestamp: Date.now(),
+			});
+			resulted.add(block.id);
+			repaired.push({ toolCallId: block.id, toolName: block.name });
+		}
+	}
+	return repaired;
+}

--- a/packages/server/src/assist/assist.ts
+++ b/packages/server/src/assist/assist.ts
@@ -9,7 +9,12 @@
  * network — and default to the real {@link completeOnce} primitive in the `agent` module.
  */
 
-import type { AssistantMessage, Message, TextContent, UserMessage } from "@thinkrail/contracts";
+import type {
+	AssistantMessage,
+	TextContent,
+	TranscriptMessage,
+	UserMessage,
+} from "@thinkrail/contracts";
 import { completeOnce, type OneShotRequest, type OneShotResult } from "../agent";
 
 /** The first turn of a session — the raw material for a workspace name. */
@@ -140,7 +145,7 @@ export function toWorkspaceSlug(raw: string): string | null {
  * are skipped the same way. `answer` is the concatenated text of the clean turn's first assistant
  * message (empty if it hasn't produced text). Pure — the host composes this with `session.getMessages`.
  */
-export function extractFirstTurn(messages: Message[]): WorkspaceNameTurn | null {
+export function extractFirstTurn(messages: TranscriptMessage[]): WorkspaceNameTurn | null {
 	for (let i = 0; i < messages.length; i += 1) {
 		const message = messages[i];
 		if (message?.role !== "user") continue;

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -29,7 +29,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
   an optional boot-time `openProject(projectPath)` (best-effort — a launcher convenience), and
   `stop()` → agent-session + terminal cleanup then socket close); `boot.ts` (`bootHost` → resolve the
   login-shell PATH, pick the port per `portMode` (`"exact"` vs `"free"`), start `createServer`, and
-  install SIGINT/SIGTERM handlers that `stop()` then exit); `handlers.ts` (the WS method→handler registry);
+  install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort
+  streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
+  transcripts land paired — then `stop()` + exit; an immediate exit would strand mid-tool transcripts on
+  the restart repair); `handlers.ts` (the WS method→handler registry);
   `ackSend.ts` (the send-ack policy — see "Get right"); `autoRename.ts` (the **workspace auto-rename
   flow** — the composition of `agent` + `assist` + `workspaces` only the host may make, in **two passes**
   the session-publisher closure in `createServer` tees fire-and-forget, both triggering a
@@ -89,8 +92,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
   use push channels. Every push channel a client should hear must be `ws.subscribe`d in the WS `open`
   handler — a publish on an unsubscribed topic reaches nobody, silently.
 - The host is the single place features are wired together — features never reach back into it.
-- **A send (prompt/steer/followUp) is acked when ACCEPTED, not when the turn ends** (`ackSend`): pi's send
-  methods resolve only at turn end, and a turn can outlive the client's request timeout (an
-  `ask_user_question` turn blocks until the user answers) — awaiting completion would surface a phantom
-  "request timed out" over a healthy turn. A rejection inside the ack window still fails the request (bad
-  model / missing key); later faults reach the client via the event stream.
+- **A send (prompt/steer/followUp/answerQuestion) is acked when ACCEPTED, not when the turn ends**
+  (`ackSend`): pi's send methods resolve only at turn end, and a turn can outlive the client's request
+  timeout (long tool rounds and multi-minute reasoning turns are routine) — awaiting completion would
+  surface a phantom "request timed out" over a healthy turn. A rejection inside the ack window still
+  fails the request (bad model / missing key; for `answerQuestion` also an unknown/answered/superseded
+  call — `assessAnswerability`'s loud verdicts); later faults reach the client via the event stream.

--- a/packages/server/src/host/ackSend.ts
+++ b/packages/server/src/host/ackSend.ts
@@ -1,7 +1,7 @@
 /**
- * How long a send (prompt/steer/followUp) may run before the wire acks it as ACCEPTED. pi's send methods
- * resolve only when the whole turn ends — but a turn can outlive any client request timeout (an
- * `ask_user_question` turn blocks until the user answers; long tool rounds are routine), so awaiting
+ * How long a send (prompt/steer/followUp/answerQuestion) may run before the wire acks it as ACCEPTED.
+ * pi's send methods resolve only when the whole turn ends — but a turn can outlive any client request
+ * timeout (long tool rounds and multi-minute reasoning models are routine), so awaiting
  * completion would time the request out client-side and surface a phantom "request timed out" error over
  * a perfectly healthy turn. An immediate rejection (bad model, missing API key, malformed send) still
  * lands well inside the window; a fault after the ack reaches the client through the event stream

--- a/packages/server/src/host/autoRename.ts
+++ b/packages/server/src/host/autoRename.ts
@@ -10,7 +10,7 @@
  * flag, and while it's unset a later settled turn retries. Never throws, never blocks a turn.
  */
 
-import type { Message, PiEvent, Workspace } from "@thinkrail/contracts";
+import type { PiEvent, TranscriptMessage, Workspace } from "@thinkrail/contracts";
 import { getSessionMessages } from "../agent";
 import { extractFirstTurn, naiveWorkspaceSlug, suggestWorkspaceName } from "../assist";
 import { getWorkspace, renameWorkspace } from "../workspaces";
@@ -51,7 +51,7 @@ const inFlight = new Set<string>();
 const naiveInFlight = new Set<string>();
 
 /** Test seam: the hook's transcript source (defaults to `getSessionMessages` on the live session). */
-export type TranscriptReader = () => Promise<Message[]>;
+export type TranscriptReader = () => Promise<TranscriptMessage[]>;
 
 /**
  * Instantly name `workspaceId` from the session's first prompt, **non-agentically** — a cheap provisional

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -1,5 +1,6 @@
 import { findFreePort } from "@thinkrail/shared/freePort";
 import { resolveShellEnv } from "@thinkrail/shared/shellEnv";
+import { settleSessionsForShutdown } from "../agent";
 import { createServer, type RunningServer } from "./server";
 
 export interface BootHostOptions {
@@ -55,8 +56,18 @@ export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
 	const shutdown = (): void => {
 		if (stopping) return;
 		stopping = true;
-		server.stop();
-		process.exit(0);
+		// Settle before exit: abort streaming sessions and give pi a bounded window to write their
+		// "Operation aborted" tool results — an immediate `process.exit` here would strand mid-tool
+		// transcripts (an open `ask_user_question` made that deterministic before the ack+terminate
+		// redesign) and lean on the restart repair for what a polite shutdown can persist cleanly.
+		void (async () => {
+			try {
+				await settleSessionsForShutdown();
+			} finally {
+				server.stop();
+				process.exit(0);
+			}
+		})();
 	};
 	process.on("SIGINT", shutdown);
 	process.on("SIGTERM", shutdown);

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -190,7 +190,7 @@ const handlers: Record<string, Handler> = {
 		});
 	},
 	// Sends are acked when ACCEPTED, not when the turn ends — see `ackSend` (a turn can outlive the
-	// client's request timeout; an `ask_user_question` turn blocks until the user answers).
+	// client's request timeout; long tool rounds are routine).
 	"session.prompt": async (params) => {
 		const p = params as { sessionId: string; text: string; images?: ImageContent[] };
 		await ackSend(promptSession(p.sessionId, p.text, p.images));
@@ -244,14 +244,16 @@ const handlers: Record<string, Handler> = {
 		resolveExtUi((params as { response: ExtUiResponse }).response);
 		return { ok: true } as const;
 	},
-	"session.answerQuestion": (params) => {
+	"session.answerQuestion": async (params) => {
 		const p = params as { sessionId: string; toolCallId: string; result: AskUserQuestionResult };
-		// Reply-style method: vet the target before holding anything (a disposed/unknown session must fail
-		// the request, not silently park an answer), and reject shapes the tool envelope can't digest.
+		// Reply-style method: vet the shape and the target up front — a disposed/unknown session or a
+		// non-awaiting tool call (already answered / superseded / legacy-resolved) fails the request loud;
+		// nothing is ever parked. Delivery starts the answer TURN, so like prompt/steer/followUp it's acked
+		// when accepted (`ackSend`), and later faults arrive via the event stream.
 		if (!hasSession(p.sessionId)) throw new Error(`Unknown session: ${p.sessionId}`);
 		if (!p.result || !Array.isArray(p.result.answers) || typeof p.result.cancelled !== "boolean")
 			throw new Error("Malformed ask_user_question result");
-		answerQuestion(p.sessionId, p.toolCallId, p.result);
+		await ackSend(answerQuestion(p.sessionId, p.toolCallId, p.result));
 		return { ok: true } as const;
 	},
 	"model.list": () => listAvailableModels(),


### PR DESCRIPTION
## Problem

`ask_user_question` did not survive a host restart — and the failure was worse than losing the question:

- The tool's `execute` **blocked** on an in-memory promise (`pending`/`early` maps); pi persists the assistant message (with the `toolCall`) *before* the tool runs, so a restart left the transcript ending in an **unpaired tool call**.
- Every provider rejects a context with unpaired `tool_use` → **every later prompt 400'd; the chat was permanently bricked.**
- The rehydrated card still *looked* answerable, but the answer fell into a held-answers map nobody would ever consume ("Answer sent — continuing…" forever).
- Even a clean Ctrl+C hit this deterministically: shutdown called `process.exit(0)` on the same stack as dispose, so the cancelled tool result never landed on disk.

The two most popular open-source pi ask-extensions (`rpiv-ask-user-question`, `pi-ask-user`) have the same hole — they lean on the TUI's graceful-abort-before-exit, which our host violated and which never covers crashes (accepted in our architecture: in-process pi).

## Design: ack + terminate — asking ends the turn; the answer starts the next one

- `execute` validates, then **immediately** returns an ack (`details {kind:"ack"}`) with **`terminate: true`** — the turn ends at the tool batch with no extra LLM call. Nothing pends in memory; the transcript is always provider-valid; the session is genuinely **idle** while the user thinks (seconds or weeks, across any number of restarts).
- The reply (`session.answerQuestion`) is vetted against the transcript by the pure `assessAnswerability` (unknown call / already answered / not-awaiting / **superseded** → fail loud, never park) and injected via pi's public `AgentSession.sendCustomMessage({triggerTurn:true})` as an **`ask-user-answers` custom message** (same LLM envelope the blocking design used, `details {toolCallId, result}`). **Answering live and answering after a restart are the same code path.**
- A free-form user message instead of an answer **supersedes** the questionnaire — the card flips to a terminal record, and the model treats the message as the reply.
- Web: the card's lifecycle (*composing → awaiting → answered/declined/superseded/dead*) derives from the transcript via the new `askState` seam; legacy blocking-era transcripts still render correctly.

## Safety net (generic, not ask-specific)

- **Repair on re-open** (`sessionRepair.ts`): before a disk session seeds its context, every dangling tool call (crashed `bash`, `web_search`, old-format asks…) gets a synthetic result — pi's abort convention for generic tools, the canonical decline + re-ask hint for asks. Heals already-bricked transcripts.
- **Polite shutdown** (`boot.ts`): SIGINT/SIGTERM now abort streaming sessions and wait (bounded 2s) so pi persists their "Operation aborted" results before exit.

## Wire

- `TranscriptMessage` (pi-canonical + `custom` role) on `session.getMessages`; `AskUserQuestionAckDetails` / `AskUserAnswersDetails` / `ASK_USER_ANSWERS_CUSTOM_TYPE`; **protocol v7**.

## Specs & skills

Durable decisions promoted into `agent`, `contracts`, `host`, `chat`, `chat/tools`, `store` SPECs (including the rejected alternatives: the old blocking design, a suspended-session variant, bundling rpiv). `asking-user-questions` skill now teaches the turn-ending + supersede semantics.

## Verification

- `check:deps` + biome + typecheck + unit tests: green (new: repair against a real in-memory pi `SessionManager`, answerability verdicts, askState derivation, reducer/hydration indexing).
- e2e no-agent: **42/42**.
- e2e `@agent` (real provider): ask suite **9/9**, incl. a new supersede test and awaiting-card-survives-reopen (the exact hydration path a restart takes); full agent suite 34/35 pre-rebase — the one failure (`error-turn.live.spec.ts`) **also fails on main with this change stashed** (pre-existing, env-dependent model resolution at `session.create`; unrelated — worth a separate issue).

## Notes

- Possible upstream follow-up: `pi -c` after a SIGKILL mid-tool has the same unpaired-call brick — a load-time repair in pi would fix the whole ecosystem.
- Deferred by design: auto-decline timeout (pi-ask-user-style) — unnecessary once nothing blocks.
