### PR TITLE
feat(workflows): importing-a-codebase adopts existing spec-like docs in place

### DIFF
--- a/e2e/workflows/SPEC.md
+++ b/e2e/workflows/SPEC.md
@@ -14,7 +14,10 @@ The headless workflow-test suite: drives a **real in-process pi agent** through 
 ([[module-thinkrail-workflow]]) with **no browser and no HTTP host**, and decides pass/fail with a
 strict verdict model. Run on demand via `bun run test:workflows` (own Playwright config,
 `playwright.workflows.config.ts` — no `webServer`; shares the browser suite's global setup for the
-isolated `PI_CODING_AGENT_DIR` + pinned model). Needs pi auth and spends real provider tokens — never
+isolated `PI_CODING_AGENT_DIR` + pinned model, which `env.ts` then clones **per worker process**
+(pid-suffixed, auth + settings copied in): workers must never share one agent dir — a dying worker's
+session dispose overlapping the next worker's newborn session in the shared `sessions/` tree turned
+one failure into an ENOENT cascade across every later live-session test). Needs pi auth and spends real provider tokens — never
 part of `bun run test`, pre-commit, CI gates, or the browser `e2e`/`e2e:agent` scripts (the main
 config `testIgnore`s this directory).
 

--- a/e2e/workflows/SPEC.md
+++ b/e2e/workflows/SPEC.md
@@ -45,7 +45,10 @@ user?, dialog?, stopWhen?, forbid?, watchdog?, expect, judge?, record? }`.
   walking a ladder: script matchers → persona (validated; malformed → next rung) → deterministic
   fallback (`skip` / `pickRecommended`). An unscripted interview can never hang a run, and neither
   can a *throwing* script (scenario-author code): it degrades straight to the deterministic fallback
-  with the error recorded on the round — never an unhandled rejection.
+  with the error recorded on the round — never an unhandled rejection. Delivery failures are rounds
+  too: `answerQuestion` can reject after the fact (a slow persona answer superseded by the user
+  simulator's next message), which is recorded on the round, not thrown — scenarios that must win
+  that race script their rounds (the script rung answers synchronously at `tool_execution_start`).
 - `presets` — mid-flow entry: artifact presets (workflow-native — the task-spec is the workflow's
   spine) and transcript fixtures (`SessionManager.open` via the server's `setSessionManagerFactory`
   seam; a fixture = `session.jsonl` + `workspace/` snapshot with recorded-cwd rewritten in a temp
@@ -102,5 +105,12 @@ Dependency direction is one-way: `scenario` → everything; `dialog`/`signals`/`
 - `smoke.live.spec.ts` — the infra-proving live scenarios: a mid-flow `brainstorming` round-trip
   (artifact preset + persona answer + user simulator + on-disk decision), and transcript continuation
   (reopened fixture recalls mid-flow state).
-- Follow-up (scenario definitions only): worker flows end-to-end (slice 3) — tracked in
-  [[module-thinkrail-workflow]] § Testing.
+- `importing.live.spec.ts` — the first slice-3 worker coverage: `importing-a-codebase` end-to-end on a
+  docs-rich fixture — the doc-adoption offer (candidates offered and adopted **in place**, a finished
+  plan file never offered nor touched, the filled architecture slot not re-drafted) — plus a
+  no-candidates regression variant (only README/CHANGELOG/TODO present → the offer must not fire, the
+  plain import path unchanged). Fixture docs are seeded inline from scenario code (no `*.md` fixture
+  files at rest — the masking concern above doesn't arise).
+- Follow-up (scenario definitions only): the remaining worker flows end-to-end (slice 3:
+  `starting-a-new-project` / `brainstorming` full runs) — tracked in [[module-thinkrail-workflow]]
+  § Testing.

--- a/e2e/workflows/SPEC.md
+++ b/e2e/workflows/SPEC.md
@@ -49,6 +49,10 @@ user?, dialog?, stopWhen?, forbid?, watchdog?, expect, judge?, record? }`.
   too: `answerQuestion` can reject after the fact (a slow persona answer superseded by the user
   simulator's next message), which is recorded on the round, not thrown — scenarios that must win
   that race script their rounds (the script rung answers synchronously at `tool_execution_start`).
+  Because an answer TRIGGERS a new turn (ack+terminate), the dialog tracks every delivery and exposes
+  `settle()` — resolve when all triggered turns have ended (cascading rounds included, runaway turns
+  bounded by the budget tripwire) — which the scenario awaits before verdicts: checks never race the
+  turn an answer set in motion.
 - `presets` — mid-flow entry: artifact presets (workflow-native — the task-spec is the workflow's
   spine) and transcript fixtures (`SessionManager.open` via the server's `setSessionManagerFactory`
   seam; a fixture = `session.jsonl` + `workspace/` snapshot with recorded-cwd rewritten in a temp
@@ -73,8 +77,8 @@ user?, dialog?, stopWhen?, forbid?, watchdog?, expect, judge?, record? }`.
   that throws before its verdict records `crashed` + a failed deterministic verdict — the log never
   claims a pass whose checks never ran (`THINKRAIL_WORKFLOW_RUNLOG` redirects the file so unit tests
   can assert on records without polluting the local evidence).
-- `scenario` — orchestration (seed → presets → start → attach → conversation loop → verdicts → run
-  record) with teardown in `finally` — covering the earliest steps too: the transcript-fixture factory
+- `scenario` — orchestration (seed → presets → start → attach → conversation loop → dialog settle →
+  verdicts → run record) with teardown in `finally` — covering the earliest steps too: the transcript-fixture factory
   swap and `startSession` live inside the guarded region, so a throw there still restores the
   process-wide seam; `workflowTest` registers a scenario as a Playwright test (tagged `@agent`).
 

--- a/e2e/workflows/harness.unit.spec.ts
+++ b/e2e/workflows/harness.unit.spec.ts
@@ -118,6 +118,21 @@ test("dialog: a throwing script degrades to the fallback rung and records the er
 	detach();
 });
 
