### PR TITLE
feat(agent): load portable cross-agent skills

### DIFF
--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -141,6 +141,13 @@ try {
 		"project.open",
 	)) as { id?: string };
 	if (!project.id) fail("project.open returned no project id");
+	// Project-scoped aliases are gated behind trust — grant it so the compiled skill.list surfaces the
+	// committed `.claude/skills` alias below (personal/bundled skills would load regardless).
+	await within(
+		rpc(rpcSocket, "project.setTrust", { id: project.id, trusted: true }),
+		10_000,
+		"project.setTrust",
+	);
 	const commands = await within(
 		rpc(rpcSocket, "skill.list", { projectId: project.id }),
 		30_000,

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -8,7 +8,7 @@
 // Usage:  bun run scripts/smoke-binary.ts [path-to-binary]
 //   Default binary: `dist/thinkrail` — run `bun run build:binary` first (we error if it's missing).
 
-import { existsSync, globSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, globSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -20,6 +20,8 @@ if (!existsSync(binary)) {
 
 const tmp = mkdtempSync(join(tmpdir(), "thinkrail-smoke-"));
 const cacheDir = join(tmp, "cache");
+const homeDir = join(tmp, "home");
+const projectDir = join(tmp, "project");
 
 function fail(message: string): never {
 	console.error(`smoke FAILED: ${message}`);
@@ -36,6 +38,16 @@ function within<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
 	]);
 }
 
+mkdirSync(homeDir, { recursive: true });
+const skillDir = join(projectDir, ".claude", "skills", "compiled-portable");
+mkdirSync(skillDir, { recursive: true });
+writeFileSync(
+	join(skillDir, "SKILL.md"),
+	"---\nname: compiled-portable\ndescription: Compiled portable smoke skill\n---\n\n# Smoke\n",
+);
+const gitInit = Bun.spawnSync(["git", "-C", projectDir, "init", "-b", "main"]);
+if (gitInit.exitCode !== 0) fail("could not initialise the portable-skill smoke project");
+
 const proc = Bun.spawn([binary, "--no-open", "--port", "24262"], {
 	env: {
 		...process.env,
@@ -44,10 +56,47 @@ const proc = Bun.spawn([binary, "--no-open", "--port", "24262"], {
 		THINKRAIL_DATA_DIR: join(tmp, "data"),
 		PI_CODING_AGENT_DIR: join(tmp, "pi-agent"),
 		XDG_CACHE_HOME: cacheDir,
+		HOME: homeDir,
+		CLAUDE_CONFIG_DIR: join(homeDir, ".claude"),
+		CODEX_HOME: join(homeDir, ".codex"),
+		GEMINI_CLI_HOME: homeDir,
 	},
 	stdout: "pipe",
 	stderr: "inherit",
 });
+
+async function connectRpc(baseUrl: string): Promise<WebSocket> {
+	const socket = new WebSocket(`${baseUrl.replace(/^http/, "ws")}/ws`);
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WebSocket connection failed")), {
+			once: true,
+		});
+	});
+	return socket;
+}
+
+let requestSequence = 0;
+function rpc(socket: WebSocket, method: string, params: unknown): Promise<unknown> {
+	const id = `smoke_${++requestSequence}`;
+	return new Promise((resolve, reject) => {
+		const onMessage = (event: MessageEvent) => {
+			if (typeof event.data !== "string") return;
+			const frame = JSON.parse(event.data) as {
+				id?: string;
+				ok?: boolean;
+				result?: unknown;
+				error?: string;
+			};
+			if (frame.id !== id) return;
+			socket.removeEventListener("message", onMessage);
+			if (frame.ok) resolve(frame.result);
+			else reject(new Error(frame.error ?? `${method} failed`));
+		};
+		socket.addEventListener("message", onMessage);
+		socket.send(JSON.stringify({ id, method, params }));
+	});
+}
 
 /** The URL from the CLI's `thinkrail → http://…` line (it may scan past a busy port). */
 async function readServedUrl(): Promise<string> {
@@ -61,6 +110,7 @@ async function readServedUrl(): Promise<string> {
 	throw new Error(`stdout closed without a serving URL (output: ${JSON.stringify(buffered)})`);
 }
 
+let rpcSocket: WebSocket | null = null;
 try {
 	const url = await within(
 		Promise.race([
@@ -80,6 +130,44 @@ try {
 	const body = await index.text();
 	if (!index.ok || !body.includes("ThinkRail")) {
 		fail(`staged web UI not served: / answered ${index.status}`);
+	}
+
+	// Exercise the binary's actual resource-loader mode, not only staged files: a recognized project alias
+	// and a bundled skill must coexist in the pre-session catalog, with truthful project provenance.
+	rpcSocket = await within(connectRpc(url), 10_000, "WebSocket connect");
+	const project = (await within(
+		rpc(rpcSocket, "project.open", { path: projectDir }),
+		10_000,
+		"project.open",
+	)) as { id?: string };
+	if (!project.id) fail("project.open returned no project id");
+	const commands = await within(
+		rpc(rpcSocket, "skill.list", { projectId: project.id }),
+		30_000,
+		"skill.list",
+	);
+	if (!Array.isArray(commands)) fail("skill.list did not return an array");
+	const portable = commands.find(
+		(command) =>
+			typeof command === "object" &&
+			command !== null &&
+			(command as { name?: string }).name === "skill:compiled-portable",
+	) as { description?: string; sourceInfo?: { scope?: string } } | undefined;
+	if (portable?.description !== "Compiled portable smoke skill") {
+		fail("compiled skill.list did not load the cross-agent project alias");
+	}
+	if (portable.sourceInfo?.scope !== "project") {
+		fail("compiled skill.list did not preserve project skill provenance");
+	}
+	if (
+		!commands.some(
+			(command) =>
+				typeof command === "object" &&
+				command !== null &&
+				(command as { name?: string }).name === "skill:brainstorming",
+		)
+	) {
+		fail("compiled skill.list did not load bundled workflow skills");
 	}
 
 	// The bundled extensions' skills must be staged to the real filesystem (pi reads SKILL.md via fs).
@@ -121,5 +209,6 @@ try {
 	proc.kill("SIGKILL");
 	fail(err instanceof Error ? err.message : String(err));
 } finally {
+	rpcSocket?.close();
 	rmSync(tmp, { recursive: true, force: true });
 }

--- a/apps/web/src/chat/ChatHeader.tsx
+++ b/apps/web/src/chat/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import type { SessionStats } from "@thinkrail/contracts";
-import { Sparkles } from "lucide-react";
+import { BookOpen } from "lucide-react";
 import type { ReactNode } from "react";
 import { SessionStatsBar } from "./SessionStatsBar";
 
@@ -39,7 +39,7 @@ export function ChatHeader({
 						title={skillsStale ? "Skills changed on disk — reload" : "Skills"}
 						className="flex shrink-0 items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-muted text-xs outline-none transition-colors hover:bg-hover hover:text-text focus-visible:ring-2 focus-visible:ring-primary"
 					>
-						<Sparkles className="size-3.5" />
+						<BookOpen className="size-3.5" />
 						Skills
 						{skillsStale ? <span className="size-1.5 rounded-full bg-gold" aria-hidden /> : null}
 					</button>

--- a/apps/web/src/chat/ChatHeader.tsx
+++ b/apps/web/src/chat/ChatHeader.tsx
@@ -10,12 +10,15 @@ export function ChatHeader({
 	statusEntries,
 	left,
 	onOpenSkills,
+	skillsStale,
 }: {
 	stats: SessionStats | null;
 	statusEntries: [string, string][];
 	left?: ReactNode;
 	/** Opens the workspace Skills manager; omitted when the owning project can't be resolved yet. */
 	onOpenSkills?: () => void;
+	/** The worktree's skills changed on disk since this session loaded — badge the trigger. */
+	skillsStale?: boolean;
 }) {
 	return (
 		<div className="flex min-h-9 shrink-0 items-center gap-md border-border2 border-b bg-bg-dark px-sm py-xs">
@@ -31,12 +34,14 @@ export function ChatHeader({
 					<button
 						type="button"
 						data-testid="open-skills"
+						data-stale={skillsStale ? "true" : undefined}
 						onClick={onOpenSkills}
-						title="Skills"
+						title={skillsStale ? "Skills changed on disk — reload" : "Skills"}
 						className="flex shrink-0 items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-muted text-xs outline-none transition-colors hover:bg-hover hover:text-text focus-visible:ring-2 focus-visible:ring-primary"
 					>
 						<Sparkles className="size-3.5" />
 						Skills
+						{skillsStale ? <span className="size-1.5 rounded-full bg-gold" aria-hidden /> : null}
 					</button>
 				) : null}
 			</div>

--- a/apps/web/src/chat/ChatHeader.tsx
+++ b/apps/web/src/chat/ChatHeader.tsx
@@ -1,16 +1,21 @@
 import type { SessionStats } from "@thinkrail/contracts";
+import { Sparkles } from "lucide-react";
 import type { ReactNode } from "react";
 import { SessionStatsBar } from "./SessionStatsBar";
 
-/** The chat tab's slim top bar: an optional left slot (the plan strip) + extension status + token/cost stats. */
+/** The chat tab's slim top bar: an optional left slot (the plan strip), extension status + token/cost
+ *  stats, and the Skills manager trigger. */
 export function ChatHeader({
 	stats,
 	statusEntries,
 	left,
+	onOpenSkills,
 }: {
 	stats: SessionStats | null;
 	statusEntries: [string, string][];
 	left?: ReactNode;
+	/** Opens the workspace Skills manager; omitted when the owning project can't be resolved yet. */
+	onOpenSkills?: () => void;
 }) {
 	return (
 		<div className="flex min-h-9 shrink-0 items-center gap-md border-border2 border-b bg-bg-dark px-sm py-xs">
@@ -22,6 +27,18 @@ export function ChatHeader({
 					</span>
 				))}
 				<SessionStatsBar stats={stats} />
+				{onOpenSkills ? (
+					<button
+						type="button"
+						data-testid="open-skills"
+						onClick={onOpenSkills}
+						title="Skills"
+						className="flex shrink-0 items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-muted text-xs outline-none transition-colors hover:bg-hover hover:text-text focus-visible:ring-2 focus-visible:ring-primary"
+					>
+						<Sparkles className="size-3.5" />
+						Skills
+					</button>
+				) : null}
 			</div>
 		</div>
 	);

--- a/apps/web/src/chat/ChatHeader.tsx
+++ b/apps/web/src/chat/ChatHeader.tsx
@@ -1,7 +1,7 @@
 import type { SessionStats } from "@thinkrail/contracts";
-import { BookOpen } from "lucide-react";
 import type { ReactNode } from "react";
 import { SessionStatsBar } from "./SessionStatsBar";
+import { SkillsButton } from "./SkillsButton";
 
 /** The chat tab's slim top bar: an optional left slot (the plan strip), extension status + token/cost
  *  stats, and the Skills manager trigger. */
@@ -31,18 +31,7 @@ export function ChatHeader({
 				))}
 				<SessionStatsBar stats={stats} />
 				{onOpenSkills ? (
-					<button
-						type="button"
-						data-testid="open-skills"
-						data-stale={skillsStale ? "true" : undefined}
-						onClick={onOpenSkills}
-						title={skillsStale ? "Skills changed on disk — reload" : "Skills"}
-						className="flex shrink-0 items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-muted text-xs outline-none transition-colors hover:bg-hover hover:text-text focus-visible:ring-2 focus-visible:ring-primary"
-					>
-						<BookOpen className="size-3.5" />
-						Skills
-						{skillsStale ? <span className="size-1.5 rounded-full bg-gold" aria-hidden /> : null}
-					</button>
+					<SkillsButton onOpen={onOpenSkills} testId="open-skills" stale={skillsStale ?? false} />
 				) : null}
 			</div>
 		</div>

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -361,14 +361,16 @@ export default function ChatView({
 					) : null}
 					{projectId ? (
 						<SkillsDialog
-							workspaceId={workspaceId}
-							sessionId={sessionId}
 							projectId={projectId}
-							streaming={isStreaming}
-							stale={skillsStale}
+							workspace={{
+								workspaceId,
+								sessionId,
+								streaming: isStreaming,
+								stale: skillsStale,
+								onReloaded: () => setSkillsStale(false),
+							}}
 							open={skillsOpen}
 							onOpenChange={setSkillsOpen}
-							onReloaded={() => setSkillsStale(false)}
 						/>
 					) : null}
 				</div>

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -17,6 +17,7 @@ import { ChatPlanContent, ChatPlanStripContent } from "./ChatPlan";
 import { Composer, type MentionCandidate, type SubmitBehavior } from "./Composer";
 import { ExtUiDialog } from "./ExtUiDialog";
 import { type ChatRow, deriveRows } from "./rows";
+import { SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
 import "./tools/register"; // side-effect: register the built-in pi tool renderers (bash/read/edit/write)
 import { ChatTurnView } from "./turns";
@@ -56,6 +57,14 @@ export default function ChatView({
 	// chat streaming into its own runtime never re-renders the foreground one.
 	const runtime = useAppStore((s) => s.sessions[sessionId]) ?? EMPTY_RUNTIME;
 	const models = useAppStore((s) => s.models);
+	// This chat's owning project (workspaces are keyed by project) — for the Skills manager's trust ops.
+	const projectId = useAppStore(
+		(s) =>
+			Object.values(s.workspaces)
+				.flat()
+				.find((w) => w.id === workspaceId)?.projectId ?? null,
+	);
+	const [skillsOpen, setSkillsOpen] = useState(false);
 	const workspaceRoot = useAppStore((s) => {
 		for (const workspaces of Object.values(s.workspaces)) {
 			const workspace = workspaces.find((w) => w.id === workspaceId);
@@ -270,6 +279,7 @@ export default function ChatView({
 											</PopoverTrigger>
 										) : null
 									}
+									{...(projectId ? { onOpenSkills: () => setSkillsOpen(true) } : {})}
 								/>
 							</div>
 						</PopoverAnchor>
@@ -337,6 +347,16 @@ export default function ChatView({
 					/>
 					{pendingExtUi ? (
 						<ExtUiDialog key={pendingExtUi.id} request={pendingExtUi} onReply={onExtUiReply} />
+					) : null}
+					{projectId ? (
+						<SkillsDialog
+							workspaceId={workspaceId}
+							sessionId={sessionId}
+							projectId={projectId}
+							streaming={isStreaming}
+							open={skillsOpen}
+							onOpenChange={setSkillsOpen}
+						/>
 					) : null}
 				</div>
 			</AskStatesContext.Provider>

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -17,7 +17,7 @@ import { ChatPlanContent, ChatPlanStripContent } from "./ChatPlan";
 import { Composer, type MentionCandidate, type SubmitBehavior } from "./Composer";
 import { ExtUiDialog } from "./ExtUiDialog";
 import { type ChatRow, deriveRows } from "./rows";
-import { SkillsDialog } from "./SkillsDialog";
+import { isSkillPath, SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
 import "./tools/register"; // side-effect: register the built-in pi tool renderers (bash/read/edit/write)
 import { ChatTurnView } from "./turns";
@@ -65,6 +65,16 @@ export default function ChatView({
 				.find((w) => w.id === workspaceId)?.projectId ?? null,
 	);
 	const [skillsOpen, setSkillsOpen] = useState(false);
+	// Auto-detect: the worktree watcher's fs nudge flags skills stale (the session loaded an older set) when
+	// a skill dir changes on disk — a pull/branch/edit. Reload is manual, so this only prompts.
+	const fsSignal = useAppStore((s) => s.fsChangesByWorkspace[workspaceId]);
+	const [skillsStale, setSkillsStale] = useState(false);
+	const lastSkillTick = useRef(0);
+	useEffect(() => {
+		if (!fsSignal || fsSignal.tick === lastSkillTick.current) return;
+		lastSkillTick.current = fsSignal.tick;
+		if (fsSignal.truncated || fsSignal.paths.some(isSkillPath)) setSkillsStale(true);
+	}, [fsSignal]);
 	const workspaceRoot = useAppStore((s) => {
 		for (const workspaces of Object.values(s.workspaces)) {
 			const workspace = workspaces.find((w) => w.id === workspaceId);
@@ -279,6 +289,7 @@ export default function ChatView({
 											</PopoverTrigger>
 										) : null
 									}
+									skillsStale={skillsStale}
 									{...(projectId ? { onOpenSkills: () => setSkillsOpen(true) } : {})}
 								/>
 							</div>
@@ -354,8 +365,10 @@ export default function ChatView({
 							sessionId={sessionId}
 							projectId={projectId}
 							streaming={isStreaming}
+							stale={skillsStale}
 							open={skillsOpen}
 							onOpenChange={setSkillsOpen}
+							onReloaded={() => setSkillsStale(false)}
 						/>
 					) : null}
 				</div>

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -14,6 +14,11 @@ import {
 	useState,
 } from "react";
 import { ModelSelector } from "./ModelSelector";
+import {
+	SlashCommandMenu,
+	selectedSlashCommandValue,
+	useSlashCommandCompletion,
+} from "./SlashCommandCompletion";
 import { ThinkingSelector } from "./ThinkingSelector";
 
 /** How a submit is delivered: a fresh turn, an interrupt, or a queued message after the current turn. */
@@ -93,29 +98,20 @@ export function Composer({
 	const ref = useRef<HTMLTextAreaElement>(null);
 	const [caret, setCaret] = useState(0);
 	const [images, setImages] = useState<PendingImage[]>([]);
-	const [activeIndex, setActiveIndex] = useState(0);
-	const [dismissed, setDismissed] = useState(false);
+	const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
+	const [mentionDismissed, setMentionDismissed] = useState(false);
 
 	const { token, start } = activeToken(value, caret);
 	const mentionQuery = token.startsWith("@") ? token.slice(1) : null;
-	// Slash commands are invoked from the start of the message (e.g. `/compact`, `/skill:foo`).
-	const slashQuery = value.startsWith("/") && !value.includes(" ") ? value.slice(1) : null;
 
 	useEffect(() => onMentionQuery(mentionQuery), [mentionQuery, onMentionQuery]);
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset selection when the query changes
 	useEffect(() => {
-		setActiveIndex(0);
-		setDismissed(false);
-	}, [mentionQuery, slashQuery]);
+		setMentionActiveIndex(0);
+		setMentionDismissed(false);
+	}, [mentionQuery]);
 
-	const slashMatches =
-		slashQuery !== null
-			? commands.filter((c) => c.name.toLowerCase().includes(slashQuery.toLowerCase())).slice(0, 8)
-			: [];
-	const mentionOpen = !dismissed && mentionQuery !== null && mentionCandidates.length > 0;
-	const slashOpen = !dismissed && slashQuery !== null && slashMatches.length > 0;
-	const menuLen = mentionOpen ? mentionCandidates.length : slashOpen ? slashMatches.length : 0;
-	const menuOpen = menuLen > 0;
+	const mentionOpen = !mentionDismissed && mentionQuery !== null && mentionCandidates.length > 0;
 
 	const focusCaret = (pos: number) => {
 		requestAnimationFrame(() => {
@@ -136,11 +132,15 @@ export function Composer({
 		focusCaret(before.length + insert.length + suffix.length);
 	};
 
-	const pickSlash = (c: SlashCommandInfo) => {
-		const next = `/${c.name} `;
-		onChange(next);
-		focusCaret(next.length);
-	};
+	const slashCompletion = useSlashCommandCompletion({
+		value,
+		commands,
+		onSelect: (command) => {
+			const next = selectedSlashCommandValue(command);
+			onChange(next);
+			focusCaret(next.length);
+		},
+	});
 
 	const addFiles = async (files: File[]) => {
 		const picked = files.filter((f) => f.type.startsWith("image/"));
@@ -165,34 +165,31 @@ export function Composer({
 	};
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-		if (menuOpen) {
+		if (mentionOpen) {
+			const menuLen = mentionCandidates.length;
 			if (e.key === "ArrowDown") {
 				e.preventDefault();
-				setActiveIndex((i) => (i + 1) % menuLen);
+				setMentionActiveIndex((i) => (i + 1) % menuLen);
 				return;
 			}
 			if (e.key === "ArrowUp") {
 				e.preventDefault();
-				setActiveIndex((i) => (i - 1 + menuLen) % menuLen);
+				setMentionActiveIndex((i) => (i - 1 + menuLen) % menuLen);
 				return;
 			}
 			if (e.key === "Escape") {
 				e.preventDefault();
-				setDismissed(true);
+				setMentionDismissed(true);
 				return;
 			}
 			if (e.key === "Enter" || e.key === "Tab") {
 				e.preventDefault();
-				if (mentionOpen) {
-					const c = mentionCandidates[activeIndex];
-					if (c) pickMention(c);
-				} else {
-					const c = slashMatches[activeIndex];
-					if (c) pickSlash(c);
-				}
+				const candidate = mentionCandidates[mentionActiveIndex];
+				if (candidate) pickMention(candidate);
 				return;
 			}
 		}
+		if (slashCompletion.handleKeyDown(e)) return;
 		if (e.key === "Enter" && !e.shiftKey) {
 			e.preventDefault();
 			const behavior: SubmitBehavior = isStreaming
@@ -221,45 +218,35 @@ export function Composer({
 
 	return (
 		<div className="relative flex shrink-0 flex-col border-border2 border-t bg-bg-dark">
-			{menuOpen ? (
+			{mentionOpen ? (
 				<div
-					data-testid={mentionOpen ? "mention-menu" : "slash-menu"}
+					data-testid="mention-menu"
 					className="absolute bottom-full left-sm mb-xs max-h-[40vh] w-[min(28rem,90%)] overflow-y-auto rounded-[var(--radius-md)] border border-border2 bg-elevated p-xs shadow-[var(--shadow-md)]"
 				>
-					{mentionOpen
-						? mentionCandidates.map((c, i) => (
-								<button
-									key={c.path}
-									type="button"
-									data-testid="mention-item"
-									onClick={() => pickMention(c)}
-									className={`flex w-full items-center gap-sm rounded-[var(--radius-sm)] px-sm py-xs text-left text-sm ${i === activeIndex ? "bg-hover text-text" : "text-muted"}`}
-								>
-									{c.kind === "dir" ? (
-										<FolderIcon className="size-3.5 shrink-0" />
-									) : (
-										<FileIcon className="size-3.5 shrink-0" />
-									)}
-									<span className="truncate">{c.path}</span>
-								</button>
-							))
-						: slashMatches.map((c, i) => (
-								<button
-									key={`${c.source}:${c.name}`}
-									type="button"
-									data-testid="slash-command"
-									data-source={c.source}
-									onClick={() => pickSlash(c)}
-									className={`flex w-full items-center gap-sm rounded-[var(--radius-sm)] px-sm py-xs text-left text-sm ${i === activeIndex ? "bg-hover text-text" : "text-muted"}`}
-								>
-									<span className="font-mono text-text">/{c.name}</span>
-									{c.description ? <span className="truncate text-xs">{c.description}</span> : null}
-									<span className="ml-auto shrink-0 text-hint text-xs">
-										{c.source}/{c.sourceInfo.scope}
-									</span>
-								</button>
-							))}
+					{mentionCandidates.map((candidate, index) => (
+						<button
+							key={candidate.path}
+							type="button"
+							data-testid="mention-item"
+							onClick={() => pickMention(candidate)}
+							className={`flex w-full items-center gap-sm rounded-[var(--radius-sm)] px-sm py-xs text-left text-sm ${index === mentionActiveIndex ? "bg-hover text-text" : "text-muted"}`}
+						>
+							{candidate.kind === "dir" ? (
+								<FolderIcon className="size-3.5 shrink-0" />
+							) : (
+								<FileIcon className="size-3.5 shrink-0" />
+							)}
+							<span className="truncate">{candidate.path}</span>
+						</button>
+					))}
 				</div>
+			) : slashCompletion.open ? (
+				<SlashCommandMenu
+					commands={slashCompletion.matches}
+					activeIndex={slashCompletion.activeIndex}
+					onSelect={slashCompletion.pick}
+					className="absolute bottom-full left-sm mb-xs"
+				/>
 			) : null}
 
 			{images.length > 0 ? (

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -102,12 +102,14 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip; its **Skills** button — badged when a skill dir changed on
-  disk — opens the manager), `ExtUiDialog`, and **`SkillsDialog`** (the **workspace-scoped Skills
-  manager**: `skills.state` catalog grouped by source — Project / Personal / **a group per installed
-  Claude plugin** / Bundled / Pi — with each skill's admission verdict, project-trust + re-confirm-new +
-  per-workspace enable/disable toggles, and a **Reload** that applies changes to *this* chat's session via
-  `session.reloadResources`, disabled while streaming). All props-driven; behavior detail lives in the
-  components' jsdoc.
+  disk — opens the manager), `ExtUiDialog`, and **`SkillsDialog`** (the **Skills manager**: a catalog
+  grouped by source — Project / Personal / **a group per installed Claude plugin** / Bundled / Pi — each
+  with its admission verdict, project-trust, re-confirm-new, a **per-group on/off** toggle + an
+  **All-plugins** master, and per-skill toggles. It runs in **two modes** via an optional `workspace` prop:
+  chat (`skills.state`, per-workspace skill overrides, + a **Reload** that applies changes to this chat's
+  session via `session.reloadResources`, disabled while streaming) or project (`project.skills`,
+  per-project-baseline toggles, no session) — the latter reused by `panels` pre-session). All props-driven;
+  behavior detail lives in the components' jsdoc.
 - **Chat TODO plan** — the chat's `pi-todos` list surfaced **only in the chat** (engine:
   [[module-pi-todos]]; host read/write: [[submodule-server-todos]]):
   `useChatTodos` (the `todo.*` data hook — fetch + live `pi.event` refetch + edits + the add-nudge + the

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -103,10 +103,11 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip; its **Skills** button — badged when a skill dir changed on
   disk — opens the manager), `ExtUiDialog`, and **`SkillsDialog`** (the **workspace-scoped Skills
-  manager**: `skills.state` catalog grouped by source with each skill's admission verdict, project-trust +
-  re-confirm-new + per-workspace enable/disable toggles, and a **Reload** that applies changes to *this*
-  chat's session via `session.reloadResources`, disabled while streaming). All props-driven; behavior
-  detail lives in the components' jsdoc.
+  manager**: `skills.state` catalog grouped by source — Project / Personal / **a group per installed
+  Claude plugin** / Bundled / Pi — with each skill's admission verdict, project-trust + re-confirm-new +
+  per-workspace enable/disable toggles, and a **Reload** that applies changes to *this* chat's session via
+  `session.reloadResources`, disabled while streaming). All props-driven; behavior detail lives in the
+  components' jsdoc.
 - **Chat TODO plan** — the chat's `pi-todos` list surfaced **only in the chat** (engine:
   [[module-pi-todos]]; host read/write: [[submodule-server-todos]]):
   `useChatTodos` (the `todo.*` data hook — fetch + live `pi.event` refetch + edits + the add-nudge + the

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -103,8 +103,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip; its **Skills** button — badged when a skill dir changed on
   disk — opens the manager), `ExtUiDialog`, and **`SkillsDialog`** (the **Skills manager**: a catalog
-  grouped by source with **sticky section headers** — first-party Bundled / Pi first, then Personal / **a
-  group per installed Claude plugin** / the repo's Project skills last — each with its admission verdict,
+  grouped by source with **sticky section headers** — the first-party **ThinkRail** and **Pi** groups lead
+  (above the All-plugins master, which governs only the plugin groups), then Personal / **a group per
+  installed Claude plugin** / the repo's Project skills last — each with its admission verdict,
   project-trust, re-confirm-new, a **per-group on/off** toggle + an **All-plugins** master, and per-skill
   toggles. It runs in **two modes** via an optional `workspace` prop: chat (`skills.state`, per-workspace
   skill overrides, + a **Reload** that applies changes to this chat's session via `session.reloadResources`,

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -101,8 +101,12 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so the two inputs cannot drift;
   `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
-  (its `left` slot carries the plan strip), `ExtUiDialog`. All props-driven; behavior detail lives in the
-  components' jsdoc.
+  (its `left` slot carries the plan strip; its **Skills** button — badged when a skill dir changed on
+  disk — opens the manager), `ExtUiDialog`, and **`SkillsDialog`** (the **workspace-scoped Skills
+  manager**: `skills.state` catalog grouped by source with each skill's admission verdict, project-trust +
+  re-confirm-new + per-workspace enable/disable toggles, and a **Reload** that applies changes to *this*
+  chat's session via `session.reloadResources`, disabled while streaming). All props-driven; behavior
+  detail lives in the components' jsdoc.
 - **Chat TODO plan** — the chat's `pi-todos` list surfaced **only in the chat** (engine:
   [[module-pi-todos]]; host read/write: [[submodule-server-todos]]):
   `useChatTodos` (the `todo.*` data hook — fetch + live `pi.event` refetch + edits + the add-nudge + the
@@ -123,7 +127,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   also **extend** the render with extra `remarkPlugins` + `components`, e.g. the file view's GitHub
   alert callouts), the view types
   (`types.ts`,
-  incl. `ToolResultState` + `ExtUiDialogRequest`), and `ChatView` (lazy-mounted by `panels/CenterTabs`).
+  incl. `ToolResultState` + `ExtUiDialogRequest`), and `ChatView` (lazy-mounted by `panels/CenterTabs`;
+  it wires `SkillsDialog` + the header Skills trigger, resolving the owning `projectId` from the store and
+  flagging staleness off the worktree `fsChanged` nudge via `SkillsDialog`'s exported `isSkillPath`).
   **No `index.ts` barrel** — chat pulls **shiki**, so per the code-splitting exception imports stay
   **per-file**; the registry is importable from `chat/toolRegistry` **without** pulling shiki.
 - **Allowed deps:** `contracts` (pi message/content-block types, **type-only**); `store` + `transport`

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -103,13 +103,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip; its **Skills** button — badged when a skill dir changed on
   disk — opens the manager), `ExtUiDialog`, and **`SkillsDialog`** (the **Skills manager**: a catalog
-  grouped by source — Project / Personal / **a group per installed Claude plugin** / Bundled / Pi — each
-  with its admission verdict, project-trust, re-confirm-new, a **per-group on/off** toggle + an
-  **All-plugins** master, and per-skill toggles. It runs in **two modes** via an optional `workspace` prop:
-  chat (`skills.state`, per-workspace skill overrides, + a **Reload** that applies changes to this chat's
-  session via `session.reloadResources`, disabled while streaming) or project (`project.skills`,
-  per-project-baseline toggles, no session) — the latter reused by `panels` pre-session). All props-driven;
-  behavior detail lives in the components' jsdoc.
+  grouped by source with **sticky section headers** — first-party Bundled / Pi first, then Personal / **a
+  group per installed Claude plugin** / the repo's Project skills last — each with its admission verdict,
+  project-trust, re-confirm-new, a **per-group on/off** toggle + an **All-plugins** master, and per-skill
+  toggles. It runs in **two modes** via an optional `workspace` prop: chat (`skills.state`, per-workspace
+  skill overrides, + a **Reload** that applies changes to this chat's session via `session.reloadResources`,
+  disabled while streaming) or project (`project.skills`, per-project-baseline toggles, no session) — the
+  latter reused by `panels` pre-session). All props-driven; behavior detail lives in the components' jsdoc.
 - **Chat TODO plan** — the chat's `pi-todos` list surfaced **only in the chat** (engine:
   [[module-pi-todos]]; host read/write: [[submodule-server-todos]]):
   `useChatTodos` (the `todo.*` data hook — fetch + live `pi.event` refetch + edits + the add-nudge + the

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -97,7 +97,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   become turns: known ones (`ask-user-answers`) index into `askAnswers`; unknown customTypes are
   ignored. No store/transport/shiki.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
-  commands, image paste/drop), `ModelSelector` + `ThinkingSelector` (shared with `NewWorkspaceDialog`;
+  commands, image paste/drop) plus its props-driven **slash-completion primitive** (filter/menu/caret +
+  Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so the two inputs cannot drift;
+  `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip), `ExtUiDialog`. All props-driven; behavior detail lives in the
   components' jsdoc.
@@ -114,8 +116,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 
 ## Boundary
 
-- **Public surface:** the registry API (`toolRegistry`), the renderers (incl. the presentational
-  `Markdown` — GFM + shiki, no store/transport; the rendering is fixed but the **prose skin** is the
+- **Public surface:** the registry API (`toolRegistry`), the props-driven slash-completion primitive, and
+  the renderers (incl. the presentational `Markdown` — GFM + shiki, no store/transport; the rendering is fixed but the **prose skin** is the
   caller's via an optional `className` — chat uses a compact bubble skin, `panels/MarkdownPreview` a
   reading-optimized document skin; code blocks size in `em` so they scale with the skin; a caller may
   also **extend** the render with extra `remarkPlugins` + `components`, e.g. the file view's GitHub

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -101,8 +101,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so the two inputs cannot drift;
   `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
-  (its `left` slot carries the plan strip; its **Skills** button — badged when a skill dir changed on
-  disk — opens the manager), `ExtUiDialog`, and **`SkillsDialog`** (the **Skills manager**: a catalog
+  (its `left` slot carries the plan strip; its **Skills** button is the presentational **`SkillsButton`**
+  primitive — a `BookOpen` pill, badged when a skill dir changed on disk — also shared with
+  `NewWorkspaceDialog` so the two triggers cannot drift), `ExtUiDialog`, and **`SkillsDialog`** (the **Skills manager**: a catalog
   grouped by source with **sticky section headers** — the first-party **ThinkRail** and **Pi** groups lead
   (above the All-plugins master, which governs only the plugin groups), then Personal / **a group per
   installed Claude plugin** / the repo's Project skills last — each with its admission verdict,

--- a/apps/web/src/chat/SkillsButton.tsx
+++ b/apps/web/src/chat/SkillsButton.tsx
@@ -1,0 +1,41 @@
+import { BookOpen } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The Skills-manager trigger: a `BookOpen` pill labelled "Skills". Shared by the chat header (workspace
+ * mode — passes `stale` for the on-disk-changed badge + Reload tooltip) and `panels/NewWorkspaceDialog`
+ * (project mode, no session, no stale) so the two triggers cannot drift. Presentational: the owner wires
+ * `onOpen`, supplies its own stable `testId`, and passes positioning via `className` (e.g. `ml-auto`).
+ */
+export function SkillsButton({
+	onOpen,
+	testId,
+	stale,
+	className,
+}: {
+	onOpen: () => void;
+	/** The owner's stable test hook (differs per surface). */
+	testId: string;
+	/** The worktree's skills changed on disk since load — badge the trigger + swap the tooltip. */
+	stale?: boolean;
+	/** Positioning utilities from the owner (merged onto the shared look). */
+	className?: string;
+}) {
+	return (
+		<button
+			type="button"
+			data-testid={testId}
+			data-stale={stale ? "true" : undefined}
+			onClick={onOpen}
+			title={stale ? "Skills changed on disk — reload" : "Skills"}
+			className={cn(
+				"flex shrink-0 items-center gap-xs rounded-[var(--radius-sm)] px-sm py-0.5 text-muted text-xs outline-none transition-colors hover:bg-hover hover:text-text focus-visible:ring-2 focus-visible:ring-primary",
+				className,
+			)}
+		>
+			<BookOpen className="size-3.5" />
+			Skills
+			{stale ? <span className="size-1.5 rounded-full bg-gold" aria-hidden /> : null}
+		</button>
+	);
+}

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -10,22 +10,43 @@ import { errorText, getTransport } from "@/transport";
 /** The workspace-scoped Skills manager (opened from the chat header). Lists every discovered skill grouped
  * by source with its admission verdict, exposes trust + per-workspace enable/disable + re-confirm-new, and
  * a Reload that applies changes to *this* chat's running session. */
-const GROUPS = ["Project", "Personal", "Bundled", "Pi"] as const;
-type Group = (typeof GROUPS)[number];
+const FIXED_HINT: Record<string, string> = {
+	Project: "Committed to the repo — gated behind trust.",
+	Personal: "Your own libraries (~/.claude, ~/.codex, …).",
+	Bundled: "Shipped with ThinkRail.",
+	Pi: "Pi-native / configured.",
+};
+const FIXED_RANK: Record<string, number> = { Project: 0, Personal: 1, Bundled: 3, Pi: 4 };
 
-function groupOf(entry: SkillCatalogEntry): Group {
+function fixedLabel(entry: SkillCatalogEntry): "Project" | "Personal" | "Bundled" | "Pi" {
 	if (entry.gated) return "Project";
 	if (entry.sourceInfo.scope === "user") return "Personal";
 	if (entry.sourceInfo.scope === "temporary") return "Bundled";
 	return "Pi";
 }
 
-const GROUP_HINT: Record<Group, string> = {
-	Project: "Committed to the repo — gated behind trust.",
-	Personal: "Your own libraries (~/.claude, ~/.codex, …).",
-	Bundled: "Shipped with ThinkRail.",
-	Pi: "Pi-native / configured.",
-};
+/** Group entries by installing plugin (if any), else by source tier; order Project → Personal → plugins
+ * (sorted) → Bundled → Pi, so a plugin's skills sit together under the plugin's name. */
+function groupCatalog(
+	entries: SkillCatalogEntry[],
+): { label: string; hint: string; items: SkillCatalogEntry[] }[] {
+	const byLabel = new Map<string, { isPlugin: boolean; items: SkillCatalogEntry[] }>();
+	for (const entry of entries) {
+		const label = entry.plugin ?? fixedLabel(entry);
+		const group = byLabel.get(label) ?? { isPlugin: Boolean(entry.plugin), items: [] };
+		group.items.push(entry);
+		byLabel.set(label, group);
+	}
+	return [...byLabel.entries()]
+		.map(([label, group]) => ({
+			label,
+			hint: group.isPlugin ? "Claude plugin" : (FIXED_HINT[label] ?? ""),
+			items: group.items,
+			rank: group.isPlugin ? 2 : (FIXED_RANK[label] ?? 5),
+		}))
+		.sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label))
+		.map(({ label, hint, items }) => ({ label, hint, items }));
+}
 
 /** A skill result carries `projectId` only when it's a Workspace; Project has no such field. */
 function isWorkspace(result: Project | Workspace): result is Workspace {
@@ -109,10 +130,7 @@ export function SkillsDialog({
 	};
 
 	const untrustedCount = entries?.filter((e) => e.decision === "untrusted").length ?? 0;
-	const grouped = GROUPS.map((group) => ({
-		group,
-		items: (entries ?? []).filter((e) => groupOf(e) === group),
-	})).filter((g) => g.items.length > 0);
+	const grouped = groupCatalog(entries ?? []);
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -175,17 +193,17 @@ export function SkillsDialog({
 							No skills discovered for this workspace.
 						</p>
 					) : (
-						grouped.map(({ group, items }) => (
-							<div key={group} className="mb-md">
+						grouped.map(({ label, hint, items }) => (
+							<div key={label} className="mb-md">
 								<div className="px-sm py-xs">
 									<span className="font-medium text-text text-xs uppercase tracking-wide">
-										{group}
+										{label}
 									</span>
-									<span className="ml-sm text-hint text-xs">{GROUP_HINT[group]}</span>
+									<span className="ml-sm text-hint text-xs">{hint}</span>
 								</div>
 								{items.map((entry) => (
 									<SkillRow
-										key={`${group}:${entry.name}`}
+										key={`${label}:${entry.name}`}
 										entry={entry}
 										busy={busy}
 										onToggle={(enabled) =>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -194,41 +194,51 @@ export function SkillsDialog({
 						</p>
 					) : (
 						grouped.map(({ label, hint, items }) => (
-							<div key={label} className="mb-md">
-								<div className="px-sm py-xs">
+							<div
+								key={label}
+								data-testid="skill-group"
+								data-group={label}
+								className="mb-md overflow-hidden rounded-[var(--radius-md)] border border-border2"
+							>
+								<div className="flex items-baseline gap-sm border-border2 border-b bg-bg-dark px-sm py-1.5">
 									<span className="font-medium text-text text-xs uppercase tracking-wide">
 										{label}
 									</span>
-									<span className="ml-sm text-hint text-xs">{hint}</span>
+									<span className="min-w-0 flex-1 truncate text-hint text-xs">{hint}</span>
+									<span className="shrink-0 rounded-full bg-hover px-1.5 text-hint text-xs">
+										{items.length}
+									</span>
 								</div>
-								{items.map((entry) => (
-									<SkillRow
-										key={`${label}:${entry.name}`}
-										entry={entry}
-										busy={busy}
-										onToggle={(enabled) =>
-											void mutate(
-												() =>
-													getTransport().request("workspace.setSkillOverride", {
-														id: workspaceId,
-														name: entry.name,
-														override: enabled ? "on" : "off",
-													}),
-												"Couldn't update skill",
-											)
-										}
-										onAcknowledge={() =>
-											void mutate(
-												() =>
-													getTransport().request("project.acknowledgeSkills", {
-														id: projectId,
-														names: [entry.name],
-													}),
-												"Couldn't confirm skill",
-											)
-										}
-									/>
-								))}
+								<div className="divide-y divide-border2">
+									{items.map((entry) => (
+										<SkillRow
+											key={`${label}:${entry.name}`}
+											entry={entry}
+											busy={busy}
+											onToggle={(enabled) =>
+												void mutate(
+													() =>
+														getTransport().request("workspace.setSkillOverride", {
+															id: workspaceId,
+															name: entry.name,
+															override: enabled ? "on" : "off",
+														}),
+													"Couldn't update skill",
+												)
+											}
+											onAcknowledge={() =>
+												void mutate(
+													() =>
+														getTransport().request("project.acknowledgeSkills", {
+															id: projectId,
+															names: [entry.name],
+														}),
+													"Couldn't confirm skill",
+												)
+											}
+										/>
+									))}
+								</div>
 							</div>
 						))
 					)}
@@ -262,7 +272,7 @@ function SkillRow({
 			data-testid="skill-row"
 			data-skill={entry.name}
 			data-decision={entry.decision}
-			className="flex items-center gap-sm rounded-[var(--radius-sm)] px-sm py-xs hover:bg-hover"
+			className="flex items-center gap-sm px-sm py-1.5 hover:bg-hover"
 		>
 			<span className="flex min-w-0 flex-1 flex-col">
 				<span className="truncate font-[var(--font-mono)] text-sm text-text">{entry.name}</span>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -1,5 +1,5 @@
 import type { Project, SkillCatalogEntry, SkillDecision, Workspace } from "@thinkrail/contracts";
-import { RefreshCw, ShieldCheck } from "lucide-react";
+import { Puzzle, RefreshCw, ShieldCheck } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -173,7 +173,8 @@ export function SkillsDialog({
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent data-testid="skills-dialog" className="max-w-[560px] gap-md p-md">
-				<div className="flex items-center justify-between gap-sm">
+				{/* pr-8 reserves room for the DialogContent's absolute close (X) so it can't overlap Reload. */}
+				<div className="flex items-center justify-between gap-sm pr-8">
 					<DialogTitle className="text-sm text-text">Skills</DialogTitle>
 					{workspace ? (
 						<Button
@@ -275,6 +276,9 @@ export function SkillsDialog({
 											hasPlugins ? "top-8" : "top-0",
 										)}
 									>
+										{group.isPlugin ? (
+											<Puzzle className="size-3.5 shrink-0 text-hint" aria-hidden />
+										) : null}
 										<span className="font-medium text-text text-xs uppercase tracking-wide">
 											{group.label}
 										</span>
@@ -289,7 +293,8 @@ export function SkillsDialog({
 											onClick={() => setGroupEnabled(group.key, !groupOn)}
 										/>
 									</div>
-									<div className="divide-y divide-border2">
+									{/* Indent + left rail nests the skills visually under their group/plugin header. */}
+									<div className="ml-sm divide-y divide-border2 border-border2 border-l">
 										{group.items.map((entry) => (
 											<SkillRow
 												key={`${group.key}:${entry.name}`}
@@ -378,7 +383,7 @@ function SkillRow({
 			data-testid="skill-row"
 			data-skill={entry.name}
 			data-decision={entry.decision}
-			className="flex items-center gap-sm px-sm py-1.5 hover:bg-hover"
+			className="flex items-center gap-sm py-1.5 pr-sm pl-md hover:bg-hover"
 		>
 			<span className="flex min-w-0 flex-1 flex-col">
 				<span className="truncate font-[var(--font-mono)] text-sm text-text">{entry.name}</span>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -229,22 +229,25 @@ export function SkillsDialog({
 					</div>
 				) : null}
 
-				{hasPlugins ? (
-					<div
-						data-testid="skills-all-plugins"
-						className="flex items-center gap-sm rounded-[var(--radius-md)] border border-border2 px-md py-1.5"
-					>
-						<span className="min-w-0 flex-1 text-sm text-text">All Claude plugins</span>
-						<Toggle
-							on={!pluginsDisabled}
-							busy={busy}
-							testid="all-plugins-toggle"
-							onClick={() => setGroupEnabled("@plugins", pluginsDisabled)}
-						/>
-					</div>
-				) : null}
-
 				<div className="max-h-[50vh] overflow-y-auto">
+					{/* The all-plugins master follows the same sticky pattern: it pins at the scroll top, then the
+					    first group's sticky header covers it as you scroll into the groups. */}
+					{hasPlugins ? (
+						<div
+							data-testid="skills-all-plugins"
+							className="sticky top-0 z-10 flex items-center gap-sm border-border2 border-y bg-bg-dark px-sm py-1.5"
+						>
+							<span className="min-w-0 flex-1 font-medium text-text text-xs uppercase tracking-wide">
+								All plugins
+							</span>
+							<Toggle
+								on={!pluginsDisabled}
+								busy={busy}
+								testid="all-plugins-toggle"
+								onClick={() => setGroupEnabled("@plugins", pluginsDisabled)}
+							/>
+						</div>
+					) : null}
 					{entries === null ? (
 						<p className="px-sm py-md text-hint text-sm">Loading skills…</p>
 					) : entries.length === 0 ? (

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -14,13 +14,14 @@ import { errorText, getTransport } from "@/transport";
  * - **project** (Welcome / New Workspace, no session yet): `project.skills` catalog, per-**project**-baseline
  *   skill toggles, no Reload.
  * Both share trust, re-confirm-new, and the per-project **group** toggles (a plugin / source tier, or all
- * plugins at once). Skills are grouped by source — Bundled / Pi / Personal / a box per Claude plugin / Project
- * — with sticky section headers.
+ * plugins at once). Skills are grouped by source — ThinkRail / Pi / Personal / a group per Claude plugin /
+ * Project — with sticky section headers; the first-party ThinkRail and Pi groups lead, above the All-plugins
+ * master (which governs only the plugin groups).
  */
 // ThinkRail-bundled + pi-native first-party skills lead; then personal, then plugins (sorted), then the
 // repo's gated project skills last.
 const TIER_META: Record<string, { label: string; hint: string; rank: number }> = {
-	bundled: { label: "Bundled", hint: "Shipped with ThinkRail.", rank: 0 },
+	bundled: { label: "ThinkRail", hint: "Bundled with the app.", rank: 0 },
 	pi: { label: "Pi", hint: "Pi-native / configured.", rank: 1 },
 	personal: { label: "Personal", hint: "Your own libraries (~/.claude, ~/.codex, …).", rank: 2 },
 	project: { label: "Project", hint: "Committed to the repo — gated behind trust.", rank: 4 },
@@ -34,7 +35,7 @@ interface Group {
 	items: SkillCatalogEntry[];
 }
 
-/** Group entries by their canonical group key; order Bundled → Pi → Personal → plugins (sorted) → Project. */
+/** Group entries by their canonical group key; order ThinkRail → Pi → Personal → plugins (sorted) → Project. */
 function groupCatalog(entries: SkillCatalogEntry[]): Group[] {
 	const byKey = new Map<string, { isPlugin: boolean; items: SkillCatalogEntry[] }>();
 	for (const entry of entries) {
@@ -169,6 +170,70 @@ export function SkillsDialog({
 	const untrustedCount = entries?.filter((e) => e.decision === "untrusted").length ?? 0;
 	const groups = groupCatalog(entries ?? []);
 	const hasPlugins = groups.some((g) => g.isPlugin);
+	// First-party skills (ThinkRail + Pi) render above the all-plugins master — they aren't plugins and
+	// the master doesn't govern them; every other group renders below it.
+	const isLeadingKey = (key: string) => key === "bundled" || key === "pi";
+	const leadingGroups = groups.filter((g) => isLeadingKey(g.key));
+	const otherGroups = groups.filter((g) => !isLeadingKey(g.key));
+
+	const renderGroup = (group: Group) => {
+		// A plugin group is locked off when the "all plugins" master is off; either way a disabled
+		// group grays its skill toggles (re-enable the group to change individual skills).
+		const lockedByMaster = group.isPlugin && pluginsDisabled;
+		const groupOn = !lockedByMaster && !disabledGroups.has(group.key);
+		return (
+			<div key={group.key} data-testid="skill-group" data-group={group.key} data-on={groupOn}>
+				{/* Sticky section header (VSCode-style): pins while the group is in view, then the next
+				    group's header pushes it out. The first-party leads (ThinkRail, Pi) sit at the scroll top
+				    (`top-0`), above the all-plugins master; every other header pins below the master at
+				    `top-8` when plugins exist. No `overflow-hidden` ancestor (would clip sticky); an opaque
+				    bg keeps rows from bleeding through. */}
+				<div
+					className={cn(
+						"sticky z-10 flex items-center gap-sm border-border2 border-y bg-bg-dark px-sm py-1.5",
+						hasPlugins && !isLeadingKey(group.key) ? "top-8" : "top-0",
+					)}
+				>
+					{group.isPlugin ? <Puzzle className="size-3.5 shrink-0 text-hint" aria-hidden /> : null}
+					<span className="font-medium text-text text-xs uppercase tracking-wide">
+						{group.label}
+					</span>
+					<span className="min-w-0 flex-1 truncate text-hint text-xs">{group.hint}</span>
+					<span className="shrink-0 rounded-full bg-hover px-1.5 text-hint text-xs">
+						{group.items.length}
+					</span>
+					<Toggle
+						on={groupOn}
+						busy={busy || lockedByMaster}
+						testid="group-toggle"
+						onClick={() => setGroupEnabled(group.key, !groupOn)}
+					/>
+				</div>
+				{/* Indent + left rail nests the skills visually under their group/plugin header. */}
+				<div className="ml-sm divide-y divide-border2 border-border2 border-l">
+					{group.items.map((entry) => (
+						<SkillRow
+							key={`${group.key}:${entry.name}`}
+							entry={entry}
+							busy={busy}
+							groupOff={!groupOn}
+							onToggle={(enabled) => setSkillEnabled(entry.name, enabled)}
+							onAcknowledge={() =>
+								void mutate(
+									() =>
+										getTransport().request("project.acknowledgeSkills", {
+											id: projectId,
+											names: [entry.name],
+										}),
+									"Couldn't confirm skill",
+								)
+							}
+						/>
+					))}
+				</div>
+			</div>
+		);
+	};
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -231,93 +296,34 @@ export function SkillsDialog({
 				) : null}
 
 				<div className="max-h-[50vh] overflow-y-auto">
-					{/* The all-plugins master stays pinned on top of everything (higher z, fixed h-8); group
-					    headers stick *below* it at `top-8`, so it's a two-level sticky (VSCode breadcrumb style). */}
-					{hasPlugins ? (
-						<div
-							data-testid="skills-all-plugins"
-							className="sticky top-0 z-20 flex h-8 items-center gap-sm border-border2 border-y bg-bg-dark px-sm"
-						>
-							<span className="min-w-0 flex-1 font-medium text-text text-xs uppercase tracking-wide">
-								All plugins
-							</span>
-							<Toggle
-								on={!pluginsDisabled}
-								busy={busy}
-								testid="all-plugins-toggle"
-								onClick={() => setGroupEnabled("@plugins", pluginsDisabled)}
-							/>
-						</div>
-					) : null}
 					{entries === null ? (
 						<p className="px-sm py-md text-hint text-sm">Loading skills…</p>
 					) : entries.length === 0 ? (
 						<p className="px-sm py-md text-hint text-sm">No skills discovered.</p>
 					) : (
-						groups.map((group) => {
-							// A plugin group is locked off when the "all plugins" master is off; either way a disabled
-							// group grays its skill toggles (re-enable the group to change individual skills).
-							const lockedByMaster = group.isPlugin && pluginsDisabled;
-							const groupOn = !lockedByMaster && !disabledGroups.has(group.key);
-							return (
+						<>
+							{/* First-party skills (ThinkRail + Pi) lead, above the all-plugins master. */}
+							{leadingGroups.map(renderGroup)}
+							{/* Once the first-party groups scroll past, the all-plugins master pins at the scroll top
+							    (higher z, fixed h-8); plugin/other headers stick below it at `top-8` — a two-level sticky. */}
+							{hasPlugins ? (
 								<div
-									key={group.key}
-									data-testid="skill-group"
-									data-group={group.key}
-									data-on={groupOn}
+									data-testid="skills-all-plugins"
+									className="sticky top-0 z-20 flex h-8 items-center gap-sm border-border2 border-y bg-bg-dark px-sm"
 								>
-									{/* Sticky section header (VSCode-style): pins while the group is in view, then the next
-									    group's header pushes it out — below the always-pinned all-plugins master (`top-8`) when
-									    present, else at the scroll top. No `overflow-hidden` ancestor (would clip sticky); an
-									    opaque bg keeps rows from bleeding through. */}
-									<div
-										className={cn(
-											"sticky z-10 flex items-center gap-sm border-border2 border-y bg-bg-dark px-sm py-1.5",
-											hasPlugins ? "top-8" : "top-0",
-										)}
-									>
-										{group.isPlugin ? (
-											<Puzzle className="size-3.5 shrink-0 text-hint" aria-hidden />
-										) : null}
-										<span className="font-medium text-text text-xs uppercase tracking-wide">
-											{group.label}
-										</span>
-										<span className="min-w-0 flex-1 truncate text-hint text-xs">{group.hint}</span>
-										<span className="shrink-0 rounded-full bg-hover px-1.5 text-hint text-xs">
-											{group.items.length}
-										</span>
-										<Toggle
-											on={groupOn}
-											busy={busy || lockedByMaster}
-											testid="group-toggle"
-											onClick={() => setGroupEnabled(group.key, !groupOn)}
-										/>
-									</div>
-									{/* Indent + left rail nests the skills visually under their group/plugin header. */}
-									<div className="ml-sm divide-y divide-border2 border-border2 border-l">
-										{group.items.map((entry) => (
-											<SkillRow
-												key={`${group.key}:${entry.name}`}
-												entry={entry}
-												busy={busy}
-												groupOff={!groupOn}
-												onToggle={(enabled) => setSkillEnabled(entry.name, enabled)}
-												onAcknowledge={() =>
-													void mutate(
-														() =>
-															getTransport().request("project.acknowledgeSkills", {
-																id: projectId,
-																names: [entry.name],
-															}),
-														"Couldn't confirm skill",
-													)
-												}
-											/>
-										))}
-									</div>
+									<span className="min-w-0 flex-1 font-medium text-text text-xs uppercase tracking-wide">
+										All plugins
+									</span>
+									<Toggle
+										on={!pluginsDisabled}
+										busy={busy}
+										testid="all-plugins-toggle"
+										onClick={() => setGroupEnabled("@plugins", pluginsDisabled)}
+									/>
 								</div>
-							);
-						})
+							) : null}
+							{otherGroups.map(renderGroup)}
+						</>
 					)}
 				</div>
 			</DialogContent>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -14,13 +14,16 @@ import { errorText, getTransport } from "@/transport";
  * - **project** (Welcome / New Workspace, no session yet): `project.skills` catalog, per-**project**-baseline
  *   skill toggles, no Reload.
  * Both share trust, re-confirm-new, and the per-project **group** toggles (a plugin / source tier, or all
- * plugins at once). Skills are grouped by source — Project / Personal / a box per Claude plugin / Bundled / Pi.
+ * plugins at once). Skills are grouped by source — Bundled / Pi / Personal / a box per Claude plugin / Project
+ * — with sticky section headers.
  */
+// ThinkRail-bundled + pi-native first-party skills lead; then personal, then plugins (sorted), then the
+// repo's gated project skills last.
 const TIER_META: Record<string, { label: string; hint: string; rank: number }> = {
-	project: { label: "Project", hint: "Committed to the repo — gated behind trust.", rank: 0 },
-	personal: { label: "Personal", hint: "Your own libraries (~/.claude, ~/.codex, …).", rank: 1 },
-	bundled: { label: "Bundled", hint: "Shipped with ThinkRail.", rank: 3 },
-	pi: { label: "Pi", hint: "Pi-native / configured.", rank: 4 },
+	bundled: { label: "Bundled", hint: "Shipped with ThinkRail.", rank: 0 },
+	pi: { label: "Pi", hint: "Pi-native / configured.", rank: 1 },
+	personal: { label: "Personal", hint: "Your own libraries (~/.claude, ~/.codex, …).", rank: 2 },
+	project: { label: "Project", hint: "Committed to the repo — gated behind trust.", rank: 4 },
 };
 
 interface Group {
@@ -31,7 +34,7 @@ interface Group {
 	items: SkillCatalogEntry[];
 }
 
-/** Group entries by their canonical group key; order Project → Personal → plugins (sorted) → Bundled → Pi. */
+/** Group entries by their canonical group key; order Bundled → Pi → Personal → plugins (sorted) → Project. */
 function groupCatalog(entries: SkillCatalogEntry[]): Group[] {
 	const byKey = new Map<string, { isPlugin: boolean; items: SkillCatalogEntry[] }>();
 	for (const entry of entries) {
@@ -48,7 +51,7 @@ function groupCatalog(entries: SkillCatalogEntry[]): Group[] {
 				hint: group.isPlugin ? "Claude plugin" : (meta?.hint ?? ""),
 				isPlugin: group.isPlugin,
 				items: group.items,
-				rank: group.isPlugin ? 2 : (meta?.rank ?? 5),
+				rank: group.isPlugin ? 3 : (meta?.rank ?? 5),
 			};
 		})
 		.sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label));
@@ -258,9 +261,11 @@ export function SkillsDialog({
 									data-testid="skill-group"
 									data-group={group.key}
 									data-on={groupOn}
-									className="mb-md overflow-hidden rounded-[var(--radius-md)] border border-border2"
 								>
-									<div className="flex items-center gap-sm border-border2 border-b bg-bg-dark px-sm py-1.5">
+									{/* Sticky section header (VSCode-style): pins to the scroll top while the group is in
+									    view, then the next group's header pushes it out. No `overflow-hidden` ancestor
+									    (that would clip sticky); an opaque bg keeps rows from bleeding through. */}
+									<div className="sticky top-0 z-10 flex items-center gap-sm border-border2 border-y bg-bg-dark px-sm py-1.5">
 										<span className="font-medium text-text text-xs uppercase tracking-wide">
 											{group.label}
 										</span>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -230,12 +230,12 @@ export function SkillsDialog({
 				) : null}
 
 				<div className="max-h-[50vh] overflow-y-auto">
-					{/* The all-plugins master follows the same sticky pattern: it pins at the scroll top, then the
-					    first group's sticky header covers it as you scroll into the groups. */}
+					{/* The all-plugins master stays pinned on top of everything (higher z, fixed h-8); group
+					    headers stick *below* it at `top-8`, so it's a two-level sticky (VSCode breadcrumb style). */}
 					{hasPlugins ? (
 						<div
 							data-testid="skills-all-plugins"
-							className="sticky top-0 z-10 flex items-center gap-sm border-border2 border-y bg-bg-dark px-sm py-1.5"
+							className="sticky top-0 z-20 flex h-8 items-center gap-sm border-border2 border-y bg-bg-dark px-sm"
 						>
 							<span className="min-w-0 flex-1 font-medium text-text text-xs uppercase tracking-wide">
 								All plugins
@@ -265,10 +265,16 @@ export function SkillsDialog({
 									data-group={group.key}
 									data-on={groupOn}
 								>
-									{/* Sticky section header (VSCode-style): pins to the scroll top while the group is in
-									    view, then the next group's header pushes it out. No `overflow-hidden` ancestor
-									    (that would clip sticky); an opaque bg keeps rows from bleeding through. */}
-									<div className="sticky top-0 z-10 flex items-center gap-sm border-border2 border-y bg-bg-dark px-sm py-1.5">
+									{/* Sticky section header (VSCode-style): pins while the group is in view, then the next
+									    group's header pushes it out — below the always-pinned all-plugins master (`top-8`) when
+									    present, else at the scroll top. No `overflow-hidden` ancestor (would clip sticky); an
+									    opaque bg keeps rows from bleeding through. */}
+									<div
+										className={cn(
+											"sticky z-10 flex items-center gap-sm border-border2 border-y bg-bg-dark px-sm py-1.5",
+											hasPlugins ? "top-8" : "top-0",
+										)}
+									>
 										<span className="font-medium text-text text-xs uppercase tracking-wide">
 											{group.label}
 										</span>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -1,0 +1,259 @@
+import type { Project, SkillCatalogEntry, SkillDecision, Workspace } from "@thinkrail/contracts";
+import { RefreshCw, ShieldCheck } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { toast, useAppStore } from "@/store";
+import { errorText, getTransport } from "@/transport";
+
+/** The workspace-scoped Skills manager (opened from the chat header). Lists every discovered skill grouped
+ * by source with its admission verdict, exposes trust + per-workspace enable/disable + re-confirm-new, and
+ * a Reload that applies changes to *this* chat's running session. */
+const GROUPS = ["Project", "Personal", "Bundled", "Pi"] as const;
+type Group = (typeof GROUPS)[number];
+
+function groupOf(entry: SkillCatalogEntry): Group {
+	if (entry.gated) return "Project";
+	if (entry.sourceInfo.scope === "user") return "Personal";
+	if (entry.sourceInfo.scope === "temporary") return "Bundled";
+	return "Pi";
+}
+
+const GROUP_HINT: Record<Group, string> = {
+	Project: "Committed to the repo — gated behind trust.",
+	Personal: "Your own libraries (~/.claude, ~/.codex, …).",
+	Bundled: "Shipped with ThinkRail.",
+	Pi: "Pi-native / configured.",
+};
+
+/** A skill result carries `projectId` only when it's a Workspace; Project has no such field. */
+function isWorkspace(result: Project | Workspace): result is Workspace {
+	return "projectId" in result;
+}
+
+export function SkillsDialog({
+	workspaceId,
+	sessionId,
+	projectId,
+	streaming,
+	open,
+	onOpenChange,
+}: {
+	workspaceId: string;
+	sessionId: string;
+	projectId: string;
+	streaming: boolean;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const [entries, setEntries] = useState<SkillCatalogEntry[] | null>(null);
+	const [busy, setBusy] = useState(false);
+
+	const refresh = useCallback(async () => {
+		try {
+			setEntries(await getTransport().request("skills.state", { workspaceId }));
+		} catch {
+			setEntries([]);
+		}
+	}, [workspaceId]);
+
+	useEffect(() => {
+		if (!open) return;
+		setEntries(null);
+		void refresh();
+	}, [open, refresh]);
+
+	// Fold a mutation's echoed record back into the store (Project only — a Workspace update also arrives on
+	// the workspace.updated push), then re-read the catalog so decisions reflect the change.
+	const mutate = async (request: () => Promise<Project | Workspace>, failure: string) => {
+		if (busy) return;
+		setBusy(true);
+		try {
+			const result = await request();
+			if (!isWorkspace(result)) {
+				const store = useAppStore.getState();
+				store.setProjects(store.projects.map((p) => (p.id === result.id ? result : p)));
+			}
+			await refresh();
+		} catch (err) {
+			toast.error(errorText(err), failure);
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const reload = async () => {
+		if (busy) return;
+		setBusy(true);
+		try {
+			await getTransport().request("session.reloadResources", { sessionId });
+			toast.success("This chat now uses the updated skills.", "Skills reloaded");
+		} catch (err) {
+			toast.error(errorText(err), "Couldn't reload skills");
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const untrustedCount = entries?.filter((e) => e.decision === "untrusted").length ?? 0;
+	const grouped = GROUPS.map((group) => ({
+		group,
+		items: (entries ?? []).filter((e) => groupOf(e) === group),
+	})).filter((g) => g.items.length > 0);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-testid="skills-dialog" className="max-w-[560px] gap-md p-md">
+				<div className="flex items-center justify-between gap-sm">
+					<DialogTitle className="text-sm text-text">Skills</DialogTitle>
+					<Button
+						size="sm"
+						variant="outline"
+						data-testid="skills-reload"
+						disabled={busy || streaming}
+						title={streaming ? "Available once the current turn finishes" : "Apply to this chat"}
+						onClick={() => void reload()}
+					>
+						<RefreshCw className="size-3.5" />
+						Reload
+					</Button>
+				</div>
+
+				{untrustedCount > 0 ? (
+					<div
+						data-testid="skills-trust-all"
+						className="flex items-center gap-sm rounded-[var(--radius-md)] border border-border2 border-l-[3px] border-l-[var(--gold)] bg-[var(--gold-tint)] px-md py-sm"
+					>
+						<span className="min-w-0 flex-1 text-sm text-text">
+							{untrustedCount} project skill{untrustedCount === 1 ? "" : "s"} off until you trust
+							this repo.
+						</span>
+						<Button
+							size="sm"
+							disabled={busy}
+							onClick={() =>
+								void mutate(
+									() =>
+										getTransport().request("project.setTrust", { id: projectId, trusted: true }),
+									"Couldn't trust project",
+								)
+							}
+						>
+							Trust project
+						</Button>
+					</div>
+				) : null}
+
+				<div className="max-h-[50vh] overflow-y-auto">
+					{entries === null ? (
+						<p className="px-sm py-md text-hint text-sm">Loading skills…</p>
+					) : entries.length === 0 ? (
+						<p className="px-sm py-md text-hint text-sm">
+							No skills discovered for this workspace.
+						</p>
+					) : (
+						grouped.map(({ group, items }) => (
+							<div key={group} className="mb-md">
+								<div className="px-sm py-xs">
+									<span className="font-medium text-text text-xs uppercase tracking-wide">
+										{group}
+									</span>
+									<span className="ml-sm text-hint text-xs">{GROUP_HINT[group]}</span>
+								</div>
+								{items.map((entry) => (
+									<SkillRow
+										key={`${group}:${entry.name}`}
+										entry={entry}
+										busy={busy}
+										onToggle={(enabled) =>
+											void mutate(
+												() =>
+													getTransport().request("workspace.setSkillOverride", {
+														id: workspaceId,
+														name: entry.name,
+														override: enabled ? "on" : "off",
+													}),
+												"Couldn't update skill",
+											)
+										}
+										onAcknowledge={() =>
+											void mutate(
+												() =>
+													getTransport().request("project.acknowledgeSkills", {
+														id: projectId,
+														names: [entry.name],
+													}),
+												"Couldn't confirm skill",
+											)
+										}
+									/>
+								))}
+							</div>
+						))
+					)}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+const DECISION_TEXT: Record<SkillDecision, string> = {
+	load: "on",
+	disabled: "off",
+	untrusted: "trust to enable",
+	"pending-ack": "new",
+};
+
+function SkillRow({
+	entry,
+	busy,
+	onToggle,
+	onAcknowledge,
+}: {
+	entry: SkillCatalogEntry;
+	busy: boolean;
+	onToggle: (enabled: boolean) => void;
+	onAcknowledge: () => void;
+}) {
+	const loaded = entry.decision === "load";
+	return (
+		<div
+			data-testid="skill-row"
+			data-skill={entry.name}
+			data-decision={entry.decision}
+			className="flex items-center gap-sm rounded-[var(--radius-sm)] px-sm py-xs hover:bg-hover"
+		>
+			<span className="flex min-w-0 flex-1 flex-col">
+				<span className="truncate font-[var(--font-mono)] text-sm text-text">{entry.name}</span>
+				{entry.description ? (
+					<span className="truncate text-hint text-xs">{entry.description}</span>
+				) : null}
+			</span>
+			{entry.decision === "pending-ack" ? (
+				<Button size="sm" data-testid="skill-ack" disabled={busy} onClick={onAcknowledge}>
+					<ShieldCheck className="size-3.5" />
+					Enable
+				</Button>
+			) : entry.decision === "untrusted" ? (
+				<span className="shrink-0 text-hint text-xs">{DECISION_TEXT.untrusted}</span>
+			) : (
+				<button
+					type="button"
+					data-testid="skill-toggle"
+					data-on={loaded}
+					disabled={busy}
+					onClick={() => onToggle(!loaded)}
+					className={cn(
+						"shrink-0 rounded-[var(--radius-sm)] border px-sm py-0.5 text-xs transition-colors disabled:opacity-50",
+						loaded
+							? "border-[var(--primary-40)] bg-[var(--primary-10)] text-primary"
+							: "border-border2 text-muted hover:bg-hover",
+					)}
+				>
+					{DECISION_TEXT[entry.decision]}
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -7,48 +7,54 @@ import { cn } from "@/lib/utils";
 import { toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 
-/** The workspace-scoped Skills manager (opened from the chat header). Lists every discovered skill grouped
- * by source with its admission verdict, exposes trust + per-workspace enable/disable + re-confirm-new, and
- * a Reload that applies changes to *this* chat's running session. */
-const FIXED_HINT: Record<string, string> = {
-	Project: "Committed to the repo — gated behind trust.",
-	Personal: "Your own libraries (~/.claude, ~/.codex, …).",
-	Bundled: "Shipped with ThinkRail.",
-	Pi: "Pi-native / configured.",
+/**
+ * The Skills manager. Two modes from one component:
+ * - **workspace** (chat header): `skills.state` catalog, per-**workspace** skill overrides, and a Reload
+ *   that applies changes to that chat's running session.
+ * - **project** (Welcome / New Workspace, no session yet): `project.skills` catalog, per-**project**-baseline
+ *   skill toggles, no Reload.
+ * Both share trust, re-confirm-new, and the per-project **group** toggles (a plugin / source tier, or all
+ * plugins at once). Skills are grouped by source — Project / Personal / a box per Claude plugin / Bundled / Pi.
+ */
+const TIER_META: Record<string, { label: string; hint: string; rank: number }> = {
+	project: { label: "Project", hint: "Committed to the repo — gated behind trust.", rank: 0 },
+	personal: { label: "Personal", hint: "Your own libraries (~/.claude, ~/.codex, …).", rank: 1 },
+	bundled: { label: "Bundled", hint: "Shipped with ThinkRail.", rank: 3 },
+	pi: { label: "Pi", hint: "Pi-native / configured.", rank: 4 },
 };
-const FIXED_RANK: Record<string, number> = { Project: 0, Personal: 1, Bundled: 3, Pi: 4 };
 
-function fixedLabel(entry: SkillCatalogEntry): "Project" | "Personal" | "Bundled" | "Pi" {
-	if (entry.gated) return "Project";
-	if (entry.sourceInfo.scope === "user") return "Personal";
-	if (entry.sourceInfo.scope === "temporary") return "Bundled";
-	return "Pi";
+interface Group {
+	key: string;
+	label: string;
+	hint: string;
+	isPlugin: boolean;
+	items: SkillCatalogEntry[];
 }
 
-/** Group entries by installing plugin (if any), else by source tier; order Project → Personal → plugins
- * (sorted) → Bundled → Pi, so a plugin's skills sit together under the plugin's name. */
-function groupCatalog(
-	entries: SkillCatalogEntry[],
-): { label: string; hint: string; items: SkillCatalogEntry[] }[] {
-	const byLabel = new Map<string, { isPlugin: boolean; items: SkillCatalogEntry[] }>();
+/** Group entries by their canonical group key; order Project → Personal → plugins (sorted) → Bundled → Pi. */
+function groupCatalog(entries: SkillCatalogEntry[]): Group[] {
+	const byKey = new Map<string, { isPlugin: boolean; items: SkillCatalogEntry[] }>();
 	for (const entry of entries) {
-		const label = entry.plugin ?? fixedLabel(entry);
-		const group = byLabel.get(label) ?? { isPlugin: Boolean(entry.plugin), items: [] };
+		const group = byKey.get(entry.group) ?? { isPlugin: Boolean(entry.plugin), items: [] };
 		group.items.push(entry);
-		byLabel.set(label, group);
+		byKey.set(entry.group, group);
 	}
-	return [...byLabel.entries()]
-		.map(([label, group]) => ({
-			label,
-			hint: group.isPlugin ? "Claude plugin" : (FIXED_HINT[label] ?? ""),
-			items: group.items,
-			rank: group.isPlugin ? 2 : (FIXED_RANK[label] ?? 5),
-		}))
-		.sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label))
-		.map(({ label, hint, items }) => ({ label, hint, items }));
+	return [...byKey.entries()]
+		.map(([key, group]) => {
+			const meta = TIER_META[key];
+			return {
+				key,
+				label: meta?.label ?? key,
+				hint: group.isPlugin ? "Claude plugin" : (meta?.hint ?? ""),
+				isPlugin: group.isPlugin,
+				items: group.items,
+				rank: group.isPlugin ? 2 : (meta?.rank ?? 5),
+			};
+		})
+		.sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label));
 }
 
-/** A skill result carries `projectId` only when it's a Workspace; Project has no such field. */
+/** A mutation result carries `projectId` only when it's a Workspace; Project has no such field. */
 function isWorkspace(result: Project | Workspace): result is Workspace {
 	return "projectId" in result;
 }
@@ -58,37 +64,44 @@ export function isSkillPath(path: string): boolean {
 	return /(^|\/)\.(claude|github|gemini|pi|agents)\/skills(\/|$)/.test(path);
 }
 
-export function SkillsDialog({
-	workspaceId,
-	sessionId,
-	projectId,
-	streaming,
-	stale,
-	open,
-	onOpenChange,
-	onReloaded,
-}: {
+/** Chat-mode extras: a live session to reload after changes. Absent in project mode (pre-session). */
+export interface SkillsWorkspaceContext {
 	workspaceId: string;
 	sessionId: string;
-	projectId: string;
 	streaming: boolean;
-	/** The worktree's skills changed on disk since this session loaded (pull/branch/edit) — prompt a reload. */
+	/** Skills changed on disk since the session loaded — prompt a reload. */
 	stale?: boolean;
-	open: boolean;
-	onOpenChange: (open: boolean) => void;
 	/** Fired after a successful reload so the caller can clear its stale flag. */
 	onReloaded?: () => void;
+}
+
+export function SkillsDialog({
+	projectId,
+	workspace,
+	open,
+	onOpenChange,
+}: {
+	projectId: string;
+	workspace?: SkillsWorkspaceContext;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
 }) {
+	const project = useAppStore((s) => s.projects.find((p) => p.id === projectId));
 	const [entries, setEntries] = useState<SkillCatalogEntry[] | null>(null);
 	const [busy, setBusy] = useState(false);
+	const workspaceId = workspace?.workspaceId;
 
 	const refresh = useCallback(async () => {
 		try {
-			setEntries(await getTransport().request("skills.state", { workspaceId }));
+			setEntries(
+				workspaceId
+					? await getTransport().request("skills.state", { workspaceId })
+					: await getTransport().request("project.skills", { projectId }),
+			);
 		} catch {
 			setEntries([]);
 		}
-	}, [workspaceId]);
+	}, [workspaceId, projectId]);
 
 	useEffect(() => {
 		if (!open) return;
@@ -96,8 +109,8 @@ export function SkillsDialog({
 		void refresh();
 	}, [open, refresh]);
 
-	// Fold a mutation's echoed record back into the store (Project only — a Workspace update also arrives on
-	// the workspace.updated push), then re-read the catalog so decisions reflect the change.
+	// Fold a mutation's echoed record into the store (Project only — a Workspace update also arrives on the
+	// workspace.updated push), then re-read the catalog so decisions reflect the change.
 	const mutate = async (request: () => Promise<Project | Workspace>, failure: string) => {
 		if (busy) return;
 		setBusy(true);
@@ -116,11 +129,11 @@ export function SkillsDialog({
 	};
 
 	const reload = async () => {
-		if (busy) return;
+		if (busy || !workspace) return;
 		setBusy(true);
 		try {
-			await getTransport().request("session.reloadResources", { sessionId });
-			onReloaded?.();
+			await getTransport().request("session.reloadResources", { sessionId: workspace.sessionId });
+			workspace.onReloaded?.();
 			toast.success("This chat now uses the updated skills.", "Skills reloaded");
 		} catch (err) {
 			toast.error(errorText(err), "Couldn't reload skills");
@@ -129,28 +142,56 @@ export function SkillsDialog({
 		}
 	};
 
+	const setGroupEnabled = (group: string, enabled: boolean) =>
+		void mutate(
+			() => getTransport().request("project.setGroupEnabled", { id: projectId, group, enabled }),
+			"Couldn't update group",
+		);
+
+	const setSkillEnabled = (name: string, enabled: boolean) =>
+		void mutate(
+			() =>
+				workspace
+					? getTransport().request("workspace.setSkillOverride", {
+							id: workspace.workspaceId,
+							name,
+							override: enabled ? "on" : "off",
+						})
+					: getTransport().request("project.setSkillEnabled", { id: projectId, name, enabled }),
+			"Couldn't update skill",
+		);
+
+	const disabledGroups = new Set(project?.disabledGroups ?? []);
+	const pluginsDisabled = disabledGroups.has("@plugins");
 	const untrustedCount = entries?.filter((e) => e.decision === "untrusted").length ?? 0;
-	const grouped = groupCatalog(entries ?? []);
+	const groups = groupCatalog(entries ?? []);
+	const hasPlugins = groups.some((g) => g.isPlugin);
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent data-testid="skills-dialog" className="max-w-[560px] gap-md p-md">
 				<div className="flex items-center justify-between gap-sm">
 					<DialogTitle className="text-sm text-text">Skills</DialogTitle>
-					<Button
-						size="sm"
-						variant="outline"
-						data-testid="skills-reload"
-						disabled={busy || streaming}
-						title={streaming ? "Available once the current turn finishes" : "Apply to this chat"}
-						onClick={() => void reload()}
-					>
-						<RefreshCw className="size-3.5" />
-						Reload
-					</Button>
+					{workspace ? (
+						<Button
+							size="sm"
+							variant="outline"
+							data-testid="skills-reload"
+							disabled={busy || workspace.streaming}
+							title={
+								workspace.streaming
+									? "Available once the current turn finishes"
+									: "Apply to this chat"
+							}
+							onClick={() => void reload()}
+						>
+							<RefreshCw className="size-3.5" />
+							Reload
+						</Button>
+					) : null}
 				</div>
 
-				{stale ? (
+				{workspace?.stale ? (
 					<div
 						data-testid="skills-stale"
 						className="rounded-[var(--radius-md)] border border-border2 bg-elevated px-md py-sm text-muted text-xs"
@@ -185,66 +226,114 @@ export function SkillsDialog({
 					</div>
 				) : null}
 
+				{hasPlugins ? (
+					<div
+						data-testid="skills-all-plugins"
+						className="flex items-center gap-sm rounded-[var(--radius-md)] border border-border2 px-md py-1.5"
+					>
+						<span className="min-w-0 flex-1 text-sm text-text">All Claude plugins</span>
+						<Toggle
+							on={!pluginsDisabled}
+							busy={busy}
+							testid="all-plugins-toggle"
+							onClick={() => setGroupEnabled("@plugins", pluginsDisabled)}
+						/>
+					</div>
+				) : null}
+
 				<div className="max-h-[50vh] overflow-y-auto">
 					{entries === null ? (
 						<p className="px-sm py-md text-hint text-sm">Loading skills…</p>
 					) : entries.length === 0 ? (
-						<p className="px-sm py-md text-hint text-sm">
-							No skills discovered for this workspace.
-						</p>
+						<p className="px-sm py-md text-hint text-sm">No skills discovered.</p>
 					) : (
-						grouped.map(({ label, hint, items }) => (
-							<div
-								key={label}
-								data-testid="skill-group"
-								data-group={label}
-								className="mb-md overflow-hidden rounded-[var(--radius-md)] border border-border2"
-							>
-								<div className="flex items-baseline gap-sm border-border2 border-b bg-bg-dark px-sm py-1.5">
-									<span className="font-medium text-text text-xs uppercase tracking-wide">
-										{label}
-									</span>
-									<span className="min-w-0 flex-1 truncate text-hint text-xs">{hint}</span>
-									<span className="shrink-0 rounded-full bg-hover px-1.5 text-hint text-xs">
-										{items.length}
-									</span>
-								</div>
-								<div className="divide-y divide-border2">
-									{items.map((entry) => (
-										<SkillRow
-											key={`${label}:${entry.name}`}
-											entry={entry}
-											busy={busy}
-											onToggle={(enabled) =>
-												void mutate(
-													() =>
-														getTransport().request("workspace.setSkillOverride", {
-															id: workspaceId,
-															name: entry.name,
-															override: enabled ? "on" : "off",
-														}),
-													"Couldn't update skill",
-												)
-											}
-											onAcknowledge={() =>
-												void mutate(
-													() =>
-														getTransport().request("project.acknowledgeSkills", {
-															id: projectId,
-															names: [entry.name],
-														}),
-													"Couldn't confirm skill",
-												)
-											}
+						groups.map((group) => {
+							// A plugin group is locked off when the "all plugins" master is off; either way a disabled
+							// group grays its skill toggles (re-enable the group to change individual skills).
+							const lockedByMaster = group.isPlugin && pluginsDisabled;
+							const groupOn = !lockedByMaster && !disabledGroups.has(group.key);
+							return (
+								<div
+									key={group.key}
+									data-testid="skill-group"
+									data-group={group.key}
+									data-on={groupOn}
+									className="mb-md overflow-hidden rounded-[var(--radius-md)] border border-border2"
+								>
+									<div className="flex items-center gap-sm border-border2 border-b bg-bg-dark px-sm py-1.5">
+										<span className="font-medium text-text text-xs uppercase tracking-wide">
+											{group.label}
+										</span>
+										<span className="min-w-0 flex-1 truncate text-hint text-xs">{group.hint}</span>
+										<span className="shrink-0 rounded-full bg-hover px-1.5 text-hint text-xs">
+											{group.items.length}
+										</span>
+										<Toggle
+											on={groupOn}
+											busy={busy || lockedByMaster}
+											testid="group-toggle"
+											onClick={() => setGroupEnabled(group.key, !groupOn)}
 										/>
-									))}
+									</div>
+									<div className="divide-y divide-border2">
+										{group.items.map((entry) => (
+											<SkillRow
+												key={`${group.key}:${entry.name}`}
+												entry={entry}
+												busy={busy}
+												groupOff={!groupOn}
+												onToggle={(enabled) => setSkillEnabled(entry.name, enabled)}
+												onAcknowledge={() =>
+													void mutate(
+														() =>
+															getTransport().request("project.acknowledgeSkills", {
+																id: projectId,
+																names: [entry.name],
+															}),
+														"Couldn't confirm skill",
+													)
+												}
+											/>
+										))}
+									</div>
 								</div>
-							</div>
-						))
+							);
+						})
 					)}
 				</div>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+/** A small on/off pill toggle (group + all-plugins controls). */
+function Toggle({
+	on,
+	busy,
+	testid,
+	onClick,
+}: {
+	on: boolean;
+	busy: boolean;
+	testid: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			data-testid={testid}
+			data-on={on}
+			disabled={busy}
+			onClick={onClick}
+			className={cn(
+				"shrink-0 rounded-[var(--radius-sm)] border px-sm py-0.5 text-xs transition-colors disabled:opacity-50",
+				on
+					? "border-[var(--primary-40)] bg-[var(--primary-10)] text-primary"
+					: "border-border2 text-muted hover:bg-hover",
+			)}
+		>
+			{on ? "on" : "off"}
+		</button>
 	);
 }
 
@@ -258,11 +347,14 @@ const DECISION_TEXT: Record<SkillDecision, string> = {
 function SkillRow({
 	entry,
 	busy,
+	groupOff,
 	onToggle,
 	onAcknowledge,
 }: {
 	entry: SkillCatalogEntry;
 	busy: boolean;
+	/** The skill's group (or the all-plugins master) is disabled — toggling this one skill won't apply. */
+	groupOff: boolean;
 	onToggle: (enabled: boolean) => void;
 	onAcknowledge: () => void;
 }) {
@@ -287,6 +379,10 @@ function SkillRow({
 				</Button>
 			) : entry.decision === "untrusted" ? (
 				<span className="shrink-0 text-hint text-xs">{DECISION_TEXT.untrusted}</span>
+			) : groupOff ? (
+				<span className="shrink-0 text-hint text-xs" title="Enable the group to change this skill">
+					group off
+				</span>
 			) : (
 				<button
 					type="button"

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -32,20 +32,31 @@ function isWorkspace(result: Project | Workspace): result is Workspace {
 	return "projectId" in result;
 }
 
+/** Whether a worktree-relative path is inside a skill directory — the auto-detect trigger for a reload. */
+export function isSkillPath(path: string): boolean {
+	return /(^|\/)\.(claude|github|gemini|pi|agents)\/skills(\/|$)/.test(path);
+}
+
 export function SkillsDialog({
 	workspaceId,
 	sessionId,
 	projectId,
 	streaming,
+	stale,
 	open,
 	onOpenChange,
+	onReloaded,
 }: {
 	workspaceId: string;
 	sessionId: string;
 	projectId: string;
 	streaming: boolean;
+	/** The worktree's skills changed on disk since this session loaded (pull/branch/edit) — prompt a reload. */
+	stale?: boolean;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	/** Fired after a successful reload so the caller can clear its stale flag. */
+	onReloaded?: () => void;
 }) {
 	const [entries, setEntries] = useState<SkillCatalogEntry[] | null>(null);
 	const [busy, setBusy] = useState(false);
@@ -88,6 +99,7 @@ export function SkillsDialog({
 		setBusy(true);
 		try {
 			await getTransport().request("session.reloadResources", { sessionId });
+			onReloaded?.();
 			toast.success("This chat now uses the updated skills.", "Skills reloaded");
 		} catch (err) {
 			toast.error(errorText(err), "Couldn't reload skills");
@@ -119,6 +131,16 @@ export function SkillsDialog({
 						Reload
 					</Button>
 				</div>
+
+				{stale ? (
+					<div
+						data-testid="skills-stale"
+						className="rounded-[var(--radius-md)] border border-border2 bg-elevated px-md py-sm text-muted text-xs"
+					>
+						This worktree's skills changed on disk — <span className="text-text">Reload</span> to
+						apply them to this chat.
+					</div>
+				) : null}
 
 				{untrustedCount > 0 ? (
 					<div

--- a/apps/web/src/chat/SlashCommandCompletion.test.ts
+++ b/apps/web/src/chat/SlashCommandCompletion.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import type { SlashCommandInfo } from "@thinkrail/contracts";
+import {
+	matchSlashCommands,
+	selectedSlashCommandValue,
+	slashCommandCatalogOrEmpty,
+	slashCommandQuery,
+	slashCompletionKeyAction,
+} from "./SlashCommandCompletion";
+
+function command(name: string): SlashCommandInfo {
+	return {
+		name,
+		description: `${name} description`,
+		source: "skill",
+		sourceInfo: {
+			path: `/skills/${name}/SKILL.md`,
+			source: "fixture",
+			scope: "project",
+			origin: "top-level",
+		},
+	};
+}
+
+describe("slash command matching", () => {
+	it("matches a leading whitespace-free query case-insensitively and caps at eight", () => {
+		const commands = Array.from({ length: 10 }, (_, index) => command(`Skill-${index}`));
+		expect(matchSlashCommands("/skill-", commands).map((item) => item.name)).toEqual(
+			commands.slice(0, 8).map((item) => item.name),
+		);
+		expect(slashCommandQuery("hello /skill")).toBeNull();
+		expect(matchSlashCommands("/skill arg", commands)).toEqual([]);
+	});
+
+	it("uses one insertion format for every caller", () => {
+		expect(selectedSlashCommandValue(command("skill:review"))).toBe("/skill:review ");
+	});
+
+	it("degrades an empty or failed optional catalog to no matches", async () => {
+		expect(await slashCommandCatalogOrEmpty(async () => [])).toEqual([]);
+		expect(
+			await slashCommandCatalogOrEmpty(async () => {
+				throw new Error("host unavailable");
+			}),
+		).toEqual([]);
+	});
+});
+
+describe("slash completion keyboard reducer", () => {
+	it("wraps arrow navigation", () => {
+		expect(slashCompletionKeyAction("ArrowDown", true, 2, 3)).toEqual({
+			type: "move",
+			index: 0,
+		});
+		expect(slashCompletionKeyAction("ArrowUp", true, 0, 3)).toEqual({
+			type: "move",
+			index: 2,
+		});
+	});
+
+	it("selects on Enter or Tab and dismisses on Escape", () => {
+		expect(slashCompletionKeyAction("Enter", true, 1, 3)).toEqual({
+			type: "select",
+			index: 1,
+		});
+		expect(slashCompletionKeyAction("Tab", true, 1, 3)).toEqual({
+			type: "select",
+			index: 1,
+		});
+		expect(slashCompletionKeyAction("Escape", true, 1, 3)).toEqual({ type: "dismiss" });
+		expect(slashCompletionKeyAction("Enter", false, 1, 3)).toEqual({ type: "none" });
+	});
+});

--- a/apps/web/src/chat/SlashCommandCompletion.tsx
+++ b/apps/web/src/chat/SlashCommandCompletion.tsx
@@ -1,5 +1,5 @@
 import type { SlashCommandInfo } from "@thinkrail/contracts";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 
 const MAX_MATCHES = 8;
@@ -80,14 +80,21 @@ export function useSlashCommandCompletion({
 	const [dismissed, setDismissed] = useState(false);
 	const query = slashCommandQuery(value);
 	const matches = matchSlashCommands(value, commands);
-	const open = !dismissed && query !== null && matches.length > 0;
-	const visibleActiveIndex = Math.min(activeIndex, Math.max(0, matches.length - 1));
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: command identity changing is the reset signal
-	useEffect(() => {
+	// Reset the highlight + dismissal whenever the query or the command set changes — done during render via
+	// a tracked signal (React's "adjust state on prop change" pattern) rather than an effect, so it needs no
+	// dependency-lint suppression. The signal keys off the command *names* (a stable content identity), so an
+	// unstable `commands` array reference can neither spuriously reset nor loop.
+	const resetSignal = JSON.stringify([query, commands.map((command) => command.name)]);
+	const [lastResetSignal, setLastResetSignal] = useState(resetSignal);
+	if (lastResetSignal !== resetSignal) {
+		setLastResetSignal(resetSignal);
 		setActiveIndex(0);
 		setDismissed(false);
-	}, [query, commands]);
+	}
+
+	const open = !dismissed && query !== null && matches.length > 0;
+	const visibleActiveIndex = Math.min(activeIndex, Math.max(0, matches.length - 1));
 
 	const dismiss = () => setDismissed(true);
 

--- a/apps/web/src/chat/SlashCommandCompletion.tsx
+++ b/apps/web/src/chat/SlashCommandCompletion.tsx
@@ -1,0 +1,159 @@
+import type { SlashCommandInfo } from "@thinkrail/contracts";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const MAX_MATCHES = 8;
+
+/** Optional autocomplete catalogs degrade to empty; catalog failure must never block the owning form. */
+export async function slashCommandCatalogOrEmpty(
+	load: () => Promise<SlashCommandInfo[]>,
+): Promise<SlashCommandInfo[]> {
+	try {
+		return await load();
+	} catch {
+		return [];
+	}
+}
+
+/** Slash commands are recognized only at the start of a message and before the first whitespace. */
+export function slashCommandQuery(value: string): string | null {
+	return value.startsWith("/") && !/\s/.test(value) ? value.slice(1) : null;
+}
+
+export function matchSlashCommands(
+	value: string,
+	commands: readonly SlashCommandInfo[],
+): SlashCommandInfo[] {
+	const query = slashCommandQuery(value);
+	if (query === null) return [];
+	const normalized = query.toLowerCase();
+	return commands
+		.filter((command) => command.name.toLowerCase().includes(normalized))
+		.slice(0, MAX_MATCHES);
+}
+
+/** The exact text both chat and New Workspace insert for a selected command. */
+export function selectedSlashCommandValue(command: SlashCommandInfo): string {
+	return `/${command.name} `;
+}
+
+export type SlashCompletionKeyAction =
+	| { type: "none" }
+	| { type: "move"; index: number }
+	| { type: "select"; index: number }
+	| { type: "dismiss" };
+
+/** Pure keyboard reducer — shared behavior without coupling callers to a particular textarea. */
+export function slashCompletionKeyAction(
+	key: string,
+	open: boolean,
+	activeIndex: number,
+	matchCount: number,
+): SlashCompletionKeyAction {
+	if (!open || matchCount === 0) return { type: "none" };
+	if (key === "ArrowDown") return { type: "move", index: (activeIndex + 1) % matchCount };
+	if (key === "ArrowUp") {
+		return { type: "move", index: (activeIndex - 1 + matchCount) % matchCount };
+	}
+	if (key === "Enter" || key === "Tab") return { type: "select", index: activeIndex };
+	if (key === "Escape") return { type: "dismiss" };
+	return { type: "none" };
+}
+
+interface CompletionKeyEvent {
+	key: string;
+	preventDefault: () => void;
+	stopPropagation: () => void;
+}
+
+/** Shared query, selection, dismissal, and keyboard state for slash-command inputs. */
+export function useSlashCommandCompletion({
+	value,
+	commands,
+	onSelect,
+}: {
+	value: string;
+	commands: readonly SlashCommandInfo[];
+	onSelect: (command: SlashCommandInfo) => void;
+}) {
+	const [activeIndex, setActiveIndex] = useState(0);
+	const [dismissed, setDismissed] = useState(false);
+	const query = slashCommandQuery(value);
+	const matches = matchSlashCommands(value, commands);
+	const open = !dismissed && query !== null && matches.length > 0;
+	const visibleActiveIndex = Math.min(activeIndex, Math.max(0, matches.length - 1));
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: command identity changing is the reset signal
+	useEffect(() => {
+		setActiveIndex(0);
+		setDismissed(false);
+	}, [query, commands]);
+
+	const dismiss = () => setDismissed(true);
+
+	const pick = (command: SlashCommandInfo) => {
+		onSelect(command);
+		dismiss();
+	};
+
+	const handleKeyDown = (event: CompletionKeyEvent): boolean => {
+		const action = slashCompletionKeyAction(event.key, open, visibleActiveIndex, matches.length);
+		if (action.type === "none") return false;
+		event.preventDefault();
+		event.stopPropagation();
+		if (action.type === "move") setActiveIndex(action.index);
+		if (action.type === "dismiss") dismiss();
+		if (action.type === "select") {
+			const command = matches[action.index];
+			if (command) pick(command);
+		}
+		return true;
+	};
+
+	return { activeIndex: visibleActiveIndex, dismiss, handleKeyDown, matches, open, pick };
+}
+
+/** Presentational command list shared by the chat composer and New Workspace prompt. */
+export function SlashCommandMenu({
+	commands,
+	activeIndex,
+	onSelect,
+	className,
+}: {
+	commands: readonly SlashCommandInfo[];
+	activeIndex: number;
+	onSelect: (command: SlashCommandInfo) => void;
+	className?: string;
+}) {
+	return (
+		<div
+			data-testid="slash-menu"
+			className={cn(
+				"max-h-[40vh] w-[min(28rem,90%)] overflow-y-auto rounded-[var(--radius-md)] border border-border2 bg-elevated p-xs shadow-[var(--shadow-md)]",
+				className,
+			)}
+		>
+			{commands.map((command, index) => (
+				<button
+					key={`${command.source}:${command.sourceInfo.path}:${command.name}`}
+					type="button"
+					data-testid="slash-command"
+					data-source={command.source}
+					onClick={() => onSelect(command)}
+					className={cn(
+						"flex w-full items-center gap-sm rounded-[var(--radius-sm)] px-sm py-xs text-left text-sm",
+						index === activeIndex ? "bg-hover text-text" : "text-muted",
+					)}
+				>
+					<span className="font-mono text-text">/{command.name}</span>
+					{command.description ? (
+						<span className="truncate text-xs">{command.description}</span>
+					) : null}
+					<span className="ml-auto shrink-0 text-hint text-xs">
+						{command.source}/{command.sourceInfo.scope}
+					</span>
+				</button>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -72,6 +72,7 @@ export function NewWorkspaceDialog({
 	const [refreshing, setRefreshing] = useState(false);
 	const [prompt, setPrompt] = useState("");
 	const [skillCommands, setSkillCommands] = useState<SlashCommandInfo[]>([]);
+	const [aliasSkills, setAliasSkills] = useState<string[]>([]);
 	const [model, setModel] = useState<WireModel | null>(null);
 	const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>("medium");
 	const [creating, setCreating] = useState(false);
@@ -120,6 +121,23 @@ export function NewWorkspaceDialog({
 		).then((commands) => {
 			if (!cancelled) setSkillCommands(commands);
 		});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, selectedProjectId]);
+
+	// Whether the selected project ships committed skills — a count, so the trust notice is presence-gated
+	// (hidden when there's nothing to trust) and never renders the skills' names before trust.
+	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
+		setAliasSkills([]);
+		getTransport()
+			.request("project.aliasSkills", { projectId: selectedProjectId })
+			.then((names) => {
+				if (!cancelled) setAliasSkills(names);
+			})
+			.catch(() => {});
 		return () => {
 			cancelled = true;
 		};
@@ -332,16 +350,15 @@ export function NewWorkspaceDialog({
 
 				{/* Trust gate: a repo's committed skills (`.claude/skills` …) are attacker-controlled for a clone,
 				    so they load only after an explicit grant. Personal + bundled skills are always on. */}
-				{selectedProject && selectedProject.trusted !== true ? (
+				{selectedProject && selectedProject.trusted !== true && aliasSkills.length > 0 ? (
 					<div
 						data-testid="ws-trust-notice"
 						className="flex w-full items-center gap-sm rounded-[var(--radius-md)] border border-border2 border-l-[3px] border-l-[var(--gold)] bg-[var(--gold-tint)] px-md py-sm text-left"
 					>
 						<TriangleAlert className="size-4 shrink-0 text-gold" />
 						<span className="min-w-0 flex-1 text-sm text-text">
-							Skills this project ships (
-							<span className="font-[var(--font-mono)]">.claude/skills</span> …) stay off until you
-							trust it. Your personal and ThinkRail's built-in skills are unaffected.
+							This project ships {aliasSkills.length} skill{aliasSkills.length === 1 ? "" : "s"} —
+							off until you trust it. Your personal and ThinkRail's built-in skills are unaffected.
 						</span>
 						<Button
 							size="sm"

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -8,6 +8,7 @@ import type {
 import { Box, Check, ChevronDown, GitBranch, RefreshCw, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
+import { SkillsDialog } from "@/chat/SkillsDialog";
 import {
 	SlashCommandMenu,
 	selectedSlashCommandValue,
@@ -77,6 +78,7 @@ export function NewWorkspaceDialog({
 	const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>("medium");
 	const [creating, setCreating] = useState(false);
 	const [trusting, setTrusting] = useState(false);
+	const [manageSkills, setManageSkills] = useState(false);
 	const promptRef = useRef<HTMLTextAreaElement>(null);
 	// The dialog content node — popovers portal into it so their lists stay scrollable under the Dialog's
 	// scroll lock (react-remove-scroll blocks wheel/trackpad on body-portaled content).
@@ -346,6 +348,14 @@ export function NewWorkspaceDialog({
 						onSelect={selectBaseRef}
 						onRefresh={() => void refreshBranches()}
 					/>
+					<button
+						type="button"
+						data-testid="ws-manage-skills"
+						onClick={() => setManageSkills(true)}
+						className="ml-auto text-hint text-xs underline-offset-2 hover:text-text hover:underline"
+					>
+						Manage skills
+					</button>
 				</div>
 
 				{/* Trust gate: a repo's committed skills (`.claude/skills` …) are attacker-controlled for a clone,
@@ -439,6 +449,11 @@ export function NewWorkspaceDialog({
 						</span>
 					</button>
 				</div>
+				<SkillsDialog
+					projectId={selectedProjectId}
+					open={manageSkills}
+					onOpenChange={setManageSkills}
+				/>
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -1,7 +1,19 @@
-import type { BranchList, ThinkingLevel, WireModel, Workspace } from "@thinkrail/contracts";
+import type {
+	BranchList,
+	SlashCommandInfo,
+	ThinkingLevel,
+	WireModel,
+	Workspace,
+} from "@thinkrail/contracts";
 import { Box, Check, ChevronDown, GitBranch, RefreshCw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
+import {
+	SlashCommandMenu,
+	selectedSlashCommandValue,
+	slashCommandCatalogOrEmpty,
+	useSlashCommandCompletion,
+} from "@/chat/SlashCommandCompletion";
 import { ThinkingSelector } from "@/chat/ThinkingSelector";
 import {
 	Command,
@@ -58,6 +70,7 @@ export function NewWorkspaceDialog({
 	const [baseRef, setBaseRef] = useState<string>("");
 	const [refreshing, setRefreshing] = useState(false);
 	const [prompt, setPrompt] = useState("");
+	const [skillCommands, setSkillCommands] = useState<SlashCommandInfo[]>([]);
 	const [model, setModel] = useState<WireModel | null>(null);
 	const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>("medium");
 	const [creating, setCreating] = useState(false);
@@ -65,6 +78,25 @@ export function NewWorkspaceDialog({
 	// The dialog content node — popovers portal into it so their lists stay scrollable under the Dialog's
 	// scroll lock (react-remove-scroll blocks wheel/trackpad on body-portaled content).
 	const [dialogEl, setDialogEl] = useState<HTMLElement | null>(null);
+
+	const focusPromptCaret = (position: number) => {
+		requestAnimationFrame(() => {
+			const input = promptRef.current;
+			if (!input) return;
+			input.focus();
+			input.setSelectionRange(position, position);
+		});
+	};
+
+	const slashCompletion = useSlashCommandCompletion({
+		value: prompt,
+		commands: skillCommands,
+		onSelect: (command) => {
+			const next = selectedSlashCommandValue(command);
+			setPrompt(next);
+			focusPromptCaret(next.length);
+		},
+	});
 
 	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on and any
 	// seed prompt (empty by default).
@@ -74,6 +106,22 @@ export function NewWorkspaceDialog({
 		setPrompt(initialPrompt ?? "");
 		setCreating(false);
 	}, [open, projectId, initialPrompt]);
+
+	// Skills are previewed from the selected project's current checkout; the created worktree/session is
+	// authoritative if its base ref differs. Autocomplete is an enhancement, so failure degrades to empty.
+	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
+		setSkillCommands([]);
+		void slashCommandCatalogOrEmpty(() =>
+			getTransport().request("skill.list", { projectId: selectedProjectId }),
+		).then((commands) => {
+			if (!cancelled) setSkillCommands(commands);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, selectedProjectId]);
 
 	// Models are global to the host — fetch once into the shared store; the picker reads them.
 	useEffect(() => {
@@ -217,6 +265,13 @@ export function NewWorkspaceDialog({
 				hideClose
 				data-testid="new-workspace-dialog"
 				className="max-w-[600px] gap-md p-md"
+				onEscapeKeyDown={(event) => {
+					// Radix handles Escape outside the textarea's React bubble path. Keep the parent dialog open
+					// while completion consumes Escape to dismiss only its menu (even if focus moved elsewhere).
+					if (!slashCompletion.open) return;
+					event.preventDefault();
+					slashCompletion.dismiss();
+				}}
 				onOpenAutoFocus={(e) => {
 					// Land focus on the prompt (the hero), not the first picker Radix would otherwise focus.
 					e.preventDefault();
@@ -250,7 +305,7 @@ export function NewWorkspaceDialog({
 				</div>
 
 				{/* hero: the prompt */}
-				<div className="flex flex-col gap-xs">
+				<div className="relative">
 					<Textarea
 						ref={promptRef}
 						data-testid="ws-prompt"
@@ -261,6 +316,7 @@ export function NewWorkspaceDialog({
 						rows={6}
 						className="min-h-[160px]"
 						onKeyDown={(e) => {
+							if (slashCompletion.handleKeyDown(e)) return;
 							// Enter creates (matching the button's ↵ affordance); Shift+Enter inserts a newline.
 							if (e.key === "Enter" && !e.shiftKey) {
 								e.preventDefault();
@@ -268,7 +324,14 @@ export function NewWorkspaceDialog({
 							}
 						}}
 					/>
-					{prompt.trim() ? (
+					{slashCompletion.open ? (
+						<SlashCommandMenu
+							commands={slashCompletion.matches}
+							activeIndex={slashCompletion.activeIndex}
+							onSelect={slashCompletion.pick}
+							className="absolute top-full left-sm z-50 mt-xs"
+						/>
+					) : prompt.trim() ? (
 						<p data-testid="workspace-naming-hint" className="px-xs text-hint text-xs">
 							ThinkRail will name the workspace and branch from your request.
 						</p>

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -8,6 +8,7 @@ import type {
 import { Box, Check, ChevronDown, GitBranch, RefreshCw, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
+import { SkillsButton } from "@/chat/SkillsButton";
 import { SkillsDialog } from "@/chat/SkillsDialog";
 import {
 	SlashCommandMenu,
@@ -348,14 +349,11 @@ export function NewWorkspaceDialog({
 						onSelect={selectBaseRef}
 						onRefresh={() => void refreshBranches()}
 					/>
-					<button
-						type="button"
-						data-testid="ws-manage-skills"
-						onClick={() => setManageSkills(true)}
-						className="ml-auto text-hint text-xs underline-offset-2 hover:text-text hover:underline"
-					>
-						Manage skills
-					</button>
+					<SkillsButton
+						onOpen={() => setManageSkills(true)}
+						testId="ws-manage-skills"
+						className="ml-auto"
+					/>
 				</div>
 
 				{/* Trust gate: a repo's committed skills (`.claude/skills` …) are attacker-controlled for a clone,

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -5,7 +5,7 @@ import type {
 	WireModel,
 	Workspace,
 } from "@thinkrail/contracts";
-import { Box, Check, ChevronDown, GitBranch, RefreshCw } from "lucide-react";
+import { Box, Check, ChevronDown, GitBranch, RefreshCw, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
 import {
@@ -15,6 +15,7 @@ import {
 	useSlashCommandCompletion,
 } from "@/chat/SlashCommandCompletion";
 import { ThinkingSelector } from "@/chat/ThinkingSelector";
+import { Button } from "@/components/ui/button";
 import {
 	Command,
 	CommandEmpty,
@@ -74,6 +75,7 @@ export function NewWorkspaceDialog({
 	const [model, setModel] = useState<WireModel | null>(null);
 	const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>("medium");
 	const [creating, setCreating] = useState(false);
+	const [trusting, setTrusting] = useState(false);
 	const promptRef = useRef<HTMLTextAreaElement>(null);
 	// The dialog content node — popovers portal into it so their lists stay scrollable under the Dialog's
 	// scroll lock (react-remove-scroll blocks wheel/trackpad on body-portaled content).
@@ -256,6 +258,30 @@ export function NewWorkspaceDialog({
 		}
 	};
 
+	// Grant the project trust, then re-preview: the skill effect keys off open/project only, so a grant
+	// wouldn't otherwise refresh the catalog. The updated project is folded back into the store so the
+	// notice clears (trust rides `Project` through the wire).
+	const trustProject = async () => {
+		if (trusting) return;
+		setTrusting(true);
+		try {
+			const updated = await getTransport().request("project.setTrust", {
+				id: selectedProjectId,
+				trusted: true,
+			});
+			const store = useAppStore.getState();
+			store.setProjects(store.projects.map((p) => (p.id === updated.id ? updated : p)));
+			const commands = await slashCommandCatalogOrEmpty(() =>
+				getTransport().request("skill.list", { projectId: selectedProjectId }),
+			);
+			setSkillCommands(commands);
+		} catch (err) {
+			toast.error(errorText(err), "Couldn't trust project");
+		} finally {
+			setTrusting(false);
+		}
+	};
+
 	const selectedProject = projects.find((p) => p.id === selectedProjectId);
 
 	return (
@@ -304,6 +330,31 @@ export function NewWorkspaceDialog({
 					/>
 				</div>
 
+				{/* Trust gate: a repo's committed skills (`.claude/skills` …) are attacker-controlled for a clone,
+				    so they load only after an explicit grant. Personal + bundled skills are always on. */}
+				{selectedProject && selectedProject.trusted !== true ? (
+					<div
+						data-testid="ws-trust-notice"
+						className="flex w-full items-center gap-sm rounded-[var(--radius-md)] border border-border2 border-l-[3px] border-l-[var(--gold)] bg-[var(--gold-tint)] px-md py-sm text-left"
+					>
+						<TriangleAlert className="size-4 shrink-0 text-gold" />
+						<span className="min-w-0 flex-1 text-sm text-text">
+							Skills this project ships (
+							<span className="font-[var(--font-mono)]">.claude/skills</span> …) stay off until you
+							trust it. Your personal and ThinkRail's built-in skills are unaffected.
+						</span>
+						<Button
+							size="sm"
+							data-testid="ws-trust-project"
+							disabled={trusting}
+							onClick={() => void trustProject()}
+							className="shrink-0"
+						>
+							Trust project
+						</Button>
+					</div>
+				) : null}
+
 				{/* hero: the prompt */}
 				<div className="relative">
 					<Textarea
@@ -335,7 +386,12 @@ export function NewWorkspaceDialog({
 						<p data-testid="workspace-naming-hint" className="px-xs text-hint text-xs">
 							ThinkRail will name the workspace and branch from your request.
 						</p>
-					) : null}
+					) : (
+						<p className="mt-xs text-hint text-xs">
+							Type <span className="font-[var(--font-mono)]">/</span> for a project skill —
+							previewed from the current checkout; the created workspace's session is authoritative.
+						</p>
+					)}
 				</div>
 
 				{/* controls-bottom: model + effort (left), Create (right) */}

--- a/apps/web/src/panels/ProjectSkillsNotice.tsx
+++ b/apps/web/src/panels/ProjectSkillsNotice.tsx
@@ -1,0 +1,110 @@
+import type { Project } from "@thinkrail/contracts";
+import { ShieldCheck, TriangleAlert } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { toast, useAppStore } from "@/store";
+import { errorText, getTransport } from "@/transport";
+
+/**
+ * The per-project trust + new-skill surface for pre-workspace contexts (the Welcome view). **Presence-
+ * gated:** renders nothing unless the project's checkout actually ships committed alias skills, and shows a
+ * COUNT — never the skills' (attacker-controlled) names/descriptions — before trust. Granting trust
+ * acknowledges the skills present now; ones that appear later (a pull/branch) surface a "review" affordance
+ * that acknowledges them. Grants/acks echo the updated `Project` back, which we fold into the store.
+ */
+export function ProjectSkillsNotice({ projectId }: { projectId: string }) {
+	const project = useAppStore((s) => s.projects.find((p) => p.id === projectId));
+	const [aliasSkills, setAliasSkills] = useState<string[] | null>(null);
+	const [busy, setBusy] = useState(false);
+
+	// The committed alias skills present in the project's current checkout (a count only — degrades to none).
+	useEffect(() => {
+		let cancelled = false;
+		setAliasSkills(null);
+		getTransport()
+			.request("project.aliasSkills", { projectId })
+			.then((names) => {
+				if (!cancelled) setAliasSkills(names);
+			})
+			.catch(() => {
+				if (!cancelled) setAliasSkills([]);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [projectId]);
+
+	if (!project || !aliasSkills || aliasSkills.length === 0) return null;
+
+	const trusted = project.trusted === true;
+	const acknowledged = new Set(project.acknowledgedSkills ?? []);
+	const pending = trusted ? aliasSkills.filter((name) => !acknowledged.has(name)) : [];
+	const count = aliasSkills.length;
+	const plural = (n: number) => (n === 1 ? "" : "s");
+
+	const applyProject = (updated: Project) => {
+		const store = useAppStore.getState();
+		store.setProjects(store.projects.map((p) => (p.id === updated.id ? updated : p)));
+	};
+
+	const run = async (request: () => Promise<Project>, failure: string) => {
+		if (busy) return;
+		setBusy(true);
+		try {
+			applyProject(await request());
+		} catch (err) {
+			toast.error(errorText(err), failure);
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	// Trusted with nothing new pending → a quiet confirmation line, no action.
+	if (trusted && pending.length === 0) {
+		return (
+			<p
+				data-testid="project-skills-notice"
+				data-state="trusted"
+				className="mt-lg flex items-center gap-xs text-hint text-xs"
+			>
+				<ShieldCheck className="size-3.5 shrink-0 text-gold" />
+				{count} project skill{plural(count)} trusted.
+			</p>
+		);
+	}
+
+	const isPending = trusted && pending.length > 0;
+	return (
+		<div
+			data-testid="project-skills-notice"
+			data-state={isPending ? "pending" : "untrusted"}
+			className="mt-lg flex w-full max-w-[560px] items-center gap-sm rounded-[var(--radius-md)] border border-border2 border-l-[3px] border-l-[var(--gold)] bg-[var(--gold-tint)] px-md py-sm text-left"
+		>
+			<TriangleAlert className="size-4 shrink-0 text-gold" />
+			<span className="min-w-0 flex-1 text-sm text-text">
+				{isPending
+					? `${pending.length} new skill${plural(pending.length)} appeared since you trusted this project.`
+					: `This project ships ${count} skill${plural(count)} — off until you trust it.`}
+			</span>
+			<Button
+				size="sm"
+				data-testid={isPending ? "project-ack-button" : "project-trust-button"}
+				disabled={busy}
+				onClick={() =>
+					void run(
+						isPending
+							? () =>
+									getTransport().request("project.acknowledgeSkills", {
+										id: projectId,
+										names: pending,
+									})
+							: () => getTransport().request("project.setTrust", { id: projectId, trusted: true }),
+						isPending ? "Couldn't confirm skills" : "Couldn't trust project",
+					)
+				}
+			>
+				{isPending ? "Review & enable" : "Trust project"}
+			</Button>
+		</div>
+	);
+}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -90,10 +90,11 @@ Beneath it, **`ProjectSkillsNotice`** is the pre-workspace trust surface (so tru
 workspace yet): **presence-gated** — renders nothing unless the selected project ships committed skills —
 showing a **count** ("ships N skills → *Trust project*"), a "N new → *Review & enable*" state for skills that
 appeared after trust (`project.acknowledgeSkills`), else a quiet "N trusted" line. It never renders the
-skills' (attacker-controlled) names before trust. Alongside it a **"Manage skills"** opener mounts
-`chat/SkillsDialog` in **project mode** (no workspace) — the full manager (trust + group/skill toggles) with
-no session yet; New Workspace mounts the same opener. This is the pre-session half of the user's skill
-settings; the chat header opens it in workspace mode (with Reload).
+skills' (attacker-controlled) names before trust. The full manager (`chat/SkillsDialog` in **project mode**
+— trust + group/skill toggles, no session yet) is reached from **New Workspace**, whose opener is the shared
+`chat/SkillsButton` primitive (so it cannot drift from the chat header's Skills trigger). This is the
+pre-session half of the user's skill settings; the chat header opens the same dialog in workspace mode
+(with Reload).
 
 **`NewWorkspaceDialog`** is the create-and-kick-off surface. It names the operation visibly — title
 **“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -85,6 +85,13 @@ CTA that opens Settings → Providers (`store.openSettings("providers")`). It re
 provider is "connected" iff any `configured`) on mount and re-checks whenever the settings dialog toggles, so
 it disappears the moment the user connects one; a transport error degrades to *not* nagging (offline ≠ "no
 provider"). All provider **management** lives in Settings, not here (the always-on strip is gone).
+
+Beneath it, **`ProjectSkillsNotice`** is the pre-workspace trust surface (so trust is reachable with no
+workspace yet): **presence-gated** — renders nothing unless the selected project ships committed skills —
+showing a **count** ("ships N skills → *Trust project*"), a "N new → *Review & enable*" state for skills that
+appeared after trust (`project.acknowledgeSkills`), else a quiet "N trusted" line. It never renders the
+skills' (attacker-controlled) names before trust. The full per-skill manager lives in `chat/SkillsDialog`.
+
 **`NewWorkspaceDialog`** is the create-and-kick-off surface. It names the operation visibly — title
 **“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new
 branch. Files, chats, changes, and terminals stay scoped to it.”** Its base-branch trigger reads **“From
@@ -101,10 +108,10 @@ a project picker, the prompt hero, and the reused
   project's **current checkout** plus personal/bundled sources, selecting one inserts `/skill:<name> `;
   failure degrades silently to no menu. Up/Down navigate, Enter/Tab select, Escape dismisses. A caption under
   the prompt marks the preview as **from the current checkout** (the created worktree's session catalog is
-  authoritative if the selected base branch differs). An **untrusted** selected project shows a **trust
-  notice** with a *Trust project* button — the repo's committed skills stay withheld until granted
-  (`project.setTrust`, which folds the updated project back into the store and re-previews); personal +
-  bundled skills show regardless. When the menu is closed, **Enter creates** (matching the Create button's
+  authoritative if the selected base branch differs). When the selected project is **untrusted AND ships
+  committed skills** (a count from `project.aliasSkills`, never their names), a **trust notice** shows a
+  *Trust project* button — the repo's skills stay withheld until granted (`project.setTrust`, which folds the
+  updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter creates** (matching the Create button's
   `↵` affordance) and
   **Shift+Enter** inserts a newline. Create = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
   `session.create({ model, thinkingLevel })` + fire-and-forget `prompt`; with an empty prompt it just

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -97,11 +97,15 @@ a project picker, the prompt hero, and the reused
   default via `model.default` so the exact model shows (values held in dialog state, applied at create
   time). The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll
   lock). On open and project-picker changes, the dialog reads **`skill.list({projectId})`** and feeds the
-  result to chat's shared slash-completion primitive: a leading `/` autocompletes portable skills from the
-  selected project's **current checkout** plus personal/bundled sources, selecting one inserts
-  `/skill:<name> `; failure degrades silently to no menu. Up/Down navigate, Enter/Tab select, Escape
-  dismisses. The created worktree's real session catalog is authoritative if the selected base branch
-  differs. When the menu is closed, **Enter creates** (matching the Create button's `↵` affordance) and
+  result to chat's shared slash-completion primitive: a leading `/` autocompletes skills from the selected
+  project's **current checkout** plus personal/bundled sources, selecting one inserts `/skill:<name> `;
+  failure degrades silently to no menu. Up/Down navigate, Enter/Tab select, Escape dismisses. A caption under
+  the prompt marks the preview as **from the current checkout** (the created worktree's session catalog is
+  authoritative if the selected base branch differs). An **untrusted** selected project shows a **trust
+  notice** with a *Trust project* button — the repo's committed skills stay withheld until granted
+  (`project.setTrust`, which folds the updated project back into the store and re-previews); personal +
+  bundled skills show regardless. When the menu is closed, **Enter creates** (matching the Create button's
+  `↵` affordance) and
   **Shift+Enter** inserts a newline. Create = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
   `session.create({ model, thinkingLevel })` + fire-and-forget `prompt`; with an empty prompt it just
   creates the workspace. A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -90,7 +90,10 @@ Beneath it, **`ProjectSkillsNotice`** is the pre-workspace trust surface (so tru
 workspace yet): **presence-gated** — renders nothing unless the selected project ships committed skills —
 showing a **count** ("ships N skills → *Trust project*"), a "N new → *Review & enable*" state for skills that
 appeared after trust (`project.acknowledgeSkills`), else a quiet "N trusted" line. It never renders the
-skills' (attacker-controlled) names before trust. The full per-skill manager lives in `chat/SkillsDialog`.
+skills' (attacker-controlled) names before trust. Alongside it a **"Manage skills"** opener mounts
+`chat/SkillsDialog` in **project mode** (no workspace) — the full manager (trust + group/skill toggles) with
+no session yet; New Workspace mounts the same opener. This is the pre-session half of the user's skill
+settings; the chat header opens it in workspace mode (with Reload).
 
 **`NewWorkspaceDialog`** is the create-and-kick-off surface. It names the operation visibly — title
 **“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -96,7 +96,12 @@ a project picker, the prompt hero, and the reused
   `chat/ModelSelector`+`ThinkingSelector` in **pre-session** mode — preselected to the host's resolved
   default via `model.default` so the exact model shows (values held in dialog state, applied at create
   time). The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll
-  lock). In the prompt hero, **Enter creates** (matching the Create button's `↵` affordance) and
+  lock). On open and project-picker changes, the dialog reads **`skill.list({projectId})`** and feeds the
+  result to chat's shared slash-completion primitive: a leading `/` autocompletes portable skills from the
+  selected project's **current checkout** plus personal/bundled sources, selecting one inserts
+  `/skill:<name> `; failure degrades silently to no menu. Up/Down navigate, Enter/Tab select, Escape
+  dismisses. The created worktree's real session catalog is authoritative if the selected base branch
+  differs. When the menu is closed, **Enter creates** (matching the Create button's `↵` affordance) and
   **Shift+Enter** inserts a newline. Create = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
   `session.create({ model, thinkingLevel })` + fire-and-forget `prompt`; with an empty prompt it just
   creates the workspace. A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -1,7 +1,6 @@
 import type { Workspace } from "@thinkrail/contracts";
 import { Folder, FolderOpen, type LucideIcon, Rocket, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, forwardRef, useEffect, useState } from "react";
-import { SkillsDialog } from "@/chat/SkillsDialog";
 import { cn } from "@/lib/utils";
 import { PRODUCT_NAME } from "../constants/branding";
 import { useAppStore } from "../store";
@@ -36,8 +35,6 @@ export function WelcomePanel() {
 	// requested only for this one project, on demand, never eagerly for every project on connect).
 	// null = pending/unknown (cards wait for it).
 	const [hasSpecs, setHasSpecs] = useState<boolean | null>(null);
-	// The project-scoped Skills manager (trust + group/skill toggles), reachable with no workspace yet.
-	const [manageSkills, setManageSkills] = useState(false);
 
 	// The project the has-specs states key off — the selected one, else the most-recent (list is sorted).
 	const project = projects.find((p) => p.id === selectedProjectId) ?? projects[0] ?? null;
@@ -131,19 +128,7 @@ export function WelcomePanel() {
 			</p>
 
 			<ProviderWarningBanner />
-			{project ? (
-				<>
-					<ProjectSkillsNotice projectId={project.id} />
-					<button
-						type="button"
-						data-testid="welcome-manage-skills"
-						onClick={() => setManageSkills(true)}
-						className="mt-sm text-hint text-xs underline-offset-2 hover:text-text hover:underline"
-					>
-						Manage skills
-					</button>
-				</>
-			) : null}
+			{project ? <ProjectSkillsNotice projectId={project.id} /> : null}
 
 			<div className="mt-xl flex flex-wrap justify-center gap-md">
 				{noProjects ? (
@@ -194,9 +179,6 @@ export function WelcomePanel() {
 				/>
 			) : null}
 			{dialogs}
-			{project ? (
-				<SkillsDialog projectId={project.id} open={manageSkills} onOpenChange={setManageSkills} />
-			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -1,6 +1,7 @@
 import type { Workspace } from "@thinkrail/contracts";
 import { Folder, FolderOpen, type LucideIcon, Rocket, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, forwardRef, useEffect, useState } from "react";
+import { SkillsDialog } from "@/chat/SkillsDialog";
 import { cn } from "@/lib/utils";
 import { PRODUCT_NAME } from "../constants/branding";
 import { useAppStore } from "../store";
@@ -35,6 +36,8 @@ export function WelcomePanel() {
 	// requested only for this one project, on demand, never eagerly for every project on connect).
 	// null = pending/unknown (cards wait for it).
 	const [hasSpecs, setHasSpecs] = useState<boolean | null>(null);
+	// The project-scoped Skills manager (trust + group/skill toggles), reachable with no workspace yet.
+	const [manageSkills, setManageSkills] = useState(false);
 
 	// The project the has-specs states key off — the selected one, else the most-recent (list is sorted).
 	const project = projects.find((p) => p.id === selectedProjectId) ?? projects[0] ?? null;
@@ -128,7 +131,19 @@ export function WelcomePanel() {
 			</p>
 
 			<ProviderWarningBanner />
-			{project ? <ProjectSkillsNotice projectId={project.id} /> : null}
+			{project ? (
+				<>
+					<ProjectSkillsNotice projectId={project.id} />
+					<button
+						type="button"
+						data-testid="welcome-manage-skills"
+						onClick={() => setManageSkills(true)}
+						className="mt-sm text-hint text-xs underline-offset-2 hover:text-text hover:underline"
+					>
+						Manage skills
+					</button>
+				</>
+			) : null}
 
 			<div className="mt-xl flex flex-wrap justify-center gap-md">
 				{noProjects ? (
@@ -179,6 +194,9 @@ export function WelcomePanel() {
 				/>
 			) : null}
 			{dialogs}
+			{project ? (
+				<SkillsDialog projectId={project.id} open={manageSkills} onOpenChange={setManageSkills} />
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "../store";
 import { getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { ProjectSkillsNotice } from "./ProjectSkillsNotice";
 import { ProviderWarningBanner } from "./ProviderWarningBanner";
 import { useOpenProject } from "./useOpenProject";
 
@@ -127,6 +128,7 @@ export function WelcomePanel() {
 			</p>
 
 			<ProviderWarningBanner />
+			{project ? <ProjectSkillsNotice projectId={project.id} /> : null}
 
 			<div className="mt-xl flex flex-wrap justify-center gap-md">
 				{noProjects ? (

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -21,6 +21,7 @@ const BASE = `http://localhost:${PORT}`;
 const DATA_DIR = join(tmpdir(), "thinkrail-e2e-restart");
 const REPO = join(DATA_DIR, "sample-project");
 const AGENT_DIR = join(DATA_DIR, "pi-agent");
+const HOME_DIR = join(DATA_DIR, "home");
 const PICK_POINTER = join(DATA_DIR, "pick-dir");
 // Outside DATA_DIR so a failed run's teardown doesn't destroy the post-mortem trail.
 const HOST_LOG = join(tmpdir(), "thinkrail-e2e-restart-host.log");
@@ -32,6 +33,7 @@ function seedState(): void {
 	rmSync(DATA_DIR, { recursive: true, force: true });
 	rmSync(HOST_LOG, { force: true });
 	mkdirSync(REPO, { recursive: true });
+	mkdirSync(HOME_DIR, { recursive: true });
 	const git = (...args: string[]) =>
 		execFileSync("git", ["-C", REPO, ...args], { stdio: "ignore" });
 	git("init", "-b", "main");
@@ -65,6 +67,10 @@ async function startHost(): Promise<void> {
 			THINKRAIL_DATA_DIR: DATA_DIR,
 			THINKRAIL_PICK_DIR: PICK_POINTER,
 			THINKRAIL_GH_OFFLINE: "1",
+			HOME: HOME_DIR,
+			CLAUDE_CONFIG_DIR: join(HOME_DIR, ".claude"),
+			CODEX_HOME: join(HOME_DIR, ".codex"),
+			GEMINI_CLI_HOME: HOME_DIR,
 			PI_CODING_AGENT_DIR: AGENT_DIR,
 		},
 	});

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -8,6 +8,13 @@ import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 /** Create a workspace, open a chat tab in it, and wait for the composer to mount. */
 async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await openFixtureProject(page);
+	// The fixture ships a committed `.claude/skills` alias; trust the project so the live session loads it
+	// (project-scoped aliases are gated behind trust). Open the dialog, grant, then create through it.
+	await page.getByTestId("add-workspace").first().click();
+	const trustDialog = page.getByTestId("new-workspace-dialog");
+	await expect(trustDialog).toBeVisible();
+	await trustDialog.getByTestId("ws-trust-project").click();
+	await expect(trustDialog.getByTestId("ws-trust-notice")).toBeHidden();
 	await createWorkspaceViaDialog(page);
 	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
 	await page.getByTestId("start-chat").click();

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -47,7 +47,7 @@ test("composer prompt is moderately tall with model and effort controls undernea
 	expect(sendBox.y).toBeGreaterThanOrEqual(belowInputY);
 });
 
-test("model picker lists models and @-mention completes a worktree file", {
+test("model picker plus file and portable-skill completion use the live session catalog", {
 	tag: "@agent",
 }, async ({ page }) => {
 	await openChat(page);
@@ -70,12 +70,27 @@ test("model picker lists models and @-mention completes a worktree file", {
 	await expect(page.getByTestId("session-stats")).toBeVisible();
 	await expect(page.getByTestId("session-stats")).toContainText(/tok/);
 
+	// The worktree session is authoritative and discovers the fixture's Claude-compatible project alias.
+	const input = page.getByTestId("chat-input");
+	await input.fill("/e2e");
+	const portableSkill = page
+		.getByTestId("slash-command")
+		.filter({ hasText: "/skill:e2e-portable" });
+	await expect(portableSkill).toBeVisible();
+	await expect(portableSkill).toContainText("skill/project");
+	await input.press("Tab");
+	await expect(input).toHaveValue("/skill:e2e-portable ");
+	// Selection restores focus/caret on the next animation frame; let that settle before replacing the value.
+	await input.evaluate(
+		() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+	);
+
 	// Composer @-mention: typing `@RE` lists the worktree's README.md and picking it inserts the path.
-	await page.getByTestId("chat-input").fill("@RE");
+	await input.fill("@RE");
 	const mention = page.getByTestId("mention-item").filter({ hasText: "README.md" });
 	await expect(mention).toBeVisible();
 	await mention.click();
-	await expect(page.getByTestId("chat-input")).toHaveValue(/@README\.md/);
+	await expect(input).toHaveValue(/@README\.md/);
 });
 
 test("stats refresh after a turn completes (cheap win #3)", { tag: "@agent" }, async ({ page }) => {

--- a/e2e/fixtures/paths.ts
+++ b/e2e/fixtures/paths.ts
@@ -4,6 +4,9 @@ import { join } from "node:path";
 /** Isolated on-disk state for an e2e run — so tests never touch the user's real ~/.thinkrail. */
 export const E2E_DATA_DIR = join(tmpdir(), "thinkrail-e2e");
 
+/** Isolated HOME so cross-agent skill discovery never reads a developer's real personal libraries. */
+export const E2E_HOME_DIR = join(E2E_DATA_DIR, "home");
+
 /** A throwaway git repo (created in global setup) used as a "project" fixture. Lives under the data dir. */
 export const E2E_FIXTURE_REPO = join(E2E_DATA_DIR, "sample-project");
 

--- a/e2e/fixtures/repo.ts
+++ b/e2e/fixtures/repo.ts
@@ -21,7 +21,8 @@ export function fixtureRepoHealthy(): boolean {
 /**
  * (Re)create the shared fixture repo: a throwaway git repo carrying the seed files every suite opens as a
  * "project" — README + a non-markdown file, the markdown-preview demos (alerts/links + a real PNG), and a
- * small seed spec graph (root + one child). Extracted so global setup seeds it once and per-test
+ * small seed spec graph (root + one child), and a portable Claude-compatible skill. Extracted so global
+ * setup seeds it once and per-test
  * `resetState` can re-seed it if a flaky `@agent` run damaged the shared repo — bounding the blast radius to
  * that one spec instead of cascading into every later test's reset.
  */
@@ -105,6 +106,13 @@ export function seedFixtureRepo(): void {
 	writeFileSync(
 		join(E2E_FIXTURE_REPO, "module-a", "SPEC.md"),
 		"---\nid: sample-module\ntype: module-design\nstatus: active\ntitle: Sample Module\nparent: sample-root\n---\n\n## Responsibility\n\nA fixture module spec, child of sample-root.\n",
+	);
+	// A portable project alias used by the no-agent New Workspace autocomplete test.
+	const skillDir = join(E2E_FIXTURE_REPO, ".claude", "skills", "e2e-portable");
+	mkdirSync(skillDir, { recursive: true });
+	writeFileSync(
+		join(skillDir, "SKILL.md"),
+		"---\nname: e2e-portable\ndescription: Portable e2e fixture skill\n---\n\n# Portable skill\n",
 	);
 	git("add", "-A");
 	git("commit", "-m", "init");

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import {
 	E2E_DATA_DIR,
 	E2E_FIXTURE_REPO,
+	E2E_HOME_DIR,
 	E2E_PI_AGENT_DIR,
 	E2E_PI_MODELS_SEED,
 	E2E_PICK_DIR_POINTER,
@@ -14,6 +15,7 @@ import { seedFixtureRepo } from "./fixtures/repo";
 export default function globalSetup(): void {
 	rmSync(E2E_DATA_DIR, { recursive: true, force: true });
 	mkdirSync(E2E_DATA_DIR, { recursive: true });
+	mkdirSync(E2E_HOME_DIR, { recursive: true });
 
 	// Isolated pi agent dir: copy the user's provider/auth config so a real provider works (the `@agent`
 	// suite needs it — auth lives across BOTH `auth.json` (OAuth providers) and `models.json` (providers

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -3,5 +3,7 @@ import { E2E_DATA_DIR } from "./fixtures/paths";
 
 /** Remove the isolated state/fixtures dir after the suite — leave nothing behind. */
 export default function globalTeardown(): void {
-	rmSync(E2E_DATA_DIR, { recursive: true, force: true });
+	// Playwright tears the webServer down alongside global teardown; retry ENOTEMPTY if the host finishes a
+	// final isolated-state write while `rmSync` is walking the tree.
+	rmSync(E2E_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 }

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -83,16 +83,25 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
 });
 
-test("project skill autocomplete selects before Enter can create", async ({ page }) => {
+test("a project's committed skills are gated behind trust, then autocomplete", async ({ page }) => {
 	await openFixtureProject(page);
 
 	await page.getByTestId("add-workspace").first().click();
 	const dialog = page.getByTestId("new-workspace-dialog");
 	await expect(dialog).toBeVisible();
 	const prompt = dialog.getByTestId("ws-prompt");
-
-	await prompt.fill("/e2e");
 	const portable = dialog.getByTestId("slash-command").filter({ hasText: "/skill:e2e-portable" });
+
+	// A freshly-opened project is untrusted (`resetState` wipes projects.json): the trust notice shows and
+	// the fixture's committed `.claude/skills/e2e-portable` alias is withheld — its prefix surfaces nothing.
+	await expect(dialog.getByTestId("ws-trust-notice")).toBeVisible();
+	await prompt.fill("/e2e");
+	await expect(portable).toHaveCount(0);
+
+	// Grant trust → the notice clears and the project skill becomes available (truthful `skill/project`).
+	await dialog.getByTestId("ws-trust-project").click();
+	await expect(dialog.getByTestId("ws-trust-notice")).toBeHidden();
+	await prompt.fill("/e2e");
 	await expect(portable).toBeVisible();
 	await expect(portable).toContainText("skill/project");
 

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -83,6 +83,33 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
 });
 
+test("project skill autocomplete selects before Enter can create", async ({ page }) => {
+	await openFixtureProject(page);
+
+	await page.getByTestId("add-workspace").first().click();
+	const dialog = page.getByTestId("new-workspace-dialog");
+	await expect(dialog).toBeVisible();
+	const prompt = dialog.getByTestId("ws-prompt");
+
+	await prompt.fill("/e2e");
+	const portable = dialog.getByTestId("slash-command").filter({ hasText: "/skill:e2e-portable" });
+	await expect(portable).toBeVisible();
+	await expect(portable).toContainText("skill/project");
+
+	// Escape dismisses completion rather than closing the parent dialog; changing the query reopens it.
+	await prompt.press("Escape");
+	await expect(dialog.getByTestId("slash-menu")).toBeHidden();
+	await expect(dialog).toBeVisible();
+	await prompt.fill("/e2");
+	await expect(portable).toBeVisible();
+
+	// Completion gets keyboard priority over the dialog's Enter-to-create behavior.
+	await prompt.press("Enter");
+	await expect(prompt).toHaveValue("/skill:e2e-portable ");
+	await expect(dialog).toBeVisible();
+	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+});
+
 test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page }) => {
 	await openFixtureProject(page);
 

--- a/e2e/workflows/SPEC.md
+++ b/e2e/workflows/SPEC.md
@@ -17,7 +17,9 @@ strict verdict model. Run on demand via `bun run test:workflows` (own Playwright
 isolated `PI_CODING_AGENT_DIR` + pinned model, which `env.ts` then clones **per worker process**
 (pid-suffixed, auth + settings copied in): workers must never share one agent dir — a dying worker's
 session dispose overlapping the next worker's newborn session in the shared `sessions/` tree turned
-one failure into an ENOENT cascade across every later live-session test). Needs pi auth and spends real provider tokens — never
+one failure into an ENOENT cascade across every later live-session test. `env.ts` also sets an isolated
+`HOME`/vendor-home set so portable skill discovery never reads a developer's personal libraries. Needs
+pi auth and spends real provider tokens — never
 part of `bun run test`, pre-commit, CI gates, or the browser `e2e`/`e2e:agent` scripts (the main
 config `testIgnore`s this directory).
 
@@ -35,7 +37,8 @@ Adding a workflow test = one `defineScenario` call: `{ name, skill, workspace, p
 user?, dialog?, stopWhen?, forbid?, watchdog?, expect, judge?, record? }`.
 
 - `session` — lifecycle over the production `@thinkrail/server/agent` barrel (`createSession` etc.);
-  sets `PI_CODING_AGENT_DIR` before the pi runtime initializes (`env.ts`, imported first); an abort
+  sets `PI_CODING_AGENT_DIR`, `HOME`, and supported vendor-home overrides before the pi runtime initializes
+  (`env.ts`, imported first); an abort
   from a stop-signal is an expected outcome — but only a *requested* one (`promptTurn` swallows an
   abort-shaped error solely when the caller confirms a signal/budget asked for it; an unrequested
   "aborted" is a provider/network crash and rethrows). Never `setModel`.

--- a/e2e/workflows/harness/env.ts
+++ b/e2e/workflows/harness/env.ts
@@ -9,9 +9,12 @@
 // worker's session dispose overlapped the next worker's newborn session in the SAME tree, and one
 // failure cascaded into ENOENT crashes for every later live-session test. A pid-suffixed clone makes
 // cross-process interaction impossible by construction; the throwaway clones die with E2E_DATA_DIR.
+//
+// HOME + vendor-home isolation: HOME and the vendor config-dir env vars point at an isolated home so
+// portable skill discovery never reads a developer's personal libraries.
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { E2E_PI_AGENT_DIR } from "../../fixtures/paths";
+import { E2E_HOME_DIR, E2E_PI_AGENT_DIR } from "../../fixtures/paths";
 
 const workerAgentDir = `${E2E_PI_AGENT_DIR}-w${process.pid}`;
 mkdirSync(workerAgentDir, { recursive: true });
@@ -20,4 +23,8 @@ for (const file of ["auth.json", "models.json", "settings.json"]) {
 	if (existsSync(src)) copyFileSync(src, join(workerAgentDir, file));
 }
 
+process.env.HOME = E2E_HOME_DIR;
+process.env.CLAUDE_CONFIG_DIR = `${E2E_HOME_DIR}/.claude`;
+process.env.CODEX_HOME = `${E2E_HOME_DIR}/.codex`;
+process.env.GEMINI_CLI_HOME = E2E_HOME_DIR;
 process.env.PI_CODING_AGENT_DIR = workerAgentDir;

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -29,7 +29,9 @@ The shell is built first, `pi` connected last:
 - **Center**: a tabbed area — Monaco file tabs + (once `pi` lands) chat tabs.
 - **Right**: an All-files tree of the active worktree + a Changes (git diff) tab; terminals below,
   scoped to the worktree.
-- Cheap wins `pi` already emits: per-session model pick (#1), token/cost display (#3), skill catalog (#2).
+- Cheap wins `pi` already emits: per-session model pick (#1), token/cost display (#3), and skill
+  catalog/autocomplete (#2), including read-through reuse of portable Agent Skills a user already keeps
+  for major coding agents — Pi remains the parser/runtime; no copying or vendor-semantic emulation.
 - Multiple chat sessions per workspace, streaming concurrently (#5).
 - A bundled **spec-graph** pi extension (`pi-spec-graph`): the agent searches, navigates, and manages
   the project's specs via `spec_*` tools + a skill.

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -31,7 +31,9 @@ The shell is built first, `pi` connected last:
   scoped to the worktree.
 - Cheap wins `pi` already emits: per-session model pick (#1), token/cost display (#3), and skill
   catalog/autocomplete (#2), including read-through reuse of portable Agent Skills a user already keeps
-  for major coding agents — Pi remains the parser/runtime; no copying or vendor-semantic emulation.
+  for major coding agents — Pi remains the parser/runtime; no copying or vendor-semantic emulation. A
+  repo's **committed** skill aliases load only after an explicit **per-project trust** grant (a clone's are
+  attacker-controlled); personal + bundled skills load regardless.
 - Multiple chat sessions per workspace, streaming concurrently (#5).
 - A bundled **spec-graph** pi extension (`pi-spec-graph`): the agent searches, navigates, and manages
   the project's specs via `spec_*` tools + a skill.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -50,7 +50,8 @@ of the host.
   - **`SessionEventPayload`** (`{ sessionId, event: PiEvent }`) — the `pi.event` push frame.
   - the cheap-win mirrors (declared in the Node-only `pi-coding-agent`): **`SessionStats`** + **`ContextUsage`**
     (tokens/cost/context bar — display only) and **`SlashCommandInfo`** + **`SlashCommandSourceInfo`** (the
-    skill catalog).
+    command/skill autocomplete catalog, returned by live `session.getCommands` and skill-only pre-session
+    `skill.list`).
   - **`SessionSummary`** — a chat session as the host reports it for hydration (read side); `live`
     distinguishes an in-memory session (auto-restored) from a disk-only one (surfaced in chat-history,
     re-opened on demand). `session.getMessages` returns `{ summary, messages }` (the transcript is
@@ -124,6 +125,8 @@ of the host.
   correlated by `loginId` / **`loginCancel`** / **`logout`** /
   the **JetBrains AI** trio **`jbcentralConnect`** (wire Claude+GPT via the jbcentral proxy → a
   `JbcentralConnectResult`) / **`jbcentralDisconnect`** / **`jbcentralLogin`** (launch `central login`)) /
+  **`skill.list`** (a pre-session, skill-only `SlashCommandInfo[]` preview for a `projectId`, resolved
+  from that project's current checkout; the eventual worktree session is authoritative) /
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -51,7 +51,8 @@ of the host.
   - the cheap-win mirrors (declared in the Node-only `pi-coding-agent`): **`SessionStats`** + **`ContextUsage`**
     (tokens/cost/context bar — display only) and **`SlashCommandInfo`** + **`SlashCommandSourceInfo`** (the
     command/skill autocomplete catalog, returned by live `session.getCommands` and skill-only pre-session
-    `skill.list`).
+    `skill.list`), and **`SkillCatalogEntry`** + **`SkillDecision`** (`load`/`untrusted`/`pending-ack`/
+    `disabled`) — the workspace Skills manager's `skills.state` rows.
   - **`SessionSummary`** — a chat session as the host reports it for hydration (read side); `live`
     distinguishes an in-memory session (auto-restored) from a disk-only one (surfaced in chat-history,
     re-opened on demand). `session.getMessages` returns `{ summary, messages }` (the transcript is
@@ -77,8 +78,10 @@ of the host.
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
     rationale); the chat renders the questionnaire **inline** and replies via `session.answerQuestion`
     (correlated by the tool call id; rejected loud when the call is unknown/answered/superseded).
-- **domain.ts** — app entities: `Project` (git repo + unique `slug` + optional **`trusted`** — the
-  per-project grant, set via `project.setTrust`, that gates loading its committed cross-agent skill aliases;
+- **domain.ts** — app entities: `Project` (git repo + unique `slug` + the skill-trust fields **`trusted`**
+  (the per-project grant), **`acknowledgedSkills`** (re-confirm-new — which committed aliases are OK'd) and
+  **`disabledSkills`** (project-baseline per-skill off), which gate what its committed cross-agent skill
+  aliases contribute; a workspace layers **`Workspace.skillOverrides`** (per-skill on/off) over that baseline;
   "does it have specs?" is **not** a field — it's the lazy `project.hasSpecs` query, since it's a full-tree
   walk), **`ProjectPathStatus`** (a
   candidate path's kind — `repo` / `initable` / `missing` / `notDirectory` — so the UI opens, offers a
@@ -131,7 +134,12 @@ of the host.
   cross-agent skill aliases) /
   **`skill.list`** (a pre-session, skill-only `SlashCommandInfo[]` preview for a `projectId`, resolved from
   that project's current checkout with its **project-scoped aliases gated by trust**; the eventual worktree
-  session is authoritative) /
+  session is authoritative) / the **Skills-manager set** — **`project.aliasSkills`** (present committed alias
+  names, for the presence-gated notice's count) / **`project.acknowledgeSkills`** (confirm skills that
+  appeared after trust) / **`project.setSkillEnabled`** (project baseline) / **`workspace.setSkillOverride`**
+  (per-workspace on/off/clear → the `Workspace`) / **`skills.state`** (`SkillCatalogEntry[]` for a
+  `workspaceId` — the full catalog + per-skill decision) / **`session.reloadResources`** (re-scan skills +
+  rebuild the system prompt for one running session; rejected while streaming) /
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -80,8 +80,9 @@ of the host.
     (correlated by the tool call id; rejected loud when the call is unknown/answered/superseded).
 - **domain.ts** — app entities: `Project` (git repo + unique `slug` + the skill-trust fields **`trusted`**
   (the per-project grant), **`acknowledgedSkills`** (re-confirm-new — which committed aliases are OK'd) and
-  **`disabledSkills`** (project-baseline per-skill off), which gate what its committed cross-agent skill
-  aliases contribute; a workspace layers **`Workspace.skillOverrides`** (per-skill on/off) over that baseline;
+  **`disabledSkills`** / **`disabledGroups`** (project-baseline per-skill and per-group off — a group is a
+  plugin, a source tier, or the special `@plugins`), which gate what its skills contribute; a workspace layers
+  **`Workspace.skillOverrides`** (per-skill on/off) over that baseline;
   "does it have specs?" is **not** a field — it's the lazy `project.hasSpecs` query, since it's a full-tree
   walk), **`ProjectPathStatus`** (a
   candidate path's kind — `repo` / `initable` / `missing` / `notDirectory` — so the UI opens, offers a
@@ -136,10 +137,12 @@ of the host.
   that project's current checkout with its **project-scoped aliases gated by trust**; the eventual worktree
   session is authoritative) / the **Skills-manager set** — **`project.aliasSkills`** (present committed alias
   names, for the presence-gated notice's count) / **`project.acknowledgeSkills`** (confirm skills that
-  appeared after trust) / **`project.setSkillEnabled`** (project baseline) / **`workspace.setSkillOverride`**
-  (per-workspace on/off/clear → the `Workspace`) / **`skills.state`** (`SkillCatalogEntry[]` for a
-  `workspaceId` — the full catalog + per-skill decision) / **`session.reloadResources`** (re-scan skills +
-  rebuild the system prompt for one running session; rejected while streaming) /
+  appeared after trust) / **`project.setSkillEnabled`** (project baseline) / **`project.setGroupEnabled`**
+  (turn a plugin / source tier / `@plugins` on/off at the baseline) / **`workspace.setSkillOverride`**
+  (per-workspace on/off/clear → the `Workspace`) / **`skills.state`** (`SkillCatalogEntry[]` — full catalog +
+  per-skill `decision` + `group` — for a `workspaceId`) / **`project.skills`** (the same, project-scoped, for
+  the pre-session manager) / **`session.reloadResources`** (re-scan skills + rebuild the system prompt for one
+  running session; rejected while streaming) /
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -77,8 +77,10 @@ of the host.
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
     rationale); the chat renders the questionnaire **inline** and replies via `session.answerQuestion`
     (correlated by the tool call id; rejected loud when the call is unknown/answered/superseded).
-- **domain.ts** — app entities: `Project` (git repo + unique `slug`; "does it have specs?" is **not** a
-  field — it's the lazy `project.hasSpecs` query, since it's a full-tree walk), **`ProjectPathStatus`** (a
+- **domain.ts** — app entities: `Project` (git repo + unique `slug` + optional **`trusted`** — the
+  per-project grant, set via `project.setTrust`, that gates loading its committed cross-agent skill aliases;
+  "does it have specs?" is **not** a field — it's the lazy `project.hasSpecs` query, since it's a full-tree
+  walk), **`ProjectPathStatus`** (a
   candidate path's kind — `repo` / `initable` / `missing` / `notDirectory` — so the UI opens, offers a
   `git init`, or shows an error), `Workspace` (git worktree; its
   optional **`renamed`** flag is the naming lifecycle — absent = **not yet locked** (either pristine
@@ -125,8 +127,11 @@ of the host.
   correlated by `loginId` / **`loginCancel`** / **`logout`** /
   the **JetBrains AI** trio **`jbcentralConnect`** (wire Claude+GPT via the jbcentral proxy → a
   `JbcentralConnectResult`) / **`jbcentralDisconnect`** / **`jbcentralLogin`** (launch `central login`)) /
-  **`skill.list`** (a pre-session, skill-only `SlashCommandInfo[]` preview for a `projectId`, resolved
-  from that project's current checkout; the eventual worktree session is authoritative) /
+  **`project.setTrust`** (persist a project's trust grant → the updated `Project`; gates its committed
+  cross-agent skill aliases) /
+  **`skill.list`** (a pre-session, skill-only `SlashCommandInfo[]` preview for a `projectId`, resolved from
+  that project's current checkout with its **project-scoped aliases gated by trust**; the eventual worktree
+  session is authoritative) /
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -12,6 +12,13 @@ export interface Project {
 	slug: string;
 	/** Epoch ms of last open, for sort order. */
 	lastOpened: number;
+	/**
+	 * Whether the user has granted this project trust. Gates loading the project's **committed cross-agent
+	 * skill aliases** (`.claude/skills`, `.github/skills`, `.gemini/skills`) — attacker-controlled for a
+	 * cloned repo, and injected into the agent's system prompt. `undefined` = undecided (treated as
+	 * untrusted). Personal (`~/.claude` …), pi-native, and ThinkRail-bundled skills load regardless.
+	 */
+	trusted?: boolean;
 }
 
 /**

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -13,12 +13,21 @@ export interface Project {
 	/** Epoch ms of last open, for sort order. */
 	lastOpened: number;
 	/**
-	 * Whether the user has granted this project trust. Gates loading the project's **committed cross-agent
-	 * skill aliases** (`.claude/skills`, `.github/skills`, `.gemini/skills`) — attacker-controlled for a
-	 * cloned repo, and injected into the agent's system prompt. `undefined` = undecided (treated as
-	 * untrusted). Personal (`~/.claude` …), pi-native, and ThinkRail-bundled skills load regardless.
+	 * Whether the user has engaged trust for this project — the gate on loading its **committed cross-agent
+	 * skill aliases** (`.claude/skills`, `.github/skills`, `.gemini/skills`), which are attacker-controlled
+	 * for a cloned repo and injected into the agent's system prompt. `undefined` = undecided (untrusted).
+	 * Personal (`~/.claude` …), pi-native, and ThinkRail-bundled skills load regardless.
 	 */
 	trusted?: boolean;
+	/**
+	 * Names of project-scoped alias skills the user has **acknowledged**. Granting trust acknowledges every
+	 * such skill present at that moment; a skill that appears later (a pull, or a branch that ships a new
+	 * one) is *not* here until confirmed — so trusting today's checkout can't silently admit tomorrow's
+	 * committed skill. A project-scoped skill loads only when `trusted` **and** its name is in this set.
+	 */
+	acknowledgedSkills?: string[];
+	/** Names disabled at the project baseline (any source), overridable per-workspace. */
+	disabledSkills?: string[];
 }
 
 /**
@@ -56,6 +65,13 @@ export interface Workspace {
 	 */
 	renamed?: boolean;
 	diffStats?: DiffStats;
+	/**
+	 * Per-skill enable/disable **overrides** for this workspace, keyed by skill name — `"on"` forces an
+	 * admissible skill on (even if the project baseline disabled it), `"off"` forces it off. Absent → the
+	 * project baseline (`Project.disabledSkills`) applies. Never un-gates an untrusted/unacknowledged
+	 * project alias (admissibility is checked first).
+	 */
+	skillOverrides?: Record<string, "on" | "off">;
 }
 
 /**

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -28,6 +28,12 @@ export interface Project {
 	acknowledgedSkills?: string[];
 	/** Names disabled at the project baseline (any source), overridable per-workspace. */
 	disabledSkills?: string[];
+	/**
+	 * Group keys disabled at the project baseline — a plugin name or a source tier
+	 * (`project`/`personal`/`bundled`/`pi`), plus the special `@plugins` (all plugin skills). Turns a whole
+	 * plugin/source off in one toggle and keeps future skills in that group off; a per-skill toggle overrides.
+	 */
+	disabledGroups?: string[];
 }
 
 /**

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -150,6 +150,25 @@ export interface SlashCommandInfo {
 	sourceInfo: SlashCommandSourceInfo;
 }
 
+/**
+ * Why a skill is or isn't loaded — the Skills manager renders all four so a hidden skill is never a silent
+ * mystery. `load` = in the agent's context; `untrusted` = a project alias under an untrusted project;
+ * `pending-ack` = a project alias that appeared after trust was granted (needs confirming); `disabled` =
+ * admissible but toggled off (workspace override, else project baseline).
+ */
+export type SkillDecision = "load" | "untrusted" | "pending-ack" | "disabled";
+
+/** One skill in the workspace Skills manager: its identity, provenance, and current admission verdict. */
+export interface SkillCatalogEntry {
+	/** Bare skill name — the key ack / enable-disable / override operations use. */
+	name: string;
+	description?: string;
+	sourceInfo: SlashCommandSourceInfo;
+	/** True for a committed project-scoped alias (the trust-gated class). */
+	gated: boolean;
+	decision: SkillDecision;
+}
+
 // Extension-UI bridge frames — OUR wire shape for pi's in-process `uiContext` calls. The server pushes an
 // `ExtUiRequest` on `pi.extensionUi`; for dialog kinds the browser replies with `ExtUiResponse`
 // (correlated by `id`), which resolves the awaiting `uiContext` promise. The fire-and-forget kinds

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -166,6 +166,8 @@ export interface SkillCatalogEntry {
 	sourceInfo: SlashCommandSourceInfo;
 	/** True for a committed project-scoped alias (the trust-gated class). */
 	gated: boolean;
+	/** The installing Claude plugin's name, when this skill came from one — lets the manager group by plugin. */
+	plugin?: string;
 	decision: SkillDecision;
 }
 

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -168,6 +168,8 @@ export interface SkillCatalogEntry {
 	gated: boolean;
 	/** The installing Claude plugin's name, when this skill came from one — lets the manager group by plugin. */
 	plugin?: string;
+	/** Canonical group key the skill toggles under: a plugin name, or `project`/`personal`/`bundled`/`pi`. */
+	group: string;
 	decision: SkillDecision;
 }
 

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -101,6 +101,9 @@ export const WS_METHODS = {
 	// enable/disable for any skill.
 	projectAcknowledgeSkills: "project.acknowledgeSkills",
 	projectSetSkillEnabled: "project.setSkillEnabled",
+	// Names of the project's committed alias skills present in its current checkout — powers the presence-
+	// gated trust notice (shown as a count, never attacker-controlled text) before any workspace exists.
+	projectAliasSkills: "project.aliasSkills",
 	workspaceCreate: "workspace.create",
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
@@ -277,6 +280,8 @@ export interface WsMethodMap {
 		params: { id: string; name: string; enabled: boolean };
 		result: Project;
 	};
+	// Present committed alias skill names in the project's current checkout (for the presence-gated notice).
+	"project.aliasSkills": { params: { projectId: string }; result: string[] };
 	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when
 	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
 	"workspace.create": {

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -50,7 +50,8 @@ import type {
 // v10: `provider.setApiKey` is removed — API-key setup goes through the interactive login channel
 // (`provider.loginStart` gains `type?: "oauth" | "api_key"`), so multi-prompt providers (azure, vertex)
 // work and `ProviderStatus.canApiKey` is pi's provider-owned truth (`Provider.auth.apiKey.login`).
-export const PROTOCOL_VERSION = 10;
+// v11: `skill.list` previews a project's skill-only command catalog before a workspace/session exists.
+export const PROTOCOL_VERSION = 11;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -114,6 +115,8 @@ export const WS_METHODS = {
 	terminalResize: "terminal.resize",
 	terminalClose: "terminal.close",
 	dialogSelectDirectory: "dialog.selectDirectory",
+	// Skill-only command preview for New Workspace, before a worktree/session exists.
+	skillList: "skill.list",
 	// session.* — the pi engine; the Composer + cheap wins (model/thinking/stats/skills).
 	sessionCreate: "session.create",
 	sessionPrompt: "session.prompt",
@@ -297,6 +300,8 @@ export interface WsMethodMap {
 	"terminal.resize": { params: { id: string; cols: number; rows: number }; result: Ack };
 	"terminal.close": { params: { id: string }; result: Ack };
 	"dialog.selectDirectory": { params: Record<string, never>; result: { path: string | null } };
+	// Preview from the selected project's current checkout; the eventual worktree session is authoritative.
+	"skill.list": { params: { projectId: string }; result: SlashCommandInfo[] };
 	"session.create": {
 		// `model`/`thinkingLevel`: applied at create time via `createAgentSession`, e.g. the
 		// New-Workspace dialog's pre-session picks. Omitted → pi resolves defaults from auth + settings.

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -51,7 +51,9 @@ import type {
 // (`provider.loginStart` gains `type?: "oauth" | "api_key"`), so multi-prompt providers (azure, vertex)
 // work and `ProviderStatus.canApiKey` is pi's provider-owned truth (`Provider.auth.apiKey.login`).
 // v11: `skill.list` previews a project's skill-only command catalog before a workspace/session exists.
-export const PROTOCOL_VERSION = 11;
+// v12: `project.setTrust` records the per-project trust grant that gates its committed cross-agent skill
+// aliases; `Project` gains an optional `trusted` field carried in `server.welcome` / `project.list`.
+export const PROTOCOL_VERSION = 12;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -88,6 +90,8 @@ export const WS_METHODS = {
 	// Lazy per-project "has any registered spec?" (the Welcome screen's "Set up project" signal) — a
 	// full-tree walk, so it's on-demand for the one project shown, never eagerly for every project.
 	projectHasSpecs: "project.hasSpecs",
+	// Record the user's trust grant for a project — gates loading its committed cross-agent skill aliases.
+	projectSetTrust: "project.setTrust",
 	workspaceCreate: "workspace.create",
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
@@ -248,6 +252,9 @@ export interface WsMethodMap {
 	// Does the project's repo carry any registered spec? Computed lazily (a full-tree walk), so it's
 	// requested only for the project the Welcome screen renders — never eagerly for every project.
 	"project.hasSpecs": { params: { projectId: string }; result: { hasSpecs: boolean } };
+	// Persist the user's trust decision for a project. Trust gates loading the repo's committed cross-agent
+	// skill aliases (`.claude/skills` etc.); the updated `Project` echoes back so the client refreshes.
+	"project.setTrust": { params: { id: string; trusted: boolean }; result: Project };
 	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when
 	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
 	"workspace.create": {

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -58,7 +58,10 @@ import type {
 // (apply skill changes to a running session), `project.acknowledgeSkills` / `project.setSkillEnabled` /
 // `workspace.setSkillOverride`; `Project` gains `acknowledgedSkills`/`disabledSkills`, `Workspace` gains
 // `skillOverrides`.
-export const PROTOCOL_VERSION = 13;
+// v14: group/source toggles + pre-session manager — `project.setGroupEnabled` (turn a plugin or source tier,
+// incl. `@plugins`, on/off at the project baseline) + `project.skills` (project-scoped catalog for Welcome /
+// New Workspace); `Project` gains `disabledGroups`, `SkillCatalogEntry` gains `group`.
+export const PROTOCOL_VERSION = 14;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -104,6 +107,10 @@ export const WS_METHODS = {
 	// Names of the project's committed alias skills present in its current checkout — powers the presence-
 	// gated trust notice (shown as a count, never attacker-controlled text) before any workspace exists.
 	projectAliasSkills: "project.aliasSkills",
+	// Turn a whole group (a plugin, a source tier, or `@plugins`) on/off at the project baseline; the
+	// project-scoped skill catalog for the pre-session manager (Welcome / New Workspace).
+	projectSetGroupEnabled: "project.setGroupEnabled",
+	projectSkills: "project.skills",
 	workspaceCreate: "workspace.create",
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
@@ -282,6 +289,13 @@ export interface WsMethodMap {
 	};
 	// Present committed alias skill names in the project's current checkout (for the presence-gated notice).
 	"project.aliasSkills": { params: { projectId: string }; result: string[] };
+	// Turn a group on/off at the project baseline (`group` = a plugin name, a source tier, or `@plugins`).
+	"project.setGroupEnabled": {
+		params: { id: string; group: string; enabled: boolean };
+		result: Project;
+	};
+	// Project-scoped skill catalog (current checkout, no workspace overrides) for the pre-session manager.
+	"project.skills": { params: { projectId: string }; result: SkillCatalogEntry[] };
 	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when
 	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
 	"workspace.create": {

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -25,6 +25,7 @@ import type {
 	ImageContent,
 	SessionStats,
 	SessionSummary,
+	SkillCatalogEntry,
 	SlashCommandInfo,
 	ThinkingLevel,
 	TranscriptMessage,
@@ -53,7 +54,11 @@ import type {
 // v11: `skill.list` previews a project's skill-only command catalog before a workspace/session exists.
 // v12: `project.setTrust` records the per-project trust grant that gates its committed cross-agent skill
 // aliases; `Project` gains an optional `trusted` field carried in `server.welcome` / `project.list`.
-export const PROTOCOL_VERSION = 12;
+// v13: the workspace Skills manager — `skills.state` (catalog + per-skill decision), `session.reloadResources`
+// (apply skill changes to a running session), `project.acknowledgeSkills` / `project.setSkillEnabled` /
+// `workspace.setSkillOverride`; `Project` gains `acknowledgedSkills`/`disabledSkills`, `Workspace` gains
+// `skillOverrides`.
+export const PROTOCOL_VERSION = 13;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -92,10 +97,16 @@ export const WS_METHODS = {
 	projectHasSpecs: "project.hasSpecs",
 	// Record the user's trust grant for a project — gates loading its committed cross-agent skill aliases.
 	projectSetTrust: "project.setTrust",
+	// Confirm project-scoped skills that appeared after trust (re-confirm-new) + set the project-baseline
+	// enable/disable for any skill.
+	projectAcknowledgeSkills: "project.acknowledgeSkills",
+	projectSetSkillEnabled: "project.setSkillEnabled",
 	workspaceCreate: "workspace.create",
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
 	workspaceDiffStats: "workspace.diffStats",
+	// Per-workspace per-skill enable/disable override (over the project baseline).
+	workspaceSetSkillOverride: "workspace.setSkillOverride",
 	// gh-backed New-Workspace surface: branch list per project + local `gh` auth status.
 	gitListBranches: "git.listBranches",
 	// Background freshness fetch of a remote base ref, fired when the New-Workspace dialog opens/picks a
@@ -121,6 +132,8 @@ export const WS_METHODS = {
 	dialogSelectDirectory: "dialog.selectDirectory",
 	// Skill-only command preview for New Workspace, before a worktree/session exists.
 	skillList: "skill.list",
+	// The workspace Skills manager: full catalog + per-skill admission decision for a workspace's worktree.
+	skillsState: "skills.state",
 	// session.* — the pi engine; the Composer + cheap wins (model/thinking/stats/skills).
 	sessionCreate: "session.create",
 	sessionPrompt: "session.prompt",
@@ -133,6 +146,8 @@ export const WS_METHODS = {
 	sessionCompact: "session.compact",
 	sessionGetStats: "session.getStats",
 	sessionGetCommands: "session.getCommands",
+	// Re-scan skills/settings and rebuild the system prompt for a running session (active-chat reload).
+	sessionReloadResources: "session.reloadResources",
 	sessionExtUiReply: "session.extUiReply",
 	// Inline `ask_user_question` reply: the browser sends the questionnaire result, correlated by the tool
 	// call's id; the host delivers it to the session as an `ask-user-answers` custom message, starting the
@@ -255,6 +270,13 @@ export interface WsMethodMap {
 	// Persist the user's trust decision for a project. Trust gates loading the repo's committed cross-agent
 	// skill aliases (`.claude/skills` etc.); the updated `Project` echoes back so the client refreshes.
 	"project.setTrust": { params: { id: string; trusted: boolean }; result: Project };
+	// Confirm project-scoped skills that appeared after trust (`names` join `acknowledgedSkills`), and set a
+	// skill's project-baseline enabled state. Both echo the updated `Project` back for the store.
+	"project.acknowledgeSkills": { params: { id: string; names: string[] }; result: Project };
+	"project.setSkillEnabled": {
+		params: { id: string; name: string; enabled: boolean };
+		result: Project;
+	};
 	// `baseRef`: the base branch the worktree is cut from (a remote ref is fetched first); when
 	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
 	"workspace.create": {
@@ -264,6 +286,11 @@ export interface WsMethodMap {
 	"workspace.list": { params: { projectId: string }; result: Workspace[] };
 	"workspace.remove": { params: { id: string }; result: Ack };
 	"workspace.diffStats": { params: { id: string }; result: DiffStats };
+	// Per-workspace per-skill override over the project baseline; `null` clears it. Echoes the `Workspace`.
+	"workspace.setSkillOverride": {
+		params: { id: string; name: string; override: "on" | "off" | null };
+		result: Workspace;
+	};
 	"git.listBranches": { params: { projectId: string }; result: BranchList };
 	// Best-effort background `git fetch` of a remote ref (`origin/<b>`); `ok` reports whether the fetch ran
 	// (offline / non-remote ref → `false`). The UI fires-and-forgets it to warm the ref before create.
@@ -309,6 +336,8 @@ export interface WsMethodMap {
 	"dialog.selectDirectory": { params: Record<string, never>; result: { path: string | null } };
 	// Preview from the selected project's current checkout; the eventual worktree session is authoritative.
 	"skill.list": { params: { projectId: string }; result: SlashCommandInfo[] };
+	// The workspace Skills manager's catalog: every discovered skill for the worktree + its admission verdict.
+	"skills.state": { params: { workspaceId: string }; result: SkillCatalogEntry[] };
 	"session.create": {
 		// `model`/`thinkingLevel`: applied at create time via `createAgentSession`, e.g. the
 		// New-Workspace dialog's pre-session picks. Omitted → pi resolves defaults from auth + settings.
@@ -335,6 +364,8 @@ export interface WsMethodMap {
 	"session.compact": { params: { sessionId: string; instructions?: string }; result: Ack };
 	"session.getStats": { params: { sessionId: string }; result: SessionStats };
 	"session.getCommands": { params: { sessionId: string }; result: SlashCommandInfo[] };
+	// Re-scan skills/settings + rebuild the system prompt for one running session (skipped while streaming).
+	"session.reloadResources": { params: { sessionId: string }; result: Ack };
 	"session.extUiReply": { params: { response: ExtUiResponse }; result: Ack };
 	// Rejects when the tool call is unknown, already answered, superseded by a later user message, or not
 	// an awaiting ask — so a stale card fails loud instead of silently parking an answer.

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -135,7 +135,7 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     the manager bullet above). Pure over pi's `SessionManager` (compaction-aware via
     `buildSessionContext`; idempotent; appends at the leaf, where orphans sit by construction) —
     unit-tested against `SessionManager.inMemory`.
-  - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager, trustedProject)` starts
+  - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager, admission)` starts
     with a `DefaultResourceLoader` (Pi's normal settings/package + `.pi` / `.agents` discovery), adds
     automatic **portable cross-agent skill aliases**, then loads the four bundled extensions — **`pi-web-access`**
     (`web_search` + `fetch_content`), **`pi-visualize`** (`visualize`), **`pi-spec-graph`** (the `spec_*`
@@ -148,15 +148,21 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     vendor-only macros/hooks/models/subagents/metadata are not emulated. First-name-wins precedence is
     Pi native/configured/shared → ThinkRail-bundled → personal aliases → project aliases, so a repo can
     never shadow your own or ThinkRail's skills; source metadata preserves truthful `project` / `user` scope.
-    **Trust gate:** a repo's committed **project-scoped** aliases are attacker-controlled for a clone and are
-    injected into the system prompt, so they load only when the owning project is **trusted** — the host
-    resolves that via the **`setProjectTrustResolver`** seam (keyed by `workspaceId`, fails closed);
-    personal / bundled / pi-native resources load regardless. (The gate is scoped to these compatibility
-    aliases; pi-native `.pi` / `.agents` project trust is unchanged.) `listSkillCommands(cwd, trustedProject)`
-    reuses the same gated skill inputs through a short-lived skills-only `DefaultResourceLoader` (no
-    model/session/transcript and no extension factory execution) for pre-workspace autocomplete, cached
-    briefly per `(cwd, trust)`; Pi's normal configured-package resolution still applies. The full session
-    loader supports **two modes**:
+    **Admission gate (`skillAdmission`):** committed **project-scoped** aliases are attacker-controlled for a
+    clone and injected into the system prompt, so per-skill they resolve to `load` / `untrusted` /
+    `pending-ack` / `disabled` from an **admission context** — the project's `trusted` + `acknowledgedSkills`
+    (granting trust acknowledges only what's present, so a later pull/branch skill is `pending-ack` until
+    confirmed) + `disabledSkills` baseline, layered with the workspace's `skillOverrides` (the trust gate is
+    checked before the toggle layer, so an "on" override can never un-gate an untrusted alias). `skillsGate`
+    filters + relabels in one `skillsOverride`; only `load` skills reach the system prompt / `/skill:` list.
+    The host resolves the context via the **`setSkillAdmissionResolver`** seam (keyed by `workspaceId`, fails
+    closed). Personal / bundled / pi-native resources are never trust-gated (only the enable/disable layer);
+    the gate is scoped to the compatibility aliases (pi-native `.pi` / `.agents` project trust is unchanged).
+    `listSkillCommands(cwd, admission)` reuses the same gated inputs through a short-lived skills-only
+    `DefaultResourceLoader` (no model/session/transcript, no extension factories) for pre-workspace
+    autocomplete, cached briefly per `(cwd, admission)`; **`listSkillCatalog(cwd, admission)`** is the Skills
+    manager's unfiltered variant (every discovered skill + its `decision`), and **`listProjectAliasSkillNames`**
+    is the notice's present-alias count. The full session loader supports **two modes**:
     - **Run-from-source (default):** `additionalExtensionPaths` pointing at the packages' raw `.ts`
       entries (pi's loader jiti-loads them — no value-import into our typecheck graph), resolved
       **lazily on first use** (never at module load: the resolve requires `node_modules`, which a
@@ -178,8 +184,11 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   `configurePiRuntime`/`getPiRuntime`; `completeOnce`/`pickModel` +
   `OneShotRequest`/`OneShotResult`/`ModelTier`; the `webUiContext` seams; the `askUserQuestion` pure
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
-  `buildAnswersMessage`); `repairDanglingToolCalls`; `listSkillCommands(cwd, trustedProject)` (pre-session
-  skill-only catalog); the **`setProjectTrustResolver`** seam (host wires `workspaceId` → project trust);
+  `buildAnswersMessage`); `repairDanglingToolCalls`; the skill catalog helpers
+  `listSkillCommands(cwd, admission)` (filtered, pre-session autocomplete) / `listSkillCatalog(cwd, admission)`
+  (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count);
+  `reloadSessionResources(sessionId)` (active-chat reload); the **`setSkillAdmissionResolver`** seam (host
+  wires `workspaceId` → the admission context);
   the compiled-binary extension seam (`setBundledExtensions` +
   `BundledExtensions`/`BundledExtensionFactory`).
 - **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (types + test

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -154,17 +154,22 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     clone and injected into the system prompt, so per-skill they resolve to `load` / `untrusted` /
     `pending-ack` / `disabled` from an **admission context** — the project's `trusted` + `acknowledgedSkills`
     (granting trust acknowledges only what's present, so a later pull/branch skill is `pending-ack` until
-    confirmed) + `disabledSkills` baseline, layered with the workspace's `skillOverrides` (the trust gate is
-    checked before the toggle layer, so an "on" override can never un-gate an untrusted alias). `skillsGate`
-    filters + relabels in one `skillsOverride`; only `load` skills reach the system prompt / `/skill:` list.
+    confirmed) + `disabledSkills` / **`disabledGroups`** baselines (a group key = a plugin name, a source tier
+    `project`/`personal`/`bundled`/`pi`, or the special `@plugins` — assigned per skill by `skillGroup`, matching
+    `SkillCatalogEntry.group`), layered with the workspace's per-skill `skillOverrides` (the trust gate is
+    checked before the toggle layer, so an "on" override can never un-gate an untrusted alias, and a per-skill
+    `on` beats a group disable). `skillsGate` filters + relabels in one `skillsOverride`; only `load` skills
+    reach the system prompt / `/skill:` list.
     The host resolves the context via the **`setSkillAdmissionResolver`** seam (keyed by `workspaceId`, fails
     closed). Personal / bundled / pi-native resources are never trust-gated (only the enable/disable layer);
     the gate is scoped to the compatibility aliases (pi-native `.pi` / `.agents` project trust is unchanged).
     `listSkillCommands(cwd, admission)` reuses the same gated inputs through a short-lived skills-only
     `DefaultResourceLoader` (no model/session/transcript, no extension factories) for pre-workspace
     autocomplete, cached briefly per `(cwd, admission)`; **`listSkillCatalog(cwd, admission)`** is the Skills
-    manager's unfiltered variant (every discovered skill + its `decision`), and **`listProjectAliasSkillNames`**
-    is the notice's present-alias count. The full session loader supports **two modes**:
+    manager's unfiltered variant (every discovered skill + its `group` + `decision`) — driven with a workspace
+    (via `skills.state`) or a project (via `project.skills`, current checkout, no overrides) — and
+    **`listProjectAliasSkillNames`** is the notice's present-alias count. The full session loader supports
+    **two modes**:
     - **Run-from-source (default):** `additionalExtensionPaths` pointing at the packages' raw `.ts`
       entries (pi's loader jiti-loads them — no value-import into our typecheck graph), resolved
       **lazily on first use** (never at module load: the resolve requires `node_modules`, which a

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -135,9 +135,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     the manager bullet above). Pure over pi's `SessionManager` (compaction-aware via
     `buildSessionContext`; idempotent; appends at the leaf, where orphans sit by construction) —
     unit-tested against `SessionManager.inMemory`.
-  - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager)` starts with a
-    `DefaultResourceLoader` (Pi's normal settings/package + `.pi` / `.agents` discovery), adds automatic
-    **portable cross-agent skill aliases**, then loads the four bundled extensions — **`pi-web-access`**
+  - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager, trustedProject)` starts
+    with a `DefaultResourceLoader` (Pi's normal settings/package + `.pi` / `.agents` discovery), adds
+    automatic **portable cross-agent skill aliases**, then loads the four bundled extensions — **`pi-web-access`**
     (`web_search` + `fetch_content`), **`pi-visualize`** (`visualize`), **`pi-spec-graph`** (the `spec_*`
     tools + its `before_agent_start` rule), and **`pi-thinkrail-workflow`** (the workflow-router rule +
     workflow skills). Existing personal aliases are Claude
@@ -146,11 +146,16 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `.github/skills`, and `.gemini/skills`. Only existing directories are added — never arbitrary
     dot-directory scanning, plugin caches, commands, or nested downward discovery. Pi remains the parser:
     vendor-only macros/hooks/models/subagents/metadata are not emulated. First-name-wins precedence is
-    Pi native/configured/shared → project aliases → personal aliases → ThinkRail-bundled skills; source
-    metadata preserves truthful `project` / `user` scope. Opening/persisting a project is the trust grant.
-    `listSkillCommands(cwd)` reuses the same skill inputs through a short-lived skills-only
-    `DefaultResourceLoader` (no model/session/transcript and no extension factory execution) for
-    pre-workspace autocomplete; Pi's normal configured-package resolution still applies. The full session
+    Pi native/configured/shared → ThinkRail-bundled → personal aliases → project aliases, so a repo can
+    never shadow your own or ThinkRail's skills; source metadata preserves truthful `project` / `user` scope.
+    **Trust gate:** a repo's committed **project-scoped** aliases are attacker-controlled for a clone and are
+    injected into the system prompt, so they load only when the owning project is **trusted** — the host
+    resolves that via the **`setProjectTrustResolver`** seam (keyed by `workspaceId`, fails closed);
+    personal / bundled / pi-native resources load regardless. (The gate is scoped to these compatibility
+    aliases; pi-native `.pi` / `.agents` project trust is unchanged.) `listSkillCommands(cwd, trustedProject)`
+    reuses the same gated skill inputs through a short-lived skills-only `DefaultResourceLoader` (no
+    model/session/transcript and no extension factory execution) for pre-workspace autocomplete, cached
+    briefly per `(cwd, trust)`; Pi's normal configured-package resolution still applies. The full session
     loader supports **two modes**:
     - **Run-from-source (default):** `additionalExtensionPaths` pointing at the packages' raw `.ts`
       entries (pi's loader jiti-loads them — no value-import into our typecheck graph), resolved
@@ -173,8 +178,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   `configurePiRuntime`/`getPiRuntime`; `completeOnce`/`pickModel` +
   `OneShotRequest`/`OneShotResult`/`ModelTier`; the `webUiContext` seams; the `askUserQuestion` pure
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
-  `buildAnswersMessage`); `repairDanglingToolCalls`; `listSkillCommands(cwd)` (pre-session skill-only
-  catalog); the compiled-binary extension seam (`setBundledExtensions` +
+  `buildAnswersMessage`); `repairDanglingToolCalls`; `listSkillCommands(cwd, trustedProject)` (pre-session
+  skill-only catalog); the **`setProjectTrustResolver`** seam (host wires `workspaceId` → project trust);
+  the compiled-binary extension seam (`setBundledExtensions` +
   `BundledExtensions`/`BundledExtensionFactory`).
 - **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (types + test
   fixtures — dispatch goes through the shared `ModelRuntime`); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
@@ -206,8 +212,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   fails closed, so a future `Model` field can't leak by default (a unit test pins the exact key set).
 - A live slash-command list is derived from the **same three sources Pi's rpc mode uses**
   (`extensionRunner.getRegisteredCommands()` + `promptTemplates` + `resourceLoader.getSkills()`). The
-  pre-session catalog maps only `resourceLoader.getSkills()` through the same skill→command helper, so
-  New Workspace preview and a real session cannot disagree except for the accepted base-branch/current-
-  checkout timing difference.
+  pre-session catalog maps only `resourceLoader.getSkills()` through the same skill→command helper and
+  applies the **same project-trust gate**, so New Workspace preview and a real session cannot disagree
+  except for the accepted base-branch/current-checkout timing difference.
 - Dialog promises honor abort/timeout and are settled (+ dismissed in the UI) on session disposal — a
   bridged `uiContext` call must never hang.

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -145,7 +145,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     (`~/.copilot/skills`), and Gemini (`${GEMINI_CLI_HOME:-~}/.gemini/skills`), **plus each installed Claude
     plugin's `skills/` dir** (read from `~/.claude/plugins/installed_plugins.json` — the resolved `installPath`,
     never a cache sweep, so stale versions and transitive `node_modules/**/skills` are excluded); project-root
-    aliases are `.claude/skills`, `.github/skills`, and `.gemini/skills`. Only existing directories are added — never arbitrary
+    aliases are `.claude/skills`, `.github/skills`, and `.gemini/skills`. The fixed project/personal alias roots are
+    registered as candidate skill paths **whether or not they exist yet**, so a `loader.reload()` picks up one a branch
+    switch / pull / clone creates mid-session (plugin dirs are the set installed at construction — a plugin added later
+    needs a fresh session); classification still only counts dirs that actually exist. Still never arbitrary
     dot-directory scanning, plugin caches, commands, or nested downward discovery. Pi remains the parser:
     vendor-only macros/hooks/models/subagents/metadata are not emulated. First-name-wins precedence is
     Pi native/configured/shared → ThinkRail-bundled → personal aliases → project aliases, so a repo can
@@ -161,9 +164,11 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `on` beats a group disable). `skillsGate` filters + relabels in one `skillsOverride`; only `load` skills
     reach the system prompt / `/skill:` list.
     The host resolves the context via the **`setSkillAdmissionResolver`** seam (keyed by `workspaceId`, fails
-    closed); `buildResourceLoader` takes the resolver as a thunk and `skillsGate` **re-reads it on every
-    `loader.reload()`**, so `session.reloadResources` picks up a mid-session trust grant or skill/group toggle
-    rather than re-applying the snapshot captured at session creation. Personal / bundled / pi-native resources are never trust-gated (only the enable/disable layer);
+    closed); `buildResourceLoader` takes the resolver as a thunk and `skillsGate` re-resolves **both** the admission
+    context (`getCtx`) **and** the live compatibility source set (fresh discovery) on every `loader.reload()`, so
+    `session.reloadResources` picks up a mid-session trust grant, skill/group toggle, **or a newly-appeared alias
+    dir** — and a late-appearing project alias is still classified + trust-gated, never slipping through as an
+    unclassified load. Personal / bundled / pi-native resources are never trust-gated (only the enable/disable layer);
     the gate is scoped to the compatibility aliases (pi-native `.pi` / `.agents` project trust is unchanged).
     `listSkillCommands(cwd, admission)` reuses the same gated inputs through a short-lived skills-only
     `DefaultResourceLoader` (no model/session/transcript, no extension factories) for pre-workspace

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -12,7 +12,8 @@ tags: [v1, pi]
 ## Responsibility
 
 The in-process `pi` engine: a shared model/auth runtime, the lifecycle of `AgentSession`s
-(one per chat tab, rooted in a workspace's worktree), the **extension-UI bridge** that turns pi's
+(one per chat tab, rooted in a workspace's worktree), Pi resource/skill loading (including portable
+cross-agent skill discovery + a pre-session skill catalog), the **extension-UI bridge** that turns pi's
 in-process `uiContext` dialog calls into WS frames, the host-owned **`ask_user_question`** tool + its
 answer-injection path, and the **restart repair** that keeps re-opened transcripts provider-valid.
 
@@ -134,11 +135,23 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     the manager bullet above). Pure over pi's `SessionManager` (compaction-aware via
     `buildSessionContext`; idempotent; appends at the leaf, where orphans sit by construction) —
     unit-tested against `SessionManager.inMemory`.
-  - `extensions` — `buildResourceLoader(cwd, settingsManager)`: a `DefaultResourceLoader` (pi's normal
-    disk discovery) that also loads the four bundled extensions — **`pi-web-access`** (`web_search` +
-    `fetch_content`), **`pi-visualize`** (`visualize`), **`pi-spec-graph`** (the `spec_*` tools + its
-    `before_agent_start` rule), and **`pi-thinkrail-workflow`** (the workflow-router rule + workflow skills) — in one
-    of **two modes**:
+  - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager)` starts with a
+    `DefaultResourceLoader` (Pi's normal settings/package + `.pi` / `.agents` discovery), adds automatic
+    **portable cross-agent skill aliases**, then loads the four bundled extensions — **`pi-web-access`**
+    (`web_search` + `fetch_content`), **`pi-visualize`** (`visualize`), **`pi-spec-graph`** (the `spec_*`
+    tools + its `before_agent_start` rule), and **`pi-thinkrail-workflow`** (the workflow-router rule +
+    workflow skills). Existing personal aliases are Claude
+    (`${CLAUDE_CONFIG_DIR:-~/.claude}/skills`), Codex (`${CODEX_HOME:-~/.codex}/skills`), Copilot
+    (`~/.copilot/skills`), and Gemini (`${GEMINI_CLI_HOME:-~}/.gemini/skills`); project-root aliases are `.claude/skills`,
+    `.github/skills`, and `.gemini/skills`. Only existing directories are added — never arbitrary
+    dot-directory scanning, plugin caches, commands, or nested downward discovery. Pi remains the parser:
+    vendor-only macros/hooks/models/subagents/metadata are not emulated. First-name-wins precedence is
+    Pi native/configured/shared → project aliases → personal aliases → ThinkRail-bundled skills; source
+    metadata preserves truthful `project` / `user` scope. Opening/persisting a project is the trust grant.
+    `listSkillCommands(cwd)` reuses the same skill inputs through a short-lived skills-only
+    `DefaultResourceLoader` (no model/session/transcript and no extension factory execution) for
+    pre-workspace autocomplete; Pi's normal configured-package resolution still applies. The full session
+    loader supports **two modes**:
     - **Run-from-source (default):** `additionalExtensionPaths` pointing at the packages' raw `.ts`
       entries (pi's loader jiti-loads them — no value-import into our typecheck graph), resolved
       **lazily on first use** (never at module load: the resolve requires `node_modules`, which a
@@ -160,8 +173,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   `configurePiRuntime`/`getPiRuntime`; `completeOnce`/`pickModel` +
   `OneShotRequest`/`OneShotResult`/`ModelTier`; the `webUiContext` seams; the `askUserQuestion` pure
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
-  `buildAnswersMessage`); `repairDanglingToolCalls`; the compiled-binary extension seam
-  (`setBundledExtensions` + `BundledExtensions`/`BundledExtensionFactory`).
+  `buildAnswersMessage`); `repairDanglingToolCalls`; `listSkillCommands(cwd)` (pre-session skill-only
+  catalog); the compiled-binary extension seam (`setBundledExtensions` +
+  `BundledExtensions`/`BundledExtensionFactory`).
 - **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (types + test
   fixtures — dispatch goes through the shared `ModelRuntime`); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
   `pi-thinkrail-workflow` (the bundled extensions — loaded by path, never value-imported here; the
@@ -190,7 +204,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   `session.setModel`) is **re-resolved** host-side by `{provider,id}` (`resolveWireModel`), never trusted.
   The wire type `WireModel = Pick<Model, id|name|provider|contextWindow|reasoning>` is an **allowlist** — it
   fails closed, so a future `Model` field can't leak by default (a unit test pins the exact key set).
-- The slash-command list is derived from the **same three sources pi's rpc mode uses**
-  (`extensionRunner.getRegisteredCommands()` + `promptTemplates` + `resourceLoader.getSkills()`).
+- A live slash-command list is derived from the **same three sources Pi's rpc mode uses**
+  (`extensionRunner.getRegisteredCommands()` + `promptTemplates` + `resourceLoader.getSkills()`). The
+  pre-session catalog maps only `resourceLoader.getSkills()` through the same skill→command helper, so
+  New Workspace preview and a real session cannot disagree except for the accepted base-branch/current-
+  checkout timing difference.
 - Dialog promises honor abort/timeout and are settled (+ dismissed in the UI) on session disposal — a
   bridged `uiContext` call must never hang.

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -135,7 +135,7 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     the manager bullet above). Pure over pi's `SessionManager` (compaction-aware via
     `buildSessionContext`; idempotent; appends at the leaf, where orphans sit by construction) —
     unit-tested against `SessionManager.inMemory`.
-  - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager, admission)` starts
+  - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager, getAdmission)` starts
     with a `DefaultResourceLoader` (Pi's normal settings/package + `.pi` / `.agents` discovery), adds
     automatic **portable cross-agent skill aliases**, then loads the four bundled extensions — **`pi-web-access`**
     (`web_search` + `fetch_content`), **`pi-visualize`** (`visualize`), **`pi-spec-graph`** (the `spec_*`
@@ -161,7 +161,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `on` beats a group disable). `skillsGate` filters + relabels in one `skillsOverride`; only `load` skills
     reach the system prompt / `/skill:` list.
     The host resolves the context via the **`setSkillAdmissionResolver`** seam (keyed by `workspaceId`, fails
-    closed). Personal / bundled / pi-native resources are never trust-gated (only the enable/disable layer);
+    closed); `buildResourceLoader` takes the resolver as a thunk and `skillsGate` **re-reads it on every
+    `loader.reload()`**, so `session.reloadResources` picks up a mid-session trust grant or skill/group toggle
+    rather than re-applying the snapshot captured at session creation. Personal / bundled / pi-native resources are never trust-gated (only the enable/disable layer);
     the gate is scoped to the compatibility aliases (pi-native `.pi` / `.agents` project trust is unchanged).
     `listSkillCommands(cwd, admission)` reuses the same gated inputs through a short-lived skills-only
     `DefaultResourceLoader` (no model/session/transcript, no extension factories) for pre-workspace

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -142,8 +142,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     tools + its `before_agent_start` rule), and **`pi-thinkrail-workflow`** (the workflow-router rule +
     workflow skills). Existing personal aliases are Claude
     (`${CLAUDE_CONFIG_DIR:-~/.claude}/skills`), Codex (`${CODEX_HOME:-~/.codex}/skills`), Copilot
-    (`~/.copilot/skills`), and Gemini (`${GEMINI_CLI_HOME:-~}/.gemini/skills`); project-root aliases are `.claude/skills`,
-    `.github/skills`, and `.gemini/skills`. Only existing directories are added — never arbitrary
+    (`~/.copilot/skills`), and Gemini (`${GEMINI_CLI_HOME:-~}/.gemini/skills`), **plus each installed Claude
+    plugin's `skills/` dir** (read from `~/.claude/plugins/installed_plugins.json` — the resolved `installPath`,
+    never a cache sweep, so stale versions and transitive `node_modules/**/skills` are excluded); project-root
+    aliases are `.claude/skills`, `.github/skills`, and `.gemini/skills`. Only existing directories are added — never arbitrary
     dot-directory scanning, plugin caches, commands, or nested downward discovery. Pi remains the parser:
     vendor-only macros/hooks/models/subagents/metadata are not emulated. First-name-wins precedence is
     Pi native/configured/shared → ThinkRail-bundled → personal aliases → project aliases, so a repo can

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -60,6 +60,7 @@ let skillAdmissionResolver: (workspaceId: string) => SkillAdmissionContext = () 
 	trusted: false,
 	acknowledged: [],
 	disabled: [],
+	disabledGroups: [],
 	overrides: {},
 });
 export function setSkillAdmissionResolver(

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -19,7 +19,7 @@ import type {
 	WireModel,
 } from "@thinkrail/contracts";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
-import { buildResourceLoader } from "./extensions";
+import { buildResourceLoader, toSkillCommands } from "./extensions";
 import { getPiRuntime, refreshCatalogsDetached } from "./piRuntime";
 import { repairDanglingToolCalls } from "./sessionRepair";
 import { cancelExtUiForSession, createWebUiContext, notifyExtUi } from "./webUiContext";
@@ -72,10 +72,11 @@ export function getSessionWorkspaceId(sessionId: string): string | undefined {
  * wasm loads via a worker + `fs` path that a compiled binary can't satisfy), and the web UI downsizes
  * user-attached images itself — so we keep image-read working everywhere without depending on photon.
  * `SettingsManager.create(cwd)` defaults its agentDir to `getAgentDir()` (honors `PI_CODING_AGENT_DIR`),
- * matching the manager `createAgentSession` builds when we omit `settingsManager`.
+ * matching the manager `createAgentSession` builds when we omit `settingsManager`. Persisting/opening a
+ * ThinkRail project is its trust grant, made explicit here instead of relying on Pi's SDK default.
  */
 export function buildSessionSettings(cwd: string): SettingsManager {
-	const settings = SettingsManager.create(cwd);
+	const settings = SettingsManager.create(cwd, undefined, { projectTrusted: true });
 	settings.applyOverrides({ images: { autoResize: false } });
 	return settings;
 }
@@ -398,12 +399,7 @@ export function getSessionCommands(sessionId: string): SlashCommandInfo[] {
 		source: "prompt" as const,
 		sourceInfo: t.sourceInfo,
 	}));
-	const skill = session.resourceLoader.getSkills().skills.map((k) => ({
-		name: `skill:${k.name}`,
-		description: k.description,
-		source: "skill" as const,
-		sourceInfo: k.sourceInfo,
-	}));
+	const skill = toSkillCommands(session.resourceLoader.getSkills().skills);
 	return [...extension, ...prompt, ...skill];
 }
 

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -198,9 +198,7 @@ export async function createSession(input: CreateSessionInput): Promise<CreateSe
 		modelRuntime,
 		sessionManager: sessionManagerFactory(input.cwd),
 		settingsManager,
-		resourceLoader: await buildResourceLoader(
-			input.cwd,
-			settingsManager,
+		resourceLoader: await buildResourceLoader(input.cwd, settingsManager, () =>
 			skillAdmissionResolver(input.workspaceId),
 		),
 		// Re-resolve the wire ref to the real model (with baseUrl) host-side — never the client's baseUrl.
@@ -298,9 +296,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 		modelRuntime,
 		sessionManager,
 		settingsManager,
-		resourceLoader: await buildResourceLoader(
-			cwd,
-			settingsManager,
+		resourceLoader: await buildResourceLoader(cwd, settingsManager, () =>
 			skillAdmissionResolver(workspaceId),
 		),
 	});

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -85,6 +85,22 @@ export function getSessionWorkspaceId(sessionId: string): string | undefined {
 }
 
 /**
+ * Re-scan skills/settings and rebuild the system prompt for a live session — the active-chat "Reload skills"
+ * path, so a trust grant or a worktree skill change lands without dropping the conversation. Refuses while
+ * the session is streaming (pi's reload rebuilds the runtime; mid-turn would desync) — the caller retries
+ * after the turn. Throws for an unknown session.
+ */
+export async function reloadSessionResources(sessionId: string): Promise<void> {
+	const session = mustGet(sessionId);
+	if (session.isStreaming) {
+		throw new Error(
+			"Can't reload skills while the session is streaming — try again after the turn.",
+		);
+	}
+	await session.reload();
+}
+
+/**
  * The pi settings a session runs with: the user's real settings **plus** an in-memory override turning
  * `images.autoResize` **off** (never persisted — `applyOverrides`, not `set…`+`save`). With it off, the
  * `read` tool sends image files to the model **raw** instead of routing them through pi's photon

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -22,6 +22,7 @@ import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "
 import { buildResourceLoader, toSkillCommands } from "./extensions";
 import { getPiRuntime, refreshCatalogsDetached } from "./piRuntime";
 import { repairDanglingToolCalls } from "./sessionRepair";
+import type { SkillAdmissionContext } from "./skillAdmission";
 import { cancelExtUiForSession, createWebUiContext, notifyExtUi } from "./webUiContext";
 
 interface Entry {
@@ -49,14 +50,22 @@ export function setSessionManagerFactory(factory: (cwd: string) => SessionManage
 }
 
 /**
- * Host seam: resolve whether a workspace's owning project is trusted. Trust gates the project's committed
- * cross-agent skill aliases (`.claude/skills` etc.) — see `buildResourceLoader`. Keyed by `workspaceId`,
- * the one id both the create and disk-restore paths hold. Fails closed (untrusted) until the host wires the
- * real resolver at boot, so a mis-wire can never silently load an untrusted repo's skills.
+ * Host seam: resolve a workspace's **skill-admission context** — the owning project's trust + acknowledged
+ * set + baseline disables, plus that workspace's per-skill overrides. Gates which skills a session loads
+ * (see `buildResourceLoader` / `skillAdmission`). Keyed by `workspaceId`, the one id both the create and
+ * disk-restore paths hold. Fails closed (nothing trusted/acknowledged) until the host wires the real
+ * resolver at boot, so a mis-wire can never silently load an untrusted repo's skills.
  */
-let projectTrustResolver: (workspaceId: string) => boolean = () => false;
-export function setProjectTrustResolver(resolver: (workspaceId: string) => boolean): void {
-	projectTrustResolver = resolver;
+let skillAdmissionResolver: (workspaceId: string) => SkillAdmissionContext = () => ({
+	trusted: false,
+	acknowledged: [],
+	disabled: [],
+	overrides: {},
+});
+export function setSkillAdmissionResolver(
+	resolver: (workspaceId: string) => SkillAdmissionContext,
+): void {
+	skillAdmissionResolver = resolver;
 }
 
 function mustGet(sessionId: string): AgentSession {
@@ -85,8 +94,8 @@ export function getSessionWorkspaceId(sessionId: string): string | undefined {
  * `SettingsManager.create(cwd)` defaults its agentDir to `getAgentDir()` (honors `PI_CODING_AGENT_DIR`),
  * matching the manager `createAgentSession` builds when we omit `settingsManager`. `projectTrusted: true`
  * here covers pi-**native** project resources (`.pi` / `.agents`, project settings) — unchanged behavior.
- * The committed **cross-agent skill aliases** carry their own explicit per-project trust gate
- * (`buildResourceLoader`'s `trustedProject` / `setProjectTrustResolver`), not this flag.
+ * The committed **cross-agent skill aliases** carry their own explicit admission gate
+ * (`buildResourceLoader`'s `admission` context / `setSkillAdmissionResolver`), not this flag.
  */
 export function buildSessionSettings(cwd: string): SettingsManager {
 	const settings = SettingsManager.create(cwd, undefined, { projectTrusted: true });
@@ -175,7 +184,7 @@ export async function createSession(input: CreateSessionInput): Promise<CreateSe
 		resourceLoader: await buildResourceLoader(
 			input.cwd,
 			settingsManager,
-			projectTrustResolver(input.workspaceId),
+			skillAdmissionResolver(input.workspaceId),
 		),
 		// Re-resolve the wire ref to the real model (with baseUrl) host-side — never the client's baseUrl.
 		...(input.model ? { model: await resolveWireModel(input.model) } : {}),
@@ -275,7 +284,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 		resourceLoader: await buildResourceLoader(
 			cwd,
 			settingsManager,
-			projectTrustResolver(workspaceId),
+			skillAdmissionResolver(workspaceId),
 		),
 	});
 	// Lost a race after the open — drop this duplicate rather than clobber the registered one.

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -48,6 +48,17 @@ export function setSessionManagerFactory(factory: (cwd: string) => SessionManage
 	sessionManagerFactory = factory;
 }
 
+/**
+ * Host seam: resolve whether a workspace's owning project is trusted. Trust gates the project's committed
+ * cross-agent skill aliases (`.claude/skills` etc.) — see `buildResourceLoader`. Keyed by `workspaceId`,
+ * the one id both the create and disk-restore paths hold. Fails closed (untrusted) until the host wires the
+ * real resolver at boot, so a mis-wire can never silently load an untrusted repo's skills.
+ */
+let projectTrustResolver: (workspaceId: string) => boolean = () => false;
+export function setProjectTrustResolver(resolver: (workspaceId: string) => boolean): void {
+	projectTrustResolver = resolver;
+}
+
 function mustGet(sessionId: string): AgentSession {
 	const entry = sessions.get(sessionId);
 	if (!entry) throw new Error(`Unknown session: ${sessionId}`);
@@ -72,8 +83,10 @@ export function getSessionWorkspaceId(sessionId: string): string | undefined {
  * wasm loads via a worker + `fs` path that a compiled binary can't satisfy), and the web UI downsizes
  * user-attached images itself — so we keep image-read working everywhere without depending on photon.
  * `SettingsManager.create(cwd)` defaults its agentDir to `getAgentDir()` (honors `PI_CODING_AGENT_DIR`),
- * matching the manager `createAgentSession` builds when we omit `settingsManager`. Persisting/opening a
- * ThinkRail project is its trust grant, made explicit here instead of relying on Pi's SDK default.
+ * matching the manager `createAgentSession` builds when we omit `settingsManager`. `projectTrusted: true`
+ * here covers pi-**native** project resources (`.pi` / `.agents`, project settings) — unchanged behavior.
+ * The committed **cross-agent skill aliases** carry their own explicit per-project trust gate
+ * (`buildResourceLoader`'s `trustedProject` / `setProjectTrustResolver`), not this flag.
  */
 export function buildSessionSettings(cwd: string): SettingsManager {
 	const settings = SettingsManager.create(cwd, undefined, { projectTrusted: true });
@@ -159,7 +172,11 @@ export async function createSession(input: CreateSessionInput): Promise<CreateSe
 		modelRuntime,
 		sessionManager: sessionManagerFactory(input.cwd),
 		settingsManager,
-		resourceLoader: await buildResourceLoader(input.cwd, settingsManager),
+		resourceLoader: await buildResourceLoader(
+			input.cwd,
+			settingsManager,
+			projectTrustResolver(input.workspaceId),
+		),
 		// Re-resolve the wire ref to the real model (with baseUrl) host-side — never the client's baseUrl.
 		...(input.model ? { model: await resolveWireModel(input.model) } : {}),
 		...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
@@ -255,7 +272,11 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 		modelRuntime,
 		sessionManager,
 		settingsManager,
-		resourceLoader: await buildResourceLoader(cwd, settingsManager),
+		resourceLoader: await buildResourceLoader(
+			cwd,
+			settingsManager,
+			projectTrustResolver(workspaceId),
+		),
 	});
 	// Lost a race after the open — drop this duplicate rather than clobber the registered one.
 	if (sessions.has(sessionId)) {

--- a/packages/server/src/agent/extensions.test.ts
+++ b/packages/server/src/agent/extensions.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { listSkillCommands } from "./extensions";
+import { listProjectAliasSkillNames, listSkillCommands } from "./extensions";
+import type { SkillAdmissionContext } from "./skillAdmission";
+
+/** A context with the given trust + acknowledged names, and no baseline disables / workspace overrides. */
+function ctx(trusted: boolean, acknowledged: string[] = []): SkillAdmissionContext {
+	return { trusted, acknowledged, disabled: [], overrides: {} };
+}
 
 function writeSkill(root: string, name: string, description: string): void {
 	const directory = join(root, name);
@@ -79,7 +85,11 @@ describe("listSkillCommands", () => {
 				`import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "ran");\nexport default () => {};\n`,
 			);
 
-			const commands = await listSkillCommands(project, true);
+			// Trusting acknowledges every project alias present now — mirror that so the aliases are admitted.
+			const commands = await listSkillCommands(
+				project,
+				ctx(true, await listProjectAliasSkillNames(project)),
+			);
 			const byName = (name: string) => commands.find((command) => command.name === `skill:${name}`);
 
 			expect(byName("configured-wins")?.description).toBe("configured description");
@@ -150,7 +160,7 @@ describe("listSkillCommands", () => {
 			writeSkill(join(project, ".pi", "skills"), "repo-native", "pi-native repo skill");
 			writeSkill(join(home, ".claude", "skills"), "personal-skill", "personal skill");
 
-			const untrusted = await listSkillCommands(project, false);
+			const untrusted = await listSkillCommands(project, ctx(false));
 			// The attacker-controlled project alias is withheld until trust is granted…
 			expect(untrusted.some((command) => command.name === "skill:repo-alias")).toBe(false);
 			// …but the user's own personal library still loads, and (this fix is scoped to the compatibility
@@ -159,7 +169,10 @@ describe("listSkillCommands", () => {
 			expect(untrusted.some((command) => command.name === "skill:repo-native")).toBe(true);
 
 			// Granting trust surfaces the project alias — a distinct cache key, so no stale untrusted hit.
-			const trusted = await listSkillCommands(project, true);
+			const trusted = await listSkillCommands(
+				project,
+				ctx(true, await listProjectAliasSkillNames(project)),
+			);
 			expect(trusted.some((command) => command.name === "skill:repo-alias")).toBe(true);
 		} finally {
 			restoreEnvironment(original);

--- a/packages/server/src/agent/extensions.test.ts
+++ b/packages/server/src/agent/extensions.test.ts
@@ -281,4 +281,75 @@ describe("buildResourceLoader", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	// Regression: a compatibility skill dir that appears AFTER session creation (a branch switch / pull
+	// adding `.claude/skills`) must be picked up on reload — the candidate roots are registered up front
+	// so pi scans them once they exist, rather than being frozen to the set present at construction.
+	it("reload picks up a compatibility dir created after construction", async () => {
+		const root = mkdtempSync(join(tmpdir(), "thinkrail-skill-newdir-"));
+		const project = join(root, "project");
+		const home = join(root, "home");
+		const agentDir = join(root, "pi-agent");
+		mkdirSync(project, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		const restore = stubSkillEnv(home, agentDir);
+
+		try {
+			// `~/.claude/skills` does not exist yet at loader construction (personal scope — not trust-gated).
+			const admission: SkillAdmissionContext = {
+				trusted: true,
+				acknowledged: [],
+				disabled: [],
+				disabledGroups: [],
+				overrides: {},
+			};
+			const settingsManager = SettingsManager.create(project, agentDir, { projectTrusted: true });
+			const loader = await buildResourceLoader(project, settingsManager, () => admission);
+			const hasLate = () => loader.getSkills().skills.some((skill) => skill.name === "late-widget");
+
+			expect(hasLate()).toBe(false);
+
+			writeSkill(join(home, ".claude", "skills"), "late-widget", "appeared after start");
+			await loader.reload();
+			expect(hasLate()).toBe(true);
+		} finally {
+			restore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	// Security regression: a project alias dir (`.claude/skills`) appearing mid-session on an UNTRUSTED
+	// project must still be withheld — the reload's fresh discovery has to classify the late dir as a
+	// project alias so the trust gate holds, not slip through as an unclassified `load`.
+	it("keeps a late-appearing untrusted project alias behind the trust gate on reload", async () => {
+		const root = mkdtempSync(join(tmpdir(), "thinkrail-skill-latetrust-"));
+		const project = join(root, "project");
+		const home = join(root, "home");
+		const agentDir = join(root, "pi-agent");
+		mkdirSync(project, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		const restore = stubSkillEnv(home, agentDir);
+
+		try {
+			const admission: SkillAdmissionContext = {
+				trusted: false,
+				acknowledged: [],
+				disabled: [],
+				disabledGroups: [],
+				overrides: {},
+			};
+			const settingsManager = SettingsManager.create(project, agentDir, { projectTrusted: true });
+			const loader = await buildResourceLoader(project, settingsManager, () => admission);
+
+			// The project has no committed skills at start; a branch switch then adds one.
+			writeSkill(join(project, ".claude", "skills"), "repo-late", "committed, appeared late");
+			await loader.reload();
+			expect(loader.getSkills().skills.some((skill) => skill.name === "repo-late")).toBe(false);
+		} finally {
+			restore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/server/src/agent/extensions.test.ts
+++ b/packages/server/src/agent/extensions.test.ts
@@ -55,15 +55,17 @@ describe("listSkillCommands", () => {
 			);
 			writeSkill(nativeRoot, "native-wins", "native description");
 			writeSkill(projectRoot, "native-wins", "alias must lose");
-			writeSkill(projectRoot, "project-wins", "project description");
-			writeSkill(personalRoot, "project-wins", "personal must lose");
+			// Personal alias outranks the project alias of the same name (precedence personal > project).
+			writeSkill(projectRoot, "personal-wins", "project alias must lose");
+			writeSkill(personalRoot, "personal-wins", "personal description");
 			writeSkill(personalRoot, "personal-only", "personal description");
 			writeSkill(join(project, ".github", "skills"), "project-copilot", "copilot project");
 			writeSkill(join(project, ".gemini", "skills"), "project-gemini", "gemini project");
 			writeSkill(join(home, ".codex", "skills"), "personal-codex", "codex personal");
 			writeSkill(join(home, ".copilot", "skills"), "personal-copilot", "copilot personal");
 			writeSkill(join(home, ".gemini", "skills"), "personal-gemini", "gemini personal");
-			// A personal portable skill deliberately shadows ThinkRail's bundled workflow skill.
+			// Bundled workflow skills now outrank personal aliases (precedence bundled > personal), so this
+			// same-named personal skill must NOT win.
 			writeSkill(personalRoot, "brainstorming", "personal brainstorming override");
 
 			const invalidDir = join(projectRoot, "invalid");
@@ -77,17 +79,17 @@ describe("listSkillCommands", () => {
 				`import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "ran");\nexport default () => {};\n`,
 			);
 
-			const commands = await listSkillCommands(project);
+			const commands = await listSkillCommands(project, true);
 			const byName = (name: string) => commands.find((command) => command.name === `skill:${name}`);
 
 			expect(byName("configured-wins")?.description).toBe("configured description");
 			expect(byName("configured-wins")?.sourceInfo.scope).toBe("user");
 			expect(byName("native-wins")?.description).toBe("native description");
 			expect(byName("native-wins")?.sourceInfo.scope).toBe("project");
-			expect(byName("project-wins")?.description).toBe("project description");
-			expect(byName("project-wins")?.sourceInfo).toMatchObject({
+			expect(byName("personal-wins")?.description).toBe("personal description");
+			expect(byName("personal-wins")?.sourceInfo).toMatchObject({
 				source: "claude",
-				scope: "project",
+				scope: "user",
 			});
 			expect(byName("personal-only")?.sourceInfo).toMatchObject({
 				source: "claude",
@@ -113,9 +115,52 @@ describe("listSkillCommands", () => {
 				source: "gemini",
 				scope: "user",
 			});
-			expect(byName("brainstorming")?.description).toBe("personal brainstorming override");
+			expect(byName("brainstorming")).toBeDefined();
+			expect(byName("brainstorming")?.description).not.toBe("personal brainstorming override");
 			expect(byName("invalid")).toBeUndefined();
 			expect(existsSync(marker)).toBe(false);
+		} finally {
+			restoreEnvironment(original);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("withholds project-scoped aliases until the project is trusted", async () => {
+		const root = mkdtempSync(join(tmpdir(), "thinkrail-skill-trust-"));
+		const project = join(root, "project");
+		const home = join(root, "home");
+		const agentDir = join(root, "pi-agent");
+		mkdirSync(project, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+
+		const original = Object.fromEntries(
+			["HOME", "PI_CODING_AGENT_DIR", "CLAUDE_CONFIG_DIR", "CODEX_HOME", "GEMINI_CLI_HOME"].map(
+				(name) => [name, process.env[name]],
+			),
+		);
+		process.env.HOME = home;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CODEX_HOME;
+		delete process.env.GEMINI_CLI_HOME;
+
+		try {
+			writeSkill(join(project, ".claude", "skills"), "repo-alias", "committed repo skill");
+			writeSkill(join(project, ".pi", "skills"), "repo-native", "pi-native repo skill");
+			writeSkill(join(home, ".claude", "skills"), "personal-skill", "personal skill");
+
+			const untrusted = await listSkillCommands(project, false);
+			// The attacker-controlled project alias is withheld until trust is granted…
+			expect(untrusted.some((command) => command.name === "skill:repo-alias")).toBe(false);
+			// …but the user's own personal library still loads, and (this fix is scoped to the compatibility
+			// aliases) pi-native project resources are intentionally left as-is.
+			expect(untrusted.some((command) => command.name === "skill:personal-skill")).toBe(true);
+			expect(untrusted.some((command) => command.name === "skill:repo-native")).toBe(true);
+
+			// Granting trust surfaces the project alias — a distinct cache key, so no stale untrusted hit.
+			const trusted = await listSkillCommands(project, true);
+			expect(trusted.some((command) => command.name === "skill:repo-alias")).toBe(true);
 		} finally {
 			restoreEnvironment(original);
 			rmSync(root, { recursive: true, force: true });

--- a/packages/server/src/agent/extensions.test.ts
+++ b/packages/server/src/agent/extensions.test.ts
@@ -2,12 +2,31 @@ import { describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { listProjectAliasSkillNames, listSkillCommands } from "./extensions";
+import { SettingsManager } from "@earendil-works/pi-coding-agent";
+import { buildResourceLoader, listProjectAliasSkillNames, listSkillCommands } from "./extensions";
 import type { SkillAdmissionContext } from "./skillAdmission";
 
 /** A context with the given trust + acknowledged names, and no baseline disables / workspace overrides. */
 function ctx(trusted: boolean, acknowledged: string[] = []): SkillAdmissionContext {
 	return { trusted, acknowledged, disabled: [], disabledGroups: [], overrides: {} };
+}
+
+/** Stub the skill-discovery env at `home`/`agentDir`; returns a restorer. Mirrors the catalog tests. */
+function stubSkillEnv(home: string, agentDir: string): () => void {
+	const names = [
+		"HOME",
+		"PI_CODING_AGENT_DIR",
+		"CLAUDE_CONFIG_DIR",
+		"CODEX_HOME",
+		"GEMINI_CLI_HOME",
+	];
+	const original = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+	process.env.HOME = home;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	delete process.env.CLAUDE_CONFIG_DIR;
+	delete process.env.CODEX_HOME;
+	delete process.env.GEMINI_CLI_HOME;
+	return () => restoreEnvironment(original);
 }
 
 function writeSkill(root: string, name: string, description: string): void {
@@ -176,6 +195,89 @@ describe("listSkillCommands", () => {
 			expect(trusted.some((command) => command.name === "skill:repo-alias")).toBe(true);
 		} finally {
 			restoreEnvironment(original);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	// Regression: the short-lived cache is keyed on the admission context, and `disabledGroups` gates the
+	// catalog (`decideSkill`) — so a group toggle that changes only `disabledGroups` must not serve the
+	// previously-cached enabled catalog for the TTL window. Two calls differing only by `disabledGroups`
+	// must return different results.
+	it("does not serve a stale catalog when only disabledGroups differs", async () => {
+		const root = mkdtempSync(join(tmpdir(), "thinkrail-skill-groups-"));
+		const project = join(root, "project");
+		const home = join(root, "home");
+		const agentDir = join(root, "pi-agent");
+		mkdirSync(project, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		const restore = stubSkillEnv(home, agentDir);
+
+		try {
+			writeSkill(join(home, ".claude", "skills"), "personal-widget", "personal skill");
+
+			const enabled = await listSkillCommands(project, {
+				trusted: true,
+				acknowledged: [],
+				disabled: [],
+				disabledGroups: [],
+				overrides: {},
+			});
+			expect(enabled.some((command) => command.name === "skill:personal-widget")).toBe(true);
+
+			// Disabling the "personal" group is a distinct cache key — the toggle applies immediately.
+			const groupOff = await listSkillCommands(project, {
+				trusted: true,
+				acknowledged: [],
+				disabled: [],
+				disabledGroups: ["personal"],
+				overrides: {},
+			});
+			expect(groupOff.some((command) => command.name === "skill:personal-widget")).toBe(false);
+		} finally {
+			restore();
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("buildResourceLoader", () => {
+	// Regression: the admission gate is resolved through a thunk that `skillsGate` re-reads on every
+	// `loader.reload()`, so a mid-session trust/group/skill change lands via `session.reloadResources`
+	// instead of re-applying the snapshot captured when the session was created.
+	it("reload re-reads admission so a mid-session group toggle applies", async () => {
+		const root = mkdtempSync(join(tmpdir(), "thinkrail-skill-reload-"));
+		const project = join(root, "project");
+		const home = join(root, "home");
+		const agentDir = join(root, "pi-agent");
+		mkdirSync(project, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		const restore = stubSkillEnv(home, agentDir);
+
+		try {
+			writeSkill(join(home, ".claude", "skills"), "reload-widget", "personal skill");
+
+			let admission: SkillAdmissionContext = {
+				trusted: true,
+				acknowledged: [],
+				disabled: [],
+				disabledGroups: [],
+				overrides: {},
+			};
+			const settingsManager = SettingsManager.create(project, agentDir, { projectTrusted: true });
+			const loader = await buildResourceLoader(project, settingsManager, () => admission);
+			const hasWidget = () =>
+				loader.getSkills().skills.some((skill) => skill.name === "reload-widget");
+
+			expect(hasWidget()).toBe(true);
+
+			// Flip the group off, then reload the SAME loader — the gate must re-read the new admission.
+			admission = { ...admission, disabledGroups: ["personal"] };
+			await loader.reload();
+			expect(hasWidget()).toBe(false);
+		} finally {
+			restore();
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/packages/server/src/agent/extensions.test.ts
+++ b/packages/server/src/agent/extensions.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listSkillCommands } from "./extensions";
+
+function writeSkill(root: string, name: string, description: string): void {
+	const directory = join(root, name);
+	mkdirSync(directory, { recursive: true });
+	writeFileSync(
+		join(directory, "SKILL.md"),
+		`---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n\nPortable fixture.\n`,
+	);
+}
+
+function restoreEnvironment(original: Record<string, string | undefined>): void {
+	for (const [name, value] of Object.entries(original)) {
+		if (value === undefined) delete process.env[name];
+		else process.env[name] = value;
+	}
+}
+
+describe("listSkillCommands", () => {
+	it("shares Pi precedence/provenance and does not execute extensions", async () => {
+		const root = mkdtempSync(join(tmpdir(), "thinkrail-skill-catalog-"));
+		const project = join(root, "project");
+		const home = join(root, "home");
+		const agentDir = join(root, "pi-agent");
+		const marker = join(root, "extension-executed");
+		mkdirSync(project, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+
+		const original = Object.fromEntries(
+			["HOME", "PI_CODING_AGENT_DIR", "CLAUDE_CONFIG_DIR", "CODEX_HOME", "GEMINI_CLI_HOME"].map(
+				(name) => [name, process.env[name]],
+			),
+		);
+		process.env.HOME = home;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CODEX_HOME;
+		delete process.env.GEMINI_CLI_HOME;
+
+		try {
+			const configuredRoot = join(root, "configured-skills");
+			const nativeRoot = join(project, ".pi", "skills");
+			const projectRoot = join(project, ".claude", "skills");
+			const personalRoot = join(home, ".claude", "skills");
+			writeSkill(configuredRoot, "configured-wins", "configured description");
+			writeSkill(projectRoot, "configured-wins", "project alias must lose");
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				`${JSON.stringify({ skills: [configuredRoot] }, null, 2)}\n`,
+			);
+			writeSkill(nativeRoot, "native-wins", "native description");
+			writeSkill(projectRoot, "native-wins", "alias must lose");
+			writeSkill(projectRoot, "project-wins", "project description");
+			writeSkill(personalRoot, "project-wins", "personal must lose");
+			writeSkill(personalRoot, "personal-only", "personal description");
+			writeSkill(join(project, ".github", "skills"), "project-copilot", "copilot project");
+			writeSkill(join(project, ".gemini", "skills"), "project-gemini", "gemini project");
+			writeSkill(join(home, ".codex", "skills"), "personal-codex", "codex personal");
+			writeSkill(join(home, ".copilot", "skills"), "personal-copilot", "copilot personal");
+			writeSkill(join(home, ".gemini", "skills"), "personal-gemini", "gemini personal");
+			// A personal portable skill deliberately shadows ThinkRail's bundled workflow skill.
+			writeSkill(personalRoot, "brainstorming", "personal brainstorming override");
+
+			const invalidDir = join(projectRoot, "invalid");
+			mkdirSync(invalidDir, { recursive: true });
+			writeFileSync(join(invalidDir, "SKILL.md"), "# no frontmatter\n");
+
+			const extensionDir = join(project, ".pi", "extensions");
+			mkdirSync(extensionDir, { recursive: true });
+			writeFileSync(
+				join(extensionDir, "probe.ts"),
+				`import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "ran");\nexport default () => {};\n`,
+			);
+
+			const commands = await listSkillCommands(project);
+			const byName = (name: string) => commands.find((command) => command.name === `skill:${name}`);
+
+			expect(byName("configured-wins")?.description).toBe("configured description");
+			expect(byName("configured-wins")?.sourceInfo.scope).toBe("user");
+			expect(byName("native-wins")?.description).toBe("native description");
+			expect(byName("native-wins")?.sourceInfo.scope).toBe("project");
+			expect(byName("project-wins")?.description).toBe("project description");
+			expect(byName("project-wins")?.sourceInfo).toMatchObject({
+				source: "claude",
+				scope: "project",
+			});
+			expect(byName("personal-only")?.sourceInfo).toMatchObject({
+				source: "claude",
+				scope: "user",
+			});
+			expect(byName("project-copilot")?.sourceInfo).toMatchObject({
+				source: "github-copilot",
+				scope: "project",
+			});
+			expect(byName("project-gemini")?.sourceInfo).toMatchObject({
+				source: "gemini",
+				scope: "project",
+			});
+			expect(byName("personal-codex")?.sourceInfo).toMatchObject({
+				source: "codex",
+				scope: "user",
+			});
+			expect(byName("personal-copilot")?.sourceInfo).toMatchObject({
+				source: "github-copilot",
+				scope: "user",
+			});
+			expect(byName("personal-gemini")?.sourceInfo).toMatchObject({
+				source: "gemini",
+				scope: "user",
+			});
+			expect(byName("brainstorming")?.description).toBe("personal brainstorming override");
+			expect(byName("invalid")).toBeUndefined();
+			expect(existsSync(marker)).toBe(false);
+		} finally {
+			restoreEnvironment(original);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/server/src/agent/extensions.test.ts
+++ b/packages/server/src/agent/extensions.test.ts
@@ -7,7 +7,7 @@ import type { SkillAdmissionContext } from "./skillAdmission";
 
 /** A context with the given trust + acknowledged names, and no baseline disables / workspace overrides. */
 function ctx(trusted: boolean, acknowledged: string[] = []): SkillAdmissionContext {
-	return { trusted, acknowledged, disabled: [], overrides: {} };
+	return { trusted, acknowledged, disabled: [], disabledGroups: [], overrides: {} };
 }
 
 function writeSkill(root: string, name: string, description: string): void {

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -27,7 +27,7 @@ import {
 	SettingsManager,
 	type Skill,
 } from "@earendil-works/pi-coding-agent";
-import type { SlashCommandInfo } from "@thinkrail/contracts";
+import type { SkillCatalogEntry, SlashCommandInfo } from "@thinkrail/contracts";
 import { askUserQuestionExtension } from "./askUserQuestion";
 import { decideSkill, type SkillAdmissionContext } from "./skillAdmission";
 import { type CompatibilitySkillSource, discoverCompatibilitySkillSources } from "./skillSources";
@@ -279,4 +279,54 @@ export async function listProjectAliasSkillNames(cwd: string): Promise<string[]>
 		.getSkills()
 		.skills.filter((skill) => projectPaths.some((path) => isUnderPath(skill.filePath, path)))
 		.map((skill) => skill.name);
+}
+
+/**
+ * The full skill catalog for a workspace's Skills manager: every discovered skill (bundled + personal +
+ * project + pi-native) with its admission verdict, so hidden skills show a reason instead of vanishing.
+ * Unlike `listSkillCommands` this does NOT filter — it relabels provenance only and attaches each skill's
+ * `decision`, letting the UI render untrusted / pending-ack / disabled entries with the right affordance.
+ */
+export async function listSkillCatalog(
+	cwd: string,
+	admission: SkillAdmissionContext,
+): Promise<SkillCatalogEntry[]> {
+	const discovered = discoverCompatibilitySkillSources(cwd);
+	const projectAliasPaths = discovered.filter((s) => s.scope === "project").map((s) => s.path);
+	const isProjectAlias = (filePath: string) =>
+		projectAliasPaths.some((path) => isUnderPath(filePath, path));
+	const personal = discovered.filter((s) => s.scope === "user");
+	const project = discovered.filter((s) => s.scope === "project");
+	const bundledSkillPaths = bundled ? [bundled.skillsDir] : resolveDevPaths().skillPaths;
+	const settingsManager = SettingsManager.create(cwd, getAgentDir(), { projectTrusted: true });
+	const loader = new DefaultResourceLoader({
+		cwd,
+		agentDir: getAgentDir(),
+		settingsManager,
+		additionalSkillPaths: [
+			...bundledSkillPaths,
+			...personal.map((s) => s.path),
+			...project.map((s) => s.path),
+		],
+		// Relabel only (no admission filter) so the manager sees every discovered skill + its verdict.
+		skillsOverride: (current) => ({
+			...current,
+			skills: current.skills.map((skill) => relabelAliasProvenance(skill, discovered)),
+		}),
+		noExtensions: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await loader.reload();
+	return loader.getSkills().skills.map((skill) => {
+		const gated = isProjectAlias(skill.filePath);
+		return {
+			name: skill.name,
+			description: skill.description,
+			sourceInfo: skill.sourceInfo,
+			gated,
+			decision: decideSkill({ name: skill.name, isProjectAlias: gated }, admission),
+		};
+	});
 }

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -292,9 +292,6 @@ export async function listSkillCatalog(
 	admission: SkillAdmissionContext,
 ): Promise<SkillCatalogEntry[]> {
 	const discovered = discoverCompatibilitySkillSources(cwd);
-	const projectAliasPaths = discovered.filter((s) => s.scope === "project").map((s) => s.path);
-	const isProjectAlias = (filePath: string) =>
-		projectAliasPaths.some((path) => isUnderPath(filePath, path));
 	const personal = discovered.filter((s) => s.scope === "user");
 	const project = discovered.filter((s) => s.scope === "project");
 	const bundledSkillPaths = bundled ? [bundled.skillsDir] : resolveDevPaths().skillPaths;
@@ -320,12 +317,14 @@ export async function listSkillCatalog(
 	});
 	await loader.reload();
 	return loader.getSkills().skills.map((skill) => {
-		const gated = isProjectAlias(skill.filePath);
+		const source = discovered.find((candidate) => isUnderPath(skill.filePath, candidate.path));
+		const gated = source?.scope === "project";
 		return {
 			name: skill.name,
 			description: skill.description,
 			sourceInfo: skill.sourceInfo,
 			gated,
+			...(source?.plugin ? { plugin: source.plugin } : {}),
 			decision: decideSkill({ name: skill.name, isProjectAlias: gated }, admission),
 		};
 	});

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -29,6 +29,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { SlashCommandInfo } from "@thinkrail/contracts";
 import { askUserQuestionExtension } from "./askUserQuestion";
+import { decideSkill, type SkillAdmissionContext } from "./skillAdmission";
 import { type CompatibilitySkillSource, discoverCompatibilitySkillSources } from "./skillSources";
 
 /** A bundled extension entry's default export — the pi factory shape the loader invokes. */
@@ -96,51 +97,67 @@ function isUnderPath(path: string, root: string): boolean {
 	return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`);
 }
 
-/** Keep compatibility aliases' provenance truthful without overwriting an explicit Pi settings source. */
-function compatibilitySkillsOverride(sources: CompatibilitySkillSource[]) {
+/** Relabel one skill's default `temporary` scope to its true provider/scope; leave configured ones alone. */
+function relabelAliasProvenance(skill: Skill, sources: CompatibilitySkillSource[]): Skill {
+	// Pi-configured/native/shared resources already carry user/project metadata and outrank inferred aliases;
+	// only the loader's default `temporary` scope (an additional path) needs relabeling.
+	if (skill.sourceInfo.scope !== "temporary") return skill;
+	const source = sources.find((candidate) => isUnderPath(skill.filePath, candidate.path));
+	if (!source) return skill;
+	return {
+		...skill,
+		sourceInfo: createSyntheticSourceInfo(skill.filePath, {
+			source: source.provider,
+			scope: source.scope,
+			origin: "top-level",
+			baseDir: source.path,
+		}),
+	};
+}
+
+/**
+ * The combined skills override: relabel compatibility aliases' provenance AND apply the admission decision,
+ * so a session only ever loads skills that resolve to `load` — untrusted / unacknowledged / disabled ones
+ * never reach the system prompt or the `/skill:` list. `sources` identifies which loaded skills are
+ * project-scoped aliases (by file path); `ctx` carries trust + acknowledged + disables + workspace overrides.
+ */
+function skillsGate(sources: CompatibilitySkillSource[], ctx: SkillAdmissionContext) {
+	const projectAliasPaths = sources.filter((s) => s.scope === "project").map((s) => s.path);
+	const isProjectAlias = (filePath: string) =>
+		projectAliasPaths.some((path) => isUnderPath(filePath, path));
 	return (current: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => ({
 		...current,
-		skills: current.skills.map((skill) => {
-			// Pi-configured/native/shared resources already carry user/project metadata and outrank inferred
-			// aliases. Only additional paths get the loader's default temporary scope and need relabeling.
-			if (skill.sourceInfo.scope !== "temporary") return skill;
-			const source = sources.find((candidate) => isUnderPath(skill.filePath, candidate.path));
-			if (!source) return skill;
-			return {
-				...skill,
-				sourceInfo: createSyntheticSourceInfo(skill.filePath, {
-					source: source.provider,
-					scope: source.scope,
-					origin: "top-level",
-					baseDir: source.path,
-				}),
-			};
-		}),
+		skills: current.skills
+			.map((skill) => relabelAliasProvenance(skill, sources))
+			.filter(
+				(skill) =>
+					decideSkill({ name: skill.name, isProjectAlias: isProjectAlias(skill.filePath) }, ctx) ===
+					"load",
+			),
 	});
 }
 
 function resolveSkillInputs(
 	cwd: string,
-	trustedProject: boolean,
+	ctx: SkillAdmissionContext,
 ): {
 	additionalSkillPaths: string[];
-	skillsOverride: ReturnType<typeof compatibilitySkillsOverride>;
+	skillsOverride: ReturnType<typeof skillsGate>;
 } {
 	const discovered = discoverCompatibilitySkillSources(cwd);
-	// Personal aliases (`~/.claude` …) are the user's own machine — always safe. Project-scoped aliases (a
-	// repo's committed `.claude/skills` etc.) are attacker-controlled for a cloned repo and get injected into
-	// the agent's system prompt, so they load only after an explicit project-trust grant. Fail closed: an
-	// untrusted (or undecided) project contributes no aliases at all.
 	const personal = discovered.filter((source) => source.scope === "user");
-	const project = trustedProject ? discovered.filter((source) => source.scope === "project") : [];
-	const sources = [...personal, ...project];
+	const project = discovered.filter((source) => source.scope === "project");
 	const bundledSkillPaths = bundled ? [bundled.skillsDir] : resolveDevPaths().skillPaths;
 	return {
-		// DefaultResourceLoader puts Pi settings/native/shared resources first. We then add ThinkRail's bundled
-		// skills, the user's personal aliases, then (only when trusted) the project's aliases — so first-name-wins
-		// gives pi-native > bundled > personal > project: a repo can never shadow your own or ThinkRail's skills.
-		additionalSkillPaths: [...bundledSkillPaths, ...sources.map((source) => source.path)],
-		skillsOverride: compatibilitySkillsOverride(sources),
+		// All alias dirs are made discoverable so the catalog can enumerate them; the per-skill admission gate
+		// (`skillsGate`) is what actually withholds untrusted/unacknowledged/disabled ones. Path order sets the
+		// first-name-wins precedence pi-native > bundled > personal > project.
+		additionalSkillPaths: [
+			...bundledSkillPaths,
+			...personal.map((source) => source.path),
+			...project.map((source) => source.path),
+		],
+		skillsOverride: skillsGate(discovered, ctx),
 	};
 }
 
@@ -158,16 +175,17 @@ export function toSkillCommands(skills: readonly Skill[]): SlashCommandInfo[] {
  * A resource loader with `pi-web-access` + `pi-visualize` + `pi-spec-graph` (and its skill) +
  * `pi-thinkrail-workflow` (and its skills) + `pi-todos` (and its skill) (+ the headless-search policy),
  * our host-owned `ask_user_question` tool, and portable cross-agent skill aliases layered onto Pi's
- * default discovery. `trustedProject` gates the project-scoped aliases (personal/bundled always load) —
- * pass the owning project's trust decision; fail closed (`false`) when it is unknown.
+ * default discovery. `admission` gates the skills (project-scoped aliases behind trust + acknowledgment,
+ * plus the per-skill enable/disable layer) — pass the owning workspace's resolved context; fail closed
+ * when it is unknown.
  */
 export async function buildResourceLoader(
 	cwd: string,
 	settingsManager: SettingsManager,
-	trustedProject: boolean,
+	admission: SkillAdmissionContext,
 ): Promise<ResourceLoader> {
 	const sharedFactories = [headlessSearchPolicy, askUserQuestionExtension];
-	const skillInputs = resolveSkillInputs(cwd, trustedProject);
+	const skillInputs = resolveSkillInputs(cwd, admission);
 	const common = {
 		cwd,
 		agentDir: getAgentDir(),
@@ -190,21 +208,32 @@ export async function buildResourceLoader(
 	return loader;
 }
 
+/** A stable cache key for a `(cwd, admission)` pair — sorted so equal contexts collide, distinct ones don't. */
+function admissionCacheKey(cwd: string, ctx: SkillAdmissionContext): string {
+	return JSON.stringify([
+		cwd,
+		ctx.trusted,
+		[...ctx.acknowledged].sort(),
+		[...ctx.disabled].sort(),
+		Object.entries(ctx.overrides).sort(([a], [b]) => a.localeCompare(b)),
+	]);
+}
+
 const SKILL_LIST_TTL_MS = 5_000;
 const skillListCache = new Map<string, { at: number; value: SlashCommandInfo[] }>();
 
 /**
  * Skill-only pre-session catalog for New Workspace autocomplete. It shares the real session's Pi settings,
  * package/native discovery, compatibility aliases, and bundled skills, but never loads extension factories
- * or creates a model/session/transcript. `trustedProject` gates the project-scoped aliases, exactly as the
- * live session does. Cached briefly per `(cwd, trust)` so flipping the project picker doesn't re-walk the
- * filesystem each time; because trust is part of the key, a fresh grant misses the stale untrusted entry.
+ * or creates a model/session/transcript. `admission` gates the skills exactly as the live session does.
+ * Cached briefly per `(cwd, admission)` so flipping the project picker doesn't re-walk the filesystem; a
+ * fresh grant changes the key, so it never returns a stale untrusted list.
  */
 export async function listSkillCommands(
 	cwd: string,
-	trustedProject: boolean,
+	admission: SkillAdmissionContext,
 ): Promise<SlashCommandInfo[]> {
-	const cacheKey = `${trustedProject ? "T" : "U"} ${cwd}`;
+	const cacheKey = admissionCacheKey(cwd, admission);
 	const cached = skillListCache.get(cacheKey);
 	if (cached && Date.now() - cached.at < SKILL_LIST_TTL_MS) return cached.value;
 	const settingsManager = SettingsManager.create(cwd, getAgentDir(), { projectTrusted: true });
@@ -212,7 +241,7 @@ export async function listSkillCommands(
 		cwd,
 		agentDir: getAgentDir(),
 		settingsManager,
-		...resolveSkillInputs(cwd, trustedProject),
+		...resolveSkillInputs(cwd, admission),
 		noExtensions: true,
 		noPromptTemplates: true,
 		noThemes: true,
@@ -222,4 +251,32 @@ export async function listSkillCommands(
 	const value = toSkillCommands(loader.getSkills().skills);
 	skillListCache.set(cacheKey, { at: Date.now(), value });
 	return value;
+}
+
+/**
+ * The project-scoped alias skill names present in a checkout right now — what granting trust acknowledges,
+ * and the count the New Workspace / Welcome trust notice shows. A skills-only loader restricted to the
+ * project alias dirs (no admission filter), so it enumerates them regardless of the current trust state.
+ */
+export async function listProjectAliasSkillNames(cwd: string): Promise<string[]> {
+	const projectPaths = discoverCompatibilitySkillSources(cwd)
+		.filter((source) => source.scope === "project")
+		.map((source) => source.path);
+	if (projectPaths.length === 0) return [];
+	const settingsManager = SettingsManager.create(cwd, getAgentDir(), { projectTrusted: true });
+	const loader = new DefaultResourceLoader({
+		cwd,
+		agentDir: getAgentDir(),
+		settingsManager,
+		additionalSkillPaths: projectPaths,
+		noExtensions: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await loader.reload();
+	return loader
+		.getSkills()
+		.skills.filter((skill) => projectPaths.some((path) => isUnderPath(skill.filePath, path)))
+		.map((skill) => skill.name);
 }

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -30,7 +30,11 @@ import {
 import type { SkillCatalogEntry, SlashCommandInfo } from "@thinkrail/contracts";
 import { askUserQuestionExtension } from "./askUserQuestion";
 import { decideSkill, type SkillAdmissionContext } from "./skillAdmission";
-import { type CompatibilitySkillSource, discoverCompatibilitySkillSources } from "./skillSources";
+import {
+	type CompatibilitySkillSource,
+	candidateCompatibilitySkillRoots,
+	discoverCompatibilitySkillSources,
+} from "./skillSources";
 
 /** A bundled extension entry's default export — the pi factory shape the loader invokes. */
 export type BundledExtensionFactory = ExtensionFactory;
@@ -138,21 +142,20 @@ function skillGroup(
 /**
  * The combined skills override: relabel compatibility aliases' provenance AND apply the admission decision,
  * so a session only ever loads skills that resolve to `load` — untrusted / unacknowledged / disabled (per
- * skill or per group) ones never reach the system prompt or the `/skill:` list. `sources` + `bundledPaths`
- * classify each loaded skill (project alias? which group?); `getCtx` yields the current trust/acknowledge/
- * disable state — **re-read on every invocation** so `session.reload()` picks up a mid-session trust grant
- * or skill/group toggle instead of re-applying the snapshot captured at session creation.
+ * skill or per group) ones never reach the system prompt or the `/skill:` list. `bundledPaths` classifies
+ * bundled skills; the compatibility `sources` **and** the admission `ctx` are **both re-resolved on every
+ * invocation** (each `loader.reload()`): `getCtx` so a mid-session trust grant or toggle lands, and fresh
+ * discovery so a compatibility dir that appeared mid-session (e.g. `.claude/skills` from a branch switch)
+ * is classified correctly — critically, a newly-appeared project alias is recognised as such and stays
+ * behind the trust gate rather than slipping through as an unclassified `load`.
  */
-function skillsGate(
-	sources: CompatibilitySkillSource[],
-	bundledPaths: string[],
-	getCtx: () => SkillAdmissionContext,
-) {
-	const projectAliasPaths = sources.filter((s) => s.scope === "project").map((s) => s.path);
-	const isProjectAlias = (filePath: string) =>
-		projectAliasPaths.some((path) => isUnderPath(filePath, path));
+function skillsGate(cwd: string, bundledPaths: string[], getCtx: () => SkillAdmissionContext) {
 	return (current: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		const ctx = getCtx();
+		const sources = discoverCompatibilitySkillSources(cwd);
+		const projectAliasPaths = sources.filter((s) => s.scope === "project").map((s) => s.path);
+		const isProjectAlias = (filePath: string) =>
+			projectAliasPaths.some((path) => isUnderPath(filePath, path));
 		return {
 			...current,
 			skills: current.skills
@@ -177,9 +180,13 @@ function resolveSkillInputs(
 	additionalSkillPaths: string[];
 	skillsOverride: ReturnType<typeof skillsGate>;
 } {
-	const discovered = discoverCompatibilitySkillSources(cwd);
-	const personal = discovered.filter((source) => source.scope === "user");
-	const project = discovered.filter((source) => source.scope === "project");
+	// Register the CANDIDATE roots (not just the ones that exist now) so `loader.reload()` picks up a
+	// compatibility dir that appears mid-session — e.g. a branch switch/pull adds `.claude/skills`. Pi
+	// tolerates a not-yet-existing path and scans it once it appears; `skillsGate` re-discovers the live
+	// source set each reload, so a late project alias is still classified + trust-gated correctly.
+	const candidates = candidateCompatibilitySkillRoots(cwd);
+	const personal = candidates.filter((source) => source.scope === "user");
+	const project = candidates.filter((source) => source.scope === "project");
 	const bundledSkillPaths = bundled ? [bundled.skillsDir] : resolveDevPaths().skillPaths;
 	return {
 		// All alias dirs are made discoverable so the catalog can enumerate them; the per-skill admission gate
@@ -190,7 +197,7 @@ function resolveSkillInputs(
 			...personal.map((source) => source.path),
 			...project.map((source) => source.path),
 		],
-		skillsOverride: skillsGate(discovered, bundledSkillPaths, getCtx),
+		skillsOverride: skillsGate(cwd, bundledSkillPaths, getCtx),
 	};
 }
 

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -139,35 +139,40 @@ function skillGroup(
  * The combined skills override: relabel compatibility aliases' provenance AND apply the admission decision,
  * so a session only ever loads skills that resolve to `load` — untrusted / unacknowledged / disabled (per
  * skill or per group) ones never reach the system prompt or the `/skill:` list. `sources` + `bundledPaths`
- * classify each loaded skill (project alias? which group?); `ctx` carries the trust/acknowledge/disable state.
+ * classify each loaded skill (project alias? which group?); `getCtx` yields the current trust/acknowledge/
+ * disable state — **re-read on every invocation** so `session.reload()` picks up a mid-session trust grant
+ * or skill/group toggle instead of re-applying the snapshot captured at session creation.
  */
 function skillsGate(
 	sources: CompatibilitySkillSource[],
 	bundledPaths: string[],
-	ctx: SkillAdmissionContext,
+	getCtx: () => SkillAdmissionContext,
 ) {
 	const projectAliasPaths = sources.filter((s) => s.scope === "project").map((s) => s.path);
 	const isProjectAlias = (filePath: string) =>
 		projectAliasPaths.some((path) => isUnderPath(filePath, path));
-	return (current: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => ({
-		...current,
-		skills: current.skills
-			.map((skill) => relabelAliasProvenance(skill, sources))
-			.filter((skill) => {
-				const { group, isPlugin } = skillGroup(skill.filePath, sources, bundledPaths);
-				return (
-					decideSkill(
-						{ name: skill.name, isProjectAlias: isProjectAlias(skill.filePath), group, isPlugin },
-						ctx,
-					) === "load"
-				);
-			}),
-	});
+	return (current: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
+		const ctx = getCtx();
+		return {
+			...current,
+			skills: current.skills
+				.map((skill) => relabelAliasProvenance(skill, sources))
+				.filter((skill) => {
+					const { group, isPlugin } = skillGroup(skill.filePath, sources, bundledPaths);
+					return (
+						decideSkill(
+							{ name: skill.name, isProjectAlias: isProjectAlias(skill.filePath), group, isPlugin },
+							ctx,
+						) === "load"
+					);
+				}),
+		};
+	};
 }
 
 function resolveSkillInputs(
 	cwd: string,
-	ctx: SkillAdmissionContext,
+	getCtx: () => SkillAdmissionContext,
 ): {
 	additionalSkillPaths: string[];
 	skillsOverride: ReturnType<typeof skillsGate>;
@@ -185,7 +190,7 @@ function resolveSkillInputs(
 			...personal.map((source) => source.path),
 			...project.map((source) => source.path),
 		],
-		skillsOverride: skillsGate(discovered, bundledSkillPaths, ctx),
+		skillsOverride: skillsGate(discovered, bundledSkillPaths, getCtx),
 	};
 }
 
@@ -203,17 +208,18 @@ export function toSkillCommands(skills: readonly Skill[]): SlashCommandInfo[] {
  * A resource loader with `pi-web-access` + `pi-visualize` + `pi-spec-graph` (and its skill) +
  * `pi-thinkrail-workflow` (and its skills) + `pi-todos` (and its skill) (+ the headless-search policy),
  * our host-owned `ask_user_question` tool, and portable cross-agent skill aliases layered onto Pi's
- * default discovery. `admission` gates the skills (project-scoped aliases behind trust + acknowledgment,
- * plus the per-skill enable/disable layer) — pass the owning workspace's resolved context; fail closed
- * when it is unknown.
+ * default discovery. `getAdmission` gates the skills (project-scoped aliases behind trust + acknowledgment,
+ * plus the per-skill enable/disable layer) — pass a resolver for the owning workspace's context, **re-read
+ * on every `loader.reload()`** so a mid-session trust grant or skill/group toggle lands via
+ * `session.reload()`; fail closed when it is unknown.
  */
 export async function buildResourceLoader(
 	cwd: string,
 	settingsManager: SettingsManager,
-	admission: SkillAdmissionContext,
+	getAdmission: () => SkillAdmissionContext,
 ): Promise<ResourceLoader> {
 	const sharedFactories = [headlessSearchPolicy, askUserQuestionExtension];
-	const skillInputs = resolveSkillInputs(cwd, admission);
+	const skillInputs = resolveSkillInputs(cwd, getAdmission);
 	const common = {
 		cwd,
 		agentDir: getAgentDir(),
@@ -243,6 +249,7 @@ function admissionCacheKey(cwd: string, ctx: SkillAdmissionContext): string {
 		ctx.trusted,
 		[...ctx.acknowledged].sort(),
 		[...ctx.disabled].sort(),
+		[...ctx.disabledGroups].sort(),
 		Object.entries(ctx.overrides).sort(([a], [b]) => a.localeCompare(b)),
 	]);
 }
@@ -269,7 +276,7 @@ export async function listSkillCommands(
 		cwd,
 		agentDir: getAgentDir(),
 		settingsManager,
-		...resolveSkillInputs(cwd, admission),
+		...resolveSkillInputs(cwd, () => admission),
 		noExtensions: true,
 		noPromptTemplates: true,
 		noThemes: true,

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -8,7 +8,8 @@
 //   first use — resolution needs `node_modules`, which a compiled binary lacks. `pi-spec-graph`,
 //   `pi-thinkrail-workflow`, and `pi-todos` are workspace packages (not pi-installed), so pi's package
 //   manager won't auto-discover their `pi.skills` manifests — we point `additionalSkillPaths` at their
-//   `skills/` dirs, after the compatible project/personal aliases.
+//   `skills/` dirs, before the personal/project aliases so bundled skills outrank them (precedence in
+//   `resolveSkillInputs`).
 // - Compiled binary: the launcher injects the same five extensions as value-imported factories + a staged
 //   on-disk skills dir via `setBundledExtensions` (pi gives `extensionFactories` full API parity with
 //   path loading; pi reads skills via plain fs, so they must live on the real filesystem).
@@ -118,16 +119,27 @@ function compatibilitySkillsOverride(sources: CompatibilitySkillSource[]) {
 	});
 }
 
-function resolveSkillInputs(cwd: string): {
+function resolveSkillInputs(
+	cwd: string,
+	trustedProject: boolean,
+): {
 	additionalSkillPaths: string[];
 	skillsOverride: ReturnType<typeof compatibilitySkillsOverride>;
 } {
-	const sources = discoverCompatibilitySkillSources(cwd);
+	const discovered = discoverCompatibilitySkillSources(cwd);
+	// Personal aliases (`~/.claude` …) are the user's own machine — always safe. Project-scoped aliases (a
+	// repo's committed `.claude/skills` etc.) are attacker-controlled for a cloned repo and get injected into
+	// the agent's system prompt, so they load only after an explicit project-trust grant. Fail closed: an
+	// untrusted (or undecided) project contributes no aliases at all.
+	const personal = discovered.filter((source) => source.scope === "user");
+	const project = trustedProject ? discovered.filter((source) => source.scope === "project") : [];
+	const sources = [...personal, ...project];
 	const bundledSkillPaths = bundled ? [bundled.skillsDir] : resolveDevPaths().skillPaths;
 	return {
-		// DefaultResourceLoader puts Pi settings/native/shared resources first. Compatibility project aliases
-		// then personal aliases are in `sources` order; bundled skills stay last so user skills can override.
-		additionalSkillPaths: [...sources.map((source) => source.path), ...bundledSkillPaths],
+		// DefaultResourceLoader puts Pi settings/native/shared resources first. We then add ThinkRail's bundled
+		// skills, the user's personal aliases, then (only when trusted) the project's aliases — so first-name-wins
+		// gives pi-native > bundled > personal > project: a repo can never shadow your own or ThinkRail's skills.
+		additionalSkillPaths: [...bundledSkillPaths, ...sources.map((source) => source.path)],
 		skillsOverride: compatibilitySkillsOverride(sources),
 	};
 }
@@ -143,16 +155,19 @@ export function toSkillCommands(skills: readonly Skill[]): SlashCommandInfo[] {
 }
 
 /**
+ * A resource loader with `pi-web-access` + `pi-visualize` + `pi-spec-graph` (and its skill) +
  * `pi-thinkrail-workflow` (and its skills) + `pi-todos` (and its skill) (+ the headless-search policy),
  * our host-owned `ask_user_question` tool, and portable cross-agent skill aliases layered onto Pi's
- * default discovery.
+ * default discovery. `trustedProject` gates the project-scoped aliases (personal/bundled always load) —
+ * pass the owning project's trust decision; fail closed (`false`) when it is unknown.
  */
 export async function buildResourceLoader(
 	cwd: string,
 	settingsManager: SettingsManager,
+	trustedProject: boolean,
 ): Promise<ResourceLoader> {
 	const sharedFactories = [headlessSearchPolicy, askUserQuestionExtension];
-	const skillInputs = resolveSkillInputs(cwd);
+	const skillInputs = resolveSkillInputs(cwd, trustedProject);
 	const common = {
 		cwd,
 		agentDir: getAgentDir(),
@@ -175,23 +190,36 @@ export async function buildResourceLoader(
 	return loader;
 }
 
+const SKILL_LIST_TTL_MS = 5_000;
+const skillListCache = new Map<string, { at: number; value: SlashCommandInfo[] }>();
+
 /**
  * Skill-only pre-session catalog for New Workspace autocomplete. It shares the real session's Pi settings,
  * package/native discovery, compatibility aliases, and bundled skills, but never loads extension factories
- * or creates a model/session/transcript.
+ * or creates a model/session/transcript. `trustedProject` gates the project-scoped aliases, exactly as the
+ * live session does. Cached briefly per `(cwd, trust)` so flipping the project picker doesn't re-walk the
+ * filesystem each time; because trust is part of the key, a fresh grant misses the stale untrusted entry.
  */
-export async function listSkillCommands(cwd: string): Promise<SlashCommandInfo[]> {
+export async function listSkillCommands(
+	cwd: string,
+	trustedProject: boolean,
+): Promise<SlashCommandInfo[]> {
+	const cacheKey = `${trustedProject ? "T" : "U"} ${cwd}`;
+	const cached = skillListCache.get(cacheKey);
+	if (cached && Date.now() - cached.at < SKILL_LIST_TTL_MS) return cached.value;
 	const settingsManager = SettingsManager.create(cwd, getAgentDir(), { projectTrusted: true });
 	const loader = new DefaultResourceLoader({
 		cwd,
 		agentDir: getAgentDir(),
 		settingsManager,
-		...resolveSkillInputs(cwd),
+		...resolveSkillInputs(cwd, trustedProject),
 		noExtensions: true,
 		noPromptTemplates: true,
 		noThemes: true,
 		noContextFiles: true,
 	});
 	await loader.reload();
-	return toSkillCommands(loader.getSkills().skills);
+	const value = toSkillCommands(loader.getSkills().skills);
+	skillListCache.set(cacheKey, { at: Date.now(), value });
+	return value;
 }

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -1,28 +1,34 @@
-// Bundles the `pi-web-access` (web_search + fetch_content), `pi-visualize` (the `visualize` tool),
 // `pi-spec-graph` (spec_* tools + the spec-graph skill), `pi-thinkrail-workflow` (the workflow-router
-// rule + workflow skills), and `pi-todos` (todo_* tools + the todos skill) extensions into a session's
-// resource loader, so the tools are present out of the box without a separate install. Two loading modes:
-// - Run-from-source: explicit `additionalExtensionPaths` (all ship raw `.ts`; pi's loader jiti-loads
+// rule + workflow skills), and `pi-todos` (todo_* tools + the todos skill) extensions and recognized
+// portable cross-agent skill aliases into a session's resource loader, so they are present without a
+// separate install/import. Two bundled-resource modes:
+// - Run-from-source: explicit `additionalExtensionPaths` (all five ship raw `.ts`; pi's loader jiti-loads
 //   TS, keeping their source out of our typecheck graph — `pi-spec-graph`'s exports map keeps `./index.ts`
 //   reachable alongside the `./core` subpath the `spec/` module value-imports). Paths resolve lazily on
-//   first use — resolution needs `node_modules`, which a compiled binary lacks. `pi-spec-graph` and
-//   `pi-thinkrail-workflow`/`pi-todos` are workspace packages (not pi-installed), so pi's package manager
-//   won't auto-discover their `pi.skills` manifests — we point `additionalSkillPaths` at their `skills/` dirs.
-// - Compiled binary: the launcher injects the same extensions as value-imported factories + a staged
+//   first use — resolution needs `node_modules`, which a compiled binary lacks. `pi-spec-graph`,
+//   `pi-thinkrail-workflow`, and `pi-todos` are workspace packages (not pi-installed), so pi's package
+//   manager won't auto-discover their `pi.skills` manifests — we point `additionalSkillPaths` at their
+//   `skills/` dirs, after the compatible project/personal aliases.
+// - Compiled binary: the launcher injects the same five extensions as value-imported factories + a staged
 //   on-disk skills dir via `setBundledExtensions` (pi gives `extensionFactories` full API parity with
 //   path loading; pi reads skills via plain fs, so they must live on the real filesystem).
 
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import {
+	createSyntheticSourceInfo,
 	DefaultResourceLoader,
 	type ExtensionAPI,
 	type ExtensionFactory,
 	getAgentDir,
+	type ResourceDiagnostic,
 	type ResourceLoader,
-	type SettingsManager,
+	SettingsManager,
+	type Skill,
 } from "@earendil-works/pi-coding-agent";
+import type { SlashCommandInfo } from "@thinkrail/contracts";
 import { askUserQuestionExtension } from "./askUserQuestion";
+import { type CompatibilitySkillSource, discoverCompatibilitySkillSources } from "./skillSources";
 
 /** A bundled extension entry's default export — the pi factory shape the loader invokes. */
 export type BundledExtensionFactory = ExtensionFactory;
@@ -83,37 +89,109 @@ const headlessSearchPolicy: ExtensionFactory = (pi: ExtensionAPI) => {
 	});
 };
 
+function isUnderPath(path: string, root: string): boolean {
+	const normalizedPath = resolve(path);
+	const normalizedRoot = resolve(root);
+	return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`);
+}
+
+/** Keep compatibility aliases' provenance truthful without overwriting an explicit Pi settings source. */
+function compatibilitySkillsOverride(sources: CompatibilitySkillSource[]) {
+	return (current: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => ({
+		...current,
+		skills: current.skills.map((skill) => {
+			// Pi-configured/native/shared resources already carry user/project metadata and outrank inferred
+			// aliases. Only additional paths get the loader's default temporary scope and need relabeling.
+			if (skill.sourceInfo.scope !== "temporary") return skill;
+			const source = sources.find((candidate) => isUnderPath(skill.filePath, candidate.path));
+			if (!source) return skill;
+			return {
+				...skill,
+				sourceInfo: createSyntheticSourceInfo(skill.filePath, {
+					source: source.provider,
+					scope: source.scope,
+					origin: "top-level",
+					baseDir: source.path,
+				}),
+			};
+		}),
+	});
+}
+
+function resolveSkillInputs(cwd: string): {
+	additionalSkillPaths: string[];
+	skillsOverride: ReturnType<typeof compatibilitySkillsOverride>;
+} {
+	const sources = discoverCompatibilitySkillSources(cwd);
+	const bundledSkillPaths = bundled ? [bundled.skillsDir] : resolveDevPaths().skillPaths;
+	return {
+		// DefaultResourceLoader puts Pi settings/native/shared resources first. Compatibility project aliases
+		// then personal aliases are in `sources` order; bundled skills stay last so user skills can override.
+		additionalSkillPaths: [...sources.map((source) => source.path), ...bundledSkillPaths],
+		skillsOverride: compatibilitySkillsOverride(sources),
+	};
+}
+
+/** Map Pi's canonical skill records onto the existing slash-command wire shape. */
+export function toSkillCommands(skills: readonly Skill[]): SlashCommandInfo[] {
+	return skills.map((skill) => ({
+		name: `skill:${skill.name}`,
+		description: skill.description,
+		source: "skill" as const,
+		sourceInfo: skill.sourceInfo,
+	}));
+}
+
 /**
- * A resource loader with `pi-web-access` + `pi-visualize` + `pi-spec-graph` (and its skill) +
- * `pi-thinkrail-workflow` (and its skills) + `pi-todos` (and its skill) (+ the headless-search policy)
- * and our host-owned `ask_user_question` tool layered onto pi's default discovery.
+ * `pi-thinkrail-workflow` (and its skills) + `pi-todos` (and its skill) (+ the headless-search policy),
+ * our host-owned `ask_user_question` tool, and portable cross-agent skill aliases layered onto Pi's
+ * default discovery.
  */
 export async function buildResourceLoader(
 	cwd: string,
 	settingsManager: SettingsManager,
 ): Promise<ResourceLoader> {
 	const sharedFactories = [headlessSearchPolicy, askUserQuestionExtension];
+	const skillInputs = resolveSkillInputs(cwd);
+	const common = {
+		cwd,
+		agentDir: getAgentDir(),
+		settingsManager,
+		...skillInputs,
+	};
 	const loader = new DefaultResourceLoader(
 		bundled
 			? {
-					cwd,
-					agentDir: getAgentDir(),
-					settingsManager,
-					additionalSkillPaths: [bundled.skillsDir],
+					...common,
 					extensionFactories: [...bundled.factories, ...sharedFactories],
 				}
-			: (() => {
-					const paths = resolveDevPaths();
-					return {
-						cwd,
-						agentDir: getAgentDir(),
-						settingsManager,
-						additionalExtensionPaths: paths.extensionPaths,
-						additionalSkillPaths: paths.skillPaths,
-						extensionFactories: sharedFactories,
-					};
-				})(),
+			: {
+					...common,
+					additionalExtensionPaths: resolveDevPaths().extensionPaths,
+					extensionFactories: sharedFactories,
+				},
 	);
 	await loader.reload();
 	return loader;
+}
+
+/**
+ * Skill-only pre-session catalog for New Workspace autocomplete. It shares the real session's Pi settings,
+ * package/native discovery, compatibility aliases, and bundled skills, but never loads extension factories
+ * or creates a model/session/transcript.
+ */
+export async function listSkillCommands(cwd: string): Promise<SlashCommandInfo[]> {
+	const settingsManager = SettingsManager.create(cwd, getAgentDir(), { projectTrusted: true });
+	const loader = new DefaultResourceLoader({
+		cwd,
+		agentDir: getAgentDir(),
+		settingsManager,
+		...resolveSkillInputs(cwd),
+		noExtensions: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await loader.reload();
+	return toSkillCommands(loader.getSkills().skills);
 }

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -116,12 +116,36 @@ function relabelAliasProvenance(skill: Skill, sources: CompatibilitySkillSource[
 }
 
 /**
- * The combined skills override: relabel compatibility aliases' provenance AND apply the admission decision,
- * so a session only ever loads skills that resolve to `load` — untrusted / unacknowledged / disabled ones
- * never reach the system prompt or the `/skill:` list. `sources` identifies which loaded skills are
- * project-scoped aliases (by file path); `ctx` carries trust + acknowledged + disables + workspace overrides.
+ * The canonical group key + plugin flag for a skill, by where its file lives — a plugin name, else the
+ * source tier (`project`/`personal`/`bundled`/`pi`). Must match the key the UI groups/toggles by
+ * (`SkillCatalogEntry.group`) so a group disable resolves consistently on both sides.
  */
-function skillsGate(sources: CompatibilitySkillSource[], ctx: SkillAdmissionContext) {
+function skillGroup(
+	filePath: string,
+	sources: CompatibilitySkillSource[],
+	bundledPaths: string[],
+): { group: string; isPlugin: boolean } {
+	const source = sources.find((candidate) => isUnderPath(filePath, candidate.path));
+	if (source?.plugin) return { group: source.plugin, isPlugin: true };
+	if (source?.scope === "project") return { group: "project", isPlugin: false };
+	if (source?.scope === "user") return { group: "personal", isPlugin: false };
+	if (bundledPaths.some((path) => isUnderPath(filePath, path))) {
+		return { group: "bundled", isPlugin: false };
+	}
+	return { group: "pi", isPlugin: false };
+}
+
+/**
+ * The combined skills override: relabel compatibility aliases' provenance AND apply the admission decision,
+ * so a session only ever loads skills that resolve to `load` — untrusted / unacknowledged / disabled (per
+ * skill or per group) ones never reach the system prompt or the `/skill:` list. `sources` + `bundledPaths`
+ * classify each loaded skill (project alias? which group?); `ctx` carries the trust/acknowledge/disable state.
+ */
+function skillsGate(
+	sources: CompatibilitySkillSource[],
+	bundledPaths: string[],
+	ctx: SkillAdmissionContext,
+) {
 	const projectAliasPaths = sources.filter((s) => s.scope === "project").map((s) => s.path);
 	const isProjectAlias = (filePath: string) =>
 		projectAliasPaths.some((path) => isUnderPath(filePath, path));
@@ -129,11 +153,15 @@ function skillsGate(sources: CompatibilitySkillSource[], ctx: SkillAdmissionCont
 		...current,
 		skills: current.skills
 			.map((skill) => relabelAliasProvenance(skill, sources))
-			.filter(
-				(skill) =>
-					decideSkill({ name: skill.name, isProjectAlias: isProjectAlias(skill.filePath) }, ctx) ===
-					"load",
-			),
+			.filter((skill) => {
+				const { group, isPlugin } = skillGroup(skill.filePath, sources, bundledPaths);
+				return (
+					decideSkill(
+						{ name: skill.name, isProjectAlias: isProjectAlias(skill.filePath), group, isPlugin },
+						ctx,
+					) === "load"
+				);
+			}),
 	});
 }
 
@@ -157,7 +185,7 @@ function resolveSkillInputs(
 			...personal.map((source) => source.path),
 			...project.map((source) => source.path),
 		],
-		skillsOverride: skillsGate(discovered, ctx),
+		skillsOverride: skillsGate(discovered, bundledSkillPaths, ctx),
 	};
 }
 
@@ -319,13 +347,18 @@ export async function listSkillCatalog(
 	return loader.getSkills().skills.map((skill) => {
 		const source = discovered.find((candidate) => isUnderPath(skill.filePath, candidate.path));
 		const gated = source?.scope === "project";
+		const { group, isPlugin } = skillGroup(skill.filePath, discovered, bundledSkillPaths);
 		return {
 			name: skill.name,
 			description: skill.description,
 			sourceInfo: skill.sourceInfo,
 			gated,
+			group,
 			...(source?.plugin ? { plugin: source.plugin } : {}),
-			decision: decideSkill({ name: skill.name, isProjectAlias: gated }, admission),
+			decision: decideSkill(
+				{ name: skill.name, isProjectAlias: gated, group, isPlugin },
+				admission,
+			),
 		};
 	});
 }

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -5,10 +5,12 @@ export * from "./askUserQuestion";
 export {
 	type BundledExtensionFactory,
 	type BundledExtensions,
+	listProjectAliasSkillNames,
 	listSkillCommands,
 	setBundledExtensions,
 } from "./extensions";
 export * from "./oneshot";
 export * from "./piRuntime";
 export * from "./sessionRepair";
+export type { SkillAdmissionContext, SkillDecision, SkillFacts } from "./skillAdmission";
 export * from "./webUiContext";

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -6,6 +6,7 @@ export {
 	type BundledExtensionFactory,
 	type BundledExtensions,
 	listProjectAliasSkillNames,
+	listSkillCatalog,
 	listSkillCommands,
 	setBundledExtensions,
 } from "./extensions";

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -5,6 +5,7 @@ export * from "./askUserQuestion";
 export {
 	type BundledExtensionFactory,
 	type BundledExtensions,
+	listSkillCommands,
 	setBundledExtensions,
 } from "./extensions";
 export * from "./oneshot";

--- a/packages/server/src/agent/skillAdmission.test.ts
+++ b/packages/server/src/agent/skillAdmission.test.ts
@@ -5,10 +5,22 @@ const EMPTY: SkillAdmissionContext = {
 	trusted: false,
 	acknowledged: [],
 	disabled: [],
+	disabledGroups: [],
 	overrides: {},
 };
-const alias = (name: string) => ({ name, isProjectAlias: true });
-const own = (name: string) => ({ name, isProjectAlias: false });
+const alias = (name: string) => ({ name, isProjectAlias: true, group: "project", isPlugin: false });
+const own = (name: string, group = "personal") => ({
+	name,
+	isProjectAlias: false,
+	group,
+	isPlugin: false,
+});
+const pluginSkill = (name: string, plugin: string) => ({
+	name,
+	isProjectAlias: false,
+	group: plugin,
+	isPlugin: true,
+});
 
 describe("decideSkill — trust gate (project-scoped aliases)", () => {
 	it("withholds an alias until the project is trusted", () => {
@@ -70,9 +82,42 @@ describe("decideSkill — the trust gate is checked before the toggle layer (saf
 				trusted: true,
 				acknowledged: ["deploy"],
 				disabled: [],
+				disabledGroups: [],
 				overrides: { deploy: "off" },
 			}),
 		).toBe("disabled");
+	});
+});
+
+describe("decideSkill — group / source disable (per-project baseline)", () => {
+	it("disables every skill in a disabled group (a plugin, or a source tier)", () => {
+		expect(
+			decideSkill(pluginSkill("x", "superpowers"), { ...EMPTY, disabledGroups: ["superpowers"] }),
+		).toBe("disabled");
+		expect(decideSkill(own("y", "personal"), { ...EMPTY, disabledGroups: ["personal"] })).toBe(
+			"disabled",
+		);
+	});
+
+	it("the @plugins super-toggle disables all plugin skills but not personal/bundled", () => {
+		const ctx = { ...EMPTY, disabledGroups: ["@plugins"] };
+		expect(decideSkill(pluginSkill("x", "superpowers"), ctx)).toBe("disabled");
+		expect(decideSkill(pluginSkill("y", "chrome-devtools-mcp"), ctx)).toBe("disabled");
+		expect(decideSkill(own("z", "personal"), ctx)).toBe("load");
+	});
+
+	it("a per-skill 'on' override re-enables one skill out of a disabled group", () => {
+		expect(
+			decideSkill(pluginSkill("x", "superpowers"), {
+				...EMPTY,
+				disabledGroups: ["superpowers"],
+				overrides: { x: "on" },
+			}),
+		).toBe("load");
+	});
+
+	it("a disabled group still can't un-gate an untrusted project alias (trust checked first)", () => {
+		expect(decideSkill(alias("a"), { ...EMPTY, disabledGroups: ["project"] })).toBe("untrusted");
 	});
 });
 

--- a/packages/server/src/agent/skillAdmission.test.ts
+++ b/packages/server/src/agent/skillAdmission.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { decideSkill, isSkillLoaded, type SkillAdmissionContext } from "./skillAdmission";
+
+const EMPTY: SkillAdmissionContext = {
+	trusted: false,
+	acknowledged: [],
+	disabled: [],
+	overrides: {},
+};
+const alias = (name: string) => ({ name, isProjectAlias: true });
+const own = (name: string) => ({ name, isProjectAlias: false });
+
+describe("decideSkill — trust gate (project-scoped aliases)", () => {
+	it("withholds an alias until the project is trusted", () => {
+		expect(decideSkill(alias("deploy"), EMPTY)).toBe("untrusted");
+	});
+
+	it("flags a trusted-but-unacknowledged alias as pending-ack (appeared after the grant)", () => {
+		expect(decideSkill(alias("deploy"), { ...EMPTY, trusted: true })).toBe("pending-ack");
+	});
+
+	it("loads an acknowledged alias under a trusted project", () => {
+		expect(
+			decideSkill(alias("deploy"), { ...EMPTY, trusted: true, acknowledged: ["deploy"] }),
+		).toBe("load");
+	});
+
+	it("never gates personal/bundled/pi-native skills on trust", () => {
+		expect(decideSkill(own("brainstorming"), EMPTY)).toBe("load");
+	});
+});
+
+describe("decideSkill — enable/disable (workspace override over project baseline)", () => {
+	it("project baseline disables a skill", () => {
+		expect(decideSkill(own("noisy"), { ...EMPTY, disabled: ["noisy"] })).toBe("disabled");
+	});
+
+	it("a workspace 'off' override disables an otherwise-loaded skill", () => {
+		expect(decideSkill(own("x"), { ...EMPTY, overrides: { x: "off" } })).toBe("disabled");
+	});
+
+	it("a workspace 'on' override re-enables a project-baseline-disabled skill", () => {
+		expect(decideSkill(own("x"), { ...EMPTY, disabled: ["x"], overrides: { x: "on" } })).toBe(
+			"load",
+		);
+	});
+
+	it("the workspace override wins over the project baseline both ways", () => {
+		expect(decideSkill(own("x"), { ...EMPTY, disabled: ["x"], overrides: { x: "off" } })).toBe(
+			"disabled",
+		);
+		expect(decideSkill(own("y"), { ...EMPTY, overrides: { y: "off" } })).toBe("disabled");
+	});
+});
+
+describe("decideSkill — the trust gate is checked before the toggle layer (safety)", () => {
+	it("an 'on' override can NOT un-gate an untrusted alias", () => {
+		expect(decideSkill(alias("evil"), { ...EMPTY, overrides: { evil: "on" } })).toBe("untrusted");
+	});
+
+	it("an 'on' override can NOT un-gate a trusted-but-unacknowledged alias", () => {
+		expect(decideSkill(alias("evil"), { ...EMPTY, trusted: true, overrides: { evil: "on" } })).toBe(
+			"pending-ack",
+		);
+	});
+
+	it("an acknowledged alias can still be turned off by a workspace override", () => {
+		expect(
+			decideSkill(alias("deploy"), {
+				trusted: true,
+				acknowledged: ["deploy"],
+				disabled: [],
+				overrides: { deploy: "off" },
+			}),
+		).toBe("disabled");
+	});
+});
+
+describe("isSkillLoaded", () => {
+	it("is true only for a 'load' verdict", () => {
+		expect(isSkillLoaded(own("a"), EMPTY)).toBe(true);
+		expect(isSkillLoaded(alias("a"), EMPTY)).toBe(false);
+	});
+});

--- a/packages/server/src/agent/skillAdmission.ts
+++ b/packages/server/src/agent/skillAdmission.ts
@@ -19,6 +19,12 @@ export interface SkillAdmissionContext {
 	acknowledged: readonly string[];
 	/** Project-baseline disabled skill names, any source (`Project.disabledSkills`). */
 	disabled: readonly string[];
+	/**
+	 * Project-baseline disabled **group** keys (`Project.disabledGroups`) — a group key is a plugin name or
+	 * a source tier (`project`/`personal`/`bundled`/`pi`), plus the special `@plugins` (all plugin skills).
+	 * Turns a whole plugin/source off in one toggle, and keeps *future* skills in that group off too.
+	 */
+	disabledGroups: readonly string[];
 	/** Per-workspace overrides by skill name (`Workspace.skillOverrides`). */
 	overrides: Readonly<Record<string, "on" | "off">>;
 }
@@ -28,12 +34,18 @@ export interface SkillFacts {
 	name: string;
 	/** True for a committed project-scoped alias (the trust-gated class); false for personal/bundled/pi. */
 	isProjectAlias: boolean;
+	/** The group key this skill toggles under (plugin name, or `project`/`personal`/`bundled`/`pi`). */
+	group: string;
+	/** Whether it belongs to a Claude plugin — subject to the `@plugins` super-toggle. */
+	isPlugin: boolean;
 }
 
 /**
- * The single source of truth for admission. Order matters: the **trust gate is checked first** for a
- * project alias (so an "on" override can never un-gate an untrusted or unacknowledged repo skill), then
- * the enable/disable layer (workspace override wins over project baseline).
+ * The single source of truth for admission. Precedence, most-specific first: the **trust gate** for a
+ * project alias (so an "on" override can never un-gate an untrusted/unacknowledged repo skill) → the
+ * per-skill **workspace override** (an explicit `on` beats a group disable; `off` always wins) → the
+ * project-baseline **group** disable (the skill's own group, or `@plugins` for any plugin skill) → the
+ * project-baseline **per-skill** disable → load.
  */
 export function decideSkill(skill: SkillFacts, ctx: SkillAdmissionContext): SkillDecision {
 	if (skill.isProjectAlias) {
@@ -43,6 +55,8 @@ export function decideSkill(skill: SkillFacts, ctx: SkillAdmissionContext): Skil
 	const override = ctx.overrides[skill.name];
 	if (override === "off") return "disabled";
 	if (override === "on") return "load";
+	if (ctx.disabledGroups.includes(skill.group)) return "disabled";
+	if (skill.isPlugin && ctx.disabledGroups.includes("@plugins")) return "disabled";
 	if (ctx.disabled.includes(skill.name)) return "disabled";
 	return "load";
 }

--- a/packages/server/src/agent/skillAdmission.ts
+++ b/packages/server/src/agent/skillAdmission.ts
@@ -1,3 +1,7 @@
+import type { SkillDecision } from "@thinkrail/contracts";
+
+export type { SkillDecision };
+
 // The pure decision layer for which skills a session actually loads. Kept free of pi/fs so it can be
 // exhaustively unit-tested: given a skill's facts and the resolved admission context (project trust +
 // acknowledged set + project-baseline disables + per-workspace overrides), it returns one verdict.
@@ -25,16 +29,6 @@ export interface SkillFacts {
 	/** True for a committed project-scoped alias (the trust-gated class); false for personal/bundled/pi. */
 	isProjectAlias: boolean;
 }
-
-/**
- * Why a skill is or isn't loaded — the UI renders all four so a hidden skill is never a silent mystery:
- * - `load` — in the agent's context / invocable.
- * - `untrusted` — a project alias, but the project isn't trusted yet (grant trust to consider it).
- * - `pending-ack` — a project alias under a trusted project that appeared *after* trust was granted
- *   (a pull / branch switch); needs a one-tap confirm before it loads.
- * - `disabled` — admissible but turned off (workspace override, else project baseline).
- */
-export type SkillDecision = "load" | "untrusted" | "pending-ack" | "disabled";
 
 /**
  * The single source of truth for admission. Order matters: the **trust gate is checked first** for a

--- a/packages/server/src/agent/skillAdmission.ts
+++ b/packages/server/src/agent/skillAdmission.ts
@@ -1,0 +1,59 @@
+// The pure decision layer for which skills a session actually loads. Kept free of pi/fs so it can be
+// exhaustively unit-tested: given a skill's facts and the resolved admission context (project trust +
+// acknowledged set + project-baseline disables + per-workspace overrides), it returns one verdict.
+//
+// Scope recap (see agent/SPEC.md): trust is per-project, availability is per-worktree, per-skill toggles
+// layer a per-workspace override over a per-project baseline. Committed **project-scoped aliases**
+// (.claude/skills etc.) are the gated class — attacker-controlled for a clone; personal / bundled /
+// pi-native skills are never gated by trust, only by the enable/disable toggles.
+
+/** The resolved inputs for one workspace's session (project fields + that workspace's overrides). */
+export interface SkillAdmissionContext {
+	/** Project engaged trust — the gate on any project-scoped alias. */
+	trusted: boolean;
+	/** Project-scoped alias skill names the user has acknowledged (see `Project.acknowledgedSkills`). */
+	acknowledged: readonly string[];
+	/** Project-baseline disabled skill names, any source (`Project.disabledSkills`). */
+	disabled: readonly string[];
+	/** Per-workspace overrides by skill name (`Workspace.skillOverrides`). */
+	overrides: Readonly<Record<string, "on" | "off">>;
+}
+
+/** One skill reduced to just what the decision needs — decoupled from pi's `Skill` for testability. */
+export interface SkillFacts {
+	name: string;
+	/** True for a committed project-scoped alias (the trust-gated class); false for personal/bundled/pi. */
+	isProjectAlias: boolean;
+}
+
+/**
+ * Why a skill is or isn't loaded — the UI renders all four so a hidden skill is never a silent mystery:
+ * - `load` — in the agent's context / invocable.
+ * - `untrusted` — a project alias, but the project isn't trusted yet (grant trust to consider it).
+ * - `pending-ack` — a project alias under a trusted project that appeared *after* trust was granted
+ *   (a pull / branch switch); needs a one-tap confirm before it loads.
+ * - `disabled` — admissible but turned off (workspace override, else project baseline).
+ */
+export type SkillDecision = "load" | "untrusted" | "pending-ack" | "disabled";
+
+/**
+ * The single source of truth for admission. Order matters: the **trust gate is checked first** for a
+ * project alias (so an "on" override can never un-gate an untrusted or unacknowledged repo skill), then
+ * the enable/disable layer (workspace override wins over project baseline).
+ */
+export function decideSkill(skill: SkillFacts, ctx: SkillAdmissionContext): SkillDecision {
+	if (skill.isProjectAlias) {
+		if (!ctx.trusted) return "untrusted";
+		if (!ctx.acknowledged.includes(skill.name)) return "pending-ack";
+	}
+	const override = ctx.overrides[skill.name];
+	if (override === "off") return "disabled";
+	if (override === "on") return "load";
+	if (ctx.disabled.includes(skill.name)) return "disabled";
+	return "load";
+}
+
+/** Convenience: is this skill in the agent's loaded set? */
+export function isSkillLoaded(skill: SkillFacts, ctx: SkillAdmissionContext): boolean {
+	return decideSkill(skill, ctx) === "load";
+}

--- a/packages/server/src/agent/skillSources.test.ts
+++ b/packages/server/src/agent/skillSources.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverCompatibilitySkillSources } from "./skillSources";
+
+const temporaryRoots: string[] = [];
+
+function temporaryRoot(): string {
+	const path = mkdtempSync(join(tmpdir(), "thinkrail-skill-sources-"));
+	temporaryRoots.push(path);
+	return path;
+}
+
+function directory(path: string): string {
+	mkdirSync(path, { recursive: true });
+	return path;
+}
+
+afterEach(() => {
+	for (const path of temporaryRoots.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("discoverCompatibilitySkillSources", () => {
+	it("discovers only the explicit project and personal allowlist in precedence order", () => {
+		const root = temporaryRoot();
+		const project = directory(join(root, "project"));
+		const home = directory(join(root, "home"));
+		const claudeConfig = directory(join(root, "claude-config"));
+		const codexHome = directory(join(root, "codex-home"));
+		const geminiHome = directory(join(root, "gemini-home"));
+
+		for (const path of [
+			join(project, ".claude", "skills"),
+			join(project, ".github", "skills"),
+			join(project, ".gemini", "skills"),
+			join(claudeConfig, "skills"),
+			join(codexHome, "skills"),
+			join(home, ".copilot", "skills"),
+			join(geminiHome, ".gemini", "skills"),
+			// Deliberately unsupported locations must not be swept in.
+			join(project, ".cursor", "skills"),
+			join(home, ".random-agent", "skills"),
+		]) {
+			directory(path);
+		}
+
+		const sources = discoverCompatibilitySkillSources(project, {
+			env: {
+				HOME: home,
+				CLAUDE_CONFIG_DIR: claudeConfig,
+				CODEX_HOME: codexHome,
+				GEMINI_CLI_HOME: geminiHome,
+			},
+		});
+
+		expect(sources.map(({ scope, provider }) => `${scope}:${provider}`)).toEqual([
+			"project:claude",
+			"project:github-copilot",
+			"project:gemini",
+			"user:claude",
+			"user:codex",
+			"user:github-copilot",
+			"user:gemini",
+		]);
+		expect(sources.map((source) => source.path)).not.toContain(join(project, ".cursor", "skills"));
+	});
+
+	it("uses default homes, ignores missing roots, and deduplicates aliased directories", () => {
+		const root = temporaryRoot();
+		const project = directory(join(root, "project"));
+		const home = directory(join(root, "home"));
+		const sharedConfig = directory(join(root, "shared-config"));
+		directory(join(home, ".claude", "skills"));
+		directory(join(home, ".codex", "skills"));
+		directory(join(home, ".gemini", "skills"));
+		directory(join(sharedConfig, "skills"));
+
+		const defaults = discoverCompatibilitySkillSources(project, { env: { HOME: home } });
+		expect(defaults.map((source) => source.provider)).toEqual(["claude", "codex", "gemini"]);
+
+		const deduplicated = discoverCompatibilitySkillSources(project, {
+			env: { HOME: home, CLAUDE_CONFIG_DIR: sharedConfig, CODEX_HOME: sharedConfig },
+		});
+		expect(
+			deduplicated.filter((source) => source.path === join(sharedConfig, "skills")),
+		).toHaveLength(1);
+		expect(
+			deduplicated.find((source) => source.path === join(sharedConfig, "skills"))?.provider,
+		).toBe("claude");
+	});
+});

--- a/packages/server/src/agent/skillSources.test.ts
+++ b/packages/server/src/agent/skillSources.test.ts
@@ -87,11 +87,14 @@ describe("discoverCompatibilitySkillSources", () => {
 			env: { HOME: home, CLAUDE_CONFIG_DIR: claudeConfig },
 		});
 
-		// The plugin's own skills dir is discovered (personal-scope)…
+		// The plugin's own skills dir is discovered (personal-scope, tagged with the plugin name)…
 		expect(
 			sources.some(
 				(s) =>
-					s.path === join(installPath, "skills") && s.scope === "user" && s.provider === "claude",
+					s.path === join(installPath, "skills") &&
+					s.scope === "user" &&
+					s.provider === "claude" &&
+					s.plugin === "superpowers",
 			),
 		).toBe(true);
 		// …but never the transitive node_modules skills junk (we read the manifest, not a blind find).

--- a/packages/server/src/agent/skillSources.test.ts
+++ b/packages/server/src/agent/skillSources.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { discoverCompatibilitySkillSources } from "./skillSources";
@@ -64,6 +64,38 @@ describe("discoverCompatibilitySkillSources", () => {
 			"user:gemini",
 		]);
 		expect(sources.map((source) => source.path)).not.toContain(join(project, ".cursor", "skills"));
+	});
+
+	it("discovers installed Claude plugins' skills from installed_plugins.json, not a cache sweep", () => {
+		const root = temporaryRoot();
+		const project = directory(join(root, "project"));
+		const home = directory(join(root, "home"));
+		const claudeConfig = directory(join(root, "claude-config"));
+		// A version-pinned plugin install with a skills dir + a transitive node_modules skills dir (junk).
+		const installPath = join(claudeConfig, "plugins", "cache", "market", "superpowers", "6.1.1");
+		directory(join(installPath, "skills", "brainstorming"));
+		directory(join(installPath, "node_modules", "dep", "skills"));
+		writeFileSync(
+			join(claudeConfig, "plugins", "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: { "superpowers@market": [{ scope: "user", installPath, version: "6.1.1" }] },
+			}),
+		);
+
+		const sources = discoverCompatibilitySkillSources(project, {
+			env: { HOME: home, CLAUDE_CONFIG_DIR: claudeConfig },
+		});
+
+		// The plugin's own skills dir is discovered (personal-scope)…
+		expect(
+			sources.some(
+				(s) =>
+					s.path === join(installPath, "skills") && s.scope === "user" && s.provider === "claude",
+			),
+		).toBe(true);
+		// …but never the transitive node_modules skills junk (we read the manifest, not a blind find).
+		expect(sources.some((s) => s.path.includes("node_modules"))).toBe(false);
 	});
 
 	it("uses default homes, ignores missing roots, and deduplicates aliased directories", () => {

--- a/packages/server/src/agent/skillSources.ts
+++ b/packages/server/src/agent/skillSources.ts
@@ -65,13 +65,14 @@ function readClaudePluginSkillDirs(claudeConfigDir: string): { path: string; plu
 }
 
 /**
- * Discover the explicit compatibility allowlist: the fixed project + personal alias dirs, plus each
- * installed Claude plugin's `skills/` dir (from `installed_plugins.json`, personal-scope). Pi-native/
- * configured/shared roots are not returned here — DefaultResourceLoader owns those and places them before
- * this list; ThinkRail's bundled skills are appended after it. `resolveSkillInputs` applies the real
- * precedence (bundled > personal > project); this returns discovery order.
+ * The full compatibility allowlist **before the existence filter**: the fixed project + personal alias
+ * dirs at their conventional paths, plus each currently-installed Claude plugin's `skills/` dir. Returned
+ * whether or not each dir exists right now — so a caller can register them as skill paths a later reload
+ * will pick up the moment a branch switch / pull / clone creates one (a worktree gaining `.claude/skills`
+ * mid-session). `discoverCompatibilitySkillSources` is the existence-filtered view for classification.
+ * (Plugins installed *after* this call are not covered — their install path isn't yet known.)
  */
-export function discoverCompatibilitySkillSources(
+export function candidateCompatibilitySkillRoots(
 	cwd: string,
 	options: DiscoverCompatibilitySkillSourcesOptions = {},
 ): CompatibilitySkillSource[] {
@@ -114,9 +115,25 @@ export function discoverCompatibilitySkillSources(
 		candidates.push({ path, scope: "user", provider: "claude", plugin });
 	}
 
+	return candidates;
+}
+
+/**
+ * The existence-filtered compatibility allowlist (each dir present + canonicalized, deduped): the fixed
+ * project + personal alias dirs, plus each installed Claude plugin's `skills/` dir (from
+ * `installed_plugins.json`, personal-scope). Pi-native/configured/shared roots are not returned here —
+ * DefaultResourceLoader owns those and places them before this list; ThinkRail's bundled skills are
+ * appended after it. `resolveSkillInputs` applies the real precedence (bundled > personal > project);
+ * this returns discovery order. Used for **classification** (group + provenance + project-alias trust
+ * gating), so it must be re-run whenever the on-disk set can have changed (every reload).
+ */
+export function discoverCompatibilitySkillSources(
+	cwd: string,
+	options: DiscoverCompatibilitySkillSourcesOptions = {},
+): CompatibilitySkillSource[] {
 	const sources: CompatibilitySkillSource[] = [];
 	const seen = new Set<string>();
-	for (const candidate of candidates) {
+	for (const candidate of candidateCompatibilitySkillRoots(cwd, options)) {
 		const path = existingDirectory(candidate.path);
 		if (!path) continue;
 		let canonical = path;

--- a/packages/server/src/agent/skillSources.ts
+++ b/packages/server/src/agent/skillSources.ts
@@ -9,6 +9,8 @@ export interface CompatibilitySkillSource {
 	path: string;
 	scope: "project" | "user";
 	provider: CompatibilitySkillProvider;
+	/** For a Claude-plugin source, the plugin's display name — lets the Skills manager group by plugin. */
+	plugin?: string;
 }
 
 interface DiscoverCompatibilitySkillSourcesOptions {
@@ -39,7 +41,7 @@ function existingDirectory(path: string): string | null {
  * which would sweep in stale versions and transitive `node_modules/**​/skills` junk. Missing/garbled
  * manifest → none. These are personal-scope (the user installed them via Claude).
  */
-function readClaudePluginSkillDirs(claudeConfigDir: string): string[] {
+function readClaudePluginSkillDirs(claudeConfigDir: string): { path: string; plugin: string }[] {
 	const manifest = join(claudeConfigDir, "plugins", "installed_plugins.json");
 	if (!existsSync(manifest)) return [];
 	let parsed: unknown;
@@ -50,12 +52,13 @@ function readClaudePluginSkillDirs(claudeConfigDir: string): string[] {
 	}
 	const plugins = (parsed as { plugins?: Record<string, unknown> } | null)?.plugins;
 	if (!plugins || typeof plugins !== "object") return [];
-	const dirs: string[] = [];
-	for (const installs of Object.values(plugins)) {
+	const dirs: { path: string; plugin: string }[] = [];
+	for (const [key, installs] of Object.entries(plugins)) {
 		if (!Array.isArray(installs)) continue;
+		const plugin = key.split("@")[0] || key; // "superpowers@claude-plugins-official" → "superpowers"
 		for (const install of installs) {
 			const installPath = (install as { installPath?: unknown } | null)?.installPath;
-			if (typeof installPath === "string") dirs.push(join(installPath, "skills"));
+			if (typeof installPath === "string") dirs.push({ path: join(installPath, "skills"), plugin });
 		}
 	}
 	return dirs;
@@ -107,8 +110,8 @@ export function discoverCompatibilitySkillSources(
 
 	// Installed Claude plugins (superpowers, etc.) — appended after the hand-written personal aliases so a
 	// loose `~/.claude/skills/<name>` wins a name collision over a plugin's.
-	for (const path of readClaudePluginSkillDirs(claudeConfigDir)) {
-		candidates.push({ path, scope: "user", provider: "claude" });
+	for (const { path, plugin } of readClaudePluginSkillDirs(claudeConfigDir)) {
+		candidates.push({ path, scope: "user", provider: "claude", plugin });
 	}
 
 	const sources: CompatibilitySkillSource[] = [];

--- a/packages/server/src/agent/skillSources.ts
+++ b/packages/server/src/agent/skillSources.ts
@@ -1,0 +1,93 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export type CompatibilitySkillProvider = "claude" | "codex" | "github-copilot" | "gemini";
+
+/** One conventional, existing skill root that another Agent Skills-compatible harness owns. */
+export interface CompatibilitySkillSource {
+	path: string;
+	scope: "project" | "user";
+	provider: CompatibilitySkillProvider;
+}
+
+interface DiscoverCompatibilitySkillSourcesOptions {
+	homeDir?: string;
+	env?: Readonly<Record<string, string | undefined>>;
+}
+
+function resolveConfiguredPath(value: string, homeDir: string): string {
+	const trimmed = value.trim();
+	if (trimmed === "~") return homeDir;
+	if (/^~[\\/]/.test(trimmed)) return resolve(homeDir, trimmed.slice(2));
+	return resolve(trimmed);
+}
+
+function existingDirectory(path: string): string | null {
+	if (!existsSync(path)) return null;
+	try {
+		return statSync(path).isDirectory() ? resolve(path) : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Discover the explicit compatibility allowlist in precedence order: project aliases before personal
+ * aliases. Pi-native/configured/shared roots are not returned here — DefaultResourceLoader owns those and
+ * places them before this list; ThinkRail's bundled skills are appended after it.
+ */
+export function discoverCompatibilitySkillSources(
+	cwd: string,
+	options: DiscoverCompatibilitySkillSourcesOptions = {},
+): CompatibilitySkillSource[] {
+	const env = options.env ?? process.env;
+	const configuredHome = options.homeDir?.trim() || env.HOME?.trim() || homedir();
+	const homeDir = resolveConfiguredPath(configuredHome, homedir());
+	const projectRoot = resolve(cwd);
+	const claudeConfigDir = resolveConfiguredPath(
+		env.CLAUDE_CONFIG_DIR?.trim() || join(homeDir, ".claude"),
+		homeDir,
+	);
+	const codexHome = resolveConfiguredPath(
+		env.CODEX_HOME?.trim() || join(homeDir, ".codex"),
+		homeDir,
+	);
+	// GEMINI_CLI_HOME is a replacement user-home root; Gemini creates `.gemini` beneath it.
+	const geminiHome = resolveConfiguredPath(env.GEMINI_CLI_HOME?.trim() || homeDir, homeDir);
+
+	const candidates: CompatibilitySkillSource[] = [
+		{ path: join(projectRoot, ".claude", "skills"), scope: "project", provider: "claude" },
+		{
+			path: join(projectRoot, ".github", "skills"),
+			scope: "project",
+			provider: "github-copilot",
+		},
+		{ path: join(projectRoot, ".gemini", "skills"), scope: "project", provider: "gemini" },
+		{ path: join(claudeConfigDir, "skills"), scope: "user", provider: "claude" },
+		{ path: join(codexHome, "skills"), scope: "user", provider: "codex" },
+		{
+			path: join(homeDir, ".copilot", "skills"),
+			scope: "user",
+			provider: "github-copilot",
+		},
+		{ path: join(geminiHome, ".gemini", "skills"), scope: "user", provider: "gemini" },
+	];
+
+	const sources: CompatibilitySkillSource[] = [];
+	const seen = new Set<string>();
+	for (const candidate of candidates) {
+		const path = existingDirectory(candidate.path);
+		if (!path) continue;
+		let canonical = path;
+		try {
+			canonical = realpathSync(path);
+		} catch {
+			// The directory was stat-able above; if canonicalization races with removal, keep the resolved path.
+		}
+		if (seen.has(canonical)) continue;
+		seen.add(canonical);
+		sources.push({ ...candidate, path });
+	}
+	return sources;
+}

--- a/packages/server/src/agent/skillSources.ts
+++ b/packages/server/src/agent/skillSources.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -33,9 +33,40 @@ function existingDirectory(path: string): string | null {
 }
 
 /**
- * Discover the explicit compatibility allowlist in precedence order: project aliases before personal
- * aliases. Pi-native/configured/shared roots are not returned here — DefaultResourceLoader owns those and
- * places them before this list; ThinkRail's bundled skills are appended after it.
+ * The `skills/` dir of each installed Claude Code **plugin**, read from the plugin manager's authoritative
+ * `installed_plugins.json` (`{ plugins: { "<name>@<market>": [{ installPath, … }] } }`). We take each
+ * install's resolved `installPath` (version-pinned) + `/skills` — never a blind scan of the plugin cache,
+ * which would sweep in stale versions and transitive `node_modules/**​/skills` junk. Missing/garbled
+ * manifest → none. These are personal-scope (the user installed them via Claude).
+ */
+function readClaudePluginSkillDirs(claudeConfigDir: string): string[] {
+	const manifest = join(claudeConfigDir, "plugins", "installed_plugins.json");
+	if (!existsSync(manifest)) return [];
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(manifest, "utf8"));
+	} catch {
+		return [];
+	}
+	const plugins = (parsed as { plugins?: Record<string, unknown> } | null)?.plugins;
+	if (!plugins || typeof plugins !== "object") return [];
+	const dirs: string[] = [];
+	for (const installs of Object.values(plugins)) {
+		if (!Array.isArray(installs)) continue;
+		for (const install of installs) {
+			const installPath = (install as { installPath?: unknown } | null)?.installPath;
+			if (typeof installPath === "string") dirs.push(join(installPath, "skills"));
+		}
+	}
+	return dirs;
+}
+
+/**
+ * Discover the explicit compatibility allowlist: the fixed project + personal alias dirs, plus each
+ * installed Claude plugin's `skills/` dir (from `installed_plugins.json`, personal-scope). Pi-native/
+ * configured/shared roots are not returned here — DefaultResourceLoader owns those and places them before
+ * this list; ThinkRail's bundled skills are appended after it. `resolveSkillInputs` applies the real
+ * precedence (bundled > personal > project); this returns discovery order.
  */
 export function discoverCompatibilitySkillSources(
 	cwd: string,
@@ -73,6 +104,12 @@ export function discoverCompatibilitySkillSources(
 		},
 		{ path: join(geminiHome, ".gemini", "skills"), scope: "user", provider: "gemini" },
 	];
+
+	// Installed Claude plugins (superpowers, etc.) — appended after the hand-written personal aliases so a
+	// loose `~/.claude/skills/<name>` wins a name collision over a plugin's.
+	for (const path of readClaudePluginSkillDirs(claudeConfigDir)) {
+		candidates.push({ path, scope: "user", provider: "claude" });
+	}
 
 	const sources: CompatibilitySkillSource[] = [];
 	const seen = new Set<string>();

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -33,10 +33,11 @@ channel fan-out, and the process-boot wrapper both launchers share.
   streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
   transcripts land paired — then `stop()` + exit; an immediate exit would strand mid-tool transcripts on
   the restart repair); `handlers.ts` (the WS method→handler registry, including the **Skills-manager set**:
-  `skill.list` / `skills.state` build the admission context from `projects` (+ the workspace's `skillOverrides`)
-  and pass it into agent's `listSkillCommands`/`listSkillCatalog`; `project.setTrust` acknowledges the
-  aliases present at grant via agent's `listProjectAliasSkillNames`; `project.acknowledgeSkills` /
-  `project.setSkillEnabled` / `project.aliasSkills` / `workspace.setSkillOverride` mutate/read the persisted
+  `skill.list` / `skills.state` / `project.skills` build the admission context from `projects` (+ the
+  workspace's `skillOverrides` when workspace-scoped) and pass it into agent's `listSkillCommands`/
+  `listSkillCatalog`; `project.setTrust` acknowledges the aliases present at grant via agent's
+  `listProjectAliasSkillNames`; `project.acknowledgeSkills` / `project.setSkillEnabled` /
+  `project.setGroupEnabled` / `project.aliasSkills` / `workspace.setSkillOverride` mutate/read the persisted
   toggles; `session.reloadResources` re-scans a running session — the composition stays here; `agent` never
   imports its sibling. `createServer` also wires **`setSkillAdmissionResolver`**, mapping a session's
   `workspaceId` → its project's trust/acknowledged/disabled + that workspace's overrides (fail-closed), so

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -32,12 +32,15 @@ channel fan-out, and the process-boot wrapper both launchers share.
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort
   streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
   transcripts land paired — then `stop()` + exit; an immediate exit would strand mid-tool transcripts on
-  the restart repair); `handlers.ts` (the WS method→handler registry, including `skill.list`: resolve the
-  requested `projectId` through `projects`, then pass its checkout path **and `trusted` flag** into agent's
-  `listSkillCommands(cwd, trusted)`, plus **`project.setTrust`** (persist the grant → updated `Project`) —
-  the composition stays here; `agent` never imports its sibling. `createServer` also wires
-  **`setProjectTrustResolver`**, mapping a session's `workspaceId` → its project's persisted `trusted`
-  (fail-closed), so `agent` gates project-scoped skill aliases without importing `projects`/`workspaces`);
+  the restart repair); `handlers.ts` (the WS method→handler registry, including the **Skills-manager set**:
+  `skill.list` / `skills.state` build the admission context from `projects` (+ the workspace's `skillOverrides`)
+  and pass it into agent's `listSkillCommands`/`listSkillCatalog`; `project.setTrust` acknowledges the
+  aliases present at grant via agent's `listProjectAliasSkillNames`; `project.acknowledgeSkills` /
+  `project.setSkillEnabled` / `project.aliasSkills` / `workspace.setSkillOverride` mutate/read the persisted
+  toggles; `session.reloadResources` re-scans a running session — the composition stays here; `agent` never
+  imports its sibling. `createServer` also wires **`setSkillAdmissionResolver`**, mapping a session's
+  `workspaceId` → its project's trust/acknowledged/disabled + that workspace's overrides (fail-closed), so
+  `agent` gates skills without importing `projects`/`workspaces`);
   `ackSend.ts` (the send-ack policy — see "Get right"); `autoRename.ts` (the **workspace auto-rename
   flow** — the composition of `agent` + `assist` + `workspaces` only the host may make, in **two passes**
   the session-publisher closure in `createServer` tees fire-and-forget, both triggering a

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -33,8 +33,11 @@ channel fan-out, and the process-boot wrapper both launchers share.
   streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
   transcripts land paired — then `stop()` + exit; an immediate exit would strand mid-tool transcripts on
   the restart repair); `handlers.ts` (the WS method→handler registry, including `skill.list`: resolve the
-  requested `projectId` through `projects`, then pass only its checkout path into agent's
-  `listSkillCommands(cwd)` — the composition stays here; `agent` never imports its sibling);
+  requested `projectId` through `projects`, then pass its checkout path **and `trusted` flag** into agent's
+  `listSkillCommands(cwd, trusted)`, plus **`project.setTrust`** (persist the grant → updated `Project`) —
+  the composition stays here; `agent` never imports its sibling. `createServer` also wires
+  **`setProjectTrustResolver`**, mapping a session's `workspaceId` → its project's persisted `trusted`
+  (fail-closed), so `agent` gates project-scoped skill aliases without importing `projects`/`workspaces`);
   `ackSend.ts` (the send-ack policy — see "Get right"); `autoRename.ts` (the **workspace auto-rename
   flow** — the composition of `agent` + `assist` + `workspaces` only the host may make, in **two passes**
   the session-publisher closure in `createServer` tees fire-and-forget, both triggering a

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -32,7 +32,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort
   streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
   transcripts land paired — then `stop()` + exit; an immediate exit would strand mid-tool transcripts on
-  the restart repair); `handlers.ts` (the WS method→handler registry);
+  the restart repair); `handlers.ts` (the WS method→handler registry, including `skill.list`: resolve the
+  requested `projectId` through `projects`, then pass only its checkout path into agent's
+  `listSkillCommands(cwd)` — the composition stays here; `agent` never imports its sibling);
   `ackSend.ts` (the send-ack policy — see "Get right"); `autoRename.ts` (the **workspace auto-rename
   flow** — the composition of `agent` + `assist` + `workspaces` only the host may make, in **two passes**
   the session-publisher closure in `createServer` tees fire-and-forget, both triggering a

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -23,8 +23,10 @@ import {
 	listAvailableModels,
 	listProjectAliasSkillNames,
 	listSessions,
+	listSkillCatalog,
 	listSkillCommands,
 	promptSession,
+	reloadSessionResources,
 	removeSession,
 	removeWorkspaceSessions,
 	resolveExtUi,
@@ -47,11 +49,13 @@ import { readDir, readFile } from "../fs";
 import { gitDiffFile, gitStatus, listBranches, prefetchBranch } from "../git";
 import { githubAuthStatus, githubRefresh } from "../github";
 import {
+	acknowledgeProjectSkills,
 	closeProject,
 	initProject,
 	inspectProjectPath,
 	listProjects,
 	openProject,
+	setProjectSkillEnabled,
 	setProjectTrust,
 } from "../projects";
 import { updateConfig } from "../settings";
@@ -71,6 +75,7 @@ import {
 	getWorkspace,
 	listWorkspaces,
 	reclaimWorktree,
+	setWorkspaceSkillOverride,
 	workspaceDiffStats,
 } from "../workspaces";
 import { ackSend } from "./ackSend";
@@ -214,6 +219,39 @@ const handlers: Record<string, Handler> = {
 			disabled: project.disabledSkills ?? [],
 			overrides: {},
 		});
+	},
+	// The workspace Skills manager: the full catalog + each skill's admission verdict, resolved against the
+	// worktree's checkout and the owning project's trust/toggles plus this workspace's overrides.
+	"skills.state": (params) => {
+		const { workspaceId } = params as { workspaceId: string };
+		const ws = getWorkspace(workspaceId);
+		const project = listProjects().find((p) => p.id === ws.projectId);
+		return listSkillCatalog(ws.worktreePath, {
+			trusted: project?.trusted === true,
+			acknowledged: project?.acknowledgedSkills ?? [],
+			disabled: project?.disabledSkills ?? [],
+			overrides: ws.skillOverrides ?? {},
+		});
+	},
+	// Confirm project-scoped skills that appeared after trust (re-confirm-new) — echoes the updated Project.
+	"project.acknowledgeSkills": (params) => {
+		const p = params as { id: string; names: string[] };
+		return acknowledgeProjectSkills(p.id, p.names);
+	},
+	// Project-baseline per-skill enable/disable.
+	"project.setSkillEnabled": (params) => {
+		const p = params as { id: string; name: string; enabled: boolean };
+		return setProjectSkillEnabled(p.id, p.name, p.enabled);
+	},
+	// Per-workspace per-skill override over the project baseline (`null` clears it).
+	"workspace.setSkillOverride": (params) => {
+		const p = params as { id: string; name: string; override: "on" | "off" | null };
+		return setWorkspaceSkillOverride(p.id, p.name, p.override);
+	},
+	// Apply skill/settings changes to a running session (active-chat reload); rejects while streaming.
+	"session.reloadResources": async (params) => {
+		await reloadSessionResources((params as { sessionId: string }).sessionId);
+		return { ok: true } as const;
 	},
 	// session.* — the pi engine. A thrown/failed call returns a `{ ok:false, error }` WS response;
 	// streaming faults arrive as `pi.event`s (the error/agent_end variants), not here.

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -21,6 +21,7 @@ import {
 	getSessionStats,
 	hasSession,
 	listAvailableModels,
+	listProjectAliasSkillNames,
 	listSessions,
 	listSkillCommands,
 	promptSession,
@@ -108,11 +109,15 @@ const handlers: Record<string, Handler> = {
 		closeProject((params as { id: string }).id);
 		return { ok: true } as const;
 	},
-	// Persist the user's trust grant; gates loading the repo's committed cross-agent skill aliases. Returns
-	// the updated project so the client refreshes its store (trust rides `Project` through `project.list`).
-	"project.setTrust": (params) => {
+	// Persist the user's trust grant → gates the repo's committed cross-agent skill aliases. Granting
+	// acknowledges the skills present *now*, so a skill that appears later (a pull / branch) stays gated
+	// until separately confirmed. Returns the updated project so the client refreshes its store.
+	"project.setTrust": async (params) => {
 		const p = params as { id: string; trusted: boolean };
-		return setProjectTrust(p.id, p.trusted);
+		const project = listProjects().find((candidate) => candidate.id === p.id);
+		if (!project) throw new Error(`Unknown project: ${p.id}`);
+		const acknowledged = p.trusted ? await listProjectAliasSkillNames(project.path) : undefined;
+		return setProjectTrust(p.id, p.trusted, acknowledged);
 	},
 	"workspace.create": (params) => {
 		const p = params as { projectId: string; name?: string; baseRef?: string };
@@ -202,8 +207,13 @@ const handlers: Record<string, Handler> = {
 		const { projectId } = params as { projectId: string };
 		const project = listProjects().find((candidate) => candidate.id === projectId);
 		if (!project) throw new Error(`Unknown project: ${projectId}`);
-		// Project-scoped aliases surface only once the project is trusted (same gate the live session uses).
-		return listSkillCommands(project.path, project.trusted === true);
+		// Same admission gate the live session uses, minus per-workspace overrides (none pre-session).
+		return listSkillCommands(project.path, {
+			trusted: project.trusted === true,
+			acknowledged: project.acknowledgedSkills ?? [],
+			disabled: project.disabledSkills ?? [],
+			overrides: {},
+		});
 	},
 	// session.* — the pi engine. A thrown/failed call returns a `{ ok:false, error }` WS response;
 	// streaming faults arrive as `pi.event`s (the error/agent_end variants), not here.

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -51,6 +51,7 @@ import {
 	inspectProjectPath,
 	listProjects,
 	openProject,
+	setProjectTrust,
 } from "../projects";
 import { updateConfig } from "../settings";
 import { evictSpecIndex, projectHasSpecs, specGraph } from "../spec";
@@ -106,6 +107,12 @@ const handlers: Record<string, Handler> = {
 	"project.close": (params) => {
 		closeProject((params as { id: string }).id);
 		return { ok: true } as const;
+	},
+	// Persist the user's trust grant; gates loading the repo's committed cross-agent skill aliases. Returns
+	// the updated project so the client refreshes its store (trust rides `Project` through `project.list`).
+	"project.setTrust": (params) => {
+		const p = params as { id: string; trusted: boolean };
+		return setProjectTrust(p.id, p.trusted);
 	},
 	"workspace.create": (params) => {
 		const p = params as { projectId: string; name?: string; baseRef?: string };
@@ -195,7 +202,8 @@ const handlers: Record<string, Handler> = {
 		const { projectId } = params as { projectId: string };
 		const project = listProjects().find((candidate) => candidate.id === projectId);
 		if (!project) throw new Error(`Unknown project: ${projectId}`);
-		return listSkillCommands(project.path);
+		// Project-scoped aliases surface only once the project is trusted (same gate the live session uses).
+		return listSkillCommands(project.path, project.trusted === true);
 	},
 	// session.* — the pi engine. A thrown/failed call returns a `{ ok:false, error }` WS response;
 	// streaming faults arrive as `pi.event`s (the error/agent_end variants), not here.

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -55,6 +55,7 @@ import {
 	inspectProjectPath,
 	listProjects,
 	openProject,
+	setProjectGroupEnabled,
 	setProjectSkillEnabled,
 	setProjectTrust,
 } from "../projects";
@@ -217,6 +218,7 @@ const handlers: Record<string, Handler> = {
 			trusted: project.trusted === true,
 			acknowledged: project.acknowledgedSkills ?? [],
 			disabled: project.disabledSkills ?? [],
+			disabledGroups: project.disabledGroups ?? [],
 			overrides: {},
 		});
 	},
@@ -230,6 +232,7 @@ const handlers: Record<string, Handler> = {
 			trusted: project?.trusted === true,
 			acknowledged: project?.acknowledgedSkills ?? [],
 			disabled: project?.disabledSkills ?? [],
+			disabledGroups: project?.disabledGroups ?? [],
 			overrides: ws.skillOverrides ?? {},
 		});
 	},
@@ -249,6 +252,24 @@ const handlers: Record<string, Handler> = {
 		const project = listProjects().find((p) => p.id === projectId);
 		if (!project) throw new Error(`Unknown project: ${projectId}`);
 		return listProjectAliasSkillNames(project.path);
+	},
+	// Turn a group (plugin / source tier / `@plugins`) on/off at the project baseline.
+	"project.setGroupEnabled": (params) => {
+		const p = params as { id: string; group: string; enabled: boolean };
+		return setProjectGroupEnabled(p.id, p.group, p.enabled);
+	},
+	// Project-scoped catalog for the pre-session manager (current checkout, no per-workspace overrides).
+	"project.skills": (params) => {
+		const { projectId } = params as { projectId: string };
+		const project = listProjects().find((p) => p.id === projectId);
+		if (!project) throw new Error(`Unknown project: ${projectId}`);
+		return listSkillCatalog(project.path, {
+			trusted: project.trusted === true,
+			acknowledged: project.acknowledgedSkills ?? [],
+			disabled: project.disabledSkills ?? [],
+			disabledGroups: project.disabledGroups ?? [],
+			overrides: {},
+		});
 	},
 	// Per-workspace per-skill override over the project baseline (`null` clears it).
 	"workspace.setSkillOverride": (params) => {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -243,6 +243,13 @@ const handlers: Record<string, Handler> = {
 		const p = params as { id: string; name: string; enabled: boolean };
 		return setProjectSkillEnabled(p.id, p.name, p.enabled);
 	},
+	// Present committed alias skill names in the project's checkout — the count behind the trust notice.
+	"project.aliasSkills": (params) => {
+		const { projectId } = params as { projectId: string };
+		const project = listProjects().find((p) => p.id === projectId);
+		if (!project) throw new Error(`Unknown project: ${projectId}`);
+		return listProjectAliasSkillNames(project.path);
+	},
 	// Per-workspace per-skill override over the project baseline (`null` clears it).
 	"workspace.setSkillOverride": (params) => {
 		const p = params as { id: string; name: string; override: "on" | "off" | null };

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -22,6 +22,7 @@ import {
 	hasSession,
 	listAvailableModels,
 	listSessions,
+	listSkillCommands,
 	promptSession,
 	removeSession,
 	removeWorkspaceSessions,
@@ -189,6 +190,12 @@ const handlers: Record<string, Handler> = {
 	"terminal.close": (params) => {
 		closeTerminal((params as { id: string }).id);
 		return { ok: true } as const;
+	},
+	"skill.list": (params) => {
+		const { projectId } = params as { projectId: string };
+		const project = listProjects().find((candidate) => candidate.id === projectId);
+		if (!project) throw new Error(`Unknown project: ${projectId}`);
+		return listSkillCommands(project.path);
 	},
 	// session.* — the pi engine. A thrown/failed call returns a `{ ok:false, error }` WS response;
 	// streaming faults arrive as `pi.event`s (the error/agent_end variants), not here.

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -5,8 +5,8 @@ import {
 	disposeAllSessions,
 	getSessionWorkspaceId,
 	setExtUiPublisher,
-	setProjectTrustResolver,
 	setSessionPublisher,
+	setSkillAdmissionResolver,
 } from "../agent";
 import { cancelAllLogins, setLoginPublisher } from "../auth";
 import { resolveWorktreeFile } from "../fs";
@@ -106,15 +106,21 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		server.publish(channel, JSON.stringify({ channel, data }));
 	});
 
-	// Gate a project's committed cross-agent skill aliases behind its trust grant: map the workspace a
-	// session belongs to back to its project's persisted `trusted` flag. Fail closed on any lookup miss, so
-	// a stale/unknown id never loads an untrusted repo's skills.
-	setProjectTrustResolver((workspaceId) => {
+	// Resolve a session's skill-admission context: map the workspace it belongs to back to its project's
+	// persisted trust + acknowledged set + baseline disables, plus that workspace's per-skill overrides.
+	// Fail closed on any lookup miss, so a stale/unknown id never loads an untrusted repo's skills.
+	setSkillAdmissionResolver((workspaceId) => {
 		try {
-			const { projectId } = getWorkspace(workspaceId);
-			return listProjects().find((project) => project.id === projectId)?.trusted === true;
+			const { projectId, skillOverrides } = getWorkspace(workspaceId);
+			const project = listProjects().find((p) => p.id === projectId);
+			return {
+				trusted: project?.trusted === true,
+				acknowledged: project?.acknowledgedSkills ?? [],
+				disabled: project?.disabledSkills ?? [],
+				overrides: skillOverrides ?? {},
+			};
 		} catch {
-			return false;
+			return { trusted: false, acknowledged: [], disabled: [], overrides: {} };
 		}
 	});
 

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -5,6 +5,7 @@ import {
 	disposeAllSessions,
 	getSessionWorkspaceId,
 	setExtUiPublisher,
+	setProjectTrustResolver,
 	setSessionPublisher,
 } from "../agent";
 import { cancelAllLogins, setLoginPublisher } from "../auth";
@@ -13,7 +14,7 @@ import { listProjects, openProject } from "../projects";
 import { getConfig, setSettingsPublisher } from "../settings";
 import { closeAllTerminals, setTerminalPublisher } from "../terminal";
 import { setWatchPublisher, stopAllWatches } from "../watch";
-import { setWorkspacePublisher } from "../workspaces";
+import { getWorkspace, setWorkspacePublisher } from "../workspaces";
 import {
 	isPromptCommitted,
 	isSettledTurn,
@@ -103,6 +104,18 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	// Stream PTY output to every subscribed client over the terminal.data channel.
 	setTerminalPublisher((channel, data) => {
 		server.publish(channel, JSON.stringify({ channel, data }));
+	});
+
+	// Gate a project's committed cross-agent skill aliases behind its trust grant: map the workspace a
+	// session belongs to back to its project's persisted `trusted` flag. Fail closed on any lookup miss, so
+	// a stale/unknown id never loads an untrusted repo's skills.
+	setProjectTrustResolver((workspaceId) => {
+		try {
+			const { projectId } = getWorkspace(workspaceId);
+			return listProjects().find((project) => project.id === projectId)?.trusted === true;
+		} catch {
+			return false;
+		}
 	});
 
 	// Fan the `workspaces` module's lifecycle events out to every subscribed client, mapping each domain

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -117,10 +117,11 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				trusted: project?.trusted === true,
 				acknowledged: project?.acknowledgedSkills ?? [],
 				disabled: project?.disabledSkills ?? [],
+				disabledGroups: project?.disabledGroups ?? [],
 				overrides: skillOverrides ?? {},
 			};
 		} catch {
-			return { trusted: false, acknowledged: [], disabled: [], overrides: {} };
+			return { trusted: false, acknowledged: [], disabled: [], disabledGroups: [], overrides: {} };
 		}
 	});
 

--- a/packages/server/src/projects/projects.test.ts
+++ b/packages/server/src/projects/projects.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { initProject, inspectProjectPath, listProjects } from "./projects";
+import {
+	initProject,
+	inspectProjectPath,
+	isProjectTrusted,
+	listProjects,
+	setProjectTrust,
+} from "./projects";
 
 function gitOut(cwd: string, ...args: string[]): string {
 	const r = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "pipe", stderr: "ignore" });
@@ -128,4 +134,25 @@ test("initProject: an existing repo is opened, not re-initialised (dedupe, histo
 	expect(listProjects()).toHaveLength(1);
 	// No fresh commit was layered on top — the original history is intact.
 	expect(gitOut(repo, "rev-parse", "HEAD")).toBe(originalHead);
+});
+
+test("setProjectTrust: persists a revocable, fail-closed trust decision", () => {
+	const repo = join(dataDir, "repo");
+	makeRepo(repo);
+	const project = initProject(repo);
+
+	// Undecided by default — fail closed.
+	expect(project.trusted).toBeUndefined();
+	expect(isProjectTrusted(project.id)).toBe(false);
+
+	const trusted = setProjectTrust(project.id, true);
+	expect(trusted.trusted).toBe(true);
+	expect(isProjectTrusted(project.id)).toBe(true);
+	// Persisted: a fresh read from projects.json reflects it.
+	expect(listProjects().find((p) => p.id === project.id)?.trusted).toBe(true);
+
+	// Revocable, and an unknown id fails loudly rather than silently trusting nothing.
+	setProjectTrust(project.id, false);
+	expect(isProjectTrusted(project.id)).toBe(false);
+	expect(() => setProjectTrust("nope", true)).toThrow();
 });

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -132,6 +132,22 @@ export function setProjectSkillEnabled(id: string, name: string, enabled: boolea
 	return project;
 }
 
+/**
+ * Turn a whole group on/off at the project baseline (`group` = a plugin name, a source tier, or the special
+ * `@plugins`). A disabled group withholds all its skills — including ones added later — until re-enabled.
+ */
+export function setProjectGroupEnabled(id: string, group: string, enabled: boolean): Project {
+	const projects = getProjects();
+	const project = projects.find((p) => p.id === id);
+	if (!project) throw new Error(`Unknown project: ${id}`);
+	const groups = new Set(project.disabledGroups ?? []);
+	if (enabled) groups.delete(group);
+	else groups.add(group);
+	project.disabledGroups = [...groups];
+	saveProjects(projects);
+	return project;
+}
+
 /** Whether a project (by id) is trusted. Unknown or undecided → false (fail closed). */
 export function isProjectTrusted(id: string): boolean {
 	return getProjects().find((p) => p.id === id)?.trusted === true;

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -89,6 +89,25 @@ export function closeProject(id: string): void {
 }
 
 /**
+ * Record the user's trust decision for a project and persist it. Trust gates loading the repo's committed
+ * cross-agent skill aliases (`.claude/skills` etc.) — attacker-controlled for a cloned repo. Returns the
+ * updated project so the wire can echo it back to the client. Throws on an unknown id.
+ */
+export function setProjectTrust(id: string, trusted: boolean): Project {
+	const projects = getProjects();
+	const project = projects.find((p) => p.id === id);
+	if (!project) throw new Error(`Unknown project: ${id}`);
+	project.trusted = trusted;
+	saveProjects(projects);
+	return project;
+}
+
+/** Whether a project (by id) is trusted. Unknown or undecided → false (fail closed). */
+export function isProjectTrusted(id: string): boolean {
+	return getProjects().find((p) => p.id === id)?.trusted === true;
+}
+
+/**
  * Classify a candidate path so the UI can decide how to open it: an existing git repo (open directly),
  * a plain directory that can be `git init`ed (offer to initialise), a path that doesn't exist, or one
  * that exists but isn't a directory. Read-only — touches nothing.

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -90,14 +90,44 @@ export function closeProject(id: string): void {
 
 /**
  * Record the user's trust decision for a project and persist it. Trust gates loading the repo's committed
- * cross-agent skill aliases (`.claude/skills` etc.) — attacker-controlled for a cloned repo. Returns the
- * updated project so the wire can echo it back to the client. Throws on an unknown id.
+ * cross-agent skill aliases (`.claude/skills` etc.) — attacker-controlled for a cloned repo. Granting trust
+ * passes the names present at that moment as `acknowledgedSkills`, so a skill that appears *later* (a pull /
+ * branch) stays gated until separately confirmed. Returns the updated project so the wire can echo it back.
+ * Throws on an unknown id.
  */
-export function setProjectTrust(id: string, trusted: boolean): Project {
+export function setProjectTrust(
+	id: string,
+	trusted: boolean,
+	acknowledgedSkills?: string[],
+): Project {
 	const projects = getProjects();
 	const project = projects.find((p) => p.id === id);
 	if (!project) throw new Error(`Unknown project: ${id}`);
 	project.trusted = trusted;
+	if (acknowledgedSkills !== undefined) project.acknowledgedSkills = acknowledgedSkills;
+	saveProjects(projects);
+	return project;
+}
+
+/** Add skill names to a project's acknowledged set (union; used to confirm skills that appeared later). */
+export function acknowledgeProjectSkills(id: string, names: string[]): Project {
+	const projects = getProjects();
+	const project = projects.find((p) => p.id === id);
+	if (!project) throw new Error(`Unknown project: ${id}`);
+	project.acknowledgedSkills = [...new Set([...(project.acknowledgedSkills ?? []), ...names])];
+	saveProjects(projects);
+	return project;
+}
+
+/** Set a skill's project-baseline enabled state (persisted in `disabledSkills`). */
+export function setProjectSkillEnabled(id: string, name: string, enabled: boolean): Project {
+	const projects = getProjects();
+	const project = projects.find((p) => p.id === id);
+	if (!project) throw new Error(`Unknown project: ${id}`);
+	const disabled = new Set(project.disabledSkills ?? []);
+	if (enabled) disabled.delete(name);
+	else disabled.add(name);
+	project.disabledSkills = [...disabled];
 	saveProjects(projects);
 	return project;
 }

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -223,6 +223,28 @@ export function renameWorkspace(
 	return target;
 }
 
+/**
+ * Set a per-workspace per-skill override (`on`/`off`) or clear it (`null`), and persist. Broadcasts the
+ * updated workspace so every client's rail converges (like `renameWorkspace`). Throws for an unknown id.
+ */
+export function setWorkspaceSkillOverride(
+	id: string,
+	name: string,
+	override: "on" | "off" | null,
+): Workspace {
+	const all = loadWorkspaces();
+	const ws = all.find((w) => w.id === id);
+	if (!ws) throw new Error(`Unknown workspace: ${id}`);
+	const overrides = { ...(ws.skillOverrides ?? {}) };
+	if (override === null) delete overrides[name];
+	else overrides[name] = override;
+	if (Object.keys(overrides).length > 0) ws.skillOverrides = overrides;
+	else delete ws.skillOverrides;
+	saveWorkspaces(all);
+	emit({ kind: "updated", workspace: ws });
+	return ws;
+}
+
 export function listWorkspaces(projectId: string): Workspace[] {
 	return loadWorkspaces()
 		.filter((w) => w.projectId === projectId)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 import {
 	E2E_CENTRAL_STATE,
 	E2E_DATA_DIR,
+	E2E_HOME_DIR,
 	E2E_PI_AGENT_DIR,
 	E2E_PICK_DIR_POINTER,
 } from "./e2e/fixtures/paths";
@@ -52,6 +53,11 @@ export default defineConfig({
 			// Force the New-Workspace dialog's `gh` probe to "Not connected" so the suite is deterministic
 			// regardless of the dev machine's real `gh` auth — and exercises the offline/local-branch degrade path.
 			THINKRAIL_GH_OFFLINE: "1",
+			// Keep cross-agent personal skill aliases away from the developer's real homes/overrides.
+			HOME: E2E_HOME_DIR,
+			CLAUDE_CONFIG_DIR: `${E2E_HOME_DIR}/.claude`,
+			CODEX_HOME: `${E2E_HOME_DIR}/.codex`,
+			GEMINI_CLI_HOME: E2E_HOME_DIR,
 			// Point pi at an ISOLATED agent dir (seeded with a copy of the user's auth in globalSetup), so the
 			// @agent suite uses a real provider yet `setModel`/`setThinkingLevel` persist here — never the
 			// user's real `~/.pi/agent`. (Provider env vars in the inherited env still resolve auth too.)

--- a/playwright.workflows.config.ts
+++ b/playwright.workflows.config.ts
@@ -3,8 +3,9 @@ import { defineConfig } from "@playwright/test";
 /**
  * The headless workflow-test suite (`bun run test:workflows`): drives a REAL in-process pi agent through
  * the workflow skills — no browser, no webServer, no page fixture. Shares the browser suite's global
- * setup/teardown, so it gets the same isolation: a fresh E2E_DATA_DIR and an isolated PI_CODING_AGENT_DIR
- * seeded with a copy of the user's auth + a pinned deterministic model (THINKRAIL_E2E_MODEL overrides).
+ * setup/teardown, so it gets the same isolation: a fresh E2E_DATA_DIR, isolated HOME/vendor skill homes,
+ * and an isolated PI_CODING_AGENT_DIR seeded with a copy of the user's auth + a pinned deterministic model
+ * (THINKRAIL_E2E_MODEL overrides).
  * On-demand only — needs pi auth and spends real provider tokens; never part of `bun run e2e` / CI gates.
  * Design: e2e/workflows/SPEC.md (module-workflow-tests).
  */


### PR DESCRIPTION
## Summary

- discover portable Agent Skills by reference from recognized Claude Code, Codex, Copilot/GitHub, and Gemini personal/project directories while keeping Pi as the sole parser and runtime
- preserve Pi-native/configured precedence, project trust, collision behavior, and truthful source scope; add a skills-only `skill.list` preview endpoint (protocol v9)
- extract slash-command completion into a shared primitive used by both the live chat Composer and New Workspace prompt
- isolate personal skill homes in tests and extend source, compiled-binary, unit, and browser coverage

## Supported compatibility aliases

- project: `.claude/skills`, `.github/skills`, `.gemini/skills`
- personal: `${CLAUDE_CONFIG_DIR:-~/.claude}/skills`, `${CODEX_HOME:-~/.codex}/skills`, `~/.copilot/skills`, `${GEMINI_CLI_HOME:-~}/.gemini/skills`

Pi-native settings, packages, `.pi/skills`, and shared `.agents/skills` remain unchanged and take precedence. Vendor-specific hooks, macros, subagents, model settings, and metadata are not emulated.

## Verification

- `bun run check:deps`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run e2e` — 45 passed
- focused `@agent` live Composer catalog test — passed
- `bun run build:binary && bun run smoke:binary`
- spec-graph validation — clean
