### PR TITLE
Clarify project and workspace context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,31 @@ Fast gates (also the husky pre-commit): `bun run check:deps` (dependency pins) +
 `bun run typecheck`. Unit tests:
 `bun run test` (bun test, per package). One-time setup for a fresh machine: `bunx playwright install chromium`.
 
+## Handoff hygiene (before any commit, PR, or "done" summary)
+
+Green gates are necessary, not sufficient — they can't see duplication, suppressions, or leftovers.
+Before committing, opening/updating a PR, or declaring work done, re-read the full diff
+(`git diff origin/main...HEAD` + working tree) as a reviewer would, and enforce:
+
+- **No silent suppressions.** Never add `biome-ignore` / `@ts-expect-error` / `@ts-ignore` /
+  `eslint-disable` / `as any` to make a gate pass. A lint/type error is a design signal: first ask
+  whether the state, dependency, or structure it flags should exist at all — prefer deleting the cause
+  over guarding it. If a suppression still seems genuinely right, stop and get user sign-off first; an
+  unrequested suppression must never be discovered in review. Audit before handoff:
+  `git diff origin/main...HEAD -U0 | rg '^\+.*(biome-ignore|eslint-disable|@ts-ignore|@ts-expect-error|as any)'`
+  → must come back empty.
+- **No duplicated derivations.** The same nontrivial expression/lookup landing in 2+ places means
+  centralize it first. Web specifics: derived state belongs in store selectors
+  (`apps/web/src/store/selectors.ts`), components never inline multi-step derivations from store state;
+  store writes that always travel together are one atomic store action, not two calls at each call site.
+- **Refactor sweep.** When a change replaces a pattern or state model, `rg` the repo for the old
+  pattern and migrate every occurrence — or name the survivors and why in the handoff. Never leave call
+  sites half-migrated.
+- **End analyses with an offer.** When the user questions your recent work and your analysis concludes a
+  change is warranted, finish with the concrete change + "apply?" (or just apply it if it's within the
+  approved scope) — never with prose that makes the user say "do the cleanup then please".
+- **UI-visible changes:** offer before/after screenshots alongside the PR without being asked.
+
 ## Stack
 
 Bun + Turbo monorepo · TypeScript (strict) · React 19 + Zustand + Tailwind v4 (web) · in-process `pi`

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -9,7 +9,13 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { messagesToRuntime } from "../chat/hydrate";
-import { type ClosedChat, type EditorTab, toast, useAppStore } from "../store";
+import {
+	type ClosedChat,
+	type EditorTab,
+	selectActiveWorkspace,
+	toast,
+	useAppStore,
+} from "../store";
 import { errorText, getTransport } from "../transport";
 import { FilePane } from "./FilePane";
 