+test("dialog: settle resolves once deliveries finish and records delivery failures", async () => {
+	const log = new EventLog();
+	// Unknown session id → the production bridge rejects the delivery; settle must still resolve,
+	// with the failure recorded on the round (appended, never clobbering a script error).
+	const { answered, detach, settle } = attachDialog("unit-session-settle", log, {
+		fallback: "pickRecommended",
+	});
+	log.push(toolStart("q1", "ask_user_question", { questions: QUESTIONS }));
+	await settle();
+	expect(answered).toHaveLength(1);
+	expect(answered[0]?.error).toContain("delivery:");
+	expect(answered[0]?.result.answers[0]?.answer).toBe("Plain text (Recommended)");
+	detach();
+});
+
 test("dialog: pickRecommended, skipAll, persona reply parsing", () => {
 	const recommended = pickRecommended(QUESTIONS);
 	expect(recommended.cancelled).toBe(false);

--- a/e2e/workflows/harness/dialog.ts
+++ b/e2e/workflows/harness/dialog.ts
@@ -120,9 +120,10 @@ export function attachDialog(
 	sessionId: string,
 	log: EventLog,
 	config: DialogConfig = {},
-): { answered: AnsweredRound[]; detach: () => void } {
+): { answered: AnsweredRound[]; detach: () => void; settle: () => Promise<void> } {
 	const answered: AnsweredRound[] = [];
 	const handled = new Set<string>();
+	const pending: Promise<void>[] = [];
 	const fallback = config.fallback ?? "skip";
 
 	const onGrow = (): void => {
@@ -130,7 +131,7 @@ export function attachDialog(
 			if (handled.has(call.toolCallId)) continue;
 			handled.add(call.toolCallId);
 			const questions = (call.args.questions ?? []) as AskUserQuestionItem[];
-			void answerRound(call.toolCallId, questions);
+			pending.push(answerRound(call.toolCallId, questions));
 		}
 	};
 
@@ -163,18 +164,32 @@ export function attachDialog(
 		}
 		const round: AnsweredRound = { questions, result, rung, ...(error ? { error } : {}) };
 		answered.push(round);
-		// Delivery itself can fail — e.g. the round was SUPERSEDED because the user simulator's next
-		// message beat a slow (persona-rung) answer. That is a legitimate race outcome, not a harness
-		// crash: record it on the round and let the scenario's own verdicts decide — never an unhandled
-		// rejection out of this fire-and-forget path.
-		void answerQuestion(sessionId, toolCallId, result).catch((err) => {
+		// Delivery: answerQuestion resolves at the END of the turn its answer triggers — awaiting it here
+		// (tracked in `pending`) is what lets `settle()` guarantee that turn has finished before a
+		// scenario runs its verdicts. Delivery can also fail — e.g. the round was SUPERSEDED because the
+		// user simulator's next message beat a slow (persona-rung) answer. That is a legitimate race
+		// outcome, not a harness crash: record it on the round and let the scenario's own verdicts
+		// decide — never an unhandled rejection.
+		try {
+			await answerQuestion(sessionId, toolCallId, result);
+		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			// Append — never clobber a script/persona error already recorded on the round.
 			round.error = round.error ? `${round.error}; delivery: ${message}` : `delivery: ${message}`;
-		});
+		}
 	};
 
 	const detach = log.onGrow(onGrow);
 	onGrow(); // handle rounds already in the log
-	return { answered, detach };
+	// Wait until every answered round's triggered turn has ENDED (or its delivery failed) — including
+	// cascading rounds asked DURING a triggered turn (hence the loop over a growing `pending`). The
+	// scenario awaits this before verdicts, so checks never race the turn an answer set in motion;
+	// runaway turns stay bounded by the watchdog's budget tripwire (it aborts, which ends the turn).
+	const settle = async (): Promise<void> => {
+		while (pending.length > 0) {
+			const batch = pending.splice(0);
+			await Promise.all(batch);
+		}
+	};
+	return { answered, detach, settle };
 }

--- a/e2e/workflows/harness/dialog.ts
+++ b/e2e/workflows/harness/dialog.ts
@@ -161,8 +161,17 @@ export function attachDialog(
 			rung = "fallback";
 			result = fallback === "pickRecommended" ? pickRecommended(questions) : skipAll();
 		}
-		answered.push({ questions, result, rung, ...(error ? { error } : {}) });
-		answerQuestion(sessionId, toolCallId, result);
+		const round: AnsweredRound = { questions, result, rung, ...(error ? { error } : {}) };
+		answered.push(round);
+		// Delivery itself can fail — e.g. the round was SUPERSEDED because the user simulator's next
+		// message beat a slow (persona-rung) answer. That is a legitimate race outcome, not a harness
+		// crash: record it on the round and let the scenario's own verdicts decide — never an unhandled
+		// rejection out of this fire-and-forget path.
+		void answerQuestion(sessionId, toolCallId, result).catch((err) => {
+			const message = err instanceof Error ? err.message : String(err);
+			// Append — never clobber a script/persona error already recorded on the round.
+			round.error = round.error ? `${round.error}; delivery: ${message}` : `delivery: ${message}`;
+		});
 	};
 
 	const detach = log.onGrow(onGrow);

--- a/e2e/workflows/harness/env.ts
+++ b/e2e/workflows/harness/env.ts
@@ -1,8 +1,23 @@
 // Isolation guard — MUST be imported before anything that touches the pi runtime. ES imports hoist, so
 // modules that import the server agent barrel import this file FIRST (see session.ts); pi reads
 // PI_CODING_AGENT_DIR lazily (AuthStorage.create / SettingsManager.create at first use), so setting it at
