### PR TITLE
feat: High Contrast theme — the classical VSCode hc-black

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -75,22 +75,29 @@ The module set: `transport` / `store` / branded `shell`; `ProjectTree`; `FileTre
 - **`src/styles/tokens.css` is the theme contract.** A *theme* is one set of CSS custom properties; a
   theme swap = changing the token block via `[data-theme="…"]` on `<html>` (`utils/theme` `applyTheme(id)`)
   — nothing in components changes. `@theme inline` keeps utilities pointing at the live `var(--token)`, so
-  the swap re-themes everything. **Ships four themes** — **Dark** (default, under `:root`), **Light**,
-  classic IntelliJ **Darcula**, and **Gruvbox** (the vim classic — warm retro darks; the one theme that
-  swaps the interactive accent to gruvbox orange with dark-on-accent text, so a `[data-theme]` block MAY
-  override the accent family when the palette demands it). Theme blocks override only the semantic
+  the swap re-themes everything. **Ships five themes** — **Dark** (default, under `:root`), **Light**,
+  classic IntelliJ **Darcula**, **Gruvbox** (the vim classic — warm retro darks; the first theme to swap
+  the interactive accent, to gruvbox orange with dark-on-accent text, so a `[data-theme]` block MAY
+  override the accent family when the palette demands it), and **High Contrast** (the classical VSCode
+  hc-black: pure black surfaces, white text, cyan `#6fc3df` contrast borders, orange `#f38518` accent
+  with dark-on-accent text, yellow selection with black selected text). Theme blocks override only the semantic
   surface/text/status tokens + `color-scheme` (+ `--ansi-*`/`--code-*`/accent where the theme calls for
   it); type scale, spacing, radii, fonts stay shared in `:root`. The choice is **server-synced** (`AppConfig.theme`, host-owned): it arrives in
   `server.welcome`, is set from the store's `theme` (fed by transport), applied by the shell's one theme
   effect, and cached in `localStorage` only as a **first-paint hint** (`main.tsx` applies it pre-React so
   the initial paint matches, before the welcome reconciles it). Changed via `settings.update`, converged on
   the `settings.changed` broadcast. The token vocabulary also carries the code surfaces: **`--ansi-*`**
