### PR TITLE
chore(deps): upgrade pi 0.80.10 → 0.81.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -187,9 +187,9 @@
     "@biomejs/biome",
   ],
   "catalog": {
-    "@earendil-works/pi-agent-core": "0.80.10",
-    "@earendil-works/pi-ai": "0.80.10",
-    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-agent-core": "0.81.1",
+    "@earendil-works/pi-ai": "0.81.1",
+    "@earendil-works/pi-coding-agent": "0.81.1",
     "@types/bun": "1.3.14",
     "typebox": "1.1.38",
     "typescript": "6.0.3",
@@ -273,13 +273,13 @@
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.81.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.81.1", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.81.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.10", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.10", "@earendil-works/pi-ai": "^0.80.10", "@earendil-works/pi-tui": "^0.80.10", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.81.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.81.1", "@earendil-works/pi-ai": "^0.81.1", "@earendil-works/pi-tui": "^0.81.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.81.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-OMEe+Zt8oQYi/rCq3upxsTlIScWL0FPhXwQus34TbQb3EmTx88S7Uzx32JxvQiEeWOw8eDCdJf2PBUBE9r6wIg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 			"packages/*"
 		],
 		"catalog": {
-			"@earendil-works/pi-agent-core": "0.80.10",
-			"@earendil-works/pi-ai": "0.80.10",
-			"@earendil-works/pi-coding-agent": "0.80.10",
+			"@earendil-works/pi-agent-core": "0.81.1",
+			"@earendil-works/pi-ai": "0.81.1",
+			"@earendil-works/pi-coding-agent": "0.81.1",
 			"@types/bun": "1.3.14",
 			"typebox": "1.1.38",
 			"typescript": "6.0.3"

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -146,7 +146,7 @@ of the host.
 
 ## Get right
 
-- **Type-only, from the package roots, always** (verified vs 0.80.6: type-only imports are erased by
+- **Type-only, from the package roots, always** (verified vs 0.81.1: type-only imports are erased by
   `verbatimModuleSyntax`, so the web bundle stays provider-free; the pi-ai provider/API subpaths
   statically import the Node SDKs — never touch them). The `/base` entries existed only in 0.79.8–0.79.9.
 - `Model` is generic — expose as `Model<any>`.

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -40,7 +40,7 @@ export type WireModel = Pick<
 
 // The unified render union the UI switches on. The real superset (`AgentSessionEvent`) is declared in the
 // Node-only `pi-coding-agent` (it pulls node:fs), so it's MIRRORED here type-only, derived from the
-// imported `AgentEvent`. Keep in sync with @earendil-works/pi-coding-agent@0.80.3
+// imported `AgentEvent`. Keep in sync with @earendil-works/pi-coding-agent@0.81.1
 // (core/agent-session.d.ts) — the session-event members below are what `session.subscribe` emits.
 export type PiEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
@@ -74,7 +74,7 @@ export interface SessionEventPayload {
 }
 
 // The shapes below are declared in the Node-only `pi-coding-agent` (it pulls node:fs), so they're
-// MIRRORED here type-only for the wire. Keep in sync with @earendil-works/pi-coding-agent@0.80.3.
+// MIRRORED here type-only for the wire. Keep in sync with @earendil-works/pi-coding-agent@0.81.1.
 
 /** Context-window usage for the active model. `tokens`/`percent` are null when unknown (post-compaction). */
 export interface ContextUsage {
@@ -247,7 +247,7 @@ export interface AskUserAnswersDetails {
 
 /**
  * MIRROR of pi-coding-agent's `CustomMessage` (that package is Node-only, so the shape is re-declared
- * type-only for the wire — keep in sync with @earendil-works/pi-coding-agent@0.80.3 core/messages.d.ts):
+ * type-only for the wire — keep in sync with @earendil-works/pi-coding-agent@0.81.1 core/messages.d.ts):
  * an extension-injected transcript message (`sendCustomMessage`). Crosses the wire in
  * `session.getMessages` and inside `message_start`/`message_end` events; the LLM sees it as a user
  * message. The web renders only the `customType`s it knows (e.g. `ask-user-answers`) and ignores the rest.

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -383,7 +383,7 @@ export function getSessionStats(sessionId: string): SessionStats {
 }
 
 // Slash commands / skills available in the session — built from the same three sources pi's own rpc mode
-// uses. In sync with @earendil-works/pi-coding-agent@0.80.3 (modes/rpc get_commands).
+// uses. In sync with @earendil-works/pi-coding-agent@0.81.1 (modes/rpc get_commands).
 export function getSessionCommands(sessionId: string): SlashCommandInfo[] {
 	const session = mustGet(sessionId);
 	const extension = session.extensionRunner.getRegisteredCommands().map((c) => ({


### PR DESCRIPTION
## What

Bumps the pi catalog pins (`pi-agent-core` / `pi-ai` / `pi-coding-agent`) from **0.80.10** to **0.81.1**, plus the mirror-stamp hygiene that goes with a pi bump.

## Why it's safe

Verified by diffing the published `.d.ts` surfaces between the two versions — all changes on surfaces we consume are **additive**:
- `Agent` constructor change (`streamFn` now required) does not affect us — we only use `createAgentSession`.
- `AgentSessionEvent` gained `summarization_retry_*` members — our `PiEvent` is a spec-documented render *subset*; the web store's `default:` case ignores unknown types.
- Wire mirrors byte-identical: `SessionStats`, `ContextUsage`, `CustomMessage`, `SourceInfo`, rpc `get_commands` → sync stamps re-verified and bumped to `@0.81.1`.
- `pi-ai/compat` subpath (used by extension packages) intact.
- Built web bundle re-verified **pi-runtime-free** (erasure stamp → 0.81.1).

## What we inherit

- Tool / compaction / branch-summary usage now included in session totals (`pi` owns the numbers — our footer just gets more accurate).
- Compaction + branch-summary retry resilience (+ `summarization_retry_*` lifecycle events — candidate for a small UI follow-up).
- Messages queued during compaction keep steering/follow-up delivery semantics.
- Faster open of large persisted sessions; persisted remote catalogs no longer shadow newer bundled catalogs (relevant to #98).
- Qwen Token Plan providers in the catalog.

## Verification

- `bun run check:deps` ✓ · `bun run lint` ✓ · `bun run typecheck` 9/9 ✓
- `bun run test` green (8/8 tasks, 2 consecutive runs)
- `bun run e2e` (no-agent suite) **46/46** ✓