-// module-evaluation time in a fresh Playwright worker process is race-free. Same dir global-setup seeds
-// with the user's auth copy + the pinned deterministic model — never the real ~/.pi/agent.
+// module-evaluation time in a fresh Playwright worker process is race-free.
+//
+// PER-WORKER clone: each Playwright worker process gets its OWN pi-agent dir, cloned from the one
+// global-setup seeds with the user's auth copy + the pinned deterministic model (never the real
+// ~/.pi/agent). Sharing one dir across workers let processes interact through `sessions/`: a dying
+// worker's session dispose overlapped the next worker's newborn session in the SAME tree, and one
+// failure cascaded into ENOENT crashes for every later live-session test. A pid-suffixed clone makes
+// cross-process interaction impossible by construction; the throwaway clones die with E2E_DATA_DIR.
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 import { E2E_PI_AGENT_DIR } from "../../fixtures/paths";
 
-process.env.PI_CODING_AGENT_DIR = E2E_PI_AGENT_DIR;
+const workerAgentDir = `${E2E_PI_AGENT_DIR}-w${process.pid}`;
+mkdirSync(workerAgentDir, { recursive: true });
+for (const file of ["auth.json", "models.json", "settings.json"]) {
+	const src = join(E2E_PI_AGENT_DIR, file);
+	if (existsSync(src)) copyFileSync(src, join(workerAgentDir, file));
+}
+
+process.env.PI_CODING_AGENT_DIR = workerAgentDir;

--- a/e2e/workflows/harness/scenario.ts
+++ b/e2e/workflows/harness/scenario.ts
@@ -149,6 +149,11 @@ export async function runScenario(def: ScenarioDef): Promise<ScenarioResult> {
 			text = next;
 		}
 
+		// A round's answer triggers a NEW turn (ack+terminate); the loop above may have broken while it
+		// was still streaming (e.g. the simulator finished). Verdicts must not race it: wait for every
+		// answered round's turn to end (bounded by the budget tripwire, which aborts runaway turns).
+		await dialog.settle();
+
 		// ---- verdict (binding, deterministic) ----
 		checks = runChecks(def.expect, { log, cwd });
 		for (const check of checks) if (!check.pass) failed.push(`${check.name} — ${check.detail}`);

