### PR TITLE
Align Darcula theme sidebar with dark theme

### DIFF
--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -203,8 +203,8 @@
 	--hint: #8b959e;
 	--sel: #214283;
 	--selection-bg: #214283;
-	/* Two-tone: lighter tool windows (sidebar) around the darker editor (content). */
-	--surface-sidebar: var(--bg);
+	/* Uniform dark surfaces (sidebar matches content) as in 'dark' theme. */
+	--surface-sidebar: var(--bg-dark);
 	--surface-content: var(--bg-dark);
 
 	/* Darcula's signature syntax palette — Monaco builds its token rules from whichever `--code-*` are


### PR DESCRIPTION
Ensures that in the Darcula theme, the left projects panel has the same background as the terminal/spec panels, matching the behavior of the default dark theme.