### PR TITLE
feat(server): migrate to pi 0.80.10 ModelRuntime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -187,9 +187,9 @@
     "@biomejs/biome",
   ],
   "catalog": {
-    "@earendil-works/pi-agent-core": "0.80.6",
-    "@earendil-works/pi-ai": "0.80.6",
-    "@earendil-works/pi-coding-agent": "0.80.6",
+    "@earendil-works/pi-agent-core": "0.80.10",
+    "@earendil-works/pi-ai": "0.80.10",
+    "@earendil-works/pi-coding-agent": "0.80.10",
     "@types/bun": "1.3.14",
     "typebox": "1.1.38",
     "typescript": "6.0.3",
@@ -273,13 +273,13 @@
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.6", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.6", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.6", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.6", "@earendil-works/pi-ai": "^0.80.6", "@earendil-works/pi-tui": "^0.80.6", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.10", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.10", "@earendil-works/pi-ai": "^0.80.10", "@earendil-works/pi-tui": "^0.80.10", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.6", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/e2e/agent.live.spec.ts
+++ b/e2e/agent.live.spec.ts
@@ -2,8 +2,8 @@ import { expect, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 
 // Tagged @agent: excluded from the default `bun run e2e` (--grep-invert @agent); run via `bun run
-// e2e:agent` (or `bun run e2e:full`). It drives a REAL pi agent using pi's **default auth** (`AuthStorage`
-// resolves provider env vars or `~/.pi/agent/auth.json`) — run it where `pi` is authenticated. No fake.
+// e2e:agent` (or `bun run e2e:full`). It drives a REAL pi agent using pi's **default auth** (the model
+// runtime resolves provider env vars or `~/.pi/agent/auth.json`) — run it where `pi` is authenticated. No fake.
 test("streams an assistant reply from a real provider", { tag: "@agent" }, async ({ page }) => {
 	test.setTimeout(90_000); // real provider latency varies — don't fail on a slow turn under the 30s default
 	await openFixtureProject(page);

--- a/e2e/workflows/harness/env.ts
+++ b/e2e/workflows/harness/env.ts
@@ -1,6 +1,6 @@
 // Isolation guard — MUST be imported before anything that touches the pi runtime. ES imports hoist, so
 // modules that import the server agent barrel import this file FIRST (see session.ts); pi reads
-// PI_CODING_AGENT_DIR lazily (AuthStorage.create / SettingsManager.create at first use), so setting it at
+// PI_CODING_AGENT_DIR lazily (ModelRuntime.create / SettingsManager.create at first use), so setting it at
 // module-evaluation time in a fresh Playwright worker process is race-free.
 //
 // PER-WORKER clone: each Playwright worker process gets its OWN pi-agent dir, cloned from the one

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 			"packages/*"
 		],
 		"catalog": {
-			"@earendil-works/pi-agent-core": "0.80.6",
-			"@earendil-works/pi-ai": "0.80.6",
-			"@earendil-works/pi-coding-agent": "0.80.6",
+			"@earendil-works/pi-agent-core": "0.80.10",
+			"@earendil-works/pi-ai": "0.80.10",
+			"@earendil-works/pi-coding-agent": "0.80.10",
 			"@types/bun": "1.3.14",
 			"typebox": "1.1.38",
 			"typescript": "6.0.3"

--- a/packages/pi-visualize/src/schema.ts
+++ b/packages/pi-visualize/src/schema.ts
@@ -1,4 +1,4 @@
-import { StringEnum } from "@earendil-works/pi-ai/compat";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 
 /** One alternative in a `comparison` visualization. */

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -11,7 +11,7 @@ tags: [v1, pi]
 
 ## Responsibility
 
-The in-process `pi` engine: a shared runtime (auth + model registry), the lifecycle of `AgentSession`s
+The in-process `pi` engine: a shared model/auth runtime, the lifecycle of `AgentSession`s
 (one per chat tab, rooted in a workspace's worktree), the **extension-UI bridge** that turns pi's
 in-process `uiContext` dialog calls into WS frames, the host-owned **`ask_user_question`** tool + its
 answer-injection path, and the **restart repair** that keeps re-opened transcripts provider-valid.
@@ -19,8 +19,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
 ## Boundary
 
 - **Owns:**
-  - `piRuntime` (one shared `AuthStorage` + `ModelRegistry`; `getPiRuntime()` lazy,
-    `configurePiRuntime()` for tests). The **provider-credential surface** over this runtime —
+  - `piRuntime` (one shared `ModelRuntime` — pi's canonical model/auth facade since 0.80.8: catalogs,
+    credentials, availability, login/logout, and request dispatch; `getPiRuntime()` is a lazily-memoized
+    **promise** (`ModelRuntime.create()` is async; a failed create clears the memo so the next call
+    retries), `configurePiRuntime()` for tests). The **provider-credential surface** over this runtime —
     `provider.status` + in-app login — lives in the sibling `auth` module (which consumes `getPiRuntime`),
     **not** here.
   - `agentSessionManager` — sessions keyed by `session.sessionId` (each `Entry` also tracks its
@@ -65,13 +67,13 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     distinct cwds; `cwd` omitted on a double-archive skips only the disk purge);
     `setSessionPublisher` + `setSessionManagerFactory` seams.
   - `oneshot` — one-shot LLM completions **without** an `AgentSession` (no tools/extensions/disk):
-    `completeOnce(request)` picks a model from the shared runtime's authenticated set, resolves its auth
-    (OAuth refresh included) via `modelRegistry.getApiKeyAndHeaders`, and dispatches a single `complete()`
-    (from `@earendil-works/pi-ai/compat` — the api-dispatch entry; re-verify on pi bumps, it's a compat
-    surface). `pickModel(tier)` = the model choice: `cheap` prefers a curated small/fast allowlist ∩ the
-    authenticated set, else the cheapest by per-token cost; `default` = first available; `null` when
-    nothing is authenticated. This is the primitive the `assist` tasks (workspace naming, PR drafting)
-    run on — the only place model **dispatch** happens outside a session.
+    `completeOnce(request)` picks a model from the shared runtime's authenticated set and dispatches a
+    single `runtime.completeSimple()` — pi's canonical provider-agnostic request path, which resolves
+    the model's auth itself (OAuth refresh included) and also serves providers that only implement
+    `streamSimple` (extension-registered ones). `pickModel(tier)` = the model choice: `cheap` prefers a
+    curated small/fast allowlist ∩ the authenticated set, else the cheapest by per-token cost; `default`
+    = first available; `null` when nothing is authenticated. This is the primitive the `assist` tasks
+    (workspace naming, PR drafting) run on — the only place model **dispatch** happens outside a session.
   - `webUiContext` — `createWebUiContext(sessionId)` builds the `ExtensionUIContext` pi calls (dialogs
     round-trip to the browser, fire-and-forget methods push, TUI-only members inert); `setExtUiPublisher`
     (server→client push seam), `resolveExtUi` (browser reply), `cancelExtUiForSession` (on dispose),
@@ -142,8 +144,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
   `buildAnswersMessage`); `repairDanglingToolCalls`; the compiled-binary extension seam
   (`setBundledExtensions` + `BundledExtensions`/`BundledExtensionFactory`).
-- **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (runtime — the
-  `complete()` dispatch used by `oneshot`); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
+- **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (types + test
+  fixtures — dispatch goes through the shared `ModelRuntime`); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
   `pi-thinkrail-workflow` (the bundled extensions — loaded by path, never value-imported here; the
   compiled binary's value-imports live in `apps/cli`'s generated build module); `typebox` (the
   `ask_user_question` parameter schema);
@@ -162,7 +164,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   derivable from the transcript alone (that's what makes restarts free); reply validity is
   `assessAnswerability`'s verdict, computed from `session.messages`, and rejections fail the WS request
   loud.
-- Share one `authStorage`/`modelRegistry`; give each session its own `SessionManager`; `dispose()` on removal.
+- Share one `ModelRuntime` (each session gets it as `createAgentSession`'s `modelRuntime`); give each
+  session its own `SessionManager`; `dispose()` on removal.
 - **A `pi` `Model` must never cross the wire raw** — its `baseUrl` carries the jbcentral proxy secret (and
   `headers` can carry auth). Every model-bearing frame (`model.list`/`model.default`, the `session.create`
   result, `SessionSummary.model`) goes through `toWireModel`; every inbound model ref (`session.create` /

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -22,7 +22,11 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   - `piRuntime` (one shared `ModelRuntime` — pi's canonical model/auth facade since 0.80.8: catalogs,
     credentials, availability, login/logout, and request dispatch; `getPiRuntime()` is a lazily-memoized
     **promise** (`ModelRuntime.create()` is async; a failed create clears the memo so the next call
-    retries), `configurePiRuntime()` for tests). The **provider-credential surface** over this runtime —
+    retries), `configurePiRuntime()` for tests). Created with **`allowModelNetwork: false`**: catalog
+    reads stay local (builtins + models.json + the persisted models-store), because `reloadConfig()`/
+    `refresh()` await remote pi.dev catalog checks with no timeout — on the `provider.status` and
+    jbcentral-connect paths that stalls wherever egress is slow or blocked. Live catalog refresh is a
+    deliberate, detached opt-in (`refresh({ allowNetwork: true })`) tracked as a follow-up (issue #98). The **provider-credential surface** over this runtime —
     `provider.status` + in-app login — lives in the sibling `auth` module (which consumes `getPiRuntime`),
     **not** here.
   - `agentSessionManager` — sessions keyed by `session.sessionId` (each `Entry` also tracks its

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -2,8 +2,9 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
 import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
-import { AuthStorage, ModelRegistry, SessionManager } from "@earendil-works/pi-coding-agent";
+import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type { ExtUiRequest } from "@thinkrail/contracts";
 import {
 	buildSessionSettings,
@@ -68,27 +69,30 @@ function tmpCwd(prefix: string): string {
 
 let priorAgentDir: string | undefined;
 
-beforeAll(() => {
+beforeAll(async () => {
 	// Isolate pi's on-disk session files to a throwaway dir — the disk-reopen test writes real ones.
 	priorAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = tmpCwd("trpi-agentdir-");
 
-	const authStorage = AuthStorage.create();
-	const modelRegistry = ModelRegistry.inMemory(authStorage);
-	// biome-ignore lint/suspicious/noExplicitAny: faux stream/model types bridge pi-ai ↔ pi-coding-agent
-	const reg = modelRegistry as any;
+	// A REAL runtime (in-memory credentials, no models.json, no network) with the faux providers
+	// registered as extension providers — their `streamSimple` does the real (in-process) work.
+	const runtime = await ModelRuntime.create({
+		credentials: new InMemoryCredentialStore(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
 	const cfg = (faux: typeof fauxA, id: string) => ({
 		api: faux.api,
-		// baseUrl + apiKey are required when models are defined; streamSimple does the real (in-process) work.
+		// baseUrl + apiKey are required when models are defined.
 		baseUrl: "http://faux.local",
 		apiKey: "faux",
 		streamSimple: faux.streamSimple,
 		models: [{ ...modelDef(id), api: faux.api }],
 	});
-	reg.registerProvider("fauxa", cfg(fauxA, "fauxa"));
-	reg.registerProvider("fauxb", cfg(fauxB, "fauxb"));
+	runtime.registerProvider("fauxa", cfg(fauxA, "fauxa"));
+	runtime.registerProvider("fauxb", cfg(fauxB, "fauxb"));
 
-	configurePiRuntime({ authStorage, modelRegistry });
+	configurePiRuntime(runtime);
 	setSessionManagerFactory(() => SessionManager.inMemory());
 	setSessionPublisher(({ sessionId, event }) => {
 		const list = events.get(sessionId) ?? [];
@@ -145,17 +149,17 @@ test("buildSessionSettings disables image autoResize (in-memory, so the read too
 	expect(buildSessionSettings(tmpCwd("trpi-settings-")).getImageAutoResize()).toBe(false);
 });
 
-test("listAvailableModels returns the configured (faux) models", () => {
-	const ids = listAvailableModels().map((m) => m.id);
+test("listAvailableModels returns the configured (faux) models", async () => {
+	const ids = (await listAvailableModels()).map((m) => m.id);
 	expect(ids).toContain("fauxa");
 	expect(ids).toContain("fauxb");
 });
 
-test("wire models expose only the allowlisted fields (no baseUrl/headers/other Model fields)", () => {
+test("wire models expose only the allowlisted fields (no baseUrl/headers/other Model fields)", async () => {
 	// The faux providers register with baseUrl "http://faux.local"; when JetBrains AI is wired the real
 	// baseUrl is `.../wire/<SECRET>/...`. `toWireModel` is an allowlist projection, so a wire model carries
 	// EXACTLY these keys — this pins the DTO shut (widening it, incl. re-adding a secret field, fails here).
-	const models = listAvailableModels();
+	const models = await listAvailableModels();
 	expect(models.length).toBeGreaterThan(0);
 	for (const m of models) {
 		expect(Object.keys(m).sort()).toEqual(["contextWindow", "id", "name", "provider", "reasoning"]);
@@ -164,7 +168,7 @@ test("wire models expose only the allowlisted fields (no baseUrl/headers/other M
 
 test("createSession re-resolves a wire model ref by {provider,id}, never trusting a client baseUrl", async () => {
 	fauxA.setResponses([fauxAssistantMessage("RESOLVED_REPLY")]);
-	const ref = listAvailableModels().find((m) => m.id === "fauxa");
+	const ref = (await listAvailableModels()).find((m) => m.id === "fauxa");
 	if (!ref) throw new Error("faux model missing");
 	// `ref` has NO baseUrl — only host-side re-resolution against the registry can reach the faux provider.
 	const s = await createSession({
@@ -181,7 +185,7 @@ test("createSession re-resolves a wire model ref by {provider,id}, never trustin
 });
 
 test("createSession rejects an unknown/unavailable model ref (no arbitrary baseUrl injection)", async () => {
-	const ref = listAvailableModels().find((m) => m.id === "fauxa");
+	const ref = (await listAvailableModels()).find((m) => m.id === "fauxa");
 	if (!ref) throw new Error("faux model missing");
 	// A client points provider/id at something not in the registry — the host refuses rather than call it.
 	const bogus = { ...ref, provider: "attacker", id: "evil" };

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -121,10 +121,9 @@ export function toWireModel(model: Model<string>): WireModel {
  * `createAgentSession` use it verbatim, so accepting it would let a client (esp. a remote V2 one) point the
  * agent's model traffic at an arbitrary URL. Throws if the ref isn't an available model.
  */
-function resolveWireModel(ref: Pick<WireModel, "provider" | "id">): Model<string> {
-	const match = getPiRuntime()
-		.modelRegistry.getAvailable()
-		.find((m) => m.provider === ref.provider && m.id === ref.id);
+async function resolveWireModel(ref: Pick<WireModel, "provider" | "id">): Promise<Model<string>> {
+	const available = await (await getPiRuntime()).getAvailable();
+	const match = available.find((m) => m.provider === ref.provider && m.id === ref.id);
 	if (!match) throw new Error(`Unknown or unavailable model: ${ref.provider}/${ref.id}`);
 	return match as unknown as Model<string>;
 }
@@ -152,17 +151,16 @@ async function registerSession(
 
 /** Create an in-process AgentSession rooted in `cwd`; its events stream out tagged with the session id. */
 export async function createSession(input: CreateSessionInput): Promise<CreateSessionResult> {
-	const { authStorage, modelRegistry } = getPiRuntime();
+	const modelRuntime = await getPiRuntime();
 	const settingsManager = buildSessionSettings(input.cwd);
 	const { session } = await createAgentSession({
 		cwd: input.cwd,
-		authStorage,
-		modelRegistry,
+		modelRuntime,
 		sessionManager: sessionManagerFactory(input.cwd),
 		settingsManager,
 		resourceLoader: await buildResourceLoader(input.cwd, settingsManager),
 		// Re-resolve the wire ref to the real model (with baseUrl) host-side — never the client's baseUrl.
-		...(input.model ? { model: resolveWireModel(input.model) } : {}),
+		...(input.model ? { model: await resolveWireModel(input.model) } : {}),
 		...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
 	});
 	return registerSession(session, input.workspaceId);
@@ -244,7 +242,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 	const info = (await SessionManager.list(cwd)).find((i) => i.id === sessionId && i.cwd === cwd);
 	if (!info) throw new Error(`Unknown session: ${sessionId}`);
 	if (sessions.has(sessionId)) return; // attached while we listed
-	const { authStorage, modelRegistry } = getPiRuntime();
+	const modelRuntime = await getPiRuntime();
 	const settingsManager = buildSessionSettings(cwd);
 	const sessionManager = SessionManager.open(info.path);
 	// Restart safety net: pair any tool call the last run left dangling (host died mid-tool) with a
@@ -253,8 +251,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 	repairDanglingToolCalls(sessionManager);
 	const { session } = await createAgentSession({
 		cwd,
-		authStorage,
-		modelRegistry,
+		modelRuntime,
 		sessionManager,
 		settingsManager,
 		resourceLoader: await buildResourceLoader(cwd, settingsManager),
@@ -358,7 +355,7 @@ export async function abortSession(sessionId: string): Promise<void> {
 
 export async function setSessionModel(sessionId: string, model: WireModel): Promise<void> {
 	// Re-resolve the wire ref to the real model host-side (pi's setModel uses baseUrl verbatim).
-	await mustGet(sessionId).setModel(resolveWireModel(model));
+	await mustGet(sessionId).setModel(await resolveWireModel(model));
 }
 
 export function setSessionThinkingLevel(sessionId: string, level: ThinkingLevel): void {
@@ -412,10 +409,9 @@ export function getSessionCommands(sessionId: string): SlashCommandInfo[] {
 
 /** Models with configured auth, for the model picker (cheap win #1). Redacted to `WireModel` — the raw
  * `Model.baseUrl` carries the jbcentral proxy secret when wired, and the picker only reads id/name/provider. */
-export function listAvailableModels(): WireModel[] {
-	return getPiRuntime()
-		.modelRegistry.getAvailable()
-		.map((m) => toWireModel(m as unknown as Model<string>));
+export async function listAvailableModels(): Promise<WireModel[]> {
+	const available = await (await getPiRuntime()).getAvailable();
+	return available.map((m) => toWireModel(m as unknown as Model<string>));
 }
 
 /** The model + thinking level a new session resolves to (settings default if available, else first available). */
@@ -430,9 +426,8 @@ export interface DefaultModelResult {
  * default (if it's available), else the first available model. Passing it back to `session.create` is a
  * no-op vs. omitting it, so an `@agent` test that doesn't touch the picker still lands on the pinned model.
  */
-export function getDefaultModel(): DefaultModelResult {
-	const { modelRegistry } = getPiRuntime();
-	const available = modelRegistry.getAvailable();
+export async function getDefaultModel(): Promise<DefaultModelResult> {
+	const available = await (await getPiRuntime()).getAvailable();
 	const settings = SettingsManager.create(process.cwd());
 	const provider = settings.getDefaultProvider();
 	const modelId = settings.getDefaultModel();

--- a/packages/server/src/agent/oneshot.test.ts
+++ b/packages/server/src/agent/oneshot.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, expect, test } from "bun:test";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
 import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { completeOnce, pickModel } from "./oneshot";
 import { configurePiRuntime } from "./piRuntime";
 
-/** A full model def for the registry (id + per-token input/output cost drives cheap-tier selection). */
+/** A full model def for the runtime (id + per-token input/output cost drives cheap-tier selection). */
 function modelDef(id: string, cost = 0) {
 	return {
 		id,
@@ -18,17 +19,13 @@ function modelDef(id: string, cost = 0) {
 }
 
 /**
- * Point the shared runtime at a fake registry exposing exactly `models` as authenticated. `pickModel` is
+ * Point the shared runtime at a fake exposing exactly `models` as authenticated. `pickModel` is
  * pure logic over `getAvailable()`, so this stays deterministic regardless of the dev machine's real
  * provider env keys.
  */
 function stubAvailable(models: ReturnType<typeof withProvider>[]): void {
-	configurePiRuntime({
-		// biome-ignore lint/suspicious/noExplicitAny: a minimal registry stub — pickModel only reads getAvailable
-		authStorage: {} as any,
-		// biome-ignore lint/suspicious/noExplicitAny: see above
-		modelRegistry: { getAvailable: () => models } as any,
-	});
+	// A minimal runtime stub — pickModel only reads getAvailable.
+	configurePiRuntime({ getAvailable: async () => models } as unknown as ModelRuntime);
 }
 
 function withProvider(provider: string, id: string, cost = 0) {
@@ -37,29 +34,28 @@ function withProvider(provider: string, id: string, cost = 0) {
 
 afterEach(() => {
 	// Reset the singleton so a later test (or file) rebuilds from real auth rather than a stub.
-	// biome-ignore lint/suspicious/noExplicitAny: intentional reset of the module singleton between tests
-	configurePiRuntime(undefined as any);
+	configurePiRuntime(null);
 });
 
-test("pickModel(cheap) prefers a known small model (allowlist) over a cheaper unlisted one", () => {
+test("pickModel(cheap) prefers a known small model (allowlist) over a cheaper unlisted one", async () => {
 	stubAvailable([
 		withProvider("anthropic", "claude-haiku-faux", 10), // allowlisted, but pricier
 		withProvider("cheapo", "cheapo-1", 1), // cheaper, but not on the allowlist
 	]);
-	expect(pickModel("cheap")?.id).toBe("claude-haiku-faux");
+	expect((await pickModel("cheap"))?.id).toBe("claude-haiku-faux");
 });
 
-test("pickModel(cheap) falls back to the cheapest by token cost when nothing is allowlisted", () => {
+test("pickModel(cheap) falls back to the cheapest by token cost when nothing is allowlisted", async () => {
 	stubAvailable([withProvider("pricey", "pricey-1", 10), withProvider("cheapo", "cheapo-1", 1)]);
-	expect(pickModel("cheap")?.id).toBe("cheapo-1");
+	expect((await pickModel("cheap"))?.id).toBe("cheapo-1");
 });
 
-test("pickModel(default) returns the first available model; empty set → null", () => {
+test("pickModel(default) returns the first available model; empty set → null", async () => {
 	stubAvailable([withProvider("pricey", "pricey-1", 10), withProvider("cheapo", "cheapo-1", 1)]);
-	expect(pickModel("default")?.id).toBe("pricey-1");
+	expect((await pickModel("default"))?.id).toBe("pricey-1");
 	stubAvailable([]);
-	expect(pickModel("cheap")).toBeNull();
-	expect(pickModel("default")).toBeNull();
+	expect(await pickModel("cheap")).toBeNull();
+	expect(await pickModel("default")).toBeNull();
 });
 
 test("completeOnce throws 'no-model' when nothing is authenticated", async () => {
@@ -69,24 +65,29 @@ test("completeOnce throws 'no-model' when nothing is authenticated", async () =>
 
 test("completeOnce dispatches a single request on the picked model and returns its text", async () => {
 	// Register a faux under the top allowlist slot (anthropic/claude-haiku) so `pickModel("cheap")` lands
-	// on it deterministically — even if the dev machine has other providers authed via env.
+	// on it deterministically — even if the dev machine has other providers authed via env. A REAL
+	// ModelRuntime (in-memory credentials, no models.json/network) exercises pi's actual auth resolution
+	// + completeSimple dispatch through the extension provider's streamSimple.
 	const faux = createFauxCore({
 		provider: "anthropic",
 		api: "faux-anthropic",
 		models: [modelDef("claude-haiku-faux")],
 		tokensPerSecond: 5000,
 	});
-	const authStorage = AuthStorage.inMemory();
-	const modelRegistry = ModelRegistry.inMemory(authStorage);
-	// biome-ignore lint/suspicious/noExplicitAny: faux stream/model types bridge pi-ai ↔ pi-coding-agent
-	(modelRegistry as any).registerProvider("anthropic", {
+	const runtime = await ModelRuntime.create({
+		credentials: new InMemoryCredentialStore(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	runtime.registerProvider("anthropic", {
 		api: "faux-anthropic",
+		// baseUrl + apiKey are required when models are defined; streamSimple does the real (in-process) work.
 		baseUrl: "http://faux.local",
 		apiKey: "faux",
 		streamSimple: faux.streamSimple,
 		models: [{ ...modelDef("claude-haiku-faux"), api: "faux-anthropic" }],
 	});
-	configurePiRuntime({ authStorage, modelRegistry });
+	configurePiRuntime(runtime);
 	faux.setResponses([fauxAssistantMessage("add-login-flow")]);
 
 	const result = await completeOnce({

--- a/packages/server/src/agent/oneshot.ts
+++ b/packages/server/src/agent/oneshot.ts
@@ -1,15 +1,12 @@
 /**
  * One-shot LLM completions — the primitive behind the ad-hoc "assist" tasks (workspace naming, PR
- * drafting). It runs a **single** `complete()` request on a cheap, already-authenticated model: no
- * `AgentSession`, no tools, no extensions, nothing written to disk. This mirrors how pi itself runs its
- * compaction summaries — pick a model from the shared runtime's authenticated set, resolve its auth
- * (OAuth refresh included), and dispatch one request.
- *
- * `complete` is imported from `@earendil-works/pi-ai/compat`, the api-dispatch entry pi's own model
- * plumbing uses. It's a compat surface pi will fold into its ModelManager migration — re-verify this
- * import on every pi bump (the `ModelRegistry` half we rely on for model + auth resolution is stable).
+ * drafting). It runs a **single** completion on a cheap, already-authenticated model: no
+ * `AgentSession`, no tools, no extensions, nothing written to disk. Dispatch goes through the shared
+ * `ModelRuntime.completeSimple()` — pi's canonical provider-agnostic request path (it also serves
+ * providers that only implement `streamSimple`, e.g. extension-registered ones), which resolves the
+ * model's auth itself (OAuth refresh included), so there is no separate auth-resolution step here.
  */
-import { type Api, type Context, complete, type Model } from "@earendil-works/pi-ai/compat";
+import type { Api, Context, Model } from "@earendil-works/pi-ai";
 import { getPiRuntime } from "./piRuntime";
 
 /** Which model a one-shot task reaches for. `cheap` = small/fast; `default` = first authenticated. */
@@ -58,8 +55,8 @@ const CHEAP_MODELS: ReadonlyArray<readonly [provider: string, idPrefix: string]>
  * For `default`: the first authenticated model. `null` when nothing is authenticated — the caller
  * degrades gracefully rather than erroring.
  */
-export function pickModel(tier: ModelTier = "cheap"): Model<Api> | null {
-	const available = getPiRuntime().modelRegistry.getAvailable();
+export async function pickModel(tier: ModelTier = "cheap"): Promise<Model<Api> | null> {
+	const available = await (await getPiRuntime()).getAvailable();
 	if (available.length === 0) return null;
 	if (tier === "default") return available[0] ?? null;
 	for (const [provider, prefix] of CHEAP_MODELS) {
@@ -80,21 +77,15 @@ export function pickModel(tier: ModelTier = "cheap"): Model<Api> | null {
  * assist tasks) wrap this and fall back.
  */
 export async function completeOnce(req: OneShotRequest): Promise<OneShotResult> {
-	const { modelRegistry } = getPiRuntime();
-	const model = pickModel(req.tier);
+	const runtime = await getPiRuntime();
+	const model = await pickModel(req.tier);
 	if (!model) throw new Error("no-model");
-
-	const auth = await modelRegistry.getApiKeyAndHeaders(model);
-	if (!auth.ok) throw new Error(auth.error);
 
 	const context: Context = {
 		...(req.system ? { systemPrompt: req.system } : {}),
 		messages: [{ role: "user", content: req.prompt, timestamp: Date.now() }],
 	};
-	const message = await complete(model, context, {
-		...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
-		...(auth.headers ? { headers: auth.headers } : {}),
-		...(auth.env ? { env: auth.env } : {}),
+	const message = await runtime.completeSimple(model, context, {
 		maxTokens: req.maxTokens ?? 256,
 		temperature: req.temperature ?? 0.2,
 		...(req.signal ? { signal: req.signal } : {}),

--- a/packages/server/src/agent/oneshot.ts
+++ b/packages/server/src/agent/oneshot.ts
@@ -39,14 +39,12 @@ export interface OneShotResult {
 // ship cheaper tiers — the cost-based fallback below covers anything not listed here.
 const CHEAP_MODELS: ReadonlyArray<readonly [provider: string, idPrefix: string]> = [
 	["anthropic", "claude-haiku"],
-	["anthropic", "claude-3-5-haiku"],
 	["openai", "gpt-5-mini"],
 	["openai", "gpt-4o-mini"],
 	["openai", "gpt-4.1-mini"],
 	["google", "gemini-2.5-flash"],
 	["google", "gemini-flash"],
-	["xai", "grok-code-fast"],
-	["xai", "grok-3-mini"],
+	["xai", "grok-build"],
 ];
 
 /**

--- a/packages/server/src/agent/piRuntime.ts
+++ b/packages/server/src/agent/piRuntime.ts
@@ -13,10 +13,19 @@ export function configurePiRuntime(rt: ModelRuntime | null): void {
 	runtime = rt ? Promise.resolve(rt) : null;
 }
 
-/** The shared runtime, built lazily from on-disk auth + catalogs (`~/.pi/agent`). */
+/**
+ * The shared runtime, built lazily from on-disk auth + catalogs (`~/.pi/agent`).
+ *
+ * `allowModelNetwork: false`: model-catalog reads stay **local** (builtin catalogs + models.json +
+ * the persisted models-store), matching the pre-0.80.8 behavior. Without it, every
+ * `reloadConfig()`/`refresh()` — i.e. every `provider.status` read and jbcentral connect — would await
+ * remote pi.dev catalog checks with **no timeout** (only `ModelRuntime.create` guards its initial
+ * refresh), stalling those paths wherever that egress is slow or blocked (CI, offline). A deliberate,
+ * detached catalog refresh (explicit `refresh({ allowNetwork: true })`) is tracked in issue #98.
+ */
 export function getPiRuntime(): Promise<ModelRuntime> {
 	if (!runtime) {
-		const created = ModelRuntime.create();
+		const created = ModelRuntime.create({ allowModelNetwork: false });
 		runtime = created;
 		// A failed create must not brick the host until restart — drop the memo so the next call retries.
 		created.catch(() => {

--- a/packages/server/src/agent/piRuntime.ts
+++ b/packages/server/src/agent/piRuntime.ts
@@ -1,23 +1,27 @@
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 
-/** Shared pi services — one `authStorage` + `modelRegistry` for every session. */
-export interface PiRuntime {
-	authStorage: AuthStorage;
-	modelRegistry: ModelRegistry;
+/**
+ * The shared pi model/auth runtime — one `ModelRuntime` for every session (pi's canonical SDK facade
+ * since 0.80.8: models, credentials, availability, login/logout, and request dispatch in one object).
+ * Built lazily on first use so `PI_CODING_AGENT_DIR` set before that point is honored (tests and the
+ * e2e harnesses rely on this), and memoized as a promise because `ModelRuntime.create()` is async.
+ */
+let runtime: Promise<ModelRuntime> | null = null;
+
+/** Override the shared runtime — tests inject a faux-backed one so no auth/network is needed. */
+export function configurePiRuntime(rt: ModelRuntime | null): void {
+	runtime = rt ? Promise.resolve(rt) : null;
 }
 
-let runtime: PiRuntime | null = null;
-
-/** Override the shared runtime — tests inject a faux-backed registry so no auth/network is needed. */
-export function configurePiRuntime(rt: PiRuntime): void {
-	runtime = rt;
-}
-
-/** The shared runtime, built lazily from on-disk auth (`~/.pi/agent`) + the built-in model registry. */
-export function getPiRuntime(): PiRuntime {
+/** The shared runtime, built lazily from on-disk auth + catalogs (`~/.pi/agent`). */
+export function getPiRuntime(): Promise<ModelRuntime> {
 	if (!runtime) {
-		const authStorage = AuthStorage.create();
-		runtime = { authStorage, modelRegistry: ModelRegistry.create(authStorage) };
+		const created = ModelRuntime.create();
+		runtime = created;
+		// A failed create must not brick the host until restart — drop the memo so the next call retries.
+		created.catch(() => {
+			if (runtime === created) runtime = null;
+		});
 	}
 	return runtime;
 }

--- a/packages/server/src/auth/SPEC.md
+++ b/packages/server/src/auth/SPEC.md
@@ -22,11 +22,12 @@ we never parse `auth.json` / `models.json` ourselves and never surface a credent
   - `providerStatus` — `getProviderStatus()` → the wire `ProviderStatusReport`: per-provider `configured`
     (pi's `hasAuth`-family truth, so env-var auth counts) + auth `kind` (oauth / api-key / env /
     **central** / other) + display name + the in-app-login capability flags **`canOAuth`/`canApiKey`**,
-    configured-first. It **revalidates on every read** (`runtime.reloadConfig()` — reload models.json,
-    recompose providers, refresh availability; auth.json itself is read live under a lock by pi's file
-    credential store, so no separate credentials reload exists or is needed) so a `pi` `/login` (or a
-    terminal `central` re-wire) — or an in-app mutation below — shows up on the next read without a host
-    restart (accepted micro-risk: refreshing the shared runtime concurrent with a streaming session —
+    configured-first. It **revalidates on every read**: `runtime.reloadConfig()` reloads models.json and
+    recomposes providers (it does **not** touch auth.json itself), and its internal availability refresh
+    re-runs the per-provider auth checks against pi's credential store — which reads auth.json fresh
+    (under a lock) on every access, so no separate credentials reload exists or is needed. A `pi`
+    `/login` (or a terminal `central` re-wire) — or an in-app mutation below — thus shows up on the next
+    read without a host restart (accepted micro-risk: refreshing the shared runtime concurrent with a streaming session —
     same as pi's TUI on `/login`). jbcentral wiring is detected from the runtime's **effective** model
     `baseUrl`s via `shared/jbcentral`'s `isJbcentralProxyUrl` — never a separate `models.json` read.
     Assembly is a pure `buildProviderReport(sources)` over a narrow sources slice, unit-tested with

--- a/packages/server/src/auth/SPEC.md
+++ b/packages/server/src/auth/SPEC.md
@@ -13,8 +13,8 @@ tags: [v1, auth, pi]
 
 Everything about **model-provider credentials**: the read side the Welcome strip renders
 (`provider.status`) and the write side that configures them from inside the app — OAuth sign-in, single
-API-key entry, and logout. All of it goes through pi's `AuthStorage` (on the shared runtime); we never
-parse `auth.json` / `models.json` ourselves and never surface a credential value over the wire.
+API-key entry, and logout. All of it goes through the shared `ModelRuntime` (pi's model/auth facade);
+we never parse `auth.json` / `models.json` ourselves and never surface a credential value over the wire.
 
 ## Boundary
 
@@ -22,43 +22,53 @@ parse `auth.json` / `models.json` ourselves and never surface a credential value
   - `providerStatus` — `getProviderStatus()` → the wire `ProviderStatusReport`: per-provider `configured`
     (pi's `hasAuth`-family truth, so env-var auth counts) + auth `kind` (oauth / api-key / env /
     **central** / other) + display name + the in-app-login capability flags **`canOAuth`/`canApiKey`**,
-    configured-first. It **revalidates on every read** (`authStorage.reload()` + `modelRegistry.refresh()`)
-    so a `pi` `/login` (or a terminal `central` re-wire) — or an in-app mutation below — shows up
-    on the next read without a host restart (accepted micro-risk: refreshing the shared registry concurrent
-    with a streaming session — same as pi's TUI on `/login`). jbcentral wiring is detected from the
-    registry's **effective** model `baseUrl`s via `shared/jbcentral`'s `isJbcentralProxyUrl` — never a
-    separate `models.json` read. Assembly is a pure `buildProviderReport(sources)` over a narrow sources
-    slice, unit-tested with fixture data.
-    - **OAuth provider ids are first-class rows.** The id universe unions model-registry providers,
-      stored-credential providers, **and** `authStorage.getOAuthProviders()` ids — because an OAuth id can
-      differ from any model-provider id (`openai-codex` ≠ `openai`; `github-copilot` has no model row until
-      authed). `canOAuth` = the row id is an OAuth provider (so `provider.loginStart(row.id)` uses the
-      credential id pi will actually store under). `canApiKey` = the row is a **single-key** model provider,
-      minus `MULTI_FIELD_PROVIDERS` (`amazon-bedrock`/`google-vertex`/`azure-openai-responses` — AWS/GCP/
-      Azure creds aren't one string) and `OAUTH_ONLY_PROVIDERS` (`github-copilot`). These two small sets
-      re-derive pi's private `isApiKeyLoginProvider` predicate, which isn't a package export (deep TUI
-      import only) — **drift note:** re-check them on pi bumps against pi's provider-display-names map.
-      `canLogout` = the id has a stored **auth.json** credential (`credentialProviders`) — the only auth the
-      host can remove; env / central (models.json) / models.json-keyed auth report `false` (Sign-out would
-      no-op, so the strip hides it).
+    configured-first. It **revalidates on every read** (`runtime.reloadConfig()` — reload models.json,
+    recompose providers, refresh availability; auth.json itself is read live under a lock by pi's file
+    credential store, so no separate credentials reload exists or is needed) so a `pi` `/login` (or a
+    terminal `central` re-wire) — or an in-app mutation below — shows up on the next read without a host
+    restart (accepted micro-risk: refreshing the shared runtime concurrent with a streaming session —
+    same as pi's TUI on `/login`). jbcentral wiring is detected from the runtime's **effective** model
+    `baseUrl`s via `shared/jbcentral`'s `isJbcentralProxyUrl` — never a separate `models.json` read.
+    Assembly is a pure `buildProviderReport(sources)` over a narrow sources slice, unit-tested with
+    fixture data.
+    - **OAuth-capable ids are first-class rows.** The id universe unions model-catalog providers,
+      stored-credential providers (`listCredentials()`), **and** providers whose `Provider.auth.oauth`
+      is present — an OAuth id can differ from any model-provider id (`openai-codex` ≠ `openai`), and a
+      stored credential can outlive its models. `canOAuth` = the row's provider carries OAuth auth (so
+      `provider.loginStart(row.id)` uses the credential id pi will actually store under); its row name
+      prefers `auth.oauth.name` (more specific for oauth-only rows). `canApiKey` = the row is a model
+      provider **whose `Provider.auth.apiKey.login` exists** (pi's public api-key-login truth —
+      `openai-codex` has model rows but no key auth), minus `MULTI_FIELD_PROVIDERS`
+      (`amazon-bedrock`/`google-vertex`/`azure-openai-responses`) and `OAUTH_ONLY_PROVIDERS`
+      (`github-copilot`): pi *can* drive those interactively (possibly multi-prompt), but our inline
+      field posts exactly **one** string — the sets stay until the strip drives api-key setup through
+      the interactive login channel (tracked as a follow-up issue). `canLogout` = the id has a stored
+      **auth.json** credential (`credentialProviders`) — the only auth the host can remove; env / central
+      (models.json) / models.json-keyed auth report `false` (Sign-out would no-op, so the strip hides it).
   - `providerLogin` — the in-app credential **writes**, session-less (a login runs on the Welcome screen
     before any session exists), so a `loginId`-keyed sibling of `agent/webUiContext`:
-    - `startLogin(providerId)` → `{ loginId }` **synchronously**; pi's `authStorage.login()` runs
-      **detached** (an OAuth flow can take minutes — awaiting it would blow the client request timeout and
-      block the WS pump). pi's login callbacks are wired to `LoginFrame` pushes on the `provider.login`
-      channel: `onAuth`→`authUrl`, `onDeviceCode`→`deviceCode`, `onProgress`→`progress`,
-      `onSelect`/`onPrompt`/`onManualCodeInput`→a parked `select`/`prompt` frame awaiting a reply. On
-      success it **refreshes the registry** (pi's `login()` writes auth.json but doesn't touch the registry —
-      skip this and the provider is authed-but-invisible) then pushes `success`; on throw, `error`.
-    - `resolveLogin({ loginId, value })` — the browser's reply resolves the parked callback.
+    - `startLogin(providerId)` → `{ loginId }` **synchronously**; `runtime.login(id, "oauth",
+      interaction)` runs **detached** (an OAuth flow can take minutes — awaiting it would blow the client
+      request timeout and block the WS pump). pi's `AuthInteraction` is wired to `LoginFrame` pushes on
+      the `provider.login` channel: `notify` `auth_url`→`authUrl`, `device_code`→`deviceCode`,
+      `progress`/`info`→`progress` (info links appended as plain URLs); `prompt`
+      `select`→a parked `select` frame, `text`/`secret`/`manual_code`→a parked `prompt` frame awaiting a
+      reply. A prompt's own `signal` abort (pi cancelling the loser of its browser-vs-paste race) settles
+      the parked input — identity-guarded so a late abort can't clear a newer parked prompt. pi persists
+      the credential **and refreshes availability inside `login()`**, so success just pushes `success`;
+      on throw, `error`.
+    - `resolveLogin({ loginId, value })` — the browser's reply resolves the parked interaction.
     - `cancelLogin(loginId)` — aborts the signal **and** settles the parked input with `undefined` (which
-      throws inside `onPrompt`/`onManualCodeInput`), because the signal alone won't stop a provider's
+      makes the awaiting `prompt` throw), because the signal alone won't stop a provider's
       browser/callback-server wait; `cancelAllLogins()` sweeps them on host `stop()`.
-    - `setProviderApiKey(id, key)` / `logoutProvider(id)` — `authStorage.set`/`logout` + a registry refresh.
+    - `setProviderApiKey(id, key)` — persists via `runtime.login(id, "api_key", <canned interaction>)`
+      answering the provider's single secret prompt with the key (`setRuntimeApiKey` is a
+      **non-persistent** overlay — never use it for this); only offered for single-key providers (see
+      `canApiKey`). `logoutProvider(id)` — `runtime.logout` (refreshes internally).
     - `setLoginPublisher(fn)` — the server→client push seam (defaults to a no-op).
   - `jbcentral` — the in-app **JetBrains AI** (jbcentral proxy) wiring, composing `@thinkrail/shared/jbcentral`
     (which owns the protocol) and adding the one live-runtime step the standalone CLI can't:
-    `connectJbcentral()` (`wireJbcentral` → on success `modelRegistry.refresh()` → a `JbcentralConnectResult`:
+    `connectJbcentral()` (`wireJbcentral` → on success `runtime.reloadConfig()` → a `JbcentralConnectResult`:
     connected / needs-install / needs-login / error), `disconnectJbcentral()` (`unwireJbcentral` + refresh),
     `jbcentralLogin()` (best-effort `central login` browser launch). `providerStatus` also surfaces
     `jbcentralInstalled` (via `isJbcentralInstalled`) **and `jbcentralInstall`** (the host's per-OS install
@@ -68,8 +78,7 @@ parse `auth.json` / `models.json` ourselves and never surface a credential value
   `startLogin`, `resolveLogin`, `cancelLogin`, `cancelAllLogins`, `setProviderApiKey`, `logoutProvider`,
   `setLoginPublisher`; `connectJbcentral`, `disconnectJbcentral`, `jbcentralLogin`.
 - **Allowed deps:** `contracts` (wire types); `shared/jbcentral`; the **`agent` barrel** for
-  `getPiRuntime()` (the shared `AuthStorage` + `ModelRegistry`); `@earendil-works/pi-ai/compat` (login
-  callback **types** only).
+  `getPiRuntime()` (the shared `ModelRuntime`); `@earendil-works/pi-ai` (auth interaction **types** only).
 - **Forbidden:** reaching into `agent` internals (only `getPiRuntime` via its barrel); importing `host` or
   any other sibling; deep-importing pi's TUI (`modes/interactive/*`) for its private provider constants;
   ever putting a credential **value** on the wire.
@@ -77,7 +86,11 @@ parse `auth.json` / `models.json` ourselves and never surface a credential value
 ## Get right
 
 - **`loginStart` must not `await` the flow** — return the handle, run `login()` detached.
-- **Refresh the registry after every write** (login success / setApiKey / logout) or the change is invisible.
+- **Writes refresh themselves** (pi's `login`/`logout` refresh availability internally) — but the status
+  read still `reloadConfig()`s, or external changes (a terminal `pi /login`, a `central` re-wire) stay
+  invisible until restart.
+- **API keys persist only through `login(id, "api_key")`** — `setRuntimeApiKey` is a session-lifetime
+  overlay and would silently drop the key on host restart.
 - **Cancel settles the parked promise**, not just `abort()`.
 - Frames **accumulate** client-side (the `authUrl` + paste-`prompt` race), so a terminal `success`/`error`
   is what closes a flow — `terminate()` guarantees exactly one terminal outcome per `loginId`.

--- a/packages/server/src/auth/jbcentral.ts
+++ b/packages/server/src/auth/jbcentral.ts
@@ -1,7 +1,7 @@
 // In-app "Connect JetBrains AI" — the server side of wiring pi's Claude+GPT picks through the local
 // jbcentral proxy. The jbcentral protocol (probe the secret, override models.json, undo it) lives in
 // `@thinkrail/shared/jbcentral`; here we compose it and add the one live-runtime step the standalone CLI
-// can't: **refresh the shared model registry** so `provider.status` (and any live session) sees the change.
+// can't: **reload the shared runtime's models.json** so `provider.status` (and any live session) sees the change.
 
 import type { JbcentralConnectResult } from "@thinkrail/contracts";
 import {
@@ -18,14 +18,14 @@ export function jbcentralInstalled(): boolean {
 }
 
 /**
- * Wire Claude+GPT through the jbcentral proxy (writes models.json), then refresh the registry so it takes
- * effect at once. Returns the outcome so the card can walk the user forward (install → sign in → connect).
+ * Wire Claude+GPT through the jbcentral proxy (writes models.json), then reload the runtime's config so
+ * it takes effect at once. Returns the outcome so the card can walk the user forward (install → sign in → connect).
  */
 export async function connectJbcentral(): Promise<JbcentralConnectResult> {
 	const result = await wireJbcentral(process.env);
 	switch (result.outcome) {
 		case "connected":
-			getPiRuntime().modelRegistry.refresh();
+			await (await getPiRuntime()).reloadConfig();
 			return { outcome: "connected" };
 		case "needs-install":
 			return { outcome: "needs-install" };
@@ -36,10 +36,10 @@ export async function connectJbcentral(): Promise<JbcentralConnectResult> {
 	}
 }
 
-/** Undo the jbcentral overrides (models.json) and refresh the registry so the built-in endpoints return. */
+/** Undo the jbcentral overrides (models.json) and reload the config so the built-in endpoints return. */
 export async function disconnectJbcentral(): Promise<void> {
 	await unwireJbcentral(process.env);
-	getPiRuntime().modelRegistry.refresh();
+	await (await getPiRuntime()).reloadConfig();
 }
 
 /** Best-effort launch of `central login` (its browser sign-in) on the host. */

--- a/packages/server/src/auth/providerLogin.test.ts
+++ b/packages/server/src/auth/providerLogin.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai/compat";
-import type { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { AuthInteraction, AuthType } from "@earendil-works/pi-ai";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { LoginPush } from "@thinkrail/contracts";
 import { configurePiRuntime } from "../agent";
 import {
@@ -16,70 +16,67 @@ import {
 /** Let queued microtasks/timers run so a detached `login()` continuation settles before we assert. */
 const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 
-type LoginImpl = (providerId: string, callbacks: OAuthLoginCallbacks) => Promise<void>;
+type LoginImpl = (providerId: string, interaction: AuthInteraction) => Promise<unknown>;
 
 interface Harness {
 	frames: LoginPush[];
-	refreshCount: () => number;
-	setCalls: () => [string, unknown][];
+	/** Every `runtime.login` call as `[providerId, type]`. */
+	loginCalls: () => [string, AuthType][];
 	logoutCalls: () => string[];
 	lastSignal: () => AbortSignal | undefined;
+	lastInteraction: () => AuthInteraction | undefined;
 }
 
-/** Install a fake pi runtime whose `authStorage.login` is `loginImpl`, and capture pushed frames + calls. */
+/** Install a fake pi runtime whose `login` is `loginImpl`, and capture pushed frames + calls. */
 function install(loginImpl: LoginImpl): Harness {
 	const frames: LoginPush[] = [];
 	setLoginPublisher((push) => frames.push(push));
 
-	let refresh = 0;
-	const set: [string, unknown][] = [];
+	const logins: [string, AuthType][] = [];
 	const logout: string[] = [];
 	let signal: AbortSignal | undefined;
+	let interaction: AuthInteraction | undefined;
 
-	const authStorage = {
-		login: (providerId: string, callbacks: OAuthLoginCallbacks) => {
-			signal = callbacks.signal;
-			return loginImpl(providerId, callbacks);
+	const runtime = {
+		login: (providerId: string, type: AuthType, i: AuthInteraction) => {
+			logins.push([providerId, type]);
+			signal = i.signal;
+			interaction = i;
+			return loginImpl(providerId, i);
 		},
-		set: (id: string, cred: unknown) => set.push([id, cred]),
-		logout: (id: string) => logout.push(id),
-	} as unknown as AuthStorage;
-	const modelRegistry = {
-		refresh: () => {
-			refresh++;
+		logout: async (id: string) => {
+			logout.push(id);
 		},
-	} as unknown as ModelRegistry;
+	} as unknown as ModelRuntime;
 
-	configurePiRuntime({ authStorage, modelRegistry });
+	configurePiRuntime(runtime);
 	return {
 		frames,
-		refreshCount: () => refresh,
-		setCalls: () => set,
+		loginCalls: () => logins,
 		logoutCalls: () => logout,
 		lastSignal: () => signal,
+		lastInteraction: () => interaction,
 	};
 }
 
 afterEach(() => {
 	cancelAllLogins();
 	setLoginPublisher(() => {});
-	configurePiRuntime(
-		undefined as unknown as { authStorage: AuthStorage; modelRegistry: ModelRegistry },
-	);
+	configurePiRuntime(null);
 });
 
 describe("startLogin", () => {
 	test("returns a handle synchronously (the flow runs detached, never awaited)", () => {
 		// A login() that never settles must not block startLogin from returning its loginId.
-		const { frames } = install(() => new Promise<void>(() => {}));
+		const { frames } = install(() => new Promise(() => {}));
 		const { loginId } = startLogin("anthropic");
 		expect(loginId).toMatch(/^login_\d+$/);
 		expect(frames).toEqual([]); // nothing pushed yet — the flow hasn't produced a frame
 	});
 
-	test("device-code flow: pushes deviceCode, refreshes the registry, then success", async () => {
-		const h = install(async (_id, cb) => {
-			cb.onDeviceCode({ userCode: "WDJB-MJHT", verificationUri: "https://x/device" });
+	test("device-code flow: pushes deviceCode, then success (as an oauth login)", async () => {
+		const h = install(async (_id, i) => {
+			i.notify({ type: "device_code", userCode: "WDJB-MJHT", verificationUri: "https://x/device" });
 		});
 		const { loginId } = startLogin("github-copilot");
 		await tick();
@@ -93,14 +90,15 @@ describe("startLogin", () => {
 				verificationUri: "https://x/device",
 			},
 		});
-		expect(h.refreshCount()).toBe(1); // refresh happens before the success frame
+		expect(h.loginCalls()).toEqual([["github-copilot", "oauth"]]);
 	});
 
-	test("progress frames stream through, then the terminal success frame", async () => {
-		const h = install(async (_id, cb) => {
-			cb.onProgress?.("Polling device…");
-			cb.onDeviceCode({ userCode: "WDJB-MJHT", verificationUri: "https://x/device" });
-			cb.onProgress?.("Authorizing…");
+	test("progress + info notifications stream through, then the terminal success frame", async () => {
+		const h = install(async (_id, i) => {
+			i.notify({ type: "progress", message: "Polling device…" });
+			i.notify({ type: "device_code", userCode: "WDJB-MJHT", verificationUri: "https://x/device" });
+			// `info` (possibly with links) renders as progress — links appended as plain URLs.
+			i.notify({ type: "info", message: "See the docs", links: [{ url: "https://docs.example" }] });
 		});
 		startLogin("github-copilot");
 		await tick();
@@ -111,12 +109,17 @@ describe("startLogin", () => {
 			"success",
 		]);
 		expect(h.frames[0]?.frame).toEqual({ kind: "progress", message: "Polling device…" });
+		expect(h.frames[2]?.frame).toEqual({
+			kind: "progress",
+			message: "See the docs https://docs.example",
+		});
 	});
 
 	test("select round-trip: a parked frame is answered by loginReply, then the flow completes", async () => {
 		let chosen: string | undefined;
-		const h = install(async (_id, cb) => {
-			chosen = await cb.onSelect({
+		const h = install(async (_id, i) => {
+			chosen = await i.prompt({
+				type: "select",
 				message: "How do you want to sign in?",
 				options: [
 					{ id: "max", label: "Claude Pro/Max" },
@@ -140,13 +143,13 @@ describe("startLogin", () => {
 		expect(h.frames.at(-1)?.frame.kind).toBe("success");
 	});
 
-	test("prompt forwards allowEmpty and returns a blank reply to pi (Copilot github.com path)", async () => {
+	test('an empty prompt reply reaches pi as "" — not swallowed as a cancel (Copilot github.com path)', async () => {
 		let answered: string | undefined;
-		const h = install(async (_id, cb) => {
-			answered = await cb.onPrompt({
+		const h = install(async (_id, i) => {
+			answered = await i.prompt({
+				type: "text",
 				message: "GitHub Enterprise URL/domain (blank for github.com)",
 				placeholder: "company.ghe.com",
-				allowEmpty: true,
 			});
 		});
 		const { loginId } = startLogin("github-copilot");
@@ -155,21 +158,19 @@ describe("startLogin", () => {
 			kind: "prompt",
 			message: "GitHub Enterprise URL/domain (blank for github.com)",
 			placeholder: "company.ghe.com",
-			allowEmpty: true,
 		});
-		// The empty (github.com) reply must reach pi as "" — not be swallowed as a cancel.
 		resolveLogin({ loginId, value: "" });
 		await tick();
 		expect(answered).toBe("");
 		expect(h.frames.at(-1)?.frame.kind).toBe("success");
 	});
 
-	test("authUrl + concurrent paste: onAuth shows the URL while onManualCodeInput awaits a paste", async () => {
+	test("authUrl + concurrent paste: notify shows the URL while a manual_code prompt awaits a paste", async () => {
 		let pasted: string | undefined;
-		const h = install(async (_id, cb) => {
-			cb.onAuth({ url: "https://provider/authorize?x=1" });
+		const h = install(async (_id, i) => {
+			i.notify({ type: "auth_url", url: "https://provider/authorize?x=1" });
 			// The browser-vs-paste race: in this test the paste wins.
-			pasted = await cb.onManualCodeInput?.();
+			pasted = await i.prompt({ type: "manual_code", message: "Paste the authorization code" });
 		});
 		const { loginId } = startLogin("openai-codex");
 		await tick();
@@ -182,6 +183,26 @@ describe("startLogin", () => {
 		await tick();
 		expect(pasted).toBe("the-code");
 		expect(h.frames.at(-1)?.frame.kind).toBe("success");
+	});
+
+	test("pi aborting a prompt's signal (race lost) settles the parked input; a late reply is a no-op", async () => {
+		const promptAbort = new AbortController();
+		const h = install(async (_id, i) => {
+			// The manual-code prompt loses to the callback server: pi aborts the prompt's own signal and
+			// resolves the flow itself. Our parked input must settle (throw) without failing the login.
+			await i
+				.prompt({ type: "manual_code", message: "Paste code", signal: promptAbort.signal })
+				.catch(() => "callback-won");
+		});
+		const { loginId } = startLogin("anthropic");
+		await tick();
+		expect(h.frames.map((f) => f.frame.kind)).toEqual(["prompt"]);
+		promptAbort.abort();
+		await tick();
+		expect(h.frames.map((f) => f.frame.kind)).toEqual(["prompt", "success"]);
+		resolveLogin({ loginId, value: "late" }); // parked input is gone — must not throw or resurrect
+		await tick();
+		expect(h.frames.map((f) => f.frame.kind)).toEqual(["prompt", "success"]);
 	});
 
 	test("error path: a rejected login() pushes an error frame with the message", async () => {
@@ -197,15 +218,14 @@ describe("startLogin", () => {
 				frame: { kind: "error", message: "provider said no" },
 			},
 		]);
-		expect(h.refreshCount()).toBe(0); // no refresh on failure
 	});
 });
 
 describe("cancelLogin", () => {
 	test("aborts the signal AND rejects the parked prompt — and pushes no stray terminal frame", async () => {
-		const h = install(async (_id, cb) => {
-			// Parks forever unless the parked prompt is settled by cancel (which makes onPrompt throw).
-			await cb.onPrompt({ message: "Paste code" });
+		const h = install(async (_id, i) => {
+			// Parks forever unless the parked prompt is settled by cancel (which makes prompt() throw).
+			await i.prompt({ type: "text", message: "Paste code" });
 		});
 		const { loginId } = startLogin("anthropic");
 		await tick();
@@ -219,26 +239,24 @@ describe("cancelLogin", () => {
 		expect(h.lastSignal()?.aborted).toBe(true);
 	});
 
-	test("a callback firing after cancel pushes no stray frame (push guards on settled)", async () => {
-		let captured: OAuthLoginCallbacks | undefined;
-		const h = install(async (_id, cb) => {
-			captured = cb;
-			await cb.onPrompt({ message: "code" });
+	test("an interaction firing after cancel pushes no stray frame (push guards on settled)", async () => {
+		const h = install(async (_id, i) => {
+			await i.prompt({ type: "text", message: "code" });
 		});
 		const { loginId } = startLogin("anthropic");
 		await tick();
 		cancelLogin(loginId);
 		await tick();
-		// pi's detached flow may invoke a callback after we've cancelled — the guard must swallow it.
-		captured?.onProgress?.("late progress");
-		captured?.onAuth({ url: "https://late" });
+		// pi's detached flow may notify after we've cancelled — the guard must swallow it.
+		h.lastInteraction()?.notify({ type: "progress", message: "late progress" });
+		h.lastInteraction()?.notify({ type: "auth_url", url: "https://late" });
 		await tick();
 		expect(h.frames.map((f) => f.frame.kind)).toEqual(["prompt"]);
 	});
 
 	test("a reply after cancel is a no-op (the login is gone)", async () => {
-		const h = install(async (_id, cb) => {
-			await cb.onPrompt({ message: "code" });
+		const h = install(async (_id, i) => {
+			await i.prompt({ type: "text", message: "code" });
 		});
 		const { loginId } = startLogin("anthropic");
 		await tick();
@@ -250,9 +268,9 @@ describe("cancelLogin", () => {
 
 	test("cancelAllLogins settles every in-flight login", async () => {
 		const signals: (AbortSignal | undefined)[] = [];
-		install(async (_id, cb) => {
-			signals.push(cb.signal);
-			await cb.onPrompt({ message: "code" });
+		install(async (_id, i) => {
+			signals.push(i.signal);
+			await i.prompt({ type: "text", message: "code" });
 		});
 		startLogin("anthropic");
 		startLogin("openai-codex");
@@ -265,22 +283,24 @@ describe("cancelLogin", () => {
 });
 
 describe("setProviderApiKey / logoutProvider", () => {
-	test("setProviderApiKey stores an api_key credential and refreshes the registry", () => {
-		const h = install(async () => {});
-		setProviderApiKey("openai", "  sk-abc  ");
-		expect(h.setCalls()).toEqual([["openai", { type: "api_key", key: "sk-abc" }]]);
-		expect(h.refreshCount()).toBe(1);
+	test("setProviderApiKey persists via login(id, 'api_key') answering the secret prompt with the key", async () => {
+		let stored: string | undefined;
+		const h = install(async (_id, i) => {
+			stored = await i.prompt({ type: "secret", message: "API key" });
+		});
+		await setProviderApiKey("openai", "  sk-abc  ");
+		expect(stored).toBe("sk-abc"); // trimmed
+		expect(h.loginCalls()).toEqual([["openai", "api_key"]]);
 	});
 
-	test("setProviderApiKey rejects an empty/blank key", () => {
+	test("setProviderApiKey rejects an empty/blank key", async () => {
 		install(async () => {});
-		expect(() => setProviderApiKey("openai", "   ")).toThrow(/must not be empty/);
+		await expect(setProviderApiKey("openai", "   ")).rejects.toThrow(/must not be empty/);
 	});
 
-	test("logoutProvider removes the credential and refreshes the registry", () => {
+	test("logoutProvider removes the credential through the runtime", async () => {
 		const h = install(async () => {});
-		logoutProvider("anthropic");
+		await logoutProvider("anthropic");
 		expect(h.logoutCalls()).toEqual(["anthropic"]);
-		expect(h.refreshCount()).toBe(1);
 	});
 });

--- a/packages/server/src/auth/providerLogin.test.ts
+++ b/packages/server/src/auth/providerLogin.test.ts
@@ -154,10 +154,12 @@ describe("startLogin", () => {
 		});
 		const { loginId } = startLogin("github-copilot");
 		await tick();
+		// `text` prompts carry allowEmpty so the dialog can submit a blank (github.com) answer.
 		expect(h.frames.at(-1)?.frame).toEqual({
 			kind: "prompt",
 			message: "GitHub Enterprise URL/domain (blank for github.com)",
 			placeholder: "company.ghe.com",
+			allowEmpty: true,
 		});
 		resolveLogin({ loginId, value: "" });
 		await tick();

--- a/packages/server/src/auth/providerLogin.ts
+++ b/packages/server/src/auth/providerLogin.ts
@@ -1,11 +1,12 @@
-// In-app provider login: drives pi's OAuth flow (`authStorage.login`) headless — the callbacks pi would
-// hand a TUI are wired to WS frames instead. Session-less (a login runs on the Welcome screen before any
-// session exists), so this is the sibling of `webUiContext`: a `loginId`-keyed pending registry, frames
-// pushed on the `provider.login` channel, and a parked input promise that the browser's `provider.loginReply`
-// resolves. Also the API-key / logout mutators (auth.json writes), each of which refreshes the registry so
-// a following `provider.status` read reflects it.
+// In-app provider login: drives pi's OAuth flow (`ModelRuntime.login`) headless — the `AuthInteraction`
+// pi would hand a TUI is wired to WS frames instead. Session-less (a login runs on the Welcome screen
+// before any session exists), so this is the sibling of `webUiContext`: a `loginId`-keyed pending
+// registry, frames pushed on the `provider.login` channel, and a parked input promise that the browser's
+// `provider.loginReply` resolves. Also the API-key / logout mutators, each of which pi persists to
+// auth.json and follows with an internal availability refresh, so a following `provider.status` read
+// reflects it.
 
-import type { OAuthLoginCallbacks } from "@earendil-works/pi-ai/compat";
+import type { AuthInteraction, AuthPrompt } from "@earendil-works/pi-ai";
 import type { LoginFrame, LoginPush, LoginReply } from "@thinkrail/contracts";
 import { getPiRuntime } from "../agent";
 
@@ -22,7 +23,7 @@ const nextId = (): string => `login_${++seq}`;
 interface Pending {
 	providerId: string;
 	abort: AbortController;
-	/** Resolver for the currently-parked `select`/`prompt`/manual-code callback, if one is awaiting input. */
+	/** Resolver for the currently-parked `select`/`prompt` interaction, if one is awaiting input. */
 	resolveInput?: (value: string | undefined) => void;
 	settled: boolean;
 }
@@ -37,88 +38,105 @@ function terminate(loginId: string): Pending | undefined {
 	return entry;
 }
 
+/** The wire frame for an interactive `AuthPrompt` (select keeps its options; the rest are text inputs). */
+function frameForPrompt(prompt: AuthPrompt): LoginFrame {
+	if (prompt.type === "select") {
+		return {
+			kind: "select",
+			message: prompt.message,
+			options: prompt.options.map((o) => ({ id: o.id, label: o.label })),
+		};
+	}
+	// `text`, `secret`, and `manual_code` all collect one string (the paste-code race included).
+	return {
+		kind: "prompt",
+		message: prompt.message,
+		...(prompt.placeholder ? { placeholder: prompt.placeholder } : {}),
+	};
+}
+
 /**
- * Start a login and return its handle **immediately** — pi's `authStorage.login()` is kicked off *detached*
- * (`void`, no `await`): an OAuth flow can take minutes of user interaction, so awaiting it here would blow
- * the client's request timeout and block the WS message pump. Frames arrive on the `provider.login` channel;
- * the terminal `success`/`error` frame lands whenever the detached flow settles.
+ * Start a login and return its handle **immediately** — pi's `ModelRuntime.login()` is kicked off
+ * *detached* (`void`, no `await`): an OAuth flow can take minutes of user interaction, so awaiting it here
+ * would blow the client's request timeout and block the WS message pump. Frames arrive on the
+ * `provider.login` channel; the terminal `success`/`error` frame lands whenever the detached flow settles.
  */
 export function startLogin(providerId: string): { loginId: string } {
 	const loginId = nextId();
 	const entry: Pending = { providerId, abort: new AbortController(), settled: false };
 	logins.set(loginId, entry);
 
-	const { authStorage, modelRegistry } = getPiRuntime();
-	// Guard on `settled`: pi's callbacks (onAuth/onProgress/…) fire from the detached flow and could race a
+	// Guard on `settled`: interaction callbacks fire from the detached flow and could race a
 	// `cancelLogin`/terminal — never publish a frame for a login that's already been terminated.
 	const push = (frame: LoginFrame): void => {
 		if (!entry.settled) publish({ loginId, providerId, frame });
 	};
 
-	// Park a `select`/`prompt` frame and await the browser's reply (or a cancel → `undefined`).
-	const awaitInput = (frame: LoginFrame): Promise<string | undefined> =>
+	// Park a `select`/`prompt` frame and await the browser's reply (or a cancel → `undefined`). pi aborts
+	// a prompt it no longer wants (e.g. the manual-code prompt when its callback server wins the race) via
+	// the prompt's own signal — settle with `undefined` then, so a late browser reply can't leak into a
+	// future prompt.
+	const awaitInput = (frame: LoginFrame, signal?: AbortSignal): Promise<string | undefined> =>
 		new Promise((resolve) => {
-			entry.resolveInput = (value) => {
-				delete entry.resolveInput;
-				resolve(value);
+			const settle = (value: string | undefined): void => {
+				// Identity guard: a late abort from a superseded prompt must not clear a newer parked one.
+				if (entry.resolveInput === settle) delete entry.resolveInput;
+				resolve(value); // resolving an already-settled promise is a no-op
 			};
+			entry.resolveInput = settle;
+			signal?.addEventListener("abort", () => settle(undefined), { once: true });
 			push(frame);
 		});
 
-	const callbacks: OAuthLoginCallbacks = {
-		onAuth: (info) =>
-			push({
-				kind: "authUrl",
-				url: info.url,
-				...(info.instructions ? { instructions: info.instructions } : {}),
-			}),
-		onDeviceCode: (info) =>
-			push({
-				kind: "deviceCode",
-				userCode: info.userCode,
-				verificationUri: info.verificationUri,
-				...(info.expiresInSeconds ? { expiresInSeconds: info.expiresInSeconds } : {}),
-			}),
-		onProgress: (message) => push({ kind: "progress", message }),
-		onSelect: (prompt) =>
-			awaitInput({ kind: "select", message: prompt.message, options: prompt.options }),
-		onPrompt: async (prompt) => {
-			const value = await awaitInput({
-				kind: "prompt",
-				message: prompt.message,
-				...(prompt.placeholder ? { placeholder: prompt.placeholder } : {}),
-				// pi flags prompts where an empty answer is valid (e.g. GitHub Copilot's "blank for github.com"
-				// GHE domain) — forward it so the dialog can let the user submit blank instead of dead-ending.
-				...(prompt.allowEmpty ? { allowEmpty: true } : {}),
-			});
-			if (value === undefined) throw new Error("Login cancelled");
-			return value;
-		},
-		// Runs *concurrently* with `onAuth`'s local callback server (the anthropic/openai browser-vs-paste
-		// race): the user opens the URL, or pastes the code here — whichever wins settles the flow. On remote
-		// access (localhost callback unreachable), paste is the only path, so this must always be offered.
-		onManualCodeInput: async () => {
-			const value = await awaitInput({
-				kind: "prompt",
-				message: "Paste the authorization code from your browser",
-				placeholder: "authorization code",
-			});
-			if (value === undefined) throw new Error("Login cancelled");
-			return value;
-		},
+	const interaction: AuthInteraction = {
 		signal: entry.abort.signal,
+		notify: (event) => {
+			switch (event.type) {
+				case "auth_url":
+					push({
+						kind: "authUrl",
+						url: event.url,
+						...(event.instructions ? { instructions: event.instructions } : {}),
+					});
+					break;
+				case "device_code":
+					push({
+						kind: "deviceCode",
+						userCode: event.userCode,
+						verificationUri: event.verificationUri,
+						...(event.expiresInSeconds ? { expiresInSeconds: event.expiresInSeconds } : {}),
+					});
+					break;
+				case "progress":
+					push({ kind: "progress", message: event.message });
+					break;
+				case "info":
+					// Informational text (may carry links) — render as progress, links appended as plain URLs.
+					push({
+						kind: "progress",
+						message: [event.message, ...(event.links ?? []).map((l) => l.url)].join(" "),
+					});
+					break;
+			}
+		},
+		prompt: async (prompt) => {
+			const value = await awaitInput(frameForPrompt(prompt), prompt.signal);
+			// `undefined` = cancelled (ours) or abandoned (pi's own abort) — throwing unblocks pi's flow;
+			// when pi aborted the prompt itself, the rejection is absorbed by its already-settled race.
+			if (value === undefined) throw new Error("Login cancelled");
+			return value;
+		},
 	};
 
 	// Terminal frames are published directly (bypassing `push`'s settled-guard): `terminate()` flips `settled`
 	// first, and it also guarantees exactly one terminal outcome per login.
 	const publishTerminal = (frame: LoginFrame): void => publish({ loginId, providerId, frame });
 
-	void authStorage
-		.login(providerId, callbacks)
+	// pi persists the credential and refreshes its availability snapshot inside `login()` — the freshly
+	// authed provider's models appear on the next `model.list`/`provider.status` read with no extra step.
+	void getPiRuntime()
+		.then((runtime) => runtime.login(providerId, "oauth", interaction))
 		.then(() => {
-			// pi's `login()` writes auth.json but does NOT touch the registry — refresh so the freshly-authed
-			// provider's models appear (otherwise `model.list`/`provider.status` stay stale: authed but invisible).
-			modelRegistry.refresh();
 			if (terminate(loginId)) publishTerminal({ kind: "success" });
 		})
 		.catch((err: unknown) => {
@@ -134,7 +152,7 @@ export function startLogin(providerId: string): { loginId: string } {
 	return { loginId };
 }
 
-/** The browser's answer to a live `select`/`prompt` frame — resolves the parked pi callback. */
+/** The browser's answer to a live `select`/`prompt` frame — resolves the parked interaction. */
 export function resolveLogin(reply: LoginReply): void {
 	logins.get(reply.loginId)?.resolveInput?.(reply.value);
 }
@@ -142,7 +160,7 @@ export function resolveLogin(reply: LoginReply): void {
 /**
  * Cancel an in-flight login. Aborting the signal alone does NOT stop a provider's browser/callback-server
  * wait (pi uses its own internal timeout there), so we also settle any parked input with `undefined` — which
- * makes the awaiting `onPrompt`/`onManualCodeInput` throw, unblocking pi's flow.
+ * makes the awaiting `prompt` throw, unblocking pi's flow.
  */
 export function cancelLogin(loginId: string): void {
 	const entry = terminate(loginId);
@@ -156,18 +174,24 @@ export function cancelAllLogins(): void {
 	for (const loginId of [...logins.keys()]) cancelLogin(loginId);
 }
 
-/** Store a single API key for a provider (auth.json) and refresh the registry so it takes effect at once. */
-export function setProviderApiKey(providerId: string, key: string): void {
+/**
+ * Store a single API key for a provider. pi 0.80.8+ persists api keys through the provider-owned login
+ * flow (`login(id, "api_key", …)` → auth.json) — `setRuntimeApiKey` is a non-persistent overlay, NOT this.
+ * The canned interaction answers the provider's single secret prompt with the key; the strip only offers
+ * this field for single-key providers (see `MULTI_FIELD_PROVIDERS` in `providerStatus`).
+ */
+export async function setProviderApiKey(providerId: string, key: string): Promise<void> {
 	const trimmed = key.trim();
 	if (!trimmed) throw new Error("API key must not be empty");
-	const { authStorage, modelRegistry } = getPiRuntime();
-	authStorage.set(providerId, { type: "api_key", key: trimmed });
-	modelRegistry.refresh();
+	const runtime = await getPiRuntime();
+	await runtime.login(providerId, "api_key", {
+		prompt: async () => trimmed,
+		notify: () => {},
+	});
 }
 
-/** Remove a provider's stored credentials (auth.json) and refresh the registry. */
-export function logoutProvider(providerId: string): void {
-	const { authStorage, modelRegistry } = getPiRuntime();
-	authStorage.logout(providerId);
-	modelRegistry.refresh();
+/** Remove a provider's stored credentials (auth.json); pi refreshes availability internally. */
+export async function logoutProvider(providerId: string): Promise<void> {
+	const runtime = await getPiRuntime();
+	await runtime.logout(providerId);
 }

--- a/packages/server/src/auth/providerLogin.ts
+++ b/packages/server/src/auth/providerLogin.ts
@@ -47,11 +47,14 @@ function frameForPrompt(prompt: AuthPrompt): LoginFrame {
 			options: prompt.options.map((o) => ({ id: o.id, label: o.label })),
 		};
 	}
-	// `text`, `secret`, and `manual_code` all collect one string (the paste-code race included).
+	// `text`, `secret`, and `manual_code` all collect one string (the paste-code race included). Only
+	// `text` prompts may be submitted blank — providers define empty semantics there (Copilot's GHE
+	// prompt treats blank as github.com), while an empty secret/auth-code is never meaningful.
 	return {
 		kind: "prompt",
 		message: prompt.message,
 		...(prompt.placeholder ? { placeholder: prompt.placeholder } : {}),
+		...(prompt.type === "text" ? { allowEmpty: true } : {}),
 	};
 }
 

--- a/packages/server/src/auth/providerStatus.test.ts
+++ b/packages/server/src/auth/providerStatus.test.ts
@@ -18,6 +18,7 @@ function sources(overrides: Partial<ProviderStatusSources> = {}): ProviderStatus
 		oauthProviders: [],
 		credentialType: () => undefined,
 		providerAuth: () => ({}),
+		apiKeyLogin: () => true,
 		displayName: (id) => id,
 		hasAuth: () => false,
 		jbcentralInstalled: false,
@@ -210,6 +211,22 @@ describe("in-app login capability flags", () => {
 			"google-vertex": false,
 			"azure-openai-responses": false,
 			openai: true,
+		});
+	});
+
+	test("canApiKey requires pi's api-key login support (openai-codex has model rows but no key auth)", () => {
+		const report = buildProviderReport(
+			sources({
+				modelProviders: new Map([["openai-codex", ["https://chatgpt.com/backend-api/codex"]]]),
+				oauthProviders: [{ id: "openai-codex", name: "OpenAI Codex" }],
+				apiKeyLogin: () => false, // pi's openai-codex provider is OAuth-only
+			}),
+		);
+		expect(report.providers[0]).toEqual({
+			id: "openai-codex",
+			name: "OpenAI Codex",
+			configured: false,
+			canOAuth: true,
 		});
 	});
 

--- a/packages/server/src/auth/providerStatus.ts
+++ b/packages/server/src/auth/providerStatus.ts
@@ -164,11 +164,12 @@ export function buildProviderReport(sources: ProviderStatusSources): ProviderSta
 }
 
 /**
- * The `provider.status` read. **Revalidates on every call** — `runtime.reloadConfig()` (reload
- * models.json, recompose providers, refresh availability; auth.json is read live by pi's credential
- * store) — so a `pi` `/login` (or a terminal `central` re-wire) shows up on the next read without
- * restarting the host. (Accepted micro-risk: refreshing the shared runtime concurrent with a streaming
- * session — the same thing pi's TUI does on `/login`.)
+ * The `provider.status` read. **Revalidates on every call** — `runtime.reloadConfig()` reloads
+ * models.json and recomposes providers (it does NOT touch auth.json itself), and its internal
+ * availability refresh re-runs the per-provider auth checks against pi's credential store, which reads
+ * auth.json fresh (under a lock) on every access — so a `pi` `/login` (or a terminal `central` re-wire)
+ * shows up on the next read without restarting the host. (Accepted micro-risk: refreshing the shared
+ * runtime concurrent with a streaming session — the same thing pi's TUI does on `/login`.)
  */
 export async function getProviderStatus(): Promise<ProviderStatusReport> {
 	const runtime = await getPiRuntime();

--- a/packages/server/src/auth/providerStatus.ts
+++ b/packages/server/src/auth/providerStatus.ts
@@ -12,10 +12,12 @@ import {
 import { getPiRuntime } from "../agent";
 
 /**
- * Providers whose api key isn't a single string (AWS creds, GCP service account, Azure resource + key) —
- * `provider.setApiKey` can't configure them, so the strip offers no inline key field. (`amazon-bedrock`
- * *is* in pi's api-key display map, so pi's own `isApiKeyLoginProvider` returns true for it, but the TUI
- * special-cases it with a multi-field dialog — we exclude it rather than mis-handle a single key.)
+ * Providers whose api-key setup isn't a single string (AWS creds, GCP service account, Azure resource +
+ * key) — `provider.setApiKey` posts one string, so the strip offers no inline key field for them. Since
+ * pi 0.80.8 the provider-owned truth is public (`Provider.auth.apiKey.login` drives an interactive,
+ * possibly multi-prompt flow — and `amazon-bedrock` now accepts a single API key that way); these sets
+ * stay until the strip adopts that flow (tracked as a follow-up issue) because the inline field can only
+ * answer a single secret prompt.
  */
 const MULTI_FIELD_PROVIDERS = new Set([
 	"amazon-bedrock",
@@ -23,7 +25,7 @@ const MULTI_FIELD_PROVIDERS = new Set([
 	"azure-openai-responses",
 ]);
 
-/** OAuth-only providers (not in pi's api-key display map) — a raw api key is never the right entry for them. */
+/** OAuth-only providers (`Provider.auth` has no api-key login) — a raw api key is never the right entry. */
 const OAUTH_ONLY_PROVIDERS = new Set(["github-copilot"]);
 
 /**
@@ -35,18 +37,21 @@ export interface ProviderStatusSources {
 	modelProviders: Map<string, string[]>;
 	/** Providers with ≥1 model whose auth resolves (the registry's `getAvailable()` truth). */
 	availableProviders: Set<string>;
-	/** Providers holding credentials in auth.json (`authStorage.list()`), even model-less ones. */
+	/** Providers holding credentials in auth.json (`listCredentials()`), even model-less ones. */
 	credentialProviders: string[];
 	/**
-	 * Registered OAuth providers (`authStorage.getOAuthProviders()`) — `id` is the login handle passed to
-	 * `provider.loginStart` (note: `openai-codex`/`github-copilot` ≠ their model-registry provider ids), and
-	 * `name` is a more specific label than the registry's for oauth-only rows.
+	 * OAuth-capable providers (`Provider.auth.oauth` present) — `id` is the login handle passed to
+	 * `provider.loginStart` (note: `openai-codex`/`github-copilot` ≠ their model-catalog provider ids), and
+	 * `name` is the OAuth method's own label, more specific than the provider's for oauth-only rows.
 	 */
 	oauthProviders: { id: string; name: string }[];
 	/** auth.json credential kind, when stored there. */
 	credentialType: (id: string) => "oauth" | "api_key" | undefined;
 	/** pi's provider auth status — `source`/`label` only; `configured` here is auth.json-centric. */
 	providerAuth: (id: string) => { source?: string; label?: string };
+	/** Whether pi's provider supports interactive api-key setup (`Provider.auth.apiKey.login` present) —
+	 * OAuth-only providers (e.g. `openai-codex`) report `false` even though they have model rows. */
+	apiKeyLogin: (id: string) => boolean;
 	displayName: (id: string) => string;
 	/** Any auth form at all (stored / runtime / env) — the fallback truth for model-less providers. */
 	hasAuth: (id: string) => boolean;
@@ -96,7 +101,7 @@ export function buildProviderReport(sources: ProviderStatusSources): ProviderSta
 	const oauthIds = new Set(sources.oauthProviders.map((p) => p.id));
 	const oauthName = new Map(sources.oauthProviders.map((p) => [p.id, p.name]));
 	// Only providers with a stored auth.json credential are removable in-app; env / central (models.json) /
-	// models.json-keyed auth can't be unset by `authStorage.logout`, so Sign-out is hidden for them.
+	// models.json-keyed auth can't be unset by the runtime's `logout`, so Sign-out is hidden for them.
 	const removable = new Set(sources.credentialProviders);
 	// Every loginable thing is a row: model providers + stored credentials + OAuth providers (so the
 	// oauth-only ids `openai-codex`/`github-copilot` show a Sign-in row even with no models registered).
@@ -116,8 +121,11 @@ export function buildProviderReport(sources: ProviderStatusSources): ProviderSta
 		const registryName = sources.displayName(id);
 		const name = registryName === id ? (oauthName.get(id) ?? registryName) : registryName;
 		const canOAuth = oauthIds.has(id);
+		// The inline key field: the provider must have models, pi must support api-key login for it, and it
+		// must not be excluded as multi-field / oauth-only (see the sets above — the field posts ONE string).
 		const canApiKey =
 			sources.modelProviders.has(id) &&
+			sources.apiKeyLogin(id) &&
 			!MULTI_FIELD_PROVIDERS.has(id) &&
 			!OAUTH_ONLY_PROVIDERS.has(id);
 		const login = {
@@ -156,32 +164,39 @@ export function buildProviderReport(sources: ProviderStatusSources): ProviderSta
 }
 
 /**
- * The `provider.status` read. **Revalidates on every call** — `authStorage.reload()` +
- * `modelRegistry.refresh()` (pi's own reload APIs) — so a `pi` `/login` (or a terminal `central` re-wire)
- * shows up on the next read without restarting the host. (Accepted micro-risk: refreshing the
- * shared registry concurrent with a streaming session — the same thing pi's TUI does on `/login`.)
+ * The `provider.status` read. **Revalidates on every call** — `runtime.reloadConfig()` (reload
+ * models.json, recompose providers, refresh availability; auth.json is read live by pi's credential
+ * store) — so a `pi` `/login` (or a terminal `central` re-wire) shows up on the next read without
+ * restarting the host. (Accepted micro-risk: refreshing the shared runtime concurrent with a streaming
+ * session — the same thing pi's TUI does on `/login`.)
  */
-export function getProviderStatus(): ProviderStatusReport {
-	const { authStorage, modelRegistry } = getPiRuntime();
-	authStorage.reload();
-	modelRegistry.refresh();
+export async function getProviderStatus(): Promise<ProviderStatusReport> {
+	const runtime = await getPiRuntime();
+	await runtime.reloadConfig();
 
 	const modelProviders = new Map<string, string[]>();
-	for (const model of modelRegistry.getAll()) {
+	for (const model of runtime.getModels()) {
 		const urls = modelProviders.get(model.provider) ?? [];
 		urls.push(model.baseUrl);
 		modelProviders.set(model.provider, urls);
 	}
+	const available = await runtime.getAvailable();
+	const credentials = await runtime.listCredentials();
+	const credentialTypes = new Map(credentials.map((c) => [c.providerId, c.type]));
 
 	return buildProviderReport({
 		modelProviders,
-		availableProviders: new Set(modelRegistry.getAvailable().map((m) => m.provider)),
-		credentialProviders: authStorage.list(),
-		oauthProviders: authStorage.getOAuthProviders().map((p) => ({ id: p.id, name: p.name })),
-		credentialType: (id) => authStorage.get(id)?.type,
-		providerAuth: (id) => modelRegistry.getProviderAuthStatus(id),
-		displayName: (id) => modelRegistry.getProviderDisplayName(id),
-		hasAuth: (id) => authStorage.hasAuth(id),
+		availableProviders: new Set(available.map((m) => m.provider)),
+		credentialProviders: credentials.map((c) => c.providerId),
+		oauthProviders: runtime
+			.getProviders()
+			.filter((p) => p.auth.oauth)
+			.map((p) => ({ id: p.id, name: p.auth.oauth?.name ?? p.name })),
+		credentialType: (id) => credentialTypes.get(id),
+		providerAuth: (id) => runtime.getProviderAuthStatus(id),
+		apiKeyLogin: (id) => Boolean(runtime.getProvider(id)?.auth.apiKey?.login),
+		displayName: (id) => runtime.getProvider(id)?.name ?? id,
+		hasAuth: (id) => runtime.getProviderAuthStatus(id).configured,
 		jbcentralInstalled: isJbcentralInstalled(),
 		jbcentralInstall: jbcentralInstall(process.platform),
 	});

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -1,25 +1,15 @@
 // Dev/e2e entry: boot the host from env. The polished `thinkrail` bin lives in apps/cli.
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
 import { bootHost } from "./host";
 
 // e2e-only: register a deterministic fake pi OAuth provider so the in-app login flow (select → open URL /
 // paste code → success) is drivable end-to-end without a real provider or browser. Gated by
 // THINKRAIL_E2E_FAKE_OAUTH; this file is the dev/e2e entry and never ships (apps/cli is the prod bin).
 if (process.env.THINKRAIL_E2E_FAKE_OAUTH === "1") {
-	const { registerOAuthProvider } = await import("@earendil-works/pi-ai/oauth");
-	const { ModelRegistry } = await import("@earendil-works/pi-coding-agent");
-	const fakeProvider = {
-		id: "e2e-oauth",
+	const { getPiRuntime } = await import("./agent");
+	const fakeOauth = {
 		name: "E2E Test Provider",
-		usesCallbackServer: false,
-		async login(callbacks: {
-			onSelect: (p: {
-				message: string;
-				options: { id: string; label: string }[];
-			}) => Promise<string | undefined>;
-			onAuth: (i: { url: string }) => void;
-			onManualCodeInput?: () => Promise<string>;
-			onProgress?: (m: string) => void;
-		}) {
+		async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
 			const choice = await callbacks.onSelect({
 				message: "How do you want to sign in?",
 				options: [
@@ -38,24 +28,16 @@ if (process.env.THINKRAIL_E2E_FAKE_OAUTH === "1") {
 				expires: 4102444800000,
 			};
 		},
-		async refreshToken(credentials: unknown) {
+		async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
 			return credentials;
 		},
-		getApiKey(credentials: { access?: unknown }) {
+		getApiKey(credentials: OAuthCredentials): string {
 			return String(credentials.access);
 		},
 	};
-	// ModelRegistry.refresh() calls resetOAuthProviders() (wiping external registrations), and the host reads
-	// provider.status (→ refresh) on every check — so re-register the fake after each refresh. Patching the
-	// prototype here keeps production code untouched; safe because dev.ts is e2e/dev-only.
-	type Refreshable = { refresh: () => void };
-	const proto = ModelRegistry.prototype as unknown as Refreshable;
-	const originalRefresh = proto.refresh;
-	proto.refresh = function reRegisterFakeOAuth(this: Refreshable) {
-		originalRefresh.call(this);
-		registerOAuthProvider(fakeProvider as never);
-	};
-	registerOAuthProvider(fakeProvider as never);
+	// An extension provider on the shared runtime: pi keeps extension registrations across
+	// refresh()/reloadConfig() (they're a composed overlay), so no re-register hook is needed.
+	(await getPiRuntime()).registerProvider("e2e-oauth", { oauth: fakeOauth });
 }
 
 const host = process.env.THINKRAIL_HOST ?? "localhost";

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -288,16 +288,16 @@ const handlers: Record<string, Handler> = {
 		cancelLogin((params as { loginId: string }).loginId);
 		return { ok: true } as const;
 	},
-	"provider.setApiKey": (params) => {
+	"provider.setApiKey": async (params) => {
 		const p = params as { providerId: string; key: string };
-		setProviderApiKey(p.providerId, p.key);
+		await setProviderApiKey(p.providerId, p.key);
 		return { ok: true } as const;
 	},
-	"provider.logout": (params) => {
-		logoutProvider((params as { providerId: string }).providerId);
+	"provider.logout": async (params) => {
+		await logoutProvider((params as { providerId: string }).providerId);
 		return { ok: true } as const;
 	},
-	// JetBrains AI (jbcentral proxy): connect/disconnect write models.json + refresh the registry; login
+	// JetBrains AI (jbcentral proxy): connect/disconnect write models.json + reload the runtime config; login
 	// launches `central login` (browser) on the host.
 	"provider.jbcentralConnect": () => connectJbcentral(),
 	"provider.jbcentralDisconnect": async () => {

--- a/packages/spec-graph/tools/create.ts
+++ b/packages/spec-graph/tools/create.ts
@@ -2,7 +2,7 @@
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { StringEnum } from "@earendil-works/pi-ai/compat";
+import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {

--- a/packages/spec-graph/tools/graph.ts
+++ b/packages/spec-graph/tools/graph.ts
@@ -1,6 +1,6 @@
 // spec_graph — a bounded slice of the graph: subtree, ancestors, or neighbors across a chosen edge.
 
-import { StringEnum } from "@earendil-works/pi-ai/compat";
+import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { type GraphSlice, graphSlice, LINK_KINDS, SLICE_DIRECTIONS } from "../core/index.ts";


### PR DESCRIPTION
## What

Bumps `@earendil-works/pi-{coding-agent,ai,agent-core}` **0.80.6 → 0.80.10** and migrates `packages/server` fully onto the new `ModelRuntime` facade. pi 0.80.8 replaced the SDK's auth/model surface (`CreateAgentSessionOptions.authStorage`/`modelRegistry` → async `modelRuntime`; `AuthStorage` no longer exported; `getApiKeyAndHeaders` → `getAuth`; refresh went async), so this is a real migration, not a version bump.

## How

| Area | Migration |
|---|---|
| `agent/piRuntime` | One shared `ModelRuntime` — lazily-memoized async create (preserves the `PI_CODING_AGENT_DIR`-at-first-use property the e2e harnesses rely on); a failed create clears the memo so the next call retries |
| `agent/agentSessionManager` | `createAgentSession({modelRuntime})`; model reads via async `getAvailable()` |
| `agent/oneshot` | `runtime.completeSimple()` — deletes the spec-flagged `pi-ai/compat` `complete()` surface and manual auth resolution (auth incl. OAuth refresh now resolves inside pi's request path) |
| `auth/providerStatus` | `reloadConfig()` revalidation — pi's file credential store reads auth.json live under a lock, so the old `reload()` dance dies; OAuth rows derive from the now-public `Provider.auth.oauth` |
| `auth/providerLogin` | Old `OAuthLoginCallbacks` → `AuthInteraction` (`notify`/`prompt`, incl. pi cancelling the loser of its browser-vs-paste race via `prompt.signal`, identity-guarded parking). **API keys persist via `login(id, \"api_key\")`** — `setRuntimeApiKey` turned out to be a non-persistent overlay that would have silently dropped keys on restart |
| `dev.ts` | Fake e2e OAuth provider via `runtime.registerProvider` — extension registrations survive refresh now, so the `ModelRegistry.prototype.refresh` monkey-patch is deleted |
| Misc | `StringEnum` moved to the pi-ai root (×3); `provider.setApiKey`/`provider.logout` handlers async; SPECs (agent + auth) updated with the code |

## Regression found & fixed during e2e

0.80.10's catalog gives `openai-codex` model rows, so the old model-rows-based `canApiKey` wrongly offered a key field to an OAuth-only provider. `ProviderStatusSources` gained an `apiKeyLogin(id)` source (pi's public `Provider.auth.apiKey.login` truth), AND-ed with the kept conservative exclusion sets — exactly the drift the auth SPEC's note warned to re-check on pi bumps. The sets' removal is tracked in #97.

## Follow-ups (filed, not in this PR)

- #97 — drive API-key setup through the interactive login channel (deletes the exclusion sets; covers Bedrock's new single-key path)
- #98 — background model-catalog refresh on `model.list` (pi 0.80.8 live catalogs)

Free wins active with the bump: prompt-cache no longer invalidates daily (pi removed the date from its system prompt), Grok 4.5 + xAI device-code OAuth (works through the existing login dialog), Kimi K3, Fable 5 `xhigh`/`max` thinking levels.

## Verification

- `bun run check:deps` ✓ · `bun run lint` ✓ · `bun run typecheck` ✓
- `bun run test` — **168/168** (providerLogin rewritten for `AuthInteraction`; oneshot + session-manager tests now drive a **real** `ModelRuntime` with in-memory credentials + faux providers through pi's actual auth/dispatch path; new `canApiKey` pin for the openai-codex case)
- `bun run e2e:full` — **80/81 + 1 retry-pass** (the one failure was an `@agent` LLM flake: the model ignored \"mark exactly one option as recommended\"; the spec passed standalone in 7.6s). Includes the in-app fake-OAuth login flow against the reworked `dev.ts`.
- Suppression audit clean (no new `biome-ignore`/`as any`/`@ts-*`); `spec_validate` ✓

No wire/protocol changes; no UI-visible changes.