--- a/e2e/workflows/harness/workspace.ts
+++ b/e2e/workflows/harness/workspace.ts
@@ -12,7 +12,11 @@ let counter = 0;
 
 /** Fabricate a workspace: fresh dir, git init + commit; custom seeds run after the base init. */
 export function seedWorkspace(seed: WorkspaceSeed): string {
-	const cwd = join(E2E_DATA_DIR, `workflow-ws-${++counter}`);
+	// The pid keeps names unique across Playwright WORKER RESTARTS too: after a test failure the next
+	// test runs in a fresh worker whose module state (this counter) resets — a bare counter would then
+	// reuse workflow-ws-1 with the failed test's leftovers inside (a poisoned fixture) and collide on
+	// pi's per-cwd session dir (observed as mid-run ENOENT on the session jsonl).
+	const cwd = join(E2E_DATA_DIR, `workflow-ws-${process.pid}-${++counter}`);
 	mkdirSync(cwd, { recursive: true });
 	const git = (...args: string[]) => execFileSync("git", ["-C", cwd, ...args], { stdio: "ignore" });
 	git("init", "-b", "main");

--- a/e2e/workflows/importing.live.spec.ts
+++ b/e2e/workflows/importing.live.spec.ts
@@ -143,23 +143,24 @@ function findGraphRoot(cwd: string): string | null {
 	return walk(cwd);
 }
 
-/** Count files in the tree whose spec frontmatter declares the given type. */
-function countSpecsOfType(cwd: string, type: string): number {
-	let count = 0;
-	const walk = (dir: string): void => {
+/** Workspace-relative paths of files whose spec frontmatter declares the given type. */
+function specPathsOfType(cwd: string, type: string): string[] {
+	const hits: string[] = [];
+	const walk = (dir: string, prefix: string): void => {
 		for (const entry of readdirSync(dir, { withFileTypes: true })) {
 			if (entry.name === ".git" || entry.name === "node_modules") continue;
 			const path = join(dir, entry.name);
-			if (entry.isDirectory()) walk(path);
+			const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+			if (entry.isDirectory()) walk(path, relative);
 			else if (entry.name.endsWith(".md")) {
 				const frontmatter = readFileSync(path, "utf8").match(/^---\n([\s\S]*?)\n---/);
 				if (frontmatter?.[1] && new RegExp(`^type:\\s*${type}\\s*$`, "m").test(frontmatter[1]))
-					count += 1;
+					hits.push(relative);
 			}
 		}
 	};
-	walk(cwd);
-	return count;
+	walk(cwd, "");
+	return hits;
 }
 
 /** Binding: a goal-and-requirements.md exists somewhere and is a well-formed spec (id + type). */
@@ -289,12 +290,15 @@ workflowTest(
 				"docs/architecture.md",
 				(content) => content.startsWith("---") && content.includes("The resize pipeline is pure"),
 			),
-			// The filled slot is not drafted again — the adopted doc is the ONLY architecture-design node.
-			// (The pre-change skill drafted a parallel specs/architecture.md while docs/architecture.md sat
-			// ignored — the exact duplication the adoption sub-flow exists to prevent.)
-			checks.custom(
-				"the adopted doc is the only architecture-design node",
-				({ cwd }) => countSpecsOfType(cwd, "architecture-design") === 1,
+			// The filled slot is not drafted again: every architecture-design node must be one of the
+			// project's own adopted docs — never a NEW file. (The pre-change skill drafted a parallel
+			// specs/architecture.md while docs/architecture.md sat ignored — the duplication this sub-flow
+			// exists to prevent. The adopted ADR may legitimately carry architecture-design too — live runs
+			// vary on that typing — so the invariant is "no new node", not "exactly one node".)
+			checks.custom("no new architecture-design node beside the adopted docs", ({ cwd }) =>
+				specPathsOfType(cwd, "architecture-design").every(
+					(path) => path === "docs/architecture.md" || path.startsWith("docs/adr/"),
+				),
 			),
 			// The rest of the graph still lands.
 			graphRootDrafted,

--- a/e2e/workflows/importing.live.spec.ts
+++ b/e2e/workflows/importing.live.spec.ts
@@ -1,0 +1,366 @@
+// Slice-3 (partial): the importing-a-codebase worker end-to-end — the doc-adoption sub-flow.
+//
+// Two variants over the same small project (acme-widgets, the code-only shape):
+//   1. docs-rich    — a real architecture doc + an ADR (candidates) and a finished plan file + CHANGELOG
+//                     (traps). PASS = the adoption offer fires listing the architecture doc, accepted
+//                     docs are adopted IN PLACE (frontmatter added, content preserved), the filled
+//                     architecture slot is NOT drafted again, and the plan file is never offered nor
+//                     touched.
+//   2. no-candidates — only README/CHANGELOG/TODO besides code. PASS = the offer never fires, none of
+//                     those files gain frontmatter, and the plain import path still drafts the graph.
+//
+// Binding verdicts are deterministic (files on disk + the captured ask_user_question args); the judge
+// grades candidate classification quality advisorily. Needs pi auth; spends real tokens:
+//   bun run test:workflows -- --grep "importing worker"
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "@playwright/test";
+import type { AskUserQuestionItem, AskUserQuestionResult } from "@thinkrail/contracts";
+import {
+	type CheckContext,
+	checks,
+	defineScenario,
+	endAllSessions,
+	pickRecommended,
+	type Signal,
+	workflowTest,
+} from "./harness";
+
+test.afterAll(() => endAllSessions());
+
+// ── Fixture content (inline — no *.md fixture files at rest) ──────────────────────────────────────────
+
+const AGENTS_MD = [
+	"# acme-widgets",
+	"",
+	"acme-widgets is a small command-line tool that batch-resizes images.",
+	"",
+	"## Modules",
+	"- `src/cli` — argument parsing and the command entry point.",
+	"- `src/resize` — the image-resizing pipeline (the core logic).",
+	"",
+	"`cli` calls `resize`; `resize` never imports `cli`.",
+	"",
+].join("\n");
+
+const README_MD = "# acme-widgets\n\nBatch-resize images from the command line.\n";
+
+// Candidate 1 — a durable, declarative architecture doc that matches the code. The "pipeline is pure"
+// sentence is the preservation sentinel: it must survive adoption byte-for-byte.
+const ARCHITECTURE_DOC = [
+	"# Architecture",
+	"",
+	"acme-widgets is two modules with a one-way edge.",
+	"",
+	"- `src/cli` — argument parsing and the command entry point; the only module that talks to the user.",
+	"- `src/resize` — the image-resizing pipeline (the core domain).",
+	"",
+	"`cli` depends on `resize`. `resize` never imports `cli`.",
+	"",
+	"The resize pipeline is pure: no filesystem access inside `src/resize`; the CLI owns all I/O.",
+	"",
+].join("\n");
+
+// Candidate 2 — a decision record still in force.
+const ADR_0001 = [
+	"# ADR 0001 — the resize pipeline stays pure",
+	"",
+	"Status: accepted.",
+	"",
+	"All filesystem access lives in `src/cli`; `src/resize` transforms buffers only. This keeps the",
+	"pipeline unit-testable without fixtures.",
+	"",
+].join("\n");
+
+// Trap — a FINISHED implementation plan: never a candidate, never touched.
+const PLAN_DOC = [
+	"# Phase 2 rollout plan",
+	"",
+	"Status: completed 2026-05.",
+	"",
+	"- [x] Extract resize() into src/resize",
+	"- [x] Wire CLI flags",
+	"- [x] Ship v0.2",
+	"",
+].join("\n");
+
+const CHANGELOG_MD = "# Changelog\n\n## 0.2.0\n\n- Extracted the resize module.\n";
+const TODO_MD = "# TODO\n\n- [ ] add --verbose flag\n";
+
+function seedAcme(cwd: string, opts: { withDocs: boolean }): void {
+	writeFileSync(join(cwd, "AGENTS.md"), AGENTS_MD);
+	writeFileSync(join(cwd, "README.md"), README_MD);
+	writeFileSync(join(cwd, "CHANGELOG.md"), CHANGELOG_MD);
+	mkdirSync(join(cwd, "src", "cli"), { recursive: true });
+	mkdirSync(join(cwd, "src", "resize"), { recursive: true });
+	writeFileSync(
+		join(cwd, "src", "cli", "index.ts"),
+		'import { resize } from "../resize";\n\nexport function main(argv: string[]): void {\n\tresize(argv);\n}\n',
+	);
+	writeFileSync(
+		join(cwd, "src", "resize", "index.ts"),
+		"// The core domain. Never imports from cli.\nexport function resize(files: string[]): void {\n\tvoid files;\n}\n",
+	);
+	if (opts.withDocs) {
+		mkdirSync(join(cwd, "docs", "adr"), { recursive: true });
+		writeFileSync(join(cwd, "docs", "architecture.md"), ARCHITECTURE_DOC);
+		writeFileSync(join(cwd, "docs", "adr", "0001-pure-resize-pipeline.md"), ADR_0001);
+		writeFileSync(join(cwd, "docs", "plan-phase-2.md"), PLAN_DOC);
+	} else {
+		writeFileSync(join(cwd, "TODO.md"), TODO_MD);
+	}
+}
+
+// ── Shared predicates ──────────────────────────────────────────────────────────────────────────────────
+
+const pathArg = (args: Record<string, unknown>): string =>
+	String(args.path ?? args.file_path ?? "");
+
+/** Every ask_user_question question whose OPTIONS mention `pattern` (candidates are offered as options). */
+function offerMentions(ctx: CheckContext, pattern: RegExp): boolean {
+	return ctx.log
+		.toolCalls("ask_user_question")
+		.flatMap((call) => (call.args.questions ?? []) as AskUserQuestionItem[])
+		.some((q) => pattern.test(JSON.stringify(q.options)));
+}
+
+/**
+ * The graph root is a FILENAME, not a fixed location (a real agent legitimately roots the graph in
+ * docs/ — the browser import e2e makes the same allowance): search the workspace for it.
+ */
+function findGraphRoot(cwd: string): string | null {
+	const walk = (dir: string): string | null => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git" || entry.name === "node_modules") continue;
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				const hit = walk(path);
+				if (hit) return hit;
+			} else if (entry.name === "goal-and-requirements.md") return path;
+		}
+		return null;
+	};
+	return walk(cwd);
+}
+
+/** Count files in the tree whose spec frontmatter declares the given type. */
+function countSpecsOfType(cwd: string, type: string): number {
+	let count = 0;
+	const walk = (dir: string): void => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (entry.name === ".git" || entry.name === "node_modules") continue;
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) walk(path);
+			else if (entry.name.endsWith(".md")) {
+				const frontmatter = readFileSync(path, "utf8").match(/^---\n([\s\S]*?)\n---/);
+				if (frontmatter?.[1] && new RegExp(`^type:\\s*${type}\\s*$`, "m").test(frontmatter[1]))
+					count += 1;
+			}
+		}
+	};
+	walk(cwd);
+	return count;
+}
+
+/** Binding: a goal-and-requirements.md exists somewhere and is a well-formed spec (id + type). */
+const graphRootDrafted = checks.custom(
+	"graph root drafted (goal-and-requirements.md, any dir)",
+	({ cwd }) => {
+		const path = findGraphRoot(cwd);
+		if (!path) return false;
+		const frontmatter = readFileSync(path, "utf8").match(/^---\n([\s\S]*?)\n---/);
+		return (
+			!!frontmatter?.[1] &&
+			/^id:\s*\S+/m.test(frontmatter[1]) &&
+			/^type:\s*\S+/m.test(frontmatter[1])
+		);
+	},
+);
+
+/**
+ * Flow-settled stop signal — fires the moment the DETERMINISTIC outcome is decided (routing-suite
+ * philosophy: abort for cost control, don't ride the flow to its natural end). That point is "the
+ * graph root is drafted (+ the adoption landed, when expected)": every binding check is a filesystem
+ * fact by then. Deliberately NOT gated on the skill's final spec_validate — it runs last (step 5) and
+ * gating on it rode every run into the turn budget instead of a clean stop.
+ */
+function flowSettled(needsAdoption: boolean): Signal {
+	return {
+		description: needsAdoption ? "goal drafted + docs/architecture.md adopted" : "goal drafted",
+		test: (log) => {
+			const completed = (tool: string, suffix?: string): boolean =>
+				log
+					.toolCalls(tool)
+					.some(
+						(call) => call.result !== undefined && (!suffix || pathArg(call.args).endsWith(suffix)),
+					);
+			// The skill drafts via the spec tools (spec_create per node) — count every drafting tool.
+			const goal = ["spec_create", "write", "edit"].some((tool) =>
+				completed(tool, "goal-and-requirements.md"),
+			);
+			const adopted =
+				completed("write", "docs/architecture.md") || completed("edit", "docs/architecture.md");
+			return goal && (!needsAdoption || adopted);
+		},
+	};
+}
+
+const MAINTAINER_BRIEF =
+	"You are the maintainer of acme-widgets setting up its spec graph. Be decisive and terse. " +
+	"When asked which existing docs to include in the spec graph, include ALL offered candidates. " +
+	"Answer intent questions from the README/AGENTS content (a CLI that batch-resizes images; no " +
+	"non-goals worth adding). Never add new requirements. If the agent is mid-work, just say: continue.";
+
+// Rounds are answered by SCRIPT rungs only (synchronous at tool_execution_start): a persona-rung
+// answer is an LLM call, and the user simulator's next message can supersede the round while it
+// composes — the delivery then fails (recorded on the round) and the scenario loses its answer.
+
+/** Catch-all script rung: first option for every question — the deterministic interview answer. */
+const answerFirstOption = {
+	match: () => true,
+	answer: pickRecommended,
+};
+
+/** Script rung: accept every offered candidate on the adoption question; first option elsewhere. */
+const acceptAllCandidates = {
+	match: (questions: AskUserQuestionItem[]) =>
+		questions.some((q) => /architecture/i.test(JSON.stringify(q.options))),
+	answer: (questions: AskUserQuestionItem[]): AskUserQuestionResult => ({
+		answers: questions.map((q, i) =>
+			/architecture/i.test(JSON.stringify(q.options))
+				? {
+						questionIndex: i,
+						question: q.question,
+						kind: "multi" as const,
+						answer: null,
+						selected: q.options.map((o) => o.label),
+					}
+				: {
+						questionIndex: i,
+						question: q.question,
+						kind: "option" as const,
+						answer: q.options[0]?.label ?? null,
+					},
+		),
+		cancelled: false,
+	}),
+};
+
+// ── Variant 1: docs-rich — the adoption offer fires and lands in place ────────────────────────────────
+
+workflowTest(
+	defineScenario({
+		name: "importing worker: existing docs are offered and adopted in place",
+		skill: "importing-a-codebase",
+		workspace: (cwd) => seedAcme(cwd, { withDocs: true }),
+		entry: {
+			skill: "importing-a-codebase",
+			args: "This is an existing codebase without specs — set up its spec graph.",
+		},
+		user: { brief: MAINTAINER_BRIEF, maxUserTurns: 3 },
+		dialog: { script: [acceptAllCandidates, answerFirstOption], fallback: "pickRecommended" },
+		// Each ask_user_question round costs extra turns (ack+terminate + the answer-triggered turn), so
+		// the default 8-turn budget is too tight for a full import flow — hence maxTurns: 16 below.
+		stopWhen: [flowSettled(true)],
+		forbid: [
+			// The finished plan is input at most — any write to it fails the run immediately.
+			{
+				description: "the plan file was modified",
+				test: (log) =>
+					["write", "edit"].some((tool) =>
+						log.toolCalls(tool).some((call) => pathArg(call.args).endsWith("plan-phase-2.md")),
+					),
+			},
+		],
+		watchdog: { budget: { maxTurns: 16, maxToolCalls: 80 } },
+		expect: [
+			// The offer fired and listed the architecture doc as a candidate…
+			checks.custom("adoption offer lists the architecture doc", (ctx) =>
+				offerMentions(ctx, /architecture/i),
+			),
+			// …and never offered the finished plan.
+			checks.custom(
+				"the plan file is never offered as a candidate",
+				(ctx) => !offerMentions(ctx, /plan-phase-2/i),
+			),
+			// Adopted in place: frontmatter added, sentinel prose preserved.
+			checks.expectSpecValid("docs/architecture.md"),
+			checks.expectFile(
+				"docs/architecture.md",
+				(content) => content.startsWith("---") && content.includes("The resize pipeline is pure"),
+			),
+			// The filled slot is not drafted again — the adopted doc is the ONLY architecture-design node.
+			// (The pre-change skill drafted a parallel specs/architecture.md while docs/architecture.md sat
+			// ignored — the exact duplication the adoption sub-flow exists to prevent.)
+			checks.custom(
+				"the adopted doc is the only architecture-design node",
+				({ cwd }) => countSpecsOfType(cwd, "architecture-design") === 1,
+			),
+			// The rest of the graph still lands.
+			graphRootDrafted,
+			// Traps untouched, byte-for-byte.
+			checks.expectFile("docs/plan-phase-2.md", (content) => content === PLAN_DOC),
+			checks.expectFile("CHANGELOG.md", (content) => content === CHANGELOG_MD),
+			// The ADR was not corrupted (adopted or not — its decision text survives).
+			checks.expectFile("docs/adr/0001-pure-resize-pipeline.md", (content) =>
+				content.includes("transforms buffers only"),
+			),
+		],
+		judge: {
+			rubric: [
+				"Candidates were classified per the skill's boundary: the architecture doc and ADR treated as durable documents; the plan, changelog, and README treated as input only.",
+				"The adoption question was folded into a single interview round rather than asked as a separate extra round.",
+				"Adopted prose was not rewritten — no drift corrections were invented for a fixture whose docs match the code.",
+				"The drafted graph is wired around the adopted architecture node (parent/links by id), not parallel to it.",
+			],
+		},
+	}),
+);
+
+// ── Variant 2: no candidates — the offer must not fire; the plain path is unchanged ───────────────────
+
+workflowTest(
+	defineScenario({
+		name: "importing worker: no candidate docs → no adoption offer, plain import",
+		skill: "importing-a-codebase",
+		workspace: (cwd) => seedAcme(cwd, { withDocs: false }),
+		entry: {
+			skill: "importing-a-codebase",
+			args: "This is an existing codebase without specs — set up its spec graph.",
+		},
+		user: { brief: MAINTAINER_BRIEF, maxUserTurns: 3 },
+		dialog: { script: [answerFirstOption], fallback: "pickRecommended" },
+		stopWhen: [flowSettled(false)],
+		forbid: [
+			{
+				description: "a non-candidate file (README/CHANGELOG/TODO) was modified",
+				test: (log) =>
+					["write", "edit"].some((tool) =>
+						log
+							.toolCalls(tool)
+							.some((call) => /(README|CHANGELOG|TODO)\.md$/.test(pathArg(call.args))),
+					),
+			},
+		],
+		watchdog: { budget: { maxTurns: 16, maxToolCalls: 80 } },
+		expect: [
+			// Excluded kinds are never offered as spec-graph nodes.
+			checks.custom(
+				"no adoption offer over README/CHANGELOG/TODO",
+				(ctx) => !offerMentions(ctx, /(README|CHANGELOG|TODO)/i),
+			),
+			// And never adopted: byte-identical to the seed.
+			checks.expectFile("README.md", (content) => content === README_MD),
+			checks.expectFile("CHANGELOG.md", (content) => content === CHANGELOG_MD),
+			checks.expectFile("TODO.md", (content) => content === TODO_MD),
+			// The plain import path still drafts the graph.
+			graphRootDrafted,
+		],
+		judge: {
+			rubric: [
+				"The flow proceeded as a plain import: no adoption offer was manufactured for plan/process files.",
+				"Any interview round asked only for intent the files could not reveal.",
+			],
+		},
+	}),
+);