-  (the 16 xterm colors — light overrides them, dark-tuned brights wash out on white) and optional
-  **`--code-*`** syntax colors (set by Darcula, whose identity is its syntax palette; unset elsewhere).
+  (the 16 xterm colors — light overrides them, dark-tuned brights wash out on white), optional
+  **`--code-*`** syntax colors (Darcula's and Gruvbox's identity; High Contrast sets only the comment
+  green over Monaco's real hc-black base), and the optional **`--sel-fg`/`--selection-fg`** selected-text
+  pair (set by High Contrast, whose yellow selection needs black text — unset elsewhere, so other themes
+  keep today's behavior; `--sel-fg` feeds Monaco's `editor.selectionForeground` + xterm's
+  `selectionForeground`, `--selection-fg` the `::selection` rule).
   Code surfaces that own their own theming track the swap: **xterm** and **Monaco** observe
-  `[data-theme]` and rebuild from the tokens (Monaco also picks its `vs`/`vs-dark` base from it, and
-  derives token rules from `--code-*`); **shiki** renders the tri palette (dark+light+darcula, the
-  darcula registration in `lib/shikiTheme.ts`) as CSS vars, flipped by the `[data-theme]` rules in
+  `[data-theme]` and rebuild from the tokens (Monaco picks its `vs`/`vs-dark`/`hc-black` base from it, and
+  derives token rules from `--code-*`); **shiki** renders every `SHIKI_THEMES` palette
+  (dark+light+darcula+gruvbox+high-contrast; the custom darcula + hc-black registrations in
+  `lib/shikiTheme.ts`) as CSS vars, flipped by the `[data-theme]` rules in
   `global.css`; **mermaid** re-derives from the tokens. **Reading color tokens from JS goes through
   `lib.cssColorToHex`** — the built CSS is minified, so `getComputedStyle` can return any equivalent form
   (`#fff`, `gray`), which strict consumers (Monaco, xterm) reject. Text/status token values hold a contrast floor (body ≥

--- a/apps/web/src/lib/SPEC.md
+++ b/apps/web/src/lib/SPEC.md
@@ -19,8 +19,9 @@ Tiny UI helpers shared across components.
   a CSS color to hex — minified CSS serves `#fff`/`gray`-style equivalents, which strict consumers like
   Monaco and xterm reject; `""` when unparseable). Also the shared
   shiki pieces, **kept out of the barrel** so the eager `@/lib` import stays shiki-free: `highlighter.ts`
-  (the chat code-block highlighter — curated grammars, JS regex engine, tri-theme render) and
-  `shikiTheme.ts` (the `SHIKI_THEMES` tri-palette map + the custom `darcula` registration, shared with
+  (the chat code-block highlighter — curated grammars, JS regex engine, one render carrying every
+  `SHIKI_THEMES` palette) and
+  `shikiTheme.ts` (the `SHIKI_THEMES` palette map + the custom `darcula` and `hc-black` registrations, shared with
   `panels/DiffViewer`); both are imported per-file (`@/lib/highlighter`, `@/lib/shikiTheme`) from lazy
   chunks only.
 - **Public surface (barrel):** `cn`, `isMarkdownPath`, `stripFrontmatter`, `cssColorToHex`.

--- a/apps/web/src/lib/highlighter.ts
+++ b/apps/web/src/lib/highlighter.ts
@@ -1,9 +1,9 @@
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
-import { DARCULA_SHIKI, SHIKI_THEMES } from "./shikiTheme";
+import { DARCULA_SHIKI, HC_BLACK_SHIKI, SHIKI_THEMES } from "./shikiTheme";
 
 // Shared shiki highlighter for chat code blocks: the JS regex engine (no WASM), a curated language set,
-// and the TRI theme (dark + light + darcula, from `shikiTheme.ts`) — all behind dynamic imports so nothing
+// and every `SHIKI_THEMES` palette (from `shikiTheme.ts`) — all behind dynamic imports so nothing
 // loads until the first code block renders. Matches the DiffViewer pattern; kept here so chat can highlight
 // many languages. One render emits every palette as CSS vars; the `[data-theme]` rules in global.css flip
 // between them, so a theme swap needs no re-highlighting.
@@ -45,6 +45,7 @@ function getHighlighter(): Promise<HighlighterCore> {
 			import("@shikijs/themes/github-light-default"),
 			import("@shikijs/themes/gruvbox-dark-hard"),
 			DARCULA_SHIKI,
+			HC_BLACK_SHIKI,
 		],
 		langs: [
 			import("@shikijs/langs/typescript"),

--- a/apps/web/src/lib/shikiTheme.ts
+++ b/apps/web/src/lib/shikiTheme.ts
@@ -33,14 +33,52 @@ export const DARCULA_SHIKI: ThemeRegistration = {
 };
 
 /**
+ * The classical VSCode "Dark High Contrast" (hc-black) palette as a shiki theme — shiki ships only the
+ * GitHub HC themes, not VSCode's. Mirrors Monaco's built-in `hc_black` rules (white numbers, #569cd6
+ * keywords, #1aebff variables, #ce9178 strings on pure black) so chat/diff code matches the editor;
+ * comments use VSCode's current brightened #7ca668 — the same value the theme's `--code-comment` token
+ * feeds Monaco (whose bundled base still ships the older #608b4e).
+ */
+export const HC_BLACK_SHIKI: ThemeRegistration = {
+	name: "hc-black",
+	type: "dark",
+	settings: [
+		{ settings: { foreground: "#ffffff", background: "#000000" } },
+		{ scope: ["comment", "comment.block.documentation"], settings: { foreground: "#7ca668" } },
+		{ scope: ["string", "punctuation.definition.string"], settings: { foreground: "#ce9178" } },
+		{ scope: ["string.regexp"], settings: { foreground: "#c0c0c0" } },
+		{
+			scope: ["keyword", "storage.type", "storage.modifier", "constant.language"],
+			settings: { foreground: "#569cd6" },
+		},
+		{ scope: ["keyword.control"], settings: { foreground: "#c586c0" } },
+		{ scope: ["constant.numeric"], settings: { foreground: "#ffffff" } },
+		{ scope: ["variable"], settings: { foreground: "#1aebff" } },
+		{ scope: ["variable.parameter"], settings: { foreground: "#9cdcfe" } },
+		{ scope: ["entity.name.type", "support.type"], settings: { foreground: "#3dc9b0" } },
+		{ scope: ["entity.name.tag"], settings: { foreground: "#569cd6" } },
+		{ scope: ["entity.other.attribute-name"], settings: { foreground: "#569cd6" } },
+		{ scope: ["support.type.property-name.json"], settings: { foreground: "#9cdcfe" } },
+		{ scope: ["markup.inserted"], settings: { foreground: "#3ff23f" } },
+		{ scope: ["markup.deleted"], settings: { foreground: "#f44747" } },
+		{
+			scope: ["meta.diff.header", "meta.diff.range", "meta.diff.index"],
+			settings: { foreground: "#569cd6" },
+		},
+	],
+};
+
+/**
  * The palette map for `codeToHtml({ themes })`: `dark` is the inline default color; every other entry is
  * emitted as a `--shiki-<name>` CSS var on every token, flipped by the `[data-theme]` rules in
- * `global.css` — a theme swap needs no re-highlighting. `darcula` is the custom registration above;
- * `gruvbox` uses the shiki-shipped `gruvbox-dark-hard` (matching the `#1d2021` content surface).
+ * `global.css` — a theme swap needs no re-highlighting. `darcula` and `high-contrast` are the custom
+ * registrations above; `gruvbox` uses the shiki-shipped `gruvbox-dark-hard` (matching the `#1d2021`
+ * content surface).
  */
 export const SHIKI_THEMES = {
 	dark: "github-dark-default",
 	light: "github-light-default",
 	darcula: "darcula",
 	gruvbox: "gruvbox-dark-hard",
+	"high-contrast": "hc-black",
 } as const;

--- a/apps/web/src/panels/DiffViewer.tsx
+++ b/apps/web/src/panels/DiffViewer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
-import { DARCULA_SHIKI, SHIKI_THEMES } from "@/lib/shikiTheme";
+import { DARCULA_SHIKI, HC_BLACK_SHIKI, SHIKI_THEMES } from "@/lib/shikiTheme";
 
-// Tri theme (dark + light + darcula, from `lib/shikiTheme.ts`) so a theme swap needs no re-highlight: one
+// Every `SHIKI_THEMES` palette (from `lib/shikiTheme.ts`) so a theme swap needs no re-highlight: one
 // render emits every palette as CSS vars and the `[data-theme]` rules in global.css flip between them.
 
 // One shared highlighter: only the `diff` grammar, on the JS regex engine (no WASM).
@@ -15,6 +15,7 @@ function getHighlighter(): Promise<HighlighterCore> {
 			import("@shikijs/themes/github-light-default"),
 			import("@shikijs/themes/gruvbox-dark-hard"),
 			DARCULA_SHIKI,
+			HC_BLACK_SHIKI,
 		],
 		langs: [import("@shikijs/langs/diff")],
 		engine: createJavaScriptRegexEngine(),

--- a/apps/web/src/panels/MonacoEditor.tsx
+++ b/apps/web/src/panels/MonacoEditor.tsx
@@ -44,7 +44,8 @@ function token(name: string): string {
 	return cssColorToHex(getComputedStyle(document.documentElement).getPropertyValue(name).trim());
 }
 
-/** Monaco token name → the `--code-*` syntax token a theme may set (only Darcula does today). */
+/** Monaco token name → the `--code-*` syntax token a theme may set (Darcula/Gruvbox set full
+ * palettes; High Contrast only the comment pair — the rest rides its hc-black base). */
 const SYNTAX_TOKENS: [string, string][] = [
 	["keyword", "--code-keyword"],
 	["string", "--code-string"],
@@ -60,7 +61,7 @@ const SYNTAX_TOKENS: [string, string][] = [
 ];
 
 /** Define (or redefine) the thinkrail Monaco theme from the live CSS tokens: chrome colors from the
- * surface tokens, the light/dark base from the active `[data-theme]`, and syntax rules from whichever
+ * surface tokens, the per-theme built-in base (`vs`/`vs-dark`/`hc-black`) from the active `[data-theme]`, and syntax rules from whichever
  * `--code-*` tokens the theme sets. Called before mount and again on every theme swap. */
 function defineThinkrailTheme(m: Monaco): void {
 	const colors: Record<string, string> = {};
@@ -98,7 +99,7 @@ const beforeMount: BeforeMount = (m) => defineThinkrailTheme(m);
 export default function MonacoEditor({ path, content }: { path: string; content: string }) {
 	const observerRef = useRef<MutationObserver | null>(null);
 
-	// Re-theme Monaco on a `[data-theme]` swap: its chrome + light/dark base are read once at define time, so
+	// Re-theme Monaco on a `[data-theme]` swap: its chrome + built-in base are read once at define time, so
 	// without this the editor would keep the theme it mounted with. Mirrors TerminalInstance's observer.
 	const onMount: OnMount = (_editor, m) => {
 		const observer = new MutationObserver(() => {

--- a/apps/web/src/panels/MonacoEditor.tsx
+++ b/apps/web/src/panels/MonacoEditor.tsx
@@ -72,11 +72,18 @@ function defineThinkrailTheme(m: Monaco): void {
 	set("editorLineNumber.foreground", token("--hint"));
 	set("editorCursor.foreground", token("--primary"));
 	set("editor.selectionBackground", token("--sel"));
+	// Optional selected-text color (high-contrast: black on the yellow selection); unset → base default.
+	set("editor.selectionForeground", token("--sel-fg"));
 	const rules = SYNTAX_TOKENS.flatMap(([monacoToken, name]) => {
 		const color = token(name);
 		return color ? [{ token: monacoToken, foreground: color.replace("#", "") }] : [];
 	});
-	const base = document.documentElement.dataset.theme === "light" ? "vs" : "vs-dark";
+	// Per-theme built-in base: `hc-black` IS the classical VSCode HC syntax palette (white numbers,
+	// #569cd6 keywords, #1aebff variables), which is why the high-contrast theme sets no `--code-*`
+	// beyond the comment green.
+	const dataTheme = document.documentElement.dataset.theme;
+	const base =
+		dataTheme === "light" ? "vs" : dataTheme === "high-contrast" ? "hc-black" : "vs-dark";
 	try {
 		m.editor.defineTheme(THEME, { base, inherit: true, rules, colors });
 	} catch {

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -191,14 +191,17 @@ prompt hero (still editable; empty by default), a base-branch
   (built from `transport.httpBase()`). A cross-file link's `#fragment` is not yet followed (opens the
   file only).
 - **Code surfaces re-theme from the tokens, resiliently.** `MonacoEditor` defines the `thinkrail` theme
-  from the live tokens (chrome from the surface tokens, `vs`/`vs-dark` base from `[data-theme]`, syntax
-  rules from whichever `--code-*` a theme sets — Darcula today) and redefines it via a `[data-theme]`
+  from the live tokens (chrome from the surface tokens, the `vs`/`vs-dark`/`hc-black` base from
+  `[data-theme]` — high-contrast rides Monaco's real hc-black palette — syntax rules from whichever
+  `--code-*` a theme sets, and the optional `--sel-fg` selected-text color, high-contrast's
+  black-on-yellow) and redefines it via a `[data-theme]`
   MutationObserver; token reads are **canonicalized to hex** (`lib.cssColorToHex` — minified CSS serves
   equivalents like `#fff`/`gray`, which Monaco rejects; unparseable → dropped, never passed through) and
   the define **degrades to the base palette instead of throwing** (a bad
   token value must never crash the editor panel). `TerminalInstance` builds the xterm theme the same way,
-  including the **16 `--ansi-*` slots** (so shell colors stay legible per theme), re-read on the same
-  observer. `DiffViewer` renders shiki's tri palette (`lib/shikiTheme`) once; the swap is pure CSS.
+  including the **16 `--ansi-*` slots** (so shell colors stay legible per theme) and the optional
+  `--sel-fg` selection foreground, re-read on the same
+  observer. `DiffViewer` renders every `SHIKI_THEMES` palette (`lib/shikiTheme`) once; the swap is pure CSS.
 - Heavy deps (Monaco / shiki / xterm) load via `React.lazy(() => import())` to stay out of the eager bundle.
   A lazy chunk that fails to load (or a render throw) is contained by the `components/ErrorBoundary` the
   **shell** wraps each region in (see `shell/SPEC.md`), so a single panel degrades instead of blanking the

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -50,6 +50,9 @@ function readTheme(): ITheme {
 	if (cursor) theme.cursor = cursor;
 	const sel = cssColorVar("--sel");
 	if (sel) theme.selectionBackground = sel;
+	// Optional selected-text color (high-contrast: black on the yellow selection); unset → xterm default.
+	const selFg = cssColorVar("--sel-fg");
+	if (selFg) theme.selectionForeground = selFg;
 	for (const [slot, name] of ANSI_TOKENS) {
 		const color = cssColorVar(name);
 		if (color) theme[slot] = color;

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -20,6 +20,9 @@ body {
 
 ::selection {
 	background: var(--selection-bg);
+	/* Optional per-theme selected-text color (high-contrast: black on yellow); `inherit` = today's
+	   behavior for the themes that don't set it. */
+	color: var(--selection-fg, inherit);
 }
 
 /*

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -51,6 +51,12 @@ body {
 	color: var(--shiki-gruvbox) !important;
 }
 
+[data-theme="high-contrast"] .shiki,
+[data-theme="high-contrast"] .shiki span {
+	/* biome-ignore lint/complexity/noImportantStyles: same inline-style override as the light rule above. */
+	color: var(--shiki-high-contrast) !important;
+}
+
 a {
 	color: var(--blue);
 }

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -110,7 +110,8 @@
 
 /*
  * Additional themes. Each overrides only the SEMANTIC surface/text/status tokens + `color-scheme` (and the
- * one-off `--selection-bg`, plus `--ansi-*` where the default terminal palette wouldn't read, optional
+ * one-off `--selection-bg` (+ `--selection-fg`/`--sel-fg` where selected text must flip, as high-contrast's
+ * yellow demands), plus `--ansi-*` where the default terminal palette wouldn't read, optional
  * `--code-*` syntax colors for Monaco, and — when the palette demands it, as gruvbox's does — the accent
  * family); type scale, spacing, radii, and fonts stay shared in `:root`. `applyTheme(id)` sets
  * `[data-theme=id]` on <html>; picking "dark" matches no block below and falls back to the `:root`
@@ -299,4 +300,61 @@
 	--code-attribute-name: #fabd2f;
 	--code-attribute-value: #b8bb26;
 	--code-json-key: #83a598;
+}
+
+/* High Contrast — the classical VSCode "Dark High Contrast" (hc-black): pure black everywhere, white
+   text, one cyan contrast border for every edge, the HC focus orange as the accent (dark-on-accent), and
+   the HC yellow selection with BLACK selected text (the optional `--sel-fg`/`--selection-fg` pair — white
+   on the yellow would be ~1:1). Surfaces don't separate this theme; BORDERS do. Deliberate deviation:
+   `--hover` is a faint fill — real VSCode HC uses outlines, but our components signal hover via
+   background, and an invisible hover would be an a11y regression. Status colors and the ANSI palette
+   inherit `:root` (all ≥ 6.5:1 on black; VSCode HC doesn't re-tint the terminal either). Monaco takes its
+   syntax from the real `hc-black` base, so no `--code-*` palette here — only the comment green, lifted to
+   VSCode's current #7ca668 (Monaco's bundled base still ships the older, dimmer #608b4e; shiki's copy of
+   the palette lives in `lib/shikiTheme.ts`). */
+[data-theme="high-contrast"] {
+	color-scheme: dark;
+
+	/* Accent: the classical HC focus orange (8.2:1 on black); text ON the accent is black, not white (2.6:1). */
+	--primary: #f38518;
+	--primary-10: rgba(243, 133, 24, 0.1);
+	--primary-20: rgba(243, 133, 24, 0.2);
+	--primary-40: rgba(243, 133, 24, 0.4);
+	--primary-60: rgba(243, 133, 24, 0.6);
+	--primary-80: rgba(243, 133, 24, 0.8);
+	--secondary: #2d2d33;
+	--on-accent: #000000;
+	--on-accent-16: rgba(0, 0, 0, 0.16);
+	/* Chat user bubble follows the accent — violet would be the one off-palette thing on screen; border
+	   alpha lifted to 0.4 (HC wants visible edges). */
+	--bubble-user-bg: rgba(243, 133, 24, 0.12);
+	--bubble-user-border: rgba(243, 133, 24, 0.4);
+
+	--bg: #000000;
+	--bg-dark: #000000;
+	--bg-input: #000000;
+	--input-bg: #000000;
+	--panel: rgba(0, 0, 0, 0.9);
+	--elevated: #000000;
+	--hover: #1f1f1f;
+	/* THE signature: the hc-black contrastBorder on every edge — panels, inputs, the scrollbar thumb. */
+	--border: #6fc3df;
+	--border2: #6fc3df;
+	--text: #ffffff;
+	--text-40: rgba(255, 255, 255, 0.4);
+	--muted: #d0d0d0;
+	--hint: #a6a6a6;
+	/* Selection: HC yellow with black selected text (17.9:1) — Monaco/xterm read `--sel` + `--sel-fg`,
+	   `::selection` reads the `--selection-*` pair. */
+	--sel: #f3f518;
+	--sel-fg: #000000;
+	--selection-bg: #f3f518;
+	--selection-fg: #000000;
+	/* Uniform black — borders, not a surface two-tone, separate the sidebar from the content. */
+	--surface-sidebar: var(--bg);
+	--surface-content: var(--bg-dark);
+
+	/* Comments only — the rest of the syntax palette comes from Monaco's `hc-black` base. */
+	--code-comment: #7ca668;
+	--code-comment-doc: #7ca668;
 }

--- a/apps/web/src/utils/theme.test.ts
+++ b/apps/web/src/utils/theme.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { Theme } from "@thinkrail/contracts";
+import { THEMES } from "./theme";
+
+// Pins the picker source: the high-contrast id exists, carries its display label, and lists last
+// (THEME_IDS is Theme-declaration order; the picker renders THEMES in order).
+test("THEMES lists high-contrast last with its display label", () => {
+	const hc = THEMES.find((t) => t.id === Theme.HighContrast);
+	expect(hc?.label).toBe("High Contrast");
+	expect(THEMES[THEMES.length - 1]?.id).toBe(Theme.HighContrast);
+});

--- a/apps/web/src/utils/theme.ts
+++ b/apps/web/src/utils/theme.ts
@@ -11,6 +11,7 @@ const LABELS: Record<ThemeId, string> = {
 	[Theme.Light]: "Light",
 	[Theme.Darcula]: "Darcula",
 	[Theme.Gruvbox]: "Gruvbox",
+	[Theme.HighContrast]: "High Contrast",
 };
 
 /** The pickable themes, in display order — the Appearance settings section's source. */

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -83,6 +83,10 @@ test("Monaco opens files and re-themes under every theme", async ({ page }) => {
 	await expect(editor).toHaveCSS("background-color", "rgb(29, 32, 33)");
 	await expect(page.getByTestId("error-boundary-fallback")).toHaveCount(0);
 
+	await pickTheme(page, "high-contrast");
+	await expect(editor).toHaveCSS("background-color", "rgb(0, 0, 0)");
+	await expect(page.getByTestId("error-boundary-fallback")).toHaveCount(0);
+
 	// Back to Dark — also restores the suite's default state for the other specs.
 	await pickTheme(page, "dark");
 	await expect(editor).toHaveCSS("background-color", "rgb(23, 23, 25)");

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -88,7 +88,8 @@ what lets the UI ship independently of the host.
   **`JbcentralConnectResult`** (the in-app connect state machine: `connected` / `needs-install` /
   `needs-login` / `error` (+`message`); the `needs-install` command comes from `jbcentralInstall`, not a
   hint on this result));
-  the **theme/config value-set** — **`Theme`** (a const-object "enum": `Dark`/`Light`/`Darcula`/`Gruvbox`;
+  the **theme/config value-set** — **`Theme`** (a const-object "enum":
+  `Dark`/`Light`/`Darcula`/`Gruvbox`/`HighContrast`;
   adding a value is wire-compatible — an older client falls back to Dark's `:root` tokens), its derived
   **`ThemeId`** type + runtime-iterable **`THEME_IDS`** (the picker source), and the server-synced
   **`AppConfig`** (`{ theme }` — an extensible bag) with its **`DEFAULT_CONFIG`** fallback (persisted host-side

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -231,15 +231,17 @@ export interface GithubAuthStatus {
  * The selectable UI themes. A const-object "enum" (the codebase's `WS_METHODS`/`WS_CHANNELS` convention):
  * enum ergonomics (`Theme.Dark`) + a runtime-iterable value list (`THEME_IDS`, the picker source), while the
  * values stay plain strings so they cross JSON/the wire with no casts. `Dark` is the default ThinkRail dark;
- * `Light`, `Darcula` (classic IntelliJ surfaces, ThinkRail violet accent), and `Gruvbox` (the vim classic —
- * warm retro darks, orange accent) are the additions. A client that doesn't know a theme id falls back to
- * Dark's `:root` tokens, so adding a value here is wire-compatible.
+ * `Light`, `Darcula` (classic IntelliJ surfaces, ThinkRail violet accent), `Gruvbox` (the vim classic —
+ * warm retro darks, orange accent), and `HighContrast` (the classical VSCode hc-black — pure black, cyan
+ * contrast borders, orange focus accent) are the additions. A client that doesn't know a theme id falls back
+ * to Dark's `:root` tokens, so adding a value here is wire-compatible.
  */
 export const Theme = {
 	Dark: "dark",
 	Light: "light",
 	Darcula: "darcula",
 	Gruvbox: "gruvbox",
+	HighContrast: "high-contrast",
 } as const;
 export type ThemeId = (typeof Theme)[keyof typeof Theme];
 export const THEME_IDS: readonly ThemeId[] = Object.values(Theme);


### PR DESCRIPTION
## What

A fifth selectable theme, **High Contrast** — the classical VSCode "Dark High Contrast" (hc-black): pure black surfaces, white text, cyan `#6fc3df` contrast borders outlining every edge, the HC focus orange `#f38518` as the interactive accent (dark-on-accent, the Gruvbox precedent), and the signature yellow `#f3f518` selection with black selected text.

## How

Everything rides the existing per-theme token mechanism:

- **contracts**: `Theme.HighContrast` — additive, wire-compatible (unknown ids fall back to Dark's `:root` tokens; no protocol bump, zero server changes).
- **tokens.css**: one `[data-theme="high-contrast"]` block. Status colors + ANSI palette deliberately inherit `:root` (already ≥ 6.5:1 on black; VSCode HC doesn't re-tint the terminal either). Deliberate deviation, documented in the block: `--hover` is a faint fill — real HC uses outlines, but our components signal hover via background.
- **Token-contract extension**: optional `--sel-fg` / `--selection-fg` selected-text pair — white on the HC yellow would be ~1:1. Monaco reads `editor.selectionForeground`, xterm `selectionForeground`, `::selection` gains `color: var(--selection-fg, inherit)`. Unset in all other themes → behavior unchanged (grep-verified: those are the only `--sel`/`--selection-*` consumers).
- **Monaco**: base map `light → vs`, `high-contrast → hc-black`, else `vs-dark` — the built-in hc-black IS the authentic palette (white numbers, `#569cd6` keywords, `#1aebff` variables), so the theme sets no `--code-*` beyond the comment green `#7ca668` (VSCode's current value; Monaco's bundled base still ships the older `#608b4e`).
- **shiki**: custom `hc-black` registration mirroring those Monaco rules (chat code + diffs match the editor), flipped by one new `[data-theme]` CSS rule. Stale "TRI theme" comments fixed while there.

All token pairs validated ≥ floors on their resting surfaces (text 21:1, muted 13.6, hint 8.6, accent 8.2, border 10.5, selection 17.9, comment 7.5).

## Verification

- e2e theme cycle extended (written red-first): picker → `data-theme` → Monaco re-themes to `rgb(0,0,0)`, no error boundary. Full no-agent suite 44/44 green; unit 435/435 (incl. a new picker-source test); check:deps/lint/typecheck clean.
- SPECs updated with the code: `packages/contracts`, `apps/web` (module + panels + lib).

Possible follow-up (review suggestion, non-blocking): an e2e pin asserting `--sel-fg` reaches Monaco/xterm selection, so a future token typo can't silently regress selected-text contrast in the accessibility theme.