### PR TITLE
Align Darcula theme sidebar background

### DIFF
--- a/apps/web/src/themes/bundled/darcula.theme.json
+++ b/apps/web/src/themes/bundled/darcula.theme.json
@@ -12,7 +12,7 @@
 		"bubbleAccent": "#6b57ff",
 		"background": "#3c3f41",
 		"content": "#2b2b2b",
-		"sidebar": "#3c3f41",
+		"sidebar": "#2b2b2b",
 		"input": "#45494a",
 		"elevated": "#3c3f41",
 		"hover": "#4c5052",


### PR DESCRIPTION
Updated the Darcula theme so that the projects panel (sidebar) uses the same background color as the content panels, matching the behavior of the Dark theme.