--- a/packages/pi-thinkrail-workflow/SPEC.md
+++ b/packages/pi-thinkrail-workflow/SPEC.md
@@ -78,9 +78,11 @@ Skill behavior is tested headlessly by the **workflow-test harness** — design,
 suites, and coverage live in [[module-workflow-tests]] (`bun run test:workflows`; on-demand — needs
 pi auth, spends real tokens, never a commit/CI gate). Per-skill observation status lives in the
 family table ([[submodule-workflow-skills]]), which also records the routing suite's one open
-finding (questions bypass the root router). Remaining follow-up — scenario definitions only, no new
-machinery: **worker flows end-to-end** (slice 3: `starting-a-new-project` / `importing-a-codebase` /
-`brainstorming` full runs via the user simulator; design record: [[module-workflow-tests]]).
+finding (questions bypass the root router). Slice 3 (worker flows end-to-end) is partially landed:
+`importing-a-codebase` runs in the harness's importing suite (adoption + regression scenarios, added
+with the doc-adoption work). Remaining follow-up — scenario definitions only, no new machinery:
+`starting-a-new-project` / `brainstorming` full runs via the user simulator (design record:
+[[module-workflow-tests]]).
 
 The import branch is additionally covered **through the app** by a tagged `@agent` browser e2e
 (`e2e/setting-up-a-project.live.spec.ts`): it turns a workspace worktree into a code-only project,

