### PR TITLE
fix(server): keep reloadConfig off the network under pi 0.81 runtime semantics

### DIFF
--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -22,10 +22,14 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   - `piRuntime` (one shared `ModelRuntime` — pi's canonical model/auth facade since 0.80.8: catalogs,
     credentials, availability, login/logout, and request dispatch; `getPiRuntime()` is a lazily-memoized
     **promise** (`ModelRuntime.create()` is async; a failed create clears the memo so the next call
-    retries), `configurePiRuntime()` for tests). Created with **`allowModelNetwork: false`**: catalog
-    reads stay local (builtins + models.json + the persisted models-store), because `reloadConfig()`/
-    `refresh()` await remote pi.dev catalog checks with no timeout — on the `provider.status` and
-    jbcentral-connect paths that stalls wherever egress is slow or blocked. Live catalog refresh is a
+    retries), `configurePiRuntime()` for tests). Created with **ambient network OFF** —
+    `allowModelNetwork: false` **plus a scoped `PI_OFFLINE` around construction** (pi 0.81 derives the
+    runtime's ambient-network default from that env at construction; the option now gates only the
+    create-time refresh — in 0.80.x it fed both; the scoped value is restored immediately, a user-set
+    one untouched — pinned by `piRuntime.test.ts`): catalog reads stay local (builtins + models.json +
+    the persisted models-store), because `reloadConfig()`/`refresh()` await remote pi.dev catalog
+    checks with no timeout — on the `provider.status` and jbcentral-connect paths that stalls wherever
+    egress is slow or blocked. Live catalog refresh is a
     deliberate, detached opt-in (`refresh({ allowNetwork: true })`) tracked as a follow-up (issue #98). The **provider-credential surface** over this runtime —
     `provider.status` + in-app login — lives in the sibling `auth` module (which consumes `getPiRuntime`),
     **not** here.

--- a/packages/server/src/agent/piRuntime.test.ts
+++ b/packages/server/src/agent/piRuntime.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
+import { configurePiRuntime, getPiRuntime } from "./piRuntime";
+
+let priorOffline: string | undefined;
+beforeEach(() => {
+	priorOffline = process.env.PI_OFFLINE;
+	delete process.env.PI_OFFLINE; // production shape — nothing external forces offline
+});
+afterEach(() => {
+	if (priorOffline === undefined) delete process.env.PI_OFFLINE;
+	else process.env.PI_OFFLINE = priorOffline;
+});
+
+// ---- getPiRuntime: ambient network stays OFF (pi 0.81 ties `modelNetworkEnabled` to PI_OFFLINE at
+// construction — the scoped-env creation in `createRuntimeOfflineByDefault` restores 0.80.x semantics) ----
+
+/** A real runtime created from an isolated, empty agent dir (no auth, no models.json, no network). */
+async function isolatedRuntime() {
+	const agentDir = mkdtempSync(join(tmpdir(), "trpi-runtime-"));
+	const priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	configurePiRuntime(null); // drop any memo a sibling test file left behind
+	try {
+		return { runtime: await getPiRuntime(), agentDir };
+	} finally {
+		if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+	}
+}
+
+function cleanup(agentDir: string): void {
+	configurePiRuntime(null);
+	rmSync(agentDir, { recursive: true, force: true });
+}
+
+test("reloadConfig() on the shared runtime never opts into the network (provider.status must not stall on pi.dev)", async () => {
+	const { runtime, agentDir } = await isolatedRuntime();
+	try {
+		// The scoped PI_OFFLINE used during construction must not leak into the process env…
+		expect(process.env.PI_OFFLINE).toBeUndefined();
+
+		// …and the constructed runtime resolves reloadConfig's refresh to allowNetwork:false.
+		const seen: (ModelsRefreshOptions | undefined)[] = [];
+		const originalRefresh = runtime.refresh.bind(runtime);
+		runtime.refresh = (options?: ModelsRefreshOptions): Promise<ModelsRefreshResult> => {
+			seen.push(options);
+			return Promise.resolve({ aborted: false, errors: new Map() });
+		};
+		try {
+			await runtime.reloadConfig();
+			expect(seen.length).toBe(1);
+			expect(seen[0]?.allowNetwork).toBe(false);
+		} finally {
+			runtime.refresh = originalRefresh;
+		}
+	} finally {
+		cleanup(agentDir);
+	}
+});
+
+test("a user-set PI_OFFLINE survives runtime creation untouched", async () => {
+	process.env.PI_OFFLINE = "yes";
+	const { agentDir } = await isolatedRuntime();
+	try {
+		expect(process.env.PI_OFFLINE).toBe("yes");
+	} finally {
+		cleanup(agentDir);
+	}
+});

--- a/packages/server/src/agent/piRuntime.ts
+++ b/packages/server/src/agent/piRuntime.ts
@@ -14,18 +14,39 @@ export function configurePiRuntime(rt: ModelRuntime | null): void {
 }
 
 /**
- * The shared runtime, built lazily from on-disk auth + catalogs (`~/.pi/agent`).
+ * Create the shared runtime from on-disk auth + catalogs (`~/.pi/agent`), with ambient network OFF.
  *
- * `allowModelNetwork: false`: model-catalog reads stay **local** (builtin catalogs + models.json +
- * the persisted models-store), matching the pre-0.80.8 behavior. Without it, every
- * `reloadConfig()`/`refresh()` — i.e. every `provider.status` read and jbcentral connect — would await
- * remote pi.dev catalog checks with **no timeout** (only `ModelRuntime.create` guards its initial
- * refresh), stalling those paths wherever that egress is slow or blocked (CI, offline). A deliberate,
- * detached catalog refresh (explicit `refresh({ allowNetwork: true })`) is tracked in issue #98.
+ * Model-catalog reads stay **local** (builtin catalogs + models.json + the persisted models-store),
+ * matching the pre-0.80.8 behavior. Without that, every `reloadConfig()`/`refresh()` — i.e. every
+ * `provider.status` read and jbcentral connect — would await remote pi.dev catalog checks with **no
+ * timeout** (the catalog fetch takes only the caller's signal, and `reloadConfig` passes none),
+ * stalling those paths wherever that egress is slow or blocked (CI, offline). A deliberate, detached
+ * catalog refresh (explicit `refresh({ allowNetwork: true })`) is tracked in issue #98.
+ *
+ * HOW it stays local changed under us in pi 0.81: `allowModelNetwork: false` now gates only the
+ * create-time refresh, while the runtime's ambient-network default (`modelNetworkEnabled`, what
+ * `reloadConfig()` resolves) is derived from **`PI_OFFLINE` at construction** — in 0.80.x the option
+ * fed both. So the runtime is constructed under a scoped `PI_OFFLINE` (restored right after — a
+ * user-set value is left untouched), which restores the 0.80.x semantics: ambient reads local,
+ * network strictly a per-call `allowNetwork: true` opt-in. One-time, at the single creation choke
+ * point; pi's other PI_OFFLINE consumers (tool downloads, version checks) never see the override
+ * because it's gone before any session exists.
  */
+async function createRuntimeOfflineByDefault(): Promise<ModelRuntime> {
+	const prior = process.env.PI_OFFLINE;
+	process.env.PI_OFFLINE = "1";
+	try {
+		return await ModelRuntime.create({ allowModelNetwork: false });
+	} finally {
+		if (prior === undefined) delete process.env.PI_OFFLINE;
+		else process.env.PI_OFFLINE = prior;
+	}
+}
+
+/** The shared runtime, built lazily on first use (see `createRuntimeOfflineByDefault` for semantics). */
 export function getPiRuntime(): Promise<ModelRuntime> {
 	if (!runtime) {
-		const created = ModelRuntime.create({ allowModelNetwork: false });
+		const created = createRuntimeOfflineByDefault();
 		runtime = created;
 		// A failed create must not brick the host until restart — drop the memo so the next call retries.
 		created.catch(() => {


### PR DESCRIPTION
## What

Follow-up to #101 (found while implementing #98, after #101 merged): **pi 0.81 changed what `allowModelNetwork: false` means**, and the upgrade silently put pi.dev egress back on hot host paths.

- **0.80.x:** `ModelRuntimeOptions.allowModelNetwork` fed the runtime's instance flag — `reloadConfig()` refreshed with `allowNetwork: false`. Local, as our agent SPEC records.
- **0.81.x:** the option gates only the *create-time* refresh; the instance flag (`modelNetworkEnabled`, what `reloadConfig()` resolves) is now derived from **`PI_OFFLINE` at construction**. On a production host (no `PI_OFFLINE`) every `provider.status` read and jbcentral connect awaits a pi.dev catalog fetch whenever the freshness window has lapsed — **with no timeout** (the fetch takes only the caller's signal; `reloadConfig` passes none). That's the exact stall `packages/server/src/agent/SPEC.md` documents as the reason catalog reads stay local.

## Fix

Construct the shared runtime under a **scoped `PI_OFFLINE`** (restored immediately after; a user-set value is left untouched) — one line of env discipline at the single creation choke point (`getPiRuntime`'s memoized create). This restores the 0.80.x semantics: ambient reads local; network is strictly a per-call `refresh({ allowNetwork: true })` opt-in (which is what #98 builds on). pi's other `PI_OFFLINE` consumers (tool downloads, version checks) never see the override — it's gone before any session exists.

## Tests

`packages/server/src/agent/piRuntime.test.ts` pins:
- `reloadConfig()` on the shared runtime resolves its refresh to `allowNetwork: false` (spied `refresh`, isolated agent dir);
- the scoped env never leaks (unset stays unset; a user-set `PI_OFFLINE` survives untouched).

Gates: lint ✓ · typecheck 9/9 ✓ · server unit suite 178/178 ✓