@@ -71,7 +77,7 @@ function ChatHistoryMenu({
 /** The center area: a strip of the active workspace's tabs (files + chats) over the active tab. */
 export function CenterTabs() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
-	const workspaces = useAppStore((s) => s.workspaces);
+	const activeWorkspace = useAppStore(selectActiveWorkspace);
 	const tabsByWorkspace = useAppStore((s) => s.tabsByWorkspace);
 	const activeTabByWorkspace = useAppStore((s) => s.activeTabByWorkspace);
 	const closedChatsByWorkspace = useAppStore((s) => s.closedChatsByWorkspace);
@@ -83,12 +89,6 @@ export function CenterTabs() {
 	const closedChats = activeWorkspaceId
 		? (closedChatsByWorkspace[activeWorkspaceId] ?? NO_CLOSED)
 		: NO_CLOSED;
-	const activeWorkspace = activeWorkspaceId
-		? Object.values(workspaces)
-				.flat()
-				.find((workspace) => workspace.id === activeWorkspaceId)
-		: undefined;
-
 	// Hydrate-on-connect: when a workspace becomes active, pull its sessions from the host. Live ones (still
 	// in host memory) auto-restore as tabs; disk-only ones (survived a host restart) go to chat-history to
 	// reopen on demand. So a reload, a second tab, or a restart all rebuild from the host.

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -1,4 +1,4 @@
-import { History, MessageSquarePlus, RotateCcw, X } from "lucide-react";
+import { GitBranch, History, MessageSquarePlus, RotateCcw, X } from "lucide-react";
 import { lazy, Suspense, useEffect } from "react";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
@@ -71,6 +71,7 @@ function ChatHistoryMenu({
 /** The center area: a strip of the active workspace's tabs (files + chats) over the active tab. */
 export function CenterTabs() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
+	const workspaces = useAppStore((s) => s.workspaces);
 	const tabsByWorkspace = useAppStore((s) => s.tabsByWorkspace);
 	const activeTabByWorkspace = useAppStore((s) => s.activeTabByWorkspace);
 	const closedChatsByWorkspace = useAppStore((s) => s.closedChatsByWorkspace);
@@ -82,6 +83,11 @@ export function CenterTabs() {
 	const closedChats = activeWorkspaceId
 		? (closedChatsByWorkspace[activeWorkspaceId] ?? NO_CLOSED)
 		: NO_CLOSED;
+	const activeWorkspace = activeWorkspaceId
+		? Object.values(workspaces)
+				.flat()
+				.find((workspace) => workspace.id === activeWorkspaceId)
+		: undefined;
 
 	// Hydrate-on-connect: when a workspace becomes active, pull its sessions from the host. Live ones (still
 	// in host memory) auto-restore as tabs; disk-only ones (survived a host restart) go to chat-history to
@@ -168,8 +174,30 @@ export function CenterTabs() {
 	};
 
 	const placeholder = (
-		<div className="flex h-full flex-col items-center justify-center gap-sm text-hint">
-			<span>Open a file or start a chat</span>
+		<div className="flex h-full flex-col items-center justify-center gap-md px-lg text-center text-hint">
+			{activeWorkspace ? (
+				<div
+					data-testid="workspace-ready"
+					className="flex max-w-[440px] flex-col items-center gap-xs"
+				>
+					<span className="font-medium text-hint text-xs uppercase tracking-wider">
+						Workspace ready
+					</span>
+					<h2 className="max-w-full truncate font-medium text-md text-text">
+						{activeWorkspace.name}
+					</h2>
+					<p className="flex max-w-full items-center gap-xs font-[var(--font-mono)] text-muted text-xs">
+						<GitBranch className="size-3.5 shrink-0" />
+						<span className="truncate">{activeWorkspace.branch}</span>
+						<span className="shrink-0 text-hint">· from {activeWorkspace.baseBranch}</span>
+					</p>
+					<p className="mt-xs text-muted text-sm">
+						Files, chats, changes, and terminals are scoped to this workspace.
+					</p>
+				</div>
+			) : (
+				<span>Open a file or start a chat</span>
+			)}
 			{activeWorkspaceId ? (
 				<button
 					type="button"

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -11,7 +11,13 @@ import {
 	CommandItem,
 	CommandList,
 } from "@/components/ui/command";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 import { toast, useAppStore } from "@/store";
@@ -175,6 +181,7 @@ export function NewWorkspaceDialog({
 		// spins up a session, and a kick-off failure can't strand the dialog open.
 		const store = useAppStore.getState();
 		onCreated(workspace);
+		store.selectProject(workspace.projectId);
 		store.setActiveWorkspace(workspace.id);
 		onOpenChange(false);
 
@@ -217,7 +224,13 @@ export function NewWorkspaceDialog({
 					promptRef.current?.focus();
 				}}
 			>
-				<DialogTitle className="sr-only">New workspace</DialogTitle>
+				<DialogHeader>
+					<DialogTitle>Create workspace</DialogTitle>
+					<DialogDescription>
+						A separate checkout on its own new branch. Files, chats, changes, and terminals stay
+						scoped to it.
+					</DialogDescription>
+				</DialogHeader>
 
 				{/* controls-top: project + base-branch pickers */}
 				<div className="flex flex-wrap items-center gap-sm">
@@ -238,23 +251,30 @@ export function NewWorkspaceDialog({
 				</div>
 
 				{/* hero: the prompt */}
-				<Textarea
-					ref={promptRef}
-					data-testid="ws-prompt"
-					value={prompt}
-					onChange={(e) => setPrompt(e.target.value)}
-					placeholder="What do you want to work on?"
-					spellCheck={false}
-					rows={6}
-					className="min-h-[160px]"
-					onKeyDown={(e) => {
-						// Enter creates (matching the button's ↵ affordance); Shift+Enter inserts a newline.
-						if (e.key === "Enter" && !e.shiftKey) {
-							e.preventDefault();
-							void create();
-						}
-					}}
-				/>
+				<div className="flex flex-col gap-xs">
+					<Textarea
+						ref={promptRef}
+						data-testid="ws-prompt"
+						value={prompt}
+						onChange={(e) => setPrompt(e.target.value)}
+						placeholder="What do you want to work on?"
+						spellCheck={false}
+						rows={6}
+						className="min-h-[160px]"
+						onKeyDown={(e) => {
+							// Enter creates (matching the button's ↵ affordance); Shift+Enter inserts a newline.
+							if (e.key === "Enter" && !e.shiftKey) {
+								e.preventDefault();
+								void create();
+							}
+						}}
+					/>
+					{prompt.trim() ? (
+						<p data-testid="workspace-naming-hint" className="px-xs text-hint text-xs">
+							ThinkRail will name the workspace and branch from your request.
+						</p>
+					) : null}
+				</div>
 
 				{/* controls-bottom: model + effort (left), Create (right) */}
 				<div className="flex flex-wrap items-center gap-sm">
@@ -394,6 +414,7 @@ function BranchPicker({
 				className={`${PILL} max-w-[220px]`}
 			>
 				<GitBranch className="size-3.5 shrink-0 text-muted" />
+				<span className="shrink-0 text-hint text-xs">From</span>
 				<span className="truncate font-[var(--font-mono)] text-muted text-xs">
 					{baseRef || "branch"}
 				</span>

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -181,8 +181,7 @@ export function NewWorkspaceDialog({
 		// spins up a session, and a kick-off failure can't strand the dialog open.
 		const store = useAppStore.getState();
 		onCreated(workspace);
-		store.selectProject(workspace.projectId);
-		store.setActiveWorkspace(workspace.id);
+		store.activateWorkspace(workspace);
 		onOpenChange(false);
 
 		const text = prompt.trim();

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -43,21 +43,16 @@ export function ProjectTree() {
 	};
 
 	const selectProject = async (projectId: string) => {
-		const store = useAppStore.getState();
-		// Selecting a project returns to its Welcome — deselect any active workspace (the shell renders the
-		// Welcome when no workspace is active). The row is a deliberate "project home" gesture; the chevron
-		// handles expand/collapse separately, so this never fires from just expanding. The workspace's tabs
-		// survive in the store, so re-selecting it restores its view.
-		store.setActiveWorkspace(null);
-		store.selectProject(projectId);
+		// Selecting a project atomically returns to its Welcome. The row is a deliberate "project home"
+		// gesture; the chevron handles expand/collapse separately, so this never fires from just expanding.
+		// The workspace's tabs survive in the store, so re-selecting it restores its view.
+		useAppStore.getState().selectProject(projectId);
 		setExpanded((prev) => new Set(prev).add(projectId));
 		await loadWorkspaces(projectId);
 	};
 
 	const selectWorkspace = (workspace: Workspace) => {
-		const store = useAppStore.getState();
-		store.selectProject(workspace.projectId);
-		store.setActiveWorkspace(workspace.id);
+		useAppStore.getState().activateWorkspace(workspace);
 	};
 
 	const toggleExpand = (projectId: string) => {

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -22,12 +22,10 @@ export function ProjectTree() {
 	// creating a workspace directly.
 	const [dialogProjectId, setDialogProjectId] = useState<string | null>(null);
 
-	// The active workspace is the user's current scope, so reveal its parent whenever that scope changes
-	// (including the Welcome → IDE remount, where this component's local expansion state starts fresh).
-	// Depend on the resolved project id rather than the workspace arrays themselves: a later auto-rename
-	// snapshot must not undo a deliberate manual collapse while the user stays in the same workspace.
+	// Reveal the active workspace's parent on mount or when its derived owner changes/resolves. Depending
+	// only on that project id preserves a deliberate manual collapse across same-project switches and
+	// workspace updates; creation expands its project explicitly in `onWorkspaceCreated` below.
 	const activeProjectId = useAppStore(selectActiveWorkspaceProjectId);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: activeWorkspaceId is the activation trigger even when two workspaces share a parent project
 	useEffect(() => {
 		if (!activeProjectId) return;
 		setExpanded((prev) => {
@@ -36,7 +34,7 @@ export function ProjectTree() {
 			next.add(activeProjectId);
 			return next;
 		});
-	}, [activeWorkspaceId, activeProjectId]);
+	}, [activeProjectId]);
 
 	const loadWorkspaces = async (projectId: string) => {
 		useAppStore

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -1,6 +1,6 @@
 import type { Project, Workspace } from "@thinkrail/contracts";
 import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
 import { toast, useAppStore } from "../store";
@@ -22,6 +22,27 @@ export function ProjectTree() {
 	// creating a workspace directly.
 	const [dialogProjectId, setDialogProjectId] = useState<string | null>(null);
 
+	// The active workspace is the user's current scope, so reveal its parent whenever that scope changes
+	// (including the Welcome → IDE remount, where this component's local expansion state starts fresh).
+	// Depend on the resolved project id rather than the workspace arrays themselves: a later auto-rename
+	// snapshot must not undo a deliberate manual collapse while the user stays in the same workspace.
+	const activeProjectId =
+		activeWorkspaceId == null
+			? null
+			: (Object.entries(workspaces).find(([, list]) =>
+					list.some((workspace) => workspace.id === activeWorkspaceId),
+				)?.[0] ?? null);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: activeWorkspaceId is the activation trigger even when two workspaces share a parent project
+	useEffect(() => {
+		if (!activeProjectId) return;
+		setExpanded((prev) => {
+			if (prev.has(activeProjectId)) return prev;
+			const next = new Set(prev);
+			next.add(activeProjectId);
+			return next;
+		});
+	}, [activeWorkspaceId, activeProjectId]);
+
 	const loadWorkspaces = async (projectId: string) => {
 		useAppStore
 			.getState()
@@ -38,6 +59,12 @@ export function ProjectTree() {
 		store.selectProject(projectId);
 		setExpanded((prev) => new Set(prev).add(projectId));
 		await loadWorkspaces(projectId);
+	};
+
+	const selectWorkspace = (workspace: Workspace) => {
+		const store = useAppStore.getState();
+		store.selectProject(workspace.projectId);
+		store.setActiveWorkspace(workspace.id);
 	};
 
 	const toggleExpand = (projectId: string) => {
@@ -121,7 +148,7 @@ export function ProjectTree() {
 												key={ws.id}
 												workspace={ws}
 												isActive={activeWorkspaceId === ws.id}
-												onSelect={() => useAppStore.getState().setActiveWorkspace(ws.id)}
+												onSelect={() => selectWorkspace(ws)}
 												onRemove={() => removeWorkspace(ws.id)}
 											/>
 										))

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Trash2 } from "luci
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
-import { toast, useAppStore } from "../store";
+import { selectActiveWorkspaceProjectId, toast, useAppStore } from "../store";
 import { errorText, getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmPopover } from "./ConfirmPopover";
@@ -26,12 +26,7 @@ export function ProjectTree() {
 	// (including the Welcome → IDE remount, where this component's local expansion state starts fresh).
 	// Depend on the resolved project id rather than the workspace arrays themselves: a later auto-rename
 	// snapshot must not undo a deliberate manual collapse while the user stays in the same workspace.
-	const activeProjectId =
-		activeWorkspaceId == null
-			? null
-			: (Object.entries(workspaces).find(([, list]) =>
-					list.some((workspace) => workspace.id === activeWorkspaceId),
-				)?.[0] ?? null);
+	const activeProjectId = useAppStore(selectActiveWorkspaceProjectId);
 	// biome-ignore lint/correctness/useExhaustiveDependencies: activeWorkspaceId is the activation trigger even when two workspaces share a parent project
 	useEffect(() => {
 		if (!activeProjectId) return;

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -27,10 +27,11 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
   name is decoupled from the git branch (see [[submodule-server-workspaces]]). The active workspace must
-  also stay visible: when `activeWorkspaceId` changes — or its owning project first becomes resolvable
-  after hydration/the Welcome → IDE remount — `ProjectTree` expands that parent project. A manual collapse
-  remains respected until the next activation; ordinary `workspace.updated` snapshots do not force it
-  open again. Selecting or creating a workspace also selects its owning project, keeping project-home and
+  also stay visible: when `ProjectTree` mounts with an active workspace, or the active workspace's derived
+  owning project changes or first becomes resolvable, it expands that parent project. A manual collapse
+  remains respected while the owning project is unchanged; ordinary `workspace.updated` snapshots and
+  same-project workspace switches do not force it open again. Workspace creation expands its project
+  explicitly. Selecting or creating a workspace also selects its owning project, keeping project-home and
   active-workspace context coherent even when the create dialog's project picker targets another project.
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -26,7 +26,12 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   surfaces an error toast, leaving the row in place). Each **workspace row** is **two-line**: the display
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
-  name is decoupled from the git branch (see [[submodule-server-workspaces]]).
+  name is decoupled from the git branch (see [[submodule-server-workspaces]]). The active workspace must
+  also stay visible: when `activeWorkspaceId` changes — or its owning project first becomes resolvable
+  after hydration/the Welcome → IDE remount — `ProjectTree` expands that parent project. A manual collapse
+  remains respected until the next activation; ordinary `workspace.updated` snapshots do not force it
+  open again. Selecting or creating a workspace also selects its owning project, keeping project-home and
+  active-workspace context coherent even when the create dialog's project picker targets another project.
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
@@ -67,10 +72,14 @@ CTA that opens Settings → Providers (`store.openSettings("providers")`). It re
 provider is "connected" iff any `configured`) on mount and re-checks whenever the settings dialog toggles, so
 it disappears the moment the user connects one; a transport error degrades to *not* nagging (offline ≠ "no
 provider"). All provider **management** lives in Settings, not here (the always-on strip is gone).
-**`NewWorkspaceDialog`** is the create-and-kick-off surface: an optional **`initialPrompt`** seeds the
-prompt hero (still editable; empty by default), a base-branch
-  combobox (`git.listBranches`, degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is
-  filtered so no stray `origin`), a project picker, the prompt hero, and the reused
+**`NewWorkspaceDialog`** is the create-and-kick-off surface. It names the operation visibly — title
+**“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new
+branch. Files, chats, changes, and terminals stay scoped to it.”** Its base-branch trigger reads **“From
+{base}”**, not an unexplained ref. An optional **`initialPrompt`** seeds the prompt hero (still editable;
+empty by default); while the prompt is non-empty, a secondary hint says ThinkRail will name the workspace
+and branch from the request. The rest stays compact: the base-branch combobox (`git.listBranches`,
+degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
+a project picker, the prompt hero, and the reused
   `chat/ModelSelector`+`ThinkingSelector` in **pre-session** mode — preselected to the host's resolved
   default via `model.default` so the exact model shows (values held in dialog state, applied at create
   time). The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll
@@ -106,7 +115,12 @@ prompt hero (still editable; empty by default), a base-branch
   the `LoginDialog` stays presentational (`auth` module).
   Panels compose their own sub-panels
   (e.g. `RightPanel`→`FileTree`/`ChangesPanel`, `CenterTabs`→`FilePane`→`MonacoEditor`) — an internal hierarchy.
-  `CenterTabs` closing a chat tab routes to `store.closeChatToHistory` (keeps the session alive) and shows a
+  When the active workspace has no open center tab, `CenterTabs` uses the empty surface as a persistent
+  creation/orientation receipt rather than a generic placeholder: **“Workspace ready”**, the display name,
+  `branch · from baseBranch`, and **“Files, chats, changes, and terminals are scoped to this workspace,”**
+  followed by the existing **New chat** action. It is neither one-time nor dismissible, so it also helps
+  after the last tab closes without introducing onboarding state. `CenterTabs` closing a chat tab routes
+  to `store.closeChatToHistory` (keeps the session alive) and shows a
   **chat-history** dropdown (recently-closed + disk-only chats, shown only when non-empty). On
   workspace-activate it **hydrates**: `session.list` → **live** sessions auto-restore as tabs
   (`session.getMessages` → `messagesToRuntime` → `store.hydrateSession`); **disk-only** ones go to history

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -14,9 +14,16 @@ later, the mobile single-view-with-switcher).
 
 ## Boundary
 
-- **Owns:** `Shell.tsx` — the topbar (wordmark + connection-status pill + a Settings gear that opens the
-  store-driven `panels/SettingsDialog` via `store.openSettings()` — open state lives in the store, not local,
-  so other surfaces (the Welcome provider warning) can open it too) over a body that branches on whether a workspace is active. **Active workspace**
+- **Owns:** `Shell.tsx` — the topbar (wordmark + a compact store-derived **location context** +
+  connection-status pill + a Settings gear that opens the store-driven `panels/SettingsDialog` via
+  `store.openSettings()` — open state lives in the store, not local, so other surfaces (the Welcome
+  provider warning) can open it too) over a body that branches on whether a workspace is active. The
+  location context makes scope persistent rather than rail-dependent: an **active workspace** renders two
+  lines — `project / workspace display name`, then the monospace git `branch · from baseBranch`; a selected
+  project with no active workspace renders `project / Project home`; no project leaves the wordmark alone.
+  It follows the existing workspace lifecycle snapshots, so auto-renames update live. Responsive
+  degradation drops the base, then the project prefix, before it drops active workspace/branch identity.
+  **Active workspace**
   → the resizable 3 columns (projects | center | right-over-terminals). **No active workspace**
   (`activeWorkspaceId == null` — fresh install / after archiving the last one) → the projects rail (kept
   resizable, `resize-left` preserved) beside the `panels/WelcomePanel`; the center/right/terminal surface
@@ -27,7 +34,7 @@ later, the mobile single-view-with-switcher).
   `writeThemeHint(theme)` (the localStorage first-paint cache). The value flows store ← transport (welcome /
   `settings.changed`); the shell just performs the swap, so no other component touches `[data-theme]`.
 - **Public surface:** `Shell`.
-- **Allowed deps:** `panels`, `store` (status + theme), `transport` (`ConnectionStatus` type), `components/ui`
+- **Allowed deps:** `panels`, `store` (status + theme + project/workspace context), `transport` (`ConnectionStatus` type), `components/ui`
   (resizable), `components/ErrorBoundary`, `constants` (branding), `utils` (`theme`'s `applyTheme`/`writeThemeHint`).
 - **Forbidden:** `server`/`shared`/`pi`; being imported by `panels`/`store`/`transport`.
 

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -1,4 +1,4 @@
-import { Settings } from "lucide-react";
+import { ChevronRight, GitBranch, Settings } from "lucide-react";
 import { useEffect } from "react";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable";
@@ -29,7 +29,18 @@ const STATUS_DOT: Record<ConnectionStatus, string> = {
 export function Shell() {
 	const status = useAppStore((s) => s.status);
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
+	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
+	const projects = useAppStore((s) => s.projects);
+	const workspaces = useAppStore((s) => s.workspaces);
 	const hasActiveWorkspace = activeWorkspaceId != null;
+	const activeWorkspace = activeWorkspaceId
+		? Object.values(workspaces)
+				.flat()
+				.find((workspace) => workspace.id === activeWorkspaceId)
+		: undefined;
+	const contextProject = activeWorkspace
+		? projects.find((project) => project.id === activeWorkspace.projectId)
+		: projects.find((project) => project.id === selectedProjectId);
 	// The single owner of the theme DOM side-effect: apply the store's (host-owned) theme + cache it as the
 	// next load's first-paint hint. The store is fed by transport (welcome / settings.changed).
 	const theme = useAppStore((s) => s.theme);
@@ -40,10 +51,45 @@ export function Shell() {
 	return (
 		<div data-testid="shell" className="grid h-full grid-rows-[auto_1fr]">
 			<header className="flex items-center justify-between border-b border-border2 bg-bg-dark px-lg py-sm">
-				<span className="font-[var(--font-accent)] text-lg font-extrabold tracking-[0.5px] text-primary">
-					{PRODUCT_NAME}
-				</span>
-				<div className="flex items-center gap-md">
+				<div className="flex min-w-0 items-center gap-md">
+					<span className="shrink-0 font-[var(--font-accent)] text-lg font-extrabold tracking-[0.5px] text-primary">
+						{PRODUCT_NAME}
+					</span>
+					{contextProject ? (
+						<div
+							data-testid="scope-context"
+							data-context={activeWorkspace ? "workspace" : "project-home"}
+							className="min-w-0 border-border2 border-l pl-md leading-tight"
+						>
+							<div className="flex min-w-0 items-center gap-xs text-xs">
+								<span className="hidden min-w-0 items-center gap-xs sm:flex">
+									<span data-testid="scope-project" className="max-w-[160px] truncate text-muted">
+										{contextProject.name}
+									</span>
+									<ChevronRight className="size-3 shrink-0 text-hint" />
+								</span>
+								<span
+									data-testid="scope-name"
+									className="max-w-[220px] truncate font-medium text-text"
+								>
+									{activeWorkspace?.name ?? "Project home"}
+								</span>
+							</div>
+							{activeWorkspace ? (
+								<div className="mt-0.5 flex min-w-0 items-center gap-xs font-[var(--font-mono)] text-[10px] text-hint">
+									<GitBranch className="size-3 shrink-0" />
+									<span data-testid="scope-branch" className="truncate">
+										{activeWorkspace.branch}
+									</span>
+									<span data-testid="scope-base" className="hidden shrink-0 md:inline">
+										· from {activeWorkspace.baseBranch}
+									</span>
+								</div>
+							) : null}
+						</div>
+					) : null}
+				</div>
+				<div className="flex shrink-0 items-center gap-md">
 					<span
 						data-testid="connection-status"
 						data-status={status}

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -10,7 +10,7 @@ import { SettingsDialog } from "../panels/SettingsDialog";
 import { TerminalsPanel } from "../panels/TerminalsPanel";
 import { Toaster } from "../panels/Toaster";
 import { WelcomePanel } from "../panels/WelcomePanel";
-import { useAppStore } from "../store";
+import { selectActiveWorkspace, selectContextProject, useAppStore } from "../store";
 import type { ConnectionStatus } from "../transport";
 import { applyTheme, writeThemeHint } from "../utils/theme";
 
@@ -29,18 +29,9 @@ const STATUS_DOT: Record<ConnectionStatus, string> = {
 export function Shell() {
 	const status = useAppStore((s) => s.status);
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
-	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
-	const projects = useAppStore((s) => s.projects);
-	const workspaces = useAppStore((s) => s.workspaces);
+	const activeWorkspace = useAppStore(selectActiveWorkspace);
+	const contextProject = useAppStore(selectContextProject);
 	const hasActiveWorkspace = activeWorkspaceId != null;
-	const activeWorkspace = activeWorkspaceId
-		? Object.values(workspaces)
-				.flat()
-				.find((workspace) => workspace.id === activeWorkspaceId)
-		: undefined;
-	const contextProject = activeWorkspace
-		? projects.find((project) => project.id === activeWorkspace.projectId)
-		: projects.find((project) => project.id === selectedProjectId);
 	// The single owner of the theme DOM side-effect: apply the store's (host-owned) theme + cache it as the
 	// next load's first-paint hint. The store is fed by transport (welcome / settings.changed).
 	const theme = useAppStore((s) => s.theme);

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -16,9 +16,13 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
 
 ## Boundary
 
-- **Owns:** `appStore.ts` — connection/projects/workspaces state + setters, incl. the **workspace
-  lifecycle reactions** every client runs identically on the `workspace.created`/`updated`/`removed`
-  pushes (no per-client optimism — the backend is authoritative): **`addWorkspace(ws)`** upserts a
+- **Owns:** `appStore.ts` — connection/projects/workspaces state + setters, including the two atomic
+  navigation transitions: **`selectProject(projectId)`** enters that Project Home (`selectedProjectId`
+  set + `activeWorkspaceId` cleared in one write), while **`activateWorkspace(workspace)`** enters the
+  workspace and selects its owner (both ids set in one write). There is no generic active-workspace setter
+  that can split that invariant. It also owns the **workspace lifecycle reactions** every client runs
+  identically on the `workspace.created`/`updated`/`removed` pushes (no per-client optimism — the backend
+  is authoritative): **`addWorkspace(ws)`** upserts a
   `workspace.created` snapshot by `id` (no-op if the project isn't listed yet — reconciles on its next
   `workspace.list` rather than seeding a partial one-row list; else add-if-absent / merge-if-present,
   idempotent with the creating client's own post-create re-list); **`updateWorkspace(ws)`** folds a
@@ -27,8 +31,8 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   record, which has none); a project never fetched or an id absent from its list is a **no-op** — the next
   `workspace.list` reconciles; **`applyWorkspaceRemoved(projectId, id)`** is the **entire** removal
   reaction (`removeWorkspace` drops the row + `clearWorkspaceTabs` drops its tabs/terminals/chat runtimes,
-  and **if it was this client's active workspace** → `setActiveWorkspace(null)` (shell falls back to the
-  project Welcome) + a neutral toast that reads right for both the initiator and an observer); the
+  and **if it was this client's active workspace** → `selectProject(projectId)` (shell falls back to its
+  owning Project Home) + a neutral toast that reads right for both the initiator and an observer); the
   primitive **`removeWorkspace(projectId, id)`** just drops the row (unknown project/id is a no-op);
   `tabsByWorkspace` /
   `activeTabByWorkspace` (`openTab`/`closeTab`/`setActiveTab`/`clearWorkspaceTabs`, plus

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -94,10 +94,13 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   **`requestChangesView(workspaceId, path)`** are a UI deep-link intent (a chat turn-divider asking the
   right panel to surface a file's diff); the panels watch it, scoped by workspace. The `EditorTab`
   (`FileTab` | `ChatTab`) + `TerminalTab` + `ClosedChat` + `SessionRuntime` types. (Chat *render* types +
-  renderers live in the `chat` module.)
-- **Public surface (barrel):** `useAppStore`, `toast` (the fire-from-anywhere helper), `Toast` (type),
-  `EditorTab` (`FileTab`/`ChatTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` + `EMPTY_RUNTIME`
-  (ChatView's pre-creation fallback), `reduceSessionEvent`.
+  renderers live in the `chat` module.) The pure context selectors in `selectors.ts` resolve the active
+  `Workspace`, its owning project id, and the shell's context project from those canonical ids and
+  collections; derived active-project state is never stored separately.
+- **Public surface (barrel):** `useAppStore`; `selectActiveWorkspace`,
+  `selectActiveWorkspaceProjectId`, and `selectContextProject`; `toast` (the fire-from-anywhere helper),
+  `Toast` (type), `EditorTab` (`FileTab`/`ChatTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` +
+  `EMPTY_RUNTIME` (ChatView's pre-creation fallback), `reduceSessionEvent`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/
   `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`/`AppConfig`/`ThemeId`; the
   `Theme` value for the default; `PiEvent`/`LoginFrame`, **type-only**); `chat`

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -49,6 +49,7 @@ beforeEach(() => {
 		tabsByWorkspace: {},
 		activeTabByWorkspace: {},
 		closedChatsByWorkspace: {},
+		selectedProjectId: null,
 		activeWorkspaceId: null,
 		activeLogin: null,
 		settingsOpen: false,
@@ -494,6 +495,22 @@ function pushedWorkspace(over: Partial<Workspace> = {}): Workspace {
 	};
 }
 
+test("project and workspace navigation update both scope ids atomically", () => {
+	useAppStore.setState({ selectedProjectId: "p1", activeWorkspaceId: "w1" });
+	const transitions: [string | null, string | null][] = [];
+	const unsubscribe = useAppStore.subscribe((state) => {
+		transitions.push([state.selectedProjectId, state.activeWorkspaceId]);
+	});
+
+	useAppStore.getState().selectProject("p2");
+	expect(transitions).toEqual([["p2", null]]);
+
+	transitions.length = 0;
+	useAppStore.getState().activateWorkspace(pushedWorkspace({ id: "w3", projectId: "p3" }));
+	expect(transitions).toEqual([["p3", "w3"]]);
+	unsubscribe();
+});
+
 test("updateWorkspace merges the pushed snapshot by id, keeping the computed diffStats badge", () => {
 	useAppStore.setState({
 		workspaces: {
@@ -571,6 +588,7 @@ test("addWorkspace is a no-op for a project whose list was never fetched", () =>
 test("applyWorkspaceRemoved drops the row, clears its tabs, and returns the active client to Welcome + toast", () => {
 	useAppStore.setState({
 		workspaces: { p1: [pushedWorkspace()] },
+		selectedProjectId: "stale-project",
 		activeWorkspaceId: "w1",
 		tabsByWorkspace: {
 			w1: [{ kind: "file", id: "w1:a", workspaceId: "w1", name: "a", path: "a", content: "" }],
@@ -585,6 +603,7 @@ test("applyWorkspaceRemoved drops the row, clears its tabs, and returns the acti
 	expect(s.workspaces.p1).toEqual([]);
 	expect(s.tabsByWorkspace.w1).toBeUndefined(); // clearWorkspaceTabs dropped its tabs
 	expect(s.activeWorkspaceId).toBeNull(); // shell falls back to the project Welcome
+	expect(s.selectedProjectId).toBe("p1"); // specifically the removed workspace's owning Project Home
 	expect(s.toasts).toHaveLength(1);
 	expect(s.toasts[0]?.message).toContain("add-login-flow"); // the removed workspace's name
 });

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -410,12 +410,14 @@ interface AppState {
 	 * React to a server-pushed `workspace.removed` — the **entire** removal reaction, run identically by
 	 * every client (including the one that initiated the remove, so there's no per-client optimism): drop
 	 * the row + clear its tabs/terminals/chat runtimes (`clearWorkspaceTabs`), and **if it was this
-	 * client's active workspace** return to the project Welcome (`setActiveWorkspace(null)`) and raise a
-	 * neutral toast (reads correctly for both the initiator and an observer).
+	 * client's active workspace** return to its owning Project Home and raise a neutral toast (reads
+	 * correctly for both the initiator and an observer).
 	 */
 	applyWorkspaceRemoved: (projectId: string, workspaceId: string) => void;
+	/** Enter a project's home, atomically clearing any active workspace. */
 	selectProject: (projectId: string) => void;
-	setActiveWorkspace: (id: string | null) => void;
+	/** Enter a workspace and select its owning project in one state transition. */
+	activateWorkspace: (workspace: Pick<Workspace, "id" | "projectId">) => void;
 	openTab: (tab: EditorTab) => void;
 	closeTab: (id: string) => void;
 	setActiveTab: (id: string) => void;
@@ -639,12 +641,13 @@ export const useAppStore = create<AppState>((set, get) => ({
 			return { fsChangesByWorkspace: rest };
 		});
 		if (wasActive) {
-			s.setActiveWorkspace(null); // the shell falls back to the project Welcome
+			s.selectProject(projectId); // atomically fall back to the removed workspace's Project Home
 			toast.info(`Workspace "${name ?? "?"}" was removed`);
 		}
 	},
-	selectProject: (selectedProjectId) => set({ selectedProjectId }),
-	setActiveWorkspace: (activeWorkspaceId) => set({ activeWorkspaceId }),
+	selectProject: (selectedProjectId) => set({ selectedProjectId, activeWorkspaceId: null }),
+	activateWorkspace: (workspace) =>
+		set({ selectedProjectId: workspace.projectId, activeWorkspaceId: workspace.id }),
 	openTab: (tab) =>
 		set((s) => {
 			const tabs = s.tabsByWorkspace[tab.workspaceId] ?? [];

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -1,3 +1,4 @@
 /** App store (Zustand): connection, projects/workspaces, workspace-scoped tabs + terminals, and a
  * per-session chat runtime (`sessions` keyed by `sessionId`) so several chats stream concurrently. */
 export * from "./appStore";
+export * from "./selectors";

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import type { Project, Workspace } from "@thinkrail/contracts";
+import {
+	selectActiveWorkspace,
+	selectActiveWorkspaceProjectId,
+	selectContextProject,
+} from "./selectors";
+
+const projects: Project[] = [
+	{ id: "p1", name: "One", path: "/one", slug: "one", lastOpened: 1 },
+	{ id: "p2", name: "Two", path: "/two", slug: "two", lastOpened: 2 },
+];
+const workspace: Workspace = {
+	id: "w2",
+	projectId: "p2",
+	name: "Second workspace",
+	branch: "second-workspace",
+	worktreePath: "/two/workspace",
+	baseBranch: "main",
+};
+const workspaces = { p1: [], p2: [workspace] };
+
+test("active workspace selectors resolve the workspace and its owning project", () => {
+	const state = { activeWorkspaceId: "w2", workspaces };
+
+	expect(selectActiveWorkspace(state)).toBe(workspace);
+	expect(selectActiveWorkspaceProjectId(state)).toBe("p2");
+});
+
+test("active workspace selectors return null when the workspace is absent", () => {
+	const state = { activeWorkspaceId: "missing", workspaces };
+
+	expect(selectActiveWorkspace(state)).toBeNull();
+	expect(selectActiveWorkspaceProjectId(state)).toBeNull();
+});
+
+test("context project prefers the active workspace owner", () => {
+	expect(
+		selectContextProject({
+			activeWorkspaceId: "w2",
+			selectedProjectId: "p1",
+			projects,
+			workspaces,
+		}),
+	).toBe(projects[1]);
+});
+
+test("context project falls back to the selected Project Home", () => {
+	expect(
+		selectContextProject({
+			activeWorkspaceId: null,
+			selectedProjectId: "p1",
+			projects,
+			workspaces,
+		}),
+	).toBe(projects[0]);
+});

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,0 +1,32 @@
+import type { Project, Workspace } from "@thinkrail/contracts";
+
+interface ActiveWorkspaceState {
+	activeWorkspaceId: string | null;
+	workspaces: Record<string, Workspace[]>;
+}
+
+interface ProjectContextState extends ActiveWorkspaceState {
+	selectedProjectId: string | null;
+	projects: Project[];
+}
+
+/** Resolve the active workspace from the project-grouped collection without duplicating it in state. */
+export function selectActiveWorkspace(state: ActiveWorkspaceState): Workspace | null {
+	if (!state.activeWorkspaceId) return null;
+	for (const workspaces of Object.values(state.workspaces)) {
+		const workspace = workspaces.find((candidate) => candidate.id === state.activeWorkspaceId);
+		if (workspace) return workspace;
+	}
+	return null;
+}
+
+/** The project that owns the active workspace; null while there is no active/resolved workspace. */
+export function selectActiveWorkspaceProjectId(state: ActiveWorkspaceState): string | null {
+	return selectActiveWorkspace(state)?.projectId ?? null;
+}
+
+/** Shell location context: the active workspace owner takes precedence over the selected Project Home. */
+export function selectContextProject(state: ProjectContextState): Project | null {
+	const projectId = selectActiveWorkspace(state)?.projectId ?? state.selectedProjectId;
+	return state.projects.find((project) => project.id === projectId) ?? null;
+}

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -28,12 +28,15 @@ test("opens a file in a center Monaco tab, focuses on re-open, and closes", asyn
 	await readme.dblclick();
 	await expect(page.getByTestId("editor-tab")).toHaveCount(1);
 
-	// Close it → back to the empty-center hint.
+	// Close it → back to the workspace receipt, which re-orients after the last tab closes.
 	const tab = page.getByTestId("editor-tab");
 	await tab.hover();
 	await tab.getByTestId("editor-tab-close").click();
 	await expect(page.getByTestId("editor-tab")).toHaveCount(0);
-	await expect(page.getByTestId("center-tabs")).toContainText("Open a file or start a chat");
+	await expect(page.getByTestId("workspace-ready")).toContainText("Workspace ready");
+	await expect(page.getByTestId("workspace-ready")).toContainText(
+		"Files, chats, changes, and terminals are scoped to this workspace",
+	);
 });
 
 test("hides YAML frontmatter in the rendered view but shows it in source", async ({ page }) => {

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -15,11 +15,18 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	const dialog = page.getByTestId("new-workspace-dialog");
 	await expect(dialog).toBeVisible();
 
+	// The operation and its scope are explicit before any controls: this is a separate checkout/branch,
+	// and the IDE surfaces the user is about to enter are all scoped to it.
+	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
+	await expect(dialog).toContainText("A separate checkout on its own new branch");
+	await expect(dialog).toContainText("Files, chats, changes, and terminals stay scoped to it");
+
 	// Project picker defaults to the project the "+" was clicked on.
 	await expect(dialog.getByTestId("ws-project-picker")).toContainText("sample-project");
 
 	// The base-branch picker preselects the repo's default (the fixture has no remote → local `main`).
 	const branchPicker = dialog.getByTestId("ws-branch-picker");
+	await expect(branchPicker).toContainText("From");
 	await expect(branchPicker).toContainText("main");
 
 	// Open it → the local branch is listed and flagged as the default; offline still lists local branches.
@@ -58,6 +65,20 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(dialog).toBeHidden();
 	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
 	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+
+	// The active scope stays visible after the Welcome → IDE remount, both in the tree and the global
+	// context spine. The empty center is a persistent receipt, not a generic blank-state prompt.
+	const scope = page.getByTestId("scope-context");
+	await expect(scope).toHaveAttribute("data-context", "workspace");
+	await expect(scope).toContainText("sample-project");
+	await expect(scope).toContainText("workspace-1");
+	await expect(scope).toContainText("from main");
+	const ready = page.getByTestId("workspace-ready");
+	await expect(ready).toContainText("Workspace ready");
+	await expect(ready).toContainText("workspace-1");
+	await expect(ready).toContainText("from main");
+	await expect(ready).toContainText("Files, chats, changes, and terminals are scoped");
+
 	// No prompt → no chat tab was opened.
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
 });
@@ -73,6 +94,9 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 	// Regression: plain Enter used to insert a newline; only Shift+Enter should. Shift+Enter keeps the
 	// dialog open and adds a line break — it must NOT create.
 	await prompt.fill("first line");
+	await expect(dialog.getByTestId("workspace-naming-hint")).toContainText(
+		"name the workspace and branch from your request",
+	);
 	await prompt.press("Shift+Enter");
 	await prompt.pressSequentially("second line");
 	await expect(prompt).toHaveValue("first line\nsecond line");
@@ -83,6 +107,7 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 	// in the no-agent suite (an empty prompt creates a bare worktree with no chat kick-off) while still
 	// exercising the same keydown→create() path the bug lived in.
 	await prompt.fill("");
+	await expect(dialog.getByTestId("workspace-naming-hint")).toHaveCount(0);
 	await prompt.press("Enter");
 	await expect(dialog).toBeHidden();
 	await expect(page.getByTestId("workspace-item")).toHaveCount(1);

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -158,6 +158,12 @@ test("a project with specs offers Start building over Set up", async ({ page }) 
 	await expect(page.getByTestId("welcome")).toBeVisible();
 	// The active project's name shows as the eyebrow above the wordmark.
 	await expect(page.getByTestId("welcome")).toContainText("sample-project");
+	// The global context makes the selected-but-not-active state explicit instead of making a project-row
+	// click look like the workspace silently disappeared.
+	const scope = page.getByTestId("scope-context");
+	await expect(scope).toHaveAttribute("data-context", "project-home");
+	await expect(scope).toContainText("sample-project");
+	await expect(scope).toContainText("Project home");
 	// Two cards: Start building (primary) + Open project — and no "Set up project".
 	await expect(page.getByTestId("welcome-cta")).toContainText("Start building");
 	await expect(

--- a/e2e/workspace-tabs.spec.ts
+++ b/e2e/workspace-tabs.spec.ts
@@ -18,11 +18,15 @@ test("editor tabs are scoped to the active workspace", async ({ page }) => {
 	await expect(workspaces).toHaveCount(2);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
 	await expect(tabs).toHaveCount(0);
-	await expect(page.getByTestId("center-tabs")).toContainText("Open a file or start a chat");
+	await expect(page.getByTestId("workspace-ready")).toContainText("workspace-2");
+	await expect(page.getByTestId("scope-name")).toHaveText("workspace-2");
+	await expect(page.getByTestId("scope-branch")).toHaveText("workspace-2");
 
 	// Switching back to workspace 1 restores its tab.
 	await workspaces.nth(0).getByRole("button").first().click();
 	await expect(workspaces.nth(0)).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("scope-name")).toHaveText("workspace-1");
+	await expect(page.getByTestId("scope-branch")).toHaveText("workspace-1");
 	await expect(tabs).toHaveCount(1);
 	await expect(tabs.filter({ hasText: "README.md" })).toBeVisible();
 });

--- a/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/asking-user-questions/SKILL.md
@@ -28,6 +28,11 @@ degrade when answers don't come. Process skills name this concept at the steps t
   why you recommend it over the alternatives (shown inline under the option as a `Why:` line).
 - Every option: a concise label (1–5 words, ≤ 60 chars) + a description carrying the trade-off or
   consequence of choosing it. Tailor options to the work at hand — never generic placeholders.
+- Options must be **decidable by the asked user**: frame them as observable behavior or outcomes
+  ("collapsing a project stays collapsed after a rename"), never as implementation mechanics
+  ("semantic guard", "activation ref"). If candidate options differ only internally — identical
+  observable behavior — don't ask: decide yourself and record the reasoning in the workflow's
+  artifact.
 - Never author your own "Other", free-text, or escape options — the tool adds a free-text row to
   every question and an always-available Skip, and reserved labels are rejected. This holds under
   `multiSelect` too: the free-text row stays and is *additive* — a typed answer arrives alongside the
@@ -56,3 +61,6 @@ through the tool's automatic free-text row — do not author an edit option. Rea
   explicitly recorded as unconfirmed in the workflow's artifact (the referencing skill says where).
 - If the host reports no interactive UI (`ask_user_question` returns "not available"), state your
   assumptions the same way instead of blocking.
+- "I don't know / help me understand" is a mis-framing signal, not a missing-knowledge one: re-explain
+  from user-visible behavior in plain language, then re-ask with behavior-framed options — don't
+  repeat the same technical options with more detail.

--- a/packages/pi-thinkrail-workflow/skills/brainstorming/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/brainstorming/SKILL.md
@@ -55,9 +55,14 @@ assumptions get caught cheaply. Scale the *depth* to the task; never skip the wo
    for its frontmatter (draft → active as it firms up), `edit` for prose. Run `spec_validate` after
    structural changes.
 9. **Final review, then build.** Ask the user to review the (now-promoted) design once more. Once
-   approved, implement directly against it — there is no separate plan-writing step here. Keep the
-   task-spec and the durable specs honest as the code lands, and retire the task-spec once **the work
-   itself** is done, not merely once the design was promoted.
+   approved, implement directly against it — there is no separate plan-writing step here. Before
+   handing off, self-review the implementation diff the way step 7 reviewed the spec: no silent
+   lint/type suppressions (a gate error is a design signal — question the flagged state or dependency
+   before guarding it; any genuinely-needed suppression gets explicit user sign-off first), no
+   nontrivial derivation duplicated across files (centralize it), and when the change replaced a
+   pattern, sweep the repo for remnants of the old one. Keep the task-spec and the durable specs
+   honest as the code lands, and retire the task-spec once **the work itself** is done, not merely
+   once the design was promoted.
 
 ## What a good task-spec looks like
 


### PR DESCRIPTION
## Summary

- keep the active workspace visible by expanding its parent project on activation
- add persistent project/workspace and branch/base context to the global top bar
- explain the checkout, branch, base, naming, and scoped surfaces in the Create workspace dialog
- replace the generic empty editor state with a persistent workspace-ready receipt
- centralize active workspace/project derivation in pure store selectors instead of duplicating lookups or state
- make Project Home and workspace activation atomic so selected project/workspace scope cannot diverge
- update the shell/panels specs and pin the behavior with e2e coverage

## Why

Users in demos—including experienced Git users—lost track of what ThinkRail created, which workspace and branch were active, and which surfaces were scoped to it. This makes that state visible before, during, and after workspace creation without changing the workspace domain model or wire protocol.

## Verification

- `bun run check:deps`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run e2e` — 44 passed
- spec graph validation
- desktop and narrow-viewport visual review with `agent-browser`

## Guidance follow-up (retrospective of this PR's review loop)

`0cf9a54` encodes what this PR's review rounds taught us, so the next change doesn't repeat them:

- **AGENTS.md — Handoff hygiene**: re-read the full diff before any commit/PR/"done"; no silent lint/type suppressions (the `biome-ignore` caught here); centralize duplicated derivations (the triplicated workspace→project lookup); sweep for remnants of replaced patterns (the leftover `selectProject` calls); end analyses with an offer; offer screenshots for UI-visible PRs.
- **asking-user-questions skill**: options must be decidable by the asked user — framed as observable behavior, never implementation mechanics.
- **brainstorming skill (step 9)**: implementation-diff self-review gate before handing off.

## Deferred follow-ups

- make the rail's New workspace action persistently discoverable
- make the Project home action explicit at its source
- add a project/worktree path-details popover for Git-heavy workflows

<img width="2880" height="1800" alt="01-project-home-context" src="https://github.com/user-attachments/assets/075af6d5-668a-43f8-8d3d-3ca1d44ec6ef" />
<img width="2880" height="1800" alt="02-create-workspace-dialog" src="https://github.com/user-attachments/assets/9372946e-ebd8-4bfd-b677-0b10e83b4c3b" />
<img width="2880" height="1800" alt="03-active-workspace-context" src="https://github.com/user-attachments/assets/01dfd660-5430-41e8-97f4-ed0204417e9d" />