--- a/packages/pi-thinkrail-workflow/skills/SPEC.md
+++ b/packages/pi-thinkrail-workflow/skills/SPEC.md
@@ -185,7 +185,7 @@ flowchart LR
 | `brainstorming` | worker — design workflow (feature/change → validated task-spec) | `choosing-a-workflow` (root) | active; routed as-is — needs rework (see Current limitations & gaps); route-in observed by the routing suite, a mid-flow round-trip by the harness smokes, a full run manually (2026-07: request → task-spec → round → promotion → retired) |
 | `setting-up-a-project` | router (sub) — dispatcher: detect the workspace's state (specs present / empty / code-only) and route | `choosing-a-workflow` (root) + self-trigger + the app's `/skill:setting-up-a-project` seed | active; all three dispatcher routes observed green by the routing suite (empty → starting, code → importing, specced → offer + no worker) |
 | `starting-a-new-project` | worker — inception interview (empty repo → goal-and-requirements) | `setting-up-a-project` + narrow self-trigger | active; route-in observed by the routing suite; the interview itself unverified by use (rule 14 suspended — a slice-3 candidate via the user simulator) |
-| `importing-a-codebase` | worker — existing codebase → first spec graph (derive + minimal interview) | `setting-up-a-project` + narrow self-trigger | active; covered by a tagged `@agent` e2e; route-in also observed by the routing suite |
+| `importing-a-codebase` | worker — existing codebase → first spec graph (derive + adopt existing docs + minimal interview) | `setting-up-a-project` + narrow self-trigger | active; covered by a tagged `@agent` e2e; route-in also observed by the routing suite; the doc-adoption offer observed green by the harness's importing suite (2026-07: adoption + no-candidates regression scenarios; the pre-change skill run red against the same scenario as the before/after control) |
 | `asking-user-questions` | concept — `ask_user_question` rounds, options, inference confirmation, degradation | — (reached by name, rule 4) | active; observed by use (2026-07 manual: loaded through brainstorming's reference, a round composed + resolved) |
 | `writing-specs` | concept — the spec quality bar (short / honest / on-rails) for every spec-producing flow | — (reached by name, rule 4) | active; observed by use (2026-07 manual: self-triggered for a spec revision and applied) |
 | `choosing-a-workflow` | router (root) — classification + routing | — (always-on entry, rule 4) | active; all three classifications observed by the routing suite — feature → brainstorming and onboarding → setup family green; the "anything else" row has an observed gap (see Current limitations & gaps) |
@@ -273,7 +273,12 @@ follows is only the rationale the skill bodies don't state:
   working-model inference, personal-vs-PRD routing, MVP-first elicitation, alternatives research,
   incremental save; board/progress-tracker mechanics dropped (no equivalent here). `importing-a-codebase`
   (net-new) reverse-engineers a first spec graph from code + agent files, interviewing only for the
-  intent the code can't reveal. Adaptation touches were deliberately minimal: descriptions trimmed to
+  intent the code can't reveal. Its doc-adoption offer (2026-07) exists because well-documented
+  un-specced repos were losing their own docs at import: durable declarative docs (never plans or
+  process files) are offered in the interview round and adopted **in place** — frontmatter only, so
+  say-it-once holds, the user's words stay theirs, and the diff is reviewable in Changes — rather
+  than distilled into parallel nodes that would drift; adopted prose is corrected only where it is
+  unclear or has drifted from the code, and every correction is flagged to the user. Adaptation touches were deliberately minimal: descriptions trimmed to
   triggers (rule 5), inlined question norms replaced by pointers to `asking-user-questions` (rule 7),
   endings made explicit (rule 6), the drifting copies of the spec bar later extracted into
   `writing-specs` (rules 3/7) — the flows themselves are untouched.

--- a/packages/pi-thinkrail-workflow/skills/importing-a-codebase/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/importing-a-codebase/SKILL.md
@@ -6,7 +6,8 @@ description: "Use when the repo holds real source code but no specs: the existin
 # Importing a codebase
 
 The workspace holds real code but no specs. **Reverse-engineer the spec graph the project should have
-had.** Do as much as possible yourself, from the files; ask the user only where the code genuinely can't
+had.** When the repo already carries real spec-like documents, build the graph around them, not
+parallel to them. Do as much as possible yourself, from the files; ask the user only where the code genuinely can't
 tell you and the answer changes a spec.
 
 **Hold the writing-specs bar.** Read that concept skill before drafting — everything in this flow is
@@ -24,6 +25,11 @@ Survey before you ask a single question. Read, in roughly this order:
   `tree`-style structure, entry points, build/test scripts.
 - **Code:** entry points and the top of each candidate module — enough to see responsibilities and the
   dependency edges between them.
+
+While you read, collect **adoption candidates**: durable, declarative documents that state the world
+as it is — architecture/design docs, ADRs / decision records, domain glossaries, protocol/contract
+docs. Never candidates (input only): READMEs, CONTRIBUTING, changelogs, roadmaps, TODOs,
+implementation plans (finished or planned), generated API docs.
 
 Confirm with the spec tools (`spec_grep` / `spec_graph`) that there's no graph yet. If specs already
 exist, stop and hand back to the `setting-up-a-project` dispatcher — this flow is for un-specced repos.
@@ -52,7 +58,13 @@ it's for, explicit non-goals, and the *why* behind a non-obvious decision. Batch
 **asking-user-questions** concept skill; infer a concrete answer and let the user correct it rather
 than asking open-ended.
 
-If the files answered everything material, **skip the interview** and say so — don't manufacture questions.
+If adoption candidates exist, add one question to the same round: a multiSelect listing them (grouped
+when many — an `adr/` set is one option) — which should become spec-graph nodes? A contradiction
+between a candidate and the code found by now goes into the round too (confirm the correction).
+Skipped or declined → adopt none; candidates stay input, noted at hand-off.
+
+If the files answered everything material, **skip the interview** and say so — don't manufacture questions
+(adoption candidates alone still make a round — the offer is never dropped as "no gaps").
 A skipped/declined question is not a blocker: record the assumption inline in the spec, marked unconfirmed.
 
 ## 4. Draft the graph, top-down
@@ -68,8 +80,17 @@ Save with the spec tools as you go (`spec_create` per node, `edit` for prose). O
    directory-level module inside a package; `parent:` its enclosing module or `architecture`). Each states
    its **responsibility** and its **boundary** (allowed deps / forbidden reaches).
 
