### PR TITLE
feat(workspaces): add workspace lifecycle hooks (onCreate/onDelete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ e2e/.workflow-runs.jsonl
 docs/*
 .playwright-mcp/
 .claude/
+.superpowers/
 
 # Build-only manifests written transiently by apps/cli/scripts/build-binary.ts
 apps/cli/src/*.generated.ts

--- a/.thinkrail/hooks.json
+++ b/.thinkrail/hooks.json
@@ -1,3 +1,3 @@
 {
-	"onCreate": "echo \"hello\""
+	"onCreate": "npm install"
 }

--- a/.thinkrail/hooks.json
+++ b/.thinkrail/hooks.json
@@ -1,0 +1,3 @@
+{
+	"onCreate": "echo \"hello\""
+}

--- a/apps/web/src/panels/HookApprovalDialog.tsx
+++ b/apps/web/src/panels/HookApprovalDialog.tsx
@@ -35,7 +35,7 @@ export function HookApprovalDialog({
 					<p className="pb-xs">
 						This command will run automatically for every workspace in this project from now on:
 					</p>
-					<code className="block overflow-auto rounded-[var(--radius-sm)] bg-elevated px-sm py-xs font-[var(--font-mono)] text-xs">
+					<code className="block overflow-auto whitespace-pre-wrap rounded-[var(--radius-sm)] bg-elevated px-sm py-xs font-[var(--font-mono)] text-xs">
 						{command}
 					</code>
 				</>

--- a/apps/web/src/panels/HookApprovalDialog.tsx
+++ b/apps/web/src/panels/HookApprovalDialog.tsx
@@ -1,0 +1,52 @@
+import type { HookName } from "@thinkrail/contracts";
+import { toast } from "../store";
+import { errorText } from "../transport";
+import { ConfirmDialog } from "./ConfirmDialog";
+import { approveAndRunHook } from "./hooksActions";
+
+/**
+ * The approval prompt for a pending hook command — shared by the workspace row's badge (fast path for
+ * `awaitingApproval`) and the Hooks panel (reachable from any workspace, any state). A centered modal, not
+ * an anchored popover: approving trusts an arbitrary shell command for every workspace in this project
+ * going forward, not just a one-off action on this row.
+ */
+export function HookApprovalDialog({
+	open,
+	onOpenChange,
+	projectId,
+	workspaceId,
+	hook,
+	command,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	projectId: string;
+	workspaceId: string;
+	hook: HookName;
+	command: string;
+}) {
+	return (
+		<ConfirmDialog
+			open={open}
+			onOpenChange={onOpenChange}
+			title={`Approve ${hook} for this project?`}
+			description={
+				<>
+					<p className="pb-xs">
+						This command will run automatically for every workspace in this project from now on:
+					</p>
+					<code className="block overflow-auto rounded-[var(--radius-sm)] bg-elevated px-sm py-xs font-[var(--font-mono)] text-xs">
+						{command}
+					</code>
+				</>
+			}
+			confirmLabel="Approve & Run"
+			confirmTestId="confirm-approve-hook"
+			onConfirm={() => {
+				void approveAndRunHook(projectId, workspaceId, hook, command).catch((err) =>
+					toast.error(errorText(err, "Failed to approve hook")),
+				);
+			}}
+		/>
+	);
+}

--- a/apps/web/src/panels/HookStatusIcon.tsx
+++ b/apps/web/src/panels/HookStatusIcon.tsx
@@ -1,0 +1,19 @@
+import type { HookStatus } from "@thinkrail/contracts";
+import { Check, Loader2, TriangleAlert, X } from "lucide-react";
+
+/** The status-icon convention shared by the workspace row's badge and the Hooks panel's per-hook rows —
+ * mirrors `ToolCard`'s running/error/done icon set, plus `awaitingApproval` (no tool-card precedent). */
+export function HookStatusIcon({ state }: { state: HookStatus["state"] }) {
+	switch (state) {
+		case "running":
+			return (
+				<Loader2 className="size-3.5 shrink-0 animate-spin text-muted motion-reduce:animate-none" />
+			);
+		case "failed":
+			return <X className="size-3.5 shrink-0 text-red" />;
+		case "succeeded":
+			return <Check className="size-3.5 shrink-0 text-green" />;
+		case "awaitingApproval":
+			return <TriangleAlert className="size-3.5 shrink-0 text-gold" />;
+	}
+}

--- a/apps/web/src/panels/HooksPanel.tsx
+++ b/apps/web/src/panels/HooksPanel.tsx
@@ -1,0 +1,112 @@
+import type { HookName, HookStatus } from "@thinkrail/contracts";
+import { RotateCcw } from "lucide-react";
+import { useState } from "react";
+import { toast, useAppStore } from "../store";
+import { errorText } from "../transport";
+import { HookApprovalDialog } from "./HookApprovalDialog";
+import { HookStatusIcon } from "./HookStatusIcon";
+import { runHookNow } from "./hooksActions";
+
+const HOOK_LABEL: Record<HookName, string> = {
+	onCreate: "onCreate",
+	onDelete: "onDelete",
+	preMerge: "preMerge",
+	postMerge: "postMerge",
+};
+
+/**
+ * Hooks for the active worktree: one row per declared lifecycle hook that has ever reported a status
+ * (`Workspace.hookStatus`), each with its live output when present (`hookOutputByWorkspace`). `preMerge`/
+ * `postMerge` never show up here in practice — nothing calls them yet — but the panel doesn't special-case
+ * that away; an empty list is just an empty list.
+ */
+export function HooksPanel({ workspaceId }: { workspaceId: string }) {
+	const workspace = useAppStore((s) =>
+		Object.values(s.workspaces)
+			.flat()
+			.find((w) => w.id === workspaceId),
+	);
+	const output = useAppStore((s) => s.hookOutputByWorkspace[workspaceId]);
+	const [approving, setApproving] = useState<{ hook: HookName; command: string } | null>(null);
+
+	if (!workspace) return <p className="px-sm py-xs text-xs text-hint">Loading…</p>;
+
+	const entries = (Object.entries(workspace.hookStatus ?? {}) as [HookName, HookStatus][]).sort(
+		([a], [b]) => a.localeCompare(b),
+	);
+
+	if (entries.length === 0) {
+		return (
+			<p data-testid="hooks-empty" className="px-sm py-xs text-xs text-hint">
+				No hooks declared for this workspace.
+			</p>
+		);
+	}
+
+	const runNow = (hook: HookName) => {
+		void runHookNow(workspaceId, hook).catch((err) =>
+			toast.error(errorText(err, `Failed to run ${hook}`)),
+		);
+	};
+
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-auto">
+			<ul className="flex flex-col divide-y divide-border2">
+				{entries.map(([hook, status]) => (
+					<li key={hook} data-testid="hook-row" data-hook={hook} data-status={status.state}>
+						<div className="flex items-center gap-sm px-sm py-xs text-sm">
+							<HookStatusIcon state={status.state} />
+							<span className="font-medium text-text">{HOOK_LABEL[hook]}</span>
+							{status.state === "failed" && (
+								<span className="text-hint text-xs">exit {status.exitCode}</span>
+							)}
+							<span className="flex-1" />
+							{status.state === "awaitingApproval" && (
+								<button
+									type="button"
+									data-testid="hook-approve"
+									onClick={() => status.command && setApproving({ hook, command: status.command })}
+									className="rounded-[var(--radius-sm)] bg-primary px-sm py-0.5 text-primary-fg text-xs hover:opacity-90"
+								>
+									Approve & Run
+								</button>
+							)}
+							{status.state === "failed" && (
+								<button
+									type="button"
+									data-testid="hook-retry"
+									aria-label={`Retry ${hook}`}
+									onClick={() => runNow(hook)}
+									className="flex items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-hint text-xs hover:bg-hover hover:text-text"
+								>
+									<RotateCcw className="size-3" /> Retry
+								</button>
+							)}
+						</div>
+						{output?.[hook]?.output ? (
+							<pre
+								data-testid="hook-output"
+								className="max-h-40 overflow-auto whitespace-pre-wrap bg-elevated px-sm py-xs font-[var(--font-mono)] text-hint text-xs"
+							>
+								{output[hook]?.output}
+							</pre>
+						) : null}
+					</li>
+				))}
+			</ul>
+
+			{approving && (
+				<HookApprovalDialog
+					open
+					onOpenChange={(o) => {
+						if (!o) setApproving(null);
+					}}
+					projectId={workspace.projectId}
+					workspaceId={workspaceId}
+					hook={approving.hook}
+					command={approving.command}
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/panels/HooksPanel.tsx
+++ b/apps/web/src/panels/HooksPanel.tsx
@@ -1,7 +1,7 @@
-import type { HookName, HookStatus } from "@thinkrail/contracts";
+import type { HookName, HookSource } from "@thinkrail/contracts";
 import { RotateCcw } from "lucide-react";
 import { useState } from "react";
-import { toast, useAppStore } from "../store";
+import { aggregateHookState, toast, useAppStore } from "../store";
 import { errorText } from "../transport";
 import { HookApprovalDialog } from "./HookApprovalDialog";
 import { HookStatusIcon } from "./HookStatusIcon";
@@ -14,9 +14,20 @@ const HOOK_LABEL: Record<HookName, string> = {
 	postMerge: "postMerge",
 };
 
+const SOURCE_LABEL: Record<HookSource, string> = {
+	shared: "Shared",
+	local: "Local",
+};
+
+/** Shared always before Local — the fixed run order `combineMode: "both"` uses. */
+const SOURCE_ORDER: readonly HookSource[] = ["shared", "local"];
+
 /**
  * Hooks for the active worktree: one row per declared lifecycle hook that has ever reported a status
- * (`Workspace.hookStatus`), each with its live output when present (`hookOutputByWorkspace`). `preMerge`/
+ * (`Workspace.hookStatus`), each with its live output when present (`hookOutputByWorkspace`). A hook's
+ * header shows the worst-of-both-tiers state (`aggregateHookState`); beneath it, one row per SOURCE
+ * (Shared/Local) that has actually reported a status shows that source's own state + command — a
+ * `combineMode` of `"both"` can have Shared and Local sitting at different states at once. `preMerge`/
  * `postMerge` never show up here in practice — nothing calls them yet — but the panel doesn't special-case
  * that away; an empty list is just an empty list.
  */
@@ -31,11 +42,11 @@ export function HooksPanel({ workspaceId }: { workspaceId: string }) {
 
 	if (!workspace) return <p className="px-sm py-xs text-xs text-hint">Loading…</p>;
 
-	const entries = (Object.entries(workspace.hookStatus ?? {}) as [HookName, HookStatus][]).sort(
-		([a], [b]) => a.localeCompare(b),
+	const hooks = (Object.keys(workspace.hookStatus ?? {}) as HookName[]).sort((a, b) =>
+		a.localeCompare(b),
 	);
 
-	if (entries.length === 0) {
+	if (hooks.length === 0) {
 		return (
 			<p data-testid="hooks-empty" className="px-sm py-xs text-xs text-hint">
 				No hooks declared for this workspace.
@@ -52,55 +63,87 @@ export function HooksPanel({ workspaceId }: { workspaceId: string }) {
 	return (
 		<div className="flex h-full min-h-0 flex-col overflow-auto">
 			<ul className="flex flex-col divide-y divide-border2">
-				{entries.map(([hook, status]) => (
-					<li key={hook} data-testid="hook-row" data-hook={hook} data-status={status.state}>
-						<div className="flex items-center gap-sm px-sm py-xs text-sm">
-							<HookStatusIcon state={status.state} />
-							<span className="font-medium text-text">{HOOK_LABEL[hook]}</span>
-							{status.state === "failed" && (
-								<span className="text-hint text-xs">exit {status.exitCode}</span>
-							)}
-							<span className="flex-1" />
-							{status.state === "awaitingApproval" && (
-								<button
-									type="button"
-									data-testid="hook-approve"
-									onClick={() => status.command && setApproving({ hook, command: status.command })}
-									className="rounded-[var(--radius-sm)] bg-primary px-sm py-0.5 text-primary-fg text-xs hover:opacity-90"
+				{hooks.map((hook) => {
+					const bySource = workspace.hookStatus?.[hook] ?? {};
+					const state = aggregateHookState(bySource);
+					if (!state) return null;
+					const sources = SOURCE_ORDER.filter((source) => bySource[source]);
+
+					return (
+						<li key={hook} data-testid="hook-row" data-hook={hook} data-status={state}>
+							<div className="flex items-center gap-sm px-sm py-xs text-sm">
+								<HookStatusIcon state={state} />
+								<span className="font-medium text-text">{HOOK_LABEL[hook]}</span>
+								<span className="flex-1" />
+								{state === "awaitingApproval" && (
+									<button
+										type="button"
+										data-testid="hook-approve"
+										onClick={() => {
+											const command = sources
+												.map((source) => bySource[source])
+												.find((s) => s?.state === "awaitingApproval")?.command;
+											if (command) setApproving({ hook, command });
+										}}
+										className="rounded-[var(--radius-sm)] bg-primary px-sm py-0.5 text-primary-fg text-xs hover:opacity-90"
+									>
+										Approve & Run
+									</button>
+								)}
+								{state === "failed" && (
+									<button
+										type="button"
+										data-testid="hook-retry"
+										aria-label={`Retry ${hook}`}
+										onClick={() => runNow(hook)}
+										className="flex items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-hint text-xs hover:bg-hover hover:text-text"
+									>
+										<RotateCcw className="size-3" /> Retry
+									</button>
+								)}
+							</div>
+							<ul className="flex flex-col gap-xs pb-xs pl-lg">
+								{sources.map((source) => {
+									const status = bySource[source];
+									if (!status) return null;
+									return (
+										<li
+											key={source}
+											data-testid={`hook-command-${source}`}
+											data-source={source}
+											data-status={status.state}
+											className="flex flex-col gap-0.5"
+										>
+											<div className="flex items-center gap-sm text-xs">
+												<HookStatusIcon state={status.state} />
+												<span className="text-hint">{SOURCE_LABEL[source]}</span>
+												{status.state === "failed" && (
+													<span className="text-hint">exit {status.exitCode}</span>
+												)}
+											</div>
+											{status.command && (
+												<code
+													data-testid="hook-command"
+													className="block whitespace-pre-wrap pl-lg font-[var(--font-mono)] text-hint text-xs"
+												>
+													{status.command}
+												</code>
+											)}
+										</li>
+									);
+								})}
+							</ul>
+							{output?.[hook]?.output ? (
+								<pre
+									data-testid="hook-output"
+									className="max-h-40 overflow-auto whitespace-pre-wrap bg-elevated px-sm py-xs font-[var(--font-mono)] text-hint text-xs"
 								>
-									Approve & Run
-								</button>
-							)}
-							{status.state === "failed" && (
-								<button
-									type="button"
-									data-testid="hook-retry"
-									aria-label={`Retry ${hook}`}
-									onClick={() => runNow(hook)}
-									className="flex items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-hint text-xs hover:bg-hover hover:text-text"
-								>
-									<RotateCcw className="size-3" /> Retry
-								</button>
-							)}
-						</div>
-						{status.command && (
-							<code
-								data-testid="hook-command"
-								className="block truncate px-sm pb-xs font-[var(--font-mono)] text-hint text-xs"
-							>
-								{status.command}
-							</code>
-						)}
-						{output?.[hook]?.output ? (
-							<pre
-								data-testid="hook-output"
-								className="max-h-40 overflow-auto whitespace-pre-wrap bg-elevated px-sm py-xs font-[var(--font-mono)] text-hint text-xs"
-							>
-								{output[hook]?.output}
-							</pre>
-						) : null}
-					</li>
-				))}
+									{output[hook]?.output}
+								</pre>
+							) : null}
+						</li>
+					);
+				})}
 			</ul>
 
 			{approving && (

--- a/apps/web/src/panels/HooksPanel.tsx
+++ b/apps/web/src/panels/HooksPanel.tsx
@@ -83,6 +83,14 @@ export function HooksPanel({ workspaceId }: { workspaceId: string }) {
 								</button>
 							)}
 						</div>
+						{status.command && (
+							<code
+								data-testid="hook-command"
+								className="block truncate px-sm pb-xs font-[var(--font-mono)] text-hint text-xs"
+							>
+								{status.command}
+							</code>
+						)}
 						{output?.[hook]?.output ? (
 							<pre
 								data-testid="hook-output"

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -75,11 +75,13 @@ export function NewWorkspaceDialog({
 	// The dialog content node — popovers portal into it so their lists stay scrollable under the Dialog's
 	// scroll lock (react-remove-scroll blocks wheel/trackpad on body-portaled content).
 	const [dialogEl, setDialogEl] = useState<HTMLElement | null>(null);
-	// The selected project's declared-hooks state, behind the Advanced disclosure: `null` means "not yet
-	// loaded" (or the fetch failed) — create() then omits `hookCombineMode` from the request rather than
-	// guessing, and the host resolves the real project default itself. `hasProjectHooks` gates whether the
-	// disclosure renders at all (hookless projects show nothing extra).
+	// The Advanced disclosure's hook-combine state. `hookCombineMode` is the user's EXPLICIT per-workspace
+	// choice: `null` = untouched (or not loaded / fetch failed) → create() omits it, so the workspace
+	// dynamically inherits the project's live committed default at every hook run (see Workspace.hookCombineMode).
+	// `projectDefaultMode` is only the value shown in the selector until the user picks. `hasProjectHooks`
+	// gates whether the disclosure renders at all (hookless projects show nothing extra).
 	const [hookCombineMode, setHookCombineMode] = useState<CombineMode | null>(null);
+	const [projectDefaultMode, setProjectDefaultMode] = useState<CombineMode>("both");
 	const [hasProjectHooks, setHasProjectHooks] = useState(false);
 	const [advancedOpen, setAdvancedOpen] = useState(false);
 
@@ -170,12 +172,13 @@ export function NewWorkspaceDialog({
 		if (!open) return;
 		let cancelled = false;
 		setHookCombineMode(null);
+		setProjectDefaultMode("both");
 		setHasProjectHooks(false);
 		setAdvancedOpen(false);
 		getProjectHooks(selectedProjectId)
 			.then((hooks) => {
 				if (cancelled) return;
-				setHookCombineMode(hooks.combineMode);
+				setProjectDefaultMode(hooks.combineMode);
 				setHasProjectHooks(
 					Object.keys(hooks.shared).length > 0 || Object.keys(hooks.local).length > 0,
 				);
@@ -310,7 +313,7 @@ export function NewWorkspaceDialog({
 				{hasProjectHooks ? (
 					<HookModeDisclosure
 						open={advancedOpen}
-						mode={hookCombineMode ?? "both"}
+						mode={hookCombineMode ?? projectDefaultMode}
 						onToggle={() => setAdvancedOpen((v) => !v)}
 						onSelect={setHookCombineMode}
 					/>

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -1,5 +1,11 @@
-import type { BranchList, ThinkingLevel, WireModel, Workspace } from "@thinkrail/contracts";
-import { Box, Check, ChevronDown, GitBranch, RefreshCw } from "lucide-react";
+import type {
+	BranchList,
+	CombineMode,
+	ThinkingLevel,
+	WireModel,
+	Workspace,
+} from "@thinkrail/contracts";
+import { Box, Check, ChevronDown, ChevronRight, GitBranch, RefreshCw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
 import { ThinkingSelector } from "@/chat/ThinkingSelector";
@@ -14,12 +20,22 @@ import {
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib";
 import { toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
+import { getProjectHooks } from "./hooksActions";
 
 /** A shared pill-trigger look for the project + branch pickers (mockup `.pill`). */
 const PILL =
 	"flex h-8 min-w-0 items-center gap-sm rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-sm text-sm text-text outline-none transition-colors hover:bg-hover focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-[var(--primary-60)] data-[open=true]:bg-hover";
+
+/** The per-workspace hook-combine-mode choices offered by `HookModeDisclosure` below — same three
+ * options/labels as `ProjectHooksDialog`'s project-level combine-mode control. */
+const HOOK_MODES: { value: CombineMode; label: string }[] = [
+	{ value: "both", label: "Both" },
+	{ value: "shared", label: "Shared only" },
+	{ value: "local", label: "Local only" },
+];
 
 /**
  * The New-Workspace "create + kick-off" surface: pick a base branch, say what to work on, pick a
@@ -59,6 +75,13 @@ export function NewWorkspaceDialog({
 	// The dialog content node — popovers portal into it so their lists stay scrollable under the Dialog's
 	// scroll lock (react-remove-scroll blocks wheel/trackpad on body-portaled content).
 	const [dialogEl, setDialogEl] = useState<HTMLElement | null>(null);
+	// The selected project's declared-hooks state, behind the Advanced disclosure: `null` means "not yet
+	// loaded" (or the fetch failed) — create() then omits `hookCombineMode` from the request rather than
+	// guessing, and the host resolves the real project default itself. `hasProjectHooks` gates whether the
+	// disclosure renders at all (hookless projects show nothing extra).
+	const [hookCombineMode, setHookCombineMode] = useState<CombineMode | null>(null);
+	const [hasProjectHooks, setHasProjectHooks] = useState(false);
+	const [advancedOpen, setAdvancedOpen] = useState(false);
 
 	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on and any
 	// seed prompt (empty by default).
@@ -139,6 +162,33 @@ export function NewWorkspaceDialog({
 		};
 	}, [open, selectedProjectId]);
 
+	// The project's declared hooks, refetched per selected project (like the branch list above) so
+	// switching projects in the picker keeps the Advanced selector's default/visibility in sync. Reset up
+	// front so a project switch can't show the previous project's stale mode/visibility while the new fetch
+	// is in flight.
+	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
+		setHookCombineMode(null);
+		setHasProjectHooks(false);
+		setAdvancedOpen(false);
+		getProjectHooks(selectedProjectId)
+			.then((hooks) => {
+				if (cancelled) return;
+				setHookCombineMode(hooks.combineMode);
+				setHasProjectHooks(
+					Object.keys(hooks.shared).length > 0 || Object.keys(hooks.local).length > 0,
+				);
+			})
+			.catch(() => {
+				// Leave hasProjectHooks false (selector hidden) and hookCombineMode null (create omits it) —
+				// the same safe fallback a genuinely hookless project gets.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, selectedProjectId]);
+
 	const refreshBranches = async () => {
 		setRefreshing(true);
 		try {
@@ -161,6 +211,7 @@ export function NewWorkspaceDialog({
 			workspace = await getTransport().request("workspace.create", {
 				projectId: selectedProjectId,
 				...(baseRef ? { baseRef } : {}),
+				...(hookCombineMode ? { hookCombineMode } : {}),
 			});
 		} catch (err) {
 			// Worktree creation failed (bad ref, etc.) — keep the dialog open so the user can retry/adjust,
@@ -255,6 +306,15 @@ export function NewWorkspaceDialog({
 						}
 					}}
 				/>
+
+				{hasProjectHooks ? (
+					<HookModeDisclosure
+						open={advancedOpen}
+						mode={hookCombineMode ?? "both"}
+						onToggle={() => setAdvancedOpen((v) => !v)}
+						onSelect={setHookCombineMode}
+					/>
+				) : null}
 
 				{/* controls-bottom: model + effort (left), Create (right) */}
 				<div className="flex flex-wrap items-center gap-sm">
@@ -426,5 +486,71 @@ function BranchPicker({
 				</Command>
 			</PopoverContent>
 		</Popover>
+	);
+}
+
+/**
+ * The per-workspace hook-mode override, tucked behind an "Advanced" disclosure so it never clutters the
+ * default create flow — the parent renders this at all only when the selected project declares at least
+ * one Shared/Local hook (`hasProjectHooks`). `mode` defaults to the project's own `combineMode`; picking a
+ * different one here threads through `create()` as `Workspace.hookCombineMode`, which then governs that
+ * one workspace's hook events for its whole life. Same three choices/labels as `ProjectHooksDialog`'s
+ * project-level combine-mode control, kept as a small local toggle here rather than a shared import — the
+ * two controls serve different scopes (project default vs. one-off per-workspace override).
+ */
+function HookModeDisclosure({
+	open,
+	mode,
+	onToggle,
+	onSelect,
+}: {
+	open: boolean;
+	mode: CombineMode;
+	onToggle: () => void;
+	onSelect: (mode: CombineMode) => void;
+}) {
+	return (
+		<div className="flex flex-col gap-xs">
+			<button
+				type="button"
+				data-testid="ws-advanced-toggle"
+				aria-expanded={open}
+				onClick={onToggle}
+				className="flex items-center gap-xs self-start rounded-[var(--radius-sm)] text-hint text-xs outline-none transition-colors hover:text-text focus-visible:ring-2 focus-visible:ring-primary"
+			>
+				{open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+				Advanced
+			</button>
+			{open ? (
+				<div className="flex flex-col gap-xs pl-md">
+					<span className="font-medium text-text text-xs">Hook mode</span>
+					<div
+						data-testid="ws-hook-mode"
+						role="toolbar"
+						aria-label="Workspace hook mode"
+						className="inline-flex items-center gap-xs self-start rounded-[var(--radius-md)] border border-border2 bg-bg-dark p-0.5"
+					>
+						{HOOK_MODES.map(({ value, label }) => (
+							<button
+								key={value}
+								type="button"
+								data-testid={`ws-hook-mode-${value}`}
+								data-active={mode === value}
+								aria-pressed={mode === value}
+								onClick={() => onSelect(value)}
+								className={cn(
+									"rounded-[var(--radius-sm)] px-sm py-0.5 text-xs transition-colors",
+									mode === value
+										? "bg-elevated text-text"
+										: "text-hint hover:bg-hover hover:text-text",
+								)}
+							>
+								{label}
+							</button>
+						))}
+					</div>
+				</div>
+			) : null}
+		</div>
 	);
 }

--- a/apps/web/src/panels/ProjectHooksDialog.tsx
+++ b/apps/web/src/panels/ProjectHooksDialog.tsx
@@ -1,10 +1,13 @@
-import type { HookName } from "@thinkrail/contracts";
+import type { CombineMode, HookName, HookSource, HookValue } from "@thinkrail/contracts";
+import { TriangleAlert, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib";
 import { toast } from "../store";
 import { errorText } from "../transport";
-import { approveProjectHook, getProjectHooks, saveProjectHooks } from "./hooksActions";
+import { getProjectHooks, saveProjectHooks } from "./hooksActions";
 
 const HOOKS: { name: HookName; label: string; description: string }[] = [
 	{
@@ -29,23 +32,83 @@ const HOOKS: { name: HookName; label: string; description: string }[] = [
 	},
 ];
 
-type FieldState = {
-	command: string;
-	overrideEnabled: boolean;
-	override: string;
+const COMBINE_MODES: { value: CombineMode; label: string }[] = [
+	{ value: "both", label: "Both" },
+	{ value: "shared", label: "Shared only" },
+	{ value: "local", label: "Local only" },
+];
+
+const COMBINE_MODE_HINT: Record<CombineMode, string> = {
+	both: "Runs Shared, then Local, for every event.",
+	shared: "Runs Shared only — Local hooks are ignored.",
+	local: "Runs Local only — Shared hooks are ignored.",
+};
+
+const SOURCE_LABEL: Record<HookSource, string> = { shared: "Shared", local: "Local" };
+
+const INLINE_PLACEHOLDER = "npm install";
+const SCRIPT_PLACEHOLDER = ".thinkrail/hooks/setup.sh";
+
+const FIELD_CLASS =
+	"w-full rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-sm py-xs font-[var(--font-mono)] text-xs text-text outline-none transition-colors placeholder:text-hint focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-[var(--primary-20)] disabled:opacity-50";
+
+type SourceFieldState = {
+	mode: "inline" | "script";
+	value: string;
 	approved: boolean;
 };
 
-function emptyField(): FieldState {
-	return { command: "", overrideEnabled: false, override: "", approved: false };
+type FieldsState = Record<HookName, Record<HookSource, SourceFieldState>>;
+
+function emptySourceField(): SourceFieldState {
+	return { mode: "inline", value: "", approved: false };
+}
+
+function emptyFields(): FieldsState {
+	const fields = {} as FieldsState;
+	for (const { name } of HOOKS)
+		fields[name] = { shared: emptySourceField(), local: emptySourceField() };
+	return fields;
+}
+
+function sourceFieldFrom(value: HookValue | undefined, approved: boolean): SourceFieldState {
+	if (value == null) return { mode: "inline", value: "", approved };
+	if (typeof value === "string") return { mode: "inline", value, approved };
+	if ("script" in value) return { mode: "script", value: value.script, approved };
+	return { mode: "inline", value: value.command, approved };
+}
+
+function fieldsFromPayload(payload: {
+	shared: Partial<Record<HookName, HookValue>>;
+	local: Partial<Record<HookName, HookValue>>;
+	approved: Partial<Record<HookName, Partial<Record<HookSource, boolean>>>>;
+}): FieldsState {
+	const fields = {} as FieldsState;
+	for (const { name } of HOOKS) {
+		fields[name] = {
+			shared: sourceFieldFrom(payload.shared[name], payload.approved[name]?.shared ?? false),
+			local: sourceFieldFrom(payload.local[name], payload.approved[name]?.local ?? false),
+		};
+	}
+	return fields;
+}
+
+/** Empty/blank → absent (lets a save clear a previously-set value); Script mode → `{ script }`; else the
+ * trimmed inline string. */
+function toHookValue(field: SourceFieldState): HookValue | undefined {
+	const trimmed = field.value.trim();
+	if (!trimmed) return undefined;
+	return field.mode === "script" ? { script: trimmed } : trimmed;
 }
 
 /**
- * The project-level hooks config surface — one row per `HookName`, reachable with zero workspaces (this
- * dialog's own `project.hooks.get`/`.save` calls need only a `projectId`). Saving writes + commits
- * `.thinkrail/hooks.json` in the project's root checkout and the host-local override map; it never
- * auto-approves — trusting a command to actually run is a separate, explicit click here (or later, via the
- * reactive per-workspace approval dialog).
+ * The project-level hooks config surface: a combine-mode control plus, per `HookName`, a Shared and a
+ * Local sub-field (each an Inline-command/Script-path toggle) — reachable with zero workspaces (this
+ * dialog's own `project.hooks.get`/`.save` calls need only a `projectId`). Saving writes + commits Shared
+ * (skipped entirely when the project gitignores `.thinkrail/`, never force-committed) and persists Local,
+ * then **approves** everything it wrote on this machine — there's no separate Approve step here; the
+ * reactive per-workspace `HookApprovalDialog` stays for commands the user didn't just author themselves
+ * (e.g. a teammate's committed Shared hook pulled fresh).
  */
 export function ProjectHooksDialog({
 	open,
@@ -58,12 +121,9 @@ export function ProjectHooksDialog({
 	projectName: string;
 	onOpenChange: (open: boolean) => void;
 }) {
-	const [fields, setFields] = useState<Record<HookName, FieldState>>(() => ({
-		onCreate: emptyField(),
-		onDelete: emptyField(),
-		preMerge: emptyField(),
-		postMerge: emptyField(),
-	}));
+	const [combineMode, setCombineMode] = useState<CombineMode>("both");
+	const [sharedCommittable, setSharedCommittable] = useState(true);
+	const [fields, setFields] = useState<FieldsState>(emptyFields);
 	const [loading, setLoading] = useState(false);
 	const [saving, setSaving] = useState(false);
 
@@ -71,66 +131,48 @@ export function ProjectHooksDialog({
 		if (!open) return;
 		setLoading(true);
 		getProjectHooks(projectId)
-			.then(({ committed, overrides, approved }) => {
-				setFields({
-					onCreate: fieldFrom("onCreate", committed, overrides, approved),
-					onDelete: fieldFrom("onDelete", committed, overrides, approved),
-					preMerge: fieldFrom("preMerge", committed, overrides, approved),
-					postMerge: fieldFrom("postMerge", committed, overrides, approved),
-				});
+			.then((payload) => {
+				setCombineMode(payload.combineMode);
+				setSharedCommittable(payload.sharedCommittable);
+				setFields(fieldsFromPayload(payload));
 			})
 			.catch((err) => toast.error(errorText(err, "Failed to load hooks")))
 			.finally(() => setLoading(false));
 	}, [open, projectId]);
 
-	const setField = (hook: HookName, patch: Partial<FieldState>) =>
-		setFields((prev) => ({ ...prev, [hook]: { ...prev[hook], ...patch } }));
+	const formDisabled = loading || saving;
 
-	const resolvedCommand = (hook: HookName): string => {
-		const f = fields[hook];
-		return f.overrideEnabled && f.override.trim() ? f.override.trim() : f.command.trim();
-	};
+	const setSourceField = (hook: HookName, source: HookSource, patch: Partial<SourceFieldState>) =>
+		setFields((prev) => ({
+			...prev,
+			[hook]: { ...prev[hook], [source]: { ...prev[hook][source], ...patch } },
+		}));
 
 	const save = async () => {
 		setSaving(true);
 		try {
-			const committed: Partial<Record<HookName, string>> = {};
-			const overrides: Partial<Record<HookName, string>> = {};
-			for (const { name } of HOOKS) {
-				const f = fields[name];
-				if (f.command.trim()) committed[name] = f.command.trim();
-				if (f.overrideEnabled && f.override.trim()) overrides[name] = f.override.trim();
+			const shared: Partial<Record<HookName, HookValue>> = {};
+			// Never attempt to write Shared when it can't be committed — the Shared column is disabled in
+			// that case, but its loaded state may still carry stale pre-gitignore content, which would
+			// otherwise reach the server and trip its "can't commit" guard for a column the user never
+			// touched.
+			if (sharedCommittable) {
+				for (const { name } of HOOKS) {
+					const value = toHookValue(fields[name].shared);
+					if (value !== undefined) shared[name] = value;
+				}
 			}
-			await saveProjectHooks(projectId, committed, overrides);
+			const local: Partial<Record<HookName, HookValue>> = {};
+			for (const { name } of HOOKS) {
+				const value = toHookValue(fields[name].local);
+				if (value !== undefined) local[name] = value;
+			}
+			await saveProjectHooks(projectId, { combineMode, shared, local });
 			const refreshed = await getProjectHooks(projectId);
-			setFields({
-				onCreate: fieldFrom(
-					"onCreate",
-					refreshed.committed,
-					refreshed.overrides,
-					refreshed.approved,
-				),
-				onDelete: fieldFrom(
-					"onDelete",
-					refreshed.committed,
-					refreshed.overrides,
-					refreshed.approved,
-				),
-				preMerge: fieldFrom(
-					"preMerge",
-					refreshed.committed,
-					refreshed.overrides,
-					refreshed.approved,
-				),
-				postMerge: fieldFrom(
-					"postMerge",
-					refreshed.committed,
-					refreshed.overrides,
-					refreshed.approved,
-				),
-			});
+			setCombineMode(refreshed.combineMode);
+			setSharedCommittable(refreshed.sharedCommittable);
+			setFields(fieldsFromPayload(refreshed));
 			toast.success("Hooks saved");
-			onOpenChange(false);
 		} catch (err) {
 			toast.error(errorText(err, "Failed to save hooks"));
 		} finally {
@@ -138,97 +180,64 @@ export function ProjectHooksDialog({
 		}
 	};
 
-	const approve = async (hook: HookName) => {
-		const command = resolvedCommand(hook);
-		if (!command) return;
-		try {
-			await approveProjectHook(projectId, hook, command);
-			setField(hook, { approved: true });
-		} catch (err) {
-			toast.error(errorText(err, `Failed to approve ${hook}`));
-		}
-	};
-
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent data-testid="project-hooks-dialog" className="max-w-[520px] gap-md">
-				<DialogHeader>
+			<DialogContent
+				data-testid="project-hooks-dialog"
+				className="flex max-h-[85vh] w-full max-w-[42rem] flex-col gap-0 overflow-hidden p-0"
+			>
+				<DialogHeader className="gap-xs border-border2 border-b px-lg py-md">
 					<DialogTitle>Hooks — {projectName}</DialogTitle>
+					<p className="text-hint text-xs">
+						Shared hooks are committed to <code>.thinkrail/hooks.json</code> and shared with your
+						team; Local hooks stay on this machine only. Saving approves everything below on this
+						machine — a new workspace runs it right away.
+					</p>
 				</DialogHeader>
-				<p className="text-hint text-xs">
-					Saved commands apply to workspaces created from now on — an existing workspace keeps
-					running whatever was committed when it was created. To change what runs on this machine
-					right now, use an override instead.
-				</p>
 				{loading ? (
-					<p className="text-hint text-sm">Loading…</p>
+					<p className="px-lg py-md text-hint text-sm">Loading…</p>
 				) : (
-					<div className="flex flex-col gap-lg">
-						{HOOKS.map(({ name, label, description }) => {
-							const f = fields[name];
-							const command = resolvedCommand(name);
-							return (
-								<div key={name} className="flex flex-col gap-xs" data-testid={`hook-field-${name}`}>
-									<label className="font-medium text-sm text-text" htmlFor={`hook-${name}`}>
-										{label}
-									</label>
-									<p className="text-hint text-xs">{description}</p>
-									<input
-										id={`hook-${name}`}
-										data-testid={`hook-command-${name}`}
-										value={f.command}
-										onChange={(e) => setField(name, { command: e.target.value })}
-										placeholder="e.g. npm install"
-										className="rounded-[var(--radius-md)] border border-border2 bg-bg px-sm py-xs font-[var(--font-mono)] text-sm text-text outline-none placeholder:text-hint focus:border-primary"
-									/>
-									<label className="flex items-center gap-xs text-hint text-xs">
-										<input
-											type="checkbox"
-											data-testid={`hook-override-toggle-${name}`}
-											checked={f.overrideEnabled}
-											onChange={(e) => setField(name, { overrideEnabled: e.target.checked })}
-										/>
-										Override on this machine
-									</label>
-									{f.overrideEnabled && (
-										<input
-											data-testid={`hook-override-${name}`}
-											value={f.override}
-											onChange={(e) => setField(name, { override: e.target.value })}
-											placeholder="Never committed — just for you"
-											className="rounded-[var(--radius-md)] border border-border2 bg-bg px-sm py-xs font-[var(--font-mono)] text-sm text-text outline-none placeholder:text-hint focus:border-primary"
-										/>
-									)}
-									{command && (
-										<div className="flex items-center gap-sm text-xs">
-											<span
-												data-testid={`hook-approved-${name}`}
-												className={f.approved ? "text-green" : "text-hint"}
-											>
-												{f.approved ? "Approved" : "Not yet approved"}
-											</span>
-											{!f.approved && (
-												<button
-													type="button"
-													data-testid={`hook-approve-${name}`}
-													onClick={() => void approve(name)}
-													className="text-primary hover:underline"
-												>
-													Approve
-												</button>
-											)}
-										</div>
-									)}
-								</div>
-							);
-						})}
+					<div className="flex min-h-0 flex-1 flex-col gap-lg overflow-y-auto px-lg py-md">
+						<CombineModeControl
+							value={combineMode}
+							onChange={setCombineMode}
+							disabled={formDisabled}
+						/>
+						{!sharedCommittable && (
+							<div
+								data-testid="shared-uncommittable-note"
+								className="flex items-start gap-sm rounded-[var(--radius-md)] border border-border2 border-l-[3px] border-l-[var(--gold)] bg-[var(--gold-tint)] px-sm py-xs text-xs text-text"
+							>
+								<TriangleAlert className="mt-0.5 size-3.5 shrink-0 text-gold" />
+								<span>
+									This project ignores .thinkrail/ — shared hooks can't be committed here. Use a
+									Local hook instead.
+								</span>
+							</div>
+						)}
+						{HOOKS.map(({ name, label, description }) => (
+							<HookRow
+								key={name}
+								hook={name}
+								label={label}
+								description={description}
+								shared={fields[name].shared}
+								local={fields[name].local}
+								sharedDisabled={!sharedCommittable || formDisabled}
+								localDisabled={formDisabled}
+								onChangeShared={(patch) => setSourceField(name, "shared", patch)}
+								onChangeLocal={(patch) => setSourceField(name, "local", patch)}
+								onRemoveShared={() => setSourceField(name, "shared", { value: "" })}
+								onRemoveLocal={() => setSourceField(name, "local", { value: "" })}
+							/>
+						))}
 					</div>
 				)}
-				<div className="flex justify-end gap-sm">
+				<div className="flex justify-end gap-sm border-border2 border-t p-lg pt-md">
 					<Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
 						Cancel
 					</Button>
-					<Button data-testid="save-hooks" onClick={() => void save()} disabled={loading || saving}>
+					<Button data-testid="save-hooks" onClick={() => void save()} disabled={formDisabled}>
 						Save
 					</Button>
 				</div>
@@ -237,16 +246,211 @@ export function ProjectHooksDialog({
 	);
 }
 
-function fieldFrom(
-	hook: HookName,
-	committed: Partial<Record<HookName, string>>,
-	overrides: Partial<Record<HookName, string>>,
-	approved: Partial<Record<HookName, boolean>>,
-): FieldState {
-	return {
-		command: committed[hook] ?? "",
-		overrideEnabled: overrides[hook] != null,
-		override: overrides[hook] ?? "",
-		approved: approved[hook] ?? false,
-	};
+function CombineModeControl({
+	value,
+	onChange,
+	disabled,
+}: {
+	value: CombineMode;
+	onChange: (mode: CombineMode) => void;
+	disabled: boolean;
+}) {
+	return (
+		<div className="flex flex-col gap-xs">
+			<span className="font-medium text-sm text-text">Combine mode</span>
+			<div
+				data-testid="hook-combine-mode"
+				role="toolbar"
+				aria-label="Combine mode"
+				className="inline-flex items-center gap-xs self-start rounded-[var(--radius-md)] border border-border2 bg-bg-dark p-0.5"
+			>
+				{COMBINE_MODES.map(({ value: mode, label }) => (
+					<ToggleSegment
+						key={mode}
+						testid={`hook-combine-mode-${mode}`}
+						label={label}
+						active={value === mode}
+						disabled={disabled}
+						onClick={() => onChange(mode)}
+					/>
+				))}
+			</div>
+			<p className="text-hint text-xs">{COMBINE_MODE_HINT[value]}</p>
+		</div>
+	);
+}
+
+function HookRow({
+	hook,
+	label,
+	description,
+	shared,
+	local,
+	sharedDisabled,
+	localDisabled,
+	onChangeShared,
+	onChangeLocal,
+	onRemoveShared,
+	onRemoveLocal,
+}: {
+	hook: HookName;
+	label: string;
+	description: string;
+	shared: SourceFieldState;
+	local: SourceFieldState;
+	sharedDisabled: boolean;
+	localDisabled: boolean;
+	onChangeShared: (patch: Partial<SourceFieldState>) => void;
+	onChangeLocal: (patch: Partial<SourceFieldState>) => void;
+	onRemoveShared: () => void;
+	onRemoveLocal: () => void;
+}) {
+	return (
+		<div className="flex flex-col gap-sm">
+			<div>
+				<h3 className="font-medium text-sm text-text">{label}</h3>
+				<p className="text-hint text-xs">{description}</p>
+			</div>
+			<div className="grid grid-cols-1 gap-sm sm:grid-cols-2">
+				<SourceField
+					hook={hook}
+					source="shared"
+					field={shared}
+					disabled={sharedDisabled}
+					onChange={onChangeShared}
+					onRemove={onRemoveShared}
+				/>
+				<SourceField
+					hook={hook}
+					source="local"
+					field={local}
+					disabled={localDisabled}
+					onChange={onChangeLocal}
+					onRemove={onRemoveLocal}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function SourceField({
+	hook,
+	source,
+	field,
+	disabled,
+	onChange,
+	onRemove,
+}: {
+	hook: HookName;
+	source: HookSource;
+	field: SourceFieldState;
+	disabled: boolean;
+	onChange: (patch: Partial<SourceFieldState>) => void;
+	onRemove: () => void;
+}) {
+	const hasValue = field.value.trim().length > 0;
+	return (
+		<div
+			className={cn(
+				"flex flex-col gap-xs rounded-[var(--radius-md)] border border-border2 bg-bg-dark p-sm",
+				disabled && "opacity-60",
+			)}
+		>
+			<div className="flex items-center justify-between gap-sm">
+				<span className="font-medium text-hint text-xs uppercase tracking-wide">
+					{SOURCE_LABEL[source]}
+				</span>
+				<div
+					data-testid={`hook-${source}-mode-${hook}`}
+					role="toolbar"
+					aria-label={`${SOURCE_LABEL[source]} ${hook} value type`}
+					className="flex items-center gap-xs"
+				>
+					<ToggleSegment
+						testid={`hook-${source}-mode-${hook}-inline`}
+						label="Inline"
+						active={field.mode === "inline"}
+						disabled={disabled}
+						onClick={() => onChange({ mode: "inline" })}
+					/>
+					<ToggleSegment
+						testid={`hook-${source}-mode-${hook}-script`}
+						label="Script"
+						active={field.mode === "script"}
+						disabled={disabled}
+						onClick={() => onChange({ mode: "script" })}
+					/>
+				</div>
+			</div>
+			{field.mode === "inline" ? (
+				<Textarea
+					data-testid={`hook-${source}-${hook}`}
+					value={field.value}
+					onChange={(e) => onChange({ value: e.target.value })}
+					disabled={disabled}
+					placeholder={INLINE_PLACEHOLDER}
+					rows={3}
+					className="whitespace-pre-wrap font-[var(--font-mono)] text-xs"
+				/>
+			) : (
+				<input
+					data-testid={`hook-${source}-${hook}`}
+					value={field.value}
+					onChange={(e) => onChange({ value: e.target.value })}
+					disabled={disabled}
+					placeholder={SCRIPT_PLACEHOLDER}
+					className={FIELD_CLASS}
+				/>
+			)}
+			<div className="flex items-center justify-between gap-sm text-xs">
+				<span
+					data-testid={`hook-approved-${source}-${hook}`}
+					className={field.approved ? "text-green" : "text-hint"}
+				>
+					{field.approved ? "Approved" : "Not yet approved"}
+				</span>
+				<button
+					type="button"
+					data-testid={`hook-${source}-remove-${hook}`}
+					aria-label={`Remove ${SOURCE_LABEL[source]} ${hook}`}
+					onClick={onRemove}
+					disabled={disabled || !hasValue}
+					className="rounded-[var(--radius-sm)] p-0.5 text-hint outline-none transition-colors hover:bg-hover hover:text-text focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-40"
+				>
+					<X className="size-3.5" />
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function ToggleSegment({
+	testid,
+	label,
+	active,
+	disabled,
+	onClick,
+}: {
+	testid: string;
+	label: string;
+	active: boolean;
+	disabled?: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			data-testid={testid}
+			data-active={active}
+			aria-pressed={active}
+			disabled={disabled}
+			onClick={onClick}
+			className={cn(
+				"rounded-[var(--radius-sm)] px-sm py-0.5 text-xs transition-colors disabled:pointer-events-none disabled:opacity-50",
+				active ? "bg-elevated text-text" : "text-hint hover:bg-hover hover:text-text",
+			)}
+		>
+			{label}
+		</button>
+	);
 }

--- a/apps/web/src/panels/ProjectHooksDialog.tsx
+++ b/apps/web/src/panels/ProjectHooksDialog.tsx
@@ -1,0 +1,247 @@
+import type { HookName } from "@thinkrail/contracts";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { toast } from "../store";
+import { errorText } from "../transport";
+import { approveProjectHook, getProjectHooks, saveProjectHooks } from "./hooksActions";
+
+const HOOKS: { name: HookName; label: string; description: string }[] = [
+	{
+		name: "onCreate",
+		label: "onCreate",
+		description: "Runs once, right after a workspace is created.",
+	},
+	{
+		name: "onDelete",
+		label: "onDelete",
+		description: "Runs before a workspace's worktree is removed.",
+	},
+	{
+		name: "preMerge",
+		label: "preMerge",
+		description: "Runs before a merge; a non-zero exit blocks it. (No merge flow exists yet.)",
+	},
+	{
+		name: "postMerge",
+		label: "postMerge",
+		description: "Runs in the background after a successful merge. (No merge flow exists yet.)",
+	},
+];
+
+type FieldState = {
+	command: string;
+	overrideEnabled: boolean;
+	override: string;
+	approved: boolean;
+};
+
+function emptyField(): FieldState {
+	return { command: "", overrideEnabled: false, override: "", approved: false };
+}
+
+/**
+ * The project-level hooks config surface — one row per `HookName`, reachable with zero workspaces (this
+ * dialog's own `project.hooks.get`/`.save` calls need only a `projectId`). Saving writes + commits
+ * `.thinkrail/hooks.json` in the project's root checkout and the host-local override map; it never
+ * auto-approves — trusting a command to actually run is a separate, explicit click here (or later, via the
+ * reactive per-workspace approval dialog).
+ */
+export function ProjectHooksDialog({
+	open,
+	projectId,
+	projectName,
+	onOpenChange,
+}: {
+	open: boolean;
+	projectId: string;
+	projectName: string;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const [fields, setFields] = useState<Record<HookName, FieldState>>(() => ({
+		onCreate: emptyField(),
+		onDelete: emptyField(),
+		preMerge: emptyField(),
+		postMerge: emptyField(),
+	}));
+	const [loading, setLoading] = useState(false);
+	const [saving, setSaving] = useState(false);
+
+	useEffect(() => {
+		if (!open) return;
+		setLoading(true);
+		getProjectHooks(projectId)
+			.then(({ committed, overrides, approved }) => {
+				setFields({
+					onCreate: fieldFrom("onCreate", committed, overrides, approved),
+					onDelete: fieldFrom("onDelete", committed, overrides, approved),
+					preMerge: fieldFrom("preMerge", committed, overrides, approved),
+					postMerge: fieldFrom("postMerge", committed, overrides, approved),
+				});
+			})
+			.catch((err) => toast.error(errorText(err, "Failed to load hooks")))
+			.finally(() => setLoading(false));
+	}, [open, projectId]);
+
+	const setField = (hook: HookName, patch: Partial<FieldState>) =>
+		setFields((prev) => ({ ...prev, [hook]: { ...prev[hook], ...patch } }));
+
+	const resolvedCommand = (hook: HookName): string => {
+		const f = fields[hook];
+		return f.overrideEnabled && f.override.trim() ? f.override.trim() : f.command.trim();
+	};
+
+	const save = async () => {
+		setSaving(true);
+		try {
+			const committed: Partial<Record<HookName, string>> = {};
+			const overrides: Partial<Record<HookName, string>> = {};
+			for (const { name } of HOOKS) {
+				const f = fields[name];
+				if (f.command.trim()) committed[name] = f.command.trim();
+				if (f.overrideEnabled && f.override.trim()) overrides[name] = f.override.trim();
+			}
+			await saveProjectHooks(projectId, committed, overrides);
+			const refreshed = await getProjectHooks(projectId);
+			setFields({
+				onCreate: fieldFrom(
+					"onCreate",
+					refreshed.committed,
+					refreshed.overrides,
+					refreshed.approved,
+				),
+				onDelete: fieldFrom(
+					"onDelete",
+					refreshed.committed,
+					refreshed.overrides,
+					refreshed.approved,
+				),
+				preMerge: fieldFrom(
+					"preMerge",
+					refreshed.committed,
+					refreshed.overrides,
+					refreshed.approved,
+				),
+				postMerge: fieldFrom(
+					"postMerge",
+					refreshed.committed,
+					refreshed.overrides,
+					refreshed.approved,
+				),
+			});
+			toast.success("Hooks saved");
+			onOpenChange(false);
+		} catch (err) {
+			toast.error(errorText(err, "Failed to save hooks"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const approve = async (hook: HookName) => {
+		const command = resolvedCommand(hook);
+		if (!command) return;
+		try {
+			await approveProjectHook(projectId, hook, command);
+			setField(hook, { approved: true });
+		} catch (err) {
+			toast.error(errorText(err, `Failed to approve ${hook}`));
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-testid="project-hooks-dialog" className="max-w-[520px] gap-md">
+				<DialogHeader>
+					<DialogTitle>Hooks — {projectName}</DialogTitle>
+				</DialogHeader>
+				{loading ? (
+					<p className="text-hint text-sm">Loading…</p>
+				) : (
+					<div className="flex flex-col gap-lg">
+						{HOOKS.map(({ name, label, description }) => {
+							const f = fields[name];
+							const command = resolvedCommand(name);
+							return (
+								<div key={name} className="flex flex-col gap-xs" data-testid={`hook-field-${name}`}>
+									<label className="font-medium text-sm text-text" htmlFor={`hook-${name}`}>
+										{label}
+									</label>
+									<p className="text-hint text-xs">{description}</p>
+									<input
+										id={`hook-${name}`}
+										data-testid={`hook-command-${name}`}
+										value={f.command}
+										onChange={(e) => setField(name, { command: e.target.value })}
+										placeholder="e.g. npm install"
+										className="rounded-[var(--radius-md)] border border-border2 bg-bg px-sm py-xs font-[var(--font-mono)] text-sm text-text outline-none placeholder:text-hint focus:border-primary"
+									/>
+									<label className="flex items-center gap-xs text-hint text-xs">
+										<input
+											type="checkbox"
+											data-testid={`hook-override-toggle-${name}`}
+											checked={f.overrideEnabled}
+											onChange={(e) => setField(name, { overrideEnabled: e.target.checked })}
+										/>
+										Override on this machine
+									</label>
+									{f.overrideEnabled && (
+										<input
+											data-testid={`hook-override-${name}`}
+											value={f.override}
+											onChange={(e) => setField(name, { override: e.target.value })}
+											placeholder="Never committed — just for you"
+											className="rounded-[var(--radius-md)] border border-border2 bg-bg px-sm py-xs font-[var(--font-mono)] text-sm text-text outline-none placeholder:text-hint focus:border-primary"
+										/>
+									)}
+									{command && (
+										<div className="flex items-center gap-sm text-xs">
+											<span
+												data-testid={`hook-approved-${name}`}
+												className={f.approved ? "text-green" : "text-hint"}
+											>
+												{f.approved ? "Approved" : "Not yet approved"}
+											</span>
+											{!f.approved && (
+												<button
+													type="button"
+													data-testid={`hook-approve-${name}`}
+													onClick={() => void approve(name)}
+													className="text-primary hover:underline"
+												>
+													Approve
+												</button>
+											)}
+										</div>
+									)}
+								</div>
+							);
+						})}
+					</div>
+				)}
+				<div className="flex justify-end gap-sm">
+					<Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+						Cancel
+					</Button>
+					<Button data-testid="save-hooks" onClick={() => void save()} disabled={loading || saving}>
+						Save
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function fieldFrom(
+	hook: HookName,
+	committed: Partial<Record<HookName, string>>,
+	overrides: Partial<Record<HookName, string>>,
+	approved: Partial<Record<HookName, boolean>>,
+): FieldState {
+	return {
+		command: committed[hook] ?? "",
+		overrideEnabled: overrides[hook] != null,
+		override: overrides[hook] ?? "",
+		approved: approved[hook] ?? false,
+	};
+}

--- a/apps/web/src/panels/ProjectHooksDialog.tsx
+++ b/apps/web/src/panels/ProjectHooksDialog.tsx
@@ -155,6 +155,11 @@ export function ProjectHooksDialog({
 				<DialogHeader>
 					<DialogTitle>Hooks — {projectName}</DialogTitle>
 				</DialogHeader>
+				<p className="text-hint text-xs">
+					Saved commands apply to workspaces created from now on — an existing workspace keeps
+					running whatever was committed when it was created. To change what runs on this machine
+					right now, use an override instead.
+				</p>
 				{loading ? (
 					<p className="text-hint text-sm">Loading…</p>
 				) : (

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -1,5 +1,5 @@
 import type { HookName, HookStatus, Project, Workspace } from "@thinkrail/contracts";
-import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Settings, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
@@ -10,6 +10,7 @@ import { ConfirmPopover } from "./ConfirmPopover";
 import { HookApprovalDialog } from "./HookApprovalDialog";
 import { HookStatusIcon } from "./HookStatusIcon";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { ProjectHooksDialog } from "./ProjectHooksDialog";
 import { useOpenProject } from "./useOpenProject";
 
 /** Lower = more attention-worthy — picks a single badge when a workspace has more than one hook's status. */
@@ -39,6 +40,8 @@ export function ProjectTree() {
 	// The project a New-Workspace dialog is open for (null = closed). The "+" opens it instead of
 	// creating a workspace directly.
 	const [dialogProjectId, setDialogProjectId] = useState<string | null>(null);
+	// The project a Hooks-config dialog is open for (null = closed).
+	const [hooksProjectId, setHooksProjectId] = useState<string | null>(null);
 
 	const loadWorkspaces = async (projectId: string) => {
 		useAppStore
@@ -128,6 +131,7 @@ export function ProjectTree() {
 								onToggle={() => toggleExpand(project.id)}
 								onSelect={() => void selectProject(project.id)}
 								onAddWorkspace={() => setDialogProjectId(project.id)}
+								onOpenHooks={() => setHooksProjectId(project.id)}
 							/>
 							{isExpanded && (
 								<ul className="flex flex-col">
@@ -162,6 +166,17 @@ export function ProjectTree() {
 				/>
 			) : null}
 
+			{hooksProjectId !== null ? (
+				<ProjectHooksDialog
+					open
+					projectId={hooksProjectId}
+					projectName={projects.find((p) => p.id === hooksProjectId)?.name ?? ""}
+					onOpenChange={(o) => {
+						if (!o) setHooksProjectId(null);
+					}}
+				/>
+			) : null}
+
 			{dialogs}
 		</nav>
 	);
@@ -175,6 +190,7 @@ function ProjectRow({
 	onToggle,
 	onSelect,
 	onAddWorkspace,
+	onOpenHooks,
 }: {
 	project: Project;
 	isSelected: boolean;
@@ -183,6 +199,7 @@ function ProjectRow({
 	onToggle: () => void;
 	onSelect: () => void;
 	onAddWorkspace: () => void;
+	onOpenHooks: () => void;
 }) {
 	const Chevron = isExpanded ? ChevronDown : ChevronRight;
 	return (
@@ -221,6 +238,15 @@ function ProjectRow({
 				className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-text group-hover:opacity-100"
 			>
 				<Plus className="size-4" />
+			</button>
+			<button
+				type="button"
+				data-testid="project-hooks"
+				aria-label="Configure hooks"
+				onClick={onOpenHooks}
+				className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-text group-hover:opacity-100"
+			>
+				<Settings className="size-4" />
 			</button>
 		</div>
 	);

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Settings, Trash2 } 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
-import { toast, useAppStore } from "../store";
+import { aggregateHookState, toast, useAppStore } from "../store";
 import { errorText, getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmPopover } from "./ConfirmPopover";
@@ -21,12 +21,31 @@ const HOOK_PRIORITY: Record<HookStatus["state"], number> = {
 	succeeded: 3,
 };
 
-function mostUrgentHook(hookStatus: Workspace["hookStatus"]): [HookName, HookStatus] | null {
-	const entries = Object.entries(hookStatus ?? {}) as [HookName, HookStatus][];
-	if (entries.length === 0) return null;
-	return entries.reduce((best, entry) =>
-		HOOK_PRIORITY[entry[1].state] < HOOK_PRIORITY[best[1].state] ? entry : best,
-	);
+/**
+ * The one (hook, state, command) a workspace row's single badge surfaces. `state` is the per-hook
+ * worst-of-both-tiers (`aggregateHookState`, worst-of Shared/Local); across a workspace's several hooks,
+ * the worst-of-hooks pick still uses `HOOK_PRIORITY` unchanged (badge semantics stay as-is — only the
+ * source of the state changed). `command` — needed only to open the approval dialog — is read off
+ * whichever source actually produced that state, not an arbitrary tier.
+ */
+interface UrgentHook {
+	hook: HookName;
+	state: HookStatus["state"];
+	command?: string | undefined;
+}
+
+function mostUrgentHook(hookStatus: Workspace["hookStatus"]): UrgentHook | null {
+	let best: UrgentHook | null = null;
+	for (const hook of Object.keys(hookStatus ?? {}) as HookName[]) {
+		const bySource = hookStatus?.[hook];
+		const state = aggregateHookState(bySource);
+		if (!state) continue;
+		if (!best || HOOK_PRIORITY[state] < HOOK_PRIORITY[best.state]) {
+			const command = Object.values(bySource ?? {}).find((s) => s.state === state)?.command;
+			best = { hook, state, command };
+		}
+	}
+	return best;
 }
 
 /** Left-nav: projects → workspaces (git worktrees). Open a repo, select it, create/select workspaces. */
@@ -275,7 +294,7 @@ function WorkspaceRow({
 	const [approving, setApproving] = useState(false);
 	const onHookBadgeClick = () => {
 		if (!urgentHook) return;
-		if (urgentHook[1].state === "awaitingApproval") {
+		if (urgentHook.state === "awaitingApproval") {
 			setApproving(true);
 		} else {
 			onSelect();
@@ -341,12 +360,12 @@ function WorkspaceRow({
 						<button
 							type="button"
 							data-testid="workspace-hook-badge"
-							data-hook-status={urgentHook[1].state}
-							aria-label={`${urgentHook[0]} ${urgentHook[1].state}`}
+							data-hook-status={urgentHook.state}
+							aria-label={`${urgentHook.hook} ${urgentHook.state}`}
 							onClick={onHookBadgeClick}
 							className="flex shrink-0 items-center"
 						>
-							<HookStatusIcon state={urgentHook[1].state} />
+							<HookStatusIcon state={urgentHook.state} />
 						</button>
 					) : (
 						hasStats && (
@@ -368,14 +387,14 @@ function WorkspaceRow({
 					</PopoverTrigger>
 				</div>
 			</ConfirmPopover>
-			{urgentHook && urgentHook[1].state === "awaitingApproval" && urgentHook[1].command && (
+			{urgentHook && urgentHook.state === "awaitingApproval" && urgentHook.command && (
 				<HookApprovalDialog
 					open={approving}
 					onOpenChange={setApproving}
 					projectId={workspace.projectId}
 					workspaceId={workspace.id}
-					hook={urgentHook[0]}
-					command={urgentHook[1].command}
+					hook={urgentHook.hook}
+					command={urgentHook.command}
 				/>
 			)}
 		</>

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -1,4 +1,4 @@
-import type { Project, Workspace } from "@thinkrail/contracts";
+import type { HookName, HookStatus, Project, Workspace } from "@thinkrail/contracts";
 import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -7,8 +7,26 @@ import { toast, useAppStore } from "../store";
 import { errorText, getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmPopover } from "./ConfirmPopover";
+import { HookApprovalDialog } from "./HookApprovalDialog";
+import { HookStatusIcon } from "./HookStatusIcon";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { useOpenProject } from "./useOpenProject";
+
+/** Lower = more attention-worthy — picks a single badge when a workspace has more than one hook's status. */
+const HOOK_PRIORITY: Record<HookStatus["state"], number> = {
+	awaitingApproval: 0,
+	failed: 1,
+	running: 2,
+	succeeded: 3,
+};
+
+function mostUrgentHook(hookStatus: Workspace["hookStatus"]): [HookName, HookStatus] | null {
+	const entries = Object.entries(hookStatus ?? {}) as [HookName, HookStatus][];
+	if (entries.length === 0) return null;
+	return entries.reduce((best, entry) =>
+		HOOK_PRIORITY[entry[1].state] < HOOK_PRIORITY[best[1].state] ? entry : best,
+	);
+}
 
 /** Left-nav: projects → workspaces (git worktrees). Open a repo, select it, create/select workspaces. */
 export function ProjectTree() {
@@ -221,77 +239,119 @@ function WorkspaceRow({
 }) {
 	const stats = workspace.diffStats;
 	const hasStats = stats != null && (stats.added > 0 || stats.removed > 0);
+	const urgentHook = mostUrgentHook(workspace.hookStatus);
 	// Confirm-before-remove lives on the row so the popover anchors right beneath it (contextual to the
 	// workspace being removed) rather than as a centered modal.
 	const [confirmOpen, setConfirmOpen] = useState(false);
+	// The approval prompt is a centered modal (approving trusts a command for the whole project, not just
+	// this row) — a click on an `awaitingApproval` badge opens it directly; any other hook state instead
+	// deep-links to the Hooks panel (`requestHooksView`), where output/retry live.
+	const [approving, setApproving] = useState(false);
+	const onHookBadgeClick = () => {
+		if (!urgentHook) return;
+		if (urgentHook[1].state === "awaitingApproval") {
+			setApproving(true);
+		} else {
+			onSelect();
+			useAppStore.getState().requestHooksView(workspace.id);
+		}
+	};
 	return (
-		<ConfirmPopover
-			open={confirmOpen}
-			onOpenChange={setConfirmOpen}
-			title={`Remove ${workspace.name} workspace`}
-			description={
-				<>
-					Deletes this workspace's chats, terminals, and its worktree. The git branch{" "}
-					<span className="font-medium text-text">{workspace.branch}</span> is kept.
-				</>
-			}
-			confirmLabel="Remove"
-			destructive
-			confirmTestId="confirm-remove"
-			onConfirm={onRemove}
-			align="end"
-		>
-			{/* Anchored to the Remove button (the PopoverTrigger), right border aligned via align="end". */}
-			<div
-				data-testid="workspace-item"
-				data-active={isActive}
-				className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
-					isActive ? "bg-hover" : "hover:bg-hover"
-				}`}
+		<>
+			<ConfirmPopover
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title={`Remove ${workspace.name} workspace`}
+				description={
+					<>
+						Deletes this workspace's chats, terminals, and its worktree. The git branch{" "}
+						<span className="font-medium text-text">{workspace.branch}</span> is kept.
+					</>
+				}
+				confirmLabel="Remove"
+				destructive
+				confirmTestId="confirm-remove"
+				onConfirm={onRemove}
+				align="end"
 			>
-				<button
-					type="button"
-					onClick={onSelect}
-					className="flex min-w-0 flex-1 items-center gap-sm text-left"
+				{/* Anchored to the Remove button (the PopoverTrigger), right border aligned via align="end". */}
+				<div
+					data-testid="workspace-item"
+					data-active={isActive}
+					className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
+						isActive ? "bg-hover" : "hover:bg-hover"
+					}`}
 				>
-					<GitBranch className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
-					{/* Name on top, the git branch on a second line beneath it — the display name is decoupled
-					    from the branch, so surface both without crowding one line. The branch line is hidden when
-					    they coincide, so pristine/legacy rows stay a single compact line. */}
-					<span className="flex min-w-0 flex-1 flex-col">
-						<span
-							data-testid="workspace-name"
-							className={`truncate text-sm leading-tight ${isActive ? "font-medium text-primary" : "text-muted"}`}
-						>
-							{workspace.name}
-						</span>
-						{workspace.branch !== workspace.name && (
-							<span
-								data-testid="workspace-branch"
-								className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
-							>
-								{workspace.branch}
-							</span>
-						)}
-					</span>
-				</button>
-				{hasStats && (
-					<span className="shrink-0 text-xs tabular-nums group-hover:hidden">
-						<span className="text-green">+{stats.added}</span>{" "}
-						<span className="text-red">−{stats.removed}</span>
-					</span>
-				)}
-				<PopoverTrigger asChild>
 					<button
 						type="button"
-						data-testid="workspace-remove"
-						aria-label="Remove workspace"
-						className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-red group-hover:opacity-100 data-[state=open]:opacity-100"
+						onClick={onSelect}
+						className="flex min-w-0 flex-1 items-center gap-sm text-left"
 					>
-						<Trash2 className="size-4" />
+						<GitBranch className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
+						{/* Name on top, the git branch on a second line beneath it — the display name is decoupled
+					    from the branch, so surface both without crowding one line. The branch line is hidden when
+					    they coincide, so pristine/legacy rows stay a single compact line. */}
+						<span className="flex min-w-0 flex-1 flex-col">
+							<span
+								data-testid="workspace-name"
+								className={`truncate text-sm leading-tight ${isActive ? "font-medium text-primary" : "text-muted"}`}
+							>
+								{workspace.name}
+							</span>
+							{workspace.branch !== workspace.name && (
+								<span
+									data-testid="workspace-branch"
+									className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
+								>
+									{workspace.branch}
+								</span>
+							)}
+						</span>
 					</button>
-				</PopoverTrigger>
-			</div>
-		</ConfirmPopover>
+					{urgentHook ? (
+						// Unlike the diffStats indicator below, this stays visible on hover — it's actionable
+						// (opens the approval dialog / deep-links to the Hooks tab), so it must survive exactly
+						// the hover state a click implies.
+						<button
+							type="button"
+							data-testid="workspace-hook-badge"
+							data-hook-status={urgentHook[1].state}
+							aria-label={`${urgentHook[0]} ${urgentHook[1].state}`}
+							onClick={onHookBadgeClick}
+							className="flex shrink-0 items-center"
+						>
+							<HookStatusIcon state={urgentHook[1].state} />
+						</button>
+					) : (
+						hasStats && (
+							<span className="shrink-0 text-xs tabular-nums group-hover:hidden">
+								<span className="text-green">+{stats.added}</span>{" "}
+								<span className="text-red">−{stats.removed}</span>
+							</span>
+						)
+					)}
+					<PopoverTrigger asChild>
+						<button
+							type="button"
+							data-testid="workspace-remove"
+							aria-label="Remove workspace"
+							className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-red group-hover:opacity-100 data-[state=open]:opacity-100"
+						>
+							<Trash2 className="size-4" />
+						</button>
+					</PopoverTrigger>
+				</div>
+			</ConfirmPopover>
+			{urgentHook && urgentHook[1].state === "awaitingApproval" && urgentHook[1].command && (
+				<HookApprovalDialog
+					open={approving}
+					onOpenChange={setApproving}
+					projectId={workspace.projectId}
+					workspaceId={workspace.id}
+					hook={urgentHook[0]}
+					command={urgentHook[1].command}
+				/>
+			)}
+		</>
 	);
 }

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -1,6 +1,6 @@
 import { RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useAppStore } from "../store";
+import { aggregateHookState, useAppStore } from "../store";
 import { ChangesPanel } from "./ChangesPanel";
 import { FileTree } from "./FileTree";
 import { HooksPanel } from "./HooksPanel";
@@ -19,9 +19,10 @@ export function RightPanel() {
 		const status = Object.values(s.workspaces)
 			.flat()
 			.find((w) => w.id === activeWorkspaceId)?.hookStatus;
-		return Object.values(status ?? {}).some(
-			(h) => h.state === "awaitingApproval" || h.state === "failed",
-		);
+		return Object.values(status ?? {}).some((bySource) => {
+			const state = aggregateHookState(bySource);
+			return state === "awaitingApproval" || state === "failed";
+		});
 	});
 	const [tab, setTab] = useState<RightTab>("specs");
 	const [specsRefresh, setSpecsRefresh] = useState(0);

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -3,14 +3,26 @@ import { useEffect, useState } from "react";
 import { useAppStore } from "../store";
 import { ChangesPanel } from "./ChangesPanel";
 import { FileTree } from "./FileTree";
+import { HooksPanel } from "./HooksPanel";
 import { SpecsPanel } from "./SpecsPanel";
 
-type RightTab = "specs" | "files" | "changes";
+type RightTab = "specs" | "files" | "changes" | "hooks";
 
-/** Right panel for the active worktree: Specs (read-only spec-graph tree), All-files tree, and Changes (git diff vs base). Checks/Review = V2. */
+/** Right panel for the active worktree: Specs (read-only spec-graph tree), All-files tree, Changes (git
+ * diff vs base), and Hooks (lifecycle hook status/approval/output). Checks/Review = V2. */
 export function RightPanel() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 	const changesRequest = useAppStore((s) => s.changesRequest);
+	const hooksRequest = useAppStore((s) => s.hooksRequest);
+	const hasHookAttention = useAppStore((s) => {
+		if (!activeWorkspaceId) return false;
+		const status = Object.values(s.workspaces)
+			.flat()
+			.find((w) => w.id === activeWorkspaceId)?.hookStatus;
+		return Object.values(status ?? {}).some(
+			(h) => h.state === "awaitingApproval" || h.state === "failed",
+		);
+	});
 	const [tab, setTab] = useState<RightTab>("specs");
 	const [specsRefresh, setSpecsRefresh] = useState(0);
 
@@ -18,6 +30,11 @@ export function RightPanel() {
 	useEffect(() => {
 		if (changesRequest?.workspaceId === activeWorkspaceId) setTab("changes");
 	}, [changesRequest, activeWorkspaceId]);
+
+	// A deep-link from a workspace row's hook badge (non-approval states) flips us to the Hooks view.
+	useEffect(() => {
+		if (hooksRequest?.workspaceId === activeWorkspaceId) setTab("hooks");
+	}, [hooksRequest, activeWorkspaceId]);
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
@@ -34,6 +51,15 @@ export function RightPanel() {
 					onClick={() => setTab("changes")}
 				>
 					Changes
+				</TabButton>
+				<TabButton testid="tab-hooks" active={tab === "hooks"} onClick={() => setTab("hooks")}>
+					Hooks
+					{hasHookAttention && (
+						<span
+							data-testid="hooks-attention-dot"
+							className="ml-xs inline-block size-1.5 rounded-full bg-gold"
+						/>
+					)}
 				</TabButton>
 				{tab === "specs" && activeWorkspaceId && (
 					<button
@@ -59,8 +85,10 @@ export function RightPanel() {
 					<div className="p-xs">
 						<FileTree workspaceId={activeWorkspaceId} />
 					</div>
-				) : (
+				) : tab === "changes" ? (
 					<ChangesPanel workspaceId={activeWorkspaceId} />
+				) : (
+					<HooksPanel workspaceId={activeWorkspaceId} />
 				)}
 			</div>
 		</div>

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -107,7 +107,14 @@ prompt hero (still editable; empty by default), a base-branch
   default via `model.default` so the exact model shows (values held in dialog state, applied at create
   time). The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll
   lock). In the prompt hero, **Enter creates** (matching the Create button's `↵` affordance) and
-  **Shift+Enter** inserts a newline. Create = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
+  **Shift+Enter** inserts a newline. When the selected project declares any hook (Shared or Local — via
+  `hooksActions.ts`'s **`getProjectHooks`**, refetched per selected project like the branch list above), an
+  **Advanced** disclosure (`ws-advanced-toggle`) reveals a per-workspace **hook mode** selector
+  (`ws-hook-mode`, three options Both/Shared only/Local only — each also its own `ws-hook-mode-{mode}`, the
+  same three choices as `ProjectHooksDialog`'s combine-mode control, kept as its own small local toggle
+  rather than a shared import since the two serve different scopes) defaulting to that project's own
+  `combineMode`; a hookless project shows nothing extra, keeping the default create flow uncluttered.
+  Create = `workspace.create({ projectId, baseRef, hookCombineMode })` → set active → (with a prompt) open a chat +
   `session.create({ model, thinkingLevel })` + fire-and-forget `prompt`; with an empty prompt it just
   creates the workspace. A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a
   nonexistent model) surfaces as an `error` turn in the just-opened chat via `store.appendErrorTurn` (with

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -39,12 +39,21 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   on a `failed` row and the same `HookApprovalDialog` reachable from an `awaitingApproval` row too (both
   call sites share it rather than duplicating the modal). `hooksActions.ts`'s
   **`approveAndRunHook`**/**`runHookNow`** wrap `workspace.hooks.approve`/`workspace.hooks.run` — approve
-  alone only records a project-scoped approval (see [[submodule-server-workspaces-hooks]]), so the dialog
-  always composes it with an explicit run to actually bootstrap the workspace that's stuck at
-  `hookAwaitingApproval`. **`ProjectHooksDialog`** is the project-level hooks config form (one row per
-  `HookName`: committed command, optional host-local override, approval status + an Approve action),
-  reachable with zero workspaces open; composes `hooksActions.ts`'s new
-  `getProjectHooks`/`saveProjectHooks`/`approveProjectHook`. Two entry points open it: a per-row **gear
+  alone only records a per-(project, hook, source) approval (see [[submodule-server-workspaces-hooks]]),
+  scoped to the given `workspaceId` (so a Shared script hook resolves/hashes against that workspace's own
+  worktree, not the project root), so the dialog always composes it with an explicit run to actually
+  bootstrap the workspace that's stuck at `hookAwaitingApproval`. **`ProjectHooksDialog`** is the
+  project-level hooks config form, reachable with zero workspaces open: a top **combine-mode** segmented
+  control (Both / Shared only / Local only, testid `hook-combine-mode` + a per-option testid) plus, per
+  `HookName`, a **Shared** and a **Local** sub-field, each an **Inline | Script** toggle (Inline = a
+  multi-line `pre-wrap` monospace textarea; Script = a single-line path input) carrying its own read-only
+  approval status ("Approved"/"Not yet approved") — **no Approve button**, since saving approves everything
+  it writes on this machine — and an explicit **remove (×)** that clears just that sub-field (instead of an
+  implicit blank-to-delete). When the project gitignores `.thinkrail/` (`sharedCommittable: false`), the
+  whole Shared column is disabled with an inline note (`shared-uncommittable-note`) and Local stays the
+  escape hatch (host-local, no git, still runs in every workspace). Composes `hooksActions.ts`'s
+  `getProjectHooks`/`saveProjectHooks`, typed to the tiered `{combineMode, shared, local}` payloads — there
+  is no standalone `approveProjectHook`; save folds approval in. Two entry points open it: a per-row **gear
   icon** (`Settings`, testid `project-hooks`) on `ProjectRow`, same hover-reveal treatment as the
   **Create workspace** `+`, and the Welcome screen's **"Configure hooks"** card (below).
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -27,22 +27,37 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
   name is decoupled from the git branch (see [[submodule-server-workspaces]]).
-  Each row also shows the **most attention-worthy hook status** (`mostUrgentHook`, priority
-  awaitingApproval > failed > running > succeeded — a plain icon button via **`HookStatusIcon`**, shared
-  with `HooksPanel`), taking the slot the diffStats +/− chip otherwise occupies, and — unlike that chip —
-  staying visible on hover (it's actionable, so it must survive exactly the hover state a click implies).
-  Clicking it: `awaitingApproval` opens **`HookApprovalDialog`** directly (a centered modal, not an
-  anchored popover — approving trusts a shell command for every workspace in the project from now on, not
-  a one-off row action); any other state instead deep-links to `RightPanel`'s Hooks tab via
+  Each row also shows the **most attention-worthy hook status** (`mostUrgentHook`: per-hook state is the
+  worst-of-both-tiers via the store's **`aggregateHookState`** (worst-of Shared/Local — failed >
+  awaitingApproval > running > succeeded), then the worst-of-hooks pick across a workspace's several
+  hooks still uses that same priority order, unchanged — a plain icon button via **`HookStatusIcon`**,
+  shared with `HooksPanel`), taking the slot the diffStats +/− chip otherwise occupies, and — unlike that
+  chip — staying visible on hover (it's actionable, so it must survive exactly the hover state a click
+  implies). Clicking it: `awaitingApproval` opens **`HookApprovalDialog`** directly (a centered modal, not
+  an anchored popover — approving trusts a shell command for every workspace in the project from now on,
+  not a one-off row action), using whichever source actually produced the aggregated state (not an
+  arbitrary tier); any other state instead deep-links to `RightPanel`'s Hooks tab via
   `store.requestHooksView`. `HooksPanel` lists every hook with a status on the active workspace
-  (`Workspace.hookStatus`) plus its live output (`store.hookOutputByWorkspace`), with a **Retry** action
-  on a `failed` row and the same `HookApprovalDialog` reachable from an `awaitingApproval` row too (both
-  call sites share it rather than duplicating the modal). `hooksActions.ts`'s
-  **`approveAndRunHook`**/**`runHookNow`** wrap `workspace.hooks.approve`/`workspace.hooks.run` — approve
-  alone only records a per-(project, hook, source) approval (see [[submodule-server-workspaces-hooks]]),
-  scoped to the given `workspaceId` (so a Shared script hook resolves/hashes against that workspace's own
-  worktree, not the project root), so the dialog always composes it with an explicit run to actually
-  bootstrap the workspace that's stuck at `hookAwaitingApproval`. **`ProjectHooksDialog`** is the
+  (`Workspace.hookStatus`, nested `HookName → HookSource → HookStatus` — a `combineMode` of `"both"` can
+  have Shared and Local sitting at different states at once) plus its live output
+  (`store.hookOutputByWorkspace`, still keyed by hook only, not per source). Each hook's row header shows
+  its aggregated state (`aggregateHookState`), with a **Retry** action on a `failed` aggregate and an
+  **Approve & Run** action on an `awaitingApproval` aggregate — both stay hook-level, matching the wire's
+  `workspace.hooks.run`/`.approve` (no source param; approving resumes the ordered Shared→Local sequence
+  from the top). Beneath the header, one row **per source that has reported a status** (labeled Shared /
+  Local, its own `HookStatusIcon` + a failed row's exit code) shows that source's own command, rendered
+  `whitespace-pre-wrap` (multi-line commands display properly; a script hook's command is already the
+  display label `script: <path>`, rendered as-is). The same `HookApprovalDialog` is reachable from both the
+  workspace-row badge and an `awaitingApproval` hook here (both call sites share it rather than duplicating
+  the modal — it stays source-agnostic, just approving whichever command the caller resolved).
+  `hooksActions.ts`'s **`approveAndRunHook`**/**`runHookNow`** wrap
+  `workspace.hooks.approve`/`workspace.hooks.run` — approve alone only records a per-(project, hook,
+  source) approval (see [[submodule-server-workspaces-hooks]]); the server resolves *which* source by
+  matching the approved command's text against the workspace's current Shared/Local entries, so the client
+  never sends a `source` on the wire — scoped to the given `workspaceId` (so a Shared script hook
+  resolves/hashes against that workspace's own worktree, not the project root), so the dialog always
+  composes it with an explicit run to actually bootstrap the workspace that's stuck at
+  `hookAwaitingApproval`. **`ProjectHooksDialog`** is the
   project-level hooks config form, reachable with zero workspaces open: a top **combine-mode** segmented
   control (Both / Shared only / Local only, testid `hook-combine-mode` + a per-option testid) plus, per
   `HookName`, a **Shared** and a **Local** sub-field, each an **Inline | Script** toggle (Inline = a

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -44,7 +44,9 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   `hookAwaitingApproval`. **`ProjectHooksDialog`** is the project-level hooks config form (one row per
   `HookName`: committed command, optional host-local override, approval status + an Approve action),
   reachable with zero workspaces open; composes `hooksActions.ts`'s new
-  `getProjectHooks`/`saveProjectHooks`/`approveProjectHook`.
+  `getProjectHooks`/`saveProjectHooks`/`approveProjectHook`. Two entry points open it: a per-row **gear
+  icon** (`Settings`, testid `project-hooks`) on `ProjectRow`, same hover-reveal treatment as the
+  **Create workspace** `+`, and the Welcome screen's **"Configure hooks"** card (below).
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
@@ -61,11 +63,14 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
 workspace is active. The `PRODUCT_NAME` wordmark as the hero (the topbar's brand styling — accent font,
 `text-primary` — enlarged), with the **active project's name as a small eyebrow** (folder icon) above it
 once a project is selected, over a **constant** spec-first pitch (not spec-conditional) and
-**one-to-three cards** (Conductor-inspired: icon top-left, label + explainer
+**one-to-four cards** (Conductor-inspired: icon top-left, label + explainer
 bottom-left; the primary is a filled-violet card carrying the stable `welcome-cta` hook, others quiet
 `welcome-action`s). The cards by state: **no projects** → **"Open project"** (one card); **project +
-`hasSpecs`** → **"Start building"** (primary) + "Open project"; **project + no specs** → a spec-first
-**"Set up project"** (primary) + "Start building" + "Open project". The **"Open project"** card hangs the shared
+`hasSpecs`** → **"Start building"** (primary) + "Open project" + "Configure hooks"; **project + no specs**
+→ a spec-first **"Set up project"** (primary) + "Start building" + "Open project" + "Configure hooks".
+Whenever a project is selected, a trailing **"Configure hooks"** card (`Settings` icon) opens the same
+**`ProjectHooksDialog`** as `ProjectRow`'s gear icon (above) — the Welcome-screen entry point reachable
+with zero workspaces. The **"Open project"** card hangs the shared
 **`AddProjectMenu`** dropdown off it (same menu as the projects-rail "+": Open project / Open GitHub (soon)
 / Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Start building"** is the
 intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` (which cuts a

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -27,6 +27,21 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
   name is decoupled from the git branch (see [[submodule-server-workspaces]]).
+  Each row also shows the **most attention-worthy hook status** (`mostUrgentHook`, priority
+  awaitingApproval > failed > running > succeeded — a plain icon button via **`HookStatusIcon`**, shared
+  with `HooksPanel`), taking the slot the diffStats +/− chip otherwise occupies, and — unlike that chip —
+  staying visible on hover (it's actionable, so it must survive exactly the hover state a click implies).
+  Clicking it: `awaitingApproval` opens **`HookApprovalDialog`** directly (a centered modal, not an
+  anchored popover — approving trusts a shell command for every workspace in the project from now on, not
+  a one-off row action); any other state instead deep-links to `RightPanel`'s Hooks tab via
+  `store.requestHooksView`. `HooksPanel` lists every hook with a status on the active workspace
+  (`Workspace.hookStatus`) plus its live output (`store.hookOutputByWorkspace`), with a **Retry** action
+  on a `failed` row and the same `HookApprovalDialog` reachable from an `awaitingApproval` row too (both
+  call sites share it rather than duplicating the modal). `hooksActions.ts`'s
+  **`approveAndRunHook`**/**`runHookNow`** wrap `workspace.hooks.approve`/`workspace.hooks.run` — approve
+  alone only records a project-scoped approval (see [[submodule-server-workspaces-hooks]]), so the dialog
+  always composes it with an explicit run to actually bootstrap the workspace that's stuck at
+  `hookAwaitingApproval`.
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
@@ -131,8 +146,11 @@ prompt hero (still editable; empty by default), a base-branch
 
 ## Get right
 
-- `RightPanel` tabs are **Specs | All files | Changes** (Specs leftmost and the **default** — specs are
-  the project's ground truth, so the rail leads with them).
+- `RightPanel` tabs are **Specs | All files | Changes | Hooks** (Specs leftmost and the **default** —
+  specs are the project's ground truth, so the rail leads with them). The Hooks tab shows a small gold
+  attention dot when the active workspace has any hook `awaitingApproval`/`failed` — the one tab whose
+  label itself carries a status signal, since it's the one thing in this row that can silently need the
+  user's action.
 - **Live refresh (the worktree panels follow the disk).** `FileTree` / `ChangesPanel` / `SpecsPanel` /
   `FilePane` watch the store's `fsChangesByWorkspace` tick for their workspace (fed by the host's
   debounced `workspace.fsChanged` push — see [[submodule-server-watch]]) and silently refetch through

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -41,7 +41,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   **`approveAndRunHook`**/**`runHookNow`** wrap `workspace.hooks.approve`/`workspace.hooks.run` — approve
   alone only records a project-scoped approval (see [[submodule-server-workspaces-hooks]]), so the dialog
   always composes it with an explicit run to actually bootstrap the workspace that's stuck at
-  `hookAwaitingApproval`.
+  `hookAwaitingApproval`. **`ProjectHooksDialog`** is the project-level hooks config form (one row per
+  `HookName`: committed command, optional host-local override, approval status + an Approve action),
+  reachable with zero workspaces open; composes `hooksActions.ts`'s new
+  `getProjectHooks`/`saveProjectHooks`/`approveProjectHook`.
   **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -1,5 +1,5 @@
 import type { Workspace } from "@thinkrail/contracts";
-import { Folder, FolderOpen, type LucideIcon, Rocket, Sparkles } from "lucide-react";
+import { Folder, FolderOpen, type LucideIcon, Rocket, Settings, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, forwardRef, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { PRODUCT_NAME } from "../constants/branding";
@@ -7,6 +7,7 @@ import { useAppStore } from "../store";
 import { getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { ProjectHooksDialog } from "./ProjectHooksDialog";
 import { ProviderWarningBanner } from "./ProviderWarningBanner";
 import { useOpenProject } from "./useOpenProject";
 
@@ -34,6 +35,8 @@ export function WelcomePanel() {
 	// requested only for this one project, on demand, never eagerly for every project on connect).
 	// null = pending/unknown (cards wait for it).
 	const [hasSpecs, setHasSpecs] = useState<boolean | null>(null);
+	// Whether the project-level Hooks-config dialog is open.
+	const [hooksOpen, setHooksOpen] = useState(false);
 
 	// The project the has-specs states key off — the selected one, else the most-recent (list is sorted).
 	const project = projects.find((p) => p.id === selectedProjectId) ?? projects[0] ?? null;
@@ -142,6 +145,12 @@ export function WelcomePanel() {
 							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
 						/>
 						{openProjectCard({ subtitle: "Add another local git repository." })}
+						<Card
+							icon={Settings}
+							title="Configure hooks"
+							subtitle="Declare setup/teardown commands this project runs per workspace."
+							onClick={() => setHooksOpen(true)}
+						/>
 					</>
 				) : (
 					<>
@@ -161,6 +170,12 @@ export function WelcomePanel() {
 							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
 						/>
 						{openProjectCard({ subtitle: "Add another local git repository." })}
+						<Card
+							icon={Settings}
+							title="Configure hooks"
+							subtitle="Declare setup/teardown commands this project runs per workspace."
+							onClick={() => setHooksOpen(true)}
+						/>
 					</>
 				)}
 			</div>
@@ -176,6 +191,14 @@ export function WelcomePanel() {
 					onCreated={(ws) => void onWorkspaceCreated(ws)}
 				/>
 			) : null}
+			{project && (
+				<ProjectHooksDialog
+					open={hooksOpen}
+					projectId={project.id}
+					projectName={project.name}
+					onOpenChange={setHooksOpen}
+				/>
+			)}
 			{dialogs}
 		</div>
 	);

--- a/apps/web/src/panels/hooksActions.ts
+++ b/apps/web/src/panels/hooksActions.ts
@@ -22,3 +22,27 @@ export async function approveAndRunHook(
 export function runHookNow(workspaceId: string, hook: HookName): Promise<Ack> {
 	return getTransport().request("workspace.hooks.run", { workspaceId, hook });
 }
+
+/** Read a project's declared hooks (committed + host-local overrides) + per-hook approval status. */
+export function getProjectHooks(projectId: string) {
+	return getTransport().request("project.hooks.get", { projectId });
+}
+
+/** Write a project's committed hooks + host-local overrides. Never touches approval. */
+export function saveProjectHooks(
+	projectId: string,
+	committed: Partial<Record<HookName, string>>,
+	overrides: Partial<Record<HookName, string>>,
+): Promise<Ack> {
+	return getTransport().request("project.hooks.save", { projectId, committed, overrides });
+}
+
+/** Approve `command` for this project+hook — the project-level "trust this now" action (no workspace
+ * needed, unlike `approveAndRunHook` above, which also re-runs a specific workspace's pending hook). */
+export function approveProjectHook(
+	projectId: string,
+	hook: HookName,
+	command: string,
+): Promise<Ack> {
+	return getTransport().request("workspace.hooks.approve", { projectId, hook, command });
+}

--- a/apps/web/src/panels/hooksActions.ts
+++ b/apps/web/src/panels/hooksActions.ts
@@ -1,0 +1,24 @@
+import type { Ack, HookName } from "@thinkrail/contracts";
+import { getTransport } from "../transport";
+
+/**
+ * Approve `command` for this project+hook, then immediately re-invoke it for this specific workspace.
+ * Approving alone never re-runs anything (server-side, it's scoped to project+hook, not a workspace) —
+ * this is the composition the approval dialog uses to actually bootstrap a workspace stuck at
+ * `hookAwaitingApproval`. Idempotent if the command was already approved via a sibling workspace: the
+ * approve call is then a no-op and the run call still does the real work.
+ */
+export async function approveAndRunHook(
+	projectId: string,
+	workspaceId: string,
+	hook: HookName,
+	command: string,
+): Promise<void> {
+	await getTransport().request("workspace.hooks.approve", { projectId, hook, command });
+	await getTransport().request("workspace.hooks.run", { workspaceId, hook });
+}
+
+/** Re-invoke an already-approved hook for a specific workspace — the manual retry-after-failure action. */
+export function runHookNow(workspaceId: string, hook: HookName): Promise<Ack> {
+	return getTransport().request("workspace.hooks.run", { workspaceId, hook });
+}

--- a/apps/web/src/panels/hooksActions.ts
+++ b/apps/web/src/panels/hooksActions.ts
@@ -1,11 +1,14 @@
-import type { Ack, HookName } from "@thinkrail/contracts";
+import type { Ack, CombineMode, HookName, HookValue } from "@thinkrail/contracts";
 import { getTransport } from "../transport";
 
 /**
- * Approve `command` for this project+hook, then immediately re-invoke it for this specific workspace.
- * Approving alone never re-runs anything (server-side, it's scoped to project+hook, not a workspace) —
- * this is the composition the approval dialog uses to actually bootstrap a workspace stuck at
- * `hookAwaitingApproval`. Idempotent if the command was already approved via a sibling workspace: the
+ * Approve `command` for this project+hook+workspace, then immediately re-invoke it for that specific
+ * workspace. Approving alone never re-runs anything (server-side, it only records the approval) — this is
+ * the composition the approval dialog uses to actually bootstrap a workspace stuck at
+ * `hookAwaitingApproval`. `workspaceId` anchors the approve call to that workspace's own worktree (matching
+ * the paired run call) rather than the project root, which matters for a Shared `{script}` hook whose
+ * worktree contents can differ from the root checkout — otherwise the hash this records would never match
+ * what `run` re-checks. Idempotent if the command was already approved via a sibling workspace: the
  * approve call is then a no-op and the run call still does the real work.
  */
 export async function approveAndRunHook(
@@ -14,7 +17,12 @@ export async function approveAndRunHook(
 	hook: HookName,
 	command: string,
 ): Promise<void> {
-	await getTransport().request("workspace.hooks.approve", { projectId, hook, command });
+	await getTransport().request("workspace.hooks.approve", {
+		projectId,
+		workspaceId,
+		hook,
+		command,
+	});
 	await getTransport().request("workspace.hooks.run", { workspaceId, hook });
 }
 
@@ -23,26 +31,30 @@ export function runHookNow(workspaceId: string, hook: HookName): Promise<Ack> {
 	return getTransport().request("workspace.hooks.run", { workspaceId, hook });
 }
 
-/** Read a project's declared hooks (committed + host-local overrides) + per-hook approval status. */
+/**
+ * Read a project's declared hooks: the combine-mode, the Shared tier (committed in
+ * `.thinkrail/hooks.json`), the Local tier (host-local overrides), a per-(hook,source) approval map, and
+ * whether Shared can even be committed here (`sharedCommittable: false` when `.thinkrail/` is gitignored —
+ * see `saveProjectHooks`, which then never attempts to write Shared).
+ */
 export function getProjectHooks(projectId: string) {
 	return getTransport().request("project.hooks.get", { projectId });
 }
 
-/** Write a project's committed hooks + host-local overrides. Never touches approval. */
+/**
+ * Write a project's combine-mode + Shared + Local hooks. Saving **approves** — on this machine — every
+ * command it writes (Shared and Local alike), so a workspace created right after never sits at
+ * `hookAwaitingApproval` for something the user just configured themselves; there is no separate approve
+ * step in this dialog. An empty `shared` clears a previously-committed Shared hook rather than being a
+ * no-op. Throws (never force-commits) if `shared` is non-empty for a project that ignores `.thinkrail/`.
+ */
 export function saveProjectHooks(
 	projectId: string,
-	committed: Partial<Record<HookName, string>>,
-	overrides: Partial<Record<HookName, string>>,
+	payload: {
+		combineMode: CombineMode;
+		shared: Partial<Record<HookName, HookValue>>;
+		local: Partial<Record<HookName, HookValue>>;
+	},
 ): Promise<Ack> {
-	return getTransport().request("project.hooks.save", { projectId, committed, overrides });
-}
-
-/** Approve `command` for this project+hook — the project-level "trust this now" action (no workspace
- * needed, unlike `approveAndRunHook` above, which also re-runs a specific workspace's pending hook). */
-export function approveProjectHook(
-	projectId: string,
-	hook: HookName,
-	command: string,
-): Promise<Ack> {
-	return getTransport().request("workspace.hooks.approve", { projectId, hook, command });
+	return getTransport().request("project.hooks.save", { projectId, ...payload });
 }

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -99,8 +99,16 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   with **`applyWorkspaceHookEvent(event)`** (folds a `workspace.hook` push: appends `hookOutput` chunks to
   the live buffer — capped, reset on a fresh `hookStarted`/`hookAwaitingApproval` — and, for every other
   kind, *also* mirrors the transition onto the matching workspace's own `hookStatus` field directly, so the
-  row badge/Hooks-tab update from the live event without waiting on a `workspace.updated` round-trip; a
-  workspace not found in any loaded project's list is ambiguous on its own — the same `!entry` shape covers
+  row badge/Hooks-tab update from the live event without waiting on a `workspace.updated` round-trip. Every
+  event carries a **`source: HookSource`** (`"shared" | "local"` — a `combineMode` of `"both"` runs both for
+  the same hook, each on its own event sequence), so the write nests by source —
+  **`hookStatus[event.hook][event.source]`** — spreading the hook's existing sources first so it never
+  clobbers the sibling one still mid-run; **`hookStatusFromEvent(event)`** derives the single-entry
+  `HookStatus` (state/command/exitCode) that lands there. **`aggregateHookState(bySource)`** is the
+  read-side counterpart a per-hook badge calls: worst-of across whatever sources are present, by fixed
+  precedence `failed > awaitingApproval > running > succeeded` (`undefined` for an absent/empty map — no
+  source has reported anything for that hook). A workspace not found in any loaded project's list is
+  ambiguous on its own — the same `!entry` shape covers
   both "genuinely removed" and "this project's list was simply never fetched yet" (the latter is the same
   no-op race `addWorkspace` already documents for `workspace.created`) — so it's disambiguated via
   **`removedWorkspaceIds: Record<workspaceId, true>`**, a tombstone map stamped by `applyWorkspaceRemoved`:
@@ -118,10 +126,11 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   renderers live in the `chat` module.)
 - **Public surface (barrel):** `useAppStore`, `toast` (the fire-from-anywhere helper), `Toast` (type),
   `EditorTab` (`FileTab`/`ChatTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` + `EMPTY_RUNTIME`
-  (ChatView's pre-creation fallback), `reduceSessionEvent`.
+  (ChatView's pre-creation fallback), `reduceSessionEvent`, `aggregateHookState` (the per-hook badge's
+  worst-of-across-sources; see above).
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/
   `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`/`AppConfig`/`ThemeId`/
-  `HookName`/`HookStatus`/`WorkspaceHookEvent`; the
+  `HookName`/`HookSource`/`HookStatus`/`WorkspaceHookEvent`; the
   `Theme` value for the default; `PiEvent`/`LoginFrame`, **type-only**); `chat`
   (`ChatTurn`/`ToolResultState`, **type-only**); `auth` (`LoginState`, **type-only**); `transport`
   (`ConnectionStatus`, **type-only**); `zustand`.

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -26,9 +26,11 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   existing record so the computed `diffStats` badge survives the push (the snapshot is the persisted
   record, which has none); a project never fetched or an id absent from its list is a **no-op** — the next
   `workspace.list` reconciles; **`applyWorkspaceRemoved(projectId, id)`** is the **entire** removal
-  reaction (`removeWorkspace` drops the row + `clearWorkspaceTabs` drops its tabs/terminals/chat runtimes,
-  and **if it was this client's active workspace** → `setActiveWorkspace(null)` (shell falls back to the
-  project Welcome) + a neutral toast that reads right for both the initiator and an observer); the
+  reaction (`removeWorkspace` drops the row + `clearWorkspaceTabs` drops its tabs/terminals/chat runtimes +
+  stamps `id` into **`removedWorkspaceIds`** (see below — the tombstone `applyWorkspaceHookEvent` relies on
+  to tell "removed" apart from "not yet loaded"), and **if it was this client's active workspace** →
+  `setActiveWorkspace(null)` (shell falls back to the project Welcome) + a neutral toast that reads right
+  for both the initiator and an observer); the
   primitive **`removeWorkspace(projectId, id)`** just drops the row (unknown project/id is a no-op);
   `tabsByWorkspace` /
   `activeTabByWorkspace` (`openTab`/`closeTab`/`setActiveTab`/`clearWorkspaceTabs`, plus
@@ -98,10 +100,16 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   the live buffer — capped, reset on a fresh `hookStarted`/`hookAwaitingApproval` — and, for every other
   kind, *also* mirrors the transition onto the matching workspace's own `hookStatus` field directly, so the
   row badge/Hooks-tab update from the live event without waiting on a `workspace.updated` round-trip; a
-  workspace not found in any loaded project's list (already removed, or not yet fetched) updates neither the
-  buffer nor `hookStatus` — `hookAwaitingApproval`/`hookFailed` instead raise a toast naming the workspace +
-  project (there's no row/tab left for them to render onto); everything else is dropped, closing what would
-  otherwise be a leak into `hookOutputByWorkspace` for an id nothing will read again) — mirrors
+  workspace not found in any loaded project's list is ambiguous on its own — the same `!entry` shape covers
+  both "genuinely removed" and "this project's list was simply never fetched yet" (the latter is the same
+  no-op race `addWorkspace` already documents for `workspace.created`) — so it's disambiguated via
+  **`removedWorkspaceIds: Record<workspaceId, true>`**, a tombstone map stamped by `applyWorkspaceRemoved`:
+  a removed id updates neither the buffer nor `hookStatus`, and `hookAwaitingApproval`/`hookFailed` instead
+  raise a toast naming the workspace + project (there's no row/tab left for them to render onto), closing
+  what would otherwise be a leak into `hookOutputByWorkspace` for an id nothing will read again; a
+  not-yet-loaded id (absent from `removedWorkspaceIds` too) updates nothing AND raises no toast — the
+  row/badge reconciles correctly once the list loads, matching `addWorkspace`'s own silent no-op for the
+  same race) — mirrors
   `noteFsChanged`'s "signal, not data" shape, but this one *also* patches durable state
   (`Workspace.hookStatus`) since that field already lives on the record the lifecycle pushes carry. The transient **`hooksRequest`** +
   **`requestHooksView(workspaceId)`** mirror `changesRequest`/`requestChangesView` — a workspace row's

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -98,9 +98,12 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   the live buffer — capped, reset on a fresh `hookStarted`/`hookAwaitingApproval` — and, for every other
   kind, *also* mirrors the transition onto the matching workspace's own `hookStatus` field directly, so the
   row badge/Hooks-tab update from the live event without waiting on a `workspace.updated` round-trip; a
-  workspace not found in any loaded project's list only updates the live buffer) — mirrors `noteFsChanged`'s
-  "signal, not data" shape, but this one *also* patches durable state (`Workspace.hookStatus`) since that
-  field already lives on the record the lifecycle pushes carry. The transient **`hooksRequest`** +
+  workspace not found in any loaded project's list (already removed, or not yet fetched) updates neither the
+  buffer nor `hookStatus` — `hookAwaitingApproval`/`hookFailed` instead raise a toast naming the workspace +
+  project (there's no row/tab left for them to render onto); everything else is dropped, closing what would
+  otherwise be a leak into `hookOutputByWorkspace` for an id nothing will read again) — mirrors
+  `noteFsChanged`'s "signal, not data" shape, but this one *also* patches durable state
+  (`Workspace.hookStatus`) since that field already lives on the record the lifecycle pushes carry. The transient **`hooksRequest`** +
   **`requestHooksView(workspaceId)`** mirror `changesRequest`/`requestChangesView` — a workspace row's
   hook badge deep-links the right panel to its Hooks tab. The `EditorTab`
   (`FileTab` | `ChatTab`) + `TerminalTab` + `ClosedChat` + `SessionRuntime` types. (Chat *render* types +

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -92,14 +92,25 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   tick)`** — a `FileTab` carries the `tick` its content was loaded at, so `FilePane` detects staleness
   (`workspaceTick > tab.loadedTick`) across tab switches. The transient **`changesRequest`** +
   **`requestChangesView(workspaceId, path)`** are a UI deep-link intent (a chat turn-divider asking the
-  right panel to surface a file's diff); the panels watch it, scoped by workspace. The `EditorTab`
+  right panel to surface a file's diff); the panels watch it, scoped by workspace. The **workspace hooks**
+  state — **`hookOutputByWorkspace: Record<workspaceId, Partial<Record<HookName, { tick, output }>>>`**
+  with **`applyWorkspaceHookEvent(event)`** (folds a `workspace.hook` push: appends `hookOutput` chunks to
+  the live buffer — capped, reset on a fresh `hookStarted`/`hookAwaitingApproval` — and, for every other
+  kind, *also* mirrors the transition onto the matching workspace's own `hookStatus` field directly, so the
+  row badge/Hooks-tab update from the live event without waiting on a `workspace.updated` round-trip; a
+  workspace not found in any loaded project's list only updates the live buffer) — mirrors `noteFsChanged`'s
+  "signal, not data" shape, but this one *also* patches durable state (`Workspace.hookStatus`) since that
+  field already lives on the record the lifecycle pushes carry. The transient **`hooksRequest`** +
+  **`requestHooksView(workspaceId)`** mirror `changesRequest`/`requestChangesView` — a workspace row's
+  hook badge deep-links the right panel to its Hooks tab. The `EditorTab`
   (`FileTab` | `ChatTab`) + `TerminalTab` + `ClosedChat` + `SessionRuntime` types. (Chat *render* types +
   renderers live in the `chat` module.)
 - **Public surface (barrel):** `useAppStore`, `toast` (the fire-from-anywhere helper), `Toast` (type),
   `EditorTab` (`FileTab`/`ChatTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` + `EMPTY_RUNTIME`
   (ChatView's pre-creation fallback), `reduceSessionEvent`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/
-  `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`/`AppConfig`/`ThemeId`; the
+  `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`/`AppConfig`/`ThemeId`/
+  `HookName`/`HookStatus`/`WorkspaceHookEvent`; the
   `Theme` value for the default; `PiEvent`/`LoginFrame`, **type-only**); `chat`
   (`ChatTurn`/`ToolResultState`, **type-only**); `auth` (`LoginState`, **type-only**); `transport`
   (`ConnectionStatus`, **type-only**); `zustand`.

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -816,3 +816,64 @@ test("applyConfig folds the server-synced app config in (theme is host-owned, a 
 	useAppStore.getState().applyConfig({ theme: "light" });
 	expect(useAppStore.getState().theme).toBe("light");
 });
+
+// ---- applyWorkspaceHookEvent: hook events for workspaces no longer in any project's list --------
+
+test("applyWorkspaceHookEvent toasts (doesn't crash/silently drop) hookAwaitingApproval for a workspace no longer in any project's list", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: {}, // the workspace is already gone — mirrors post-removal
+		toasts: [],
+	});
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookAwaitingApproval",
+		workspaceId: "gone-1",
+		workspaceName: "workspace-3",
+		projectId: "p1",
+		hook: "onDelete",
+		command: "docker compose down",
+	});
+	const toasts = useAppStore.getState().toasts;
+	expect(toasts).toHaveLength(1);
+	expect(toasts[0]?.variant).toBe("error");
+	expect(toasts[0]?.message).toContain("workspace-3");
+	expect(toasts[0]?.message).toContain("demo");
+});
+
+test("applyWorkspaceHookEvent toasts hookFailed for a workspace no longer in any project's list", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: {},
+		toasts: [],
+	});
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookFailed",
+		workspaceId: "gone-1",
+		workspaceName: "workspace-3",
+		projectId: "p1",
+		hook: "onDelete",
+		command: "docker compose down",
+		exitCode: 1,
+	});
+	const toasts = useAppStore.getState().toasts;
+	expect(toasts).toHaveLength(1);
+	expect(toasts[0]?.message).toContain("workspace-3");
+	expect(toasts[0]?.message).toContain("exit 1");
+});
+
+test("applyWorkspaceHookEvent doesn't leak into hookOutputByWorkspace for a workspace no longer in any project's list", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: {},
+		hookOutputByWorkspace: {},
+	});
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookOutput",
+		workspaceId: "gone-1",
+		workspaceName: "workspace-3",
+		projectId: "p1",
+		hook: "onDelete",
+		chunk: "tearing down\n",
+	});
+	expect(useAppStore.getState().hookOutputByWorkspace).toEqual({});
+});

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, test } from "bun:test";
 import type { ExtUiRequest, PiEvent, SessionSummary, Workspace } from "@thinkrail/contracts";
-import { type SessionRuntime, toast, useAppStore } from "./appStore";
+import { aggregateHookState, type SessionRuntime, toast, useAppStore } from "./appStore";
 
 // Event fixtures — the reducer only reads the fields below, so casting minimal objects is safe here.
 const agentStart = { type: "agent_start" } as unknown as PiEvent;
@@ -952,4 +952,125 @@ test("applyWorkspaceRemoved tombstones the id end-to-end, so a subsequent hookAw
 	expect(toasts).toHaveLength(1);
 	expect(toasts[0]?.variant).toBe("error");
 	expect(toasts[0]?.message).toContain("add-login-flow");
+});
+
+// ---- applyWorkspaceHookEvent: per-source status, nested by HookSource under hookStatus[hook] ------
+// A `combineMode` of "both" runs Shared then Local for the same hook, each with its own event sequence
+// tagged by `source` — the write must land both side by side, never clobbering one with the other.
+
+test("applyWorkspaceHookEvent writes hookStarted(shared) then hookSucceeded(local) for one hook, preserving both sources", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: { p1: [pushedWorkspace()] },
+		removedWorkspaceIds: {},
+		hookOutputByWorkspace: {},
+	});
+
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookStarted",
+		workspaceId: "w1",
+		workspaceName: "add-login-flow",
+		projectId: "p1",
+		hook: "onCreate",
+		source: "shared",
+		command: "pnpm install",
+	});
+	expect(useAppStore.getState().workspaces.p1?.[0]?.hookStatus).toEqual({
+		onCreate: { shared: { state: "running", command: "pnpm install" } },
+	});
+
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookSucceeded",
+		workspaceId: "w1",
+		workspaceName: "add-login-flow",
+		projectId: "p1",
+		hook: "onCreate",
+		source: "local",
+		command: "echo local ok",
+	});
+	// The shared entry written by the first event is untouched by the local one that follows it.
+	expect(useAppStore.getState().workspaces.p1?.[0]?.hookStatus).toEqual({
+		onCreate: {
+			shared: { state: "running", command: "pnpm install" },
+			local: { state: "succeeded", command: "echo local ok" },
+		},
+	});
+});
+
+test("applyWorkspaceHookEvent leaves other hooks' status untouched when one hook/source updates", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: {
+			p1: [
+				{
+					...pushedWorkspace(),
+					hookStatus: {
+						onDelete: { shared: { state: "succeeded", command: "docker compose down" } },
+					},
+				},
+			],
+		},
+		removedWorkspaceIds: {},
+		hookOutputByWorkspace: {},
+	});
+
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookFailed",
+		workspaceId: "w1",
+		workspaceName: "add-login-flow",
+		projectId: "p1",
+		hook: "onCreate",
+		source: "shared",
+		command: "pnpm install",
+		exitCode: 1,
+	});
+
+	expect(useAppStore.getState().workspaces.p1?.[0]?.hookStatus).toEqual({
+		onDelete: { shared: { state: "succeeded", command: "docker compose down" } },
+		onCreate: { shared: { state: "failed", command: "pnpm install", exitCode: 1 } },
+	});
+});
+
+// ---- aggregateHookState: the per-hook badge's worst-of across sources ------------------------------
+
+test("aggregateHookState: failed outranks every other state", () => {
+	expect(
+		aggregateHookState({
+			shared: { state: "failed", command: "a", exitCode: 1 },
+			local: { state: "succeeded", command: "b" },
+		}),
+	).toBe("failed");
+	expect(
+		aggregateHookState({
+			shared: { state: "awaitingApproval", command: "a" },
+			local: { state: "failed", command: "b", exitCode: 1 },
+		}),
+	).toBe("failed");
+});
+
+test("aggregateHookState: awaitingApproval outranks running/succeeded", () => {
+	expect(
+		aggregateHookState({
+			shared: { state: "awaitingApproval", command: "a" },
+			local: { state: "succeeded", command: "b" },
+		}),
+	).toBe("awaitingApproval");
+});
+
+test("aggregateHookState: running outranks succeeded", () => {
+	expect(
+		aggregateHookState({
+			shared: { state: "running", command: "a" },
+			local: { state: "succeeded", command: "b" },
+		}),
+	).toBe("running");
+});
+
+test("aggregateHookState is undefined for an empty or absent map; a single source reports its own state", () => {
+	expect(aggregateHookState({})).toBeUndefined();
+	expect(aggregateHookState(undefined)).toBeUndefined();
+	expect(aggregateHookState({ local: { state: "succeeded", command: "b" } })).toBe("succeeded");
+	expect(aggregateHookState({ shared: { state: "awaitingApproval", command: "a" } })).toBe(
+		"awaitingApproval",
+	);
 });

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -819,10 +819,11 @@ test("applyConfig folds the server-synced app config in (theme is host-owned, a 
 
 // ---- applyWorkspaceHookEvent: hook events for workspaces no longer in any project's list --------
 
-test("applyWorkspaceHookEvent toasts (doesn't crash/silently drop) hookAwaitingApproval for a workspace no longer in any project's list", () => {
+test("applyWorkspaceHookEvent toasts (doesn't crash/silently drop) hookAwaitingApproval for a workspace that was genuinely removed", () => {
 	useAppStore.setState({
 		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
 		workspaces: {}, // the workspace is already gone — mirrors post-removal
+		removedWorkspaceIds: { "gone-1": true }, // the tombstone is what marks this as "genuinely removed"
 		toasts: [],
 	});
 	useAppStore.getState().applyWorkspaceHookEvent({
@@ -840,10 +841,11 @@ test("applyWorkspaceHookEvent toasts (doesn't crash/silently drop) hookAwaitingA
 	expect(toasts[0]?.message).toContain("demo");
 });
 
-test("applyWorkspaceHookEvent toasts hookFailed for a workspace no longer in any project's list", () => {
+test("applyWorkspaceHookEvent toasts hookFailed for a workspace that was genuinely removed", () => {
 	useAppStore.setState({
 		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
 		workspaces: {},
+		removedWorkspaceIds: { "gone-1": true },
 		toasts: [],
 	});
 	useAppStore.getState().applyWorkspaceHookEvent({
@@ -861,10 +863,11 @@ test("applyWorkspaceHookEvent toasts hookFailed for a workspace no longer in any
 	expect(toasts[0]?.message).toContain("exit 1");
 });
 
-test("applyWorkspaceHookEvent doesn't leak into hookOutputByWorkspace for a workspace no longer in any project's list", () => {
+test("applyWorkspaceHookEvent doesn't leak into hookOutputByWorkspace for a workspace that was genuinely removed", () => {
 	useAppStore.setState({
 		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
 		workspaces: {},
+		removedWorkspaceIds: { "gone-1": true },
 		hookOutputByWorkspace: {},
 	});
 	useAppStore.getState().applyWorkspaceHookEvent({
@@ -876,4 +879,77 @@ test("applyWorkspaceHookEvent doesn't leak into hookOutputByWorkspace for a work
 		chunk: "tearing down\n",
 	});
 	expect(useAppStore.getState().hookOutputByWorkspace).toEqual({});
+});
+
+// ---- applyWorkspaceHookEvent: the "not yet loaded" race (brand-new project, list never fetched) ----
+// This is NOT a removal: `addWorkspace`'s own `workspace.created` push is already a documented no-op for
+// an unfetched project's list, so a hook event arriving in that same window must resolve the same way —
+// silently, reconciling once `workspace.list` populates the row — rather than raising a false "was skipped"
+// toast for a workspace that is very much alive.
+
+test("applyWorkspaceHookEvent silently drops hookAwaitingApproval for a workspace whose project list hasn't loaded yet (not removed)", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: {}, // p1's list was never fetched — the workspace was just created, not removed
+		removedWorkspaceIds: {},
+		toasts: [],
+		hookOutputByWorkspace: {},
+	});
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookAwaitingApproval",
+		workspaceId: "brand-new-1",
+		workspaceName: "workspace-1",
+		projectId: "p1",
+		hook: "onCreate",
+		command: "pnpm install",
+	});
+	expect(useAppStore.getState().toasts).toHaveLength(0);
+	expect(useAppStore.getState().hookOutputByWorkspace).toEqual({});
+});
+
+test("applyWorkspaceHookEvent silently drops hookFailed for the same not-yet-loaded race", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: {},
+		removedWorkspaceIds: {},
+		toasts: [],
+		hookOutputByWorkspace: {},
+	});
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookFailed",
+		workspaceId: "brand-new-1",
+		workspaceName: "workspace-1",
+		projectId: "p1",
+		hook: "onCreate",
+		command: "pnpm install",
+		exitCode: 1,
+	});
+	expect(useAppStore.getState().toasts).toHaveLength(0);
+	expect(useAppStore.getState().hookOutputByWorkspace).toEqual({});
+});
+
+test("applyWorkspaceRemoved tombstones the id end-to-end, so a subsequent hookAwaitingApproval for it toasts", () => {
+	useAppStore.setState({
+		projects: [{ id: "p1", name: "demo", path: "/tmp/demo", slug: "demo", lastOpened: 0 }],
+		workspaces: { p1: [pushedWorkspace()] },
+		activeWorkspaceId: "other-active", // not the removed workspace, so no active-workspace toast fires
+		toasts: [],
+	});
+
+	useAppStore.getState().applyWorkspaceRemoved("p1", "w1"); // the real removal path, not hand-seeded state
+	expect(useAppStore.getState().toasts).toHaveLength(0); // background removal — no toast yet
+
+	useAppStore.getState().applyWorkspaceHookEvent({
+		kind: "hookAwaitingApproval",
+		workspaceId: "w1",
+		workspaceName: "add-login-flow",
+		projectId: "p1",
+		hook: "onDelete",
+		command: "docker compose down",
+	});
+
+	const toasts = useAppStore.getState().toasts;
+	expect(toasts).toHaveLength(1);
+	expect(toasts[0]?.variant).toBe("error");
+	expect(toasts[0]?.message).toContain("add-login-flow");
 });

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -3,6 +3,7 @@ import type {
 	AskUserQuestionResult,
 	ExtUiRequest,
 	HookName,
+	HookSource,
 	HookStatus,
 	LoginFrame,
 	LoginPush,
@@ -76,9 +77,11 @@ const MAX_TOASTS = 5;
  * unboundedly in memory; the Hooks panel only ever needs to show the tail. */
 const HOOK_OUTPUT_CAP = 20_000;
 
-/** Derive the durable `HookStatus` a non-output `WorkspaceHookEvent` implies — mirrors the same mapping
- * the host persists server-side (`workspaces/hooks/hooks.ts`); duplicated here rather than shared, since
- * `apps/web` depends on `@thinkrail/contracts` only, never server code. */
+/** Derive the durable `HookStatus` a non-output `WorkspaceHookEvent` implies for its one (hook, source)
+ * entry — mirrors the same mapping the host persists server-side (`workspaces/hooks/hooks.ts`); duplicated
+ * here rather than shared, since `apps/web` depends on `@thinkrail/contracts` only, never server code. The
+ * caller (`applyWorkspaceHookEvent`) nests this under `hookStatus[event.hook][event.source]` — it never
+ * spans sources itself. */
 function hookStatusFromEvent(
 	event: Exclude<WorkspaceHookEvent, { kind: "hookOutput" }>,
 ): HookStatus {
@@ -92,6 +95,33 @@ function hookStatusFromEvent(
 		case "hookFailed":
 			return { state: "failed", command: event.command, exitCode: event.exitCode };
 	}
+}
+
+/** Worst-of precedence for `aggregateHookState`: lower = more urgent. A failure outranks a still-pending
+ * approval, which outranks an in-flight run, which outranks a clean success. */
+const HOOK_STATE_SEVERITY: Record<HookStatus["state"], number> = {
+	failed: 0,
+	awaitingApproval: 1,
+	running: 2,
+	succeeded: 3,
+};
+
+/**
+ * The per-hook badge's aggregate across sources: a `combineMode` of `"both"` runs Shared and Local for the
+ * same hook, so the two can sit at different states at once (e.g. Shared succeeded, Local still running) —
+ * this picks the single state worth surfacing, by `HOOK_STATE_SEVERITY` (worst-of: `failed >
+ * awaitingApproval > running > succeeded`). `undefined` when no source has reported anything yet (an absent
+ * hook, or an empty map).
+ */
+export function aggregateHookState(
+	bySource: Partial<Record<HookSource, HookStatus>> | undefined,
+): HookStatus["state"] | undefined {
+	let worst: HookStatus["state"] | undefined;
+	for (const status of Object.values(bySource ?? {})) {
+		if (!worst || HOOK_STATE_SEVERITY[status.state] < HOOK_STATE_SEVERITY[worst])
+			worst = status.state;
+	}
+	return worst;
 }
 
 /** A terminal tab. `clientId` is the stable UI key; the server PTY id is owned by its `TerminalInstance`. */
@@ -474,13 +504,17 @@ interface AppState {
 	/**
 	 * Fold a `workspace.hook` push: append to the live output buffer (reset on a fresh run), and — for
 	 * every kind but `hookOutput` — mirror the transition onto the workspace's own `hookStatus` field too,
-	 * so the row badge/tab updates immediately without waiting on a `workspace.updated` round-trip. A
-	 * workspace not found in any loaded project's list is ambiguous on its own — it could mean "genuinely
-	 * removed" OR "this project's list was simply never fetched yet" (the same no-op race `addWorkspace`
-	 * already documents for `workspace.created`) — so it's disambiguated via `removedWorkspaceIds`:
-	 * genuinely removed (id is tombstoned) touches neither buffer nor `hookStatus`, and raises a toast for
-	 * `hookAwaitingApproval`/`hookFailed` (there's no row/tab left to show it); not-yet-loaded (id is NOT
-	 * tombstoned) touches nothing AND raises no toast — the row reconciles correctly once the list loads.
+	 * so the row badge/tab updates immediately without waiting on a `workspace.updated` round-trip. The
+	 * write nests by source — `hookStatus[event.hook][event.source]` — immutably preserving the sibling
+	 * source (a `combineMode` of `"both"` runs Shared *and* Local for the same hook, each on its own event
+	 * sequence) and every other hook untouched; see `aggregateHookState` for the per-hook worst-of a badge
+	 * reads across both. A workspace not found in any loaded project's list is ambiguous on its own — it
+	 * could mean "genuinely removed" OR "this project's list was simply never fetched yet" (the same no-op
+	 * race `addWorkspace` already documents for `workspace.created`) — so it's disambiguated via
+	 * `removedWorkspaceIds`: genuinely removed (id is tombstoned) touches neither buffer nor `hookStatus`,
+	 * and raises a toast for `hookAwaitingApproval`/`hookFailed` (there's no row/tab left to show it);
+	 * not-yet-loaded (id is NOT tombstoned) touches nothing AND raises no toast — the row reconciles
+	 * correctly once the list loads.
 	 */
 	applyWorkspaceHookEvent: (event: WorkspaceHookEvent) => void;
 	/** Replace a file tab's content after a live re-read, recording the fs tick it was loaded at. The tab
@@ -839,7 +873,15 @@ export const useAppStore = create<AppState>((set, get) => ({
 					...s.workspaces,
 					[projectId]: list.map((w) =>
 						w.id === event.workspaceId
-							? { ...w, hookStatus: { ...w.hookStatus, [event.hook]: status } }
+							? {
+									...w,
+									hookStatus: {
+										...w.hookStatus,
+										// Nest by source, spreading the hook's existing sources first so the sibling
+										// (e.g. a `both` run's other tier) survives this write untouched.
+										[event.hook]: { ...w.hookStatus?.[event.hook], [event.source]: status },
+									},
+								}
 							: w,
 					),
 				},

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -412,6 +412,13 @@ interface AppState {
 		Partial<Record<HookName, { tick: number; output: string }>>
 	>;
 	/**
+	 * Tombstones for workspaces genuinely removed (stamped by `applyWorkspaceRemoved`) — the ONLY signal
+	 * `applyWorkspaceHookEvent` trusts to distinguish "removed" from "this project's list simply hasn't
+	 * loaded yet" (both look identical as `!entry` — absent from every project's `workspaces` list — but
+	 * only the former should raise a toast; see `applyWorkspaceHookEvent`'s doc comment).
+	 */
+	removedWorkspaceIds: Record<string, true>;
+	/**
 	 * The in-flight in-app OAuth login, if any (flat + session-less — a login runs on the Welcome screen
 	 * before any session exists, so it must NOT live under a session runtime, or its frames get dropped).
 	 * At most one at a time (the dialog is modal).
@@ -468,9 +475,12 @@ interface AppState {
 	 * Fold a `workspace.hook` push: append to the live output buffer (reset on a fresh run), and — for
 	 * every kind but `hookOutput` — mirror the transition onto the workspace's own `hookStatus` field too,
 	 * so the row badge/tab updates immediately without waiting on a `workspace.updated` round-trip. A
-	 * workspace not found in any loaded project's list (already removed, or not yet fetched) touches
-	 * neither: `hookAwaitingApproval`/`hookFailed` instead raise a toast (there's no row/tab left to show
-	 * it), everything else is dropped.
+	 * workspace not found in any loaded project's list is ambiguous on its own — it could mean "genuinely
+	 * removed" OR "this project's list was simply never fetched yet" (the same no-op race `addWorkspace`
+	 * already documents for `workspace.created`) — so it's disambiguated via `removedWorkspaceIds`:
+	 * genuinely removed (id is tombstoned) touches neither buffer nor `hookStatus`, and raises a toast for
+	 * `hookAwaitingApproval`/`hookFailed` (there's no row/tab left to show it); not-yet-loaded (id is NOT
+	 * tombstoned) touches nothing AND raises no toast — the row reconciles correctly once the list loads.
 	 */
 	applyWorkspaceHookEvent: (event: WorkspaceHookEvent) => void;
 	/** Replace a file tab's content after a live re-read, recording the fs tick it was loaded at. The tab
@@ -633,6 +643,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	fsChangesByWorkspace: {},
 	hooksRequest: null,
 	hookOutputByWorkspace: {},
+	removedWorkspaceIds: {},
 	activeLogin: null,
 	settingsOpen: false,
 	settingsSection: SettingsSection.Providers,
@@ -687,11 +698,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 		const name = s.workspaces[projectId]?.find((w) => w.id === workspaceId)?.name;
 		s.removeWorkspace(projectId, workspaceId);
 		s.clearWorkspaceTabs(workspaceId); // drops the row's tabs + terminals + chat runtimes
-		// Drop the live-refresh signal too — a removed workspace's fs tick record must not linger.
+		// Drop the live-refresh signal too — a removed workspace's fs tick record must not linger. Stamp the
+		// tombstone here too, so a hook event for this id that arrives after this point (e.g. an in-flight
+		// onDelete's hookAwaitingApproval) can tell "genuinely removed" apart from "list not loaded yet".
 		set((state) => {
 			const { [workspaceId]: _gone, ...rest } = state.fsChangesByWorkspace;
 			const { [workspaceId]: _goneHooks, ...restHooks } = state.hookOutputByWorkspace;
-			return { fsChangesByWorkspace: rest, hookOutputByWorkspace: restHooks };
+			return {
+				fsChangesByWorkspace: rest,
+				hookOutputByWorkspace: restHooks,
+				removedWorkspaceIds: { ...state.removedWorkspaceIds, [workspaceId]: true },
+			};
 		});
 		if (wasActive) {
 			s.setActiveWorkspace(null); // the shell falls back to the project Welcome
@@ -764,12 +781,21 @@ export const useAppStore = create<AppState>((set, get) => ({
 			);
 
 			if (!entry) {
-				// The workspace's row/tab is already gone (e.g. removed mid-teardown, per the onDelete
-				// visibility fix) — there's nothing left to update. hookAwaitingApproval/hookFailed would
-				// otherwise vanish silently, so surface just those two as a toast naming the workspace + project;
-				// the rest (hookStarted/hookOutput/hookSucceeded) have nothing actionable to say and are
-				// dropped — this also closes a latent leak where any kind used to still write into
-				// `hookOutputByWorkspace` for an id nothing will ever read again.
+				// `!entry` is ambiguous on its own: it also fires for a brand-new project whose `workspaces`
+				// list was never fetched (see `addWorkspace`'s doc comment — the same `workspace.created` push
+				// is already a documented no-op for that case). Only `removedWorkspaceIds` (stamped by
+				// `applyWorkspaceRemoved`) tells "genuinely removed" apart from "not yet loaded".
+				if (!s.removedWorkspaceIds[event.workspaceId]) {
+					// Not yet loaded: the workspace is alive, its row just hasn't arrived. Nothing to update and
+					// nothing to say — the row/badge reconciles correctly once the list loads.
+					return {};
+				}
+				// Genuinely removed (e.g. mid-teardown, per the onDelete visibility fix) — there's nothing left
+				// to update. hookAwaitingApproval/hookFailed would otherwise vanish silently, so surface just
+				// those two as a toast naming the workspace + project; the rest (hookStarted/hookOutput/
+				// hookSucceeded) have nothing actionable to say and are dropped — this also closes a latent leak
+				// where any kind used to still write into `hookOutputByWorkspace` for an id nothing will ever
+				// read again.
 				const projectName = s.projects.find((p) => p.id === event.projectId)?.name ?? "the project";
 				if (event.kind === "hookAwaitingApproval") {
 					toast.error(

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -2,6 +2,8 @@ import type {
 	AppConfig,
 	AskUserQuestionResult,
 	ExtUiRequest,
+	HookName,
+	HookStatus,
 	LoginFrame,
 	LoginPush,
 	PiEvent,
@@ -14,6 +16,7 @@ import type {
 	WireModel,
 	Workspace,
 	WorkspaceFsChangedPayload,
+	WorkspaceHookEvent,
 } from "@thinkrail/contracts";
 import { isAskUserAnswersMessage, Theme } from "@thinkrail/contracts";
 import { create } from "zustand";
@@ -68,6 +71,28 @@ export interface Toast {
 /** Toast-queue cap: the viewport stacks without scrolling, so past a screenful the oldest drop to keep
  * the newest visible. */
 const MAX_TOASTS = 5;
+
+/** Live hook-output cap (chars) — a chatty `onCreate` (e.g. `pnpm install`) shouldn't grow this
+ * unboundedly in memory; the Hooks panel only ever needs to show the tail. */
+const HOOK_OUTPUT_CAP = 20_000;
+
+/** Derive the durable `HookStatus` a non-output `WorkspaceHookEvent` implies — mirrors the same mapping
+ * the host persists server-side (`workspaces/hooks/hooks.ts`); duplicated here rather than shared, since
+ * `apps/web` depends on `@thinkrail/contracts` only, never server code. */
+function hookStatusFromEvent(
+	event: Exclude<WorkspaceHookEvent, { kind: "hookOutput" }>,
+): HookStatus {
+	switch (event.kind) {
+		case "hookAwaitingApproval":
+			return { state: "awaitingApproval", command: event.command };
+		case "hookStarted":
+			return { state: "running" };
+		case "hookSucceeded":
+			return { state: "succeeded" };
+		case "hookFailed":
+			return { state: "failed", exitCode: event.exitCode };
+	}
+}
 
 /** A terminal tab. `clientId` is the stable UI key; the server PTY id is owned by its `TerminalInstance`. */
 export interface TerminalTab {
@@ -371,6 +396,22 @@ interface AppState {
 	 */
 	fsChangesByWorkspace: Record<string, { tick: number; paths: string[]; truncated: boolean }>;
 	/**
+	 * A request to surface a workspace's Hooks view in the right panel (mirrors `changesRequest`) — set
+	 * when a row's hook badge is clicked for anything other than an approval prompt (that opens a dialog
+	 * instead of switching tabs).
+	 */
+	hooksRequest: { workspaceId: string } | null;
+	/**
+	 * Live hook output, per workspace + hook name: `tick` increments on every `workspace.hook` push for that
+	 * pair; `output` accumulates streamed `hookOutput` chunks (capped) and resets on a fresh
+	 * `hookStarted`/`hookAwaitingApproval`. Purely a live view for the currently-open panel — the durable
+	 * last-known state (survives a reload) lives on `Workspace.hookStatus` instead.
+	 */
+	hookOutputByWorkspace: Record<
+		string,
+		Partial<Record<HookName, { tick: number; output: string }>>
+	>;
+	/**
 	 * The in-flight in-app OAuth login, if any (flat + session-less — a login runs on the Welcome screen
 	 * before any session exists, so it must NOT live under a session runtime, or its frames get dropped).
 	 * At most one at a time (the dialog is modal).
@@ -423,6 +464,13 @@ interface AppState {
 	setFileTabView: (id: string, view: "rendered" | "source") => void;
 	/** Fold a `workspace.fsChanged` push into the live-refresh signal (tick++, last batch replaces). */
 	noteFsChanged: (payload: WorkspaceFsChangedPayload) => void;
+	/**
+	 * Fold a `workspace.hook` push: append to the live output buffer (reset on a fresh run), and — for
+	 * every kind but `hookOutput` — mirror the transition onto the workspace's own `hookStatus` field too,
+	 * so the row badge/tab updates immediately without waiting on a `workspace.updated` round-trip. A
+	 * workspace not found in any loaded project's list (not yet fetched) only updates the live buffer.
+	 */
+	applyWorkspaceHookEvent: (event: WorkspaceHookEvent) => void;
 	/** Replace a file tab's content after a live re-read, recording the fs tick it was loaded at. The tab
 	 * is located across workspaces by its (globally unique) id; a closed tab is a no-op. */
 	updateFileTabContent: (id: string, content: string, tick: number) => void;
@@ -487,6 +535,8 @@ interface AppState {
 	applyConfig: (config: AppConfig) => void;
 	/** Ask the right panel to open `path`'s diff in its Changes view (deep-link from chat). */
 	requestChangesView: (workspaceId: string, path: string) => void;
+	/** Ask the right panel to switch to its Hooks view for `workspaceId` (deep-link from a row's badge). */
+	requestHooksView: (workspaceId: string) => void;
 	/** Enqueue a toast; returns its id so a caller can dismiss it early. An identical live toast (same
 	 * variant/title/message — e.g. a retried failure) coalesces: no twin is added, the existing id returns.
 	 * The queue caps at `MAX_TOASTS` (oldest drop). Prefer the `toast` helper. */
@@ -579,6 +629,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 	models: [],
 	changesRequest: null,
 	fsChangesByWorkspace: {},
+	hooksRequest: null,
+	hookOutputByWorkspace: {},
 	activeLogin: null,
 	settingsOpen: false,
 	settingsSection: SettingsSection.Providers,
@@ -636,7 +688,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 		// Drop the live-refresh signal too — a removed workspace's fs tick record must not linger.
 		set((state) => {
 			const { [workspaceId]: _gone, ...rest } = state.fsChangesByWorkspace;
-			return { fsChangesByWorkspace: rest };
+			const { [workspaceId]: _goneHooks, ...restHooks } = state.hookOutputByWorkspace;
+			return { fsChangesByWorkspace: rest, hookOutputByWorkspace: restHooks };
 		});
 		if (wasActive) {
 			s.setActiveWorkspace(null); // the shell falls back to the project Welcome
@@ -699,6 +752,48 @@ export const useAppStore = create<AppState>((set, get) => ({
 						paths: payload.paths,
 						truncated: payload.truncated,
 					},
+				},
+			};
+		}),
+	applyWorkspaceHookEvent: (event) =>
+		set((s) => {
+			const wsOutput = s.hookOutputByWorkspace[event.workspaceId] ?? {};
+			const prev = wsOutput[event.hook];
+			// A fresh attempt (approval-pending or actually starting) clears the prior run's output; a
+			// terminal state (succeeded/failed) keeps it visible until the next fresh attempt overwrites it.
+			const resetOutput = event.kind === "hookStarted" || event.kind === "hookAwaitingApproval";
+			const hookOutputByWorkspace = {
+				...s.hookOutputByWorkspace,
+				[event.workspaceId]: {
+					...wsOutput,
+					[event.hook]: {
+						tick: (prev?.tick ?? 0) + 1,
+						output:
+							event.kind === "hookOutput"
+								? ((prev?.output ?? "") + event.chunk).slice(-HOOK_OUTPUT_CAP)
+								: resetOutput
+									? ""
+									: (prev?.output ?? ""),
+					},
+				},
+			};
+			if (event.kind === "hookOutput") return { hookOutputByWorkspace };
+
+			const status = hookStatusFromEvent(event);
+			const entry = Object.entries(s.workspaces).find(([, list]) =>
+				list.some((w) => w.id === event.workspaceId),
+			);
+			if (!entry) return { hookOutputByWorkspace }; // not yet fetched — the next workspace.list reconciles
+			const [projectId, list] = entry;
+			return {
+				hookOutputByWorkspace,
+				workspaces: {
+					...s.workspaces,
+					[projectId]: list.map((w) =>
+						w.id === event.workspaceId
+							? { ...w, hookStatus: { ...w.hookStatus, [event.hook]: status } }
+							: w,
+					),
 				},
 			};
 		}),
@@ -998,6 +1093,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	setSettingsSection: (section) => set({ settingsSection: section }),
 	applyConfig: (config) => set({ theme: config.theme }),
 	requestChangesView: (workspaceId, path) => set({ changesRequest: { workspaceId, path } }),
+	requestHooksView: (workspaceId) => set({ hooksRequest: { workspaceId } }),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(
 			(t) => t.variant === toast.variant && t.title === toast.title && t.message === toast.message,

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -86,11 +86,11 @@ function hookStatusFromEvent(
 		case "hookAwaitingApproval":
 			return { state: "awaitingApproval", command: event.command };
 		case "hookStarted":
-			return { state: "running" };
+			return { state: "running", command: event.command };
 		case "hookSucceeded":
-			return { state: "succeeded" };
+			return { state: "succeeded", command: event.command };
 		case "hookFailed":
-			return { state: "failed", exitCode: event.exitCode };
+			return { state: "failed", command: event.command, exitCode: event.exitCode };
 	}
 }
 
@@ -468,7 +468,9 @@ interface AppState {
 	 * Fold a `workspace.hook` push: append to the live output buffer (reset on a fresh run), and — for
 	 * every kind but `hookOutput` — mirror the transition onto the workspace's own `hookStatus` field too,
 	 * so the row badge/tab updates immediately without waiting on a `workspace.updated` round-trip. A
-	 * workspace not found in any loaded project's list (not yet fetched) only updates the live buffer.
+	 * workspace not found in any loaded project's list (already removed, or not yet fetched) touches
+	 * neither: `hookAwaitingApproval`/`hookFailed` instead raise a toast (there's no row/tab left to show
+	 * it), everything else is dropped.
 	 */
 	applyWorkspaceHookEvent: (event: WorkspaceHookEvent) => void;
 	/** Replace a file tab's content after a live re-read, recording the fs tick it was loaded at. The tab
@@ -757,6 +759,30 @@ export const useAppStore = create<AppState>((set, get) => ({
 		}),
 	applyWorkspaceHookEvent: (event) =>
 		set((s) => {
+			const entry = Object.entries(s.workspaces).find(([, list]) =>
+				list.some((w) => w.id === event.workspaceId),
+			);
+
+			if (!entry) {
+				// The workspace's row/tab is already gone (e.g. removed mid-teardown, per the onDelete
+				// visibility fix) — there's nothing left to update. hookAwaitingApproval/hookFailed would
+				// otherwise vanish silently, so surface just those two as a toast naming the workspace + project;
+				// the rest (hookStarted/hookOutput/hookSucceeded) have nothing actionable to say and are
+				// dropped — this also closes a latent leak where any kind used to still write into
+				// `hookOutputByWorkspace` for an id nothing will ever read again.
+				const projectName = s.projects.find((p) => p.id === event.projectId)?.name ?? "the project";
+				if (event.kind === "hookAwaitingApproval") {
+					toast.error(
+						`${event.workspaceName}'s ${event.hook} was skipped — it still needs approval. Approve it in ${projectName} → Hooks so future removals aren't skipped too.`,
+					);
+				} else if (event.kind === "hookFailed") {
+					toast.error(
+						`${event.workspaceName}'s ${event.hook} failed (exit ${event.exitCode}) while the workspace was being removed.`,
+					);
+				}
+				return {};
+			}
+
 			const wsOutput = s.hookOutputByWorkspace[event.workspaceId] ?? {};
 			const prev = wsOutput[event.hook];
 			// A fresh attempt (approval-pending or actually starting) clears the prior run's output; a
@@ -780,10 +806,6 @@ export const useAppStore = create<AppState>((set, get) => ({
 			if (event.kind === "hookOutput") return { hookOutputByWorkspace };
 
 			const status = hookStatusFromEvent(event);
-			const entry = Object.entries(s.workspaces).find(([, list]) =>
-				list.some((w) => w.id === event.workspaceId),
-			);
-			if (!entry) return { hookOutputByWorkspace }; // not yet fetched — the next workspace.list reconciles
 			const [projectId, list] = entry;
 			return {
 				hookOutputByWorkspace,

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -19,11 +19,13 @@ The single WebSocket client to the host, and its app-wide singleton.
   from the WS `url` — for building host HTTP URLs like the `/files/<workspaceId>/<path>` worktree-file
   endpoint the markdown viewer points relative `<img>`s at, targeting the same host the transport dials); `wireTransport.ts` (`initTransport`/
   `getTransport` singleton; routes the `server.welcome`, `pi.event`, `pi.extensionUi`, **the
-  `workspace.created`/`updated`/`removed` lifecycle trio, and `workspace.fsChanged`** into the store —
+  `workspace.created`/`updated`/`removed` lifecycle trio, `workspace.fsChanged`, and `workspace.hook`**
+  into the store —
   `pi.event` via `handlePiEvent(event, sessionId)`, `pi.extensionUi` via `applyExtUi(request)`,
   `workspace.created` via `addWorkspace(workspace)`, `workspace.updated` via `updateWorkspace(workspace)`,
   `workspace.removed` via `applyWorkspaceRemoved(projectId, id)`, `workspace.fsChanged` via
-  `noteFsChanged(payload)`, and **`settings.changed`** (+ the `config` field in `server.welcome`) via
+  `noteFsChanged(payload)`, `workspace.hook` via `applyWorkspaceHookEvent(event)`, and
+  **`settings.changed`** (+ the `config` field in `server.welcome`) via
   `applyConfig(config)` — the server-synced app config (theme, …), applied on connect + on every broadcast
   so clients converge; all subscriptions happen once at init, never in component effects);
   `errorText.ts` (**`errorText(err, fallback?)`** — normalizes a rejected `request` (the host's error
@@ -32,6 +34,7 @@ The single WebSocket client to the host, and its app-wide singleton.
 - **Allowed deps:** `contracts` (method maps, `WS_CHANNELS`, `Project` for welcome, `SessionEventPayload`
   for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.created`/`updated`,
   `WorkspaceRemoved` for `workspace.removed`, `WorkspaceFsChangedPayload` for `workspace.fsChanged`,
+  `WorkspaceHookEvent` for `workspace.hook`,
   `AppConfig` for `server.welcome`'s config + `settings.changed`); `store`
   (welcome + event routing — a runtime edge owned by the parent graph); the browser `WebSocket`.
 - **Forbidden:** `server`/`shared`/any `pi` package; importing `panels`/`shell`.

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -6,6 +6,7 @@ import type {
 	SessionEventPayload,
 	Workspace,
 	WorkspaceFsChangedPayload,
+	WorkspaceHookEvent,
 	WorkspaceRemoved,
 } from "@thinkrail/contracts";
 import { WS_CHANNELS } from "@thinkrail/contracts";
@@ -67,6 +68,10 @@ export function initTransport(): WsTransport {
 
 	transport.subscribe(WS_CHANNELS.workspaceFsChanged, (data) => {
 		useAppStore.getState().noteFsChanged(data as WorkspaceFsChangedPayload);
+	});
+
+	transport.subscribe(WS_CHANNELS.workspaceHook, (data) => {
+		useAppStore.getState().applyWorkspaceHookEvent(data as WorkspaceHookEvent);
 	});
 
 	// A server-synced settings change (theme, …) — every client converges on this broadcast, including the

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -9,7 +9,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import type { Workspace } from "@thinkrail/contracts";
@@ -98,8 +98,20 @@ export function stagePlainFolder(): string {
  * Reset state, create a *fresh, dedicated* git repo (never `E2E_FIXTURE_REPO` — other specs share that one
  * and don't expect a `.thinkrail/hooks.json` on its `main`) with the given hook config committed at
  * `.thinkrail/hooks.json`, and point the stubbed picker at it. Returns the repo path.
+ *
+ * `opts.scripts` additionally commits one or more script files, keyed by their path relative to the repo
+ * root (e.g. `.thinkrail/hooks/setup.sh`) — for exercising a `{ script: "<path>" }` hook value that points
+ * at a real, committed file (propagates into a worktree exactly like `hooks.json` does).
+ *
+ * `opts.gitignoreThinkrail` commits a `.gitignore` covering `.thinkrail/` *before* `git add -A` runs, so
+ * anything under `.thinkrail/` (including `hooks.json` itself) is silently skipped by `add -A` rather than
+ * committed — `git add -A` never errors on an ignored path, it just leaves it untracked. This reproduces a
+ * project that can't commit a Shared hook at all (`project.hooks.get`'s `sharedCommittable: false`).
  */
-export function stageHookProject(hooks: Record<string, string>): string {
+export function stageHookProject(
+	hooks: Record<string, string>,
+	opts?: { scripts?: Record<string, string>; gitignoreThinkrail?: boolean },
+): string {
 	resetState();
 	const repo = mkdtempSync(join(tmpdir(), "thinkrail-e2e-hooks-"));
 	const git = (...args: string[]): void => {
@@ -109,8 +121,14 @@ export function stageHookProject(hooks: Record<string, string>): string {
 	git("config", "user.email", "e2e@thinkrail.test");
 	git("config", "user.name", "e2e");
 	writeFileSync(join(repo, "README.md"), "# hooks fixture\n");
+	if (opts?.gitignoreThinkrail) writeFileSync(join(repo, ".gitignore"), ".thinkrail/\n");
 	mkdirSync(join(repo, ".thinkrail"), { recursive: true });
 	writeFileSync(join(repo, ".thinkrail", "hooks.json"), JSON.stringify(hooks, null, 2));
+	for (const [relPath, contents] of Object.entries(opts?.scripts ?? {})) {
+		const abs = join(repo, relPath);
+		mkdirSync(dirname(abs), { recursive: true });
+		writeFileSync(abs, contents);
+	}
 	git("add", "-A");
 	git("commit", "-m", "init + hooks.json");
 	writeFileSync(E2E_PICK_DIR_POINTER, repo);

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -1,5 +1,14 @@
 import { execFileSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
@@ -83,6 +92,29 @@ export function stagePlainFolder(): string {
 	writeFileSync(join(E2E_PLAIN_DIR, "notes.txt"), "hello from a plain folder\n");
 	writeFileSync(E2E_PICK_DIR_POINTER, E2E_PLAIN_DIR);
 	return E2E_PLAIN_DIR;
+}
+
+/**
+ * Reset state, create a *fresh, dedicated* git repo (never `E2E_FIXTURE_REPO` — other specs share that one
+ * and don't expect a `.thinkrail/hooks.json` on its `main`) with the given hook config committed at
+ * `.thinkrail/hooks.json`, and point the stubbed picker at it. Returns the repo path.
+ */
+export function stageHookProject(hooks: Record<string, string>): string {
+	resetState();
+	const repo = mkdtempSync(join(tmpdir(), "thinkrail-e2e-hooks-"));
+	const git = (...args: string[]): void => {
+		execFileSync("git", ["-C", repo, ...args], { stdio: "ignore" });
+	};
+	git("init", "-b", "main");
+	git("config", "user.email", "e2e@thinkrail.test");
+	git("config", "user.name", "e2e");
+	writeFileSync(join(repo, "README.md"), "# hooks fixture\n");
+	mkdirSync(join(repo, ".thinkrail"), { recursive: true });
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), JSON.stringify(hooks, null, 2));
+	git("add", "-A");
+	git("commit", "-m", "init + hooks.json");
+	writeFileSync(E2E_PICK_DIR_POINTER, repo);
+	return repo;
 }
 
 function loadPersistedWorkspaces(): Workspace[] {

--- a/e2e/project-hooks-config.spec.ts
+++ b/e2e/project-hooks-config.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "@playwright/test";
 import { createWorkspaceViaDialog, stageHookProject } from "./fixtures/app";
 
-// Real host, real git commits to the project's root checkout, real `sh -c` subprocess — no agent needed.
+// Real host, real git commits to the project's root checkout, real `sh -c`/`sh <script>` subprocesses — no
+// agent needed. Covers the tiered shared/local hooks dialog (combine-mode, inline/script toggle,
+// approve-on-save, gitignore handling, per-workspace mode override) end to end against a real repo.
 
 test.describe("project hooks config", () => {
 	test("the gear icon and the Welcome 'Configure hooks' card both open the dialog with zero workspaces", async ({
@@ -26,7 +28,7 @@ test.describe("project hooks config", () => {
 		await expect(page.getByTestId("project-hooks-dialog")).toBeVisible();
 	});
 
-	test("saving a committed onCreate command actually takes effect for a workspace created afterward", async ({
+	test("a multi-line inline command survives save and reopen (no newline fusion)", async ({
 		page,
 	}) => {
 		stageHookProject({});
@@ -37,19 +39,32 @@ test.describe("project hooks config", () => {
 
 		await page.getByTestId("project-item").first().hover();
 		await page.getByTestId("project-hooks").click();
-		await page.getByTestId("hook-command-onCreate").fill("echo configured-via-ui");
+
+		// The old widget was a single-line `<input>`, which a browser silently fuses multi-line text into —
+		// the confirmed data-corruption bug this rebuild fixes. The field is now a `<textarea>`, which must
+		// carry a real embedded newline through fill → save → server round trip → reopen unmolested.
+		const script = "echo line-one\necho line-two";
+		const field = page.getByTestId("hook-shared-onCreate");
+		await field.fill(script);
+		await expect(field).toHaveValue(script);
+		expect(await field.inputValue()).toContain("\n");
+
 		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-approved-shared-onCreate")).toHaveText("Approved");
+		await page.keyboard.press("Escape");
 		await expect(page.getByTestId("project-hooks-dialog")).not.toBeVisible();
 
-		await createWorkspaceViaDialog(page);
-		const badge = page.getByTestId("workspace-item").first().getByTestId("workspace-hook-badge");
-		await expect(badge).toHaveAttribute("data-hook-status", "awaitingApproval");
+		// Reopen — a fresh `project.hooks.get`, not just the in-memory post-save state — and confirm the
+		// newline is still there.
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		const reopened = page.getByTestId("hook-shared-onCreate");
+		await expect(reopened).toHaveValue(script);
+		expect(await reopened.inputValue()).toContain("\n");
 	});
 
-	test("toggling a host-local override persists independently of the committed command", async ({
-		page,
-	}) => {
-		stageHookProject({ onCreate: "echo committed" });
+	test("a Shared script hook runs for a workspace created afterward", async ({ page }) => {
+		stageHookProject({}, { scripts: { ".thinkrail/hooks/setup.sh": "echo script-hook-ran\n" } });
 		await page.goto("/");
 		await page.getByTestId("add-project-menu").click();
 		await page.getByTestId("menu-open-project").click();
@@ -57,17 +72,215 @@ test.describe("project hooks config", () => {
 
 		await page.getByTestId("project-item").first().hover();
 		await page.getByTestId("project-hooks").click();
-		await page.getByTestId("hook-override-toggle-onCreate").check();
-		await page.getByTestId("hook-override-onCreate").fill("echo overridden");
-		await page.getByTestId("save-hooks").click();
-		await expect(page.getByTestId("project-hooks-dialog")).not.toBeVisible();
 
-		// Re-open and confirm it round-tripped.
+		// Switch Shared/onCreate to Script mode and point it at the fixture's committed script.
+		await page.getByTestId("hook-shared-mode-onCreate-script").click();
+		await expect(page.getByTestId("hook-shared-mode-onCreate-script")).toHaveAttribute(
+			"data-active",
+			"true",
+		);
+		await page.getByTestId("hook-shared-onCreate").fill(".thinkrail/hooks/setup.sh");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-approved-shared-onCreate")).toHaveText("Approved");
+		await page.keyboard.press("Escape");
+
+		await createWorkspaceViaDialog(page);
+		const row = page.getByTestId("workspace-item").first();
+		const badge = row.getByTestId("workspace-hook-badge");
+		await expect(badge).toHaveAttribute("data-hook-status", "succeeded", { timeout: 10_000 });
+
+		await row.click();
+		await page.getByTestId("tab-hooks").click();
+		const hookRow = page.getByTestId("hook-row").filter({ hasText: "onCreate" });
+		await expect(hookRow).toHaveAttribute("data-status", "succeeded");
+		await expect(hookRow.getByTestId("hook-command-shared")).toContainText(
+			"script: .thinkrail/hooks/setup.sh",
+		);
+		await expect(hookRow.getByTestId("hook-output")).toContainText("script-hook-ran");
+	});
+
+	test("combine-mode both runs Shared then Local for a created workspace", async ({ page }) => {
+		stageHookProject({});
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
 		await page.getByTestId("project-item").first().hover();
 		await page.getByTestId("project-hooks").click();
-		await expect(page.getByTestId("hook-override-toggle-onCreate")).toBeChecked();
-		await expect(page.getByTestId("hook-override-onCreate")).toHaveValue("echo overridden");
-		await expect(page.getByTestId("hook-command-onCreate")).toHaveValue("echo committed");
+
+		await page.getByTestId("hook-combine-mode-both").click();
+		await expect(page.getByTestId("hook-combine-mode-both")).toHaveAttribute("data-active", "true");
+		await page.getByTestId("hook-shared-onCreate").fill("echo shared-ran");
+		await page.getByTestId("hook-local-onCreate").fill("echo local-ran");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-approved-shared-onCreate")).toHaveText("Approved");
+		await expect(page.getByTestId("hook-approved-local-onCreate")).toHaveText("Approved");
+		await page.keyboard.press("Escape");
+
+		await createWorkspaceViaDialog(page);
+		const row = page.getByTestId("workspace-item").first();
+		await expect(row.getByTestId("workspace-hook-badge")).toHaveAttribute(
+			"data-hook-status",
+			"succeeded",
+			{ timeout: 10_000 },
+		);
+
+		await row.click();
+		await page.getByTestId("tab-hooks").click();
+		const hookRow = page.getByTestId("hook-row").filter({ hasText: "onCreate" });
+		// Both tiers reported and both succeeded — `both` ran Shared *and* Local, not one or the other.
+		await expect(hookRow.getByTestId("hook-command-shared")).toHaveAttribute(
+			"data-status",
+			"succeeded",
+		);
+		await expect(hookRow.getByTestId("hook-command-local")).toHaveAttribute(
+			"data-status",
+			"succeeded",
+		);
+	});
+
+	test("save approves the hook, so a workspace created afterward runs without a separate Approve click", async ({
+		page,
+	}) => {
+		stageHookProject({});
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await page.getByTestId("hook-shared-onCreate").fill("echo configured-via-ui");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-approved-shared-onCreate")).toHaveText("Approved");
+		await page.keyboard.press("Escape");
+		await expect(page.getByTestId("project-hooks-dialog")).not.toBeVisible();
+
+		await createWorkspaceViaDialog(page);
+		// No lingering `awaitingApproval` and no separate approve click — saving already approved this exact
+		// command on this machine, so the badge converges straight through to succeeded.
+		const badge = page.getByTestId("workspace-item").first().getByTestId("workspace-hook-badge");
+		await expect(badge).toHaveAttribute("data-hook-status", "succeeded", { timeout: 10_000 });
+	});
+
+	test("a gitignored .thinkrail/ disables Shared but Local still saves and runs", async ({
+		page,
+	}) => {
+		stageHookProject({}, { gitignoreThinkrail: true });
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await expect(page.getByTestId("shared-uncommittable-note")).toBeVisible();
+		await expect(page.getByTestId("hook-shared-onCreate")).toBeDisabled();
+
+		await page.getByTestId("hook-local-onCreate").fill("echo local-only-ran");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-approved-local-onCreate")).toHaveText("Approved");
+		await page.keyboard.press("Escape");
+
+		await createWorkspaceViaDialog(page);
+		const row = page.getByTestId("workspace-item").first();
+		await expect(row.getByTestId("workspace-hook-badge")).toHaveAttribute(
+			"data-hook-status",
+			"succeeded",
+			{ timeout: 10_000 },
+		);
+
+		await row.click();
+		await page.getByTestId("tab-hooks").click();
+		const hookRow = page.getByTestId("hook-row").filter({ hasText: "onCreate" });
+		await expect(hookRow.getByTestId("hook-command-local")).toBeVisible();
+		await expect(hookRow.getByTestId("hook-command-shared")).toHaveCount(0);
+	});
+
+	test("per-workspace hook mode 'shared' skips the Local hook even when both exist", async ({
+		page,
+	}) => {
+		stageHookProject({});
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await page.getByTestId("hook-shared-onCreate").fill("echo shared-mode-ran");
+		await page.getByTestId("hook-local-onCreate").fill("echo local-mode-ran");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-approved-shared-onCreate")).toHaveText("Approved");
+		await expect(page.getByTestId("hook-approved-local-onCreate")).toHaveText("Approved");
+		await page.keyboard.press("Escape");
+
+		// Create via the raw dialog flow (not `createWorkspaceViaDialog`, which never touches the Advanced
+		// disclosure) so the per-workspace hook-mode override can be picked before creating.
+		await page.getByTestId("add-workspace").first().click();
+		const dialog = page.getByTestId("new-workspace-dialog");
+		await expect(dialog).toBeVisible();
+		await expect(page.getByTestId("ws-advanced-toggle")).toBeVisible();
+		await page.getByTestId("ws-advanced-toggle").click();
+		await page.getByTestId("ws-hook-mode-shared").click();
+		await expect(page.getByTestId("ws-hook-mode-shared")).toHaveAttribute("data-active", "true");
+		await page.getByTestId("create-workspace").click();
+		await expect(dialog).toBeHidden();
+
+		const row = page.getByTestId("workspace-item").first();
+		await expect(row.getByTestId("workspace-hook-badge")).toHaveAttribute(
+			"data-hook-status",
+			"succeeded",
+			{ timeout: 10_000 },
+		);
+
+		await row.click();
+		await page.getByTestId("tab-hooks").click();
+		const hookRow = page.getByTestId("hook-row").filter({ hasText: "onCreate" });
+		await expect(hookRow.getByTestId("hook-command-shared")).toBeVisible();
+		// Local was never even attempted — the workspace's `hookCombineMode: "shared"` override excludes it
+		// entirely, it isn't just skipped mid-run.
+		await expect(hookRow.getByTestId("hook-command-local")).toHaveCount(0);
+	});
+
+	test("removing a Shared onCreate via the × clears it so a later workspace doesn't run it", async ({
+		page,
+	}) => {
+		stageHookProject({});
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await page.getByTestId("hook-shared-onCreate").fill("echo remove-me");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-approved-shared-onCreate")).toHaveText("Approved");
+		await page.keyboard.press("Escape");
+
+		// Reopen, remove it via the × (not a blank-to-delete), save.
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await expect(page.getByTestId("hook-shared-onCreate")).toHaveValue("echo remove-me");
+		await page.getByTestId("hook-shared-remove-onCreate").click();
+		await expect(page.getByTestId("hook-shared-onCreate")).toHaveValue("");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("hook-shared-onCreate")).toHaveValue("");
+		await page.keyboard.press("Escape");
+
+		// Reopen once more — a fresh GET — to confirm it's gone for good, not just cleared client-side.
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await expect(page.getByTestId("hook-shared-onCreate")).toHaveValue("");
+		await page.keyboard.press("Escape");
+
+		await createWorkspaceViaDialog(page);
+		const row = page.getByTestId("workspace-item").first();
+		// Nothing declared for onCreate (Shared cleared, Local never set) ⇒ no entries ever run for it, so
+		// `Workspace.hookStatus` never gains an `onCreate` key at all — no badge, not even a transient one.
+		await expect(row.getByTestId("workspace-hook-badge")).toHaveCount(0);
 	});
 
 	test("removing a workspace with an unapproved onDelete surfaces a toast instead of failing silently", async ({

--- a/e2e/project-hooks-config.spec.ts
+++ b/e2e/project-hooks-config.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, stageHookProject } from "./fixtures/app";
+
+// Real host, real git commits to the project's root checkout, real `sh -c` subprocess — no agent needed.
+
+test.describe("project hooks config", () => {
+	test("the gear icon and the Welcome 'Configure hooks' card both open the dialog with zero workspaces", async ({
+		page,
+	}) => {
+		stageHookProject({});
+		await page.goto("/");
+		await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		// Welcome card, reachable before any workspace exists.
+		await page.getByTestId("welcome-action").filter({ hasText: "Configure hooks" }).click();
+		await expect(page.getByTestId("project-hooks-dialog")).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(page.getByTestId("project-hooks-dialog")).not.toBeVisible();
+
+		// Gear icon on the project row.
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await expect(page.getByTestId("project-hooks-dialog")).toBeVisible();
+	});
+
+	test("saving a committed onCreate command actually takes effect for a workspace created afterward", async ({
+		page,
+	}) => {
+		stageHookProject({});
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await page.getByTestId("hook-command-onCreate").fill("echo configured-via-ui");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("project-hooks-dialog")).not.toBeVisible();
+
+		await createWorkspaceViaDialog(page);
+		const badge = page.getByTestId("workspace-item").first().getByTestId("workspace-hook-badge");
+		await expect(badge).toHaveAttribute("data-hook-status", "awaitingApproval");
+	});
+
+	test("toggling a host-local override persists independently of the committed command", async ({
+		page,
+	}) => {
+		stageHookProject({ onCreate: "echo committed" });
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await page.getByTestId("hook-override-toggle-onCreate").check();
+		await page.getByTestId("hook-override-onCreate").fill("echo overridden");
+		await page.getByTestId("save-hooks").click();
+		await expect(page.getByTestId("project-hooks-dialog")).not.toBeVisible();
+
+		// Re-open and confirm it round-tripped.
+		await page.getByTestId("project-item").first().hover();
+		await page.getByTestId("project-hooks").click();
+		await expect(page.getByTestId("hook-override-toggle-onCreate")).toBeChecked();
+		await expect(page.getByTestId("hook-override-onCreate")).toHaveValue("echo overridden");
+		await expect(page.getByTestId("hook-command-onCreate")).toHaveValue("echo committed");
+	});
+
+	test("removing a workspace with an unapproved onDelete surfaces a toast instead of failing silently", async ({
+		page,
+	}) => {
+		stageHookProject({ onCreate: "true", onDelete: "echo tearing-down" });
+		await page.goto("/");
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+		await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+		// Approve onCreate only (via the reactive badge flow), leaving onDelete unapproved.
+		await createWorkspaceViaDialog(page);
+		const row = page.getByTestId("workspace-item").first();
+		const badge = row.getByTestId("workspace-hook-badge");
+		await expect(badge).toHaveAttribute("data-hook-status", "awaitingApproval");
+		await badge.click();
+		await page.getByTestId("confirm-approve-hook").click();
+		await expect(badge).toHaveAttribute("data-hook-status", "succeeded", { timeout: 10_000 });
+
+		// Remove it — onDelete was never approved, so it should be skipped, and the skip should be visible.
+		await row.getByTestId("workspace-remove").click();
+		await page.getByTestId("confirm-remove").click();
+		await expect(
+			page.getByTestId("toast").filter({ hasText: "onDelete" }).filter({ hasText: "approval" }),
+		).toBeVisible({ timeout: 10_000 });
+	});
+});

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,11 +1,15 @@
 import { basename } from "node:path";
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, stagePlainFolder } from "./fixtures/app";
+import { createWorkspaceViaDialog, openAppFresh, stagePlainFolder } from "./fixtures/app";
 import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
 test("opens a git repo as a project via the directory picker", async ({ page }) => {
-	await page.goto("/");
-	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	// Explicit reset (not just `page.goto`): this test asserts on a *specific* project-item, so it must not
+	// depend on whatever the previous spec file's last test left behind — e.g. `stageHookProject` (used by
+	// `workspace-hooks.spec.ts` / `project-hooks-config.spec.ts`) repoints the stubbed picker at its own
+	// throwaway repo and leaves it there, which used to leak into this test purely by lucky alphabetical
+	// ordering (this file happening to run right after a spec that reset back to `E2E_FIXTURE_REPO`).
+	await openAppFresh(page);
 
 	// "Open project" invokes the host's native directory picker — stubbed to E2E_FIXTURE_REPO in e2e.
 	await page.getByTestId("add-project-menu").click();

--- a/e2e/workspace-hooks.spec.ts
+++ b/e2e/workspace-hooks.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, stageHookProject } from "./fixtures/app";
+
+// Real host, real worktree, real `sh -c` subprocess — no agent needed (`onCreate` is a plain shell
+// command declared in `.thinkrail/hooks.json`, not anything pi-driven). Covers the whole loop: an
+// unapproved hook holds at `hookAwaitingApproval` (badge on the row), approving composes
+// `workspace.hooks.approve` + `workspace.hooks.run` (the retrigger this feature exists for), and the
+// result streams back over `workspace.hook` into both the row badge and the Hooks panel's live output.
+
+test("an unapproved onCreate hook holds for approval, then runs and streams output on approve", async ({
+	page,
+}) => {
+	stageHookProject({ onCreate: "echo hello-from-onCreate" });
+	await page.goto("/");
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("add-project-menu").click();
+	await page.getByTestId("menu-open-project").click();
+	await expect(page.getByTestId("project-item").first()).toBeVisible();
+
+	await createWorkspaceViaDialog(page);
+	const row = page.getByTestId("workspace-item").first();
+	const badge = row.getByTestId("workspace-hook-badge");
+
+	// The unapproved command holds the workspace at `hookAwaitingApproval` — a badge on the row, not a
+	// blocked workspace: the row itself is fully created and selectable regardless.
+	await expect(badge).toHaveAttribute("data-hook-status", "awaitingApproval");
+
+	// Clicking the badge (awaitingApproval) opens the approval modal directly, showing the exact command.
+	await badge.click();
+	const dialog = page.getByTestId("confirm-dialog");
+	await expect(dialog).toBeVisible();
+	await expect(dialog).toContainText("echo hello-from-onCreate");
+
+	// Approve — composes workspace.hooks.approve + workspace.hooks.run, so this specific workspace's
+	// pending onCreate actually gets bootstrapped (not just "approved for next time").
+	await page.getByTestId("confirm-approve-hook").click();
+	await expect(dialog).toBeHidden();
+
+	// The row badge converges to succeeded via the live `workspace.hook` event stream.
+	await expect(badge).toHaveAttribute("data-hook-status", "succeeded", { timeout: 10_000 });
+
+	// The Hooks panel (reached via the row, since the badge is no longer the awaitingApproval fast-path)
+	// shows the same state plus the streamed output.
+	await row.click();
+	await page.getByTestId("tab-hooks").click();
+	const hookRow = page.getByTestId("hook-row").filter({ hasText: "onCreate" });
+	await expect(hookRow).toHaveAttribute("data-status", "succeeded");
+	await expect(hookRow.getByTestId("hook-output")).toContainText("hello-from-onCreate");
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -107,15 +107,32 @@ what lets the UI ship independently of the host.
   **`SpecGraphNode`/`SpecGraphSnapshot`** — the
   Specs-viewer read DTOs, **mirrored** (like `PiEvent`), never imported from `pi-spec-graph` — the wire
   carries only what the panel renders (`type`/`status` stay `string`: tolerate whatever is on disk);
-  the **workspace hooks wire** — **`HookName`** (`onCreate`/`onDelete`/`preMerge`/`postMerge`, the four
-  points a project can declare in its own `.thinkrail/hooks.json`), **`HookStatus`** (`{ state, command?,
-  exitCode? }` — the last known state of one hook, persisted on **`Workspace.hookStatus`** so a
-  reconnecting/reloaded client learns about a still-pending `onCreate` without a live push) and
+  the **workspace hooks wire** — two tiers, one combine-mode, richer values: **`HookName`**
+  (`onCreate`/`onDelete`/`preMerge`/`postMerge`, the four points a project can declare in its own
+  `.thinkrail/hooks.json`); **`CombineMode`** (`both`/`shared`/`local` — how a Shared and a Local command
+  for the *same* event combine, one setting for all four events, not per-event; resolved as
+  `Workspace.hookCombineMode ?? HookConfigFile.combineMode ?? "both"`; `both` runs Shared then Local, fixed
+  order, so a personal addition can only extend the team's baseline, never silently replace it);
+  **`HookSource`** (`shared`/`local` — which tier a command/status/event belongs to: Shared is committed in
+  `.thinkrail/hooks.json` and versioned for the whole repo, Local is host-local (`hookOverrides.json`) and
+  never committed; both scoped to a single project — no machine-global or role tier); **`HookValue`**
+  (`string | { command } | { script }` — a hook's declared value: a bare string / `{ command }` is inline,
+  `{ script }` is a path run with `sh <path>` instead of `sh -c`; a Shared `script` path resolves relative
+  to the worktree root, a Local one may be absolute); **`HookConfigFile`** (`{ version: 1, combineMode,
+  hooks }` — the parsed shape of the committed `.thinkrail/hooks.json`; types-only, the server owns parsing
+  and the legacy flat-file back-compat); **`HookStatus`** (`{ state, command?, exitCode? }` — the last known
+  state of one hook for one source; for a script hook, `command` carries a display label like `script:
+  .thinkrail/hooks/teardown.sh`, not the file contents) persisted on **`Workspace.hookStatus`**, now nested
+  `Partial<Record<HookName, Partial<Record<HookSource, HookStatus>>>>` (a `combineMode` of `"both"` can run
+  both tiers for the same event) so a reconnecting/reloaded client learns about a still-pending `onCreate`
+  without a live push, alongside **`Workspace.hookCombineMode`** (the workspace's own combine-mode
+  override, chosen at create time; `undefined` inherits the project's committed default); and
   **`WorkspaceHookEvent`** (the `workspace.hook` push payload — `hookAwaitingApproval` / `hookStarted` /
-  `hookOutput` / `hookSucceeded` / `hookFailed`, each keyed by `workspaceId` + `hook`, and each also
-  carrying `projectId` + `workspaceName` so a client can still describe the event after the workspace's own
-  record is gone — see the server's `workspaces/hooks` module SPEC for the execution/approval design this
-  wire serves).
+  `hookOutput` / `hookSucceeded` / `hookFailed`, each keyed by `workspaceId` + `hook` + **`source:
+  HookSource`** (a `both` run emits two tagged sequences per hook, Shared then Local, so a client tells
+  them apart instead of conflating them), and each also carrying `projectId` + `workspaceName` so a client
+  can still describe the event after the workspace's own record is gone — see the server's
+  `workspaces/hooks` module SPEC for the execution/approval design this wire serves).
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.inspect`** (classify a path) +
   **`project.init`** (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "has any
   registered spec?" for the Welcome screen — a full-tree walk, so requested only for the shown project,
@@ -136,10 +153,16 @@ what lets the UI ship independently of the host.
   (`{ workspaceId, hook }` → re-invokes a hook for one specific workspace on demand; `onCreate`/`onDelete`
   only — the approval UI composes it with `approve` to bootstrap a workspace stuck at
   `hookAwaitingApproval`, and it doubles as a manual retry-after-failure action)) / the **project hooks
-  pair** — **`project.hooks.get`** (`{ projectId }` → committed + host-local-override commands per hook,
-  plus whether each hook's resolved command is currently approved — no workspace needed, so it's readable
-  before any workspace exists) and **`project.hooks.save`** (writes both the committed config — committed
-  to the project's root checkout — and the override map; never touches approval),
+  pair** — **`project.hooks.get`** (`{ projectId }` → `{ combineMode, shared, local, approved,
+  sharedCommittable }`: both tiers' declared `HookValue`s per hook, the project's `CombineMode` default,
+  per-`(hook, source)` approval, and whether Shared can even be committed here — `sharedCommittable: false`
+  when `.thinkrail/` is gitignored — no workspace needed, so it's readable before any workspace exists) and
+  **`project.hooks.save`** (`{ projectId, combineMode, shared, local }` → `Ack`: writes+commits Shared to
+  the project's root checkout when committable, persists Local, and **approves** every `(hook, source)` it
+  writes on this machine — unlike the superseded committed/override model, saving no longer leaves a hook
+  sitting unapproved) / `workspace.create` params also gain an optional **`hookCombineMode`** (the
+  New-Workspace "Advanced" override of the project's combine-mode default, stamped onto the created
+  `Workspace` record),
   `WS_CHANNELS` (`server.welcome` — which carries the initial `config: AppConfig` alongside `projects` /
   `pi.event` / `pi.extensionUi` / **`settings.changed`** (the full `AppConfig`, broadcast so every client
   converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -106,7 +106,14 @@ what lets the UI ship independently of the host.
   as `config.json`, delivered in `server.welcome`, mutated via `settings.update`);
   **`SpecGraphNode`/`SpecGraphSnapshot`** — the
   Specs-viewer read DTOs, **mirrored** (like `PiEvent`), never imported from `pi-spec-graph` — the wire
-  carries only what the panel renders (`type`/`status` stay `string`: tolerate whatever is on disk).
+  carries only what the panel renders (`type`/`status` stay `string`: tolerate whatever is on disk);
+  the **workspace hooks wire** — **`HookName`** (`onCreate`/`onDelete`/`preMerge`/`postMerge`, the four
+  points a project can declare in its own `.thinkrail/hooks.json`), **`HookStatus`** (`{ state, command?,
+  exitCode? }` — the last known state of one hook, persisted on **`Workspace.hookStatus`** so a
+  reconnecting/reloaded client learns about a still-pending `onCreate` without a live push) and
+  **`WorkspaceHookEvent`** (the `workspace.hook` push payload — `hookAwaitingApproval` / `hookStarted` /
+  `hookOutput` / `hookSucceeded` / `hookFailed`, each keyed by `workspaceId` + `hook`; see the server's
+  `workspaces/hooks` module SPEC for the execution/approval design this wire serves).
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.inspect`** (classify a path) +
   **`project.init`** (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "has any
   registered spec?" for the Welcome screen — a full-tree walk, so requested only for the shown project,
@@ -121,7 +128,12 @@ what lets the UI ship independently of the host.
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
-  read side) / **`settings.update`** (merge + persist a partial `AppConfig`, returns the merged config)),
+  read side) / **`settings.update`** (merge + persist a partial `AppConfig`, returns the merged config)) /
+  the **workspace hooks pair** — **`workspace.hooks.approve`** (`{ projectId, hook, command }` → records a
+  sha256'd approval, scoped to the project+hook, not a single workspace) and **`workspace.hooks.run`**
+  (`{ workspaceId, hook }` → re-invokes a hook for one specific workspace on demand; `onCreate`/`onDelete`
+  only — the approval UI composes it with `approve` to bootstrap a workspace stuck at
+  `hookAwaitingApproval`, and it doubles as a manual retry-after-failure action)),
   `WS_CHANNELS` (`server.welcome` — which carries the initial `config: AppConfig` alongside `projects` /
   `pi.event` / `pi.extensionUi` / **`settings.changed`** (the full `AppConfig`, broadcast so every client
   converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`
@@ -135,7 +147,10 @@ what lets the UI ship independently of the host.
   pair (`{ projectId, id }` — the record is already gone) / **`workspace.fsChanged`** — the worktree
   change-notifier push (**`WorkspaceFsChangedPayload`**: `{ workspaceId, paths, truncated }`,
   worktree-relative deduped paths, capped — `truncated` = treat as wildcard); an **invalidation nudge,
-  not data**: clients re-read via the existing read methods, so a duplicate/replayed frame is harmless.
+  not data**: clients re-read via the existing read methods, so a duplicate/replayed frame is harmless /
+  **`workspace.hook`** — one channel for every `WorkspaceHookEvent` transition (not a per-kind split like
+  the lifecycle trio — every transition for every hook shares this one channel, the same
+  single-channel-carries-a-typed-payload shape `workspace.fsChanged` uses).
   The `WsMethodMap` typed request/result map +
   `WsParams`/`WsResult` helpers, and `PROTOCOL_VERSION`.
 

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -148,8 +148,11 @@ what lets the UI ship independently of the host.
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
   read side) / **`settings.update`** (merge + persist a partial `AppConfig`, returns the merged config)) /
-  the **workspace hooks pair** — **`workspace.hooks.approve`** (`{ projectId, hook, command }` → records a
-  sha256'd approval, scoped to the project+hook, not a single workspace) and **`workspace.hooks.run`**
+  the **workspace hooks pair** — **`workspace.hooks.approve`** (`{ projectId, hook, command, workspaceId?
+  }` → records a sha256'd approval, scoped to the project+hook; an optional `workspaceId` anchors
+  resolution/hashing to that workspace's worktree — matching `workspace.hooks.run`'s basePath — instead of
+  the project root, so a Shared script hook's approval hashes the exact worktree contents `run` will
+  re-check; omitted falls back to the legacy project-root-based resolution) and **`workspace.hooks.run`**
   (`{ workspaceId, hook }` → re-invokes a hook for one specific workspace on demand; `onCreate`/`onDelete`
   only — the approval UI composes it with `approve` to bootstrap a workspace stuck at
   `hookAwaitingApproval`, and it doubles as a manual retry-after-failure action)) / the **project hooks

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -112,8 +112,10 @@ what lets the UI ship independently of the host.
   exitCode? }` — the last known state of one hook, persisted on **`Workspace.hookStatus`** so a
   reconnecting/reloaded client learns about a still-pending `onCreate` without a live push) and
   **`WorkspaceHookEvent`** (the `workspace.hook` push payload — `hookAwaitingApproval` / `hookStarted` /
-  `hookOutput` / `hookSucceeded` / `hookFailed`, each keyed by `workspaceId` + `hook`; see the server's
-  `workspaces/hooks` module SPEC for the execution/approval design this wire serves).
+  `hookOutput` / `hookSucceeded` / `hookFailed`, each keyed by `workspaceId` + `hook`, and each also
+  carrying `projectId` + `workspaceName` so a client can still describe the event after the workspace's own
+  record is gone — see the server's `workspaces/hooks` module SPEC for the execution/approval design this
+  wire serves).
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.inspect`** (classify a path) +
   **`project.init`** (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "has any
   registered spec?" for the Welcome screen — a full-tree walk, so requested only for the shown project,
@@ -133,7 +135,11 @@ what lets the UI ship independently of the host.
   sha256'd approval, scoped to the project+hook, not a single workspace) and **`workspace.hooks.run`**
   (`{ workspaceId, hook }` → re-invokes a hook for one specific workspace on demand; `onCreate`/`onDelete`
   only — the approval UI composes it with `approve` to bootstrap a workspace stuck at
-  `hookAwaitingApproval`, and it doubles as a manual retry-after-failure action)),
+  `hookAwaitingApproval`, and it doubles as a manual retry-after-failure action)) / the **project hooks
+  pair** — **`project.hooks.get`** (`{ projectId }` → committed + host-local-override commands per hook,
+  plus whether each hook's resolved command is currently approved — no workspace needed, so it's readable
+  before any workspace exists) and **`project.hooks.save`** (writes both the committed config — committed
+  to the project's root checkout — and the override map; never touches approval),
   `WS_CHANNELS` (`server.welcome` — which carries the initial `config: AppConfig` alongside `projects` /
   `pi.event` / `pi.extensionUi` / **`settings.changed`** (the full `AppConfig`, broadcast so every client
   converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -50,12 +50,22 @@ export interface Workspace {
 	renamed?: boolean;
 	diffStats?: DiffStats;
 	/**
-	 * The last known state of each declared lifecycle hook, persisted so a reconnecting/reloaded client
-	 * learns about a still-pending `onCreate` without waiting on a live `workspace.hook` push. An
-	 * already-connected client's live view comes from the `workspace.hook` event stream directly, not a
-	 * round-trip through this field — this is durability across reconnects, not the live update path.
+	 * This workspace's combine-mode override, chosen at create time (an "Advanced" control, shown only
+	 * when the project declares hooks) and fixed for the workspace's whole life — read at every hook
+	 * invocation, not just `onCreate`. `undefined` inherits the project's committed default
+	 * (`HookConfigFile.combineMode`, itself defaulting to `"both"`).
 	 */
-	hookStatus?: Partial<Record<HookName, HookStatus>>;
+	hookCombineMode?: CombineMode;
+	/**
+	 * The last known state of each declared lifecycle hook, nested by `HookSource` because a
+	 * `combineMode` of `"both"` runs Shared *and* Local for the same event — persisted so a
+	 * reconnecting/reloaded client learns about a still-pending `onCreate` without waiting on a live
+	 * `workspace.hook` push. An already-connected client's live view comes from the `workspace.hook`
+	 * event stream directly, not a round-trip through this field — this is durability across reconnects,
+	 * not the live update path. For a script hook, `HookStatus.command` carries a display label (e.g.
+	 * `script: .thinkrail/hooks/teardown.sh`), not the file contents.
+	 */
+	hookStatus?: Partial<Record<HookName, Partial<Record<HookSource, HookStatus>>>>;
 }
 
 /**
@@ -73,6 +83,43 @@ export interface WorkspaceFsChangedPayload {
 /** Names of the workspace lifecycle hooks a project can declare in `.thinkrail/hooks.json`. */
 export type HookName = "onCreate" | "onDelete" | "preMerge" | "postMerge";
 
+/**
+ * How a project's Shared and Local commands for the *same* event combine — one setting for all four
+ * `HookName`s, not per-event. `both` (the default) runs Shared then Local, in that fixed order, so a
+ * personal addition can only extend the team's baseline, never silently replace it; `shared`/`local` run
+ * only that one tier. Resolved as `Workspace.hookCombineMode ?? HookConfigFile.combineMode ?? "both"`.
+ */
+export type CombineMode = "both" | "shared" | "local";
+
+/**
+ * Which tier a hook command/status/event belongs to: `shared` is committed in `.thinkrail/hooks.json`
+ * (versioned, delivered to everyone on the repo — the team's reviewed setup); `local` is host-local
+ * (`hookOverrides.json`), this machine only, never committed. Both tiers are scoped to a single project —
+ * there is no machine-global or role tier.
+ */
+export type HookSource = "shared" | "local";
+
+/**
+ * One hook's declared value. A bare string is an inline command (the back-compatible shorthand — same as
+ * `{ command }`, spelled out); `{ script }` is a path to a script file, run with `sh <path>` instead of
+ * `sh -c "<command>"`. A Shared `script` path resolves relative to the worktree root (it propagates into
+ * every worktree the same way the rest of `.thinkrail/hooks.json` does); a Local `script` path may be
+ * absolute or worktree-relative.
+ */
+export type HookValue = string | { command: string } | { script: string };
+
+/**
+ * The parsed shape of a project's committed `.thinkrail/hooks.json` — the Shared tier's declared hooks
+ * plus the project-wide default `combineMode`. Types-only: the server owns parsing, including back-compat
+ * with the legacy flat file (`{ onCreate: "…" }`, no `version`/`hooks` keys), which reads as
+ * `{ version: 1, combineMode: "both", hooks: <the flat object> }`.
+ */
+export interface HookConfigFile {
+	version: 1;
+	combineMode: CombineMode;
+	hooks: Partial<Record<HookName, HookValue>>;
+}
+
 /** One hook's last known state, persisted on its `Workspace` record — see `Workspace.hookStatus`. */
 export interface HookStatus {
 	state: "awaitingApproval" | "running" | "succeeded" | "failed";
@@ -87,6 +134,12 @@ export interface HookStatus {
  * workspace tab's setup/teardown status stays in sync everywhere (same convergence model as the
  * workspace-lifecycle trio). `hookAwaitingApproval` fires instead of `hookStarted` when the hook's command
  * hasn't been approved yet (or has changed since).
+ *
+ * Every variant carries `source: HookSource`. A `combineMode` of `"both"` runs Shared *then* Local for the
+ * same `hook`, as two ordered entries (Shared first) — each gets its own
+ * `hookStarted`/`hookOutput`/`hookSucceeded`/`hookFailed`/`hookAwaitingApproval` sequence tagged by its
+ * `source`, so a client tells the two runs apart instead of conflating them into one. An unapproved entry
+ * halts the remaining ones (see `submodule-server-workspaces-hooks`'s SPEC.md for the run/approval order).
  *
  * `workspace.hooks.approve` only records the approval for that project+hook — it does not itself re-run
  * anything. For `onDelete`/`preMerge`, that's enough: their next natural invocation (the next delete, the
@@ -106,6 +159,7 @@ export type WorkspaceHookEvent =
 			workspaceName: string;
 			projectId: string;
 			hook: HookName;
+			source: HookSource;
 			command: string;
 	  }
 	| {
@@ -114,6 +168,7 @@ export type WorkspaceHookEvent =
 			workspaceName: string;
 			projectId: string;
 			hook: HookName;
+			source: HookSource;
 			command: string;
 	  }
 	| {
@@ -122,6 +177,7 @@ export type WorkspaceHookEvent =
 			workspaceName: string;
 			projectId: string;
 			hook: HookName;
+			source: HookSource;
 			chunk: string;
 	  }
 	| {
@@ -130,6 +186,7 @@ export type WorkspaceHookEvent =
 			workspaceName: string;
 			projectId: string;
 			hook: HookName;
+			source: HookSource;
 			command: string;
 	  }
 	| {
@@ -138,6 +195,7 @@ export type WorkspaceHookEvent =
 			workspaceName: string;
 			projectId: string;
 			hook: HookName;
+			source: HookSource;
 			command: string;
 			exitCode: number;
 	  };

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -49,6 +49,13 @@ export interface Workspace {
 	 */
 	renamed?: boolean;
 	diffStats?: DiffStats;
+	/**
+	 * The last known state of each declared lifecycle hook, persisted so a reconnecting/reloaded client
+	 * learns about a still-pending `onCreate` without waiting on a live `workspace.hook` push. An
+	 * already-connected client's live view comes from the `workspace.hook` event stream directly, not a
+	 * round-trip through this field — this is durability across reconnects, not the live update path.
+	 */
+	hookStatus?: Partial<Record<HookName, HookStatus>>;
 }
 
 /**
@@ -65,6 +72,15 @@ export interface WorkspaceFsChangedPayload {
 
 /** Names of the workspace lifecycle hooks a project can declare in `.thinkrail/hooks.json`. */
 export type HookName = "onCreate" | "onDelete" | "preMerge" | "postMerge";
+
+/** One hook's last known state, persisted on its `Workspace` record — see `Workspace.hookStatus`. */
+export interface HookStatus {
+	state: "awaitingApproval" | "running" | "succeeded" | "failed";
+	/** The exact command that produced this state — carried so an approval prompt can show it verbatim. */
+	command?: string;
+	/** Set only when `state === "failed"` and the command actually ran (vs. never got approved). */
+	exitCode?: number;
+}
 
 /**
  * The `workspace.hook` push payload — one frame per hook-state transition, broadcast to every client so a

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -70,8 +70,14 @@ export type HookName = "onCreate" | "onDelete" | "preMerge" | "postMerge";
  * The `workspace.hook` push payload — one frame per hook-state transition, broadcast to every client so a
  * workspace tab's setup/teardown status stays in sync everywhere (same convergence model as the
  * workspace-lifecycle trio). `hookAwaitingApproval` fires instead of `hookStarted` when the hook's command
- * hasn't been approved yet (or has changed since) — nothing else fires until a `workspace.hooks.approve`
- * call.
+ * hasn't been approved yet (or has changed since).
+ *
+ * `workspace.hooks.approve` only records the approval for that project+hook — it does not itself re-run
+ * anything. For `onDelete`/`preMerge`, that's enough: their next natural invocation (the next delete, the
+ * next merge) checks approval fresh and runs. `onCreate` has no such "next invocation" — it fires exactly
+ * once, at creation time — so approving it after the fact does not retroactively bootstrap a workspace
+ * already sitting at `hookAwaitingApproval`. Re-running an already-created workspace's `onCreate` is not
+ * implemented; see `submodule-server-workspaces-hooks`'s SPEC.md.
  */
 export type WorkspaceHookEvent =
 	| { kind: "hookAwaitingApproval"; workspaceId: string; hook: HookName; command: string }

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -63,6 +63,23 @@ export interface WorkspaceFsChangedPayload {
 	truncated: boolean;
 }
 
+/** Names of the workspace lifecycle hooks a project can declare in `.thinkrail/hooks.json`. */
+export type HookName = "onCreate" | "onDelete" | "preMerge" | "postMerge";
+
+/**
+ * The `workspace.hook` push payload — one frame per hook-state transition, broadcast to every client so a
+ * workspace tab's setup/teardown status stays in sync everywhere (same convergence model as the
+ * workspace-lifecycle trio). `hookAwaitingApproval` fires instead of `hookStarted` when the hook's command
+ * hasn't been approved yet (or has changed since) — nothing else fires until a `workspace.hooks.approve`
+ * call.
+ */
+export type WorkspaceHookEvent =
+	| { kind: "hookAwaitingApproval"; workspaceId: string; hook: HookName; command: string }
+	| { kind: "hookStarted"; workspaceId: string; hook: HookName }
+	| { kind: "hookOutput"; workspaceId: string; hook: HookName; chunk: string }
+	| { kind: "hookSucceeded"; workspaceId: string; hook: HookName }
+	| { kind: "hookFailed"; workspaceId: string; hook: HookName; exitCode: number };
+
 /** A chat tab bound to a workspace. `id` is the UI tab id; `sessionId` is the pi `AgentSession` id. */
 export interface Session {
 	id: string;

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -94,13 +94,53 @@ export interface HookStatus {
  * once, at creation time — so approving it after the fact does not retroactively bootstrap a workspace
  * already sitting at `hookAwaitingApproval`. Re-running an already-created workspace's `onCreate` is not
  * implemented; see `submodule-server-workspaces-hooks`'s SPEC.md.
+ *
+ * `projectId` and `workspaceName` travel on every variant so a client can still describe a hook event
+ * usefully after the workspace's own record is gone (e.g. removed mid-teardown) — see
+ * `submodule-web-store`'s `applyWorkspaceHookEvent`.
  */
 export type WorkspaceHookEvent =
-	| { kind: "hookAwaitingApproval"; workspaceId: string; hook: HookName; command: string }
-	| { kind: "hookStarted"; workspaceId: string; hook: HookName }
-	| { kind: "hookOutput"; workspaceId: string; hook: HookName; chunk: string }
-	| { kind: "hookSucceeded"; workspaceId: string; hook: HookName }
-	| { kind: "hookFailed"; workspaceId: string; hook: HookName; exitCode: number };
+	| {
+			kind: "hookAwaitingApproval";
+			workspaceId: string;
+			workspaceName: string;
+			projectId: string;
+			hook: HookName;
+			command: string;
+	  }
+	| {
+			kind: "hookStarted";
+			workspaceId: string;
+			workspaceName: string;
+			projectId: string;
+			hook: HookName;
+			command: string;
+	  }
+	| {
+			kind: "hookOutput";
+			workspaceId: string;
+			workspaceName: string;
+			projectId: string;
+			hook: HookName;
+			chunk: string;
+	  }
+	| {
+			kind: "hookSucceeded";
+			workspaceId: string;
+			workspaceName: string;
+			projectId: string;
+			hook: HookName;
+			command: string;
+	  }
+	| {
+			kind: "hookFailed";
+			workspaceId: string;
+			workspaceName: string;
+			projectId: string;
+			hook: HookName;
+			command: string;
+			exitCode: number;
+	  };
 
 /** A chat tab bound to a workspace. `id` is the UI tab id; `sessionId` is the pi `AgentSession` id. */
 export interface Session {

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -7,6 +7,7 @@ import type {
 	FileNode,
 	GithubAuthStatus,
 	GitStatus,
+	HookName,
 	JbcentralConnectResult,
 	LoginReply,
 	Project,
@@ -83,6 +84,9 @@ export const WS_METHODS = {
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
 	workspaceDiffStats: "workspace.diffStats",
+	// Records the given command as approved for this project+hook (sha256'd, host-local) so its next run
+	// isn't held at `hookAwaitingApproval`.
+	workspaceHooksApprove: "workspace.hooks.approve",
 	// gh-backed New-Workspace surface: branch list per project + local `gh` auth status.
 	gitListBranches: "git.listBranches",
 	// Background freshness fetch of a remote base ref, fired when the New-Workspace dialog opens/picks a
@@ -166,6 +170,10 @@ export const WS_CHANNELS = {
 	// The worktree change notifier (a `WorkspaceFsChangedPayload` per frame), broadcast to every client.
 	// A debounced invalidation nudge, not data — receivers re-read via the read methods they already use.
 	workspaceFsChanged: "workspace.fsChanged",
+	// One frame per workspace-hook state transition (`WorkspaceHookEvent`), broadcast to every client —
+	// same single-channel-carries-a-typed-payload shape as `workspaceFsChanged`, not the lifecycle trio's
+	// kind→channel mapping (every hook transition shares this one channel).
+	workspaceHook: "workspace.hook",
 	// The server-synced app settings changed (carries the full `AppConfig`), broadcast to every client so
 	// they converge — the initiator applies on this push too, never optimistically.
 	settingsChanged: "settings.changed",
@@ -240,6 +248,10 @@ export interface WsMethodMap {
 	"workspace.list": { params: { projectId: string }; result: Workspace[] };
 	"workspace.remove": { params: { id: string }; result: Ack };
 	"workspace.diffStats": { params: { id: string }; result: DiffStats };
+	"workspace.hooks.approve": {
+		params: { projectId: string; hook: HookName; command: string };
+		result: Ack;
+	};
 	"git.listBranches": { params: { projectId: string }; result: BranchList };
 	// Best-effort background `git fetch` of a remote ref (`origin/<b>`); `ok` reports whether the fetch ran
 	// (offline / non-remote ref → `false`). The UI fires-and-forgets it to warm the ref before create.

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -3,11 +3,14 @@
 import type {
 	AppConfig,
 	BranchList,
+	CombineMode,
 	DiffStats,
 	FileNode,
 	GithubAuthStatus,
 	GitStatus,
 	HookName,
+	HookSource,
+	HookValue,
 	JbcentralConnectResult,
 	LoginReply,
 	Project,
@@ -43,7 +46,12 @@ import type {
 // v8: `ask_user_question` is ack + terminate — the tool no longer blocks; answers travel as
 // `ask-user-answers` custom messages, and `session.getMessages` now returns `TranscriptMessage[]`
 // (pi-canonical + `custom` role) so the questionnaire card can pair answers by tool call id.
-export const PROTOCOL_VERSION = 8;
+// v9: workspace hooks widen to two tiers (Shared/Local) with a `combineMode` and script-file values —
+// `project.hooks.get`/`.save` reshape entirely (`shared`/`local`/`combineMode`/`sharedCommittable` replace
+// the old `committed`/`overrides`), `workspace.create` gains `hookCombineMode`, and every
+// `WorkspaceHookEvent` variant gains `source: HookSource` (a `both` run emits two tagged sequences per
+// hook instead of one).
+export const PROTOCOL_VERSION = 9;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -80,13 +88,17 @@ export const WS_METHODS = {
 	// Lazy per-project "has any registered spec?" (the Welcome screen's "Set up project" signal) — a
 	// full-tree walk, so it's on-demand for the one project shown, never eagerly for every project.
 	projectHasSpecs: "project.hasSpecs",
-	// Read a project's declared hooks (committed `.thinkrail/hooks.json` in its root checkout) + host-local
-	// overrides + whether each hook's *resolved* (override-if-set-else-committed) command is currently
-	// approved — the Project Settings Hooks form's single read. No workspace needed.
+	// Read a project's declared hooks, both tiers — Shared (committed `.thinkrail/hooks.json` in its root
+	// checkout) and Local (host-local overrides) — plus the project's combine-mode default, whether each
+	// (hook, source) is currently approved, and whether Shared can even be committed here (a gitignored
+	// `.thinkrail/` reports `sharedCommittable: false`) — the Project Settings Hooks form's single read. No
+	// workspace needed.
 	projectHooksGet: "project.hooks.get",
-	// Write `.thinkrail/hooks.json` (committed to the project's root checkout, pathspec-scoped so it can
-	// never sweep up unrelated staged changes there) + the host-local override map. Never touches approval —
-	// saving a command and trusting it to run are separate decisions.
+	// Write both tiers: Shared (committed to the project's root checkout, pathspec-scoped so it can never
+	// sweep up unrelated staged changes there — skipped when `sharedCommittable` is false) and Local
+	// (host-local). Unlike the old override model, this DOES approve — every (hook, source) it writes is
+	// approved on this machine, closing the "configured but never ran" gap; see `WorkspaceHookEvent`'s doc
+	// comment for why `onCreate` still can't be retroactively bootstrapped by an approval alone.
 	projectHooksSave: "project.hooks.save",
 	workspaceCreate: "workspace.create",
 	workspaceList: "workspace.list",
@@ -257,23 +269,30 @@ export interface WsMethodMap {
 	"project.hooks.get": {
 		params: { projectId: string };
 		result: {
-			committed: Partial<Record<HookName, string>>;
-			overrides: Partial<Record<HookName, string>>;
-			approved: Partial<Record<HookName, boolean>>;
+			combineMode: CombineMode;
+			shared: Partial<Record<HookName, HookValue>>;
+			local: Partial<Record<HookName, HookValue>>;
+			approved: Partial<Record<HookName, Partial<Record<HookSource, boolean>>>>;
+			// Whether Shared can even be committed here — `false` when `.thinkrail/` is gitignored (see
+			// `project.hooks.save`, which then skips writing Shared rather than force-committing it).
+			sharedCommittable: boolean;
 		};
 	};
 	"project.hooks.save": {
 		params: {
 			projectId: string;
-			committed: Partial<Record<HookName, string>>;
-			overrides: Partial<Record<HookName, string>>;
+			combineMode: CombineMode;
+			shared: Partial<Record<HookName, HookValue>>;
+			local: Partial<Record<HookName, HookValue>>;
 		};
 		result: Ack;
 	};
-	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when
-	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
+	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when omitted,
+	// the worktree branches off the repo's current HEAD (the default behavior). `hookCombineMode`: an
+	// optional per-workspace override of the project's committed combine-mode default (an "Advanced"
+	// New-Workspace control) — omitted inherits that default.
 	"workspace.create": {
-		params: { projectId: string; name?: string; baseRef?: string };
+		params: { projectId: string; name?: string; baseRef?: string; hookCombineMode?: CombineMode };
 		result: Workspace;
 	};
 	"workspace.list": { params: { projectId: string }; result: Workspace[] };

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -84,8 +84,9 @@ export const WS_METHODS = {
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
 	workspaceDiffStats: "workspace.diffStats",
-	// Records the given command as approved for this project+hook (sha256'd, host-local) so its next run
-	// isn't held at `hookAwaitingApproval`.
+	// Records the given command as approved for this project+hook (sha256'd, host-local) — a future
+	// onDelete/preMerge invocation checks this fresh and runs; it does not retroactively re-run onCreate
+	// for a workspace already sitting at `hookAwaitingApproval` (see WorkspaceHookEvent's doc comment).
 	workspaceHooksApprove: "workspace.hooks.approve",
 	// gh-backed New-Workspace surface: branch list per project + local `gh` auth status.
 	gitListBranches: "git.listBranches",

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -85,9 +85,15 @@ export const WS_METHODS = {
 	workspaceRemove: "workspace.remove",
 	workspaceDiffStats: "workspace.diffStats",
 	// Records the given command as approved for this project+hook (sha256'd, host-local) — a future
-	// onDelete/preMerge invocation checks this fresh and runs; it does not retroactively re-run onCreate
-	// for a workspace already sitting at `hookAwaitingApproval` (see WorkspaceHookEvent's doc comment).
+	// onDelete/preMerge invocation checks this fresh and runs; it does not itself re-run onCreate for a
+	// workspace already sitting at `hookAwaitingApproval` (see WorkspaceHookEvent's doc comment) — the
+	// approval UI composes this with `workspaceHooksRun` below to actually bootstrap that workspace.
 	workspaceHooksApprove: "workspace.hooks.approve",
+	// Re-invoke a specific hook for a specific workspace on demand — the general-purpose "run this now"
+	// primitive: what the approval flow uses to bootstrap a workspace whose onCreate was pending approval,
+	// and (independently) what a manual retry-after-failure would use. Only onCreate/onDelete are
+	// supported (preMerge/postMerge have no caller anywhere yet, so "run now" has no meaning for them).
+	workspaceHooksRun: "workspace.hooks.run",
 	// gh-backed New-Workspace surface: branch list per project + local `gh` auth status.
 	gitListBranches: "git.listBranches",
 	// Background freshness fetch of a remote base ref, fired when the New-Workspace dialog opens/picks a
@@ -253,6 +259,7 @@ export interface WsMethodMap {
 		params: { projectId: string; hook: HookName; command: string };
 		result: Ack;
 	};
+	"workspace.hooks.run": { params: { workspaceId: string; hook: HookName }; result: Ack };
 	"git.listBranches": { params: { projectId: string }; result: BranchList };
 	// Best-effort background `git fetch` of a remote ref (`origin/<b>`); `ok` reports whether the fetch ran
 	// (offline / non-remote ref → `false`). The UI fires-and-forgets it to warm the ref before create.

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -80,6 +80,14 @@ export const WS_METHODS = {
 	// Lazy per-project "has any registered spec?" (the Welcome screen's "Set up project" signal) — a
 	// full-tree walk, so it's on-demand for the one project shown, never eagerly for every project.
 	projectHasSpecs: "project.hasSpecs",
+	// Read a project's declared hooks (committed `.thinkrail/hooks.json` in its root checkout) + host-local
+	// overrides + whether each hook's *resolved* (override-if-set-else-committed) command is currently
+	// approved — the Project Settings Hooks form's single read. No workspace needed.
+	projectHooksGet: "project.hooks.get",
+	// Write `.thinkrail/hooks.json` (committed to the project's root checkout, pathspec-scoped so it can
+	// never sweep up unrelated staged changes there) + the host-local override map. Never touches approval —
+	// saving a command and trusting it to run are separate decisions.
+	projectHooksSave: "project.hooks.save",
 	workspaceCreate: "workspace.create",
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
@@ -246,6 +254,22 @@ export interface WsMethodMap {
 	// Does the project's repo carry any registered spec? Computed lazily (a full-tree walk), so it's
 	// requested only for the project the Welcome screen renders — never eagerly for every project.
 	"project.hasSpecs": { params: { projectId: string }; result: { hasSpecs: boolean } };
+	"project.hooks.get": {
+		params: { projectId: string };
+		result: {
+			committed: Partial<Record<HookName, string>>;
+			overrides: Partial<Record<HookName, string>>;
+			approved: Partial<Record<HookName, boolean>>;
+		};
+	};
+	"project.hooks.save": {
+		params: {
+			projectId: string;
+			committed: Partial<Record<HookName, string>>;
+			overrides: Partial<Record<HookName, string>>;
+		};
+		result: Ack;
+	};
 	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when
 	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
 	"workspace.create": {

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -107,7 +107,9 @@ export const WS_METHODS = {
 	// Records the given command as approved for this project+hook (sha256'd, host-local) — a future
 	// onDelete/preMerge invocation checks this fresh and runs; it does not itself re-run onCreate for a
 	// workspace already sitting at `hookAwaitingApproval` (see WorkspaceHookEvent's doc comment) — the
-	// approval UI composes this with `workspaceHooksRun` below to actually bootstrap that workspace.
+	// approval UI composes this with `workspaceHooksRun` below to actually bootstrap that workspace. An
+	// optional `workspaceId` anchors resolution to that workspace's worktree instead of the project root —
+	// see `WsMethodMap`'s doc comment on this method for why.
 	workspaceHooksApprove: "workspace.hooks.approve",
 	// Re-invoke a specific hook for a specific workspace on demand — the general-purpose "run this now"
 	// primitive: what the approval flow uses to bootstrap a workspace whose onCreate was pending approval,
@@ -299,7 +301,11 @@ export interface WsMethodMap {
 	"workspace.remove": { params: { id: string }; result: Ack };
 	"workspace.diffStats": { params: { id: string }; result: DiffStats };
 	"workspace.hooks.approve": {
-		params: { projectId: string; hook: HookName; command: string };
+		// `workspaceId` is optional: when given, the host resolves/hashes against that workspace's worktree
+		// (matching `workspace.hooks.run`'s basePath) instead of the project root — needed for a Shared
+		// script hook whose worktree contents can differ from the root checkout. Omitted keeps the legacy
+		// project-root-based resolution for backward compatibility.
+		params: { projectId: string; hook: HookName; command: string; workspaceId?: string };
 		result: Ack;
 	};
 	"workspace.hooks.run": { params: { workspaceId: string; hook: HookName }; result: Ack };

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -83,17 +83,33 @@ channel fan-out, and the process-boot wrapper both launchers share.
   (`setHookPublisher`), publishing every `WorkspaceHookEvent` directly as the `workspace.hook` push
   `data` — a single channel carries the whole discriminated union (no kind→channel split, unlike the
   lifecycle trio; the same shape `watch`'s `workspace.fsChanged` uses), also `ws.subscribe`d in `open`.
-  `handlers.ts` adds `workspace.hooks.approve` (records an approval) and `workspace.hooks.run`
-  (re-invokes a specific workspace's hook on demand — what the approval flow composes with `approve` to
-  actually bootstrap a workspace stuck at `hookAwaitingApproval`, and the standalone manual-retry
-  action) — the latter is also why `archiveTeardown`'s `reclaimWorktree(ws)` call is `await`ed: that
-  function became `async` once it started awaiting the `onDelete` hook.
+  `handlers.ts` adds `workspace.hooks.approve` and `workspace.hooks.run` (re-invokes a specific
+  workspace's hook on demand — what the approval flow composes with `approve` to actually bootstrap a
+  workspace stuck at `hookAwaitingApproval`, and the standalone manual-retry action) — the latter is
+  also why `archiveTeardown`'s `reclaimWorktree(ws)` call is `await`ed: that function became `async`
+  once it started awaiting the `onDelete` hook. `workspace.hooks.approve`'s wire shape pre-dates
+  per-source approval (`{ projectId, hook, command }` — no `source`), so the handler never trusts the
+  client's `command` as the material to hash: it re-resolves both tiers fresh off the **project's root
+  path** (`workspaces/hooks`'s `resolveHookRun`, mode `"both"`) and calls `approveHook` (with `source`)
+  for whichever resolved entry's *current* `display` matches `command` — for an inline entry `display`
+  IS the material, but for a `{script}` entry `display` is just its label (`` `script: <path>` ``) while
+  the material actually hashed is the script's live file contents, read fresh at approval time.
 - **Project-level hooks config surface:** `project.hooks.get`/`project.hooks.save` (no workspace
-  needed) — `get` reads `workspaces/hooks`'s `loadHookConfig` off the **project's root path** (not a
-  workspace worktree) + `persistence`'s `loadHookOverrides`, and computes per-hook approval via
-  `resolveHookCommand` + `isApproved`; `save` writes via `workspaces/hooks`'s `writeHookConfig` then
-  commits via `projects`'s `commitProjectFile`, and persists the override map via `saveHookOverrides` —
-  approval itself is untouched by a save.
+  needed), both keyed off the **project's root path** (never a workspace worktree — a script's
+  `approvalMaterial`/`missing` there reflects the project root's on-disk state, not any one workspace's
+  checkout). `get` loads `workspaces/hooks`'s `loadHookConfig` (the committed Shared tier +
+  `combineMode`) and `persistence`'s `loadHookOverrides` (the Local tier), computes `sharedCommittable`
+  via `projects`'s `isPathIgnored` against `WORKSPACE_HOOKS_CONFIG_FILE`, and for each of the four hooks
+  calls `resolveHookRun` (mode `"both"`, so both tiers' entries always resolve regardless of the
+  project's actual combine-mode) to fill a per-source `approved` map via `isApproved` — an entry whose
+  `approvalMaterial` is `null` (a missing script) is left out, not marked unapproved. `save` throws a
+  friendly, actionable error (never the raw `git add failed` string) if asked to write a non-empty
+  Shared map on a project where `sharedCommittable` is false; otherwise, whenever committable, it writes
+  via `writeHookConfig` and commits via `projects`'s `commitProjectFile` **even with an empty Shared
+  map**, so the chosen `combineMode` still persists as the project's default. It always persists the
+  Local tier via `saveHookOverrides`, then **approves on save**: `resolveHookRun` again (over what was
+  just written, mode `"both"`) and `approveHook` per resolved entry — so a workspace created right after
+  saving never sits at `hookAwaitingApproval` for something the user just configured on this machine.
 - **Public surface (barrel):** `createServer`, `CreateServerOptions`, `RunningServer`, `bootHost`,
   `BootHostOptions`, `BootedHost`.
 - **Allowed deps:** `contracts` (`PROTOCOL_VERSION`, `WS_CHANNELS`); `shared` (`freePort`, `shellEnv` — for

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -93,7 +93,14 @@ channel fan-out, and the process-boot wrapper both launchers share.
   path** (`workspaces/hooks`'s `resolveHookRun`, mode `"both"`) and calls `approveHook` (with `source`)
   for whichever resolved entry's *current* `display` matches `command` — for an inline entry `display`
   IS the material, but for a `{script}` entry `display` is just its label (`` `script: <path>` ``) while
-  the material actually hashed is the script's live file contents, read fresh at approval time.
+  the material actually hashed is the script's live file contents, read fresh at approval time. An
+  optional `workspaceId` on the request anchors this whole re-resolve to that workspace instead —
+  `basePath`/`loadHookConfig` become `workspace.worktreePath` and `local` keys off `workspace.projectId`
+  — matching what the paired `workspace.hooks.run` always resolves against, so a Shared `{script}` hook
+  whose worktree contents differ from the project root's is approved against the SAME content `run` will
+  re-check (otherwise the hash never matches and the hook loops back to `hookAwaitingApproval` forever).
+  Omitted (older/legacy callers) falls back to the project-root-based resolution described above,
+  unchanged.
 - **Project-level hooks config surface:** `project.hooks.get`/`project.hooks.save` (no workspace
   needed), both keyed off the **project's root path** (never a workspace worktree — a script's
   `approvalMaterial`/`missing` there reflects the project root's on-disk state, not any one workspace's
@@ -105,10 +112,13 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `approvalMaterial` is `null` (a missing script) is left out, not marked unapproved. `save` throws a
   friendly, actionable error (never the raw `git add failed` string) if asked to write a non-empty
   Shared map on a project where `sharedCommittable` is false; otherwise it writes via `writeHookConfig`
-  and commits via `projects`'s `commitProjectFile` **only when committable AND the Shared map is
-  non-empty** — an empty map isn't worth a commit (an absent/untouched file already means "no Shared
-  hooks"; there's no separate on-disk slot for `combineMode` alone, so a project with zero Shared hooks
-  can't persist a bare `combineMode` change through this call). It always persists the Local tier via
+  and commits via `projects`'s `commitProjectFile` when committable AND *either* the submitted Shared
+  map is non-empty *or* the existing committed file already had Shared hooks — the second clause is what
+  lets a save with an empty Shared map actually CLEAR a previously-committed hook (writes `hooks: {}` and
+  commits it) instead of leaving the stale file untouched forever; a brand-new project with nothing
+  committed and an empty Shared map still writes nothing (no noise — there's no separate on-disk slot for
+  `combineMode` alone, so an empty write only matters once something was committed before). It always
+  persists the Local tier via
   `saveHookOverrides`, then **approves on save**: `resolveHookRun` again (over the just-submitted
   `{combineMode, shared, local}`, mode `"both"`) and `approveHook` per resolved entry — so a workspace
   created right after saving never sits at `hookAwaitingApproval` for something the user just configured

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -88,6 +88,12 @@ channel fan-out, and the process-boot wrapper both launchers share.
   actually bootstrap a workspace stuck at `hookAwaitingApproval`, and the standalone manual-retry
   action) — the latter is also why `archiveTeardown`'s `reclaimWorktree(ws)` call is `await`ed: that
   function became `async` once it started awaiting the `onDelete` hook.
+- **Project-level hooks config surface:** `project.hooks.get`/`project.hooks.save` (no workspace
+  needed) — `get` reads `workspaces/hooks`'s `loadHookConfig` off the **project's root path** (not a
+  workspace worktree) + `persistence`'s `loadHookOverrides`, and computes per-hook approval via
+  `resolveHookCommand` + `isApproved`; `save` writes via `workspaces/hooks`'s `writeHookConfig` then
+  commits via `projects`'s `commitProjectFile`, and persists the override map via `saveHookOverrides` —
+  approval itself is untouched by a save.
 - **Public surface (barrel):** `createServer`, `CreateServerOptions`, `RunningServer`, `bootHost`,
   `BootHostOptions`, `BootedHost`.
 - **Allowed deps:** `contracts` (`PROTOCOL_VERSION`, `WS_CHANNELS`); `shared` (`freePort`, `shellEnv` — for

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -104,12 +104,15 @@ channel fan-out, and the process-boot wrapper both launchers share.
   project's actual combine-mode) to fill a per-source `approved` map via `isApproved` — an entry whose
   `approvalMaterial` is `null` (a missing script) is left out, not marked unapproved. `save` throws a
   friendly, actionable error (never the raw `git add failed` string) if asked to write a non-empty
-  Shared map on a project where `sharedCommittable` is false; otherwise, whenever committable, it writes
-  via `writeHookConfig` and commits via `projects`'s `commitProjectFile` **even with an empty Shared
-  map**, so the chosen `combineMode` still persists as the project's default. It always persists the
-  Local tier via `saveHookOverrides`, then **approves on save**: `resolveHookRun` again (over what was
-  just written, mode `"both"`) and `approveHook` per resolved entry — so a workspace created right after
-  saving never sits at `hookAwaitingApproval` for something the user just configured on this machine.
+  Shared map on a project where `sharedCommittable` is false; otherwise it writes via `writeHookConfig`
+  and commits via `projects`'s `commitProjectFile` **only when committable AND the Shared map is
+  non-empty** — an empty map isn't worth a commit (an absent/untouched file already means "no Shared
+  hooks"; there's no separate on-disk slot for `combineMode` alone, so a project with zero Shared hooks
+  can't persist a bare `combineMode` change through this call). It always persists the Local tier via
+  `saveHookOverrides`, then **approves on save**: `resolveHookRun` again (over the just-submitted
+  `{combineMode, shared, local}`, mode `"both"`) and `approveHook` per resolved entry — so a workspace
+  created right after saving never sits at `hookAwaitingApproval` for something the user just configured
+  on this machine.
 - **Public surface (barrel):** `createServer`, `CreateServerOptions`, `RunningServer`, `bootHost`,
   `BootHostOptions`, `BootedHost`.
 - **Allowed deps:** `contracts` (`PROTOCOL_VERSION`, `WS_CHANNELS`); `shared` (`freePort`, `shellEnv` — for

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -79,6 +79,15 @@ channel fan-out, and the process-boot wrapper both launchers share.
   is the **single** place workspace membership changes reach the wire — create/rename/archive all flow
   through it, so every client (including the initiator) converges by reacting, never by per-client optimism.
   The two new channels are `ws.subscribe`d in the WS `open` handler alongside `workspace.updated`.
+- **Workspace hooks wiring:** `createServer` installs the `workspaces/hooks` submodule's publisher
+  (`setHookPublisher`), publishing every `WorkspaceHookEvent` directly as the `workspace.hook` push
+  `data` — a single channel carries the whole discriminated union (no kind→channel split, unlike the
+  lifecycle trio; the same shape `watch`'s `workspace.fsChanged` uses), also `ws.subscribe`d in `open`.
+  `handlers.ts` adds `workspace.hooks.approve` (records an approval) and `workspace.hooks.run`
+  (re-invokes a specific workspace's hook on demand — what the approval flow composes with `approve` to
+  actually bootstrap a workspace stuck at `hookAwaitingApproval`, and the standalone manual-retry
+  action) — the latter is also why `archiveTeardown`'s `reclaimWorktree(ws)` call is `await`ed: that
+  function became `async` once it started awaiting the `onDelete` hook.
 - **Public surface (barrel):** `createServer`, `CreateServerOptions`, `RunningServer`, `bootHost`,
   `BootHostOptions`, `BootedHost`.
 - **Allowed deps:** `contracts` (`PROTOCOL_VERSION`, `WS_CHANNELS`); `shared` (`freePort`, `shellEnv` — for

--- a/packages/server/src/host/autoRename.test.ts
+++ b/packages/server/src/host/autoRename.test.ts
@@ -165,7 +165,7 @@ test("a workspace archived during the one-shot is not renamed or resurrected", a
 	});
 
 	const pending = maybeAutoRenameWorkspace("s1", ws.id, firstTurn);
-	removeWorkspace(ws.id);
+	await removeWorkspace(ws.id);
 	release();
 
 	expect(await pending).toBeNull();

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -69,6 +69,8 @@ import {
 	getWorkspace,
 	listWorkspaces,
 	reclaimWorktree,
+	runOnCreateHook,
+	runOnDeleteHook,
 	workspaceDiffStats,
 } from "../workspaces";
 import { ackSend } from "./ackSend";
@@ -128,6 +130,20 @@ const handlers: Record<string, Handler> = {
 	"workspace.hooks.approve": (params) => {
 		const p = params as { projectId: string; hook: HookName; command: string };
 		approveHook(p.projectId, p.hook, p.command);
+		return { ok: true } as const;
+	},
+	// Re-invoke a specific hook for a specific workspace on demand (the approval flow's "run now" —
+	// composed with `workspace.hooks.approve` — and a standalone manual-retry primitive). Only
+	// onCreate/onDelete are supported: preMerge/postMerge have no caller anywhere yet, so "run now" has no
+	// meaning for them.
+	"workspace.hooks.run": (params) => {
+		const p = params as { workspaceId: string; hook: HookName };
+		const workspace = getWorkspace(p.workspaceId);
+		const project = listProjects().find((proj) => proj.id === workspace.projectId);
+		if (!project) throw new Error(`Unknown project: ${workspace.projectId}`);
+		if (p.hook === "onCreate") runOnCreateHook(workspace, project);
+		else if (p.hook === "onDelete") void runOnDeleteHook(workspace, project);
+		else throw new Error(`Manual run isn't supported for ${p.hook}`);
 		return { ok: true } as const;
 	},
 	"git.listBranches": (params) => listBranches((params as { projectId: string }).projectId),

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -2,6 +2,7 @@ import type {
 	AppConfig,
 	AskUserQuestionResult,
 	ExtUiResponse,
+	HookName,
 	ImageContent,
 	LoginReply,
 	ThinkingLevel,
@@ -62,6 +63,7 @@ import {
 } from "../terminal";
 import { ensureWatch, stopWatch } from "../watch";
 import {
+	approveHook,
 	createWorkspace,
 	forgetWorkspace,
 	getWorkspace,
@@ -83,7 +85,7 @@ type Handler = (params: unknown) => unknown | Promise<unknown>;
 async function archiveTeardown(ws: Workspace): Promise<void> {
 	try {
 		await removeWorkspaceSessions(ws.id, ws.worktreePath);
-		reclaimWorktree(ws);
+		await reclaimWorktree(ws);
 	} catch (error) {
 		console.warn(`workspace archive teardown failed for ${ws.id}: ${error}`);
 	}
@@ -123,6 +125,11 @@ const handlers: Record<string, Handler> = {
 		return { ok: true } as const;
 	},
 	"workspace.diffStats": (params) => workspaceDiffStats((params as { id: string }).id),
+	"workspace.hooks.approve": (params) => {
+		const p = params as { projectId: string; hook: HookName; command: string };
+		approveHook(p.projectId, p.hook, p.command);
+		return { ok: true } as const;
+	},
 	"git.listBranches": (params) => listBranches((params as { projectId: string }).projectId),
 	"git.prefetch": (params) => {
 		const p = params as { projectId: string; ref: string };

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -1,8 +1,11 @@
 import type {
 	AppConfig,
 	AskUserQuestionResult,
+	CombineMode,
 	ExtUiResponse,
 	HookName,
+	HookSource,
+	HookValue,
 	ImageContent,
 	LoginReply,
 	ThinkingLevel,
@@ -52,6 +55,7 @@ import {
 	commitProjectFile,
 	initProject,
 	inspectProjectPath,
+	isPathIgnored,
 	listProjects,
 	openProject,
 } from "../projects";
@@ -74,7 +78,7 @@ import {
 	listWorkspaces,
 	loadHookConfig,
 	reclaimWorktree,
-	resolveHookCommand,
+	resolveHookRun,
 	runOnCreateHook,
 	runOnDeleteHook,
 	workspaceDiffStats,
@@ -117,8 +121,13 @@ const handlers: Record<string, Handler> = {
 		return { ok: true } as const;
 	},
 	"workspace.create": (params) => {
-		const p = params as { projectId: string; name?: string; baseRef?: string };
-		return createWorkspace(p.projectId, p.name, p.baseRef);
+		const p = params as {
+			projectId: string;
+			name?: string;
+			baseRef?: string;
+			hookCombineMode?: CombineMode;
+		};
+		return createWorkspace(p.projectId, p.name, p.baseRef, p.hookCombineMode);
 	},
 	"workspace.list": (params) => listWorkspaces((params as { projectId: string }).projectId),
 	"workspace.remove": (params) => {
@@ -134,9 +143,30 @@ const handlers: Record<string, Handler> = {
 		return { ok: true } as const;
 	},
 	"workspace.diffStats": (params) => workspaceDiffStats((params as { id: string }).id),
+	// Pre-dates per-source approval and carries no `source` over the wire — so this re-resolves both tiers
+	// fresh off disk (never trusts the client's `command` as the material to hash) and approves whichever
+	// entry's *current* display matches it. For an inline entry display IS the material; for a `{script}`
+	// entry the display is just its label (`script: <path>`) while the material actually hashed is the
+	// script's live file contents, read here — so approving a script through this path still content-hashes
+	// correctly rather than hashing the label string.
 	"workspace.hooks.approve": (params) => {
 		const p = params as { projectId: string; hook: HookName; command: string };
-		approveHook(p.projectId, p.hook, p.command);
+		const project = listProjects().find((proj) => proj.id === p.projectId);
+		if (!project) throw new Error(`Unknown project: ${p.projectId}`);
+		const committed = loadHookConfig(project.path);
+		const local = loadHookOverrides()[p.projectId] ?? {};
+		const entries = resolveHookRun({
+			hook: p.hook,
+			committed,
+			local,
+			mode: "both",
+			basePath: project.path,
+		});
+		for (const entry of entries) {
+			if (entry.display === p.command && entry.approvalMaterial != null) {
+				approveHook(p.projectId, p.hook, entry.source, entry.approvalMaterial);
+			}
+		}
 		return { ok: true } as const;
 	},
 	// Re-invoke a specific hook for a specific workspace on demand (the approval flow's "run now" —
@@ -158,27 +188,82 @@ const handlers: Record<string, Handler> = {
 		const project = listProjects().find((proj) => proj.id === p.projectId);
 		if (!project) throw new Error(`Unknown project: ${p.projectId}`);
 		const committed = loadHookConfig(project.path);
-		const overrides = loadHookOverrides()[project.id] ?? {};
-		const hooks: HookName[] = ["onCreate", "onDelete", "preMerge", "postMerge"];
-		const approved: Partial<Record<HookName, boolean>> = {};
-		for (const hook of hooks) {
-			const resolved = resolveHookCommand(hook, committed, overrides);
-			if (resolved) approved[hook] = isApproved(project.id, hook, resolved);
+		const local = loadHookOverrides()[project.id] ?? {};
+		// A project whose `.gitignore` covers `.thinkrail/` can't commit a Shared hook there at all — see
+		// `project.hooks.save`, which skips writing Shared rather than force-committing it in that case.
+		const sharedCommittable = !isPathIgnored(project.path, WORKSPACE_HOOKS_CONFIG_FILE);
+		const hookNames: HookName[] = ["onCreate", "onDelete", "preMerge", "postMerge"];
+		const approved: Partial<Record<HookName, Partial<Record<HookSource, boolean>>>> = {};
+		for (const hook of hookNames) {
+			// mode "both" so BOTH tiers' entries resolve, regardless of the project's actual combine-mode —
+			// this map reports every declared entry's approval state, not just the ones that would run.
+			const entries = resolveHookRun({
+				hook,
+				committed,
+				local,
+				mode: "both",
+				basePath: project.path,
+			});
+			for (const entry of entries) {
+				if (entry.approvalMaterial == null) continue; // a missing script has nothing to hash
+				approved[hook] = {
+					...approved[hook],
+					[entry.source]: isApproved(project.id, hook, entry.source, entry.approvalMaterial),
+				};
+			}
 		}
-		return { committed, overrides, approved };
+		return {
+			combineMode: committed.combineMode,
+			shared: committed.hooks,
+			local,
+			approved,
+			sharedCommittable,
+		};
 	},
 	"project.hooks.save": (params) => {
 		const p = params as {
 			projectId: string;
-			committed: Partial<Record<HookName, string>>;
-			overrides: Partial<Record<HookName, string>>;
+			combineMode: CombineMode;
+			shared: Partial<Record<HookName, HookValue>>;
+			local: Partial<Record<HookName, HookValue>>;
 		};
 		const project = listProjects().find((proj) => proj.id === p.projectId);
 		if (!project) throw new Error(`Unknown project: ${p.projectId}`);
-		writeHookConfig(project.path, p.committed);
-		commitProjectFile(project.path, WORKSPACE_HOOKS_CONFIG_FILE, "chore: update workspace hooks");
-		const allOverrides = loadHookOverrides();
-		saveHookOverrides({ ...allOverrides, [project.id]: p.overrides });
+
+		const sharedCommittable = !isPathIgnored(project.path, WORKSPACE_HOOKS_CONFIG_FILE);
+		if (Object.keys(p.shared).length > 0 && !sharedCommittable) {
+			throw new Error(
+				"This project ignores .thinkrail/ — shared hooks can't be committed here. Use a Local hook instead.",
+			);
+		}
+		// Committable: always write+commit, even with an empty `shared` map, so the chosen `combineMode`
+		// still persists as the project's default. Not committable: `shared` is already known empty (the
+		// guard above threw otherwise), so there's nothing to write — Shared stays unavailable, by design.
+		if (sharedCommittable) {
+			writeHookConfig(project.path, { version: 1, combineMode: p.combineMode, hooks: p.shared });
+			commitProjectFile(project.path, WORKSPACE_HOOKS_CONFIG_FILE, "chore: update workspace hooks");
+		}
+		saveHookOverrides({ ...loadHookOverrides(), [project.id]: p.local });
+
+		// Approve-on-save (this machine): every entry this save just wrote — Shared (when committable) and
+		// Local — is now trusted, so a workspace created right after never sits at `hookAwaitingApproval` for
+		// something the user just configured themselves. A script whose file is absent has null material
+		// (nothing to hash) and is simply skipped — it approves on its next run instead.
+		const hookNames: HookName[] = ["onCreate", "onDelete", "preMerge", "postMerge"];
+		for (const hook of hookNames) {
+			const entries = resolveHookRun({
+				hook,
+				committed: { version: 1, combineMode: p.combineMode, hooks: p.shared },
+				local: p.local,
+				mode: "both",
+				basePath: project.path,
+			});
+			for (const entry of entries) {
+				if (entry.approvalMaterial != null) {
+					approveHook(project.id, hook, entry.source, entry.approvalMaterial);
+				}
+			}
+		}
 		return { ok: true } as const;
 	},
 	"git.listBranches": (params) => listBranches((params as { projectId: string }).projectId),

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -236,10 +236,11 @@ const handlers: Record<string, Handler> = {
 				"This project ignores .thinkrail/ — shared hooks can't be committed here. Use a Local hook instead.",
 			);
 		}
-		// Committable: always write+commit, even with an empty `shared` map, so the chosen `combineMode`
-		// still persists as the project's default. Not committable: `shared` is already known empty (the
-		// guard above threw otherwise), so there's nothing to write — Shared stays unavailable, by design.
-		if (sharedCommittable) {
+		// Write+commit only when committable AND `shared` is non-empty — an empty map isn't worth a commit
+		// (an absent/untouched file already means "no Shared hooks"; there's no separate on-disk slot for
+		// `combineMode` alone). Not committable: the guard above already ensured `shared` is empty in that
+		// case, so this condition still correctly skips — Shared stays unavailable there, by design.
+		if (sharedCommittable && Object.keys(p.shared).length > 0) {
 			writeHookConfig(project.path, { version: 1, combineMode: p.combineMode, hooks: p.shared });
 			commitProjectFile(project.path, WORKSPACE_HOOKS_CONFIG_FILE, "chore: update workspace hooks");
 		}

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -149,22 +149,43 @@ const handlers: Record<string, Handler> = {
 	// entry the display is just its label (`script: <path>`) while the material actually hashed is the
 	// script's live file contents, read here — so approving a script through this path still content-hashes
 	// correctly rather than hashing the label string.
+	// `workspaceId` (optional) anchors that re-resolve to a specific workspace's worktree — the paired
+	// `workspace.hooks.run` always resolves against `workspace.worktreePath`, so a Shared `{script}` hook
+	// whose worktree contents differ from the project root's must be approved against that SAME worktree,
+	// or the hash this records never matches what `run` re-checks and the hook loops back to
+	// `hookAwaitingApproval` forever. Omitted (older/legacy callers) falls back to the project-root-based
+	// resolution below, unchanged.
 	"workspace.hooks.approve": (params) => {
-		const p = params as { projectId: string; hook: HookName; command: string };
-		const project = listProjects().find((proj) => proj.id === p.projectId);
-		if (!project) throw new Error(`Unknown project: ${p.projectId}`);
-		const committed = loadHookConfig(project.path);
-		const local = loadHookOverrides()[p.projectId] ?? {};
+		const p = params as {
+			projectId: string;
+			hook: HookName;
+			command: string;
+			workspaceId?: string;
+		};
+		let projectId: string;
+		let basePath: string;
+		if (p.workspaceId) {
+			const ws = getWorkspace(p.workspaceId);
+			projectId = ws.projectId;
+			basePath = ws.worktreePath;
+		} else {
+			const project = listProjects().find((proj) => proj.id === p.projectId);
+			if (!project) throw new Error(`Unknown project: ${p.projectId}`);
+			projectId = p.projectId;
+			basePath = project.path;
+		}
+		const committed = loadHookConfig(basePath);
+		const local = loadHookOverrides()[projectId] ?? {};
 		const entries = resolveHookRun({
 			hook: p.hook,
 			committed,
 			local,
 			mode: "both",
-			basePath: project.path,
+			basePath,
 		});
 		for (const entry of entries) {
 			if (entry.display === p.command && entry.approvalMaterial != null) {
-				approveHook(p.projectId, p.hook, entry.source, entry.approvalMaterial);
+				approveHook(projectId, p.hook, entry.source, entry.approvalMaterial);
 			}
 		}
 		return { ok: true } as const;
@@ -236,11 +257,17 @@ const handlers: Record<string, Handler> = {
 				"This project ignores .thinkrail/ — shared hooks can't be committed here. Use a Local hook instead.",
 			);
 		}
-		// Write+commit only when committable AND `shared` is non-empty — an empty map isn't worth a commit
-		// (an absent/untouched file already means "no Shared hooks"; there's no separate on-disk slot for
-		// `combineMode` alone). Not committable: the guard above already ensured `shared` is empty in that
-		// case, so this condition still correctly skips — Shared stays unavailable there, by design.
-		if (sharedCommittable && Object.keys(p.shared).length > 0) {
+		// Write+commit when committable AND either the new `shared` is non-empty OR the existing committed
+		// file already had Shared hooks — the second half is what lets a save with `shared: {}` actually
+		// CLEAR a previously-committed hook (writes `hooks: {}` and commits it) rather than leaving the
+		// stale file untouched forever (there's no separate on-disk slot for `combineMode` alone, so an
+		// empty write is still meaningful once something was committed before). A brand-new project with
+		// nothing committed and an empty `shared` still writes nothing (no noise). Not committable: the
+		// guard above already ensured `shared` is empty in that case, so this condition still correctly
+		// skips — Shared stays unavailable there, by design.
+		const existing = loadHookConfig(project.path);
+		const hadShared = Object.keys(existing.hooks).length > 0;
+		if (sharedCommittable && (Object.keys(p.shared).length > 0 || hadShared)) {
 			writeHookConfig(project.path, { version: 1, combineMode: p.combineMode, hooks: p.shared });
 			commitProjectFile(project.path, WORKSPACE_HOOKS_CONFIG_FILE, "chore: update workspace hooks");
 		}

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -9,6 +9,7 @@ import type {
 	WireModel,
 	Workspace,
 } from "@thinkrail/contracts";
+import { WORKSPACE_HOOKS_CONFIG_FILE } from "@thinkrail/shared/paths";
 import {
 	abortSession,
 	answerQuestion,
@@ -45,8 +46,10 @@ import { selectDirectory } from "../dialog";
 import { readDir, readFile } from "../fs";
 import { gitDiff, gitStatus, listBranches, prefetchBranch } from "../git";
 import { githubAuthStatus, githubRefresh } from "../github";
+import { loadHookOverrides, saveHookOverrides } from "../persistence";
 import {
 	closeProject,
+	commitProjectFile,
 	initProject,
 	inspectProjectPath,
 	listProjects,
@@ -67,11 +70,15 @@ import {
 	createWorkspace,
 	forgetWorkspace,
 	getWorkspace,
+	isApproved,
 	listWorkspaces,
+	loadHookConfig,
 	reclaimWorktree,
+	resolveHookCommand,
 	runOnCreateHook,
 	runOnDeleteHook,
 	workspaceDiffStats,
+	writeHookConfig,
 } from "../workspaces";
 import { ackSend } from "./ackSend";
 
@@ -144,6 +151,34 @@ const handlers: Record<string, Handler> = {
 		if (p.hook === "onCreate") runOnCreateHook(workspace, project);
 		else if (p.hook === "onDelete") void runOnDeleteHook(workspace, project);
 		else throw new Error(`Manual run isn't supported for ${p.hook}`);
+		return { ok: true } as const;
+	},
+	"project.hooks.get": (params) => {
+		const p = params as { projectId: string };
+		const project = listProjects().find((proj) => proj.id === p.projectId);
+		if (!project) throw new Error(`Unknown project: ${p.projectId}`);
+		const committed = loadHookConfig(project.path);
+		const overrides = loadHookOverrides()[project.id] ?? {};
+		const hooks: HookName[] = ["onCreate", "onDelete", "preMerge", "postMerge"];
+		const approved: Partial<Record<HookName, boolean>> = {};
+		for (const hook of hooks) {
+			const resolved = resolveHookCommand(hook, committed, overrides);
+			if (resolved) approved[hook] = isApproved(project.id, hook, resolved);
+		}
+		return { committed, overrides, approved };
+	},
+	"project.hooks.save": (params) => {
+		const p = params as {
+			projectId: string;
+			committed: Partial<Record<HookName, string>>;
+			overrides: Partial<Record<HookName, string>>;
+		};
+		const project = listProjects().find((proj) => proj.id === p.projectId);
+		if (!project) throw new Error(`Unknown project: ${p.projectId}`);
+		writeHookConfig(project.path, p.committed);
+		commitProjectFile(project.path, WORKSPACE_HOOKS_CONFIG_FILE, "chore: update workspace hooks");
+		const allOverrides = loadHookOverrides();
+		saveHookOverrides({ ...allOverrides, [project.id]: p.overrides });
 		return { ok: true } as const;
 	},
 	"git.listBranches": (params) => listBranches((params as { projectId: string }).projectId),

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -13,7 +13,7 @@ import { listProjects, openProject } from "../projects";
 import { getConfig, setSettingsPublisher } from "../settings";
 import { closeAllTerminals, setTerminalPublisher } from "../terminal";
 import { setWatchPublisher, stopAllWatches } from "../watch";
-import { setWorkspacePublisher } from "../workspaces";
+import { setHookPublisher, setWorkspacePublisher } from "../workspaces";
 import {
 	isPromptCommitted,
 	isSettledTurn,
@@ -71,6 +71,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				ws.subscribe(WS_CHANNELS.workspaceUpdated);
 				ws.subscribe(WS_CHANNELS.workspaceRemoved);
 				ws.subscribe(WS_CHANNELS.workspaceFsChanged);
+				ws.subscribe(WS_CHANNELS.workspaceHook);
 				ws.subscribe(WS_CHANNELS.settingsChanged);
 				const welcome: ServerWelcome = {
 					protocolVersion: PROTOCOL_VERSION,
@@ -120,6 +121,17 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		const data =
 			event.kind === "removed" ? { projectId: event.projectId, id: event.id } : event.workspace;
 		server.publish(channel, JSON.stringify({ channel, data }));
+	});
+
+	// Fan the `workspaces/hooks` submodule's state transitions (setup/teardown/merge-hook runs) out to
+	// every subscribed client over `workspace.hook` — the `WorkspaceHookEvent` from `contracts` is the wire
+	// payload directly, no kind→channel mapping needed (same shape as the watcher's `fsChanged` push, not
+	// the workspace-lifecycle trio's three-channel split, since every hook transition shares one channel).
+	setHookPublisher((event) => {
+		server.publish(
+			WS_CHANNELS.workspaceHook,
+			JSON.stringify({ channel: WS_CHANNELS.workspaceHook, data: event }),
+		);
 	});
 
 	// Push the worktree change notifier's debounced invalidation batches (agent edits, terminal

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -10,16 +10,22 @@ tags: [v1]
 
 ## Responsibility
 
-Durable app state — projects, workspaces, and the server-synced app config — as JSON under the data dir.
+Durable app state — projects, workspaces, the server-synced app config, and the `workspaces/hooks`
+submodule's host-local hook overrides/approvals — as JSON under the data dir.
 
 ## Boundary
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
-  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, and `loadConfig`/`saveConfig`
-  (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly) — all
-  tab-indented JSON.
+  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, `loadConfig`/`saveConfig`
+  (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly), and
+  `loadHookOverrides`/`saveHookOverrides` (`hookOverrides.json` — a per-project, host-local hook-command
+  override, keyed by `HookName`, that replaces rather than merges with the committed
+  `.thinkrail/hooks.json` value) + `loadHookApprovals`/`saveHookApprovals` (`hookApprovals.json` — a
+  per-project sha256 of the approved command per `HookName`, read/written by `workspaces/hooks`'s approval
+  gate) — all tab-indented JSON.
 - **Public surface (barrel):** `dataDir`, `loadProjects`, `saveProjects`, `loadWorkspaces`,
-  `saveWorkspaces`, `loadConfig`, `saveConfig`.
-- **Allowed deps:** `contracts` (`Project`/`Workspace`/`AppConfig` types + `DEFAULT_CONFIG`); Node
-  `fs`/`os`/`path`.
+  `saveWorkspaces`, `loadConfig`, `saveConfig`, `loadHookOverrides`, `saveHookOverrides`,
+  `loadHookApprovals`, `saveHookApprovals`.
+- **Allowed deps:** `contracts` (`Project`/`Workspace`/`AppConfig`/`HookName` types + `DEFAULT_CONFIG`);
+  Node `fs`/`os`/`path`.
 - **Forbidden:** importing any sibling module or `host` — this is a leaf others depend on.

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -18,9 +18,10 @@ submodule's host-local hook overrides/approvals — as JSON under the data dir.
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
   `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, `loadConfig`/`saveConfig`
   (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly), and
-  `loadHookOverrides`/`saveHookOverrides` (`hookOverrides.json` — a per-project, host-local hook-command
-  override, keyed by `HookName`, that replaces rather than merges with the committed
-  `.thinkrail/hooks.json` value) + `loadHookApprovals`/`saveHookApprovals` (`hookApprovals.json` —
+  `loadHookOverrides`/`saveHookOverrides` (`hookOverrides.json` — a per-project, host-local hook-value
+  override, keyed by `HookName`, valued `HookValue` (inline command or `{ script }` reference) — that
+  replaces rather than merges with the committed `.thinkrail/hooks.json` value) +
+  `loadHookApprovals`/`saveHookApprovals` (`hookApprovals.json` —
   `Record<string, Partial<Record<HookName, { shared?: string; local?: string }>>>`: per-project, per-hook,
   a sha256 of the approved material for *each* `HookSource` independently — Shared and Local approve
   separately since `combineMode: "both"` can run both for the same event; read/written by
@@ -28,6 +29,6 @@ submodule's host-local hook overrides/approvals — as JSON under the data dir.
 - **Public surface (barrel):** `dataDir`, `loadProjects`, `saveProjects`, `loadWorkspaces`,
   `saveWorkspaces`, `loadConfig`, `saveConfig`, `loadHookOverrides`, `saveHookOverrides`,
   `loadHookApprovals`, `saveHookApprovals`.
-- **Allowed deps:** `contracts` (`Project`/`Workspace`/`AppConfig`/`HookName` types + `DEFAULT_CONFIG`);
-  Node `fs`/`os`/`path`.
+- **Allowed deps:** `contracts` (`Project`/`Workspace`/`AppConfig`/`HookName`/`HookValue` types +
+  `DEFAULT_CONFIG`); Node `fs`/`os`/`path`.
 - **Forbidden:** importing any sibling module or `host` — this is a leaf others depend on.

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -20,9 +20,11 @@ submodule's host-local hook overrides/approvals — as JSON under the data dir.
   (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly), and
   `loadHookOverrides`/`saveHookOverrides` (`hookOverrides.json` — a per-project, host-local hook-command
   override, keyed by `HookName`, that replaces rather than merges with the committed
-  `.thinkrail/hooks.json` value) + `loadHookApprovals`/`saveHookApprovals` (`hookApprovals.json` — a
-  per-project sha256 of the approved command per `HookName`, read/written by `workspaces/hooks`'s approval
-  gate) — all tab-indented JSON.
+  `.thinkrail/hooks.json` value) + `loadHookApprovals`/`saveHookApprovals` (`hookApprovals.json` —
+  `Record<string, Partial<Record<HookName, { shared?: string; local?: string }>>>`: per-project, per-hook,
+  a sha256 of the approved material for *each* `HookSource` independently — Shared and Local approve
+  separately since `combineMode: "both"` can run both for the same event; read/written by
+  `workspaces/hooks`'s approval gate) — all tab-indented JSON.
 - **Public surface (barrel):** `dataDir`, `loadProjects`, `saveProjects`, `loadWorkspaces`,
   `saveWorkspaces`, `loadConfig`, `saveConfig`, `loadHookOverrides`, `saveHookOverrides`,
   `loadHookApprovals`, `saveHookApprovals`.

--- a/packages/server/src/persistence/persistence.test.ts
+++ b/packages/server/src/persistence/persistence.test.ts
@@ -37,6 +37,8 @@ test("loadHookApprovals defaults to an empty object when the file doesn't exist"
 });
 
 test("saveHookApprovals then loadHookApprovals round-trips", () => {
-	saveHookApprovals({ p1: { onCreate: "abc123hash" } });
-	expect(loadHookApprovals()).toEqual({ p1: { onCreate: "abc123hash" } });
+	saveHookApprovals({ p1: { onCreate: { shared: "abc123hash", local: "def456hash" } } });
+	expect(loadHookApprovals()).toEqual({
+		p1: { onCreate: { shared: "abc123hash", local: "def456hash" } },
+	});
 });

--- a/packages/server/src/persistence/persistence.test.ts
+++ b/packages/server/src/persistence/persistence.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	loadHookApprovals,
+	loadHookOverrides,
+	saveHookApprovals,
+	saveHookOverrides,
+} from "./persistence";
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-persistence-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("loadHookOverrides defaults to an empty object when the file doesn't exist", () => {
+	expect(loadHookOverrides()).toEqual({});
+});
+
+test("saveHookOverrides then loadHookOverrides round-trips", () => {
+	saveHookOverrides({ p1: { onCreate: "pnpm install" } });
+	expect(loadHookOverrides()).toEqual({ p1: { onCreate: "pnpm install" } });
+});
+
+test("loadHookApprovals defaults to an empty object when the file doesn't exist", () => {
+	expect(loadHookApprovals()).toEqual({});
+});
+
+test("saveHookApprovals then loadHookApprovals round-trips", () => {
+	saveHookApprovals({ p1: { onCreate: "abc123hash" } });
+	expect(loadHookApprovals()).toEqual({ p1: { onCreate: "abc123hash" } });
+});

--- a/packages/server/src/persistence/persistence.test.ts
+++ b/packages/server/src/persistence/persistence.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	loadHookApprovals,
 	loadHookOverrides,
+	loadWorkspaces,
 	saveHookApprovals,
 	saveHookOverrides,
 } from "./persistence";
@@ -40,5 +41,57 @@ test("saveHookApprovals then loadHookApprovals round-trips", () => {
 	saveHookApprovals({ p1: { onCreate: { shared: "abc123hash", local: "def456hash" } } });
 	expect(loadHookApprovals()).toEqual({
 		p1: { onCreate: { shared: "abc123hash", local: "def456hash" } },
+	});
+});
+
+test("loadWorkspaces migrates a legacy flat hookStatus to source-nested under 'shared'", () => {
+	writeFileSync(
+		join(dataDir, "workspaces.json"),
+		JSON.stringify([
+			{
+				id: "w1",
+				projectId: "p1",
+				name: "workspace-1",
+				branch: "workspace-1",
+				worktreePath: "/tmp/w1",
+				baseBranch: "main",
+				hookStatus: {
+					onCreate: { state: "failed", command: "npm install", exitCode: 1 },
+				},
+			},
+		]),
+	);
+
+	expect(loadWorkspaces()[0]?.hookStatus).toEqual({
+		onCreate: { shared: { state: "failed", command: "npm install", exitCode: 1 } },
+	});
+});
+
+test("loadWorkspaces leaves an already source-nested hookStatus unchanged", () => {
+	writeFileSync(
+		join(dataDir, "workspaces.json"),
+		JSON.stringify([
+			{
+				id: "w2",
+				projectId: "p1",
+				name: "workspace-2",
+				branch: "workspace-2",
+				worktreePath: "/tmp/w2",
+				baseBranch: "main",
+				hookStatus: {
+					onCreate: {
+						shared: { state: "succeeded", command: "npm install" },
+						local: { state: "running", command: "npm run setup" },
+					},
+				},
+			},
+		]),
+	);
+
+	expect(loadWorkspaces()[0]?.hookStatus).toEqual({
+		onCreate: {
+			shared: { state: "succeeded", command: "npm install" },
+			local: { state: "running", command: "npm run setup" },
+		},
 	});
 });

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -68,15 +68,20 @@ export function saveHookOverrides(
 }
 
 /**
- * Per-project record of which hook command (as a sha256) the user has approved to auto-run. Editing a
- * committed or overridden command invalidates its approval — the stored hash no longer matches.
+ * Per-project, per-hook, per-`HookSource` record of which material (as a sha256) the user has approved to
+ * auto-run — Shared and Local are approved independently since `combineMode: "both"` can run both for the
+ * same event. Editing the approved material (the inline command, or a script's file contents) invalidates
+ * that source's approval — the stored hash no longer matches.
  */
-export function loadHookApprovals(): Record<string, Partial<Record<HookName, string>>> {
+export function loadHookApprovals(): Record<
+	string,
+	Partial<Record<HookName, { shared?: string; local?: string }>>
+> {
 	return readJson("hookApprovals.json", {});
 }
 
 export function saveHookApprovals(
-	approvals: Record<string, Partial<Record<HookName, string>>>,
+	approvals: Record<string, Partial<Record<HookName, { shared?: string; local?: string }>>>,
 ): void {
 	writeJson("hookApprovals.json", approvals);
 }

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -3,7 +3,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { type AppConfig, DEFAULT_CONFIG, type HookName, type Project, type Workspace } from "@thinkrail/contracts";
+import {
+	type AppConfig,
+	DEFAULT_CONFIG,
+	type HookName,
+	type Project,
+	type Workspace,
+} from "@thinkrail/contracts";
 
 export function dataDir(): string {
 	return process.env.THINKRAIL_DATA_DIR ?? join(homedir(), ".thinkrail");
@@ -55,7 +61,9 @@ export function loadHookOverrides(): Record<string, Partial<Record<HookName, str
 	return readJson("hookOverrides.json", {});
 }
 
-export function saveHookOverrides(overrides: Record<string, Partial<Record<HookName, string>>>): void {
+export function saveHookOverrides(
+	overrides: Record<string, Partial<Record<HookName, string>>>,
+): void {
 	writeJson("hookOverrides.json", overrides);
 }
 
@@ -67,6 +75,8 @@ export function loadHookApprovals(): Record<string, Partial<Record<HookName, str
 	return readJson("hookApprovals.json", {});
 }
 
-export function saveHookApprovals(approvals: Record<string, Partial<Record<HookName, string>>>): void {
+export function saveHookApprovals(
+	approvals: Record<string, Partial<Record<HookName, string>>>,
+): void {
 	writeJson("hookApprovals.json", approvals);
 }

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -7,6 +7,8 @@ import {
 	type AppConfig,
 	DEFAULT_CONFIG,
 	type HookName,
+	type HookSource,
+	type HookStatus,
 	type HookValue,
 	type Project,
 	type Workspace,
@@ -37,8 +39,35 @@ export function saveProjects(projects: Project[]): void {
 	writeJson("projects.json", projects);
 }
 
+/**
+ * Pre-upgrade `Workspace.hookStatus` records held one flat `HookStatus` per hook — no `HookSource`
+ * nesting, because only the committed ("shared") command existed before Local hooks landed. Detect that
+ * legacy shape by its top-level `state` string (a source-nested value never has one) and wrap it under
+ * `shared`, so an old `workspaces.json` reads the same as a freshly-written one. Already-nested values
+ * (and absent hooks) pass through untouched.
+ */
+function normalizeHookStatus(
+	hookStatus: Partial<Record<HookName, unknown>>,
+): Partial<Record<HookName, Partial<Record<HookSource, HookStatus>>>> {
+	const normalized: Partial<Record<HookName, Partial<Record<HookSource, HookStatus>>>> = {};
+	for (const hook of Object.keys(hookStatus) as HookName[]) {
+		const value = hookStatus[hook];
+		if (value === undefined) continue;
+		normalized[hook] =
+			typeof (value as { state?: unknown }).state === "string"
+				? { shared: value as HookStatus }
+				: (value as Partial<Record<HookSource, HookStatus>>);
+	}
+	return normalized;
+}
+
 export function loadWorkspaces(): Workspace[] {
-	return readJson<Workspace[]>("workspaces.json", []);
+	const workspaces = readJson<Workspace[]>("workspaces.json", []);
+	for (const workspace of workspaces) {
+		const { hookStatus } = workspace;
+		if (hookStatus) workspace.hookStatus = normalizeHookStatus(hookStatus);
+	}
+	return workspaces;
 }
 
 export function saveWorkspaces(workspaces: Workspace[]): void {

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -7,6 +7,7 @@ import {
 	type AppConfig,
 	DEFAULT_CONFIG,
 	type HookName,
+	type HookValue,
 	type Project,
 	type Workspace,
 } from "@thinkrail/contracts";
@@ -54,15 +55,16 @@ export function saveConfig(config: AppConfig): void {
 }
 
 /**
- * Per-project, host-local override of a hook command — read by `workspaces/hooks`; replaces (never merges
- * with) the committed `.thinkrail/hooks.json` value for that hook. Never touches the repo.
+ * Per-project, host-local override of a hook value (inline command or `{ script }` reference) — read by
+ * `workspaces/hooks`; replaces (never merges with) the committed `.thinkrail/hooks.json` value for that
+ * hook. Never touches the repo.
  */
-export function loadHookOverrides(): Record<string, Partial<Record<HookName, string>>> {
+export function loadHookOverrides(): Record<string, Partial<Record<HookName, HookValue>>> {
 	return readJson("hookOverrides.json", {});
 }
 
 export function saveHookOverrides(
-	overrides: Record<string, Partial<Record<HookName, string>>>,
+	overrides: Record<string, Partial<Record<HookName, HookValue>>>,
 ): void {
 	writeJson("hookOverrides.json", overrides);
 }

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -3,7 +3,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { type AppConfig, DEFAULT_CONFIG, type Project, type Workspace } from "@thinkrail/contracts";
+import { type AppConfig, DEFAULT_CONFIG, type HookName, type Project, type Workspace } from "@thinkrail/contracts";
 
 export function dataDir(): string {
 	return process.env.THINKRAIL_DATA_DIR ?? join(homedir(), ".thinkrail");
@@ -45,4 +45,28 @@ export function loadConfig(): AppConfig {
 
 export function saveConfig(config: AppConfig): void {
 	writeJson("config.json", config);
+}
+
+/**
+ * Per-project, host-local override of a hook command — read by `workspaces/hooks`; replaces (never merges
+ * with) the committed `.thinkrail/hooks.json` value for that hook. Never touches the repo.
+ */
+export function loadHookOverrides(): Record<string, Partial<Record<HookName, string>>> {
+	return readJson("hookOverrides.json", {});
+}
+
+export function saveHookOverrides(overrides: Record<string, Partial<Record<HookName, string>>>): void {
+	writeJson("hookOverrides.json", overrides);
+}
+
+/**
+ * Per-project record of which hook command (as a sha256) the user has approved to auto-run. Editing a
+ * committed or overridden command invalidates its approval — the stored hash no longer matches.
+ */
+export function loadHookApprovals(): Record<string, Partial<Record<HookName, string>>> {
+	return readJson("hookApprovals.json", {});
+}
+
+export function saveHookApprovals(approvals: Record<string, Partial<Record<HookName, string>>>): void {
+	writeJson("hookApprovals.json", approvals);
 }

--- a/packages/server/src/projects/SPEC.md
+++ b/packages/server/src/projects/SPEC.md
@@ -25,9 +25,13 @@ classify it and bootstrap it into one so it can be opened.
   path throws). The commit supplies a **fallback `user.name`/`user.email` only for a field git has none
   configured for**, so a real global identity is never overridden. ("Does the project have specs?" is
   **not** computed here — `host` answers the lazy `project.hasSpecs` query via `spec.projectHasSpecs`,
-  keeping this module free of any spec dependency.)
+  keeping this module free of any spec dependency.) **`commitProjectFile`** — commits an already-written
+  project-root file, pathspec-scoped (never sweeps up unrelated staged changes), reusing the same
+  git-identity fallback `initProject` has. Used by `host/handlers.ts`'s `project.hooks.save` to commit
+  `.thinkrail/hooks.json` after `workspaces/hooks`'s `writeHookConfig` writes it — `workspaces/hooks` stays
+  git-free per its own SPEC; this module is the one place that already commits to a project's root.
 - **Public surface (barrel):** `openProject`, `listProjects`, `closeProject`, `getProjects`,
-  `inspectProjectPath`, `initProject`.
+  `inspectProjectPath`, `initProject`, `commitProjectFile`.
 - **Allowed deps:** `persistence`; the `git` sub-module (shared `git()` runner, bound to live `env` for
   config overrides); `contracts` (`Project`, `ProjectPathStatus`); Node/Bun.
 - **Forbidden:** `host`; sibling features other than `git` (`workspaces` depends on `projects`, never the

--- a/packages/server/src/projects/SPEC.md
+++ b/packages/server/src/projects/SPEC.md
@@ -30,8 +30,13 @@ classify it and bootstrap it into one so it can be opened.
   git-identity fallback `initProject` has. Used by `host/handlers.ts`'s `project.hooks.save` to commit
   `.thinkrail/hooks.json` after `workspaces/hooks`'s `writeHookConfig` writes it — `workspaces/hooks` stays
   git-free per its own SPEC; this module is the one place that already commits to a project's root.
+  **`isPathIgnored(projectPath, relPath)`** — `git check-ignore --quiet -- <relPath>` in `projectPath`;
+  exit 0 (ignored) → `true`, exit 1 (not ignored) → `false`, and any other outcome (a git error — not a
+  repo, missing path, …) also reads as `false`, the safer default. Never throws. Backs the host's
+  `sharedCommittable` computation (`project.hooks.get`): a project whose `.gitignore` covers `.thinkrail/`
+  can't commit a Shared hook there, so the UI steers the user to a Local (host-local) hook instead.
 - **Public surface (barrel):** `openProject`, `listProjects`, `closeProject`, `getProjects`,
-  `inspectProjectPath`, `initProject`, `commitProjectFile`.
+  `inspectProjectPath`, `initProject`, `commitProjectFile`, `isPathIgnored`.
 - **Allowed deps:** `persistence`; the `git` sub-module (shared `git()` runner, bound to live `env` for
   config overrides); `contracts` (`Project`, `ProjectPathStatus`); Node/Bun.
 - **Forbidden:** `host`; sibling features other than `git` (`workspaces` depends on `projects`, never the

--- a/packages/server/src/projects/projects.test.ts
+++ b/packages/server/src/projects/projects.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { initProject, inspectProjectPath, listProjects } from "./projects";
+import { commitProjectFile, initProject, inspectProjectPath, listProjects } from "./projects";
 
 function gitOut(cwd: string, ...args: string[]): string {
 	const r = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "pipe", stderr: "ignore" });
@@ -128,4 +136,70 @@ test("initProject: an existing repo is opened, not re-initialised (dedupe, histo
 	expect(listProjects()).toHaveLength(1);
 	// No fresh commit was layered on top — the original history is intact.
 	expect(gitOut(repo, "rev-parse", "HEAD")).toBe(originalHead);
+});
+
+test("commitProjectFile commits a brand-new untracked file", () => {
+	const repo = mkdtempSync(join(tmpdir(), "trpi-projects-test-"));
+	makeRepo(repo);
+	mkdirSync(join(repo, ".thinkrail"), { recursive: true });
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), '{"onCreate":"npm install"}\n');
+
+	commitProjectFile(repo, ".thinkrail/hooks.json", "chore: update workspace hooks");
+
+	expect(gitOut(repo, "log", "-1", "--format=%s")).toBe("chore: update workspace hooks");
+	expect(gitOut(repo, "status", "--short")).toBe("");
+	rmSync(repo, { recursive: true, force: true });
+});
+
+test("commitProjectFile commits a change to an already-tracked file", () => {
+	const repo = mkdtempSync(join(tmpdir(), "trpi-projects-test-"));
+	makeRepo(repo);
+	mkdirSync(join(repo, ".thinkrail"), { recursive: true });
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), '{"onCreate":"npm install"}\n');
+	git(repo, "add", "--", ".thinkrail/hooks.json");
+	git(repo, "commit", "-m", "add hooks.json");
+
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), '{"onCreate":"pnpm install"}\n');
+	commitProjectFile(repo, ".thinkrail/hooks.json", "chore: update workspace hooks");
+
+	expect(JSON.parse(readFileSync(join(repo, ".thinkrail", "hooks.json"), "utf8"))).toEqual({
+		onCreate: "pnpm install",
+	});
+	expect(gitOut(repo, "log", "-1", "--format=%s")).toBe("chore: update workspace hooks");
+	rmSync(repo, { recursive: true, force: true });
+});
+
+test("commitProjectFile is a no-op (doesn't throw) when the file is unchanged", () => {
+	const repo = mkdtempSync(join(tmpdir(), "trpi-projects-test-"));
+	makeRepo(repo);
+	mkdirSync(join(repo, ".thinkrail"), { recursive: true });
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), '{"onCreate":"npm install"}\n');
+	git(repo, "add", "--", ".thinkrail/hooks.json");
+	git(repo, "commit", "-m", "add hooks.json");
+	const before = gitOut(repo, "rev-parse", "HEAD");
+
+	expect(() =>
+		commitProjectFile(repo, ".thinkrail/hooks.json", "chore: update workspace hooks"),
+	).not.toThrow();
+	expect(gitOut(repo, "rev-parse", "HEAD")).toBe(before); // no new commit was made
+	rmSync(repo, { recursive: true, force: true });
+});
+
+test("commitProjectFile never sweeps up an unrelated file already staged", () => {
+	const repo = mkdtempSync(join(tmpdir(), "trpi-projects-test-"));
+	makeRepo(repo);
+	mkdirSync(join(repo, ".thinkrail"), { recursive: true });
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), '{"onCreate":"npm install"}\n');
+	git(repo, "add", "--", ".thinkrail/hooks.json");
+	git(repo, "commit", "-m", "add hooks.json");
+
+	writeFileSync(join(repo, "unrelated.txt"), "pre-staged by something else\n");
+	git(repo, "add", "--", "unrelated.txt"); // simulates unrelated staged work already in the index
+
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), '{"onCreate":"pnpm install"}\n');
+	commitProjectFile(repo, ".thinkrail/hooks.json", "chore: update workspace hooks");
+
+	// unrelated.txt must still be staged, not committed alongside our file.
+	expect(gitOut(repo, "status", "--short")).toBe("A  unrelated.txt");
+	rmSync(repo, { recursive: true, force: true });
 });

--- a/packages/server/src/projects/projects.test.ts
+++ b/packages/server/src/projects/projects.test.ts
@@ -10,7 +10,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { commitProjectFile, initProject, inspectProjectPath, listProjects } from "./projects";
+import {
+	commitProjectFile,
+	initProject,
+	inspectProjectPath,
+	isPathIgnored,
+	listProjects,
+} from "./projects";
 
 function gitOut(cwd: string, ...args: string[]): string {
 	const r = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "pipe", stderr: "ignore" });
@@ -202,4 +208,27 @@ test("commitProjectFile never sweeps up an unrelated file already staged", () =>
 	// unrelated.txt must still be staged, not committed alongside our file.
 	expect(gitOut(repo, "status", "--short")).toBe("A  unrelated.txt");
 	rmSync(repo, { recursive: true, force: true });
+});
+
+test("isPathIgnored: true for a path covered by a committed .gitignore rule", () => {
+	const repo = join(dataDir, "repo");
+	makeRepo(repo);
+	writeFileSync(join(repo, ".gitignore"), ".thinkrail/\n");
+
+	expect(isPathIgnored(repo, ".thinkrail/hooks.json")).toBe(true);
+});
+
+test("isPathIgnored: false in a plain repo with no matching ignore rule", () => {
+	const repo = join(dataDir, "repo");
+	makeRepo(repo);
+
+	expect(isPathIgnored(repo, ".thinkrail/hooks.json")).toBe(false);
+});
+
+test("isPathIgnored: false (never throws) when git itself errors, e.g. not a repo at all", () => {
+	const notARepo = join(dataDir, "not-a-repo");
+	mkdirSync(notARepo, { recursive: true });
+
+	expect(() => isPathIgnored(notARepo, ".thinkrail/hooks.json")).not.toThrow();
+	expect(isPathIgnored(notARepo, ".thinkrail/hooks.json")).toBe(false);
 });

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -16,6 +16,20 @@ function gitToplevel(path: string): string | null {
 	return result.ok ? result.out || null : null;
 }
 
+/**
+ * `-c` overrides for `user.name`/`user.email`, supplied **only when not already configured** so a real
+ * global identity is never overridden. Shared by every place this module commits directly to a project's
+ * root checkout (`initProject`, `commitProjectFile`) — a fresh machine may have neither set, which would
+ * otherwise make `git commit` fail.
+ */
+function gitIdentityArgs(path: string): string[] {
+	const identity: string[] = [];
+	if (!git(path, ["config", "user.name"]).out) identity.push("-c", "user.name=ThinkRail");
+	if (!git(path, ["config", "user.email"]).out)
+		identity.push("-c", "user.email=thinkrail@localhost");
+	return identity;
+}
+
 function slugify(name: string): string {
 	return (
 		name
@@ -129,11 +143,13 @@ export function initProject(path: string): Project {
 		const added = git(path, ["add", "-A"]);
 		if (!added.ok) throw new Error(`git add failed: ${path}`);
 
-		const identity: string[] = [];
-		if (!git(path, ["config", "user.name"]).out) identity.push("-c", "user.name=ThinkRail");
-		if (!git(path, ["config", "user.email"]).out)
-			identity.push("-c", "user.email=thinkrail@localhost");
-		const commit = git(path, [...identity, "commit", "--allow-empty", "-m", "Initial commit"]);
+		const commit = git(path, [
+			...gitIdentityArgs(path),
+			"commit",
+			"--allow-empty",
+			"-m",
+			"Initial commit",
+		]);
 		if (!commit.ok) throw new Error(`git commit failed: ${path}`);
 	} catch (err) {
 		// Remove the `.git` we just created (path was `initable`) so a retry re-inits cleanly.
@@ -142,4 +158,23 @@ export function initProject(path: string): Project {
 	}
 
 	return openProject(path);
+}
+
+/**
+ * Commit `relPath`'s current on-disk content (whatever the caller already wrote, e.g. via
+ * `writeHookConfig`) in the project rooted at `path` — the only surface in this module (besides
+ * `initProject`) that commits directly to a project's root checkout rather than an isolated worktree.
+ * `git add` then a **pathspec-scoped commit** (`commit -m … -- relPath`), never `add -A`/a bare `commit`:
+ * the `add` is required for a never-before-tracked file (a pathspec-only commit fails with "did not match
+ * any file(s) known to git" for one, verified empirically), and the pathspec on the commit itself ensures
+ * nothing else already staged in the user's checkout gets swept in even though it's technically in the
+ * index. "Nothing to commit" (unchanged content) is a benign no-op, not a thrown error.
+ */
+export function commitProjectFile(path: string, relPath: string, message: string): void {
+	const added = git(path, ["add", "--", relPath]);
+	if (!added.ok) throw new Error(`git add failed: ${relPath}`);
+	const commit = git(path, [...gitIdentityArgs(path), "commit", "-m", message, "--", relPath]);
+	if (!commit.ok && !/nothing to commit/i.test(`${commit.out}\n${commit.err}`)) {
+		throw new Error(`git commit failed: ${relPath}`);
+	}
 }

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -161,6 +161,19 @@ export function initProject(path: string): Project {
 }
 
 /**
+ * Whether `relPath` is git-ignored in the repo rooted at `projectPath` — `git check-ignore --quiet --
+ * <relPath>` exits 0 when the path is ignored, 1 when it isn't; pattern-matches the path string, so it
+ * works whether or not `relPath` actually exists on disk yet. Gates `sharedCommittable`: a project whose
+ * `.gitignore` covers `.thinkrail/` can't commit a Shared hook there, only a Local (host-local) one. Any
+ * other outcome (a git error — not a repo, `projectPath` missing, …) reads as "not ignored", the safer
+ * default: a caller that goes on to `git add` it gets its own clear failure rather than the hook silently
+ * vanishing into "ignored". Never throws.
+ */
+export function isPathIgnored(projectPath: string, relPath: string): boolean {
+	return git(projectPath, ["check-ignore", "--quiet", "--", relPath]).ok;
+}
+
+/**
  * Commit `relPath`'s current on-disk content (whatever the caller already wrote, e.g. via
  * `writeHookConfig`) in the project rooted at `path` — the only surface in this module (besides
  * `initProject`) that commits directly to a project's root checkout rather than an isolated worktree.

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -32,7 +32,11 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   [[submodule-workflow-skills]]'s artifacts rules); a **user-supplied name is the display name** (casing +
   punctuation preserved via `toDisplayName`; the branch is derived from it) and **sets `renamed: true`** at
   create — the user already chose, so the auto-namer never touches it; auto-`workspace-N` leaves it unset,
-  where `name === branch`),
+  where `name === branch`; an optional 4th `hookCombineMode` param is **stamped onto the record before
+  `runOnCreateHook` fires** — so the workspace's very first hook run already honors it — when given;
+  omitted leaves the field absent entirely (not present-but-`undefined`), inheriting the project's committed
+  default (`HookConfigFile.combineMode`, itself `"both"` unless the project overrides it); see
+  [[submodule-server-workspaces-hooks]]),
   `renameWorkspace` (**sync**; sets the **display `name`** (sanitized, casing preserved) and derives the
   **git branch** from it via `toBranch`, uniqued against refs + worktree dirs, `git branch -m` from the
   project repo — the branch ref moves and the worktree's HEAD follows, but the **worktree dir never moves**

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -51,9 +51,10 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   unknown — anchors a chat session's cwd), and the **archive** primitives, split so the fast record-drop
   and the slow git reclaim are separable (the host archives off the request's critical path):
   `forgetWorkspace(id)` (drop the persistence record, return the removed record or `null` — gone from
-  `listWorkspaces` immediately), `reclaimWorktree(ws)` (the slow half — `git worktree remove --force`,
-  keeps the branch; hardened: rm + `prune` if git fails), and `removeWorkspace(id)` (the synchronous
-  composition of the two, kept for callers/tests that want the whole archive in one call).
+  `listWorkspaces` immediately), `reclaimWorktree(ws)` (**async** — the slow half: awaits the `onDelete`
+  hook, then `git worktree remove --force`, keeps the branch; hardened: rm + `prune` if git fails), and
+  `removeWorkspace(id)` (**async**; the composition of the two, kept for callers/tests that want the whole
+  archive in one call).
 - **Lifecycle events:** every membership mutation — `createWorkspace` (`created`), `renameWorkspace`
   (`updated`, both the naive and agentic auto-rename passes since both go through it), `forgetWorkspace`
   (`removed`) — emits a `WorkspaceLifecycleEvent` through an **injected publisher** (`setWorkspacePublisher`,
@@ -66,5 +67,8 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`, `setWorkspacePublisher`,
   `WorkspaceLifecycleEvent`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`;
-  `@thinkrail/shared/paths` (the scratch-dir path convention); Node.
+  `@thinkrail/shared/paths` (the scratch-dir path convention); its own nested `hooks` submodule (called at
+  exactly two points: `createWorkspace` fires `runOnCreateHook` right after the scratch-dir seed,
+  fire-and-forget; `reclaimWorktree` awaits `runOnDeleteHook` before `git worktree remove` — see
+  [[submodule-server-workspaces-hooks]]); Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/hooks/SPEC.md
+++ b/packages/server/src/workspaces/hooks/SPEC.md
@@ -1,0 +1,41 @@
+---
+id: submodule-server-workspaces-hooks
+type: submodule-design
+status: active
+title: workspaces/hooks — lifecycle hook execution
+parent: submodule-server-workspaces
+depends-on: [module-contracts]
+tags: [v1]
+---
+
+## Responsibility
+
+Runs a project's own declared setup/teardown/merge-time commands around a workspace's lifecycle, without
+`workspaces` (or anything else in the host) knowing what those commands do. Four named hook points —
+`onCreate`, `onDelete`, `preMerge`, `postMerge` — each with its own timing and failure semantics (see the
+doc comments on `runOnCreateHook`/etc. in `hooks.ts`); `preMerge`/`postMerge` are fully implemented but have
+no caller yet (no merge-initiating code exists in v1) — real extension points, not dead code.
+
+## Boundary
+
+- **Owns:** command resolution (`.thinkrail/hooks.json` in the workspace's own worktree, committed;
+  `~/.thinkrail/hookOverrides.json`, host-local, replaces per-hook — never merged), the approval gate
+  (`~/.thinkrail/hookApprovals.json`, a sha256 of the approved command per project+hook — editing a command
+  invalidates its approval), and the subprocess runner (`sh -c`, streamed stdout/stderr, an optional
+  timeout). `runOnCreateHook`/`runPostMergeHook` are fire-and-forget; `runOnDeleteHook`/`runPreMergeHook` are
+  awaited by their caller — all four never throw, converting every failure mode (missing approval, non-zero
+  exit, timeout, an unexpected error) into either a published `hookFailed`/`hookAwaitingApproval` event or
+  (for `preMerge`) a `false` return.
+- **Lifecycle events:** every hook-state transition (`hookAwaitingApproval`, `hookStarted`, `hookOutput`,
+  `hookSucceeded`, `hookFailed`) is emitted through an **injected publisher** (`setHookPublisher`, the same
+  inversion `workspaces`/`terminal`/`settings` use), carrying the wire-shaped `WorkspaceHookEvent` from
+  `contracts` directly — no server-internal-to-wire mapping needed (the same pattern `watch`'s
+  `WorkspaceFsChangedPayload` uses, not the workspace-lifecycle trio's kind→channel mapping, since every
+  transition here shares one `workspace.hook` channel).
+- **Public surface (barrel):** `runOnCreateHook`, `runOnDeleteHook`, `runPreMergeHook`, `runPostMergeHook`,
+  `setHookPublisher`, `approveHook`.
+- **Allowed deps:** `persistence` (override/approval storage); `contracts`; `@thinkrail/shared/paths` (the
+  `.thinkrail/` namespace convention); Node (`node:crypto`, `node:fs`).
+- **Forbidden:** `host`; `git` (no git operation of its own — the caller already has the worktree);
+  `terminal` (hook output is self-contained, never routed through a PTY — see the parent module's
+  boundary note on why `workspaces` doesn't depend on `terminal`).

--- a/packages/server/src/workspaces/hooks/SPEC.md
+++ b/packages/server/src/workspaces/hooks/SPEC.md
@@ -33,7 +33,11 @@ no caller yet (no merge-initiating code exists in v1) — real extension points,
   `WorkspaceFsChangedPayload` uses, not the workspace-lifecycle trio's kind→channel mapping, since every
   transition here shares one `workspace.hook` channel).
 - **Public surface (barrel):** `runOnCreateHook`, `runOnDeleteHook`, `runPreMergeHook`, `runPostMergeHook`,
-  `setHookPublisher`, `approveHook`.
+  `setHookPublisher`, `approveHook`, `isApproved` (project+hook+resolved-command approval check — the new
+  `project.hooks.get` handler in `host` uses it to report per-hook approval status), `loadHookConfig`,
+  `resolveHookCommand` (both re-exported from `config.ts` for the same handler — reading a project's
+  committed/resolved hooks needs no workspace, so these are called directly on a project's root path, not
+  just a workspace's worktree; both were already generic over any directory).
 - **Persisted status:** every transition `emit`s through (except the ephemeral `hookOutput`) also writes
   the hook's latest `HookStatus` onto its workspace's `hookStatus` field via `persistence`'s
   `loadWorkspaces`/`saveWorkspaces` — durability for a reconnecting/reloaded client (`workspace.list` and
@@ -45,6 +49,9 @@ no caller yet (no merge-initiating code exists in v1) — real extension points,
   dispatching to `runOnCreateHook`/`runOnDeleteHook` by name) is the explicit re-run trigger the approval UI
   composes with `approveHook` to actually bootstrap a workspace stuck at `hookAwaitingApproval` — also a
   general-purpose manual-retry primitive, not approval-specific.
+- **`HookStatus.command` is populated on every transition**, not just `hookAwaitingApproval` — so a client
+  reading `Workspace.hookStatus` (the Hooks tab; `apps/web/src/panels/HooksPanel.tsx`) can show the
+  resolved command regardless of the hook's current state.
 - **Allowed deps:** `persistence` (override/approval storage, and now `hookStatus` persistence); `contracts`;
   `@thinkrail/shared/paths` (the `.thinkrail/` namespace convention); Node (`node:crypto`, `node:fs`).
 - **Forbidden:** `host`; `git` (no git operation of its own — the caller already has the worktree);

--- a/packages/server/src/workspaces/hooks/SPEC.md
+++ b/packages/server/src/workspaces/hooks/SPEC.md
@@ -63,20 +63,17 @@ semantics.
   `"script"` (`{ script }`, resolved to an absolute path — a Shared path and a relative Local path resolve
   against `args.basePath`, an absolute Local path is used as-is); a script entry pre-reads the file into
   `approvalMaterial` at resolve time, so a missing script becomes `missing: true, approvalMaterial: null`
-  rather than throwing. `resolveHookCommand` — the older single-tier resolver (a flat committed-map and a
-  flat host-local-override-map, override replacing outright) — stays in place only because
-  `host/handlers.ts` still calls it; it's dropped once that last caller migrates to `resolveHookRun` (a
-  later task). `hooks.ts`'s own `runHook` already runs on `resolveHookRun`, and re-exports it through this
-  module's barrel; `ResolvedHookEntry` itself isn't re-exported — reached only by `hooks.ts` importing
-  `./config` directly.
+  rather than throwing. `hooks.ts`'s own `runHook` and every `host/handlers.ts` caller (`project.hooks.get`/
+  `.save`, `workspace.hooks.approve`) now run on `resolveHookRun` alone — the older single-tier
+  `resolveHookCommand` (a flat committed-map and a flat host-local-override-map, override replacing
+  outright) is gone; `resolveHookRun` is re-exported through this module's barrel, and `ResolvedHookEntry`
+  itself isn't re-exported — reached only by `hooks.ts` importing `./config` directly.
 - **Public surface (barrel):** `runOnCreateHook`, `runOnDeleteHook`, `runPreMergeHook`, `runPostMergeHook`,
   `setHookPublisher`, `approveHook`, `isApproved` (project+hook+`HookSource`+material approval check — the
   `project.hooks.get` handler in `host` uses it to report per-source approval status), `loadHookConfig`,
-  `resolveHookCommand`, `resolveHookRun`, `writeHookConfig` (all four re-exported from `config.ts` — reading/
-  writing/resolving a project's committed hooks needs no workspace, so these are called directly on a
-  project's root path, not just a workspace's worktree; all were already generic over any directory).
-  `resolveHookCommand` is the older single-tier resolver, kept only until `host/handlers.ts` — its last
-  remaining caller — migrates to `resolveHookRun` too (`hooks.ts` itself already has).
+  `resolveHookRun`, `writeHookConfig` (all three re-exported from `config.ts` — reading/writing/resolving a
+  project's committed hooks needs no workspace, so these are called directly on a project's root path, not
+  just a workspace's worktree; all were already generic over any directory).
 - **Persisted status:** every transition `emit`s through (except the ephemeral `hookOutput`) also writes
   the hook's latest `HookStatus` onto its workspace's `hookStatus` field via `persistence`'s
   `loadWorkspaces`/`saveWorkspaces` — durability for a reconnecting/reloaded client (`workspace.list` and

--- a/packages/server/src/workspaces/hooks/SPEC.md
+++ b/packages/server/src/workspaces/hooks/SPEC.md
@@ -34,6 +34,13 @@ no caller yet (no merge-initiating code exists in v1) — real extension points,
   transition here shares one `workspace.hook` channel).
 - **Public surface (barrel):** `runOnCreateHook`, `runOnDeleteHook`, `runPreMergeHook`, `runPostMergeHook`,
   `setHookPublisher`, `approveHook`.
+- **Known limitation:** `approveHook` only records the approval — it never re-invokes a hook itself. That's
+  sufficient for `onDelete`/`preMerge`, whose next natural invocation (the next delete, the next merge)
+  checks approval fresh and runs. It is **not** sufficient for `onCreate`, which fires exactly once at
+  creation time: a workspace created before its `onCreate` command was approved stays un-bootstrapped
+  forever unless something explicitly re-runs `runOnCreateHook` after approval. No such re-run trigger
+  exists yet — deferred until the approval UI is built (that's naturally when a "run now" affordance would
+  be designed anyway), tracked here rather than silently assumed away.
 - **Allowed deps:** `persistence` (override/approval storage); `contracts`; `@thinkrail/shared/paths` (the
   `.thinkrail/` namespace convention); Node (`node:crypto`, `node:fs`).
 - **Forbidden:** `host`; `git` (no git operation of its own — the caller already has the worktree);

--- a/packages/server/src/workspaces/hooks/SPEC.md
+++ b/packages/server/src/workspaces/hooks/SPEC.md
@@ -34,15 +34,19 @@ no caller yet (no merge-initiating code exists in v1) — real extension points,
   transition here shares one `workspace.hook` channel).
 - **Public surface (barrel):** `runOnCreateHook`, `runOnDeleteHook`, `runPreMergeHook`, `runPostMergeHook`,
   `setHookPublisher`, `approveHook`.
-- **Known limitation:** `approveHook` only records the approval — it never re-invokes a hook itself. That's
-  sufficient for `onDelete`/`preMerge`, whose next natural invocation (the next delete, the next merge)
-  checks approval fresh and runs. It is **not** sufficient for `onCreate`, which fires exactly once at
-  creation time: a workspace created before its `onCreate` command was approved stays un-bootstrapped
-  forever unless something explicitly re-runs `runOnCreateHook` after approval. No such re-run trigger
-  exists yet — deferred until the approval UI is built (that's naturally when a "run now" affordance would
-  be designed anyway), tracked here rather than silently assumed away.
-- **Allowed deps:** `persistence` (override/approval storage); `contracts`; `@thinkrail/shared/paths` (the
-  `.thinkrail/` namespace convention); Node (`node:crypto`, `node:fs`).
+- **Persisted status:** every transition `emit`s through (except the ephemeral `hookOutput`) also writes
+  the hook's latest `HookStatus` onto its workspace's `hookStatus` field via `persistence`'s
+  `loadWorkspaces`/`saveWorkspaces` — durability for a reconnecting/reloaded client (`workspace.list` and
+  the lifecycle trio's `created`/`updated` snapshots carry it "for free"), not the live update path (an
+  already-connected client updates straight from the `workspace.hook` event). `approveHook` itself still
+  only records the approval — it never re-invokes a hook. That's sufficient for `onDelete`/`preMerge`,
+  whose next natural invocation checks approval fresh and runs; it is **not** sufficient for `onCreate`,
+  which fires exactly once at creation time. The host's `workspace.hooks.run` RPC (`host/handlers.ts`,
+  dispatching to `runOnCreateHook`/`runOnDeleteHook` by name) is the explicit re-run trigger the approval UI
+  composes with `approveHook` to actually bootstrap a workspace stuck at `hookAwaitingApproval` — also a
+  general-purpose manual-retry primitive, not approval-specific.
+- **Allowed deps:** `persistence` (override/approval storage, and now `hookStatus` persistence); `contracts`;
+  `@thinkrail/shared/paths` (the `.thinkrail/` namespace convention); Node (`node:crypto`, `node:fs`).
 - **Forbidden:** `host`; `git` (no git operation of its own — the caller already has the worktree);
   `terminal` (hook output is self-contained, never routed through a PTY — see the parent module's
   boundary note on why `workspaces` doesn't depend on `terminal`).

--- a/packages/server/src/workspaces/hooks/SPEC.md
+++ b/packages/server/src/workspaces/hooks/SPEC.md
@@ -32,12 +32,33 @@ no caller yet (no merge-initiating code exists in v1) — real extension points,
   `contracts` directly — no server-internal-to-wire mapping needed (the same pattern `watch`'s
   `WorkspaceFsChangedPayload` uses, not the workspace-lifecycle trio's kind→channel mapping, since every
   transition here shares one `workspace.hook` channel).
+- **`config.ts` owns the on-disk schema, back-compat, and per-source resolution — still git-free (fs only;
+  no git operation of its own, per the Forbidden list below).** `loadHookConfig(dir)` parses a project's
+  committed `.thinkrail/hooks.json` into the versioned `HookConfigFile` shape
+  (`{ version: 1, combineMode, hooks }`), with back-compat for the legacy flat file (`{ onCreate: "…" }`,
+  no `version`/`hooks` keys of its own) — the whole object is treated as `hooks`, `combineMode` defaulting
+  to `"both"`; missing file, malformed JSON, or a parsed non-object all fall back to the same default
+  (`{ version: 1, combineMode: "both", hooks: {} }`), never throwing. `writeHookConfig(projectPath, config)`
+  writes the versioned object back, pretty-printed, via the shared `WORKSPACE_INTERNAL_DIR`/
+  `WORKSPACE_HOOKS_CONFIG_FILE` constants. `resolveHookRun(args)` resolves one `HookName` into an **ordered
+  list** of `ResolvedHookEntry` per `CombineMode` — `"both"` → `[shared?, local?]` (Shared first; a tier
+  with no value for this hook is simply omitted, not a gap in the order), `"shared"`/`"local"` → that one
+  tier only. Each entry carries its `source` and is either `"inline"` (a bare string or `{ command }`) or
+  `"script"` (`{ script }`, resolved to an absolute path — a Shared path and a relative Local path resolve
+  against `args.basePath`, an absolute Local path is used as-is); a script entry pre-reads the file into
+  `approvalMaterial` at resolve time, so a missing script becomes `missing: true, approvalMaterial: null`
+  rather than throwing. `resolveHookCommand` — the older single-tier resolver (a flat committed-map and a
+  flat host-local-override-map, override replacing outright) — stays in place only because `hooks.ts` and
+  `host/handlers.ts` still call it; it's dropped once they migrate to `resolveHookRun` (this pass's later
+  tasks). `resolveHookRun`/`ResolvedHookEntry` aren't re-exported through this module's barrel yet — reached
+  only by sibling files inside `workspaces/hooks/` importing `./config` directly — until that migration
+  wires them through `hooks.ts`/`index.ts`.
 - **Public surface (barrel):** `runOnCreateHook`, `runOnDeleteHook`, `runPreMergeHook`, `runPostMergeHook`,
   `setHookPublisher`, `approveHook`, `isApproved` (project+hook+resolved-command approval check — the new
   `project.hooks.get` handler in `host` uses it to report per-hook approval status), `loadHookConfig`,
-  `resolveHookCommand` (both re-exported from `config.ts` for the same handler — reading a project's
-  committed/resolved hooks needs no workspace, so these are called directly on a project's root path, not
-  just a workspace's worktree; both were already generic over any directory).
+  `resolveHookCommand`, `writeHookConfig` (all three re-exported from `config.ts` for the same handler —
+  reading/writing a project's committed hooks needs no workspace, so these are called directly on a
+  project's root path, not just a workspace's worktree; all were already generic over any directory).
 - **Persisted status:** every transition `emit`s through (except the ephemeral `hookOutput`) also writes
   the hook's latest `HookStatus` onto its workspace's `hookStatus` field via `persistence`'s
   `loadWorkspaces`/`saveWorkspaces` — durability for a reconnecting/reloaded client (`workspace.list` and
@@ -53,7 +74,8 @@ no caller yet (no merge-initiating code exists in v1) — real extension points,
   reading `Workspace.hookStatus` (the Hooks tab; `apps/web/src/panels/HooksPanel.tsx`) can show the
   resolved command regardless of the hook's current state.
 - **Allowed deps:** `persistence` (override/approval storage, and now `hookStatus` persistence); `contracts`;
-  `@thinkrail/shared/paths` (the `.thinkrail/` namespace convention); Node (`node:crypto`, `node:fs`).
+  `@thinkrail/shared/paths` (the `.thinkrail/` namespace convention); Node (`node:crypto`, `node:fs`,
+  `node:path`).
 - **Forbidden:** `host`; `git` (no git operation of its own — the caller already has the worktree);
   `terminal` (hook output is self-contained, never routed through a PTY — see the parent module's
   boundary note on why `workspaces` doesn't depend on `terminal`).

--- a/packages/server/src/workspaces/hooks/SPEC.md
+++ b/packages/server/src/workspaces/hooks/SPEC.md
@@ -14,24 +14,40 @@ Runs a project's own declared setup/teardown/merge-time commands around a worksp
 `workspaces` (or anything else in the host) knowing what those commands do. Four named hook points —
 `onCreate`, `onDelete`, `preMerge`, `postMerge` — each with its own timing and failure semantics (see the
 doc comments on `runOnCreateHook`/etc. in `hooks.ts`); `preMerge`/`postMerge` are fully implemented but have
-no caller yet (no merge-initiating code exists in v1) — real extension points, not dead code.
+no caller yet (no merge-initiating code exists in v1) — real extension points, not dead code. Each hook
+point resolves to an **ordered list** of commands, not just one — the project's committed Shared tier
+and/or a host-local Local tier, combined per `CombineMode` — run one at a time, stopping at the first that
+isn't a clean, approved, zero-exit run; see `runHook`/`runHookEntry` in `hooks.ts` for the exact order/stop
+semantics.
 
 ## Boundary
 
-- **Owns:** command resolution (`.thinkrail/hooks.json` in the workspace's own worktree, committed;
-  `~/.thinkrail/hookOverrides.json`, host-local, replaces per-hook — never merged), the approval gate
-  (`~/.thinkrail/hookApprovals.json`, a sha256 of the approved command per project+hook — editing a command
-  invalidates its approval), and the subprocess runner (`sh -c`, streamed stdout/stderr, an optional
-  timeout). `runOnCreateHook`/`runPostMergeHook` are fire-and-forget; `runOnDeleteHook`/`runPreMergeHook` are
-  awaited by their caller — all four never throw, converting every failure mode (missing approval, non-zero
-  exit, timeout, an unexpected error) into either a published `hookFailed`/`hookAwaitingApproval` event or
-  (for `preMerge`) a `false` return.
+- **Owns:** command resolution — `resolveHookRun` (`config.ts`) builds a hook's ordered run list from the
+  workspace's own worktree's committed `.thinkrail/hooks.json` (the Shared tier) and
+  `~/.thinkrail/hookOverrides.json`'s per-project entry (the Local tier), combined per the effective
+  `CombineMode` (`Workspace.hookCombineMode ?? committedConfig.combineMode ?? "both"`); the per-source
+  approval gate (`~/.thinkrail/hookApprovals.json`, a sha256 of the approved material — the command text,
+  or a script's current file contents — keyed per project+hook+`HookSource`; editing the material
+  invalidates that source's approval); and the subprocess runner (`sh -c "<command>"` for an inline entry,
+  `sh <script>` for a script entry — both streamed stdout/stderr with an optional timeout). `runHook` walks
+  a hook's resolved entries **one at a time, in order** (Shared before Local under `"both"`) via
+  `runHookEntry`, and **stops at the first entry that isn't a clean, approved, zero-exit run** — a missing
+  script, an unapproved entry, or a non-zero exit all halt the remaining entries for that invocation, the
+  same `&&` semantics as a shell pipeline; overall success requires every entry to have run and succeeded
+  (including the vacuous case of an empty list — nothing declared for this hook is not a failure).
+  `runOnCreateHook`/`runPostMergeHook` are fire-and-forget; `runOnDeleteHook`/`runPreMergeHook` are awaited
+  by their caller — all four never throw, converting every failure mode (missing approval, a missing
+  script, a non-zero exit, timeout, an unexpected error) into either a published
+  `hookFailed`/`hookAwaitingApproval` event (tagged with the `HookSource` that produced it) or (for
+  `preMerge`) a `false` return.
 - **Lifecycle events:** every hook-state transition (`hookAwaitingApproval`, `hookStarted`, `hookOutput`,
   `hookSucceeded`, `hookFailed`) is emitted through an **injected publisher** (`setHookPublisher`, the same
   inversion `workspaces`/`terminal`/`settings` use), carrying the wire-shaped `WorkspaceHookEvent` from
   `contracts` directly — no server-internal-to-wire mapping needed (the same pattern `watch`'s
   `WorkspaceFsChangedPayload` uses, not the workspace-lifecycle trio's kind→channel mapping, since every
-  transition here shares one `workspace.hook` channel).
+  transition here shares one `workspace.hook` channel). Every variant carries `source: HookSource`, so a
+  `combineMode: "both"` run's two tagged sequences — Shared's, then (if reached) Local's — are told apart
+  instead of conflated into one.
 - **`config.ts` owns the on-disk schema, back-compat, and per-source resolution — still git-free (fs only;
   no git operation of its own, per the Forbidden list below).** `loadHookConfig(dir)` parses a project's
   committed `.thinkrail/hooks.json` into the versioned `HookConfigFile` shape
@@ -48,22 +64,27 @@ no caller yet (no merge-initiating code exists in v1) — real extension points,
   against `args.basePath`, an absolute Local path is used as-is); a script entry pre-reads the file into
   `approvalMaterial` at resolve time, so a missing script becomes `missing: true, approvalMaterial: null`
   rather than throwing. `resolveHookCommand` — the older single-tier resolver (a flat committed-map and a
-  flat host-local-override-map, override replacing outright) — stays in place only because `hooks.ts` and
-  `host/handlers.ts` still call it; it's dropped once they migrate to `resolveHookRun` (this pass's later
-  tasks). `resolveHookRun`/`ResolvedHookEntry` aren't re-exported through this module's barrel yet — reached
-  only by sibling files inside `workspaces/hooks/` importing `./config` directly — until that migration
-  wires them through `hooks.ts`/`index.ts`.
+  flat host-local-override-map, override replacing outright) — stays in place only because
+  `host/handlers.ts` still calls it; it's dropped once that last caller migrates to `resolveHookRun` (a
+  later task). `hooks.ts`'s own `runHook` already runs on `resolveHookRun`, and re-exports it through this
+  module's barrel; `ResolvedHookEntry` itself isn't re-exported — reached only by `hooks.ts` importing
+  `./config` directly.
 - **Public surface (barrel):** `runOnCreateHook`, `runOnDeleteHook`, `runPreMergeHook`, `runPostMergeHook`,
-  `setHookPublisher`, `approveHook`, `isApproved` (project+hook+resolved-command approval check — the new
-  `project.hooks.get` handler in `host` uses it to report per-hook approval status), `loadHookConfig`,
-  `resolveHookCommand`, `writeHookConfig` (all three re-exported from `config.ts` for the same handler —
-  reading/writing a project's committed hooks needs no workspace, so these are called directly on a
+  `setHookPublisher`, `approveHook`, `isApproved` (project+hook+`HookSource`+material approval check — the
+  `project.hooks.get` handler in `host` uses it to report per-source approval status), `loadHookConfig`,
+  `resolveHookCommand`, `resolveHookRun`, `writeHookConfig` (all four re-exported from `config.ts` — reading/
+  writing/resolving a project's committed hooks needs no workspace, so these are called directly on a
   project's root path, not just a workspace's worktree; all were already generic over any directory).
+  `resolveHookCommand` is the older single-tier resolver, kept only until `host/handlers.ts` — its last
+  remaining caller — migrates to `resolveHookRun` too (`hooks.ts` itself already has).
 - **Persisted status:** every transition `emit`s through (except the ephemeral `hookOutput`) also writes
   the hook's latest `HookStatus` onto its workspace's `hookStatus` field via `persistence`'s
   `loadWorkspaces`/`saveWorkspaces` — durability for a reconnecting/reloaded client (`workspace.list` and
   the lifecycle trio's `created`/`updated` snapshots carry it "for free"), not the live update path (an
-  already-connected client updates straight from the `workspace.hook` event). `approveHook` itself still
+  already-connected client updates straight from the `workspace.hook` event). Nested per `HookSource`
+  (`Workspace.hookStatus[hook][source]`) and merged onto the hook's existing entry, so persisting one
+  source's transition never clobbers the sibling source's last-known status (Shared sitting at
+  `succeeded` while Local is now `running`, say). `approveHook` itself still
   only records the approval — it never re-invokes a hook. That's sufficient for `onDelete`/`preMerge`,
   whose next natural invocation checks approval fresh and runs; it is **not** sufficient for `onCreate`,
   which fires exactly once at creation time. The host's `workspace.hooks.run` RPC (`host/handlers.ts`,

--- a/packages/server/src/workspaces/hooks/approvals.test.ts
+++ b/packages/server/src/workspaces/hooks/approvals.test.ts
@@ -19,25 +19,59 @@ afterEach(() => {
 });
 
 test("isApproved is false for a command that's never been approved", () => {
-	expect(isApproved("p1", "onCreate", "pnpm install")).toBe(false);
+	expect(isApproved("p1", "onCreate", "shared", "pnpm install")).toBe(false);
 });
 
-test("approveHook then isApproved is true for the exact same command", () => {
-	approveHook("p1", "onCreate", "pnpm install");
-	expect(isApproved("p1", "onCreate", "pnpm install")).toBe(true);
+test("approveHook then isApproved is true for the exact same material", () => {
+	approveHook("p1", "onCreate", "shared", "pnpm install");
+	expect(isApproved("p1", "onCreate", "shared", "pnpm install")).toBe(true);
 });
 
-test("isApproved is false once the command string changes", () => {
-	approveHook("p1", "onCreate", "pnpm install");
-	expect(isApproved("p1", "onCreate", "pnpm install --frozen-lockfile")).toBe(false);
+test("isApproved is false once the material changes", () => {
+	approveHook("p1", "onCreate", "shared", "pnpm install");
+	expect(isApproved("p1", "onCreate", "shared", "pnpm install --frozen-lockfile")).toBe(false);
 });
 
 test("approvals are scoped per hook — approving onCreate doesn't approve onDelete", () => {
-	approveHook("p1", "onCreate", "pnpm install");
-	expect(isApproved("p1", "onDelete", "pnpm install")).toBe(false);
+	approveHook("p1", "onCreate", "shared", "pnpm install");
+	expect(isApproved("p1", "onDelete", "shared", "pnpm install")).toBe(false);
 });
 
 test("approvals are scoped per project", () => {
-	approveHook("p1", "onCreate", "pnpm install");
-	expect(isApproved("p2", "onCreate", "pnpm install")).toBe(false);
+	approveHook("p1", "onCreate", "shared", "pnpm install");
+	expect(isApproved("p2", "onCreate", "shared", "pnpm install")).toBe(false);
+});
+
+test("shared and local sources are approved independently for the same project+hook", () => {
+	approveHook("p1", "onCreate", "shared", "cmdA");
+	approveHook("p1", "onCreate", "local", "cmdB");
+
+	expect(isApproved("p1", "onCreate", "shared", "cmdA")).toBe(true);
+	expect(isApproved("p1", "onCreate", "local", "cmdB")).toBe(true);
+});
+
+test("approving one source does not approve the other source's material", () => {
+	approveHook("p1", "onCreate", "shared", "cmdA");
+
+	// The local source has no approval at all yet, regardless of material.
+	expect(isApproved("p1", "onCreate", "local", "cmdA")).toBe(false);
+	// Checking the shared material against the local source is also false.
+	expect(isApproved("p1", "onCreate", "local", "cmdB")).toBe(false);
+});
+
+test("isApproved is false for the right material but the wrong source", () => {
+	approveHook("p1", "onCreate", "shared", "cmdA");
+	expect(isApproved("p1", "onCreate", "local", "cmdA")).toBe(false);
+});
+
+test("re-approving a source replaces its prior hash without disturbing the other source", () => {
+	approveHook("p1", "onCreate", "shared", "cmdA");
+	approveHook("p1", "onCreate", "local", "cmdB");
+
+	approveHook("p1", "onCreate", "local", "cmdC");
+
+	expect(isApproved("p1", "onCreate", "local", "cmdB")).toBe(false);
+	expect(isApproved("p1", "onCreate", "local", "cmdC")).toBe(true);
+	// Re-approving local left the shared approval untouched.
+	expect(isApproved("p1", "onCreate", "shared", "cmdA")).toBe(true);
 });

--- a/packages/server/src/workspaces/hooks/approvals.test.ts
+++ b/packages/server/src/workspaces/hooks/approvals.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { approveHook, isApproved } from "./approvals";
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-hooks-approvals-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("isApproved is false for a command that's never been approved", () => {
+	expect(isApproved("p1", "onCreate", "pnpm install")).toBe(false);
+});
+
+test("approveHook then isApproved is true for the exact same command", () => {
+	approveHook("p1", "onCreate", "pnpm install");
+	expect(isApproved("p1", "onCreate", "pnpm install")).toBe(true);
+});
+
+test("isApproved is false once the command string changes", () => {
+	approveHook("p1", "onCreate", "pnpm install");
+	expect(isApproved("p1", "onCreate", "pnpm install --frozen-lockfile")).toBe(false);
+});
+
+test("approvals are scoped per hook — approving onCreate doesn't approve onDelete", () => {
+	approveHook("p1", "onCreate", "pnpm install");
+	expect(isApproved("p1", "onDelete", "pnpm install")).toBe(false);
+});
+
+test("approvals are scoped per project", () => {
+	approveHook("p1", "onCreate", "pnpm install");
+	expect(isApproved("p2", "onCreate", "pnpm install")).toBe(false);
+});

--- a/packages/server/src/workspaces/hooks/approvals.ts
+++ b/packages/server/src/workspaces/hooks/approvals.ts
@@ -1,0 +1,23 @@
+// Approval gate: before auto-running a project's committed/override hook command, the exact command string
+// must have been explicitly approved. Approvals are keyed by project id + hook name, storing a sha256 of
+// the approved command — editing the command (committed or override) invalidates the approval and the
+// hook goes back to `hookAwaitingApproval` until re-approved. Host-local only (`~/.thinkrail`), never the repo.
+import { createHash } from "node:crypto";
+import type { HookName } from "@thinkrail/contracts";
+import { loadHookApprovals, saveHookApprovals } from "../../persistence";
+
+function hash(command: string): string {
+	return createHash("sha256").update(command).digest("hex");
+}
+
+/** Whether `command` is the exact, currently-approved command for this project's `hook`. */
+export function isApproved(projectId: string, hook: HookName, command: string): boolean {
+	return loadHookApprovals()[projectId]?.[hook] === hash(command);
+}
+
+/** Record `command` as the approved command for this project's `hook` (replaces any prior approval). */
+export function approveHook(projectId: string, hook: HookName, command: string): void {
+	const all = loadHookApprovals();
+	all[projectId] = { ...all[projectId], [hook]: hash(command) };
+	saveHookApprovals(all);
+}

--- a/packages/server/src/workspaces/hooks/approvals.ts
+++ b/packages/server/src/workspaces/hooks/approvals.ts
@@ -1,23 +1,42 @@
-// Approval gate: before auto-running a project's committed/override hook command, the exact command string
-// must have been explicitly approved. Approvals are keyed by project id + hook name, storing a sha256 of
-// the approved command — editing the command (committed or override) invalidates the approval and the
-// hook goes back to `hookAwaitingApproval` until re-approved. Host-local only (`~/.thinkrail`), never the repo.
+// Approval gate: before auto-running a project's Shared or Local hook, the exact material that would run
+// must have been explicitly approved. Approvals are keyed by project id + hook name + `HookSource`, storing
+// a sha256 of the approved material — editing the material (an inline command, or a script's file
+// contents) invalidates that source's approval and the hook goes back to `hookAwaitingApproval` until
+// re-approved. Shared and Local approve independently (combineMode `"both"` can run both for one event).
+// Host-local only (`~/.thinkrail`), never the repo. "Material" is opaque here — the caller decides whether
+// it's the command text (inline) or the script's file contents (script); this module just hashes it.
 import { createHash } from "node:crypto";
-import type { HookName } from "@thinkrail/contracts";
+import type { HookName, HookSource } from "@thinkrail/contracts";
 import { loadHookApprovals, saveHookApprovals } from "../../persistence";
 
-function hash(command: string): string {
-	return createHash("sha256").update(command).digest("hex");
+function hash(material: string): string {
+	return createHash("sha256").update(material).digest("hex");
 }
 
-/** Whether `command` is the exact, currently-approved command for this project's `hook`. */
-export function isApproved(projectId: string, hook: HookName, command: string): boolean {
-	return loadHookApprovals()[projectId]?.[hook] === hash(command);
+/** Whether `material` is the exact, currently-approved material for this project's `hook` + `source`. */
+export function isApproved(
+	projectId: string,
+	hook: HookName,
+	source: HookSource,
+	material: string,
+): boolean {
+	return loadHookApprovals()[projectId]?.[hook]?.[source] === hash(material);
 }
 
-/** Record `command` as the approved command for this project's `hook` (replaces any prior approval). */
-export function approveHook(projectId: string, hook: HookName, command: string): void {
+/**
+ * Record `material` as the approved material for this project's `hook` + `source` (replaces any prior
+ * approval for that source only — the other source's approval, if any, is untouched).
+ */
+export function approveHook(
+	projectId: string,
+	hook: HookName,
+	source: HookSource,
+	material: string,
+): void {
 	const all = loadHookApprovals();
-	all[projectId] = { ...all[projectId], [hook]: hash(command) };
+	all[projectId] = {
+		...all[projectId],
+		[hook]: { ...all[projectId]?.[hook], [source]: hash(material) },
+	};
 	saveHookApprovals(all);
 }

--- a/packages/server/src/workspaces/hooks/config.test.ts
+++ b/packages/server/src/workspaces/hooks/config.test.ts
@@ -70,6 +70,20 @@ test("loadHookConfig returns the default config when the file is valid JSON but 
 	expect(loadHookConfig(worktree)).toEqual(DEFAULT_CONFIG);
 });
 
+test("loadHookConfig returns the default config for a literal empty {} file", () => {
+	writeRawHooksJson({});
+	expect(loadHookConfig(worktree)).toEqual(DEFAULT_CONFIG);
+});
+
+test('loadHookConfig: a new-shape file with an invalid combineMode defaults it to "both" instead of passing it through', () => {
+	writeRawHooksJson({ combineMode: "bogus", hooks: { onCreate: "npm i" } });
+	expect(loadHookConfig(worktree)).toEqual({
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm i" },
+	});
+});
+
 // --- writeHookConfig -----------------------------------------------------------------------
 
 test("writeHookConfig creates .thinkrail/ and writes the given versioned config as pretty JSON", () => {
@@ -404,6 +418,114 @@ test("resolveHookRun: a missing script file resolves with missing:true and appro
 			display: "script: .thinkrail/hooks/missing.sh",
 			approvalMaterial: null,
 			missing: true,
+		},
+	]);
+});
+
+// --- resolveHookRun: malformed HookValue (hand-edited hooks.json/hookOverrides.json aren't validated,
+// so a value that isn't a string, {command}, or {script} must be skipped, never thrown) --------------
+
+test("resolveHookRun: a null hook value is skipped (treated as absent), not thrown", () => {
+	const committed = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: null },
+	} as unknown as HookConfigFile;
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([]);
+});
+
+test("resolveHookRun: an empty-object ({}) hook value is skipped, not thrown", () => {
+	const committed = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: {} },
+	} as unknown as HookConfigFile;
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([]);
+});
+
+test("resolveHookRun: an array ([]) hook value is skipped, not thrown", () => {
+	const committed = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: [] },
+	} as unknown as HookConfigFile;
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([]);
+});
+
+test("resolveHookRun: a {script: 123} hook value (non-string script) is skipped, not thrown", () => {
+	const committed = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: { script: 123 } },
+	} as unknown as HookConfigFile;
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([]);
+});
+
+test("resolveHookRun: a {command: 5} hook value (non-string command) is skipped, not thrown", () => {
+	const committed = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: { command: 5 } },
+	} as unknown as HookConfigFile;
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([]);
+});
+
+test("resolveHookRun: a malformed shared value doesn't block a well-formed local entry in the same resolve", () => {
+	const committed = {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: null },
+	} as unknown as HookConfigFile;
+	const local = { onCreate: "echo local-ok" };
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local,
+		mode: "both",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "local",
+			kind: "inline",
+			exec: "echo local-ok",
+			display: "echo local-ok",
+			approvalMaterial: "echo local-ok",
 		},
 	]);
 });

--- a/packages/server/src/workspaces/hooks/config.test.ts
+++ b/packages/server/src/workspaces/hooks/config.test.ts
@@ -225,7 +225,7 @@ test('resolveHookRun: mode "local" returns only the local entry, ignoring shared
 	]);
 });
 
-test('resolveHookRun: mode "both" skips a tier that doesn\'t declare the hook', () => {
+test('resolveHookRun: mode "both" skips local when it doesn\'t declare the hook', () => {
 	const committed: HookConfigFile = {
 		version: 1,
 		combineMode: "both",
@@ -245,6 +245,27 @@ test('resolveHookRun: mode "both" skips a tier that doesn\'t declare the hook', 
 			exec: "npm i",
 			display: "npm i",
 			approvalMaterial: "npm i",
+		},
+	]);
+});
+
+test('resolveHookRun: mode "both" skips shared when it doesn\'t declare the hook', () => {
+	const committed: HookConfigFile = { version: 1, combineMode: "both", hooks: {} };
+	const local = { onCreate: "echo local-only" };
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local,
+		mode: "both",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "local",
+			kind: "inline",
+			exec: "echo local-only",
+			display: "echo local-only",
+			approvalMaterial: "echo local-only",
 		},
 	]);
 });

--- a/packages/server/src/workspaces/hooks/config.test.ts
+++ b/packages/server/src/workspaces/hooks/config.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { HookConfigFile } from "@thinkrail/contracts";
-import { loadHookConfig, resolveHookCommand, resolveHookRun, writeHookConfig } from "./config";
+import { loadHookConfig, resolveHookRun, writeHookConfig } from "./config";
 
 let worktree: string;
 
@@ -133,26 +133,6 @@ test("writeHookConfig with an empty hooks map still writes a file, not leaving i
 	writeHookConfig(worktree, { version: 1, combineMode: "both", hooks: {} });
 	expect(existsSync(join(worktree, ".thinkrail", "hooks.json"))).toBe(true);
 	expect(loadHookConfig(worktree)).toEqual({ version: 1, combineMode: "both", hooks: {} });
-});
-
-// --- resolveHookCommand (legacy; still called by hooks.ts/handlers.ts until later tasks) --------
-
-test("resolveHookCommand: an override replaces the committed value entirely", () => {
-	const committed = { onCreate: "pnpm install" };
-	const override = { onCreate: "pnpm install --frozen-lockfile" };
-	expect(resolveHookCommand("onCreate", committed, override)).toBe(
-		"pnpm install --frozen-lockfile",
-	);
-});
-
-test("resolveHookCommand: falls through to committed when there's no override for that hook", () => {
-	const committed = { onCreate: "pnpm install", onDelete: "rm -rf tmp" };
-	const override = { onCreate: "pnpm install --frozen-lockfile" };
-	expect(resolveHookCommand("onDelete", committed, override)).toBe("rm -rf tmp");
-});
-
-test("resolveHookCommand: undefined when neither committed nor override declares the hook", () => {
-	expect(resolveHookCommand("preMerge", {}, {})).toBeUndefined();
 });
 
 // --- resolveHookRun -----------------------------------------------------------------------

--- a/packages/server/src/workspaces/hooks/config.test.ts
+++ b/packages/server/src/workspaces/hooks/config.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadHookConfig, resolveHookCommand } from "./config";
+import { loadHookConfig, resolveHookCommand, writeHookConfig } from "./config";
 
 let worktree: string;
 
@@ -49,4 +49,22 @@ test("resolveHookCommand: falls through to committed when there's no override fo
 
 test("resolveHookCommand: undefined when neither committed nor override declares the hook", () => {
 	expect(resolveHookCommand("preMerge", {}, {})).toBeUndefined();
+});
+
+test("writeHookConfig creates .thinkrail/ and writes the given hooks as JSON", () => {
+	writeHookConfig(worktree, { onCreate: "npm install" });
+	expect(loadHookConfig(worktree)).toEqual({ onCreate: "npm install" });
+});
+
+test("writeHookConfig overwrites a prior file entirely (not a merge)", () => {
+	writeHookConfig(worktree, { onCreate: "npm install", onDelete: "echo bye" });
+	writeHookConfig(worktree, { onCreate: "pnpm install" });
+	expect(loadHookConfig(worktree)).toEqual({ onCreate: "pnpm install" });
+});
+
+test("writeHookConfig with {} writes an empty object, not a missing file", () => {
+	writeHookConfig(worktree, { onCreate: "npm install" });
+	writeHookConfig(worktree, {});
+	expect(existsSync(join(worktree, ".thinkrail", "hooks.json"))).toBe(true);
+	expect(loadHookConfig(worktree)).toEqual({});
 });

--- a/packages/server/src/workspaces/hooks/config.test.ts
+++ b/packages/server/src/workspaces/hooks/config.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadHookConfig, resolveHookCommand, writeHookConfig } from "./config";
+import type { HookConfigFile } from "@thinkrail/contracts";
+import { loadHookConfig, resolveHookCommand, resolveHookRun, writeHookConfig } from "./config";
 
 let worktree: string;
 
@@ -14,24 +15,113 @@ afterEach(() => {
 	rmSync(worktree, { recursive: true, force: true });
 });
 
-test("loadHookConfig returns {} when .thinkrail/hooks.json doesn't exist", () => {
-	expect(loadHookConfig(worktree)).toEqual({});
-});
+const DEFAULT_CONFIG: HookConfigFile = { version: 1, combineMode: "both", hooks: {} };
 
-test("loadHookConfig reads committed hook commands", () => {
+function writeRawHooksJson(value: unknown): void {
 	mkdirSync(join(worktree, ".thinkrail"), { recursive: true });
-	writeFileSync(
-		join(worktree, ".thinkrail", "hooks.json"),
-		JSON.stringify({ onCreate: "pnpm install" }),
-	);
-	expect(loadHookConfig(worktree)).toEqual({ onCreate: "pnpm install" });
+	writeFileSync(join(worktree, ".thinkrail", "hooks.json"), JSON.stringify(value));
+}
+
+// --- loadHookConfig -----------------------------------------------------------------------
+
+test("loadHookConfig returns the default config when .thinkrail/hooks.json doesn't exist", () => {
+	expect(loadHookConfig(worktree)).toEqual(DEFAULT_CONFIG);
 });
 
-test("loadHookConfig returns {} on malformed JSON rather than throwing", () => {
+test("loadHookConfig: a legacy flat file (no version/hooks keys) back-compats into a versioned config wrapping it as hooks", () => {
+	writeRawHooksJson({ onCreate: "npm i" });
+	expect(loadHookConfig(worktree)).toEqual({
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm i" },
+	});
+});
+
+test("loadHookConfig: a new-shape file round-trips as-is", () => {
+	const config: HookConfigFile = {
+		version: 1,
+		combineMode: "local",
+		hooks: {
+			onCreate: { command: "npm i" },
+			onDelete: { script: ".thinkrail/hooks/teardown.sh" },
+		},
+	};
+	writeRawHooksJson(config);
+	expect(loadHookConfig(worktree)).toEqual(config);
+});
+
+test('loadHookConfig: a new-shape file missing combineMode defaults it to "both"', () => {
+	writeRawHooksJson({ hooks: { onCreate: "npm i" } });
+	expect(loadHookConfig(worktree)).toEqual({
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm i" },
+	});
+});
+
+test("loadHookConfig returns the default config on malformed JSON rather than throwing", () => {
 	mkdirSync(join(worktree, ".thinkrail"), { recursive: true });
 	writeFileSync(join(worktree, ".thinkrail", "hooks.json"), "{ not json");
-	expect(loadHookConfig(worktree)).toEqual({});
+	expect(loadHookConfig(worktree)).toEqual(DEFAULT_CONFIG);
 });
+
+test("loadHookConfig returns the default config when the file is valid JSON but not an object (e.g. an array)", () => {
+	writeRawHooksJson([1, 2, 3]);
+	expect(loadHookConfig(worktree)).toEqual(DEFAULT_CONFIG);
+});
+
+// --- writeHookConfig -----------------------------------------------------------------------
+
+test("writeHookConfig creates .thinkrail/ and writes the given versioned config as pretty JSON", () => {
+	const config: HookConfigFile = {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm install" },
+	};
+	writeHookConfig(worktree, config);
+	expect(loadHookConfig(worktree)).toEqual(config);
+});
+
+test("writeHookConfig round-trips combineMode and script values", () => {
+	const config: HookConfigFile = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onDelete: { script: ".thinkrail/hooks/teardown.sh" } },
+	};
+	writeHookConfig(worktree, config);
+	expect(loadHookConfig(worktree)).toEqual(config);
+});
+
+test("writeHookConfig overwrites a prior file entirely (not a merge)", () => {
+	writeHookConfig(worktree, {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm install", onDelete: "echo bye" },
+	});
+	writeHookConfig(worktree, {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "pnpm install" },
+	});
+	expect(loadHookConfig(worktree)).toEqual({
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "pnpm install" },
+	});
+});
+
+test("writeHookConfig with an empty hooks map still writes a file, not leaving it missing", () => {
+	writeHookConfig(worktree, {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm install" },
+	});
+	writeHookConfig(worktree, { version: 1, combineMode: "both", hooks: {} });
+	expect(existsSync(join(worktree, ".thinkrail", "hooks.json"))).toBe(true);
+	expect(loadHookConfig(worktree)).toEqual({ version: 1, combineMode: "both", hooks: {} });
+});
+
+// --- resolveHookCommand (legacy; still called by hooks.ts/handlers.ts until later tasks) --------
 
 test("resolveHookCommand: an override replaces the committed value entirely", () => {
 	const committed = { onCreate: "pnpm install" };
@@ -51,20 +141,248 @@ test("resolveHookCommand: undefined when neither committed nor override declares
 	expect(resolveHookCommand("preMerge", {}, {})).toBeUndefined();
 });
 
-test("writeHookConfig creates .thinkrail/ and writes the given hooks as JSON", () => {
-	writeHookConfig(worktree, { onCreate: "npm install" });
-	expect(loadHookConfig(worktree)).toEqual({ onCreate: "npm install" });
+// --- resolveHookRun -----------------------------------------------------------------------
+
+test('resolveHookRun: mode "both" returns [shared, local] in that order when both tiers declare the hook', () => {
+	const committed: HookConfigFile = {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm i" },
+	};
+	const local = { onCreate: "echo local-extra" };
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local,
+		mode: "both",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "shared",
+			kind: "inline",
+			exec: "npm i",
+			display: "npm i",
+			approvalMaterial: "npm i",
+		},
+		{
+			source: "local",
+			kind: "inline",
+			exec: "echo local-extra",
+			display: "echo local-extra",
+			approvalMaterial: "echo local-extra",
+		},
+	]);
 });
 
-test("writeHookConfig overwrites a prior file entirely (not a merge)", () => {
-	writeHookConfig(worktree, { onCreate: "npm install", onDelete: "echo bye" });
-	writeHookConfig(worktree, { onCreate: "pnpm install" });
-	expect(loadHookConfig(worktree)).toEqual({ onCreate: "pnpm install" });
+test('resolveHookRun: mode "shared" returns only the shared entry, ignoring local', () => {
+	const committed: HookConfigFile = {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm i" },
+	};
+	const local = { onCreate: "echo local-extra" };
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local,
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "shared",
+			kind: "inline",
+			exec: "npm i",
+			display: "npm i",
+			approvalMaterial: "npm i",
+		},
+	]);
 });
 
-test("writeHookConfig with {} writes an empty object, not a missing file", () => {
-	writeHookConfig(worktree, { onCreate: "npm install" });
-	writeHookConfig(worktree, {});
-	expect(existsSync(join(worktree, ".thinkrail", "hooks.json"))).toBe(true);
-	expect(loadHookConfig(worktree)).toEqual({});
+test('resolveHookRun: mode "local" returns only the local entry, ignoring shared', () => {
+	const committed: HookConfigFile = {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm i" },
+	};
+	const local = { onCreate: "echo local-extra" };
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local,
+		mode: "local",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "local",
+			kind: "inline",
+			exec: "echo local-extra",
+			display: "echo local-extra",
+			approvalMaterial: "echo local-extra",
+		},
+	]);
+});
+
+test('resolveHookRun: mode "both" skips a tier that doesn\'t declare the hook', () => {
+	const committed: HookConfigFile = {
+		version: 1,
+		combineMode: "both",
+		hooks: { onCreate: "npm i" },
+	};
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "both",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "shared",
+			kind: "inline",
+			exec: "npm i",
+			display: "npm i",
+			approvalMaterial: "npm i",
+		},
+	]);
+});
+
+test("resolveHookRun: returns [] when neither tier declares the hook", () => {
+	const committed: HookConfigFile = { version: 1, combineMode: "both", hooks: {} };
+	const result = resolveHookRun({
+		hook: "preMerge",
+		committed,
+		local: {},
+		mode: "both",
+		basePath: worktree,
+	});
+	expect(result).toEqual([]);
+});
+
+test("resolveHookRun: a {command} object value yields the same inline entry as an equivalent bare string", () => {
+	const committed: HookConfigFile = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: { command: "npm i" } },
+	};
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "shared",
+			kind: "inline",
+			exec: "npm i",
+			display: "npm i",
+			approvalMaterial: "npm i",
+		},
+	]);
+});
+
+test("resolveHookRun: a shared {script} path resolves against basePath, with the file's contents as approvalMaterial", () => {
+	mkdirSync(join(worktree, ".thinkrail", "hooks"), { recursive: true });
+	writeFileSync(join(worktree, ".thinkrail", "hooks", "setup.sh"), "#!/bin/sh\necho hi\n");
+	const committed: HookConfigFile = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: { script: ".thinkrail/hooks/setup.sh" } },
+	};
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "shared",
+			kind: "script",
+			exec: join(worktree, ".thinkrail/hooks/setup.sh"),
+			display: "script: .thinkrail/hooks/setup.sh",
+			approvalMaterial: "#!/bin/sh\necho hi\n",
+		},
+	]);
+});
+
+test("resolveHookRun: a relative local {script} path also resolves against basePath", () => {
+	mkdirSync(join(worktree, "scripts"), { recursive: true });
+	writeFileSync(join(worktree, "scripts", "teardown.sh"), "echo teardown\n");
+	const local = { onDelete: { script: "scripts/teardown.sh" } };
+	const committed: HookConfigFile = { version: 1, combineMode: "local", hooks: {} };
+	const result = resolveHookRun({
+		hook: "onDelete",
+		committed,
+		local,
+		mode: "local",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "local",
+			kind: "script",
+			exec: join(worktree, "scripts/teardown.sh"),
+			display: "script: scripts/teardown.sh",
+			approvalMaterial: "echo teardown\n",
+		},
+	]);
+});
+
+test("resolveHookRun: an absolute local {script} path is used as-is, not joined with basePath", () => {
+	const scriptDir = mkdtempSync(join(tmpdir(), "trpi-hooks-config-abs-script-"));
+	const scriptPath = join(scriptDir, "abs-setup.sh");
+	writeFileSync(scriptPath, "echo abs\n");
+	try {
+		const local = { onCreate: { script: scriptPath } };
+		const committed: HookConfigFile = { version: 1, combineMode: "local", hooks: {} };
+		const result = resolveHookRun({
+			hook: "onCreate",
+			committed,
+			local,
+			mode: "local",
+			basePath: worktree, // a different dir entirely — proves the absolute path isn't joined against it
+		});
+		expect(result).toEqual([
+			{
+				source: "local",
+				kind: "script",
+				exec: scriptPath,
+				display: `script: ${scriptPath}`,
+				approvalMaterial: "echo abs\n",
+			},
+		]);
+	} finally {
+		rmSync(scriptDir, { recursive: true, force: true });
+	}
+});
+
+test("resolveHookRun: a missing script file resolves with missing:true and approvalMaterial:null, without throwing", () => {
+	const committed: HookConfigFile = {
+		version: 1,
+		combineMode: "shared",
+		hooks: { onCreate: { script: ".thinkrail/hooks/missing.sh" } },
+	};
+	const result = resolveHookRun({
+		hook: "onCreate",
+		committed,
+		local: {},
+		mode: "shared",
+		basePath: worktree,
+	});
+	expect(result).toEqual([
+		{
+			source: "shared",
+			kind: "script",
+			exec: join(worktree, ".thinkrail/hooks/missing.sh"),
+			display: "script: .thinkrail/hooks/missing.sh",
+			approvalMaterial: null,
+			missing: true,
+		},
+	]);
 });

--- a/packages/server/src/workspaces/hooks/config.test.ts
+++ b/packages/server/src/workspaces/hooks/config.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadHookConfig, resolveHookCommand } from "./config";
+
+let worktree: string;
+
+beforeEach(() => {
+	worktree = mkdtempSync(join(tmpdir(), "trpi-hooks-config-test-"));
+});
+
+afterEach(() => {
+	rmSync(worktree, { recursive: true, force: true });
+});
+
+test("loadHookConfig returns {} when .thinkrail/hooks.json doesn't exist", () => {
+	expect(loadHookConfig(worktree)).toEqual({});
+});
+
+test("loadHookConfig reads committed hook commands", () => {
+	mkdirSync(join(worktree, ".thinkrail"), { recursive: true });
+	writeFileSync(
+		join(worktree, ".thinkrail", "hooks.json"),
+		JSON.stringify({ onCreate: "pnpm install" }),
+	);
+	expect(loadHookConfig(worktree)).toEqual({ onCreate: "pnpm install" });
+});
+
+test("loadHookConfig returns {} on malformed JSON rather than throwing", () => {
+	mkdirSync(join(worktree, ".thinkrail"), { recursive: true });
+	writeFileSync(join(worktree, ".thinkrail", "hooks.json"), "{ not json");
+	expect(loadHookConfig(worktree)).toEqual({});
+});
+
+test("resolveHookCommand: an override replaces the committed value entirely", () => {
+	const committed = { onCreate: "pnpm install" };
+	const override = { onCreate: "pnpm install --frozen-lockfile" };
+	expect(resolveHookCommand("onCreate", committed, override)).toBe(
+		"pnpm install --frozen-lockfile",
+	);
+});
+
+test("resolveHookCommand: falls through to committed when there's no override for that hook", () => {
+	const committed = { onCreate: "pnpm install", onDelete: "rm -rf tmp" };
+	const override = { onCreate: "pnpm install --frozen-lockfile" };
+	expect(resolveHookCommand("onDelete", committed, override)).toBe("rm -rf tmp");
+});
+
+test("resolveHookCommand: undefined when neither committed nor override declares the hook", () => {
+	expect(resolveHookCommand("preMerge", {}, {})).toBeUndefined();
+});

--- a/packages/server/src/workspaces/hooks/config.ts
+++ b/packages/server/src/workspaces/hooks/config.ts
@@ -4,7 +4,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { HookName } from "@thinkrail/contracts";
-import { WORKSPACE_HOOKS_CONFIG_FILE } from "@thinkrail/shared/paths";
+import { WORKSPACE_HOOKS_CONFIG_FILE, WORKSPACE_INTERNAL_DIR } from "@thinkrail/shared/paths";
 
 /** The committed hook commands declared in a workspace's own worktree. Missing/corrupt file → `{}`. */
 export function loadHookConfig(worktreePath: string): Partial<Record<HookName, string>> {
@@ -28,9 +28,11 @@ export function writeHookConfig(
 	projectPath: string,
 	hooks: Partial<Record<HookName, string>>,
 ): void {
-	const dir = join(projectPath, ".thinkrail");
-	mkdirSync(dir, { recursive: true });
-	writeFileSync(join(dir, "hooks.json"), `${JSON.stringify(hooks, null, "\t")}\n`);
+	mkdirSync(join(projectPath, WORKSPACE_INTERNAL_DIR), { recursive: true });
+	writeFileSync(
+		join(projectPath, WORKSPACE_HOOKS_CONFIG_FILE),
+		`${JSON.stringify(hooks, null, "\t")}\n`,
+	);
 }
 
 /**

--- a/packages/server/src/workspaces/hooks/config.ts
+++ b/packages/server/src/workspaces/hooks/config.ts
@@ -19,6 +19,14 @@ function defaultConfig(): HookConfigFile {
 	return { version: 1, combineMode: "both", hooks: {} };
 }
 
+const COMBINE_MODES: readonly CombineMode[] = ["both", "shared", "local"];
+
+/** Narrows a parsed `combineMode` field to a real `CombineMode` — anything else (missing, a typo, a
+ * stray number) defaults to `"both"` rather than passing an arbitrary value through. */
+function isCombineMode(value: unknown): value is CombineMode {
+	return typeof value === "string" && (COMBINE_MODES as readonly string[]).includes(value);
+}
+
 /**
  * Parse a project's committed `.thinkrail/hooks.json` into the versioned `HookConfigFile` shape, with
  * back-compat for the legacy flat file (`{ onCreate: "…" }`, no `version`/`hooks` keys of its own) — that
@@ -46,7 +54,7 @@ export function loadHookConfig(dir: string): HookConfigFile {
 		}
 		return {
 			version: 1,
-			combineMode: (obj.combineMode as CombineMode | undefined) ?? "both",
+			combineMode: isCombineMode(obj.combineMode) ? obj.combineMode : "both",
 			hooks: (obj.hooks as Partial<Record<HookName, HookValue>> | undefined) ?? {},
 		};
 	} catch {
@@ -87,7 +95,9 @@ export function resolveHookCommand(
 export interface ResolvedHookEntry {
 	/** Which tier this entry came from — carried onto every event/status this entry produces. */
 	source: HookSource;
-	/** `"inline"` runs via `sh -c "<exec>"`; `"script"` runs via `sh "<exec>"` (both in `hooks.ts`/`runner.ts`). */
+	/** `"inline"` is meant to run via `sh -c "<exec>"`; `"script"` via `sh "<exec>"` — intended behavior
+	 * once `hooks.ts`/`runner.ts` are wired to consume `ResolvedHookEntry` (a later task; today `runner.ts`
+	 * only runs inline commands, resolved via the deprecated `resolveHookCommand`). */
 	kind: "inline" | "script";
 	/** Inline: the command text itself. Script: the resolved ABSOLUTE path to the script file. */
 	exec: string;
@@ -106,9 +116,23 @@ function resolveScriptPath(source: HookSource, scriptPath: string, basePath: str
 	return join(basePath, scriptPath);
 }
 
+/** Whether a parsed-JSON value is a well-formed `HookValue` — a string, `{ command: <string> }`, or
+ * `{ script: <string> }`. `hooks.json`/`hookOverrides.json` are hand-editable and never validated on
+ * write, so a value reaching `toEntry` may be anything JSON allows (`null`, `{}`, `[]`, `{ script: 123 }`,
+ * …); this guard is what lets `toEntry` treat those as absent instead of crashing on them. */
+function isHookValue(value: unknown): value is HookValue {
+	if (typeof value === "string") return true;
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	return typeof record.command === "string" || typeof record.script === "string";
+}
+
 /** Turn one tier's raw `HookValue` into its resolved run entry — reading the script file (if any) now, so
- * approval/missing status is decided once, at resolve time, not re-derived later. */
-function toEntry(source: HookSource, value: HookValue, basePath: string): ResolvedHookEntry {
+ * approval/missing status is decided once, at resolve time, not re-derived later. Returns `null` for a
+ * malformed value (see `isHookValue`) — treated as if that tier declared nothing for this hook, not as an
+ * error. */
+function toEntry(source: HookSource, value: unknown, basePath: string): ResolvedHookEntry | null {
+	if (!isHookValue(value)) return null;
 	if (typeof value === "string" || "command" in value) {
 		const command = typeof value === "string" ? value : value.command;
 		return { source, kind: "inline", exec: command, display: command, approvalMaterial: command };
@@ -128,7 +152,9 @@ function toEntry(source: HookSource, value: HookValue, basePath: string): Resolv
  * order); `"shared"` → `[shared?]`; `"local"` → `[local?]`. `args.basePath` is the worktree root at run
  * time or the project root at get-time — Shared script paths and relative Local script paths resolve
  * against it; an absolute Local script path is used as-is. Reads script files synchronously to fill
- * `approvalMaterial`/`missing` — never throws (a missing script becomes `missing: true`, not an error).
+ * `approvalMaterial`/`missing` — never throws: a missing script becomes `missing: true`, and a malformed
+ * `HookValue` (not a string, `{command}`, or `{script}` — hand-edited JSON is never validated on write)
+ * is skipped entirely, as if that tier hadn't declared the hook.
  */
 export function resolveHookRun(args: {
 	hook: HookName;
@@ -141,11 +167,13 @@ export function resolveHookRun(args: {
 	const entries: ResolvedHookEntry[] = [];
 	const sharedValue = committed.hooks[hook];
 	if (mode !== "local" && sharedValue !== undefined) {
-		entries.push(toEntry("shared", sharedValue, basePath));
+		const entry = toEntry("shared", sharedValue, basePath);
+		if (entry) entries.push(entry);
 	}
 	const localValue = local[hook];
 	if (mode !== "shared" && localValue !== undefined) {
-		entries.push(toEntry("local", localValue, basePath));
+		const entry = toEntry("local", localValue, basePath);
+		if (entry) entries.push(entry);
 	}
 	return entries;
 }

--- a/packages/server/src/workspaces/hooks/config.ts
+++ b/packages/server/src/workspaces/hooks/config.ts
@@ -1,43 +1,79 @@
 // Committed hook config: `.thinkrail/hooks.json` in a workspace's own worktree — a normal tracked file, so
 // it's already checked out the moment `git worktree add` creates the worktree. Host-local overrides (per
 // developer, never touching the repo) come from `persistence`'s `hookOverrides.json` — see `hooks.ts`.
+// Git-free by design (fs only) — the caller (`host/handlers.ts`'s `project.hooks.save`) commits the
+// written file separately via `projects.ts`'s `commitProjectFile`.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import type { HookName } from "@thinkrail/contracts";
+import { isAbsolute, join } from "node:path";
+import type {
+	CombineMode,
+	HookConfigFile,
+	HookName,
+	HookSource,
+	HookValue,
+} from "@thinkrail/contracts";
 import { WORKSPACE_HOOKS_CONFIG_FILE, WORKSPACE_INTERNAL_DIR } from "@thinkrail/shared/paths";
 
-/** The committed hook commands declared in a workspace's own worktree. Missing/corrupt file → `{}`. */
-export function loadHookConfig(worktreePath: string): Partial<Record<HookName, string>> {
-	const file = join(worktreePath, WORKSPACE_HOOKS_CONFIG_FILE);
-	if (!existsSync(file)) return {};
+/** The empty config a missing/corrupt/non-object file falls back to. */
+function defaultConfig(): HookConfigFile {
+	return { version: 1, combineMode: "both", hooks: {} };
+}
+
+/**
+ * Parse a project's committed `.thinkrail/hooks.json` into the versioned `HookConfigFile` shape, with
+ * back-compat for the legacy flat file (`{ onCreate: "…" }`, no `version`/`hooks` keys of its own) — that
+ * whole object is treated as `hooks`, `combineMode` defaults to `"both"`. A new-shape file (has a `hooks`
+ * key) is used as-is, `combineMode` defaulting to `"both"` only when absent. Missing file, malformed JSON,
+ * or a parsed value that isn't a plain object all fall back to `defaultConfig()` — this never throws.
+ */
+export function loadHookConfig(dir: string): HookConfigFile {
+	const file = join(dir, WORKSPACE_HOOKS_CONFIG_FILE);
+	if (!existsSync(file)) return defaultConfig();
 	try {
-		return JSON.parse(readFileSync(file, "utf8")) as Partial<Record<HookName, string>>;
+		const parsed = JSON.parse(readFileSync(file, "utf8"));
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+			return defaultConfig();
+		}
+		const obj = parsed as Record<string, unknown>;
+		// Legacy flat file: neither a `version` nor a `hooks` key of its own ⇒ the whole object IS the
+		// hooks map.
+		if (!("version" in obj) && !("hooks" in obj)) {
+			return {
+				version: 1,
+				combineMode: "both",
+				hooks: obj as Partial<Record<HookName, HookValue>>,
+			};
+		}
+		return {
+			version: 1,
+			combineMode: (obj.combineMode as CombineMode | undefined) ?? "both",
+			hooks: (obj.hooks as Partial<Record<HookName, HookValue>> | undefined) ?? {},
+		};
 	} catch {
-		return {};
+		return defaultConfig();
 	}
 }
 
 /**
- * Write `hooks` as `.thinkrail/hooks.json` in `projectPath` (creating `.thinkrail/` if needed) — a full
+ * Write `config` as `.thinkrail/hooks.json` in `projectPath` (creating `.thinkrail/` if needed) — a full
  * overwrite, not a merge, matching the committed file's own semantics (it's just JSON on disk; the caller
- * decides what the whole object should be). Pure fs write — no git. The caller (`host/handlers.ts`'s
- * `project.hooks.save`) commits it separately via `projects.ts`'s `commitProjectFile`, keeping this module
- * git-free per its SPEC.
+ * decides what the whole object should be). Pure fs write — no git; the caller commits it separately.
  */
-export function writeHookConfig(
-	projectPath: string,
-	hooks: Partial<Record<HookName, string>>,
-): void {
+export function writeHookConfig(projectPath: string, config: HookConfigFile): void {
 	mkdirSync(join(projectPath, WORKSPACE_INTERNAL_DIR), { recursive: true });
 	writeFileSync(
 		join(projectPath, WORKSPACE_HOOKS_CONFIG_FILE),
-		`${JSON.stringify(hooks, null, "\t")}\n`,
+		`${JSON.stringify(config, null, "\t")}\n`,
 	);
 }
 
 /**
  * Resolve the command that should run for `hook`: a host-local override replaces the committed value
  * entirely (never merged) — if you override a hook, you own its whole command.
+ *
+ * @deprecated Superseded by `resolveHookRun`, which resolves both tiers (per `CombineMode`) into an
+ * ordered list instead of one tier winning outright. Kept in place — and still called by `hooks.ts` and
+ * `host/handlers.ts` — until those callers migrate; removed once its last caller is gone.
  */
 export function resolveHookCommand(
 	hook: HookName,
@@ -45,4 +81,71 @@ export function resolveHookCommand(
 	override: Partial<Record<HookName, string>>,
 ): string | undefined {
 	return override[hook] ?? committed[hook];
+}
+
+/** One resolved entry in a hook's ordered run list — see `resolveHookRun`. */
+export interface ResolvedHookEntry {
+	/** Which tier this entry came from — carried onto every event/status this entry produces. */
+	source: HookSource;
+	/** `"inline"` runs via `sh -c "<exec>"`; `"script"` runs via `sh "<exec>"` (both in `hooks.ts`/`runner.ts`). */
+	kind: "inline" | "script";
+	/** Inline: the command text itself. Script: the resolved ABSOLUTE path to the script file. */
+	exec: string;
+	/** UI/event label: the command text (inline), or `` `script: <original path>` `` (script, unresolved). */
+	display: string;
+	/** What to hash for approval: the command text (inline), or the script's current contents (script) —
+	 * `null` when the script file is missing (nothing to hash; see `missing`). */
+	approvalMaterial: string | null;
+	/** Set (never `false`) only for a script entry whose file didn't exist at resolve time. */
+	missing?: boolean;
+}
+
+/** A Shared `script` path always resolves against `basePath`; a Local one only when it's not already absolute. */
+function resolveScriptPath(source: HookSource, scriptPath: string, basePath: string): string {
+	if (source === "local" && isAbsolute(scriptPath)) return scriptPath;
+	return join(basePath, scriptPath);
+}
+
+/** Turn one tier's raw `HookValue` into its resolved run entry — reading the script file (if any) now, so
+ * approval/missing status is decided once, at resolve time, not re-derived later. */
+function toEntry(source: HookSource, value: HookValue, basePath: string): ResolvedHookEntry {
+	if (typeof value === "string" || "command" in value) {
+		const command = typeof value === "string" ? value : value.command;
+		return { source, kind: "inline", exec: command, display: command, approvalMaterial: command };
+	}
+	const exec = resolveScriptPath(source, value.script, basePath);
+	const display = `script: ${value.script}`;
+	try {
+		return { source, kind: "script", exec, display, approvalMaterial: readFileSync(exec, "utf8") };
+	} catch {
+		return { source, kind: "script", exec, display, approvalMaterial: null, missing: true };
+	}
+}
+
+/**
+ * Resolve `args.hook` into an ordered list of run entries per `args.mode`: `"both"` → `[shared?, local?]`
+ * (Shared first, personal extras after — a tier with no value for this hook is skipped, not a gap in the
+ * order); `"shared"` → `[shared?]`; `"local"` → `[local?]`. `args.basePath` is the worktree root at run
+ * time or the project root at get-time — Shared script paths and relative Local script paths resolve
+ * against it; an absolute Local script path is used as-is. Reads script files synchronously to fill
+ * `approvalMaterial`/`missing` — never throws (a missing script becomes `missing: true`, not an error).
+ */
+export function resolveHookRun(args: {
+	hook: HookName;
+	committed: HookConfigFile;
+	local: Partial<Record<HookName, HookValue>>;
+	mode: CombineMode;
+	basePath: string;
+}): ResolvedHookEntry[] {
+	const { hook, committed, local, mode, basePath } = args;
+	const entries: ResolvedHookEntry[] = [];
+	const sharedValue = committed.hooks[hook];
+	if (mode !== "local" && sharedValue !== undefined) {
+		entries.push(toEntry("shared", sharedValue, basePath));
+	}
+	const localValue = local[hook];
+	if (mode !== "shared" && localValue !== undefined) {
+		entries.push(toEntry("local", localValue, basePath));
+	}
+	return entries;
 }

--- a/packages/server/src/workspaces/hooks/config.ts
+++ b/packages/server/src/workspaces/hooks/config.ts
@@ -1,7 +1,7 @@
 // Committed hook config: `.thinkrail/hooks.json` in a workspace's own worktree — a normal tracked file, so
 // it's already checked out the moment `git worktree add` creates the worktree. Host-local overrides (per
 // developer, never touching the repo) come from `persistence`'s `hookOverrides.json` — see `hooks.ts`.
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { HookName } from "@thinkrail/contracts";
 import { WORKSPACE_HOOKS_CONFIG_FILE } from "@thinkrail/shared/paths";
@@ -15,6 +15,22 @@ export function loadHookConfig(worktreePath: string): Partial<Record<HookName, s
 	} catch {
 		return {};
 	}
+}
+
+/**
+ * Write `hooks` as `.thinkrail/hooks.json` in `projectPath` (creating `.thinkrail/` if needed) — a full
+ * overwrite, not a merge, matching the committed file's own semantics (it's just JSON on disk; the caller
+ * decides what the whole object should be). Pure fs write — no git. The caller (`host/handlers.ts`'s
+ * `project.hooks.save`) commits it separately via `projects.ts`'s `commitProjectFile`, keeping this module
+ * git-free per its SPEC.
+ */
+export function writeHookConfig(
+	projectPath: string,
+	hooks: Partial<Record<HookName, string>>,
+): void {
+	const dir = join(projectPath, ".thinkrail");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "hooks.json"), `${JSON.stringify(hooks, null, "\t")}\n`);
 }
 
 /**

--- a/packages/server/src/workspaces/hooks/config.ts
+++ b/packages/server/src/workspaces/hooks/config.ts
@@ -75,29 +75,12 @@ export function writeHookConfig(projectPath: string, config: HookConfigFile): vo
 	);
 }
 
-/**
- * Resolve the command that should run for `hook`: a host-local override replaces the committed value
- * entirely (never merged) — if you override a hook, you own its whole command.
- *
- * @deprecated Superseded by `resolveHookRun`, which resolves both tiers (per `CombineMode`) into an
- * ordered list instead of one tier winning outright. Kept in place — and still called by `hooks.ts` and
- * `host/handlers.ts` — until those callers migrate; removed once its last caller is gone.
- */
-export function resolveHookCommand(
-	hook: HookName,
-	committed: Partial<Record<HookName, string>>,
-	override: Partial<Record<HookName, string>>,
-): string | undefined {
-	return override[hook] ?? committed[hook];
-}
-
 /** One resolved entry in a hook's ordered run list — see `resolveHookRun`. */
 export interface ResolvedHookEntry {
 	/** Which tier this entry came from — carried onto every event/status this entry produces. */
 	source: HookSource;
-	/** `"inline"` is meant to run via `sh -c "<exec>"`; `"script"` via `sh "<exec>"` — intended behavior
-	 * once `hooks.ts`/`runner.ts` are wired to consume `ResolvedHookEntry` (a later task; today `runner.ts`
-	 * only runs inline commands, resolved via the deprecated `resolveHookCommand`). */
+	/** `"inline"` runs via `sh -c "<exec>"`; `"script"` via `sh "<exec>"` — see `hooks.ts`'s `runHookEntry`,
+	 * which dispatches on this to build the `runner.ts` call. */
 	kind: "inline" | "script";
 	/** Inline: the command text itself. Script: the resolved ABSOLUTE path to the script file. */
 	exec: string;

--- a/packages/server/src/workspaces/hooks/config.ts
+++ b/packages/server/src/workspaces/hooks/config.ts
@@ -1,0 +1,30 @@
+// Committed hook config: `.thinkrail/hooks.json` in a workspace's own worktree — a normal tracked file, so
+// it's already checked out the moment `git worktree add` creates the worktree. Host-local overrides (per
+// developer, never touching the repo) come from `persistence`'s `hookOverrides.json` — see `hooks.ts`.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { HookName } from "@thinkrail/contracts";
+import { WORKSPACE_HOOKS_CONFIG_FILE } from "@thinkrail/shared/paths";
+
+/** The committed hook commands declared in a workspace's own worktree. Missing/corrupt file → `{}`. */
+export function loadHookConfig(worktreePath: string): Partial<Record<HookName, string>> {
+	const file = join(worktreePath, WORKSPACE_HOOKS_CONFIG_FILE);
+	if (!existsSync(file)) return {};
+	try {
+		return JSON.parse(readFileSync(file, "utf8")) as Partial<Record<HookName, string>>;
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Resolve the command that should run for `hook`: a host-local override replaces the committed value
+ * entirely (never merged) — if you override a hook, you own its whole command.
+ */
+export function resolveHookCommand(
+	hook: HookName,
+	committed: Partial<Record<HookName, string>>,
+	override: Partial<Record<HookName, string>>,
+): string | undefined {
+	return override[hook] ?? committed[hook];
+}

--- a/packages/server/src/workspaces/hooks/hooks.test.ts
+++ b/packages/server/src/workspaces/hooks/hooks.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Project, Workspace, WorkspaceHookEvent } from "@thinkrail/contracts";
+import {
+	approveHook,
+	runOnCreateHook,
+	runOnDeleteHook,
+	runPreMergeHook,
+	setHookPublisher,
+} from "./hooks";
+
+let dataDir: string;
+let worktree: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+const project: Project = { id: "p1", name: "repo", path: "/unused", slug: "repo", lastOpened: 0 };
+let workspace: Workspace;
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-hooks-test-data-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	worktree = mkdtempSync(join(tmpdir(), "trpi-hooks-test-wt-"));
+	workspace = {
+		id: "ws1",
+		projectId: project.id,
+		name: "ws1",
+		branch: "ws1",
+		worktreePath: worktree,
+		baseBranch: "main",
+	};
+});
+
+afterEach(() => {
+	setHookPublisher(null);
+	rmSync(dataDir, { recursive: true, force: true });
+	rmSync(worktree, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+function writeHookConfig(config: Record<string, string>): void {
+	mkdirSync(join(worktree, ".thinkrail"), { recursive: true });
+	writeFileSync(join(worktree, ".thinkrail", "hooks.json"), JSON.stringify(config));
+}
+
+test("a workspace with no .thinkrail/hooks.json runs no hook and emits nothing", async () => {
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+	await runOnDeleteHook(workspace, project);
+	expect(events).toEqual([]);
+});
+
+test("an unapproved hook emits hookAwaitingApproval and does not run", async () => {
+	writeHookConfig({ onDelete: "echo should-not-run" });
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+	await runOnDeleteHook(workspace, project);
+	expect(events).toEqual([
+		{
+			kind: "hookAwaitingApproval",
+			workspaceId: "ws1",
+			hook: "onDelete",
+			command: "echo should-not-run",
+		},
+	]);
+});
+
+test("an approved hook runs and emits started then succeeded", async () => {
+	writeHookConfig({ onDelete: "true" });
+	approveHook("p1", "onDelete", "true");
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+	await runOnDeleteHook(workspace, project);
+	expect(events.map((e) => e.kind)).toEqual(["hookStarted", "hookSucceeded"]);
+});
+
+test("a failing approved hook emits hookFailed with the real exit code", async () => {
+	writeHookConfig({ onDelete: "exit 3" });
+	approveHook("p1", "onDelete", "exit 3");
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+	await runOnDeleteHook(workspace, project);
+	expect(events).toEqual([
+		{ kind: "hookStarted", workspaceId: "ws1", hook: "onDelete" },
+		{ kind: "hookFailed", workspaceId: "ws1", hook: "onDelete", exitCode: 3 },
+	]);
+});
+
+test("runOnCreateHook doesn't block — it returns before the hook has finished running", async () => {
+	writeHookConfig({ onCreate: "sleep 0.2 && echo done" });
+	approveHook("p1", "onCreate", "sleep 0.2 && echo done");
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+	runOnCreateHook(workspace, project); // not awaited on purpose — this is the behavior under test
+	expect(events).toEqual([]); // nothing has run yet — the call returned synchronously
+	await new Promise((resolve) => setTimeout(resolve, 400));
+	// "echo done" genuinely writes to stdout, which the real runner streams through as a hookOutput event
+	// between hookStarted and hookSucceeded — included here rather than expected away.
+	expect(events.map((e) => e.kind)).toEqual(["hookStarted", "hookOutput", "hookSucceeded"]);
+});
+
+test("runPreMergeHook returns false when the command fails", async () => {
+	writeHookConfig({ preMerge: "exit 1" });
+	approveHook("p1", "preMerge", "exit 1");
+	expect(await runPreMergeHook(workspace, project)).toBe(false);
+});
+
+test("runPreMergeHook returns true when the command succeeds", async () => {
+	writeHookConfig({ preMerge: "true" });
+	approveHook("p1", "preMerge", "true");
+	expect(await runPreMergeHook(workspace, project)).toBe(true);
+});
+
+test("runPreMergeHook returns false (fail-closed) when the command is unapproved", async () => {
+	writeHookConfig({ preMerge: "true" });
+	expect(await runPreMergeHook(workspace, project)).toBe(false);
+});

--- a/packages/server/src/workspaces/hooks/hooks.test.ts
+++ b/packages/server/src/workspaces/hooks/hooks.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Project, Workspace, WorkspaceHookEvent } from "@thinkrail/contracts";
+import { loadWorkspaces, saveWorkspaces } from "../../persistence";
 import {
 	approveHook,
 	runOnCreateHook,
@@ -116,4 +117,54 @@ test("runPreMergeHook returns true when the command succeeds", async () => {
 test("runPreMergeHook returns false (fail-closed) when the command is unapproved", async () => {
 	writeHookConfig({ preMerge: "true" });
 	expect(await runPreMergeHook(workspace, project)).toBe(false);
+});
+
+test("an unapproved hook persists hookStatus: awaitingApproval onto the workspace record", async () => {
+	writeHookConfig({ onDelete: "echo should-not-run" });
+	saveWorkspaces([workspace]);
+	await runOnDeleteHook(workspace, project);
+	const saved = loadWorkspaces().find((w) => w.id === "ws1");
+	expect(saved?.hookStatus?.onDelete).toEqual({
+		state: "awaitingApproval",
+		command: "echo should-not-run",
+	});
+});
+
+test("a succeeding approved hook persists hookStatus: succeeded, replacing the prior state", async () => {
+	writeHookConfig({ onDelete: "true" });
+	approveHook("p1", "onDelete", "true");
+	saveWorkspaces([workspace]);
+	await runOnDeleteHook(workspace, project);
+	const saved = loadWorkspaces().find((w) => w.id === "ws1");
+	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded" });
+});
+
+test("a failing approved hook persists hookStatus: failed with the real exit code", async () => {
+	writeHookConfig({ onDelete: "exit 3" });
+	approveHook("p1", "onDelete", "exit 3");
+	saveWorkspaces([workspace]);
+	await runOnDeleteHook(workspace, project);
+	const saved = loadWorkspaces().find((w) => w.id === "ws1");
+	expect(saved?.hookStatus?.onDelete).toEqual({ state: "failed", exitCode: 3 });
+});
+
+test("persisting hookStatus for a workspace whose record is already gone is a silent no-op", async () => {
+	writeHookConfig({ onDelete: "true" });
+	approveHook("p1", "onDelete", "true");
+	// Deliberately never saved to workspaces.json — mirrors an archived-mid-run workspace.
+	await expect(runOnDeleteHook(workspace, project)).resolves.toBeUndefined();
+	expect(loadWorkspaces()).toEqual([]);
+});
+
+test("hookStatus is set per-hook — persisting onDelete's status doesn't touch onCreate's", async () => {
+	writeHookConfig({ onCreate: "true", onDelete: "true" });
+	approveHook("p1", "onCreate", "true");
+	approveHook("p1", "onDelete", "true");
+	saveWorkspaces([workspace]);
+	runOnCreateHook(workspace, project);
+	await new Promise((resolve) => setTimeout(resolve, 200));
+	await runOnDeleteHook(workspace, project);
+	const saved = loadWorkspaces().find((w) => w.id === "ws1");
+	expect(saved?.hookStatus?.onCreate).toEqual({ state: "succeeded" });
+	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded" });
 });

--- a/packages/server/src/workspaces/hooks/hooks.test.ts
+++ b/packages/server/src/workspaces/hooks/hooks.test.ts
@@ -2,8 +2,13 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Project, Workspace, WorkspaceHookEvent } from "@thinkrail/contracts";
-import { loadWorkspaces, saveWorkspaces } from "../../persistence";
+import type { HookName, Project, Workspace, WorkspaceHookEvent } from "@thinkrail/contracts";
+import {
+	loadHookOverrides,
+	loadWorkspaces,
+	saveHookOverrides,
+	saveWorkspaces,
+} from "../../persistence";
 import {
 	approveHook,
 	runOnCreateHook,
@@ -41,9 +46,42 @@ afterEach(() => {
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
 });
 
+/** Writes the Shared tier as a legacy flat `.thinkrail/hooks.json` (back-compat shape) — `combineMode`
+ * defaults to `"both"`, which is all these tests need; `config.test.ts` covers the versioned shape itself. */
 function writeHookConfig(config: Record<string, string>): void {
 	mkdirSync(join(worktree, ".thinkrail"), { recursive: true });
 	writeFileSync(join(worktree, ".thinkrail", "hooks.json"), JSON.stringify(config));
+}
+
+/** Writes the Shared tier's `hook` as a `{ script }` entry (same legacy flat shape as `writeHookConfig`,
+ * just with a script-object value instead of a bare string) — `scriptPath` is intentionally never created
+ * on disk when the test wants a "missing script" entry. */
+function writeScriptHook(hook: HookName, scriptPath: string): void {
+	mkdirSync(join(worktree, ".thinkrail"), { recursive: true });
+	writeFileSync(
+		join(worktree, ".thinkrail", "hooks.json"),
+		JSON.stringify({ [hook]: { script: scriptPath } }),
+	);
+}
+
+/** Sets this project's Local (host-local, never committed) tier for one hook to an inline command. */
+function setLocalHook(hook: HookName, command: string): void {
+	const all = loadHookOverrides();
+	saveHookOverrides({ ...all, [project.id]: { ...all[project.id], [hook]: command } });
+}
+
+/** The persisted per-source status map for one hook on `workspace`'s saved record — `undefined` when the
+ * record itself is missing, or absent whenever the hook has no recorded status yet. */
+function hookStatusOf(hook: HookName) {
+	return loadWorkspaces().find((w) => w.id === "ws1")?.hookStatus?.[hook];
+}
+
+/** Drops every ephemeral `hookOutput` event — a real `echo`'s stdout chunking isn't deterministic (one
+ * chunk vs. several), so ordering assertions key on the state-transition events only. */
+function withoutOutput(events: WorkspaceHookEvent[]) {
+	return events
+		.filter((e) => e.kind !== "hookOutput")
+		.map((e) => ({ kind: e.kind, source: e.source }));
 }
 
 test("a workspace with no .thinkrail/hooks.json runs no hook and emits nothing", async () => {
@@ -65,6 +103,7 @@ test("an unapproved hook emits hookAwaitingApproval and does not run", async () 
 			workspaceName: "ws1",
 			projectId: "p1",
 			hook: "onDelete",
+			source: "shared",
 			command: "echo should-not-run",
 		},
 	]);
@@ -72,7 +111,7 @@ test("an unapproved hook emits hookAwaitingApproval and does not run", async () 
 
 test("an approved hook runs and emits started then succeeded", async () => {
 	writeHookConfig({ onDelete: "true" });
-	approveHook("p1", "onDelete", "true");
+	approveHook("p1", "onDelete", "shared", "true");
 	const events: WorkspaceHookEvent[] = [];
 	setHookPublisher((e) => events.push(e));
 	await runOnDeleteHook(workspace, project);
@@ -83,6 +122,7 @@ test("an approved hook runs and emits started then succeeded", async () => {
 			workspaceName: "ws1",
 			projectId: "p1",
 			hook: "onDelete",
+			source: "shared",
 			command: "true",
 		},
 		{
@@ -91,6 +131,7 @@ test("an approved hook runs and emits started then succeeded", async () => {
 			workspaceName: "ws1",
 			projectId: "p1",
 			hook: "onDelete",
+			source: "shared",
 			command: "true",
 		},
 	]);
@@ -98,7 +139,7 @@ test("an approved hook runs and emits started then succeeded", async () => {
 
 test("a failing approved hook emits hookFailed with the real exit code", async () => {
 	writeHookConfig({ onDelete: "exit 3" });
-	approveHook("p1", "onDelete", "exit 3");
+	approveHook("p1", "onDelete", "shared", "exit 3");
 	const events: WorkspaceHookEvent[] = [];
 	setHookPublisher((e) => events.push(e));
 	await runOnDeleteHook(workspace, project);
@@ -109,6 +150,7 @@ test("a failing approved hook emits hookFailed with the real exit code", async (
 			workspaceName: "ws1",
 			projectId: "p1",
 			hook: "onDelete",
+			source: "shared",
 			command: "exit 3",
 		},
 		{
@@ -117,6 +159,7 @@ test("a failing approved hook emits hookFailed with the real exit code", async (
 			workspaceName: "ws1",
 			projectId: "p1",
 			hook: "onDelete",
+			source: "shared",
 			command: "exit 3",
 			exitCode: 3,
 		},
@@ -125,7 +168,7 @@ test("a failing approved hook emits hookFailed with the real exit code", async (
 
 test("runOnCreateHook doesn't block — it returns before the hook has finished running", async () => {
 	writeHookConfig({ onCreate: "sleep 0.2 && echo done" });
-	approveHook("p1", "onCreate", "sleep 0.2 && echo done");
+	approveHook("p1", "onCreate", "shared", "sleep 0.2 && echo done");
 	const events: WorkspaceHookEvent[] = [];
 	setHookPublisher((e) => events.push(e));
 	runOnCreateHook(workspace, project); // not awaited on purpose — this is the behavior under test
@@ -138,13 +181,13 @@ test("runOnCreateHook doesn't block — it returns before the hook has finished 
 
 test("runPreMergeHook returns false when the command fails", async () => {
 	writeHookConfig({ preMerge: "exit 1" });
-	approveHook("p1", "preMerge", "exit 1");
+	approveHook("p1", "preMerge", "shared", "exit 1");
 	expect(await runPreMergeHook(workspace, project)).toBe(false);
 });
 
 test("runPreMergeHook returns true when the command succeeds", async () => {
 	writeHookConfig({ preMerge: "true" });
-	approveHook("p1", "preMerge", "true");
+	approveHook("p1", "preMerge", "shared", "true");
 	expect(await runPreMergeHook(workspace, project)).toBe(true);
 });
 
@@ -157,34 +200,32 @@ test("an unapproved hook persists hookStatus: awaitingApproval onto the workspac
 	writeHookConfig({ onDelete: "echo should-not-run" });
 	saveWorkspaces([workspace]);
 	await runOnDeleteHook(workspace, project);
-	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onDelete).toEqual({
-		state: "awaitingApproval",
-		command: "echo should-not-run",
+	expect(hookStatusOf("onDelete")).toEqual({
+		shared: { state: "awaitingApproval", command: "echo should-not-run" },
 	});
 });
 
 test("a succeeding approved hook persists hookStatus: succeeded, replacing the prior state", async () => {
 	writeHookConfig({ onDelete: "true" });
-	approveHook("p1", "onDelete", "true");
+	approveHook("p1", "onDelete", "shared", "true");
 	saveWorkspaces([workspace]);
 	await runOnDeleteHook(workspace, project);
-	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded", command: "true" });
+	expect(hookStatusOf("onDelete")).toEqual({ shared: { state: "succeeded", command: "true" } });
 });
 
 test("a failing approved hook persists hookStatus: failed with the real exit code", async () => {
 	writeHookConfig({ onDelete: "exit 3" });
-	approveHook("p1", "onDelete", "exit 3");
+	approveHook("p1", "onDelete", "shared", "exit 3");
 	saveWorkspaces([workspace]);
 	await runOnDeleteHook(workspace, project);
-	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onDelete).toEqual({ state: "failed", command: "exit 3", exitCode: 3 });
+	expect(hookStatusOf("onDelete")).toEqual({
+		shared: { state: "failed", command: "exit 3", exitCode: 3 },
+	});
 });
 
 test("persisting hookStatus for a workspace whose record is already gone is a silent no-op", async () => {
 	writeHookConfig({ onDelete: "true" });
-	approveHook("p1", "onDelete", "true");
+	approveHook("p1", "onDelete", "shared", "true");
 	// Deliberately never saved to workspaces.json — mirrors an archived-mid-run workspace.
 	await expect(runOnDeleteHook(workspace, project)).resolves.toBeUndefined();
 	expect(loadWorkspaces()).toEqual([]);
@@ -192,22 +233,147 @@ test("persisting hookStatus for a workspace whose record is already gone is a si
 
 test("hookStatus is set per-hook — persisting onDelete's status doesn't touch onCreate's", async () => {
 	writeHookConfig({ onCreate: "true", onDelete: "true" });
-	approveHook("p1", "onCreate", "true");
-	approveHook("p1", "onDelete", "true");
+	approveHook("p1", "onCreate", "shared", "true");
+	approveHook("p1", "onDelete", "shared", "true");
 	saveWorkspaces([workspace]);
 	runOnCreateHook(workspace, project);
 	await new Promise((resolve) => setTimeout(resolve, 200));
 	await runOnDeleteHook(workspace, project);
-	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onCreate).toEqual({ state: "succeeded", command: "true" });
-	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded", command: "true" });
+	expect(hookStatusOf("onCreate")).toEqual({ shared: { state: "succeeded", command: "true" } });
+	expect(hookStatusOf("onDelete")).toEqual({ shared: { state: "succeeded", command: "true" } });
 });
 
 test("a succeeding hook persists its command onto hookStatus too, not just on awaitingApproval", async () => {
 	writeHookConfig({ onDelete: "true" });
-	approveHook("p1", "onDelete", "true");
+	approveHook("p1", "onDelete", "shared", "true");
 	saveWorkspaces([workspace]);
 	await runOnDeleteHook(workspace, project);
-	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded", command: "true" });
+	expect(hookStatusOf("onDelete")).toEqual({ shared: { state: "succeeded", command: "true" } });
+});
+
+// --- combine-mode "both": ordered, per-source, stop-on-first --------------------------------
+
+test("combine-mode both runs the shared entry then the local entry, in order, when both are approved", async () => {
+	writeHookConfig({ preMerge: "echo a" });
+	setLocalHook("preMerge", "echo b");
+	approveHook("p1", "preMerge", "shared", "echo a");
+	approveHook("p1", "preMerge", "local", "echo b");
+	saveWorkspaces([workspace]);
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+
+	expect(await runPreMergeHook(workspace, project)).toBe(true);
+
+	expect(withoutOutput(events)).toEqual([
+		{ kind: "hookStarted", source: "shared" },
+		{ kind: "hookSucceeded", source: "shared" },
+		{ kind: "hookStarted", source: "local" },
+		{ kind: "hookSucceeded", source: "local" },
+	]);
+	expect(hookStatusOf("preMerge")).toEqual({
+		shared: { state: "succeeded", command: "echo a" },
+		local: { state: "succeeded", command: "echo b" },
+	});
+});
+
+test("combine-mode both stops before the local entry when the shared entry fails, and reports not ok", async () => {
+	writeHookConfig({ preMerge: "exit 1" });
+	setLocalHook("preMerge", "echo should-not-run");
+	approveHook("p1", "preMerge", "shared", "exit 1");
+	approveHook("p1", "preMerge", "local", "echo should-not-run");
+	saveWorkspaces([workspace]);
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+
+	expect(await runPreMergeHook(workspace, project)).toBe(false);
+
+	expect(withoutOutput(events)).toEqual([
+		{ kind: "hookStarted", source: "shared" },
+		{ kind: "hookFailed", source: "shared" },
+	]);
+	// The local entry never started: no event tagged "local", and no persisted status for it either.
+	expect(events.some((e) => e.source === "local")).toBe(false);
+	expect(hookStatusOf("preMerge")).toEqual({
+		shared: { state: "failed", command: "exit 1", exitCode: 1 },
+	});
+});
+
+test("combine-mode both halts at an unapproved shared entry and never starts the local entry", async () => {
+	writeHookConfig({ preMerge: "echo a" });
+	setLocalHook("preMerge", "echo b");
+	approveHook("p1", "preMerge", "local", "echo b"); // local is approved; shared deliberately is not
+	saveWorkspaces([workspace]);
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+
+	expect(await runPreMergeHook(workspace, project)).toBe(false);
+
+	expect(events).toEqual([
+		{
+			kind: "hookAwaitingApproval",
+			workspaceId: "ws1",
+			workspaceName: "ws1",
+			projectId: "p1",
+			hook: "preMerge",
+			source: "shared",
+			command: "echo a",
+		},
+	]);
+	expect(hookStatusOf("preMerge")).toEqual({
+		shared: { state: "awaitingApproval", command: "echo a" },
+	});
+});
+
+test("a missing script entry emits hookFailed (exitCode -1) and halts before the local entry", async () => {
+	writeScriptHook("onDelete", ".thinkrail/hooks/does-not-exist.sh");
+	setLocalHook("onDelete", "echo should-not-run");
+	approveHook("p1", "onDelete", "local", "echo should-not-run");
+	saveWorkspaces([workspace]);
+	const events: WorkspaceHookEvent[] = [];
+	setHookPublisher((e) => events.push(e));
+
+	await runOnDeleteHook(workspace, project);
+
+	expect(events).toEqual([
+		{
+			kind: "hookFailed",
+			workspaceId: "ws1",
+			workspaceName: "ws1",
+			projectId: "p1",
+			hook: "onDelete",
+			source: "shared",
+			command: "script: .thinkrail/hooks/does-not-exist.sh",
+			exitCode: -1,
+		},
+	]);
+	// The local entry never started: no event tagged "local", and no persisted status for it either.
+	expect(events.some((e) => e.source === "local")).toBe(false);
+	expect(hookStatusOf("onDelete")).toEqual({
+		shared: {
+			state: "failed",
+			command: "script: .thinkrail/hooks/does-not-exist.sh",
+			exitCode: -1,
+		},
+	});
+});
+
+test("persisting one source's hookStatus preserves the sibling source's prior status", async () => {
+	writeHookConfig({ onDelete: "true" });
+	setLocalHook("onDelete", "true");
+	approveHook("p1", "onDelete", "shared", "true");
+	approveHook("p1", "onDelete", "local", "true");
+	saveWorkspaces([workspace]);
+
+	// Run Shared only first (mode "shared" — Local is not even resolved).
+	workspace.hookCombineMode = "shared";
+	await runOnDeleteHook(workspace, project);
+	expect(hookStatusOf("onDelete")).toEqual({ shared: { state: "succeeded", command: "true" } });
+
+	// Now run Local only — Shared's already-persisted status must survive untouched.
+	workspace.hookCombineMode = "local";
+	await runOnDeleteHook(workspace, project);
+	expect(hookStatusOf("onDelete")).toEqual({
+		shared: { state: "succeeded", command: "true" },
+		local: { state: "succeeded", command: "true" },
+	});
 });

--- a/packages/server/src/workspaces/hooks/hooks.test.ts
+++ b/packages/server/src/workspaces/hooks/hooks.test.ts
@@ -62,6 +62,8 @@ test("an unapproved hook emits hookAwaitingApproval and does not run", async () 
 		{
 			kind: "hookAwaitingApproval",
 			workspaceId: "ws1",
+			workspaceName: "ws1",
+			projectId: "p1",
 			hook: "onDelete",
 			command: "echo should-not-run",
 		},
@@ -74,7 +76,24 @@ test("an approved hook runs and emits started then succeeded", async () => {
 	const events: WorkspaceHookEvent[] = [];
 	setHookPublisher((e) => events.push(e));
 	await runOnDeleteHook(workspace, project);
-	expect(events.map((e) => e.kind)).toEqual(["hookStarted", "hookSucceeded"]);
+	expect(events).toEqual([
+		{
+			kind: "hookStarted",
+			workspaceId: "ws1",
+			workspaceName: "ws1",
+			projectId: "p1",
+			hook: "onDelete",
+			command: "true",
+		},
+		{
+			kind: "hookSucceeded",
+			workspaceId: "ws1",
+			workspaceName: "ws1",
+			projectId: "p1",
+			hook: "onDelete",
+			command: "true",
+		},
+	]);
 });
 
 test("a failing approved hook emits hookFailed with the real exit code", async () => {
@@ -84,8 +103,23 @@ test("a failing approved hook emits hookFailed with the real exit code", async (
 	setHookPublisher((e) => events.push(e));
 	await runOnDeleteHook(workspace, project);
 	expect(events).toEqual([
-		{ kind: "hookStarted", workspaceId: "ws1", hook: "onDelete" },
-		{ kind: "hookFailed", workspaceId: "ws1", hook: "onDelete", exitCode: 3 },
+		{
+			kind: "hookStarted",
+			workspaceId: "ws1",
+			workspaceName: "ws1",
+			projectId: "p1",
+			hook: "onDelete",
+			command: "exit 3",
+		},
+		{
+			kind: "hookFailed",
+			workspaceId: "ws1",
+			workspaceName: "ws1",
+			projectId: "p1",
+			hook: "onDelete",
+			command: "exit 3",
+			exitCode: 3,
+		},
 	]);
 });
 
@@ -136,7 +170,7 @@ test("a succeeding approved hook persists hookStatus: succeeded, replacing the p
 	saveWorkspaces([workspace]);
 	await runOnDeleteHook(workspace, project);
 	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded" });
+	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded", command: "true" });
 });
 
 test("a failing approved hook persists hookStatus: failed with the real exit code", async () => {
@@ -145,7 +179,7 @@ test("a failing approved hook persists hookStatus: failed with the real exit cod
 	saveWorkspaces([workspace]);
 	await runOnDeleteHook(workspace, project);
 	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onDelete).toEqual({ state: "failed", exitCode: 3 });
+	expect(saved?.hookStatus?.onDelete).toEqual({ state: "failed", command: "exit 3", exitCode: 3 });
 });
 
 test("persisting hookStatus for a workspace whose record is already gone is a silent no-op", async () => {
@@ -165,6 +199,15 @@ test("hookStatus is set per-hook — persisting onDelete's status doesn't touch 
 	await new Promise((resolve) => setTimeout(resolve, 200));
 	await runOnDeleteHook(workspace, project);
 	const saved = loadWorkspaces().find((w) => w.id === "ws1");
-	expect(saved?.hookStatus?.onCreate).toEqual({ state: "succeeded" });
-	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded" });
+	expect(saved?.hookStatus?.onCreate).toEqual({ state: "succeeded", command: "true" });
+	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded", command: "true" });
+});
+
+test("a succeeding hook persists its command onto hookStatus too, not just on awaitingApproval", async () => {
+	writeHookConfig({ onDelete: "true" });
+	approveHook("p1", "onDelete", "true");
+	saveWorkspaces([workspace]);
+	await runOnDeleteHook(workspace, project);
+	const saved = loadWorkspaces().find((w) => w.id === "ws1");
+	expect(saved?.hookStatus?.onDelete).toEqual({ state: "succeeded", command: "true" });
 });

--- a/packages/server/src/workspaces/hooks/hooks.ts
+++ b/packages/server/src/workspaces/hooks/hooks.ts
@@ -1,8 +1,14 @@
 // Orchestrates one hook run: resolve its command (committed + host-local override), gate it behind
 // approval, execute it, and publish every state transition through the injected publisher (the same
 // inversion `workspaces`/`terminal`/`settings` use) so the host can fan it out over `workspace.hook`.
-import type { HookName, Project, Workspace, WorkspaceHookEvent } from "@thinkrail/contracts";
-import { loadHookOverrides } from "../../persistence";
+import type {
+	HookName,
+	HookStatus,
+	Project,
+	Workspace,
+	WorkspaceHookEvent,
+} from "@thinkrail/contracts";
+import { loadHookOverrides, loadWorkspaces, saveWorkspaces } from "../../persistence";
 import { approveHook, isApproved } from "./approvals";
 import { loadHookConfig, resolveHookCommand } from "./config";
 import { runShellCommand } from "./runner";
@@ -17,8 +23,44 @@ export function setHookPublisher(fn: HookPublisher | null): void {
 	publishHookEvent = fn;
 }
 
+/**
+ * Persist `hook`'s latest state onto its workspace record (`Workspace.hookStatus`) — durability for a
+ * reconnecting/reloaded client, not the live update path (an already-connected client updates from the
+ * `workspace.hook` event itself). Best-effort: a workspace archived mid-run (record already gone) is a
+ * silent no-op — there's nothing left to persist onto.
+ */
+function persistHookStatus(workspaceId: string, hook: HookName, status: HookStatus): void {
+	const all = loadWorkspaces();
+	const target = all.find((w) => w.id === workspaceId);
+	if (!target) return;
+	target.hookStatus = { ...target.hookStatus, [hook]: status };
+	saveWorkspaces(all);
+}
+
 function emit(event: WorkspaceHookEvent): void {
 	publishHookEvent?.(event);
+	switch (event.kind) {
+		case "hookAwaitingApproval":
+			persistHookStatus(event.workspaceId, event.hook, {
+				state: "awaitingApproval",
+				command: event.command,
+			});
+			break;
+		case "hookStarted":
+			persistHookStatus(event.workspaceId, event.hook, { state: "running" });
+			break;
+		case "hookSucceeded":
+			persistHookStatus(event.workspaceId, event.hook, { state: "succeeded" });
+			break;
+		case "hookFailed":
+			persistHookStatus(event.workspaceId, event.hook, {
+				state: "failed",
+				exitCode: event.exitCode,
+			});
+			break;
+		case "hookOutput":
+			break; // ephemeral — never persisted
+	}
 }
 
 /** A blocking hook's default ceiling — `onDelete`/`preMerge` are awaited by their caller. */

--- a/packages/server/src/workspaces/hooks/hooks.ts
+++ b/packages/server/src/workspaces/hooks/hooks.ts
@@ -47,14 +47,21 @@ function emit(event: WorkspaceHookEvent): void {
 			});
 			break;
 		case "hookStarted":
-			persistHookStatus(event.workspaceId, event.hook, { state: "running" });
+			persistHookStatus(event.workspaceId, event.hook, {
+				state: "running",
+				command: event.command,
+			});
 			break;
 		case "hookSucceeded":
-			persistHookStatus(event.workspaceId, event.hook, { state: "succeeded" });
+			persistHookStatus(event.workspaceId, event.hook, {
+				state: "succeeded",
+				command: event.command,
+			});
 			break;
 		case "hookFailed":
 			persistHookStatus(event.workspaceId, event.hook, {
 				state: "failed",
+				command: event.command,
 				exitCode: event.exitCode,
 			});
 			break;
@@ -99,16 +106,31 @@ async function runHook(
 	project: Project,
 	timeoutMs: number | undefined,
 ): Promise<{ ok: boolean }> {
+	let command: string | undefined;
 	try {
-		const command = resolveCommand(hook, workspace, project);
+		command = resolveCommand(hook, workspace, project);
 		if (!command) return { ok: true }; // nothing declared for this hook — not a failure
 
 		if (!isApproved(project.id, hook, command)) {
-			emit({ kind: "hookAwaitingApproval", workspaceId: workspace.id, hook, command });
+			emit({
+				kind: "hookAwaitingApproval",
+				workspaceId: workspace.id,
+				workspaceName: workspace.name,
+				projectId: project.id,
+				hook,
+				command,
+			});
 			return { ok: false };
 		}
 
-		emit({ kind: "hookStarted", workspaceId: workspace.id, hook });
+		emit({
+			kind: "hookStarted",
+			workspaceId: workspace.id,
+			workspaceName: workspace.name,
+			projectId: project.id,
+			hook,
+			command,
+		});
 		const result = await runShellCommand({
 			command,
 			cwd: workspace.worktreePath,
@@ -117,16 +139,46 @@ async function runHook(
 			// entirely for fire-and-forget hooks instead.
 			...(timeoutMs !== undefined ? { timeoutMs } : {}),
 			onChunk: (_stream, chunk) =>
-				emit({ kind: "hookOutput", workspaceId: workspace.id, hook, chunk }),
+				emit({
+					kind: "hookOutput",
+					workspaceId: workspace.id,
+					workspaceName: workspace.name,
+					projectId: project.id,
+					hook,
+					chunk,
+				}),
 		});
 		if (result.ok) {
-			emit({ kind: "hookSucceeded", workspaceId: workspace.id, hook });
+			emit({
+				kind: "hookSucceeded",
+				workspaceId: workspace.id,
+				workspaceName: workspace.name,
+				projectId: project.id,
+				hook,
+				command,
+			});
 		} else {
-			emit({ kind: "hookFailed", workspaceId: workspace.id, hook, exitCode: result.exitCode });
+			emit({
+				kind: "hookFailed",
+				workspaceId: workspace.id,
+				workspaceName: workspace.name,
+				projectId: project.id,
+				hook,
+				command,
+				exitCode: result.exitCode,
+			});
 		}
 		return { ok: result.ok };
 	} catch (error) {
-		emit({ kind: "hookFailed", workspaceId: workspace.id, hook, exitCode: -1 });
+		emit({
+			kind: "hookFailed",
+			workspaceId: workspace.id,
+			workspaceName: workspace.name,
+			projectId: project.id,
+			hook,
+			command: command ?? "(unknown)",
+			exitCode: -1,
+		});
 		console.warn(`workspace hook ${hook} failed for ${workspace.id}: ${error}`);
 		return { ok: false };
 	}
@@ -159,4 +211,5 @@ export function runPostMergeHook(workspace: Workspace, project: Project): void {
 	queueMicrotask(() => void runHook("postMerge", workspace, project, undefined));
 }
 
-export { approveHook };
+export { loadHookConfig, resolveHookCommand } from "./config";
+export { approveHook, isApproved };

--- a/packages/server/src/workspaces/hooks/hooks.ts
+++ b/packages/server/src/workspaces/hooks/hooks.ts
@@ -211,5 +211,5 @@ export function runPostMergeHook(workspace: Workspace, project: Project): void {
 	queueMicrotask(() => void runHook("postMerge", workspace, project, undefined));
 }
 
-export { loadHookConfig, resolveHookCommand } from "./config";
+export { loadHookConfig, resolveHookCommand, writeHookConfig } from "./config";
 export { approveHook, isApproved };

--- a/packages/server/src/workspaces/hooks/hooks.ts
+++ b/packages/server/src/workspaces/hooks/hooks.ts
@@ -1,0 +1,120 @@
+// Orchestrates one hook run: resolve its command (committed + host-local override), gate it behind
+// approval, execute it, and publish every state transition through the injected publisher (the same
+// inversion `workspaces`/`terminal`/`settings` use) so the host can fan it out over `workspace.hook`.
+import type { HookName, Project, Workspace, WorkspaceHookEvent } from "@thinkrail/contracts";
+import { loadHookOverrides } from "../../persistence";
+import { approveHook, isApproved } from "./approvals";
+import { loadHookConfig, resolveHookCommand } from "./config";
+import { runShellCommand } from "./runner";
+
+type HookPublisher = (event: WorkspaceHookEvent) => void;
+
+// Injected by the host; `null` in unit tests → emits are silent no-ops.
+let publishHookEvent: HookPublisher | null = null;
+
+/** Install (or clear with `null`) the sink hook state transitions are fanned out through. */
+export function setHookPublisher(fn: HookPublisher | null): void {
+	publishHookEvent = fn;
+}
+
+function emit(event: WorkspaceHookEvent): void {
+	publishHookEvent?.(event);
+}
+
+/** A blocking hook's default ceiling — `onDelete`/`preMerge` are awaited by their caller. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function buildHookEnv(workspace: Workspace): Record<string, string | undefined> {
+	return {
+		...process.env,
+		THINKRAIL_WORKSPACE_ID: workspace.id,
+		THINKRAIL_WORKSPACE_PATH: workspace.worktreePath,
+		THINKRAIL_WORKSPACE_BRANCH: workspace.branch,
+		THINKRAIL_PROJECT_ID: workspace.projectId,
+	};
+}
+
+/** Resolve `hook`'s command from this workspace's own worktree (committed) + the host-local override for
+ * its project. */
+function resolveCommand(
+	hook: HookName,
+	workspace: Workspace,
+	project: Project,
+): string | undefined {
+	const committed = loadHookConfig(workspace.worktreePath);
+	const override = loadHookOverrides()[project.id] ?? {};
+	return resolveHookCommand(hook, committed, override);
+}
+
+/**
+ * Run `hook` for this workspace/project if it has a resolved command and that command is approved. Never
+ * throws — any failure (missing approval, non-zero exit, timeout, an unexpected error) resolves to
+ * `ok: false`; callers decide what that means for their own hook (abort a merge, or just log it).
+ */
+async function runHook(
+	hook: HookName,
+	workspace: Workspace,
+	project: Project,
+	timeoutMs: number | undefined,
+): Promise<{ ok: boolean }> {
+	try {
+		const command = resolveCommand(hook, workspace, project);
+		if (!command) return { ok: true }; // nothing declared for this hook — not a failure
+
+		if (!isApproved(project.id, hook, command)) {
+			emit({ kind: "hookAwaitingApproval", workspaceId: workspace.id, hook, command });
+			return { ok: false };
+		}
+
+		emit({ kind: "hookStarted", workspaceId: workspace.id, hook });
+		const result = await runShellCommand({
+			command,
+			cwd: workspace.worktreePath,
+			env: buildHookEnv(workspace),
+			// `exactOptionalPropertyTypes` forbids passing an explicit `timeoutMs: undefined` — omit the key
+			// entirely for fire-and-forget hooks instead.
+			...(timeoutMs !== undefined ? { timeoutMs } : {}),
+			onChunk: (_stream, chunk) =>
+				emit({ kind: "hookOutput", workspaceId: workspace.id, hook, chunk }),
+		});
+		if (result.ok) {
+			emit({ kind: "hookSucceeded", workspaceId: workspace.id, hook });
+		} else {
+			emit({ kind: "hookFailed", workspaceId: workspace.id, hook, exitCode: result.exitCode });
+		}
+		return { ok: result.ok };
+	} catch (error) {
+		emit({ kind: "hookFailed", workspaceId: workspace.id, hook, exitCode: -1 });
+		console.warn(`workspace hook ${hook} failed for ${workspace.id}: ${error}`);
+		return { ok: false };
+	}
+}
+
+/** Fire the `onCreate` hook in the background — never blocks workspace creation. Deferred to a microtask:
+ * `runHook`'s own body runs synchronously up to its first `await` (normal JS async-function semantics), so
+ * without this, `resolveCommand`/`isApproved`/the `hookStarted` emit would run inline on this call's stack
+ * — this call must return before any of that happens. */
+export function runOnCreateHook(workspace: Workspace, project: Project): void {
+	queueMicrotask(() => void runHook("onCreate", workspace, project, undefined));
+}
+
+/** Run the `onDelete` hook before the worktree is removed. Best-effort: always resolves, never rejects —
+ * `reclaimWorktree` proceeds with the removal regardless of the result. */
+export async function runOnDeleteHook(workspace: Workspace, project: Project): Promise<void> {
+	await runHook("onDelete", workspace, project, DEFAULT_TIMEOUT_MS);
+}
+
+/** Run the `preMerge` hook and report whether the merge should proceed — `false` (incl. on timeout or a
+ * missing approval) means abort. */
+export async function runPreMergeHook(workspace: Workspace, project: Project): Promise<boolean> {
+	const { ok } = await runHook("preMerge", workspace, project, DEFAULT_TIMEOUT_MS);
+	return ok;
+}
+
+/** Fire the `postMerge` hook in the background — never blocks the caller. Deferred to a microtask for the
+ * same reason as `runOnCreateHook` above. */
+export function runPostMergeHook(workspace: Workspace, project: Project): void {
+	queueMicrotask(() => void runHook("postMerge", workspace, project, undefined));
+}
+
+export { approveHook };

--- a/packages/server/src/workspaces/hooks/hooks.ts
+++ b/packages/server/src/workspaces/hooks/hooks.ts
@@ -1,8 +1,10 @@
-// Orchestrates one hook run: resolve its command (committed + host-local override), gate it behind
-// approval, execute it, and publish every state transition through the injected publisher (the same
-// inversion `workspaces`/`terminal`/`settings` use) so the host can fan it out over `workspace.hook`.
+// Orchestrates one hook's run: resolve its ordered list of run entries (Shared/Local, combined per the
+// effective `CombineMode`), gate each entry behind its own per-source approval, execute it, and publish
+// every state transition through the injected publisher (the same inversion `workspaces`/`terminal`/
+// `settings` use) so the host can fan it out over `workspace.hook`.
 import type {
 	HookName,
+	HookSource,
 	HookStatus,
 	Project,
 	Workspace,
@@ -10,7 +12,7 @@ import type {
 } from "@thinkrail/contracts";
 import { loadHookOverrides, loadWorkspaces, saveWorkspaces } from "../../persistence";
 import { approveHook, isApproved } from "./approvals";
-import { loadHookConfig, resolveHookCommand } from "./config";
+import { loadHookConfig, type ResolvedHookEntry, resolveHookRun } from "./config";
 import { runShellCommand } from "./runner";
 
 type HookPublisher = (event: WorkspaceHookEvent) => void;
@@ -24,16 +26,26 @@ export function setHookPublisher(fn: HookPublisher | null): void {
 }
 
 /**
- * Persist `hook`'s latest state onto its workspace record (`Workspace.hookStatus`) — durability for a
- * reconnecting/reloaded client, not the live update path (an already-connected client updates from the
- * `workspace.hook` event itself). Best-effort: a workspace archived mid-run (record already gone) is a
- * silent no-op — there's nothing left to persist onto.
+ * Persist `hook`'s latest per-`HookSource` state onto its workspace record (`Workspace.hookStatus`) —
+ * durability for a reconnecting/reloaded client, not the live update path (an already-connected client
+ * updates from the `workspace.hook` event itself). Merges into the hook's existing entry so the sibling
+ * source's last-known status (e.g. Shared sitting at `succeeded` while Local is now `running`) is never
+ * clobbered. Best-effort: a workspace archived mid-run (record already gone) is a silent no-op — there's
+ * nothing left to persist onto.
  */
-function persistHookStatus(workspaceId: string, hook: HookName, status: HookStatus): void {
+function persistHookStatus(
+	workspaceId: string,
+	hook: HookName,
+	source: HookSource,
+	status: HookStatus,
+): void {
 	const all = loadWorkspaces();
 	const target = all.find((w) => w.id === workspaceId);
 	if (!target) return;
-	target.hookStatus = { ...target.hookStatus, [hook]: status };
+	target.hookStatus = {
+		...target.hookStatus,
+		[hook]: { ...target.hookStatus?.[hook], [source]: status },
+	};
 	saveWorkspaces(all);
 }
 
@@ -41,25 +53,25 @@ function emit(event: WorkspaceHookEvent): void {
 	publishHookEvent?.(event);
 	switch (event.kind) {
 		case "hookAwaitingApproval":
-			persistHookStatus(event.workspaceId, event.hook, {
+			persistHookStatus(event.workspaceId, event.hook, event.source, {
 				state: "awaitingApproval",
 				command: event.command,
 			});
 			break;
 		case "hookStarted":
-			persistHookStatus(event.workspaceId, event.hook, {
+			persistHookStatus(event.workspaceId, event.hook, event.source, {
 				state: "running",
 				command: event.command,
 			});
 			break;
 		case "hookSucceeded":
-			persistHookStatus(event.workspaceId, event.hook, {
+			persistHookStatus(event.workspaceId, event.hook, event.source, {
 				state: "succeeded",
 				command: event.command,
 			});
 			break;
 		case "hookFailed":
-			persistHookStatus(event.workspaceId, event.hook, {
+			persistHookStatus(event.workspaceId, event.hook, event.source, {
 				state: "failed",
 				command: event.command,
 				exitCode: event.exitCode,
@@ -83,44 +95,53 @@ function buildHookEnv(workspace: Workspace): Record<string, string | undefined> 
 	};
 }
 
-/** Resolve `hook`'s command from this workspace's own worktree (committed) + the host-local override for
- * its project. */
-function resolveCommand(
-	hook: HookName,
-	workspace: Workspace,
-	project: Project,
-): string | undefined {
-	const committed = loadHookConfig(workspace.worktreePath);
-	const override = loadHookOverrides()[project.id] ?? {};
-	return resolveHookCommand(hook, committed, override);
-}
-
 /**
- * Run `hook` for this workspace/project if it has a resolved command and that command is approved. Never
- * throws — any failure (missing approval, non-zero exit, timeout, an unexpected error) resolves to
- * `ok: false`; callers decide what that means for their own hook (abort a merge, or just log it).
+ * Run one resolved entry to completion, gating it behind its own approval first. Returns whether it's safe
+ * to continue on to the next entry in the list — `true` only for a clean, approved, zero-exit run; `false`
+ * for a missing script, unapproved material, a non-zero exit, or an unexpected error — which is exactly
+ * what gives the caller its stop-on-first-non-clean-entry behavior. Never throws: an error the subprocess
+ * layer itself raises (as opposed to a non-zero exit, which it reports normally) is caught and converted
+ * into a `hookFailed`, the same public shape as any other failure.
  */
-async function runHook(
+async function runHookEntry(
 	hook: HookName,
 	workspace: Workspace,
 	project: Project,
+	entry: ResolvedHookEntry,
 	timeoutMs: number | undefined,
-): Promise<{ ok: boolean }> {
-	let command: string | undefined;
+): Promise<boolean> {
+	const { source, display } = entry;
 	try {
-		command = resolveCommand(hook, workspace, project);
-		if (!command) return { ok: true }; // nothing declared for this hook — not a failure
-
-		if (!isApproved(project.id, hook, command)) {
+		if (entry.missing) {
+			emit({
+				kind: "hookFailed",
+				workspaceId: workspace.id,
+				workspaceName: workspace.name,
+				projectId: project.id,
+				hook,
+				source,
+				command: display,
+				exitCode: -1,
+			});
+			return false;
+		}
+		// `approvalMaterial` is `null` only when `entry.missing` is set (nothing to hash) — already handled
+		// above — but the type doesn't encode that link, so this null check both guards `isApproved` (which
+		// takes a plain `string`) and doubles as the "may be null → not approved" case the caller must honor.
+		if (
+			entry.approvalMaterial === null ||
+			!isApproved(project.id, hook, source, entry.approvalMaterial)
+		) {
 			emit({
 				kind: "hookAwaitingApproval",
 				workspaceId: workspace.id,
 				workspaceName: workspace.name,
 				projectId: project.id,
 				hook,
-				command,
+				source,
+				command: display,
 			});
-			return { ok: false };
+			return false;
 		}
 
 		emit({
@@ -129,10 +150,11 @@ async function runHook(
 			workspaceName: workspace.name,
 			projectId: project.id,
 			hook,
-			command,
+			source,
+			command: display,
 		});
 		const result = await runShellCommand({
-			command,
+			...(entry.kind === "script" ? { script: entry.exec } : { command: entry.exec }),
 			cwd: workspace.worktreePath,
 			env: buildHookEnv(workspace),
 			// `exactOptionalPropertyTypes` forbids passing an explicit `timeoutMs: undefined` — omit the key
@@ -145,6 +167,7 @@ async function runHook(
 					workspaceName: workspace.name,
 					projectId: project.id,
 					hook,
+					source,
 					chunk,
 				}),
 		});
@@ -155,7 +178,8 @@ async function runHook(
 				workspaceName: workspace.name,
 				projectId: project.id,
 				hook,
-				command,
+				source,
+				command: display,
 			});
 		} else {
 			emit({
@@ -164,11 +188,12 @@ async function runHook(
 				workspaceName: workspace.name,
 				projectId: project.id,
 				hook,
-				command,
+				source,
+				command: display,
 				exitCode: result.exitCode,
 			});
 		}
-		return { ok: result.ok };
+		return result.ok;
 	} catch (error) {
 		emit({
 			kind: "hookFailed",
@@ -176,17 +201,52 @@ async function runHook(
 			workspaceName: workspace.name,
 			projectId: project.id,
 			hook,
-			command: command ?? "(unknown)",
+			source,
+			command: display,
 			exitCode: -1,
 		});
-		console.warn(`workspace hook ${hook} failed for ${workspace.id}: ${error}`);
-		return { ok: false };
+		console.warn(`workspace hook ${hook} (${source}) failed for ${workspace.id}: ${error}`);
+		return false;
 	}
+}
+
+/**
+ * Run `hook` for this workspace/project: resolve its ordered list of run entries — Shared/Local per the
+ * effective `CombineMode` (`workspace.hookCombineMode`, falling back to the project's committed default,
+ * falling back to `"both"`) — then run them one at a time, in that order. Stops at the first entry that
+ * isn't a clean approved zero-exit run (`&&` semantics) and returns `{ ok: false }` without touching the
+ * remaining entries; `{ ok: true }` only when every entry ran and succeeded, including the vacuous case
+ * where the list is empty (nothing declared for this hook is not a failure). Never throws — any failure
+ * mode (missing approval, a missing script, a non-zero exit, timeout, an unexpected error) resolves to
+ * `ok: false`; callers decide what that means for their own hook (abort a merge, or just log it).
+ */
+async function runHook(
+	hook: HookName,
+	workspace: Workspace,
+	project: Project,
+	timeoutMs: number | undefined,
+): Promise<{ ok: boolean }> {
+	const committed = loadHookConfig(workspace.worktreePath);
+	const mode = workspace.hookCombineMode ?? committed.combineMode ?? "both";
+	const local = loadHookOverrides()[project.id] ?? {};
+	const entries = resolveHookRun({
+		hook,
+		committed,
+		local,
+		mode,
+		basePath: workspace.worktreePath,
+	});
+
+	for (const entry of entries) {
+		const ok = await runHookEntry(hook, workspace, project, entry, timeoutMs);
+		if (!ok) return { ok: false };
+	}
+	return { ok: true };
 }
 
 /** Fire the `onCreate` hook in the background — never blocks workspace creation. Deferred to a microtask:
  * `runHook`'s own body runs synchronously up to its first `await` (normal JS async-function semantics), so
- * without this, `resolveCommand`/`isApproved`/the `hookStarted` emit would run inline on this call's stack
+ * without this, entry resolution/`isApproved`/the `hookStarted` emit would run inline on this call's stack
  * — this call must return before any of that happens. */
 export function runOnCreateHook(workspace: Workspace, project: Project): void {
 	queueMicrotask(() => void runHook("onCreate", workspace, project, undefined));
@@ -211,5 +271,5 @@ export function runPostMergeHook(workspace: Workspace, project: Project): void {
 	queueMicrotask(() => void runHook("postMerge", workspace, project, undefined));
 }
 
-export { loadHookConfig, resolveHookCommand, writeHookConfig } from "./config";
+export { loadHookConfig, resolveHookCommand, resolveHookRun, writeHookConfig } from "./config";
 export { approveHook, isApproved };

--- a/packages/server/src/workspaces/hooks/hooks.ts
+++ b/packages/server/src/workspaces/hooks/hooks.ts
@@ -271,5 +271,5 @@ export function runPostMergeHook(workspace: Workspace, project: Project): void {
 	queueMicrotask(() => void runHook("postMerge", workspace, project, undefined));
 }
 
-export { loadHookConfig, resolveHookCommand, resolveHookRun, writeHookConfig } from "./config";
+export { loadHookConfig, resolveHookRun, writeHookConfig } from "./config";
 export { approveHook, isApproved };

--- a/packages/server/src/workspaces/hooks/index.ts
+++ b/packages/server/src/workspaces/hooks/index.ts
@@ -1,0 +1,2 @@
+/** Workspace lifecycle hooks: project-declared onCreate/onDelete/preMerge/postMerge commands. */
+export * from "./hooks";

--- a/packages/server/src/workspaces/hooks/runner.test.ts
+++ b/packages/server/src/workspaces/hooks/runner.test.ts
@@ -1,8 +1,13 @@
 import { expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runShellCommand } from "./runner";
+
+/** True if a process with this pid currently exists (checked via `ps`, portable across macOS/Linux). */
+function isProcessAlive(pid: number): boolean {
+	return Bun.spawnSync(["ps", "-p", String(pid)]).exitCode === 0;
+}
 
 test("runShellCommand reports ok:true and exitCode 0 for a successful command", async () => {
 	const result = await runShellCommand({ command: "true", cwd: tmpdir(), env: {} });
@@ -51,3 +56,44 @@ test("runShellCommand marks timedOut and kills a command that overruns timeoutMs
 	expect(result.ok).toBe(false);
 	expect(result.timedOut).toBe(true);
 });
+
+test("runShellCommand kills the whole process tree, not just the shell, when a compound command overruns timeoutMs", async () => {
+	// This command forks a real descendant (the backgrounded `sleep 5`) distinct from the "sh -c ..."
+	// process the runner spawns: `sh` must fork here (rather than exec-replacing itself) because it has
+	// more work to do (the `wait`) after starting the background job. `$!` captures that descendant's
+	// real pid so the test can check on it directly, independent of whatever pid `sh` itself has.
+	const dir = mkdtempSync(join(tmpdir(), "trpi-runner-test-"));
+	const pidFile = join(dir, "descendant.pid");
+	try {
+		// The whole point of timeoutMs is a bounded-execution guarantee: runShellCommand must return
+		// promptly once the timeout fires. Race it against a generous-but-bounded window (well past the
+		// 100ms timeoutMs, but well short of the leaked descendant's 5s sleep) — if the runner is stuck
+		// waiting for an orphaned descendant to close inherited stdout/stderr pipes, this fails fast
+		// instead of the whole test hanging for ~5s.
+		const BOUND_MS = 2000;
+		const boundExceeded = Symbol("bound-exceeded");
+		const raced = await Promise.race([
+			runShellCommand({
+				command: `sleep 5 & echo $! > ${pidFile}; wait`,
+				cwd: dir,
+				env: {},
+				timeoutMs: 100,
+			}),
+			new Promise((resolve) => setTimeout(() => resolve(boundExceeded), BOUND_MS)),
+		]);
+		expect(raced).not.toBe(boundExceeded);
+		const result = raced as Awaited<ReturnType<typeof runShellCommand>>;
+		expect(result.ok).toBe(false);
+		expect(result.timedOut).toBe(true);
+
+		expect(existsSync(pidFile)).toBe(true);
+		const descendantPid = Number(readFileSync(pidFile, "utf8").trim());
+		expect(Number.isInteger(descendantPid)).toBe(true);
+
+		// Give the OS a brief moment to finish tearing down the signaled descendant.
+		await Bun.sleep(200);
+		expect(isProcessAlive(descendantPid)).toBe(false);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}, 10000);

--- a/packages/server/src/workspaces/hooks/runner.test.ts
+++ b/packages/server/src/workspaces/hooks/runner.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runShellCommand } from "./runner";
@@ -97,3 +97,49 @@ test("runShellCommand kills the whole process tree, not just the shell, when a c
 		rmSync(dir, { recursive: true, force: true });
 	}
 }, 10000);
+
+test("runShellCommand with script mode runs the script file and reports ok:true and exitCode 0 for success", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "trpi-runner-script-test-"));
+	try {
+		const scriptPath = join(dir, "test.sh");
+		writeFileSync(scriptPath, "#!/bin/sh\necho hello\nexit 0\n", { mode: 0o755 });
+
+		const chunks: Array<{ stream: string; chunk: string }> = [];
+		const result = await runShellCommand({
+			script: scriptPath,
+			cwd: dir,
+			env: {},
+			onChunk: (stream, chunk) => chunks.push({ stream, chunk }),
+		});
+
+		expect(result).toEqual({ ok: true, exitCode: 0, timedOut: false });
+
+		const stdout = chunks
+			.filter((c) => c.stream === "stdout")
+			.map((c) => c.chunk)
+			.join("");
+		expect(stdout).toBe("hello\n");
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("runShellCommand with script mode reports the correct exit code for a failing script", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "trpi-runner-script-test-"));
+	try {
+		const scriptPath = join(dir, "test.sh");
+		writeFileSync(scriptPath, "#!/bin/sh\nexit 3\n", { mode: 0o755 });
+
+		const result = await runShellCommand({
+			script: scriptPath,
+			cwd: dir,
+			env: {},
+		});
+
+		expect(result.ok).toBe(false);
+		expect(result.exitCode).toBe(3);
+		expect(result.timedOut).toBe(false);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/packages/server/src/workspaces/hooks/runner.test.ts
+++ b/packages/server/src/workspaces/hooks/runner.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runShellCommand } from "./runner";
+
+test("runShellCommand reports ok:true and exitCode 0 for a successful command", async () => {
+	const result = await runShellCommand({ command: "true", cwd: tmpdir(), env: {} });
+	expect(result).toEqual({ ok: true, exitCode: 0, timedOut: false });
+});
+
+test("runShellCommand reports ok:false and the real exit code for a failing command", async () => {
+	const result = await runShellCommand({ command: "exit 7", cwd: tmpdir(), env: {} });
+	expect(result.ok).toBe(false);
+	expect(result.exitCode).toBe(7);
+	expect(result.timedOut).toBe(false);
+});
+
+test("runShellCommand streams stdout chunks via onChunk", async () => {
+	const chunks: Array<{ stream: string; chunk: string }> = [];
+	await runShellCommand({
+		command: "echo hello",
+		cwd: tmpdir(),
+		env: {},
+		onChunk: (stream, chunk) => chunks.push({ stream, chunk }),
+	});
+	const stdout = chunks
+		.filter((c) => c.stream === "stdout")
+		.map((c) => c.chunk)
+		.join("");
+	expect(stdout).toBe("hello\n");
+});
+
+test("runShellCommand runs in the given cwd", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "trpi-runner-test-"));
+	try {
+		await runShellCommand({ command: "touch marker.txt", cwd: dir, env: {} });
+		expect(existsSync(join(dir, "marker.txt"))).toBe(true);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("runShellCommand marks timedOut and kills a command that overruns timeoutMs", async () => {
+	const result = await runShellCommand({
+		command: "sleep 5",
+		cwd: tmpdir(),
+		env: {},
+		timeoutMs: 50,
+	});
+	expect(result.ok).toBe(false);
+	expect(result.timedOut).toBe(true);
+});

--- a/packages/server/src/workspaces/hooks/runner.ts
+++ b/packages/server/src/workspaces/hooks/runner.ts
@@ -31,6 +31,25 @@ async function pump(
 	}
 }
 
+/**
+ * Sends `signal` to every process in `pid`'s process group (`pid` included), not just `pid` itself.
+ *
+ * `sh -c "<command>"` self-execs into the real command only when it's a single simple command in tail
+ * position — anything compound (`&&`, `;`, `|`, a subshell, a backgrounded job, ...) makes `sh` fork a
+ * child to run the earlier stage(s), so signalling just the `sh` pid orphans those forked descendants.
+ * `Bun.spawn`'s `detached: true` makes the spawned `sh` call `setsid()`, so it becomes the leader of its
+ * own new process group (pgid === pid). POSIX `kill(-pgid, signal)` then reaches the leader and every
+ * descendant that hasn't broken out of that group — exactly the compound-command case above. Confirmed
+ * empirically (not just from docs) against a real `sh -c "sleep 5 & ...; wait"` tree on macOS/arm64.
+ */
+function killProcessGroup(pid: number, signal: NodeJS.Signals = "SIGTERM"): void {
+	try {
+		process.kill(-pid, signal);
+	} catch {
+		// ESRCH (group already gone) or a same-shape race — the process tree is dead either way.
+	}
+}
+
 export async function runShellCommand(
 	opts: RunShellCommandOptions,
 ): Promise<RunShellCommandResult> {
@@ -39,6 +58,9 @@ export async function runShellCommand(
 		env: opts.env,
 		stdout: "pipe",
 		stderr: "pipe",
+		// Makes `sh` its own process-group leader (via setsid()) so a timeout can kill the whole tree it
+		// spawns, not just the `sh` pid Bun handed back — see killProcessGroup() above.
+		detached: true,
 	});
 
 	let timedOut = false;
@@ -46,7 +68,7 @@ export async function runShellCommand(
 		opts.timeoutMs !== undefined
 			? setTimeout(() => {
 					timedOut = true;
-					proc.kill();
+					killProcessGroup(proc.pid);
 				}, opts.timeoutMs)
 			: undefined;
 

--- a/packages/server/src/workspaces/hooks/runner.ts
+++ b/packages/server/src/workspaces/hooks/runner.ts
@@ -1,0 +1,63 @@
+// Spawns one hook command as a POSIX shell subprocess (`sh -c "<command>"`), streaming stdout/stderr chunks
+// to a callback and enforcing an optional timeout. Assumes a POSIX shell is on PATH — Windows-native (no
+// WSL/git-bash) isn't supported by this runner.
+export interface RunShellCommandOptions {
+	command: string;
+	cwd: string;
+	env: Record<string, string | undefined>;
+	/** No timeout when omitted — the caller is fire-and-forget and never awaits this anyway. */
+	timeoutMs?: number;
+	onChunk?: (stream: "stdout" | "stderr", chunk: string) => void;
+}
+
+export interface RunShellCommandResult {
+	ok: boolean;
+	exitCode: number;
+	timedOut: boolean;
+}
+
+async function pump(
+	stream: ReadableStream<Uint8Array>,
+	kind: "stdout" | "stderr",
+	onChunk?: (stream: "stdout" | "stderr", chunk: string) => void,
+): Promise<void> {
+	if (!onChunk) {
+		await new Response(stream).text(); // drain so the process doesn't block on a full pipe
+		return;
+	}
+	const decoder = new TextDecoder();
+	for await (const value of stream) {
+		onChunk(kind, decoder.decode(value, { stream: true }));
+	}
+}
+
+export async function runShellCommand(
+	opts: RunShellCommandOptions,
+): Promise<RunShellCommandResult> {
+	const proc = Bun.spawn(["sh", "-c", opts.command], {
+		cwd: opts.cwd,
+		env: opts.env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	let timedOut = false;
+	const timeout =
+		opts.timeoutMs !== undefined
+			? setTimeout(() => {
+					timedOut = true;
+					proc.kill();
+				}, opts.timeoutMs)
+			: undefined;
+
+	try {
+		await Promise.all([
+			pump(proc.stdout, "stdout", opts.onChunk),
+			pump(proc.stderr, "stderr", opts.onChunk),
+		]);
+		const exitCode = await proc.exited;
+		return { ok: !timedOut && exitCode === 0, exitCode, timedOut };
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}

--- a/packages/server/src/workspaces/hooks/runner.ts
+++ b/packages/server/src/workspaces/hooks/runner.ts
@@ -1,8 +1,11 @@
-// Spawns one hook command as a POSIX shell subprocess (`sh -c "<command>"`), streaming stdout/stderr chunks
-// to a callback and enforcing an optional timeout. Assumes a POSIX shell is on PATH — Windows-native (no
-// WSL/git-bash) isn't supported by this runner.
+// Spawns one hook command as a POSIX shell subprocess (`sh -c "<command>"` or `sh <script>`),
+// streaming stdout/stderr chunks to a callback and enforcing an optional timeout. Assumes a POSIX
+// shell is on PATH — Windows-native (no WSL/git-bash) isn't supported by this runner.
 export interface RunShellCommandOptions {
-	command: string;
+	/** Inline shell command (e.g., "echo hello"). Either `command` or `script` must be provided, not both. */
+	command?: string;
+	/** Path to a shell script file to execute. Either `command` or `script` must be provided, not both. */
+	script?: string;
 	cwd: string;
 	env: Record<string, string | undefined>;
 	/** No timeout when omitted — the caller is fire-and-forget and never awaits this anyway. */
@@ -53,7 +56,8 @@ function killProcessGroup(pid: number, signal: NodeJS.Signals = "SIGTERM"): void
 export async function runShellCommand(
 	opts: RunShellCommandOptions,
 ): Promise<RunShellCommandResult> {
-	const proc = Bun.spawn(["sh", "-c", opts.command], {
+	const argv = opts.script ? ["sh", opts.script] : ["sh", "-c", opts.command ?? ""];
+	const proc = Bun.spawn(argv, {
 		cwd: opts.cwd,
 		env: opts.env,
 		stdout: "pipe",

--- a/packages/server/src/workspaces/index.ts
+++ b/packages/server/src/workspaces/index.ts
@@ -1,2 +1,4 @@
 /** Workspaces = git worktrees on their own branch under the data dir. */
+
+export * from "./hooks";
 export * from "./workspaces";

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { approveHook } from "./hooks";
 import {
 	createWorkspace,
 	forgetWorkspace,
@@ -208,7 +209,7 @@ test("forgetWorkspace drops the record + returns it, but leaves the worktree for
 	expect(new TextDecoder().decode(before.stdout)).toContain(ws.worktreePath);
 
 	// reclaimWorktree then removes it from git + disk.
-	reclaimWorktree(forgotten as NonNullable<typeof forgotten>);
+	await reclaimWorktree(forgotten as NonNullable<typeof forgotten>);
 	const after = Bun.spawnSync(["git", "-C", repo, "worktree", "list"], { stdout: "pipe" });
 	expect(new TextDecoder().decode(after.stdout)).not.toContain(ws.worktreePath);
 
@@ -237,7 +238,7 @@ test("membership mutations emit lifecycle events through the injected publisher"
 test("a null publisher makes lifecycle emits silent no-ops", async () => {
 	setWorkspacePublisher(null);
 	const ws = await createWorkspace("p1");
-	expect(() => removeWorkspace(ws.id)).not.toThrow();
+	await expect(removeWorkspace(ws.id)).resolves.toBeUndefined();
 	expect(listWorkspaces("p1")).toHaveLength(0);
 });
 
@@ -248,10 +249,46 @@ test("removeWorkspace cleans up even when the worktree dir is already gone", asy
 	// Simulate drift: delete the worktree dir behind git's back so `git worktree remove` can't.
 	rmSync(ws.worktreePath, { recursive: true, force: true });
 
-	expect(() => removeWorkspace(ws.id)).not.toThrow();
+	await expect(removeWorkspace(ws.id)).resolves.toBeUndefined();
 	expect(listWorkspaces("p1")).toHaveLength(0);
 
 	// git's worktree registration is pruned — no orphan left behind.
 	const list = Bun.spawnSync(["git", "-C", repo, "worktree", "list"], { stdout: "pipe" });
 	expect(new TextDecoder().decode(list.stdout)).not.toContain(ws.worktreePath);
+});
+
+test("onDelete hook runs before the worktree directory is actually removed", async () => {
+	const ws = await createWorkspace("p1");
+	const command = `test -d "${ws.worktreePath}" && touch "${dataDir}/onDelete-ran"`;
+	mkdirSync(join(ws.worktreePath, ".thinkrail"), { recursive: true });
+	writeFileSync(
+		join(ws.worktreePath, ".thinkrail", "hooks.json"),
+		JSON.stringify({ onDelete: command }),
+	);
+	approveHook("p1", "onDelete", command);
+
+	await reclaimWorktree(ws);
+
+	expect(existsSync(join(dataDir, "onDelete-ran"))).toBe(true); // saw the worktree while it still existed
+	expect(existsSync(ws.worktreePath)).toBe(false); // and the worktree is gone afterward
+});
+
+test("onCreate hook runs in the background and doesn't block createWorkspace's return", async () => {
+	// Commit a slow onCreate hook to the base branch first, so it's already checked out the moment the new
+	// worktree is created.
+	const command = `sleep 0.5 && touch "${dataDir}/onCreate-ran"`;
+	mkdirSync(join(repo, ".thinkrail"), { recursive: true });
+	writeFileSync(join(repo, ".thinkrail", "hooks.json"), JSON.stringify({ onCreate: command }));
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "add onCreate hook");
+	approveHook("p1", "onCreate", command);
+
+	const start = Date.now();
+	const ws = await createWorkspace("p1");
+	expect(Date.now() - start).toBeLessThan(500); // returned well before the 0.5s hook could have finished
+	expect(existsSync(join(dataDir, "onCreate-ran"))).toBe(false); // hook hasn't finished yet
+
+	await new Promise((resolve) => setTimeout(resolve, 700));
+	expect(existsSync(join(dataDir, "onCreate-ran"))).toBe(true); // …but it did finish, in the background
+	expect(ws.id).toBeTruthy();
 });

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -114,6 +114,21 @@ test("createWorkspace marks a user-named workspace renamed; an auto-named one st
 	expect(named.renamed).toBe(true);
 });
 
+test("createWorkspace stamps hookCombineMode onto the record when given; omitted leaves it absent", async () => {
+	const withMode = await createWorkspace("p1", undefined, undefined, "shared");
+	expect(withMode.hookCombineMode).toBe("shared");
+	// Persisted, not just returned — a reload sees the same value.
+	expect(listWorkspaces("p1").find((w) => w.id === withMode.id)?.hookCombineMode).toBe("shared");
+
+	const withoutMode = await createWorkspace("p1");
+	expect(withoutMode.hookCombineMode).toBeUndefined();
+	// Not merely `undefined` — the key itself must be absent (exactOptionalPropertyTypes discipline).
+	expect(Object.hasOwn(withoutMode, "hookCombineMode")).toBe(false);
+	expect(
+		listWorkspaces("p1").find((w) => w.id === withoutMode.id)?.hookCombineMode,
+	).toBeUndefined();
+});
+
 test("renameWorkspace moves the branch in place: record + git follow, the worktree dir does not", async () => {
 	const ws = await createWorkspace("p1");
 	const renamed = renameWorkspace(ws.id, "add login flow");
@@ -265,7 +280,7 @@ test("onDelete hook runs before the worktree directory is actually removed", asy
 		join(ws.worktreePath, ".thinkrail", "hooks.json"),
 		JSON.stringify({ onDelete: command }),
 	);
-	approveHook("p1", "onDelete", command);
+	approveHook("p1", "onDelete", "shared", command);
 
 	await reclaimWorktree(ws);
 
@@ -281,7 +296,7 @@ test("onCreate hook runs in the background and doesn't block createWorkspace's r
 	writeFileSync(join(repo, ".thinkrail", "hooks.json"), JSON.stringify({ onCreate: command }));
 	git(repo, "add", "-A");
 	git(repo, "commit", "-m", "add onCreate hook");
-	approveHook("p1", "onCreate", command);
+	approveHook("p1", "onCreate", "shared", command);
 
 	const start = Date.now();
 	const ws = await createWorkspace("p1");

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import type { DiffStats, Project, Workspace } from "@thinkrail/contracts";
+import type { CombineMode, DiffStats, Project, Workspace } from "@thinkrail/contracts";
 import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
 import { git, gitAsync } from "../git";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
@@ -106,11 +106,16 @@ function diffStats(worktreePath: string, baseBranch: string): DiffStats {
  * `prefetchBranch`es it in the background when it opens, so the local remote-tracking ref is already
  * current by the time we branch. We only fetch *here* as a cheap fallback when the ref isn't present
  * locally at all (never fetched) — a ~10ms `rev-parse` guard, so the common case pays no network cost.
+ *
+ * `hookCombineMode`, when given, is stamped onto the new record (before `runOnCreateHook` fires, so the
+ * very first hook run already sees it) as this workspace's fixed override of how Shared/Local hooks combine
+ * for its whole life — omitted leaves the field absent entirely, inheriting the project's committed default.
  */
 export async function createWorkspace(
 	projectId: string,
 	name?: string,
 	baseRef?: string,
+	hookCombineMode?: CombineMode,
 ): Promise<Workspace> {
 	const project = getProjects().find((p) => p.id === projectId);
 	if (!project) throw new Error(`Unknown project: ${projectId}`);
@@ -165,6 +170,8 @@ export async function createWorkspace(
 		// A user-chosen name is a deliberate one — the auto-namer must never touch it. Auto `workspace-N`
 		// leaves the flag unset: eligible for one assist rename.
 		...(displayName ? { renamed: true } : {}),
+		// Omitted ⇒ field absent (not present-but-undefined) — inherits the project's committed default.
+		...(hookCombineMode ? { hookCombineMode } : {}),
 	};
 	all.push(workspace);
 	saveWorkspaces(all);

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -6,6 +6,7 @@ import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
 import { git, gitAsync } from "../git";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
 import { getProjects } from "../projects";
+import { runOnCreateHook, runOnDeleteHook } from "./hooks";
 
 /**
  * A workspace-registry membership change, emitted on every create/rename/archive so the host can fan it
@@ -168,6 +169,7 @@ export async function createWorkspace(
 	all.push(workspace);
 	saveWorkspaces(all);
 	emit({ kind: "created", workspace });
+	runOnCreateHook(workspace, project); // fire-and-forget — never blocks workspace creation
 	return workspace;
 }
 
@@ -249,9 +251,10 @@ export function forgetWorkspace(id: string): Workspace | null {
  * Keeps the branch, so the work stays recoverable. Best-effort and hardened: on git failure, delete the
  * dir if it lingers then `prune` the stale registration so `git worktree list` never orphans it.
  */
-export function reclaimWorktree(ws: Workspace): void {
+export async function reclaimWorktree(ws: Workspace): Promise<void> {
 	const project = loadProjects().find((p) => p.id === ws.projectId);
 	if (!project) return;
+	await runOnDeleteHook(ws, project); // best-effort — never throws, removal proceeds regardless
 	const removed = git(project.path, ["worktree", "remove", "--force", ws.worktreePath]);
 	if (!removed.ok) {
 		rmSync(ws.worktreePath, { recursive: true, force: true });
@@ -259,10 +262,10 @@ export function reclaimWorktree(ws: Workspace): void {
 	}
 }
 
-/** Archive a workspace synchronously: drop the record then reclaim the worktree (keeps the branch). */
-export function removeWorkspace(id: string): void {
+/** Archive a workspace: drop the record then reclaim the worktree (keeps the branch). */
+export async function removeWorkspace(id: string): Promise<void> {
 	const ws = forgetWorkspace(id);
-	if (ws) reclaimWorktree(ws);
+	if (ws) await reclaimWorktree(ws);
 }
 
 export function workspaceDiffStats(id: string): DiffStats {

--- a/packages/shared/src/paths.ts
+++ b/packages/shared/src/paths.ts
@@ -18,3 +18,10 @@ export const WORKSPACE_INTERNAL_DIR = ".thinkrail";
  * invisible to git.
  */
 export const WORKSPACE_CONTEXT_DIR = `${WORKSPACE_INTERNAL_DIR}/context`;
+
+/**
+ * Committed hook config (relative to the worktree root) — a project's own `onCreate`/`onDelete`/`preMerge`/
+ * `postMerge` commands. Unlike `context/`, this one is a normal tracked file: it's checked out the moment
+ * `git worktree add` creates the worktree, so it's already present by the time the `onCreate` hook needs it.
+ */
+export const WORKSPACE_HOOKS_CONFIG_FILE = `${WORKSPACE_INTERNAL_DIR}/hooks.json`;


### PR DESCRIPTION
## Workspace lifecycle hooks

Projects can declare shell commands that run around a workspace's lifecycle — `onCreate` (right after a
worktree is created), `onDelete` (before it's reclaimed), and `preMerge`/`postMerge` (reserved; no merge
flow in V1 yet). Everything is **UI over well-structured, human-editable JSON** — the app is a thin editor
over `.thinkrail/hooks.json` (committed) and per-machine files under `~/.thinkrail`.

### The model (two tiers + combine-mode + script files)

- **Shared hooks** — committed to `.thinkrail/hooks.json` (a versioned `{ version, combineMode, hooks }`
  object), shared with the team via git.
- **Local hooks** — per-project, host-local (`~/.thinkrail/hookOverrides.json`), this machine only, never
  committed. The right home for personal/per-developer setup.
- **Combine-mode** (`both` / `shared` / `local`) — a committed project default, overridable per-workspace
  at create time. `both` runs Shared → Local (stop on first non-zero exit). Default `both` keeps the team
  baseline always running, so a personal hook can only *add*, never silently replace the team's setup.
- **Script-file hooks** — a hook value is `string | { command } | { script }`; a `{ script }` points at a
  file (`sh <path>`), so real multi-step scripts live in a proper, testable `.sh` file. Shared script paths
  resolve in the worktree (committed & propagated); Local ones may be absolute.
- **Approvals** are per-`(project, hook, source)` and content-hashed (a script is approved by its file
  contents). **Saving in the dialog approves on this machine**, so a freshly-configured hook runs on the
  next workspace without a second step. Teammates still approve committed hooks on their own machine.

### What this latest pass changed

An audit of the earlier config-UI (grounded in a live browser session) turned up two real bugs and a
usability gap; this pass re-designed the model to fix them:

1. **Multi-line scripts were silently corrupted** — the single-line `<input>` deleted newlines on paste
   (`npm install⏎npm run build` → `npm installnpm run build`). Now a `<textarea>` (Inline) or a script-file
   reference (Script). *(Fixes the "can't add a real script" report.)*
2. **"Save hooks" hard-failed on any project that gitignores `.thinkrail/`** (`git add` refused the ignored
   path, surfacing a raw `git add failed` toast). Now the Shared column is disabled with a clear note and
   you use a Local hook — no force-committing an ignored file.
3. **Saving didn't approve**, so a configured hook silently sat in "awaiting approval" and never ran. Now
   save approves on this machine.

Plus: per-source status/badges, a per-workspace hook-mode selector in New Workspace, a legacy-flat
`hooks.json` back-compat path, and a read-time migration for pre-upgrade persisted `hookStatus`.

### Design & structure

Contracts (`CombineMode`/`HookSource`/`HookValue`/`HookConfigFile`, per-source events, `project.hooks.*`
RPCs) → server (`workspaces/hooks`: versioned config + resolver + per-source approvals + `sh <path>` runner
+ ordered run; `project.hooks.get/save` with committability + approve-on-save; per-workspace mode) → web
(rebuilt `ProjectHooksDialog`, New-Workspace mode selector, per-source `HooksPanel`/badge/approval). Each
module's `SPEC.md` was updated alongside the code.

### Verification

- Full gate green: `check:deps` · `lint` · `typecheck` (8/8 packages) · `test` (server 247, web 176,
  others) · `e2e` (no-agent suite).
- New e2e (`e2e/project-hooks-config.spec.ts`): multi-line survives save/reopen, a committed script hook
  runs, `both` runs shared+local, save-approves, gitignore disables Shared + Local still runs, per-workspace
  `shared`-only mode, and removing a hook clears it.
- Live browser walk-through of every scenario (screenshots below).

### Notes for review

- Two pre-existing `chore: update workspace hooks` commits (`ed34cdc`, `320d910`) came from dogfooding the
  feature on this repo itself — they commit a `.thinkrail/hooks.json` (`onCreate: npm install`) into the
  ThinkRail repo. They're incidental test artifacts (and `npm install` is wrong for a Bun repo); **worth
  dropping from the branch** before merge. Happy to rebase them out on request.
- Screenshots (attached below): **01** tiered dialog · **02** multi-line Shared + Local · **03**
  approve-on-save · **04** per-workspace hook-mode · **05** `both` runs both sources · **06** gitignored
  `.thinkrail/` disables Shared · **07** a committed script hook running.
