### PR TITLE
feat(workspaces): decouple display name from git branch

### DIFF
--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -245,7 +245,7 @@ function WorkspaceRow({
 			<div
 				data-testid="workspace-item"
 				data-active={isActive}
-				className={`group flex h-7 items-center gap-sm rounded-[var(--radius-sm)] pr-xs pl-xl transition-colors ${
+				className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
 					isActive ? "bg-hover" : "hover:bg-hover"
 				}`}
 			>
@@ -255,22 +255,25 @@ function WorkspaceRow({
 					className="flex min-w-0 flex-1 items-center gap-sm text-left"
 				>
 					<GitBranch className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
-					<span
-						data-testid="workspace-name"
-						className={`min-w-0 truncate text-sm ${isActive ? "font-medium text-primary" : "text-muted"}`}
-					>
-						{workspace.name}
-					</span>
-					{/* Secondary git-branch chip — the display name is decoupled from the branch, so surface the
-					    branch for matching against git. Hidden when they coincide (pristine/legacy rows). */}
-					{workspace.branch !== workspace.name && (
+					{/* Name on top, the git branch on a second line beneath it — the display name is decoupled
+					    from the branch, so surface both without crowding one line. The branch line is hidden when
+					    they coincide, so pristine/legacy rows stay a single compact line. */}
+					<span className="flex min-w-0 flex-1 flex-col">
 						<span
-							data-testid="workspace-branch"
-							className="shrink-0 truncate font-[var(--font-mono)] text-hint text-xs"
+							data-testid="workspace-name"
+							className={`truncate text-sm leading-tight ${isActive ? "font-medium text-primary" : "text-muted"}`}
 						>
-							{workspace.branch}
+							{workspace.name}
 						</span>
-					)}
+						{workspace.branch !== workspace.name && (
+							<span
+								data-testid="workspace-branch"
+								className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
+							>
+								{workspace.branch}
+							</span>
+						)}
+					</span>
 				</button>
 				{hasStats && (
 					<span className="shrink-0 text-xs tabular-nums group-hover:hidden">

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -257,10 +257,20 @@ function WorkspaceRow({
 					<GitBranch className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
 					<span
 						data-testid="workspace-name"
-						className={`truncate text-sm ${isActive ? "font-medium text-primary" : "text-muted"}`}
+						className={`min-w-0 truncate text-sm ${isActive ? "font-medium text-primary" : "text-muted"}`}
 					>
 						{workspace.name}
 					</span>
+					{/* Secondary git-branch chip — the display name is decoupled from the branch, so surface the
+					    branch for matching against git. Hidden when they coincide (pristine/legacy rows). */}
+					{workspace.branch !== workspace.name && (
+						<span
+							data-testid="workspace-branch"
+							className="shrink-0 truncate font-[var(--font-mono)] text-hint text-xs"
+						>
+							{workspace.branch}
+						</span>
+					)}
 				</button>
 				{hasStats && (
 					<span className="shrink-0 text-xs tabular-nums group-hover:hidden">

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -23,7 +23,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   button; Esc + outside-click cancel); removal is **event-driven** (no per-client optimism): on confirm it
   just fires `workspace.remove` and lets every client — including this one — react to the host's
   `workspace.removed` push via the store's `applyWorkspaceRemoved`; a rejected request (no event will come)
-  surfaces an error toast, leaving the row in place).
+  surfaces an error toast, leaving the row in place). Each **workspace row** shows the display `name` with
+  a secondary, muted, **monospace branch chip** (`workspace.branch`) rendered only when it differs from the
+  name (so pristine/legacy `workspace-N` rows stay clean) — the display name is decoupled from the git
+  branch (see [[submodule-server-workspaces]]).
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -23,10 +23,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   button; Esc + outside-click cancel); removal is **event-driven** (no per-client optimism): on confirm it
   just fires `workspace.remove` and lets every client — including this one — react to the host's
   `workspace.removed` push via the store's `applyWorkspaceRemoved`; a rejected request (no event will come)
-  surfaces an error toast, leaving the row in place). Each **workspace row** shows the display `name` with
-  a secondary, muted, **monospace branch chip** (`workspace.branch`) rendered only when it differs from the
-  name (so pristine/legacy `workspace-N` rows stay clean) — the display name is decoupled from the git
-  branch (see [[submodule-server-workspaces]]).
+  surfaces an error toast, leaving the row in place). Each **workspace row** is **two-line**: the display
+  `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
+  it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
+  name is decoupled from the git branch (see [[submodule-server-workspaces]]).
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**

--- a/e2e/auto-rename.live.spec.ts
+++ b/e2e/auto-rename.live.spec.ts
@@ -23,8 +23,8 @@ test("turn start names the workspace instantly, then the settled turn refines it
 	// The chat is scoped to the ACTIVE workspace — key everything off its pre-rename record.
 	const activeRow = page.locator('[data-testid="workspace-item"][data-active="true"]');
 	const name = activeRow.getByTestId("workspace-name");
-	// The git branch is surfaced as a secondary chip, shown only once the display name diverges from it.
-	const branchChip = activeRow.getByTestId("workspace-branch");
+	// The git branch is surfaced on a second line beneath the name, shown only once they diverge.
+	const branchLine = activeRow.getByTestId("workspace-branch");
 	const initialName = (await name.textContent()) ?? "";
 	expect(initialName).toMatch(/^workspace-\d+$/);
 	const before = persistedWorkspaces().find((w) => w.name === initialName);
@@ -40,9 +40,9 @@ test("turn start names the workspace instantly, then the settled turn refines it
 	// login form…" → the first ~5 words), pushed live over workspace.updated — so the workspace leaves
 	// `workspace-N` immediately, without waiting for the (possibly long) turn to settle.
 	await expect(name).toHaveText("Plan How To Add A", { timeout: 20_000 });
-	// The display name now differs from the branch, so the branch chip appears with the derived kebab slug
+	// The display name now differs from the branch, so the branch line appears with the derived kebab slug
 	// (`(-\d+)?` tolerates a uniqueness suffix on the branch — never on the display name).
-	await expect(branchChip).toHaveText(/^plan-how-to-add-a(-\d+)?$/, { timeout: 20_000 });
+	await expect(branchLine).toHaveText(/^plan-how-to-add-a(-\d+)?$/, { timeout: 20_000 });
 
 	const done = page
 		.locator('[data-testid="chat-message"][data-role="system"]')
@@ -74,9 +74,9 @@ test("turn start names the workspace instantly, then the settled turn refines it
 	expect(branch).toMatch(/^[a-z0-9][a-z0-9-]*$/); // branch stays a git-clean kebab slug
 	expect(renamed?.renamed).toBe(true);
 	expect(renamed?.worktreePath).toBe(before.worktreePath);
-	// The refined name is live in the tree too (workspace.updated push, no refetch), branch on the chip.
+	// The refined name is live in the tree too (workspace.updated push, no refetch), branch on its line.
 	await expect(name).toHaveText(displayName, { timeout: 20_000 });
-	await expect(branchChip).toHaveText(branch, { timeout: 20_000 });
+	await expect(branchLine).toHaveText(branch, { timeout: 20_000 });
 
 	// Git followed: the old auto-branch is gone, the new one exists — and the worktree DIR kept its name.
 	const branches = execFileSync(

--- a/e2e/auto-rename.live.spec.ts
+++ b/e2e/auto-rename.live.spec.ts
@@ -21,9 +21,10 @@ test("turn start names the workspace instantly, then the settled turn refines it
 	await openWorkspaceChat(page); // auto-named workspace, chat tab, composer ready
 
 	// The chat is scoped to the ACTIVE workspace — key everything off its pre-rename record.
-	const name = page
-		.locator('[data-testid="workspace-item"][data-active="true"]')
-		.getByTestId("workspace-name");
+	const activeRow = page.locator('[data-testid="workspace-item"][data-active="true"]');
+	const name = activeRow.getByTestId("workspace-name");
+	// The git branch is surfaced as a secondary chip, shown only once the display name diverges from it.
+	const branchChip = activeRow.getByTestId("workspace-branch");
 	const initialName = (await name.textContent()) ?? "";
 	expect(initialName).toMatch(/^workspace-\d+$/);
 	const before = persistedWorkspaces().find((w) => w.name === initialName);
@@ -35,10 +36,13 @@ test("turn start names the workspace instantly, then the settled turn refines it
 	await page.getByTestId("chat-send").click();
 
 	// Instant naive rename the moment the first prompt lands (a user message_end, before the model
-	// responds): a deterministic, non-agentic slug from the first prompt ("Plan how to add a login form…"
-	// → the first ~5 words), pushed live over workspace.updated — so the workspace leaves `workspace-N`
-	// immediately, without waiting for the (possibly long) turn to settle. `(-\d+)?` tolerates a suffix.
-	await expect(name).toHaveText(/^plan-how-to-add-a(-\d+)?$/, { timeout: 20_000 });
+	// responds): a deterministic, non-agentic Title Case name from the first prompt ("Plan how to add a
+	// login form…" → the first ~5 words), pushed live over workspace.updated — so the workspace leaves
+	// `workspace-N` immediately, without waiting for the (possibly long) turn to settle.
+	await expect(name).toHaveText("Plan How To Add A", { timeout: 20_000 });
+	// The display name now differs from the branch, so the branch chip appears with the derived kebab slug
+	// (`(-\d+)?` tolerates a uniqueness suffix on the branch — never on the display name).
+	await expect(branchChip).toHaveText(/^plan-how-to-add-a(-\d+)?$/, { timeout: 20_000 });
 
 	const done = page
 		.locator('[data-testid="chat-message"][data-role="system"]')
@@ -61,15 +65,18 @@ test("turn start names the workspace instantly, then the settled turn refines it
 		await expect.poll(isFlagged, { timeout: 30_000 }).toBe(true);
 	}
 
-	// The persisted record moved with it: same id, name === branch, flagged renamed, dir untouched.
+	// The persisted record moved with it: same id, a human display name DECOUPLED from a kebab branch,
+	// flagged renamed, dir untouched.
 	const renamed = persistedWorkspaces().find((w) => w.id === before.id);
-	const slug = renamed?.name ?? "";
-	expect(slug).toMatch(/^[a-z0-9][a-z0-9-]*$/);
-	expect(renamed?.branch).toBe(slug);
+	const displayName = renamed?.name ?? "";
+	const branch = renamed?.branch ?? "";
+	expect(displayName.length).toBeGreaterThan(0);
+	expect(branch).toMatch(/^[a-z0-9][a-z0-9-]*$/); // branch stays a git-clean kebab slug
 	expect(renamed?.renamed).toBe(true);
 	expect(renamed?.worktreePath).toBe(before.worktreePath);
-	// The refined name is live in the tree too (workspace.updated push, no refetch).
-	await expect(name).toHaveText(slug, { timeout: 20_000 });
+	// The refined name is live in the tree too (workspace.updated push, no refetch), branch on the chip.
+	await expect(name).toHaveText(displayName, { timeout: 20_000 });
+	await expect(branchChip).toHaveText(branch, { timeout: 20_000 });
 
 	// Git followed: the old auto-branch is gone, the new one exists — and the worktree DIR kept its name.
 	const branches = execFileSync(
@@ -78,7 +85,7 @@ test("turn start names the workspace instantly, then the settled turn refines it
 		{ encoding: "utf8" },
 	);
 	expect(branches.split("\n")).not.toContain(initialName);
-	expect(branches.split("\n")).toContain(slug);
+	expect(branches.split("\n")).toContain(branch);
 	const worktrees = execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "list"], {
 		encoding: "utf8",
 	});

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -30,7 +30,13 @@ export interface DiffStats {
 export interface Workspace {
 	id: string;
 	projectId: string;
+	/**
+	 * Human-readable display label shown in the UI (Title Case, spaces) — decoupled from `branch`. May
+	 * repeat across workspaces; the branch is what's uniqued. Equals `branch` only for the auto
+	 * `workspace-N` placeholder.
+	 */
 	name: string;
+	/** The git branch this worktree is on — a kebab slug derived from `name`, uniqued (refs + worktree dirs). */
 	branch: string;
 	/** Absolute path to the worktree (the cwd everything downstream uses). */
 	worktreePath: string;

--- a/packages/server/src/assist/SPEC.md
+++ b/packages/server/src/assist/SPEC.md
@@ -14,25 +14,27 @@ Small, **best-effort** agentic helpers that run a single cheap-model completion 
 task service." Each task owns its prompt, its output parsing/guards, and its graceful-degrade fallback;
 it never blocks or crashes its caller. First task: **workspace naming** from a session's first turn,
 consumed by the host's auto-rename flow (`host/autoRename` — it owns the turn gating, the flag lifecycle,
-and the rename/push; assist only turns a prompt/turn into a slug). Naming has two halves here: the agentic
-`suggestWorkspaceName` (a cheap-model refinement) and the pure `naiveWorkspaceSlug` (the instant
-non-agentic name the host shows first). PR-draft (title/body) and similar
+and the rename/push; assist only turns a prompt/turn into a **display name**, never a branch — branch
+derivation belongs to `workspaces`). Naming has two halves here: the agentic `suggestWorkspaceName` (a
+cheap-model refinement) and the pure `naiveWorkspaceName` (the instant non-agentic name the host shows
+first). Both emit a human-readable name (Title Case, spaces), not a slug. PR-draft (title/body) and similar
 tasks land here next. The tasks are a **library surface** — no wire method; consumers are host-side flows.
 
 ## Boundary
 
 - **Owns:**
   - The task catalog + their prompts, output guards, and fallbacks. `suggestWorkspaceName(turn)` →
-    a `≤5`-word kebab-case slug or `null` (best-effort: returns `null` — never throws — on nothing
-    authenticated, timeout, or unusable output, so the caller keeps its `workspace-N` default). Always
-    time-boxed (`AbortSignal.timeout`) and bounded (`maxTokens`).
-  - `toWorkspaceSlug(raw)` — pure model-output → safe slug normalization (strip wrapping quotes/backticks,
-    collapse to kebab-case, clamp words + length).
-  - `naiveWorkspaceSlug(prompt)` — pure, **non-agentic** raw-prompt → short kebab slug (or `null` on a
-    blank/unusable prompt). Grows the slug a word at a time to *at least* a minimum (so a run of very
-    short words still reads) and stops *before* a maximum (words + chars); same slug alphabet as
-    `toWorkspaceSlug`. No runner — the host's naive-rename pass shows this the moment a turn starts,
-    before the agentic `suggestWorkspaceName` refinement lands.
+    a short (`≤5`-word) **human-readable Title Case name** or `null` (best-effort: returns `null` — never
+    throws — on nothing authenticated, timeout, or unusable output, so the caller keeps its `workspace-N`
+    default). Always time-boxed (`AbortSignal.timeout`) and bounded (`maxTokens`).
+  - `toWorkspaceName(raw)` — pure model-output → safe display-name normalization (strip wrapping
+    quotes/backticks, drop other punctuation to spaces, collapse whitespace, clamp words + length) that
+    **preserves the model's casing** (so `Add OAuth login` survives).
+  - `naiveWorkspaceName(prompt)` — pure, **non-agentic** raw-prompt → short **Title Case** name (or `null`
+    on a blank/unusable prompt). Grows a word at a time to *at least* a minimum (so a run of very short
+    words still reads) and stops *before* a maximum (words + chars), then Title Cases + joins with spaces.
+    No runner — the host's naive-rename pass shows this the moment a turn starts, before the agentic
+    `suggestWorkspaceName` refinement lands.
   - `extractFirstTurn(messages)` — pure: pull the first **clean** `{ prompt, answer }` turn out of a
     pi-canonical transcript (`Message[]`), or `null` if there is none. **Killed turns are skipped, not
     just gated:** a turn whose terminal assistant message stopped `error`/`aborted` is passed over
@@ -42,7 +44,7 @@ tasks land here next. The tasks are a **library surface** — no wire method; co
     caller's job.
   - `setOneShotRunner(fn)` — a test seam swapping the one-shot runner (default = `agent.completeOnce`) so
     tasks unit-test against a fake with no pi/auth/network.
-- **Public surface (barrel):** `suggestWorkspaceName`, `naiveWorkspaceSlug`, `toWorkspaceSlug`,
+- **Public surface (barrel):** `suggestWorkspaceName`, `naiveWorkspaceName`, `toWorkspaceName`,
   `extractFirstTurn`, `setOneShotRunner`; `WorkspaceNameTurn`, `OneShotRunner`.
 - **Allowed deps:** `agent` (the `completeOnce`/`OneShotRequest`/`OneShotResult` primitive, via its
   barrel); `contracts` (`Message`/`UserMessage`/`AssistantMessage`/`TextContent`); Node.

--- a/packages/server/src/assist/assist.test.ts
+++ b/packages/server/src/assist/assist.test.ts
@@ -2,11 +2,11 @@ import { afterEach, expect, test } from "bun:test";
 import type { AssistantMessage, Message, UserMessage } from "@thinkrail/contracts";
 import {
 	extractFirstTurn,
-	naiveWorkspaceSlug,
+	naiveWorkspaceName,
 	type OneShotRunner,
 	setOneShotRunner,
 	suggestWorkspaceName,
-	toWorkspaceSlug,
+	toWorkspaceName,
 } from "./assist";
 
 /** Inject a fake one-shot runner returning a fixed text (or throwing) — no pi/auth/network. */
@@ -39,42 +39,43 @@ function assistant(text: string, stopReason: AssistantMessage["stopReason"] = "s
 	} as AssistantMessage as Message;
 }
 
-test("toWorkspaceSlug normalizes model output into a safe, bounded kebab slug", () => {
-	expect(toWorkspaceSlug('"Add Login Flow"')).toBe("add-login-flow");
-	expect(toWorkspaceSlug("`fix: the parser!!!`")).toBe("fix-the-parser");
-	expect(toWorkspaceSlug("  Refactor   Auth  ")).toBe("refactor-auth");
-	expect(toWorkspaceSlug("one two three four five six")).toBe("one-two-three-four-five"); // ≤5 words
-	expect(toWorkspaceSlug("!!! ??? ...")).toBeNull(); // nothing usable
-	expect(toWorkspaceSlug("")).toBeNull();
+test("toWorkspaceName normalizes model output into a safe, bounded display name, preserving casing", () => {
+	expect(toWorkspaceName('"Add Login Flow"')).toBe("Add Login Flow"); // wrapping quotes stripped
+	expect(toWorkspaceName("`fix: the parser!!!`")).toBe("fix the parser"); // backticks + punctuation gone
+	expect(toWorkspaceName("  Refactor   Auth  ")).toBe("Refactor Auth"); // whitespace collapsed
+	expect(toWorkspaceName("one two three four five six")).toBe("one two three four five"); // ≤5 words
+	expect(toWorkspaceName("Add OAuth login")).toBe("Add OAuth login"); // acronym casing survives
+	expect(toWorkspaceName("!!! ??? ...")).toBeNull(); // nothing usable
+	expect(toWorkspaceName("")).toBeNull();
 });
 
-test("naiveWorkspaceSlug derives a bounded kebab slug straight from the first prompt", () => {
-	// Word-boundary growth stops at the 5-word cap; apostrophes split like the shared slug alphabet.
-	expect(naiveWorkspaceSlug("Let's figure out how to better implement")).toBe(
-		"let-s-figure-out-how",
+test("naiveWorkspaceName derives a bounded Title Case name straight from the first prompt", () => {
+	// Word-boundary growth stops at the 5-word cap; apostrophes split into separate words.
+	expect(naiveWorkspaceName("Let's figure out how to better implement")).toBe(
+		"Let S Figure Out How",
 	);
-	expect(naiveWorkspaceSlug("refactor the workspace naming flow please")).toBe(
-		"refactor-the-workspace-naming-flow",
+	expect(naiveWorkspaceName("refactor the workspace naming flow please")).toBe(
+		"Refactor The Workspace Naming Flow",
 	);
-	// Punctuation collapses to the slug alphabet; leading/trailing junk is trimmed.
-	expect(naiveWorkspaceSlug("  add a login form!!! ")).toBe("add-a-login-form");
+	// Punctuation collapses to spaces; leading/trailing junk is trimmed; each word is Title Cased.
+	expect(naiveWorkspaceName("  add a login form!!! ")).toBe("Add A Login Form");
 });
 
-test("naiveWorkspaceSlug grows short words to the minimum but never past the maxima", () => {
+test("naiveWorkspaceName grows short words to the minimum but never past the maxima", () => {
 	// A run of very short words keeps growing until ~10 chars / 2 words is met.
-	expect(naiveWorkspaceSlug("a b c d e f g")).toBe("a-b-c-d-e"); // 5-word cap
+	expect(naiveWorkspaceName("a b c d e f g")).toBe("A B C D E"); // 5-word cap
 	// Long words stop before the 40-char cap once the minimum (2 words / 10 chars) is met.
-	expect(naiveWorkspaceSlug("implement authentication authorization middleware refactor")).toBe(
-		"implement-authentication-authorization",
+	expect(naiveWorkspaceName("implement authentication authorization middleware refactor")).toBe(
+		"Implement Authentication Authorization",
 	);
 	// A prompt shorter than the minimum simply uses what it has (words ran out).
-	expect(naiveWorkspaceSlug("add login")).toBe("add-login");
+	expect(naiveWorkspaceName("add login")).toBe("Add Login");
 });
 
-test("naiveWorkspaceSlug returns null for a blank or unusable prompt", () => {
-	expect(naiveWorkspaceSlug("")).toBeNull();
-	expect(naiveWorkspaceSlug("   ")).toBeNull();
-	expect(naiveWorkspaceSlug("!!! ??? ...")).toBeNull();
+test("naiveWorkspaceName returns null for a blank or unusable prompt", () => {
+	expect(naiveWorkspaceName("")).toBeNull();
+	expect(naiveWorkspaceName("   ")).toBeNull();
+	expect(naiveWorkspaceName("!!! ??? ...")).toBeNull();
 });
 
 test("extractFirstTurn pulls the first prompt + first assistant answer from a transcript", () => {
@@ -134,14 +135,14 @@ test("extractFirstTurn skips a killed multi-round turn by its terminal assistant
 	expect(turn).toEqual({ prompt: "second task", answer: "on it" });
 });
 
-test("suggestWorkspaceName runs the turn through the runner and slugifies the reply", async () => {
+test("suggestWorkspaceName runs the turn through the runner and normalizes the reply", async () => {
 	let seen: string | undefined;
 	fakeRunner(async (req) => {
 		seen = req.prompt;
 		return { text: "Add Login Flow", model: { provider: "p", id: "m" } };
 	});
 	const name = await suggestWorkspaceName({ prompt: "add a login flow", answer: "ok" });
-	expect(name).toBe("add-login-flow");
+	expect(name).toBe("Add Login Flow"); // display name, casing preserved
 	expect(seen).toContain("add a login flow"); // the prompt carried the turn
 	expect(seen).toContain("ok");
 });

--- a/packages/server/src/assist/assist.ts
+++ b/packages/server/src/assist/assist.ts
@@ -30,14 +30,18 @@ export function setOneShotRunner(fn: OneShotRunner | null): void {
 }
 
 const NAME_SYSTEM =
-	"You name coding workspaces. Given the first turn of a session, reply with a 2-4 word kebab-case " +
-	"branch name that captures the task. Reply with the name only — no quotes, no prose, no path.";
+	"You name coding workspaces. Given the first turn of a session, reply with a short, human-readable " +
+	'name (2-4 words, Title Case) that captures the task — e.g. "Fix Auth Redirect". Reply with the ' +
+	"name only — no quotes, no prose, no kebab-case, no slashes.";
 
 /** Max ms a name suggestion may take before we give up and let the caller keep its default. */
 const NAME_TIMEOUT_MS = 12_000;
 
-/** Longest slug we keep — long branch names are unwieldy; the model is asked for 2-4 words anyway. */
-const MAX_SLUG_LENGTH = 60;
+/** Longest display name we keep — long names are unwieldy; the model is asked for 2-4 words anyway. */
+const MAX_NAME_LENGTH = 60;
+
+/** Words we keep in a display name — the model is asked for 2-4; this is the hard clamp. */
+const MAX_NAME_WORDS = 5;
 
 /**
  * Naive-slug bounds. Grow the slug word-by-word to *at least* the minimum (so a run of very short words
@@ -49,14 +53,15 @@ const NAIVE_MIN_CHARS = 10;
 const NAIVE_MAX_CHARS = 40;
 
 /**
- * Derive a short kebab slug straight from a raw user prompt — the **non-agentic** instant name shown the
- * moment a turn starts, before the agentic {@link suggestWorkspaceName} refinement lands. Grows a word at
- * a time: never stops before `MIN_WORDS`/`MIN_CHARS` (unless the prompt runs out of words), never exceeds
- * `MAX_WORDS`, and stops before `MAX_CHARS` once that minimum is met; the result is hard-clamped and its
- * trailing `-` stripped. Returns `null` for a blank/unusable prompt so the caller keeps its default.
- * Pure — same slug alphabet as {@link toWorkspaceSlug}; no runner, no auth, no network.
+ * Derive a short **Title Case display name** straight from a raw user prompt — the **non-agentic** instant
+ * name shown the moment a turn starts, before the agentic {@link suggestWorkspaceName} refinement lands.
+ * Grows a word at a time: never stops before `MIN_WORDS`/`MIN_CHARS` (unless the prompt runs out of words),
+ * never exceeds `MAX_WORDS`, and stops before `MAX_CHARS` once that minimum is met; each picked word is
+ * Title Cased and the words are joined with spaces. Returns `null` for a blank/unusable prompt so the
+ * caller keeps its default. Pure — no runner, no auth, no network; the branch is derived from this name
+ * downstream by `workspaces`.
  */
-export function naiveWorkspaceSlug(prompt: string): string | null {
+export function naiveWorkspaceName(prompt: string): string | null {
 	const words = prompt
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, " ")
@@ -66,7 +71,7 @@ export function naiveWorkspaceSlug(prompt: string): string | null {
 	if (words.length === 0) return null;
 
 	const picked: string[] = [];
-	let length = 0; // running length of the joined kebab slug
+	let length = 0; // running length of the joined name (word chars + single-char separators)
 	for (const word of words) {
 		const next = length === 0 ? word.length : length + 1 + word.length;
 		const haveMinimum = picked.length >= NAIVE_MIN_WORDS && length >= NAIVE_MIN_CHARS;
@@ -76,14 +81,20 @@ export function naiveWorkspaceSlug(prompt: string): string | null {
 		length = next;
 	}
 
-	const slug = picked.join("-").slice(0, NAIVE_MAX_CHARS).replace(/-+$/g, "");
-	return slug.length > 0 ? slug : null;
+	const name = picked.map(titleCaseWord).join(" ").slice(0, NAIVE_MAX_CHARS).trimEnd();
+	return name.length > 0 ? name : null;
+}
+
+/** Capitalize the first character of a single (already-lowercased) word; the rest is left as-is. */
+function titleCaseWord(word: string): string {
+	return word.charAt(0).toUpperCase() + word.slice(1);
 }
 
 /**
- * Suggest a short kebab-case workspace/branch name from a session's first turn. **Best-effort**: returns
- * `null` on any failure (nothing authenticated, timeout, empty/garbage output) so the caller keeps its
- * `workspace-N` default. Never throws.
+ * Suggest a short, human-readable Title Case workspace name from a session's first turn. **Best-effort**:
+ * returns `null` on any failure (nothing authenticated, timeout, empty/garbage output) so the caller keeps
+ * its `workspace-N` default. Never throws. The git branch is derived from this name downstream by
+ * `workspaces`.
  */
 export async function suggestWorkspaceName(turn: WorkspaceNameTurn): Promise<string | null> {
 	const prompt = buildNamePrompt(turn);
@@ -93,10 +104,10 @@ export async function suggestWorkspaceName(turn: WorkspaceNameTurn): Promise<str
 			system: NAME_SYSTEM,
 			prompt,
 			tier: "cheap",
-			maxTokens: 24,
+			maxTokens: 32,
 			signal: AbortSignal.timeout(NAME_TIMEOUT_MS),
 		});
-		return toWorkspaceSlug(text);
+		return toWorkspaceName(text);
 	} catch {
 		return null;
 	}
@@ -112,24 +123,24 @@ function buildNamePrompt(turn: WorkspaceNameTurn): string | null {
 }
 
 /**
- * Normalize raw model output into a safe, bounded kebab-case slug; `null` if nothing usable remains.
- * Strips wrapping quotes/backticks the model may add, collapses non-alphanumerics to `-`, clamps to a few
- * words and a max length. Pure — shared with `toBranch` in spirit, but this owns the model-output cleanup.
+ * Normalize raw model output into a safe, bounded **display name**; `null` if nothing usable remains.
+ * Strips wrapping quotes/backticks the model may add, drops other punctuation to spaces, collapses runs of
+ * whitespace, and clamps to a few words and a max length — but **preserves the model's casing** (so
+ * `Add OAuth login` survives intact). Pure. The git branch is derived from this by `workspaces`' `toBranch`.
  */
-export function toWorkspaceSlug(raw: string): string | null {
-	const slug = raw
+export function toWorkspaceName(raw: string): string | null {
+	const name = raw
 		.trim()
-		.toLowerCase()
 		.replace(/^[`'"]+|[`'"]+$/g, "")
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-+|-+$/g, "")
-		.split("-")
+		.replace(/[^A-Za-z0-9]+/g, " ")
+		.trim()
+		.split(/\s+/)
 		.filter(Boolean)
-		.slice(0, 5)
-		.join("-")
-		.slice(0, MAX_SLUG_LENGTH)
-		.replace(/-+$/g, "");
-	return slug.length > 0 ? slug : null;
+		.slice(0, MAX_NAME_WORDS)
+		.join(" ")
+		.slice(0, MAX_NAME_LENGTH)
+		.trimEnd();
+	return name.length > 0 ? name : null;
 }
 
 /**

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -42,17 +42,18 @@ channel fan-out, and the process-boot wrapper both launchers share.
     (`isPromptCommitted(event)`, exported: a **user `message_end`** — `agent_start`/`turn_start` fire
     *before* the prompt's `message_end`, so the transcript wouldn't yet hold the prompt at those; this
     still fires before the model responds, so the name is instant and no tool/question can block it). It
-    derives a slug from the first prompt with assist's non-agentic `naiveWorkspaceSlug` (no model call)
-    and renames **provisionally** (`renameWorkspace(..., { lock: false })` — name + branch move but
-    `renamed` stays unset). It fires only on a **pristine** workspace (`!renamed` AND name still
-    `workspace-N`), so it lands once and never overwrites a user/agentic name; a per-workspace `naiveInFlight`
+    derives a **display name** from the first prompt with assist's non-agentic `naiveWorkspaceName` (no
+    model call) and renames **provisionally** (`renameWorkspace(..., { lock: false })` — name + derived
+    branch move but `renamed` stays unset). It fires only on a **pristine** workspace (`!renamed` AND its
+    **branch** still `workspace-N` — gated on the branch, not the display name, so the two stay decoupled),
+    so it lands once and never overwrites a user/agentic name; a per-workspace `naiveInFlight`
     set dedupes re-fired prompt-commits. This is why a long first turn no longer leaves the workspace as
     `workspace-N` for minutes.
   - **Agentic (refine):** `maybeAutoRenameWorkspace(sessionId, workspaceId)` on every **settled** turn
-    (`isSettledTurn(event)`, exported: `agent_end` with `willRetry: false`). It asks assist for a slug
-    (cheap model), re-checks the workspace (exists, not `renamed`) after the await, then calls
-    `renameWorkspace` in the same tick — upgrading the provisional naive slug into the final name and
-    **locking** it (`renamed: true`). Best-effort by contract: every failure path resolves `null` and
+    (`isSettledTurn(event)`, exported: `agent_end` with `willRetry: false`). It asks assist for a
+    human-readable name (cheap model), re-checks the workspace (exists, not `renamed`) after the await,
+    then calls `renameWorkspace` in the same tick — upgrading the provisional naive name into the final
+    name (and its derived branch) and **locking** it (`renamed: true`). Best-effort by contract: every failure path resolves `null` and
     leaves the flag unset so a later settled turn retries — but a swallowed exception is `console.warn`ed
     (a broken rename path must stay distinguishable from "assist had nothing"). Its own per-workspace
     **in-flight set** (independent of the naive one — the two passes can overlap on a short turn) dedupes

--- a/packages/server/src/host/autoRename.test.ts
+++ b/packages/server/src/host/autoRename.test.ts
@@ -76,12 +76,12 @@ test("renames the workspace off the first settled turn and flags it", async () =
 
 	const renamed = await maybeAutoRenameWorkspace("s1", ws.id, firstTurn);
 
-	expect(renamed?.name).toBe("add-login-flow");
-	expect(renamed?.branch).toBe("add-login-flow");
+	expect(renamed?.name).toBe("Add Login Flow"); // display name (Title Case)
+	expect(renamed?.branch).toBe("add-login-flow"); // derived kebab branch
 	expect(renamed?.renamed).toBe(true);
 	expect(renamed?.worktreePath).toBe(ws.worktreePath);
 	expect(runner.calls()).toBe(1);
-	expect(listWorkspaces("p1")[0]?.name).toBe("add-login-flow");
+	expect(listWorkspaces("p1")[0]?.name).toBe("Add Login Flow");
 });
 
 test("a renamed workspace is never touched again", async () => {
@@ -110,7 +110,7 @@ test("a failed suggestion leaves the flag unset so a later turn retries", async 
 
 	fakeRunner("Fix The Parser");
 	const retried = await maybeAutoRenameWorkspace("s1", ws.id, firstTurn);
-	expect(retried?.name).toBe("fix-the-parser");
+	expect(retried?.name).toBe("Fix The Parser");
 });
 
 test("a throwing runner degrades to null", async () => {
@@ -148,7 +148,7 @@ test("a retracted first prompt is never naming material — the first clean turn
 	];
 	const renamed = await maybeAutoRenameWorkspace("s1", ws.id, transcript);
 
-	expect(renamed?.name).toBe("fix-header-layout");
+	expect(renamed?.name).toBe("Fix Header Layout");
 	expect(runner.prompts[0]).toContain("fix the header layout");
 	expect(runner.prompts[0]).not.toContain("billing");
 });
@@ -188,7 +188,7 @@ test("a user rename landing during the one-shot wins; the late suggestion is dro
 	release();
 
 	expect(await pending).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("user-picked-this");
+	expect(listWorkspaces("p1")[0]?.name).toBe("user picked this");
 });
 
 test("naive-rename names the workspace instantly from the first prompt, provisionally", async () => {
@@ -196,8 +196,8 @@ test("naive-rename names the workspace instantly from the first prompt, provisio
 
 	const named = await maybeNaiveNameWorkspace("s1", ws.id, firstTurn);
 
-	// Bounded kebab slug from "add a login form to the settings page" (5-word cap).
-	expect(named?.name).toBe("add-a-login-form-to");
+	// Bounded Title Case name from "add a login form to the settings page" (5-word cap); branch derived.
+	expect(named?.name).toBe("Add A Login Form To");
 	expect(named?.branch).toBe("add-a-login-form-to");
 	expect(named?.worktreePath).toBe(ws.worktreePath); // dir never moves
 	// Provisional: `renamed` stays unset so the agentic pass still refines it.
@@ -209,16 +209,16 @@ test("naive-rename fires only while the name is pristine (workspace-N)", async (
 	const ws = await createWorkspace("p1");
 	await maybeNaiveNameWorkspace("s1", ws.id, firstTurn);
 
-	// Second turn start: the name is no longer `workspace-N`, so it never re-fires.
+	// Second turn start: the branch is no longer `workspace-N`, so it never re-fires.
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("add-a-login-form-to");
+	expect(listWorkspaces("p1")[0]?.name).toBe("Add A Login Form To");
 });
 
 test("naive-rename never touches a user-named workspace", async () => {
 	const ws = await createWorkspace("p1", "chosen name");
 
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("chosen-name");
+	expect(listWorkspaces("p1")[0]?.name).toBe("chosen name");
 });
 
 test("the agentic pass refines a provisional naive name and locks it", async () => {
@@ -226,17 +226,17 @@ test("the agentic pass refines a provisional naive name and locks it", async () 
 	fakeRunner("Add Login Flow");
 
 	const provisional = await maybeNaiveNameWorkspace("s1", ws.id, firstTurn);
-	expect(provisional?.name).toBe("add-a-login-form-to");
+	expect(provisional?.name).toBe("Add A Login Form To");
 	expect(provisional?.renamed).toBeUndefined();
 
 	// Settled turn: the agentic namer still runs (renamed was unset) and upgrades + locks.
 	const refined = await maybeAutoRenameWorkspace("s1", ws.id, firstTurn);
-	expect(refined?.name).toBe("add-login-flow");
+	expect(refined?.name).toBe("Add Login Flow");
 	expect(refined?.renamed).toBe(true);
 
 	// And the now-locked name is inert to a further turn start.
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("add-login-flow");
+	expect(listWorkspaces("p1")[0]?.name).toBe("Add Login Flow");
 });
 
 test("naive-rename resolves null when the first prompt is blank or unusable", async () => {
@@ -305,7 +305,7 @@ test("concurrent settling turns dedupe to one attempt", async () => {
 	release();
 	const [a, b] = await Promise.all([first, second]);
 
-	expect(a?.name).toBe("slow-name");
+	expect(a?.name).toBe("Slow Name");
 	expect(b).toBeNull();
 	expect(calls).toBe(1);
 });

--- a/packages/server/src/host/autoRename.ts
+++ b/packages/server/src/host/autoRename.ts
@@ -12,11 +12,15 @@
 
 import type { Message, PiEvent, Workspace } from "@thinkrail/contracts";
 import { getSessionMessages } from "../agent";
-import { extractFirstTurn, naiveWorkspaceSlug, suggestWorkspaceName } from "../assist";
+import { extractFirstTurn, naiveWorkspaceName, suggestWorkspaceName } from "../assist";
 import { getWorkspace, renameWorkspace } from "../workspaces";
 
-/** A pristine, never-touched auto name (`workspace-N`) — the only state the naive pass may overwrite. */
-const PRISTINE_NAME = /^workspace-\d+$/;
+/**
+ * A pristine, never-touched auto workspace — the only state the naive pass may overwrite. Keyed off the
+ * **branch** (always `workspace-N` when auto), not the display `name`, so the two are decoupled: the
+ * display name's format can change without breaking this gate.
+ */
+const PRISTINE_BRANCH = /^workspace-\d+$/;
 
 /**
  * A settled turn: the run concluded and no auto-retry follows. `turn_end` is NOT settlement (it fires
@@ -59,9 +63,9 @@ export type TranscriptReader = () => Promise<Message[]>;
  * `workspace-N` for minutes while the agentic pass waits for the turn to settle.
  *
  * Provisional by contract: it renames name + branch but leaves `renamed` unset (`lock: false`), so
- * {@link maybeAutoRenameWorkspace} still refines the slug into a final name and locks it on settle. It
- * fires only on a **pristine** workspace (`!renamed` AND name still `workspace-N`) — once the naive slug
- * lands the name no longer matches, so it never fires twice and never overwrites a user/agentic name.
+ * {@link maybeAutoRenameWorkspace} still refines the name and locks it on settle. It fires only on a
+ * **pristine** workspace (`!renamed` AND its branch still `workspace-N`) — once the naive rename lands the
+ * branch no longer matches, so it never fires twice and never overwrites a user/agentic name.
  * Best-effort like the agentic pass: every failure path resolves `null`; never throws, never blocks.
  */
 export async function maybeNaiveNameWorkspace(
@@ -81,13 +85,13 @@ export async function maybeNaiveNameWorkspace(
 					.messages);
 		const turn = extractFirstTurn(await read());
 		if (!turn) return null;
-		const slug = naiveWorkspaceSlug(turn.prompt);
-		if (!slug) return null;
+		const name = naiveWorkspaceName(turn.prompt);
+		if (!name) return null;
 
 		// Re-check across the await, then rename in the same synchronous tick. `lock: false` keeps the
 		// workspace eligible for the agentic refinement that follows on the settled turn.
 		if (!isPristine(workspaceId)) return null;
-		return renameWorkspace(workspaceId, slug, { lock: false });
+		return renameWorkspace(workspaceId, name, { lock: false });
 	} catch (err) {
 		console.warn(
 			`workspace naive-rename skipped (${workspaceId}): ${err instanceof Error ? err.message : err}`,
@@ -98,11 +102,11 @@ export async function maybeNaiveNameWorkspace(
 	}
 }
 
-/** A workspace still carrying its pristine auto name (`workspace-N`, never renamed). `false` if gone. */
+/** A workspace still on its pristine auto branch (`workspace-N`, never renamed). `false` if gone. */
 function isPristine(workspaceId: string): boolean {
 	try {
 		const ws = getWorkspace(workspaceId);
-		return !ws.renamed && PRISTINE_NAME.test(ws.name);
+		return !ws.renamed && PRISTINE_BRANCH.test(ws.branch);
 	} catch {
 		return false; // archived out from under the starting turn
 	}
@@ -140,14 +144,14 @@ export async function maybeAutoRenameWorkspace(
 
 		const turn = extractFirstTurn(messages);
 		if (!turn) return null;
-		const slug = await suggestWorkspaceName(turn);
-		if (!slug) return null;
+		const name = await suggestWorkspaceName(turn);
+		if (!name) return null;
 
 		// Re-check across the awaits, then rename in the same synchronous tick — no interleaving possible
 		// on this event loop between the check and the save (renameWorkspace is sync).
 		const fresh = getWorkspace(workspaceId);
 		if (fresh.renamed) return null;
-		return renameWorkspace(workspaceId, slug);
+		return renameWorkspace(workspaceId, name);
 	} catch (err) {
 		// Best-effort means null, not silent: without the trace, a permanently-broken rename path would be
 		// indistinguishable from the tolerated "assist had nothing to offer" case.

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -11,7 +11,9 @@ tags: [v1]
 ## Responsibility
 
 A workspace is a `git worktree` on its own branch under the data dir — the anchor for files/git/terminals/
-chats.
+chats. Its **display `name` is decoupled from its git `branch`**: `name` is a human-readable label
+(Title Case, spaces) and `branch` is a kebab slug derived from it — they were once held equal, and still
+coincide for the auto `workspace-N` placeholder, but a named workspace carries both distinctly.
 
 ## Boundary
 
@@ -27,12 +29,17 @@ chats.
   (`WORKSPACE_CONTEXT_DIR`, with a self-ignoring `*` `.gitignore` — zero git footprint) in the
   new worktree, the home for temp docs (task-specs / working files) that stay out of git yet remain
   scannable by the spec tools (the path convention lives in `@thinkrail/shared/paths`; see
-  [[submodule-workflow-skills]]'s artifacts rules); a **user-supplied name sets `renamed: true`** at create —
-  the user already chose, so the auto-namer never touches it; auto-`workspace-N` leaves it unset),
-  `renameWorkspace` (**sync**; slugs + uniques the requested name, `git branch -m` from the project repo
-  — the branch ref moves and the worktree's HEAD follows, but the **worktree dir never moves** (pi keys
-  sessions by exact cwd; terminals/tabs are cwd'd there — the stale dir name is the accepted cost);
-  keeps the `name === branch` invariant by setting both to the final unique branch; **re-points sibling
+  [[submodule-workflow-skills]]'s artifacts rules); a **user-supplied name is the display name** (casing +
+  punctuation preserved via `toDisplayName`; the branch is derived from it) and **sets `renamed: true`** at
+  create — the user already chose, so the auto-namer never touches it; auto-`workspace-N` leaves it unset,
+  where `name === branch`),
+  `renameWorkspace` (**sync**; sets the **display `name`** (sanitized, casing preserved) and derives the
+  **git branch** from it via `toBranch`, uniqued against refs + worktree dirs, `git branch -m` from the
+  project repo — the branch ref moves and the worktree's HEAD follows, but the **worktree dir never moves**
+  (pi keys sessions by exact cwd; terminals/tabs are cwd'd there — the stale dir name is the accepted cost);
+  **`name` and `branch` deliberately differ** (e.g. `Fix Auth Redirect` / `fix-auth-redirect`) — the name
+  is display-only, never a path/id; only the branch is uniqued (display names may repeat, the branch chip
+  disambiguates — see [[submodule-web-panels]]); **re-points sibling
   records whose `baseBranch` was the old branch** in the same save so their diffs don't silently empty;
   **re-loads the records after the git subprocess** — a record that vanished meanwhile (archived / e2e
   reset) aborts the save instead of resurrecting it; throws on unknown id or git failure — callers decide,

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -38,8 +38,8 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   project repo — the branch ref moves and the worktree's HEAD follows, but the **worktree dir never moves**
   (pi keys sessions by exact cwd; terminals/tabs are cwd'd there — the stale dir name is the accepted cost);
   **`name` and `branch` deliberately differ** (e.g. `Fix Auth Redirect` / `fix-auth-redirect`) — the name
-  is display-only, never a path/id; only the branch is uniqued (display names may repeat, the branch chip
-  disambiguates — see [[submodule-web-panels]]); **re-points sibling
+  is display-only, never a path/id; only the branch is uniqued (display names may repeat, the branch
+  shown beneath the name in the nav disambiguates — see [[submodule-web-panels]]); **re-points sibling
   records whose `baseBranch` was the old branch** in the same save so their diffs don't silently empty;
   **re-loads the records after the git subprocess** — a record that vanished meanwhile (archived / e2e
   reset) aborts the save instead of resurrecting it; throws on unknown id or git failure — callers decide,

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -108,8 +108,8 @@ test("createWorkspace marks a user-named workspace renamed; an auto-named one st
 	expect(auto.renamed).toBeUndefined();
 
 	const named = await createWorkspace("p1", "My Feature");
-	expect(named.name).toBe("my-feature");
-	expect(named.branch).toBe("my-feature");
+	expect(named.name).toBe("My Feature"); // display name: casing preserved
+	expect(named.branch).toBe("my-feature"); // branch: derived kebab slug
 	expect(named.renamed).toBe(true);
 });
 
@@ -117,8 +117,8 @@ test("renameWorkspace moves the branch in place: record + git follow, the worktr
 	const ws = await createWorkspace("p1");
 	const renamed = renameWorkspace(ws.id, "add login flow");
 
-	expect(renamed.name).toBe("add-login-flow");
-	expect(renamed.branch).toBe("add-login-flow");
+	expect(renamed.name).toBe("add login flow"); // display name (sanitized), decoupled from the branch
+	expect(renamed.branch).toBe("add-login-flow"); // branch: derived kebab slug
 	expect(renamed.renamed).toBe(true);
 	expect(renamed.worktreePath).toBe(ws.worktreePath);
 	// The worktree's HEAD followed the ref rename; the old branch is gone from the repo.
@@ -127,14 +127,15 @@ test("renameWorkspace moves the branch in place: record + git follow, the worktr
 		"workspace-1",
 	);
 	// And the record on disk agrees.
-	expect(listWorkspaces("p1")[0]?.name).toBe("add-login-flow");
+	expect(listWorkspaces("p1")[0]?.name).toBe("add login flow");
+	expect(listWorkspaces("p1")[0]?.branch).toBe("add-login-flow");
 });
 
 test("renameWorkspace with lock:false renames name + branch but leaves renamed unset (provisional)", async () => {
 	const ws = await createWorkspace("p1");
 	const renamed = renameWorkspace(ws.id, "add login flow", { lock: false });
 
-	expect(renamed.name).toBe("add-login-flow");
+	expect(renamed.name).toBe("add login flow");
 	expect(renamed.branch).toBe("add-login-flow");
 	expect(renamed.renamed).toBeUndefined(); // still eligible for the agentic refinement
 	expect(gitOut(ws.worktreePath, "rev-parse", "--abbrev-ref", "HEAD")).toBe("add-login-flow");
@@ -142,7 +143,8 @@ test("renameWorkspace with lock:false renames name + branch but leaves renamed u
 
 	// A later default (lock) rename still moves the branch and now locks it.
 	const locked = renameWorkspace(ws.id, "final name");
-	expect(locked.name).toBe("final-name");
+	expect(locked.name).toBe("final name");
+	expect(locked.branch).toBe("final-name");
 	expect(locked.renamed).toBe(true);
 });
 
@@ -150,8 +152,9 @@ test("renameWorkspace suffixes on collision with an existing branch", async () =
 	git(repo, "branch", "add-login-flow");
 	const ws = await createWorkspace("p1");
 	const renamed = renameWorkspace(ws.id, "add login flow");
+	// The branch is uniqued on collision; the display name stays clean (the chip disambiguates).
 	expect(renamed.branch).toBe("add-login-flow-2");
-	expect(renamed.name).toBe("add-login-flow-2");
+	expect(renamed.name).toBe("add login flow");
 });
 
 test("renameWorkspace re-points siblings basing their diff on the old branch", async () => {
@@ -176,7 +179,7 @@ test("renameWorkspace also suffixes when the candidate's worktree dir is occupie
 	const second = await createWorkspace("p1"); // dir-aware create lands on workspace-2
 	const renamed = renameWorkspace(second.id, "workspace 1"); // branch free, dir taken → suffix
 	expect(renamed.branch).toBe("workspace-1-2");
-	expect(renamed.name).toBe("workspace-1-2");
+	expect(renamed.name).toBe("workspace 1"); // display name unaffected by the branch's dir-collision suffix
 });
 
 test("creating after a rename skips the freed name whose worktree dir is still occupied", async () => {
@@ -226,7 +229,7 @@ test("membership mutations emit lifecycle events through the injected publisher"
 	expect(events[0]).toMatchObject({ kind: "created", workspace: { id: ws.id, projectId: "p1" } });
 	expect(events[1]).toMatchObject({
 		kind: "updated",
-		workspace: { id: ws.id, name: "my-feature" },
+		workspace: { id: ws.id, name: "my feature", branch: "my-feature" },
 	});
 	expect(events[2]).toEqual({ kind: "removed", projectId: "p1", id: ws.id });
 });

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -42,6 +42,19 @@ function toBranch(name: string): string {
 	);
 }
 
+/** Longest display name we store — keeps the left-nav readable; the branch is derived from it. */
+const MAX_DISPLAY_NAME = 60;
+
+/**
+ * Sanitize a requested **display name** for storage: trim, collapse whitespace, clamp length — casing and
+ * punctuation preserved (unlike `toBranch`). `null` if nothing usable remains. The stored `Workspace.name`
+ * is display-only; its git branch is derived separately via `toBranch`.
+ */
+function toDisplayName(raw: string): string | null {
+	const name = raw.trim().replace(/\s+/g, " ").slice(0, MAX_DISPLAY_NAME).trimEnd();
+	return name.length > 0 ? name : null;
+}
+
 function branchExists(repoPath: string, branch: string): boolean {
 	return git(repoPath, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]).ok;
 }
@@ -102,11 +115,13 @@ export async function createWorkspace(
 	if (!project) throw new Error(`Unknown project: ${projectId}`);
 
 	const all = loadWorkspaces();
-	const trimmedName = name?.trim();
-	const branch = trimmedName
-		? uniqueBranch(project, toBranch(trimmedName))
+	// A user-supplied name is the display name (casing/punctuation preserved); the branch is derived from
+	// it. Omitted (or unusable) → the auto `workspace-N` placeholder, where name === branch.
+	const displayName = name ? toDisplayName(name) : null;
+	const branch = displayName
+		? uniqueBranch(project, toBranch(displayName))
 		: nextAutoBranch(project);
-	const wsName = branch;
+	const wsName = displayName ?? branch;
 
 	const base = baseRef?.trim();
 	let baseBranch: string;
@@ -148,7 +163,7 @@ export async function createWorkspace(
 		baseBranch,
 		// A user-chosen name is a deliberate one — the auto-namer must never touch it. Auto `workspace-N`
 		// leaves the flag unset: eligible for one assist rename.
-		...(trimmedName ? { renamed: true } : {}),
+		...(displayName ? { renamed: true } : {}),
 	};
 	all.push(workspace);
 	saveWorkspaces(all);
@@ -157,12 +172,14 @@ export async function createWorkspace(
 }
 
 /**
- * Rename a workspace: its record (display name + branch, kept equal) and its git branch — in place. The
- * branch ref moves via `git branch -m` from the project repo (the worktree's HEAD follows); the worktree
- * directory never moves — pi keys sessions by exact cwd, and terminals/tabs are rooted there, so the dir
- * keeps its creation name. The requested name is slugified and made unique (refs + worktree dirs), and
- * re-points sibling records that based their diff on the old branch. Sync on purpose: a caller's
- * check-then-rename can't interleave on the event loop. Throws on unknown id / git failure.
+ * Rename a workspace: its **display name** and its **git branch** (derived from the name), in place. The
+ * name carries the human label (casing/punctuation preserved); the branch is `toBranch(name)`, made unique
+ * (refs + worktree dirs) — so `name` and `branch` deliberately differ (e.g. `Fix Auth Redirect` /
+ * `fix-auth-redirect`). The branch ref moves via `git branch -m` from the project repo (the worktree's
+ * HEAD follows); the worktree directory never moves — pi keys sessions by exact cwd, and terminals/tabs are
+ * rooted there, so the dir keeps its creation name. Re-points sibling records that based their diff on the
+ * old branch. Sync on purpose: a caller's check-then-rename can't interleave on the event loop. Throws on
+ * unknown id / git failure / an empty requested name.
  *
  * `lock` (default `true`) sets `renamed`, marking the name deliberate so the auto-namer never touches it
  * again — what a user rename and the agentic auto-rename want. The **provisional naive rename** passes
@@ -180,7 +197,9 @@ export function renameWorkspace(
 	const project = getProjects().find((p) => p.id === ws.projectId);
 	if (!project) throw new Error(`Unknown project: ${ws.projectId}`);
 
-	const wanted = toBranch(requestedName);
+	const displayName = toDisplayName(requestedName);
+	if (!displayName) throw new Error(`Invalid workspace name: ${requestedName}`);
+	const wanted = toBranch(displayName);
 	const branch = wanted === ws.branch ? ws.branch : uniqueBranch(project, wanted);
 	if (branch !== ws.branch) {
 		const moved = git(project.path, ["branch", "-m", ws.branch, branch]);
@@ -196,7 +215,7 @@ export function renameWorkspace(
 	for (const w of all) {
 		if (w.projectId === target.projectId && w.baseBranch === ws.branch) w.baseBranch = branch;
 	}
-	target.name = branch;
+	target.name = displayName;
 	target.branch = branch;
 	if (lock) target.renamed = true;
 	saveWorkspaces(all);


### PR DESCRIPTION
## What & why

Workspace names rendered in the left-nav as **kebab slugs** (e.g. `fix-auth-redirect`) because a workspace's `name` doubled as its git **branch**. That reads poorly. This splits the two:

- **`name`** — a human-readable display label (Title Case, spaces), shown in the sidebar.
- **`branch`** — a kebab slug **derived** from the name and uniqued against refs + worktree dirs (git-clean, unchanged behavior).

The left-nav now shows the display name with a **secondary monospace branch chip**, rendered only when it differs from the name (so pristine `workspace-N` / legacy rows stay clean). The git branch stays glanceable for matching against git.

The contract already had separate `name` / `branch` fields — the server just forced them equal, so there is **no wire-shape or protocol-version change**.

## Changes

- **`assist`** — namers emit Title Case display names: `naiveWorkspaceSlug → naiveWorkspaceName` (Title Case phrase), `toWorkspaceSlug → toWorkspaceName` (casing-preserving clamp, so `Add OAuth login` survives), and `suggestWorkspaceName`'s system prompt asks for a short human-readable name. Branch derivation stays out of `assist`.
- **`workspaces`** — drop the `name === branch` invariant; `createWorkspace` / `renameWorkspace` set the display `name` and the derived `branch` **independently**. Display names may repeat; only the branch is uniqued (the chip disambiguates). The auto `workspace-N` placeholder is unchanged (`name === branch`).
- **`host/autoRename`** — the pristine-gate keys off the **branch** (`^workspace-\d+$`), not the display name, so the format decoupling cannot break it.
- **web** — `WorkspaceRow` gains a secondary mono branch chip (`data-testid="workspace-branch"`), token utilities only.
- **specs** — updated `contracts` / `assist` / `workspaces` / `host` / `panels` SPECs to record the decoupling.

## Out of scope

- A `workspace.rename` wire method / UI rename affordance (does not exist today).
- A name field in the New-Workspace dialog (it sends no name today).
- Migrating/prettifying existing workspace names (they keep their stored name, which equals their branch).

## Verification

- `check:deps` + `lint` + `typecheck` — green (pre-commit).
- `bun run test` — 151 server unit tests pass (updated `assist` / `workspaces` / `autoRename` specs), plus web/contracts.
- `bun run e2e` (no-agent gate) — passes; the intermittent failures observed were confirmed flaky (each passed in isolation; different specs failed across runs, none in the changed area).
- `e2e/auto-rename.live.spec.ts` (@agent) updated to assert Title Case names + the branch chip.