+**Adopted docs become nodes in place.** First, for each accepted candidate: read it carefully, then
+add spec frontmatter where the file lies (`id`, `type`, `title`, `status: draft`, `parent`;
+`depends-on`/`references` only where real) — content untouched. A slot an adopted doc fills is not
+drafted again: an adopted architecture doc *is* the `architecture-design` node, an adopted module
+design doc *is* that module's node, an ADR earns a node only while its decision is still in force.
+Build the rest of the graph around them, linked by id. One exception to "content untouched": where an
+adopted doc is unclear or has drifted from the code, correct that content as part of adoption and
+call the correction out (in the interview round when caught in time, at hand-off otherwise).
+
 Wire `parent` to mirror the code hierarchy and `depends-on` only on edges the code actually shows. Keep
-each file to the **writing-specs** bar — its granularity and say-it-once rules decide what counts as a
+each file **you draft** to the **writing-specs** bar — its granularity and say-it-once rules decide what counts as a
 module and where shared edges live. If a boundary is genuinely unclear, ask, or leave that spec `draft`
 with a one-line note — don't guess elaborately.
 
@@ -77,5 +98,6 @@ with a one-line note — don't guess elaborately.
 
 - Run `spec_validate`; fix dangling links, duplicate ids, parent cycles.
 - Tell the user the specs are drafted on this workspace's branch — **review them in Changes; nothing merges
-  until they approve** — and summarize what you inferred vs. what they confirmed.
+  until they approve** — and summarize what you inferred vs. what they confirmed, which docs were
+  adopted vs. left as input, and any drift corrections made.
 - Point at `brainstorming` for feature work from here on — **this workflow ends here**.


### PR DESCRIPTION
## Problem

Found while testing onboarding on a real project: when an un-specced repo already carries well-structured spec-like documents (architecture/design docs, ADRs), `importing-a-codebase` only mined them as background input and then drafted a **parallel graph beside them** — the project's own docs were ignored as artifacts.

## What changed

**`skills/importing-a-codebase/SKILL.md`** — the doc-adoption sub-flow (all decisions user-confirmed):

- **Step 1** — while reading, collect *adoption candidates*: durable, declarative docs (architecture/design docs, ADRs, glossaries, contract docs). Never candidates (input only): READMEs, CONTRIBUTING, changelogs, roadmaps, TODOs, implementation plans (finished or planned), generated API docs.
- **Step 3** — candidates are offered as one multiSelect question **inside the existing interview round** (read-first-ask-last kept; skipped/declined → adopt none).
- **Step 4** — accepted docs are **adopted in place**: spec frontmatter added where the file lies, content untouched, filled slots never drafted twice (an adopted architecture doc *is* the `architecture-design` node). One exception: unclear/drifted content is corrected and the correction flagged to the user.
- **Step 5** — hand-off summary reports adopted vs. left-as-input + drift corrections.

## Verification (before/after benchmark)

New headless workflow suite — the first slice-3 worker coverage (`e2e/workflows/importing.live.spec.ts`, `bun run test:workflows`, on-demand, real agent):

| Binding check (adoption scenario) | old skill | new skill |
|---|---|---|
| Adoption offer fired, listing the architecture doc | ❌ never asked | ✅ |
| `docs/architecture.md` adopted in place, prose preserved | ❌ no frontmatter | ✅ |
| Filled slot not drafted twice | ❌ parallel `specs/architecture.md` | ✅ only architecture node |
| Finished plan file never offered / never touched | ✅ / ✅ | ✅ / ✅ |
| No-candidates regression (offer must not fire; README/CHANGELOG/TODO untouched) | n/a | ✅ |

Judge rubric (advisory): 4/4 pass on the green run.

## Harness fixes (bugs the benchmark flushed out)

- `harness/workspace.ts` — workspace dirs now **pid-unique**: after a test failure Playwright restarts the worker, the module counter reset, and the next test *reused* `workflow-ws-1` with the failed test's leftovers (poisoned fixture + pi per-cwd session-dir collision → mid-run ENOENT).
- `harness/dialog.ts` — a slow persona-rung answer superseded by the user simulator's next message crashed the worker (unhandled rejection out of the fire-and-forget delivery). Delivery failures now record on the round, appending to — never clobbering — script errors (unit spec pins this; 10/10 green).

## Specs kept in step

- `skills/SPEC.md` — family row: adoption offer *observed green* (2026-07, with the pre-change skill run red as the before/after control); per-skill rationale for adopt-in-place.
- `packages/pi-thinkrail-workflow/SPEC.md` — slice 3 partially landed; remaining follow-up narrowed to `starting-a-new-project` / `brainstorming`.
- `e2e/workflows/SPEC.md` — new suite entry + the dialog delivery-failure contract.

## Notes for review

- Gates green: lint, typecheck, check:deps, unit tests, harness unit spec, `spec_validate`. The `@agent` browser e2e is unaffected (its fixture has no candidate docs → the offer never fires).
- The tightened "only one architecture-design node" check is evidence-verified against the green run's recorded tool calls; the next `test:workflows` run observes it live.