### PR TITLE
feat: built-in Default workspace + an explicit choice between the two working modes

### DIFF
--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -21,6 +21,7 @@ import {
 	type DocTab,
 	type EditorTab,
 	selectActiveWorkspace,
+	selectContextProject,
 	selectWorkspaceTick,
 	toast,
 	useAppStore,
@@ -95,6 +96,7 @@ function ChatHistoryMenu({
 export function CenterTabs() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 	const activeWorkspace = useAppStore(selectActiveWorkspace);
+	const contextProject = useAppStore(selectContextProject);
 	const tabsByWorkspace = useAppStore((s) => s.tabsByWorkspace);
 	const activeTabByWorkspace = useAppStore((s) => s.activeTabByWorkspace);
 	const closedChatsByWorkspace = useAppStore((s) => s.closedChatsByWorkspace);
@@ -238,6 +240,9 @@ export function CenterTabs() {
 		else closeTab(tab.id);
 	};
 
+	// The Default workspace is the project folder itself — its receipt must tell the truth ("runs
+	// directly in your project folder") instead of promising worktree isolation.
+	const isDefaultWorkspace = activeWorkspace?.kind === "default";
 	const placeholder = (
 		<div className="flex h-full flex-col items-center justify-center gap-md px-lg text-center text-hint">
 			{activeWorkspace ? (
@@ -246,18 +251,28 @@ export function CenterTabs() {
 					className="flex max-w-[440px] flex-col items-center gap-xs"
 				>
 					<span className="font-medium text-hint text-xs uppercase tracking-wider">
-						Workspace ready
+						{isDefaultWorkspace ? "Default workspace" : "Workspace ready"}
 					</span>
 					<h2 className="max-w-full truncate font-medium text-md text-text">
-						{activeWorkspace.name}
+						{isDefaultWorkspace
+							? (contextProject?.name ?? activeWorkspace.name)
+							: activeWorkspace.name}
 					</h2>
 					<p className="flex max-w-full items-center gap-xs font-[var(--font-mono)] text-muted text-xs">
 						<GitBranch className="size-3.5 shrink-0" />
-						<span className="truncate">{activeWorkspace.branch}</span>
-						<span className="shrink-0 text-hint">· from {activeWorkspace.baseBranch}</span>
+						{isDefaultWorkspace ? (
+							<span className="truncate">on {activeWorkspace.branch}</span>
+						) : (
+							<>
+								<span className="truncate">{activeWorkspace.branch}</span>
+								<span className="shrink-0 text-hint">· from {activeWorkspace.baseBranch}</span>
+							</>
+						)}
 					</p>
 					<p className="mt-xs text-muted text-sm">
-						Files, chats, changes, and terminals are scoped to this workspace.
+						{isDefaultWorkspace
+							? "Chats, changes, and terminals run directly in your project folder."
+							: "Files, chats, changes, and terminals are scoped to this workspace."}
 					</p>
 				</div>
 			) : (

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -10,6 +10,8 @@ import {
 	Check,
 	ChevronDown,
 	GitBranch,
+	House,
+	type LucideIcon,
 	RefreshCw,
 	Sparkles,
 	TriangleAlert,
@@ -43,17 +45,25 @@ import {
 } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import { selectWorkspaceTick, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
+import { resolveDefaultWorkspace } from "./defaultWorkspace";
+
+/** Where the work runs: cut an isolated worktree, or enter the project folder (Default workspace). */
+export type WorkspaceTarget = "worktree" | "default";
 
 /** A shared pill-trigger look for the project + branch pickers (mockup `.pill`). */
 const PILL =
 	"flex h-8 min-w-0 items-center gap-sm rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-sm text-sm text-text outline-none transition-colors hover:bg-hover focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-[var(--primary-60)] data-[open=true]:bg-hover";
 
 /**
- * The New-Workspace "create + kick-off" surface: pick a base branch, say what to work on, pick a
- * model + effort, then Create → cut a worktree from that base, open a chat in it, and send the prompt.
- * With an empty prompt it just creates the workspace (no chat) — the fast path for poking at files.
+ * The start-working surface: a **target control** chooses where the work runs — an isolated worktree
+ * ("Create workspace": pick a base branch, cut a worktree from it) or the project folder itself ("Work
+ * in project folder": nothing is created, submit enters the built-in Default workspace). Either way:
+ * say what to work on, pick a model + effort, submit → enter the target and (with a prompt) open a chat
+ * there and send it. With an empty prompt it just creates/enters the target — the fast path for poking
+ * at files. The header is mode-aware so it always names the operation truthfully.
  *
  * The only app-integration piece here: it wires the store + transport. `onCreated(ws)` lets the parent
  * (ProjectTree) expand + reload its list; the dialog itself sets the active workspace + kicks off the chat.
@@ -62,6 +72,7 @@ export function NewWorkspaceDialog({
 	open,
 	projectId,
 	initialPrompt,
+	initialTarget,
 	promptNote,
 	onOpenChange,
 	onCreated,
@@ -71,6 +82,8 @@ export function NewWorkspaceDialog({
 	projectId: string;
 	/** Optional seed for the prompt hero (still fully editable) — e.g. Welcome's "Set up project". */
 	initialPrompt?: string;
+	/** The preselected target (the control stays visible either way). Defaults to "worktree". */
+	initialTarget?: WorkspaceTarget;
 	/** Optional info strip above the prompt — e.g. what a seeded skill command does (copy owned by the opener). */
 	promptNote?: string;
 	onOpenChange: (open: boolean) => void;
@@ -80,6 +93,7 @@ export function NewWorkspaceDialog({
 	const models = useAppStore((s) => s.models);
 
 	const [selectedProjectId, setSelectedProjectId] = useState(projectId);
+	const [target, setTarget] = useState<WorkspaceTarget>(initialTarget ?? "worktree");
 	const [branches, setBranches] = useState<BranchList | null>(null);
 	const [baseRef, setBaseRef] = useState<string>("");
 	const [refreshing, setRefreshing] = useState(false);
@@ -115,14 +129,15 @@ export function NewWorkspaceDialog({
 		},
 	});
 
-	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on and any
-	// seed prompt (empty by default).
+	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on, any
+	// seed prompt (empty by default), and the opener's preselected target.
 	useEffect(() => {
 		if (!open) return;
 		setSelectedProjectId(projectId);
 		setPrompt(initialPrompt ?? "");
+		setTarget(initialTarget ?? "worktree");
 		setCreating(false);
-	}, [open, projectId, initialPrompt]);
+	}, [open, projectId, initialPrompt, initialTarget]);
 
 	// Skills are previewed from the selected project's current checkout; the created worktree/session is
 	// authoritative if its base ref differs. Autocomplete is an enhancement, so failure degrades to empty.
@@ -245,20 +260,31 @@ export function NewWorkspaceDialog({
 		if (creating) return;
 		setCreating(true);
 		let workspace: Workspace;
-		try {
-			workspace = await getTransport().request("workspace.create", {
-				projectId: selectedProjectId,
-				...(baseRef ? { baseRef } : {}),
-			});
-		} catch (err) {
-			// Worktree creation failed (bad ref, etc.) — keep the dialog open so the user can retry/adjust,
-			// and surface the reason (it's otherwise invisible — the dialog just refuses to close).
-			toast.error(errorText(err), "Couldn't create workspace");
-			setCreating(false);
-			return;
+		if (target === "default") {
+			// Folder mode: nothing is created — resolve + enter the project's built-in Default workspace
+			// (the shared helper folds the fresh list into the store and toasts on failure).
+			const def = await resolveDefaultWorkspace(selectedProjectId);
+			if (!def) {
+				setCreating(false);
+				return;
+			}
+			workspace = def;
+		} else {
+			try {
+				workspace = await getTransport().request("workspace.create", {
+					projectId: selectedProjectId,
+					...(baseRef ? { baseRef } : {}),
+				});
+			} catch (err) {
+				// Worktree creation failed (bad ref, etc.) — keep the dialog open so the user can retry/adjust,
+				// and surface the reason (it's otherwise invisible — the dialog just refuses to close).
+				toast.error(errorText(err), "Couldn't create workspace");
+				setCreating(false);
+				return;
+			}
 		}
 
-		// The worktree exists — the "new workspace" intent is fulfilled, so close the dialog *now* and run the
+		// The target exists — the intent is fulfilled, so close the dialog *now* and run the
 		// (slower, optional) chat kick-off in the background. This keeps the dialog from lingering while pi
 		// spins up a session, and a kick-off failure can't strand the dialog open.
 		const store = useAppStore.getState();
@@ -323,6 +349,7 @@ export function NewWorkspaceDialog({
 	};
 
 	const selectedProject = projects.find((p) => p.id === selectedProjectId);
+	const isolated = target === "worktree";
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -345,14 +372,36 @@ export function NewWorkspaceDialog({
 				}}
 			>
 				<DialogHeader>
-					<DialogTitle>Create workspace</DialogTitle>
+					<DialogTitle>{isolated ? "Create workspace" : "Work in project folder"}</DialogTitle>
 					<DialogDescription>
-						A separate checkout on its own new branch. Files, chats, changes, and terminals stay
-						scoped to it.
+						{isolated
+							? "A separate checkout on its own new branch. Files, chats, changes, and terminals stay scoped to it."
+							: "Runs directly in your project folder — no isolation. Changes land on the current branch."}
 					</DialogDescription>
 				</DialogHeader>
 
-				{/* controls-top: project + base-branch pickers */}
+				{/* where: the target control — both modes always visible, the two-mode model in one glance */}
+				<div
+					data-testid="ws-target"
+					className="flex w-fit items-center gap-0.5 rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] p-0.5"
+				>
+					<TargetButton
+						icon={GitBranch}
+						label="Isolated workspace"
+						active={isolated}
+						testid="ws-target-worktree"
+						onClick={() => setTarget("worktree")}
+					/>
+					<TargetButton
+						icon={House}
+						label="Project folder"
+						active={!isolated}
+						testid="ws-target-default"
+						onClick={() => setTarget("default")}
+					/>
+				</div>
+
+				{/* controls-top: project + (worktree mode) base-branch pickers */}
 				<div className="flex flex-wrap items-center gap-sm">
 					<ProjectPicker
 						projects={projects}
@@ -360,14 +409,16 @@ export function NewWorkspaceDialog({
 						container={dialogEl}
 						onSelect={setSelectedProjectId}
 					/>
-					<BranchPicker
-						branches={branches}
-						baseRef={baseRef}
-						refreshing={refreshing}
-						container={dialogEl}
-						onSelect={selectBaseRef}
-						onRefresh={() => void refreshBranches()}
-					/>
+					{isolated ? (
+						<BranchPicker
+							branches={branches}
+							baseRef={baseRef}
+							refreshing={refreshing}
+							container={dialogEl}
+							onSelect={selectBaseRef}
+							onRefresh={() => void refreshBranches()}
+						/>
+					) : null}
 					<SkillsButton
 						onOpen={() => setManageSkills(true)}
 						testId="ws-manage-skills"
@@ -435,7 +486,7 @@ export function NewWorkspaceDialog({
 							onSelect={slashCompletion.pick}
 							className="absolute top-full left-sm z-50 mt-xs"
 						/>
-					) : prompt.trim() ? (
+					) : prompt.trim() && isolated ? (
 						<p data-testid="workspace-naming-hint" className="px-xs text-hint text-xs">
 							ThinkRail will name the workspace and branch from your request.
 						</p>
@@ -469,7 +520,7 @@ export function NewWorkspaceDialog({
 						onClick={() => void create()}
 						className="flex h-8 shrink-0 items-center gap-sm rounded-[var(--radius-md)] bg-primary px-md font-medium text-on-accent text-sm outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50"
 					>
-						Create
+						{isolated ? "Create" : "Start"}
 						<span className="inline-flex h-4 min-w-4 items-center justify-center rounded-[3px] bg-[var(--on-accent-16)] px-1 font-[var(--font-mono)] text-xs">
 							↵
 						</span>
@@ -482,6 +533,38 @@ export function NewWorkspaceDialog({
 				/>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+/** One option of the target control — a toggle button styled like the app's active-nav pattern. */
+function TargetButton({
+	icon: Icon,
+	label,
+	active,
+	testid,
+	onClick,
+}: {
+	icon: LucideIcon;
+	label: string;
+	active: boolean;
+	testid: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={active}
+			data-testid={testid}
+			data-active={active}
+			onClick={onClick}
+			className={cn(
+				"flex h-7 items-center gap-sm rounded-[7px] px-md text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+				active ? "bg-[var(--primary-10)] font-medium text-primary" : "text-muted hover:text-text",
+			)}
+		>
+			<Icon className="size-3.5 shrink-0" />
+			{label}
+		</button>
 	);
 }
 

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -1,5 +1,5 @@
 import type { Project, Workspace } from "@thinkrail/contracts";
-import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Folder, GitBranch, House, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
@@ -236,9 +236,70 @@ function WorkspaceRow({
 	onRemove: () => void;
 }) {
 	const stats = workspace.diffStats;
+	// The built-in Default workspace (the project folder itself) is non-removable — the server enforces
+	// it; the UI simply offers nothing. It wears a House icon in place of the branch glyph.
+	const isDefault = workspace.kind === "default";
+	const Icon = isDefault ? House : GitBranch;
 	// Confirm-before-remove lives on the row so the popover anchors right beneath it (contextual to the
 	// workspace being removed) rather than as a centered modal.
 	const [confirmOpen, setConfirmOpen] = useState(false);
+	const row = (
+		<div
+			data-testid="workspace-item"
+			data-active={isActive}
+			data-kind={workspace.kind ?? "worktree"}
+			className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
+				isActive ? "bg-hover" : "hover:bg-hover"
+			}`}
+		>
+			<button
+				type="button"
+				onClick={onSelect}
+				className="flex min-w-0 flex-1 items-center gap-sm text-left"
+			>
+				<Icon className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
+				{/* Name on top, the git branch on a second line beneath it — the display name is decoupled
+				    from the branch, so surface both without crowding one line. The branch line is hidden when
+				    they coincide, so pristine/legacy rows stay a single compact line. */}
+				<span className="flex min-w-0 flex-1 flex-col">
+					<span
+						data-testid="workspace-name"
+						className={`truncate text-sm leading-tight ${isActive ? "font-medium text-primary" : "text-muted"}`}
+					>
+						{workspace.name}
+					</span>
+					{workspace.branch !== workspace.name && (
+						<span
+							data-testid="workspace-branch"
+							className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
+						>
+							{workspace.branch}
+						</span>
+					)}
+				</span>
+			</button>
+			<DiffStatBadge
+				added={stats?.added ?? 0}
+				removed={stats?.removed ?? 0}
+				className="group-hover:hidden"
+			/>
+			{!isDefault && (
+				<PopoverTrigger asChild>
+					<button
+						type="button"
+						data-testid="workspace-remove"
+						aria-label="Remove workspace"
+						className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-red group-hover:opacity-100 data-[state=open]:opacity-100"
+					>
+						<Trash2 className="size-4" />
+					</button>
+				</PopoverTrigger>
+			)}
+		</div>
+	);
+	// No ConfirmPopover for the Default row — there is nothing to confirm (and PopoverTrigger only
+	// renders inside the popover context of the removable branch below).
+	if (isDefault) return row;
 	return (
 		<ConfirmPopover
 			open={confirmOpen}
@@ -257,55 +318,7 @@ function WorkspaceRow({
 			align="end"
 		>
 			{/* Anchored to the Remove button (the PopoverTrigger), right border aligned via align="end". */}
-			<div
-				data-testid="workspace-item"
-				data-active={isActive}
-				className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
-					isActive ? "bg-hover" : "hover:bg-hover"
-				}`}
-			>
-				<button
-					type="button"
-					onClick={onSelect}
-					className="flex min-w-0 flex-1 items-center gap-sm text-left"
-				>
-					<GitBranch className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
-					{/* Name on top, the git branch on a second line beneath it — the display name is decoupled
-					    from the branch, so surface both without crowding one line. The branch line is hidden when
-					    they coincide, so pristine/legacy rows stay a single compact line. */}
-					<span className="flex min-w-0 flex-1 flex-col">
-						<span
-							data-testid="workspace-name"
-							className={`truncate text-sm leading-tight ${isActive ? "font-medium text-primary" : "text-muted"}`}
-						>
-							{workspace.name}
-						</span>
-						{workspace.branch !== workspace.name && (
-							<span
-								data-testid="workspace-branch"
-								className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
-							>
-								{workspace.branch}
-							</span>
-						)}
-					</span>
-				</button>
-				<DiffStatBadge
-					added={stats?.added ?? 0}
-					removed={stats?.removed ?? 0}
-					className="group-hover:hidden"
-				/>
-				<PopoverTrigger asChild>
-					<button
-						type="button"
-						data-testid="workspace-remove"
-						aria-label="Remove workspace"
-						className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-red group-hover:opacity-100 data-[state=open]:opacity-100"
-					>
-						<Trash2 className="size-4" />
-					</button>
-				</PopoverTrigger>
-			</div>
+			{row}
 		</ConfirmPopover>
 	);
 }

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -37,12 +37,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   same-project workspace switches do not force it open again. Workspace creation expands its project
   explicitly. Selecting or creating a workspace also selects its owning project, keeping project-home and
   active-workspace context coherent even when the create dialog's project picker targets another project.
-  **Opening a project** ends by **auto-entering that project's Default workspace**: after a successful
-  open the hook lists the project's workspaces and activates the `kind === "default"` row (store's
-  existing activate action), so the user lands in the IDE view — files, changes, terminals — of their
-  project folder, not on Welcome. (No Default in the list — an older host — degrades to the previous
-  select-project behavior.) Clicking an already-listed **project row** keeps the "project home" gesture
-  below — Welcome, with the spec-first cards, stays one click away. Opening goes through the shared
+  **Opening a project lands on that project's Welcome** — deliberately **no auto-enter** into any
+  workspace: Welcome is the fork where the two working modes (isolated worktree vs the project folder's
+  Default workspace) are presented as an explicit choice (see `WelcomePanel`), so opening and the
+  "project home" gesture converge on the same surface. Opening goes through the shared
   **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
@@ -71,22 +69,31 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
 workspace is active. The `PRODUCT_NAME` wordmark as the hero (the topbar's brand styling — accent font,
 `text-primary` — enlarged), with the **active project's name as a small eyebrow** (folder icon) above it
 once a project is selected, over a **constant** spec-first pitch (not spec-conditional) and
-**one-to-three cards** (Conductor-inspired: icon top-left, label + explainer
+**one-to-four cards** (Conductor-inspired: icon top-left, label + explainer
 bottom-left; the primary is a filled-violet card carrying the stable `welcome-cta` hook, others quiet
-`welcome-action`s). The cards by state: **no projects** → **"Open project"** (one card); **project +
-`hasSpecs`** → **"Start building"** (primary) + "Open project"; **project + no specs** → a spec-first
-**"Set up project"** (primary) + "Start building" + "Open project". The **"Open project"** card hangs the shared
+`welcome-action`s). Welcome is **the mode fork**: with a project shown it always pairs **"Start
+building"** (isolated worktree) with **"Work in project folder"** (the Default workspace) so the two
+working modes are a visible choice, not a hidden default. The cards by state: **no projects** → **"Open
+project"** (one card); **project + `hasSpecs`** → **"Start building"** (primary) + "Work in project
+folder" + "Open project"; **project + no specs** → a spec-first **"Set up project"** (primary) + "Start
+building" + "Work in project folder" + "Open project". The **"Open project"** card hangs the shared
 **`AddProjectMenu`** dropdown off it (same menu as the projects-rail "+": Open project / Open GitHub (soon)
-/ Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Start building"** is the
-intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` (which cuts a
-worktree-isolated workspace + starts a chat); *workspace* is the mechanism, not the label. **"Set up
+/ Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Work in project folder"**
+(`House` icon, matching the rail's Default row) **direct-enters** the Default workspace — no dialog: it
+lists the project's workspaces, stores them, and activates the `kind === "default"` row; an older host
+with no Default row degrades to an error toast. **"Start building"** is the
+intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` preselected to the
+**Isolated workspace** target; *workspace* is the mechanism, not the label. **"Set up
 project"** opens the same dialog with an `initialPrompt` seed **and a `promptNote`** — the note is the
 card's own copy (the dialog stays skill-agnostic), saying what the seeded command does: the agent drafts
 the project's specs (goal, architecture, modules) before building. The seed is the
 `/skill:setting-up-a-project` command,
 which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command syntax; expanded on the
 `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
-new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]). Which
+new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]) — plus a
+**`promptNote`** ("Runs the setting-up-a-project skill — the agent drafts your project's specs…", copy
+owned here so the dialog stays skill-agnostic) and the **Project folder** target preselected (specs are
+ground truth — they land in place, no merge-back; the worktree alternative stays one click away). Which
 project drives the has-specs states = `selectedProjectId ?? projects[0]`, read reactively (so the visible
 nav's selection updates it). Its `hasSpecs` is **fetched lazily** via `project.hasSpecs` for that one
 project (a full-tree walk, kept off the connect handshake) — pending until it resolves, so the cards wait
@@ -109,13 +116,24 @@ skills' (attacker-controlled) names before trust. The full manager (`chat/Skills
 pre-session half of the user's skill settings; the chat header opens the same dialog in workspace mode
 (with Reload).
 
-**`NewWorkspaceDialog`** is the create-and-kick-off surface. It names the operation visibly — title
-**“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new
-branch. Files, chats, changes, and terminals stay scoped to it.”** Its base-branch trigger reads **“From
+**`NewWorkspaceDialog`** is the start-working surface: **a target control** (a two-option segment, both
+always visible — the two-mode model in one glance) chooses **where** the work runs, and the header is
+**mode-aware** so it always names the operation truthfully: **Isolated workspace** → title **“Create
+workspace”**, description **“A separate checkout on its own new branch. Files, chats, changes, and
+terminals stay scoped to it.”**; **Project folder** → title **“Work in project folder”**, description
+**“Runs directly in your project folder — no isolation. Changes land on the current branch.”** In folder
+mode the base-branch picker and the naming hint are hidden (nothing is created — submit **enters** the
+project's Default workspace via the shared **`resolveDefaultWorkspace`** helper (`defaultWorkspace.ts`:
+`workspace.list` → fold into the store → the `kind === "default"` row; error toast + null if an older
+host has none — the same helper behind the Welcome fork card, so the resolve + degrade path lives once))
+and the submit button reads **Start** instead of **Create**; the branch-list fetch + background base
+prefetch still run (fire-and-forget, keeps a toggle back to worktree instant); the optional chat
+kick-off tail is identical in both modes. Openers preselect the target (rail "+" / "Start building" →
+worktree; "Set up project" → folder). An optional **`promptNote`** renders as a small info strip above
+the prompt (used by "Set up project" to say what the seeded skill command does). The worktree mode's
+base-branch trigger reads **“From
 {base}”**, not an unexplained ref. An optional **`initialPrompt`** seeds the prompt hero (still editable;
-empty by default) and an optional **`promptNote`** renders as a small info strip above it
-(`ws-prompt-note`) — the opener's chance to explain a seeded command, since the dialog's own header only
-ever describes creating a workspace; while the prompt is non-empty, a secondary hint says ThinkRail will name the workspace
+empty by default); while the prompt is non-empty (worktree mode), a secondary hint says ThinkRail will name the workspace
 and branch from the request. The rest stays compact: the base-branch combobox (`git.listBranches`,
 degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
 a project picker, the prompt hero, and the reused
@@ -130,11 +148,11 @@ a project picker, the prompt hero, and the reused
   authoritative if the selected base branch differs). When the selected project is **untrusted AND ships
   committed skills** (a count from `project.aliasSkills`, never their names), a **trust notice** shows a
   *Trust project* button — the repo's skills stay withheld until granted (`project.setTrust`, which folds the
-  updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter creates** (matching the Create button's
+  updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter submits** (matching the submit button's
   `↵` affordance) and
-  **Shift+Enter** inserts a newline. Create = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
+  **Shift+Enter** inserts a newline. Worktree-mode submit = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
   `session.create({ model, thinkingLevel })` + fire-and-forget `prompt`; with an empty prompt it just
-  creates the workspace. A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a
+  creates the workspace (folder mode: just enters Default). A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a
   nonexistent model) surfaces as an `error` turn in the just-opened chat via `store.appendErrorTurn` (with
   `transport`'s `errorText`) rather than vanishing. The two rejections with **no chat to host a turn** raise a
   `store.toast.error` instead: a failed **`workspace.create`** (keeps the dialog open to retry) and a failed

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -26,14 +26,24 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   surfaces an error toast, leaving the row in place). Each **workspace row** is **two-line**: the display
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
-  name is decoupled from the git branch (see [[submodule-server-workspaces]]). The active workspace must
+  name is decoupled from the git branch (see [[submodule-server-workspaces]]). The **Default workspace**
+  (`kind === "default"` — the project folder itself) renders **pinned first** (the server pins it in
+  `workspace.list`; `addWorkspace` appends created worktree rows after it), with a **`House` icon** in
+  place of the `GitBranch` glyph and **no Remove button** (non-removable — the server enforces it; the UI
+  simply offers nothing). Its branch line shows the folder's real current branch. The active workspace must
   also stay visible: when `ProjectTree` mounts with an active workspace, or the active workspace's derived
   owning project changes or first becomes resolvable, it expands that parent project. A manual collapse
   remains respected while the owning project is unchanged; ordinary `workspace.updated` snapshots and
   same-project workspace switches do not force it open again. Workspace creation expands its project
   explicitly. Selecting or creating a workspace also selects its owning project, keeping project-home and
   active-workspace context coherent even when the create dialog's project picker targets another project.
-  **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
+  **Opening a project** ends by **auto-entering that project's Default workspace**: after a successful
+  open the hook lists the project's workspaces and activates the `kind === "default"` row (store's
+  existing activate action), so the user lands in the IDE view — files, changes, terminals — of their
+  project folder, not on Welcome. (No Default in the list — an older host — degrades to the previous
+  select-project behavior.) Clicking an already-listed **project row** keeps the "project home" gesture
+  below — Welcome, with the spec-first cards, stays one click away. Opening goes through the shared
+  **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
   (confirm → `project.init`) — when it's `initable`, or surfaces the error in a **`NoticeDialog`** — so a
@@ -195,7 +205,9 @@ a project picker, the prompt hero, and the reused
   When the active workspace has no open center tab, `CenterTabs` uses the empty surface as a persistent
   creation/orientation receipt rather than a generic placeholder: **“Workspace ready”**, the display name,
   `branch · from baseBranch`, and **“Files, chats, changes, and terminals are scoped to this workspace,”**
-  followed by the existing **New chat** action. It is neither one-time nor dismissible, so it also helps
+  followed by the existing **New chat** action. For the **Default workspace** the receipt tells the truth
+  instead of promising isolation: **“Default workspace”**, the project name, `on <branch>`, and “Chats,
+  changes, and terminals run directly in your project folder.” It is neither one-time nor dismissible, so it also helps
   after the last tab closes without introducing onboarding state. `CenterTabs` also renders ephemeral
   **`doc`** tabs (`DocTab` — inline rendered markdown, no file on disk) via its own
   `DocPane`→`MarkdownPreview`; used for the plan-as-markdown snapshot (see the `chat` module). `CenterTabs`

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -86,7 +86,10 @@ intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceD
 **Isolated workspace** target; *workspace* is the mechanism, not the label. **"Set up
 project"** opens the same dialog with an `initialPrompt` seed **and a `promptNote`** — the note is the
 card's own copy (the dialog stays skill-agnostic), saying what the seeded command does: the agent drafts
-the project's specs (goal, architecture, modules) before building. The seed is the
+the project's specs, starting from its goal, before building — deliberately **not** an enumeration of
+artifacts, since the dispatcher's routes differ (starting-a-new-project stops at goal-and-requirements;
+only importing-a-codebase drafts architecture + module SPECs) and the card can't know the route up
+front. The seed is the
 `/skill:setting-up-a-project` command,
 which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command syntax; expanded on the
 `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -22,7 +22,7 @@ const SETUP_PROMPT = "/skill:setting-up-a-project";
 // alone can't: the dialog it opens is the generic create surface). The copy lives here, with the card
 // that seeds it, so the dialog stays skill-agnostic.
 const SETUP_NOTE =
-	"Runs the setting-up-a-project skill — the agent drafts your project's specs (goal, architecture, modules) before building.";
+	"Runs the setting-up-a-project skill — the agent drafts your project's specs, starting from its goal, before building.";
 
 /**
  * The first-touch surface the shell mounts (centered, beside the projects rail) whenever no workspace is
@@ -186,7 +186,7 @@ export function WelcomePanel() {
 							icon={Sparkles}
 							title="Set up project"
 							tag="spec-first"
-							subtitle="Draft the project's specs with the agent first — goal, architecture, modules — before building."
+							subtitle="Draft the project's specs with the agent before building, starting from its goal."
 							onClick={() =>
 								setDialog({
 									projectId: project.id,

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -156,7 +156,7 @@ export function WelcomePanel() {
 			<p className="mt-lg max-w-[440px] text-md text-muted">
 				A spec-first way to build with AI. ThinkRail keeps your project's intent as a{" "}
 				<span className="text-text">connected spec graph</span> that the agent reads, plans, and
-				builds from — each task in its own isolated git worktree.
+				builds from — in your project folder, or an isolated git worktree per task.
 			</p>
 
 			<ProviderWarningBanner />

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -1,12 +1,13 @@
 import type { Workspace } from "@thinkrail/contracts";
-import { Folder, FolderOpen, type LucideIcon, Rocket, Sparkles } from "lucide-react";
+import { Folder, FolderOpen, House, type LucideIcon, Rocket, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, forwardRef, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { PRODUCT_NAME } from "../constants/branding";
 import { useAppStore } from "../store";
 import { getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
-import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { resolveDefaultWorkspace } from "./defaultWorkspace";
+import { NewWorkspaceDialog, type WorkspaceTarget } from "./NewWorkspaceDialog";
 import { ProjectSkillsNotice } from "./ProjectSkillsNotice";
 import { ProviderWarningBanner } from "./ProviderWarningBanner";
 import { useOpenProject } from "./useOpenProject";
@@ -25,20 +26,23 @@ const SETUP_NOTE =
 
 /**
  * The first-touch surface the shell mounts (centered, beside the projects rail) whenever no workspace is
- * active. The ThinkRail wordmark (topbar brand styling, scaled up) over a state-driven pitch and up-to-two
+ * active. The ThinkRail wordmark (topbar brand styling, scaled up) over a state-driven pitch and up-to-four
  * cards, adaptive across three states: no projects → "Open project"; a project with specs → "Start
- * building"; a project without a goal-and-requirements.md → a spec-first "Set up project". "Start
- * building" is the intent-first framing of creating a worktree-isolated workspace + kicking off a chat
- * (workspace is the mechanism, not the label).
+ * building"; a project without a goal-and-requirements.md → a spec-first "Set up project". With a
+ * project shown, Welcome is **the mode fork**: "Start building" (an isolated worktree — the intent-first
+ * framing of create + kick off a chat) always sits beside "Work in project folder" (direct-enters the
+ * built-in Default workspace), so the two working modes are a visible choice, not a hidden default.
  */
 export function WelcomePanel() {
 	const projects = useAppStore((s) => s.projects);
 	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
-	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero — "" for a plain
-	// create, the setup command for "Set up project", which also carries the explanatory `note`.
+	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero ("" for a plain
+	// create; the setup command for "Set up project", which also carries the explanatory `note` and
+	// preselects the project-folder target — specs are ground truth, they belong in place).
 	const [dialog, setDialog] = useState<{
 		projectId: string;
 		prompt: string;
+		target: WorkspaceTarget;
 		note?: string;
 	} | null>(null);
 	// Whether the shown project has any registered spec, fetched lazily (a full-tree walk — so it's
@@ -90,7 +94,25 @@ export function WelcomePanel() {
 			);
 	};
 
+	// The Welcome fork's "no isolation" side: direct-enter the project's built-in Default workspace —
+	// no dialog (it's navigation; the Default receipt + New chat cover kick-off). Degrades to the
+	// helper's error toast on an older host with no Default.
+	const enterProjectFolder = async (projectId: string) => {
+		const def = await resolveDefaultWorkspace(projectId);
+		if (def) useAppStore.getState().activateWorkspace(def);
+	};
+
 	const noProjects = project == null;
+
+	// The fork's "no isolation" card — identical in both project states, so it's built once.
+	const projectFolderCard = (projectId: string) => (
+		<Card
+			icon={House}
+			title="Work in project folder"
+			subtitle="Chats, changes, and terminals run directly in your project folder — no isolation."
+			onClick={() => void enterProjectFolder(projectId)}
+		/>
+	);
 
 	// The "Open project" card triggers the same dropdown as the projects-rail "+".
 	const openProjectCard = ({
@@ -151,8 +173,9 @@ export function WelcomePanel() {
 							icon={Rocket}
 							title="Start building"
 							subtitle="Cut an isolated worktree + branch, then pair with the agent to build it."
-							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
+							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
 						/>
+						{projectFolderCard(project.id)}
 						{openProjectCard({ subtitle: "Add another local git repository." })}
 					</>
 				) : (
@@ -165,15 +188,21 @@ export function WelcomePanel() {
 							tag="spec-first"
 							subtitle="Draft the project's specs with the agent first — goal, architecture, modules — before building."
 							onClick={() =>
-								setDialog({ projectId: project.id, prompt: SETUP_PROMPT, note: SETUP_NOTE })
+								setDialog({
+									projectId: project.id,
+									prompt: SETUP_PROMPT,
+									target: "default",
+									note: SETUP_NOTE,
+								})
 							}
 						/>
 						<Card
 							icon={Rocket}
 							title="Start building"
 							subtitle="Cut an isolated worktree + branch and pair with the agent."
-							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
+							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
 						/>
+						{projectFolderCard(project.id)}
 						{openProjectCard({ subtitle: "Add another local git repository." })}
 					</>
 				)}
@@ -184,6 +213,7 @@ export function WelcomePanel() {
 					open
 					projectId={dialog.projectId}
 					initialPrompt={dialog.prompt}
+					initialTarget={dialog.target}
 					{...(dialog.note !== undefined ? { promptNote: dialog.note } : {})}
 					onOpenChange={(o) => {
 						if (!o) setDialog(null);

--- a/apps/web/src/panels/defaultWorkspace.ts
+++ b/apps/web/src/panels/defaultWorkspace.ts
@@ -1,0 +1,24 @@
+import type { Workspace } from "@thinkrail/contracts";
+import { toast, useAppStore } from "@/store";
+import { errorText, getTransport } from "@/transport";
+
+/**
+ * Resolve a project's built-in Default workspace (the project folder itself): list the project's
+ * workspaces (the host's list *ensures* the Default exists — see submodule-server-workspaces), fold the
+ * fresh list into the store, and return the `kind === "default"` row. Shared by the Welcome "Work in
+ * project folder" fork card and the NewWorkspaceDialog's folder mode, so the resolve + degrade path
+ * lives once. On failure — a transport error, or an older host that serves no Default — raises the
+ * error toast and returns null (the caller decides what to do with its surface).
+ */
+export async function resolveDefaultWorkspace(projectId: string): Promise<Workspace | null> {
+	try {
+		const workspaces = await getTransport().request("workspace.list", { projectId });
+		useAppStore.getState().setWorkspaces(projectId, workspaces);
+		const def = workspaces.find((w) => w.kind === "default");
+		if (!def) throw new Error("This host has no Default workspace for this project.");
+		return def;
+	} catch (err) {
+		toast.error(errorText(err), "Couldn't open the project folder");
+		return null;
+	}
+}

--- a/apps/web/src/panels/useOpenProject.tsx
+++ b/apps/web/src/panels/useOpenProject.tsx
@@ -25,10 +25,22 @@ export function useOpenProject(onOpened: (project: Project) => void | Promise<vo
 	// A non-actionable open failure to surface (a stale recent, a broken path). null = no notice.
 	const [openError, setOpenError] = useState<string | null>(null);
 
-	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project.
+	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project,
+	// then auto-enter the project's built-in **Default workspace** (the project folder itself) so opening
+	// a project lands in the IDE view — files, changes, terminals — not on Welcome. The list also ensures
+	// the Default exists host-side. Best-effort: no Default row (an older host) or a failed list degrades
+	// to the caller's select-project behavior (Welcome) — the open itself already succeeded.
 	const adopt = async (project: Project) => {
 		useAppStore.getState().setProjects(await getTransport().request("project.list", {}));
 		await onOpened(project);
+		try {
+			const workspaces = await getTransport().request("workspace.list", { projectId: project.id });
+			useAppStore.getState().setWorkspaces(project.id, workspaces);
+			const def = workspaces.find((w) => w.kind === "default");
+			if (def) useAppStore.getState().activateWorkspace(def);
+		} catch {
+			// Entering Default is additive — a failure leaves the caller's selection (Welcome) in place.
+		}
 	};
 
 	const openProject = async (rawPath: string) => {

--- a/apps/web/src/panels/useOpenProject.tsx
+++ b/apps/web/src/panels/useOpenProject.tsx
@@ -25,22 +25,13 @@ export function useOpenProject(onOpened: (project: Project) => void | Promise<vo
 	// A non-actionable open failure to surface (a stale recent, a broken path). null = no notice.
 	const [openError, setOpenError] = useState<string | null>(null);
 
-	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project,
-	// then auto-enter the project's built-in **Default workspace** (the project folder itself) so opening
-	// a project lands in the IDE view — files, changes, terminals — not on Welcome. The list also ensures
-	// the Default exists host-side. Best-effort: no Default row (an older host) or a failed list degrades
-	// to the caller's select-project behavior (Welcome) — the open itself already succeeded.
+	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project.
+	// Deliberately NO auto-enter into any workspace: opening lands on the project's Welcome — the fork
+	// where the two working modes (isolated worktree vs the project folder's Default workspace) are an
+	// explicit choice (see task-workspace-mode-clarity).
 	const adopt = async (project: Project) => {
 		useAppStore.getState().setProjects(await getTransport().request("project.list", {}));
 		await onOpened(project);
-		try {
-			const workspaces = await getTransport().request("workspace.list", { projectId: project.id });
-			useAppStore.getState().setWorkspaces(project.id, workspaces);
-			const def = workspaces.find((w) => w.kind === "default");
-			if (def) useAppStore.getState().activateWorkspace(def);
-		} catch {
-			// Entering Default is additive — a failure leaves the caller's selection (Welcome) in place.
-		}
 	};
 
 	const openProject = async (rawPath: string) => {

--- a/architecture.md
+++ b/architecture.md
@@ -57,7 +57,11 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    tabs + chat tabs**. The shell arranges panels by layout mode: desktop multi-pane /
    mobile single-view-with-switcher. Both modes share the same panels and store.
 6. **Workspaces are git worktrees (V1).** project (git repo) → workspace (`git worktree` on its own
-   branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. The shell is built first,
+   branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. **One deliberate
+   exception:** every project carries exactly one built-in **Default workspace** (`kind: "default"`)
+   whose cwd is the project folder itself (git's *main working tree*) — auto-entered on open,
+   non-removable, non-renamable — the "just work in my project folder" anchor for users lost in the
+   worktree model (see [[submodule-server-workspaces]]). The shell is built first,
    `pi` connected last. Real PR / Checks / Review stay V2.
 7. **Auth is external.** Tailscale ACLs / device identity are the auth; the app carries an `owner` field,
    not a login UI.

--- a/e2e/agent.live.spec.ts
+++ b/e2e/agent.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent: excluded from the default `bun run e2e` (--grep-invert @agent); run via `bun run
 // e2e:agent` (or `bun run e2e:full`). It drives a REAL pi agent using pi's **default auth** (the model
@@ -10,7 +10,7 @@ test("streams an assistant reply from a real provider", { tag: "@agent" }, async
 
 	// Create a workspace → it becomes active → chat is scoped to it.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	// Start a chat from the empty-state button, then send a tiny prompt.
 	await page.getByTestId("start-chat").click();

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
+import { worktreeRows } from "./fixtures/app";
 import { E2E_PI_AGENT_DIR } from "./fixtures/paths";
 
 // Tagged @agent: drives a real pi agent. THE restart test — the one scenario the shared-host suite
@@ -160,8 +161,8 @@ test("a pending questionnaire survives a host kill -9: reboot, reopen, answer, a
 	await page.getByTestId("project-item").first().click();
 	// The workspace persisted; its session is now DISK-ONLY (the live one died with the host), so it
 	// surfaces in chat history and re-opens through the hydration path.
-	await expect(page.getByTestId("workspace-item").first()).toBeVisible({ timeout: 15_000 });
-	await page.getByTestId("workspace-item").first().click();
+	await expect(worktreeRows(page).first()).toBeVisible({ timeout: 15_000 });
+	await worktreeRows(page).first().click();
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);

--- a/e2e/changes.spec.ts
+++ b/e2e/changes.spec.ts
@@ -8,7 +8,7 @@ import { largeRepetitiveMarkdownEdited } from "./fixtures/repo";
 test("Changes tab shows the active worktree's diff and swaps per workspace", async ({ page }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(page.getByTestId("workspace-item")).toHaveCount(2); // the built-in Default + the worktree
 
 	// Edit a tracked file inside the worktree (outside the app), then surface it in the Changes tab.
 	const worktree = join(E2E_DATA_DIR, "worktrees", "sample-project", "workspace-1");
@@ -56,7 +56,7 @@ test("Changes tab shows the active worktree's diff and swaps per workspace", asy
 
 	// A fresh second workspace has its own (empty) change set.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(2);
+	await expect(page.getByTestId("workspace-item")).toHaveCount(3);
 	await expect(page.getByTestId("changes-empty")).toBeVisible();
 });
 

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): excluded from the default `bun run e2e`; run via
 // `bun run e2e:agent`. These exercise the Composer + cheap wins against a REAL pi agent + pi's
@@ -16,7 +16,7 @@ async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await trustDialog.getByTestId("ws-trust-project").click();
 	await expect(trustDialog.getByTestId("ws-trust-notice")).toBeHidden();
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await expect(page.getByTestId("chat-input")).toBeVisible();

--- a/e2e/default-workspace.spec.ts
+++ b/e2e/default-workspace.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import {
+	createWorkspaceViaDialog,
+	defaultWorkspaceRow,
+	goProjectHome,
+	openFixtureProject,
+	runInTerminal,
+	visibleTerminalScreen,
+	waitTerminalReady,
+	worktreeRows,
+} from "./fixtures/app";
+
+// The built-in Default workspace: every project carries exactly one (kind: "default") whose cwd is the
+// project folder itself. It appears as soon as the project opens, is pinned first, and is non-removable
+// and non-renamable — the "just work in my project folder" anchor for people lost in the worktree model.
+
+test("opening a project auto-enters its Default workspace — the project folder itself", async ({
+	page,
+}) => {
+	await openFixtureProject(page); // asserts the Default row is active (the auto-enter)
+
+	// The IDE surface is mounted (not the Welcome screen), scoped to the Default workspace on `main`.
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+	await expect(page.getByTestId("scope-name")).toHaveText("Default");
+	await expect(page.getByTestId("scope-branch")).toHaveText("main");
+
+	// Pinned first, labeled Default, with the folder's real branch on the second line.
+	const row = defaultWorkspaceRow(page);
+	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-kind", "default");
+	await expect(row.getByTestId("workspace-name")).toHaveText("Default");
+	await expect(row.getByTestId("workspace-branch")).toHaveText("main");
+
+	// The empty-center receipt tells the truth: this is the project folder, not an isolated worktree.
+	const ready = page.getByTestId("workspace-ready");
+	await expect(ready).toContainText("Default workspace");
+	await expect(ready).toContainText("sample-project");
+	await expect(ready).toContainText("on main");
+	await expect(ready).toContainText("run directly in your project folder");
+
+	// The file tree shows the repo's own files (the workspace cwd is the project folder)…
+	await page.getByTestId("tab-files").click();
+	await expect(page.getByTestId("file-node").filter({ hasText: "README.md" })).toBeVisible();
+
+	// …the Changes tab measures vs the repo's default branch (on main with a clean tree → empty)…
+	await page.getByTestId("tab-changes").click();
+	await expect(page.getByTestId("changes-empty")).toBeVisible();
+
+	// …and the auto-opened terminal is rooted in the project folder itself.
+	await waitTerminalReady(page);
+	await runInTerminal(page, 'basename "$(pwd)"');
+	await expect(visibleTerminalScreen(page)).toContainText("sample-project");
+});
+
+test("the Default workspace is non-removable and unique; project home stays reachable", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+
+	// No Remove affordance on the Default row — while a worktree row offers one on hover.
+	await createWorkspaceViaDialog(page);
+	const row = defaultWorkspaceRow(page);
+	await row.hover();
+	await expect(row.getByTestId("workspace-remove")).toHaveCount(0);
+	await worktreeRows(page).first().hover();
+	await expect(worktreeRows(page).first().getByTestId("workspace-remove")).toBeVisible();
+
+	// Re-opening the same project (the picker points at the same repo) does not duplicate the Default.
+	await page.getByTestId("add-project-menu").click();
+	await page.getByTestId("menu-open-project").click();
+	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await expect(defaultWorkspaceRow(page)).toHaveCount(1);
+
+	// The project-home gesture still works: click the project row → Welcome; click Default → back in.
+	await goProjectHome(page);
+	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
+	await defaultWorkspaceRow(page).getByRole("button").first().click();
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+});

--- a/e2e/default-workspace.spec.ts
+++ b/e2e/default-workspace.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
 	defaultWorkspaceRow,
+	enterDefaultWorkspace,
 	goProjectHome,
 	openFixtureProject,
 	runInTerminal,
@@ -13,13 +14,18 @@ import {
 // The built-in Default workspace: every project carries exactly one (kind: "default") whose cwd is the
 // project folder itself. It appears as soon as the project opens, is pinned first, and is non-removable
 // and non-renamable — the "just work in my project folder" anchor for people lost in the worktree model.
+// Opening a project deliberately does NOT auto-enter it: the Welcome screen is the fork where working
+// in the project folder is an explicit choice beside cutting an isolated worktree.
 
-test("opening a project auto-enters its Default workspace — the project folder itself", async ({
+test("the Welcome fork's “Work in project folder” enters the Default workspace — the project folder itself", async ({
 	page,
 }) => {
-	await openFixtureProject(page); // asserts the Default row is active (the auto-enter)
+	await openFixtureProject(page); // lands on the project's Welcome — nothing auto-entered
 
-	// The IDE surface is mounted (not the Welcome screen), scoped to the Default workspace on `main`.
+	// The fork card direct-enters the built-in Default workspace (no dialog).
+	await enterDefaultWorkspace(page);
+
+	// The IDE surface is mounted, scoped to the Default workspace on `main`.
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 	await expect(page.getByTestId("scope-name")).toHaveText("Default");
 	await expect(page.getByTestId("scope-branch")).toHaveText("main");
@@ -64,16 +70,18 @@ test("the Default workspace is non-removable and unique; project home stays reac
 	await worktreeRows(page).first().hover();
 	await expect(worktreeRows(page).first().getByTestId("workspace-remove")).toBeVisible();
 
-	// Re-opening the same project (the picker points at the same repo) does not duplicate the Default.
+	// Re-opening the same project (the picker points at the same repo) does not duplicate the Default,
+	// and lands back on the Welcome fork (deselecting the active workspace — the project-home surface).
 	await page.getByTestId("add-project-menu").click();
 	await page.getByTestId("menu-open-project").click();
-	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("welcome")).toBeVisible();
 	await expect(defaultWorkspaceRow(page)).toHaveCount(1);
 
-	// The project-home gesture still works: click the project row → Welcome; click Default → back in.
-	await goProjectHome(page);
-	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
+	// The Default stays one click away in the rail: click its row → the IDE surface; the project-home
+	// gesture then returns to Welcome.
 	await defaultWorkspaceRow(page).getByRole("button").first().click();
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await goProjectHome(page);
+	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
 });

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -119,12 +119,33 @@ export async function openAppFresh(page: Page): Promise<void> {
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 }
 
-/** Reset state, then open the fixture repo as a project via the (stubbed) picker; auto-selects + expands. */
+/**
+ * Reset state, then open the fixture repo as a project via the (stubbed) picker; auto-selects + expands
+ * — and, per the open flow, **auto-enters the project's built-in Default workspace** (the project folder
+ * itself), so the page lands on the IDE surface, not the Welcome screen.
+ */
 export async function openFixtureProject(page: Page): Promise<void> {
 	await openAppFresh(page);
 	await page.getByTestId("add-project-menu").click();
 	await page.getByTestId("menu-open-project").click();
 	await expect(page.getByTestId("project-item").first()).toBeVisible();
+	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+}
+
+/** The built-in Default workspace's row (exactly one per open project in the rail). */
+export function defaultWorkspaceRow(page: Page): Locator {
+	return page.locator('[data-testid="workspace-item"][data-kind="default"]');
+}
+
+/** The *worktree* workspace rows — every workspace row minus the always-present Default. */
+export function worktreeRows(page: Page): Locator {
+	return page.locator('[data-testid="workspace-item"]:not([data-kind="default"])');
+}
+
+/** The "project home" gesture: click the project row to deselect the workspace → its Welcome screen. */
+export async function goProjectHome(page: Page): Promise<void> {
+	await page.getByTestId("project-item").first().getByText("sample-project").click();
+	await expect(page.getByTestId("welcome")).toBeVisible();
 }
 
 /**
@@ -135,16 +156,20 @@ export async function openFixtureProject(page: Page): Promise<void> {
  */
 export async function openWorkspaceChat(page: Page): Promise<void> {
 	await openFixtureProject(page);
+	// Chat in a *worktree* workspace, not the auto-entered Default (the fixture repo itself): agent specs
+	// run bash/edits in the workspace cwd, and worktree isolation is what keeps them off the shared repo.
 	await expect(async () => {
-		if ((await page.getByTestId("workspace-item").count()) === 0) {
+		if ((await worktreeRows(page).count()) === 0) {
 			await createWorkspaceViaDialog(page);
 		}
-		await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(
-			1,
-			{
-				timeout: 5_000,
-			},
-		);
+		// Activate it explicitly (a no-op when the dialog's create already did) — the auto-entered Default
+		// must not stay active, and a lost activation would otherwise never self-heal.
+		await worktreeRows(page).first().getByRole("button").first().click();
+		await expect(
+			page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+		).toHaveCount(1, {
+			timeout: 5_000,
+		});
 	}).toPass({ timeout: 30_000 });
 	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -121,15 +121,27 @@ export async function openAppFresh(page: Page): Promise<void> {
 
 /**
  * Reset state, then open the fixture repo as a project via the (stubbed) picker; auto-selects + expands
- * — and, per the open flow, **auto-enters the project's built-in Default workspace** (the project folder
- * itself), so the page lands on the IDE surface, not the Welcome screen.
+ * — landing on the project's **Welcome screen** (the mode fork: isolated worktree vs project folder).
+ * Deliberately no workspace is auto-entered; the rail lists the built-in Default row (the list ensures
+ * it host-side).
  */
 export async function openFixtureProject(page: Page): Promise<void> {
 	await openAppFresh(page);
 	await page.getByTestId("add-project-menu").click();
 	await page.getByTestId("menu-open-project").click();
 	await expect(page.getByTestId("project-item").first()).toBeVisible();
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+}
+
+/**
+ * From the project's Welcome, take the "Work in project folder" fork card — direct-enters the built-in
+ * Default workspace (the project folder itself) and lands on the IDE surface.
+ */
+export async function enterDefaultWorkspace(page: Page): Promise<void> {
+	await page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }).click();
 	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
 }
 
 /** The built-in Default workspace's row (exactly one per open project in the rail). */
@@ -156,14 +168,14 @@ export async function goProjectHome(page: Page): Promise<void> {
  */
 export async function openWorkspaceChat(page: Page): Promise<void> {
 	await openFixtureProject(page);
-	// Chat in a *worktree* workspace, not the auto-entered Default (the fixture repo itself): agent specs
-	// run bash/edits in the workspace cwd, and worktree isolation is what keeps them off the shared repo.
+	// Chat in a *worktree* workspace, never the project-folder Default (the shared fixture repo itself):
+	// agent specs run bash/edits in the workspace cwd, and worktree isolation keeps them off the repo.
 	await expect(async () => {
 		if ((await worktreeRows(page).count()) === 0) {
 			await createWorkspaceViaDialog(page);
 		}
-		// Activate it explicitly (a no-op when the dialog's create already did) — the auto-entered Default
-		// must not stay active, and a lost activation would otherwise never self-heal.
+		// Activate it explicitly (a no-op when the dialog's create already did) — a lost activation would
+		// otherwise never self-heal.
 		await worktreeRows(page).first().getByRole("button").first().click();
 		await expect(
 			page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
 
 // Selecting a message hit in the Ctrl+R history overlay (A7) jumps to it: `useHistorySearch`'s
@@ -50,8 +50,10 @@ test("selecting a same-workspace message hit opens the chat and flashes the matc
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	// A fresh chat (not the seeded one) so a composer exists; the seeded session stays unopened — jumping
 	// to it must open a *second* tab, not reuse this one.
@@ -108,7 +110,7 @@ test("selecting a cross-workspace message hit switches the active workspace and 
 
 	// Workspace B: created second, so it's the active one — the search below runs from *its* chat, not A's.
 	await createWorkspaceViaDialog(page);
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
 	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
@@ -177,7 +179,7 @@ test("an unmapped message hit is a no-op — the overlay stays open and the acti
 	// No-op: overlay stays open, no new tab, active workspace unchanged (still B).
 	await expect(overlay).toBeVisible();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
 	await expect(workspaces.nth(0)).not.toHaveAttribute("data-active", "true");
 });
@@ -331,7 +333,7 @@ test("an unmapped prompt hit shows no jump icon, and Shift+Enter on it is a no-o
 	// No-op: overlay stays open, no new tab, active workspace unchanged (still B).
 	await expect(overlay).toBeVisible();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
 	await expect(workspaces.nth(0)).not.toHaveAttribute("data-active", "true");
 });

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -6,6 +6,7 @@ import {
 	openWorkspaceChat,
 	visibleTerminal,
 	visibleTerminalScreen,
+	worktreeRows,
 } from "./fixtures/app";
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
 
@@ -280,8 +281,10 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -359,8 +362,10 @@ test("a recall step immediately followed by a full-value replace never doubles t
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -414,8 +419,10 @@ test("a prompt repeated earlier in the chat recalls at its most recent position,
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();

--- a/e2e/multi-chat.live.spec.ts
+++ b/e2e/multi-chat.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): runs a REAL pi agent. Proves several chats in one
 // workspace, each its own runtime, streaming concurrently; switching is an instant swap; closing one
@@ -10,7 +10,7 @@ test("two chats in one workspace stream independently; closing one keeps the oth
 	test.setTimeout(120_000);
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	const chatTabs = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
 	const doneNotice = page

--- a/e2e/multi-tab.live.spec.ts
+++ b/e2e/multi-tab.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): a REAL pi agent + two browser tabs against ONE host. Proves
 // hydrate-then-stream: a second client reconstructs the workspace's chats + transcript on connect, and
@@ -14,7 +14,7 @@ test("a second tab hydrates the same workspace's chats and then sees live update
 	// --- Tab A: create a workspace, open a chat, run a turn -----------------------------------------
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await page.getByTestId("chat-input").fill("Reply with the single word: alpha");
@@ -30,7 +30,7 @@ test("a second tab hydrates the same workspace's chats and then sees live update
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	// Navigate to the workspace tab A created (it's persisted + listed) → activating it triggers hydration.
 	await page2.getByTestId("project-expand").first().click(); // expand → load workspaces
-	await page2.getByTestId("workspace-item").first().click(); // activate → hydrate-on-connect
+	await worktreeRows(page2).first().click(); // activate → hydrate-on-connect
 
 	// Tab B rebuilds the chat tab + its transcript purely from the host (it never witnessed the turn).
 	await expect(page2.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1, {

--- a/e2e/new-workspace.live.spec.ts
+++ b/e2e/new-workspace.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openFixtureProject } from "./fixtures/app";
+import { openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): drives a REAL pi agent. Proves the New-Workspace headline — the
 // New-Workspace dialog's "create + kick-off": Create with a prompt cuts a worktree, opens a chat in it,
@@ -51,7 +51,7 @@ test("Create with a prompt cuts a worktree and streams the answer in a new chat"
 	await kickOff(page, "Reply with the single word: pong");
 
 	// A worktree appears + becomes active, and a chat tab opened with the prompt already sent.
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await expect(
 		page.locator('[data-testid="chat-message"][data-role="user"]').filter({ hasText: "pong" }),
@@ -75,16 +75,16 @@ test("two dialog kick-offs in separate workspaces stream concurrently", {
 
 	// Workspace A — kick off a turn…
 	await kickOff(page, "Reply with the single word: alpha");
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// …then immediately spin up workspace B with its own kick-off, before A necessarily finishes.
 	await kickOff(page, "Reply with the single word: bravo");
-	await expect(page.getByTestId("workspace-item")).toHaveCount(2);
+	await expect(worktreeRows(page)).toHaveCount(2);
 
 	// B (now active) reaches its turn-completion notice while A streamed in the background.
 	await expect(doneNotice).toBeVisible({ timeout: 90_000 });
 
 	// Switch back to workspace A → its chat streamed to completion concurrently (background runtime).
-	await page.getByTestId("workspace-item").nth(0).getByRole("button").first().click();
+	await worktreeRows(page).nth(0).getByRole("button").first().click();
 	await expect(doneNotice).toBeVisible({ timeout: 90_000 });
 });

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openFixtureProject } from "./fixtures/app";
+import { openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // The New-Workspace dialog, no agent required: project + base-branch pickers, the effort picker, and
 // the bare-create flow. The agent kick-off (Create with a prompt → streaming chat) and the model-list
@@ -55,18 +55,18 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await page.locator('[data-testid="thinking-option"][data-level="minimal"]').click();
 	await expect(effort).toContainText("minimal");
 
-	// Dismissing the dialog (Escape) creates nothing.
+	// Dismissing the dialog (Escape) creates nothing (only the built-in Default row is present).
 	await page.keyboard.press("Escape");
 	await expect(dialog).toBeHidden();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page)).toHaveCount(0);
 
 	// Reopen and Create with an empty prompt → a worktree is created (no chat), and it becomes active.
 	await page.getByTestId("add-workspace").first().click();
 	await expect(dialog).toBeVisible();
 	await page.getByTestId("create-workspace").click();
 	await expect(dialog).toBeHidden();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page)).toHaveCount(1);
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	// The active scope stays visible after the Welcome → IDE remount, both in the tree and the global
 	// context spine. The empty center is a persistent receipt, not a generic blank-state prompt.
@@ -118,7 +118,8 @@ test("a project's committed skills are gated behind trust, then autocomplete", a
 	await prompt.press("Enter");
 	await expect(prompt).toHaveValue("/skill:e2e-portable ");
 	await expect(dialog).toBeVisible();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	// Nothing was created — only the project's built-in Default row exists.
+	await expect(worktreeRows(page)).toHaveCount(0);
 });
 
 test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page }) => {
@@ -139,7 +140,7 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 	await prompt.pressSequentially("second line");
 	await expect(prompt).toHaveValue("first line\nsecond line");
 	await expect(dialog).toBeVisible();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page)).toHaveCount(0);
 
 	// Plain Enter submits, matching the Create button's ↵ affordance. Clearing the prompt first keeps this
 	// in the no-agent suite (an empty prompt creates a bare worktree with no chat kick-off) while still
@@ -148,6 +149,6 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 	await expect(dialog.getByTestId("workspace-naming-hint")).toHaveCount(0);
 	await prompt.press("Enter");
 	await expect(dialog).toBeHidden();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
 });

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -16,12 +16,27 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(dialog).toBeVisible();
 
 	// The operation and its scope are explicit before any controls: this is a separate checkout/branch,
-	// and the IDE surfaces the user is about to enter are all scoped to it.
+	// and the IDE surfaces the user is about to enter are all scoped to it. The rail's "+" preselects the
+	// isolated-workspace target.
 	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
 	await expect(dialog).toContainText("A separate checkout on its own new branch");
 	// The note strip belongs to openers that seed a command (Welcome's "Set up project") — not the rail "+".
 	await expect(dialog.getByTestId("ws-prompt-note")).toHaveCount(0);
 	await expect(dialog).toContainText("Files, chats, changes, and terminals stay scoped to it");
+	await expect(dialog.getByTestId("ws-target-worktree")).toHaveAttribute("data-active", "true");
+
+	// The target control makes the two working modes one visible choice: toggling to "Project folder"
+	// swaps the header to the truthful no-isolation copy, hides the base-branch picker (nothing gets
+	// created), and relabels the submit — and toggling back restores the worktree form.
+	await dialog.getByTestId("ws-target-default").click();
+	await expect(dialog.getByRole("heading", { name: "Work in project folder" })).toBeVisible();
+	await expect(dialog).toContainText("no isolation");
+	await expect(dialog.getByTestId("ws-branch-picker")).toHaveCount(0);
+	await expect(page.getByTestId("create-workspace")).toHaveText(/Start/);
+	await dialog.getByTestId("ws-target-worktree").click();
+	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
+	await expect(dialog.getByTestId("ws-branch-picker")).toBeVisible();
+	await expect(page.getByTestId("create-workspace")).toHaveText(/Create/);
 
 	// Project picker defaults to the project the "+" was clicked on.
 	await expect(dialog.getByTestId("ws-project-picker")).toContainText("sample-project");

--- a/e2e/reopen-chat.live.spec.ts
+++ b/e2e/reopen-chat.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): needs a real session. Proves the "reopen closed chat" feature —
 // closing a chat moves it to history (its session/runtime stay alive); reopening restores the full
@@ -10,7 +10,7 @@ test("a closed chat reopens from history with its transcript intact", { tag: "@a
 	test.setTimeout(90_000);
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	const chatTabs = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
 	const history = page.getByTestId("chat-history");

--- a/e2e/templates.live.spec.ts
+++ b/e2e/templates.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openWorkspaceChat, waitForDone } from "./fixtures/app";
+import { openWorkspaceChat, waitForDone, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): drives a REAL pi agent against the seeded prompt-template
 // fixtures (`e2e/fixtures/templates.ts`). The no-agent `templates-compose.spec.ts` already covers the
@@ -85,8 +85,10 @@ test("a typed-through /name command is expanded by pi itself, not the composer's
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	// The session is still live in the host's memory (never closed), so it auto-restores as the active
 	// tab — no history entry to reopen from.

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -6,6 +6,7 @@ import {
 	runInTerminal,
 	visibleTerminalScreen,
 	waitTerminalReady,
+	worktreeRows,
 } from "./fixtures/app";
 
 test("a workspace opens a terminal automatically, rooted in the worktree, with working I/O", async ({
@@ -13,7 +14,7 @@ test("a workspace opens a terminal automatically, rooted in the worktree, with w
 }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// No click needed — landing on the workspace opens a terminal on its own.
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
@@ -38,13 +39,13 @@ test("terminals are workspace-scoped and survive workspace switches", async ({ p
 
 	// A fresh second workspace gets its own auto terminal — not workspace 1's.
 	await createWorkspaceViaDialog(page); // workspace 2 (now active)
-	await expect(page.getByTestId("workspace-item")).toHaveCount(2);
+	await expect(worktreeRows(page)).toHaveCount(2);
 	await waitTerminalReady(page);
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
 	await expect(visibleTerminalScreen(page)).not.toContainText("TR_WS1_BUFFER");
 
 	// Back to workspace 1 → its terminal and buffer are restored (never unmounted).
-	await page.getByTestId("workspace-item").nth(0).getByRole("button").first().click();
+	await worktreeRows(page).nth(0).getByRole("button").first().click();
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
 	await expect(visibleTerminalScreen(page)).toContainText("TR_WS1_BUFFER");
 });

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -4,9 +4,11 @@ import { basename, join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
+	goProjectHome,
 	openAppFresh,
 	openFixtureProject,
 	stagePlainFolder,
+	worktreeRows,
 } from "./fixtures/app";
 import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
@@ -172,6 +174,8 @@ test("a project with specs offers Start building over Set up", async ({ page }) 
 	// The fixture repo already carries SPEC.md files → the host reports it has specs.
 	await openFixtureProject(page);
 
+	// Opening auto-entered the Default workspace; the Welcome cards live one project-row click away.
+	await goProjectHome(page);
 	await expect(page.getByTestId("welcome")).toBeVisible();
 	// The active project's name shows as the eyebrow above the wordmark.
 	await expect(page.getByTestId("welcome")).toContainText("sample-project");
@@ -196,6 +200,8 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 	try {
 		await openFixtureProject(page);
 
+		// Opening auto-entered the Default workspace — back to the project home for the spec-first cards.
+		await goProjectHome(page);
 		await expect(page.getByTestId("welcome")).toBeVisible();
 		await expect(page.getByTestId("welcome")).toContainText("sample-project");
 		// Three cards: Set up project (primary) + Start building + Open project.
@@ -247,10 +253,17 @@ test("opening a non-git folder from the Welcome screen offers to initialise a re
 	await expect(confirmInit).toBeVisible();
 	await confirmInit.click();
 
-	// It initialises + opens → the folder now shows up as a project in the rail.
+	// It initialises + opens → the folder now shows up as a project in the rail…
 	await expect(
 		page.getByTestId("project-item").filter({ hasText: basename(E2E_PLAIN_DIR) }),
 	).toBeVisible();
+	// …and the open auto-enters its built-in Default workspace (the folder itself): the IDE surface
+	// mounts, and the just-initialised repo's file is already browsable.
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+	await expect(page.locator('[data-testid="workspace-item"][data-kind="default"]')).toHaveAttribute(
+		"data-active",
+		"true",
+	);
 });
 
 test("clicking a project returns to its Welcome, deselecting the active workspace", async ({
@@ -269,6 +282,6 @@ test("clicking a project returns to its Welcome, deselecting the active workspac
 	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(0);
 
 	// Re-selecting the workspace restores the IDE (its tabs/session survive the deselect).
-	await page.getByTestId("workspace-item").first().getByRole("button").first().click();
+	await worktreeRows(page).first().getByRole("button").first().click();
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 });

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -4,7 +4,6 @@ import { basename, join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
-	goProjectHome,
 	openAppFresh,
 	openFixtureProject,
 	stagePlainFolder,
@@ -13,10 +12,13 @@ import {
 import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
 // The first-touch Welcome screen. It replaces the center/right/terminal surface until a workspace is
-// active, and its cards adapt across three states:
+// active — and with a project shown it is THE MODE FORK: "Start building" (isolated worktree) always
+// sits beside "Work in project folder" (the built-in Default workspace), so the two working modes are a
+// visible choice, not a hidden default. Opening a project lands here (no auto-enter). Cards by state:
 //   1. no projects        → one "Open project" card (opens the same dropdown as the projects-rail "+")
-//   2. project, has specs → "Start building" + "Open project"
-//   3. project, no specs  → spec-first "Set up project" + "Start building" + "Open project"
+//   2. project, has specs → "Start building" + "Work in project folder" + "Open project"
+//   3. project, no specs  → spec-first "Set up project" + "Start building" + "Work in project folder"
+//                           + "Open project"
 // "Has specs" = the repo has ANY registered spec (a file with id+type frontmatter), via the spec index —
 // not a lowercased goal-and-requirements.md filename. The fixture ships SPEC.md files, so it's "has specs"
 // by default; state 3 is exercised by stripping those specs for the duration of one test.
@@ -170,23 +172,24 @@ test("Settings → Providers offers JetBrains AI, guiding install when the centr
 	}
 });
 
-test("a project with specs offers Start building over Set up", async ({ page }) => {
-	// The fixture repo already carries SPEC.md files → the host reports it has specs.
+test("a project with specs offers Start building over Set up, beside the project-folder fork", async ({
+	page,
+}) => {
+	// The fixture repo already carries SPEC.md files → the host reports it has specs. Opening lands
+	// directly on the project's Welcome — the fork surface (no auto-enter).
 	await openFixtureProject(page);
-
-	// Opening auto-entered the Default workspace; the Welcome cards live one project-row click away.
-	await goProjectHome(page);
-	await expect(page.getByTestId("welcome")).toBeVisible();
 	// The active project's name shows as the eyebrow above the wordmark.
 	await expect(page.getByTestId("welcome")).toContainText("sample-project");
-	// The global context makes the selected-but-not-active state explicit instead of making a project-row
-	// click look like the workspace silently disappeared.
+	// The global context makes the selected-but-not-active state explicit.
 	const scope = page.getByTestId("scope-context");
 	await expect(scope).toHaveAttribute("data-context", "project-home");
 	await expect(scope).toContainText("sample-project");
 	await expect(scope).toContainText("Project home");
-	// Two cards: Start building (primary) + Open project — and no "Set up project".
+	// Three cards: Start building (primary) + the project-folder fork + Open project — no "Set up project".
 	await expect(page.getByTestId("welcome-cta")).toContainText("Start building");
+	await expect(
+		page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
+	).toBeVisible();
 	await expect(
 		page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
 	).toBeVisible();
@@ -198,38 +201,49 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 	// serial — workers: 1 — so this can't race, and git restores the exact committed content).
 	for (const spec of FIXTURE_SPECS) rmSync(join(E2E_FIXTURE_REPO, spec), { force: true });
 	try {
-		await openFixtureProject(page);
-
-		// Opening auto-entered the Default workspace — back to the project home for the spec-first cards.
-		await goProjectHome(page);
-		await expect(page.getByTestId("welcome")).toBeVisible();
+		await openFixtureProject(page); // lands on the project's Welcome — the spec-first cards
 		await expect(page.getByTestId("welcome")).toContainText("sample-project");
-		// Three cards: Set up project (primary) + Start building + Open project.
+		// Four cards: Set up project (primary) + Start building + the project-folder fork + Open project.
 		await expect(page.getByTestId("welcome-cta")).toContainText("Set up project");
 		await expect(
 			page.getByTestId("welcome-action").filter({ hasText: "Start building" }),
 		).toBeVisible();
 		await expect(
+			page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
+		).toBeVisible();
+		await expect(
 			page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
 		).toBeVisible();
 
-		// "Set up project" opens the New-Workspace dialog with the prompt hero pre-seeded, and the note
-		// strip explains what the seeded command will do (the dialog header only names the create op).
+		// "Set up project" opens the dialog pre-seeded with the skill command, preselected to the
+		// project-folder target (specs are ground truth — they land in place), with the explanatory note
+		// (the header only names the create op) and the mode-aware header; the base-branch picker is
+		// hidden (nothing gets created).
 		await page.getByTestId("welcome-cta").click();
 		const dialog = page.getByTestId("new-workspace-dialog");
 		await expect(dialog).toBeVisible();
 		await expect(dialog.getByTestId("ws-prompt")).toHaveValue(/^\/skill:setting-up-a-project\b/);
+		await expect(dialog.getByTestId("ws-target-default")).toHaveAttribute("data-active", "true");
+		await expect(dialog.getByRole("heading", { name: "Work in project folder" })).toBeVisible();
+		await expect(dialog).toContainText("no isolation");
 		await expect(dialog.getByTestId("ws-prompt-note")).toContainText("setting-up-a-project skill");
+		await expect(dialog.getByTestId("ws-branch-picker")).toHaveCount(0);
 
-		// Clear the seed (no agent kick-off — keeps this in the no-agent suite) and create the worktree; it
-		// becomes active → the welcome unmounts and the full 3-column surface appears.
+		// Clear the seed (no agent kick-off — keeps this in the no-agent suite) and Start → no worktree is
+		// created; the project's built-in Default workspace becomes active → the welcome unmounts and the
+		// full 3-column surface appears, scoped to the project folder itself.
 		await dialog.getByTestId("ws-prompt").fill("");
+		await expect(page.getByTestId("create-workspace")).toHaveText(/Start/);
 		await page.getByTestId("create-workspace").click();
 		await expect(dialog).toBeHidden();
 		await expect(page.getByTestId("welcome")).toHaveCount(0);
 		await expect(page.getByTestId("center-tabs")).toBeVisible();
 		await expect(page.getByTestId("right-panel")).toBeVisible();
 		await expect(page.getByTestId("terminal-panel")).toBeVisible();
+		await expect(
+			page.locator('[data-testid="workspace-item"][data-kind="default"]'),
+		).toHaveAttribute("data-active", "true");
+		await expect(worktreeRows(page)).toHaveCount(0);
 	} finally {
 		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "checkout", "--", ...FIXTURE_SPECS]);
 	}
@@ -257,13 +271,15 @@ test("opening a non-git folder from the Welcome screen offers to initialise a re
 	await expect(
 		page.getByTestId("project-item").filter({ hasText: basename(E2E_PLAIN_DIR) }),
 	).toBeVisible();
-	// …and the open auto-enters its built-in Default workspace (the folder itself): the IDE surface
-	// mounts, and the just-initialised repo's file is already browsable.
-	await expect(page.getByTestId("center-tabs")).toBeVisible();
-	await expect(page.locator('[data-testid="workspace-item"][data-kind="default"]')).toHaveAttribute(
-		"data-active",
-		"true",
-	);
+	// …and lands on the fresh project's Welcome (no auto-enter): the just-initialised repo has no specs,
+	// so the spec-first funnel leads, with the project-folder fork beside it.
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
+	await expect(page.getByTestId("welcome")).toContainText(basename(E2E_PLAIN_DIR));
+	await expect(page.getByTestId("welcome-cta")).toContainText("Set up project");
+	await expect(
+		page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
+	).toBeVisible();
 });
 
 test("clicking a project returns to its Welcome, deselecting the active workspace", async ({

--- a/e2e/workspace-lifecycle.spec.ts
+++ b/e2e/workspace-lifecycle.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Two tabs on ONE host, no agent. Registry membership is backend-owned shared domain state (architecture
 // #9), so a create/remove in one tab streams to the other via the workspace lifecycle pushes — every
@@ -10,26 +10,26 @@ test("workspace removal propagates — no zombie row in a second tab", async ({ 
 	// Tab A: open the project + create a workspace (it becomes A's active workspace).
 	await openFixtureProject(page);
 	const created = await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// Tab B: a second tab on the same host — expand the project (loads the list) + activate the workspace.
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page2.getByTestId("project-expand").first().click();
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(1);
-	await page2.getByTestId("workspace-item").first().click();
-	await expect(page2.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page2)).toHaveCount(1);
+	await worktreeRows(page2).first().click();
+	await expect(worktreeRows(page2).first()).toHaveAttribute("data-active", "true");
 
 	// Tab A: remove the workspace (confirm-popover → confirm).
-	await page.getByTestId("workspace-item").first().hover();
-	await page.getByTestId("workspace-item").first().getByTestId("workspace-remove").click();
+	await worktreeRows(page).first().hover();
+	await worktreeRows(page).first().getByTestId("workspace-remove").click();
 	await page.getByTestId("confirm-remove").click();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page)).toHaveCount(0);
 
 	// Tab B converges purely by reacting to the `workspace.removed` push: the row disappears (no zombie),
 	// and — since it was B's active workspace — B returns to the Welcome screen with a neutral toast.
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page2)).toHaveCount(0);
 	await expect(page2.getByTestId("welcome")).toBeVisible();
 	await expect(page2.getByTestId("toast").filter({ hasText: created.name })).toBeVisible();
 });
@@ -43,12 +43,12 @@ test("workspace creation propagates to a second tab's rail", async ({ page, cont
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page2.getByTestId("project-expand").first().click();
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page2)).toHaveCount(0); // only the built-in Default row so far
 
 	// Tab A: create a workspace.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// Tab B sees it appear via the `workspace.created` push — no manual re-list, no focus stolen.
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page2)).toHaveCount(1);
 });

--- a/e2e/workspace-tabs.spec.ts
+++ b/e2e/workspace-tabs.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 test("editor tabs are scoped to the active workspace", async ({ page }) => {
 	await openFixtureProject(page);
 	const tabs = page.getByTestId("editor-tab");
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 
 	// Workspace 1: open README.md in a center tab.
 	await createWorkspaceViaDialog(page);

--- a/e2e/workspaces.spec.ts
+++ b/e2e/workspaces.spec.ts
@@ -1,13 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
 
 test("creates, removes, and re-creates worktree workspaces (no branch collision)", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
-	const items = page.getByTestId("workspace-item");
+	const items = worktreeRows(page);
 
 	// Create a workspace via the New-Workspace dialog — a real git worktree appears.
 	await createWorkspaceViaDialog(page);

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -25,7 +25,9 @@ A ThinkRail, git-worktree IDE, driven by a CLI you run that opens a browser UI.
 The shell is built first, `pi` connected last:
 
 - **Projects → workspaces**: open a git repo as a project; a workspace is a `git worktree` (own branch +
-  cwd) under `~/.thinkrail/worktrees`.
+  cwd) under `~/.thinkrail/worktrees` — plus one built-in, non-removable **Default workspace** per
+  project (the project folder itself), auto-entered on open so newcomers aren't lost in the worktree
+  model.
 - **Center**: a tabbed area — Monaco file tabs + (once `pi` lands) chat tabs.
 - **Right**: an All-files tree of the active worktree + a Changes (git diff) tab; terminals below,
   scoped to the worktree.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -92,7 +92,10 @@ of the host.
   optional **`renamed`** flag is the naming lifecycle — absent = **not yet locked** (either pristine
   `workspace-N`, or a *provisional* non-agentic name the host applied from the first prompt), so still
   eligible for the agentic auto-rename; `true` = deliberately named (agentic or user), never auto-touched
-  again), `Session` (chat tab),
+  again; its optional **`kind: "default"`** marks the built-in per-project **Default workspace** — the
+  project folder itself as a workspace, exactly one per project, pinned first in `workspace.list`,
+  non-removable and non-renamable server-side; absent = a normal worktree workspace — an explicit wire
+  field, never an id convention), `Session` (chat tab),
   `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types; **`ProviderStatus`/`ProviderStatusReport`**
   — the auth-provider status rows the Welcome strip renders (per-provider `configured` + auth `kind`:
   oauth / api-key / env / central / other — never credential values; plus `canOAuth`/`canApiKey`/`canLogout`,

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -53,6 +53,13 @@ export interface Workspace {
 	id: string;
 	projectId: string;
 	/**
+	 * `"default"` marks the built-in per-project **Default workspace** — the project folder itself
+	 * (git's main working tree) surfaced as a workspace. Exactly one per project, pinned first in
+	 * `workspace.list`, non-removable and non-renamable (enforced server-side). Absent = a normal
+	 * worktree workspace. An explicit wire field — clients must never detect it by id convention.
+	 */
+	kind?: "default";
+	/**
 	 * Human-readable display label shown in the UI (Title Case, spaces) — decoupled from `branch`. May
 	 * repeat across workspaces; the branch is what's uniqued. Equals `branch` only for the auto
 	 * `workspace-N` placeholder.

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -75,7 +75,10 @@ import type {
 // templates stay pi-CLI-portable. `template.list` is metadata-only (`TemplateInfo`, no `content` — the
 // host reads just each file's bounded frontmatter head); the full text travels solely on the by-name
 // `template.get`/`template.save` path (`Template`), both size-capped host-side.
-export const PROTOCOL_VERSION = 16;
+// v17: the built-in Default workspace — `Workspace.kind: "default"` marks the project folder itself as
+// a per-project, non-removable, non-renamable workspace, ensured lazily and pinned first in
+// `workspace.list`; `workspace.remove` rejects it.
+export const PROTOCOL_VERSION = 17;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -28,11 +28,20 @@ warms a remote base ref off the workspace-create critical path.
   added, or a renamed file's new path, degrading to an add-style diff; `modified` = the worktree file,
   empty when deleted; the path is escape-checked against the worktree root); `listBranches(projectId)` → `{ local, remote,
   defaultBranch }` (local `refs/heads`, remote `refs/remotes/origin` minus `origin/HEAD`, default =
-  `origin/HEAD`→`origin/main`→repo `HEAD`); `prefetchBranch(projectId, ref)` — best-effort background
+  `origin/HEAD`→`origin/main`→repo `HEAD`); **`resolveDefaultBranch(repoPath)`** — that default-branch
+  resolution factored out (named once), shared by `listBranches` and the `workspaces` module's
+  Default-workspace ensure (its `baseBranch`); `prefetchBranch(projectId, ref)` — best-effort background
   `git fetch` of a remote ref (via `gitAsync`, branch passed after `--` so a `-`-prefixed name can't be
   parsed as a git option), so a later `createWorkspace` branches off a fresh tip without the network
   round-trip on its critical path (non-`origin/` ref / offline → no-op).
-- **Public surface (barrel):** `git`, `gitAsync`, `gitStatus`, `gitDiffFile`, `listBranches`, `prefetchBranch`.
+- **Public surface (barrel):** `git`, `gitAsync`, `gitStatus`, `gitDiffFile`, `listBranches`,
+  `resolveDefaultBranch`, `prefetchBranch`.
+
+## Get right
+
+- `gitStatus` reports the **live** current branch for a `kind: "default"` workspace (the project
+  folder's branch moves out-of-band — a terminal `git checkout` — and the persisted snapshot self-heals
+  only at list time; the Changes header must not lag).
 - **Allowed deps:** `persistence` (workspace + project lookup); `contracts` (`Git*`/`BranchList` types);
   Bun (spawn).
 - **Forbidden:** `host`; sibling features.

--- a/packages/server/src/git/git.test.ts
+++ b/packages/server/src/git/git.test.ts
@@ -181,3 +181,24 @@ test("prefetchBranch fetches a remote ref and no-ops on a local ref or unknown p
 	expect(await prefetchBranch("p1", "main")).toEqual({ ok: false });
 	expect(await prefetchBranch("nope", "origin/main")).toEqual({ ok: false });
 });
+
+test("gitStatus reads the Default workspace's branch live, not the persisted snapshot", () => {
+	// A default-kind record whose persisted branch is already stale (the folder moved on).
+	writeFileSync(
+		join(dataDir, "workspaces.json"),
+		JSON.stringify([
+			{
+				id: "w-default",
+				projectId: "p1",
+				kind: "default",
+				name: "Default",
+				branch: "main", // stale — the checkout below moves to feature/live
+				worktreePath: repo,
+				baseBranch: "main",
+				renamed: true,
+			},
+		]),
+	);
+	git(repo, "switch", "-c", "feature/live");
+	expect(gitStatus("w-default").branch).toBe("feature/live");
+});

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -44,16 +44,32 @@ export function listBranches(projectId: string): BranchList {
 		.map((parts) => parts[0] ?? "")
 		.filter(Boolean);
 
-	let defaultBranch: string;
-	const head = git(repo, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
-	if (head.ok && head.out) defaultBranch = head.out;
-	else if (remote.includes("origin/main")) defaultBranch = "origin/main";
-	else {
-		const repoHead = git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]);
-		defaultBranch = repoHead.ok && repoHead.out ? repoHead.out : "HEAD";
-	}
+	return { local, remote, defaultBranch: resolveDefaultBranch(repo) };
+}
 
-	return { local, remote, defaultBranch };
+/**
+ * The repo's default branch, resolved from what git knows locally: `origin/HEAD`'s target →
+ * `origin/main` → the repo's current `HEAD` branch. Named once — shared by `listBranches` (the base
+ * picker's preselection) and the `workspaces` module's Default-workspace ensure (its `baseBranch`).
+ */
+export function resolveDefaultBranch(repoPath: string): string {
+	const head = git(repoPath, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+	if (head.ok && head.out) return head.out;
+	if (git(repoPath, ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"]).ok)
+		return "origin/main";
+	const repoHead = git(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+	return repoHead.ok && repoHead.out ? repoHead.out : "HEAD";
+}
+
+/**
+ * The branch a checkout currently has out — `symbolic-ref --short HEAD`, which (unlike `rev-parse
+ * --abbrev-ref`) also answers on an unborn HEAD (a repo with no commits yet). Detached HEAD → the
+ * literal `"HEAD"`. Used for the Default workspace, whose branch is whatever the project folder has
+ * checked out (it moves out-of-band — a terminal `git checkout` — unlike a worktree's pinned branch).
+ */
+export function currentBranch(repoPath: string): string {
+	const head = git(repoPath, ["symbolic-ref", "--short", "HEAD"]);
+	return head.ok && head.out ? head.out : "HEAD";
 }
 
 /**
@@ -177,7 +193,9 @@ export function gitStatus(workspaceId: string): GitStatus {
 	}
 
 	changes.sort((a, b) => a.path.localeCompare(b.path));
-	return { branch: ws.branch, changes };
+	// The Default workspace's branch is folder-truth that moves out-of-band (a terminal `git checkout`);
+	// the persisted snapshot self-heals only at list time, so the Changes header reads it live.
+	return { branch: ws.kind === "default" ? currentBranch(ws.worktreePath) : ws.branch, changes };
 }
 
 /**

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -81,7 +81,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
     **in-flight set** (independent of the naive one — the two passes can overlap on a short turn) dedupes
     concurrent turns/sessions.
   - The **workspace-archive teardown** — the other composition of `agent` + `terminal` + `workspaces` only
-    the host may make. `workspace.remove` reaps *everything* rooted in the worktree but is **non-blocking**:
+    the host may make. `workspace.remove` **rejects a `kind: "default"` workspace loudly, before any
+    side-effect** (the record's `worktreePath` is the project folder — the reclaim's `rm -rf` fallback
+    must never see it; the UI hides Remove, this guard is for buggy/rogue clients). Otherwise it
+    reaps *everything* rooted in the worktree but is **non-blocking**:
     it does the fast part synchronously — `forgetWorkspace` (drop the record → gone from `workspace.list`
     immediately) → `evictSpecIndex` (drop the spec cache) → `closeWorkspaceTerminals` (kill its PTYs) —
     **acks**, then runs the slow reclamation in the **background** (`archiveTeardown`, fire-and-forget):
@@ -92,6 +95,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
     a failed background teardown is `console.warn`ed, never thrown into the void (nothing awaits it), like
     the auto-rename tee. **Archive keeps the branch but not the chat:** the git branch stays (code is
     recoverable), yet chat history is purged with the worktree — a deliberate scope choice, not a leak.
+- **Scratch-dir seeding on chat start:** the `session.create` handler calls `workspaces`'
+  `ensureWorkspaceScratchDir` before creating the session — the Default workspace's gitignored
+  `.thinkrail/context/` lands in the user's repo only when a chat actually starts there (and a
+  worktree's deleted scratch dir self-heals). Host-composed — no new module edges.
 - **Workspace lifecycle fan-out:** `createServer` installs the `workspaces` module's publisher
   (`setWorkspacePublisher`), mapping each domain event `kind` → its `WS_CHANNELS.workspace*` channel
   (`created`/`updated` → the full record; `removed` → `{ projectId, id }`) and `server.publish`ing it. This

--- a/packages/server/src/host/autoRename.test.ts
+++ b/packages/server/src/host/autoRename.test.ts
@@ -12,6 +12,11 @@ import {
 	maybeNaiveNameWorkspace,
 } from "./autoRename";
 
+/** The project's worktree workspaces — `listWorkspaces` minus the always-ensured Default. */
+function worktrees(projectId = "p1") {
+	return listWorkspaces(projectId).filter((w) => w.kind !== "default");
+}
+
 let dataDir: string;
 let repo: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
@@ -81,7 +86,7 @@ test("renames the workspace off the first settled turn and flags it", async () =
 	expect(renamed?.renamed).toBe(true);
 	expect(renamed?.worktreePath).toBe(ws.worktreePath);
 	expect(runner.calls()).toBe(1);
-	expect(listWorkspaces("p1")[0]?.name).toBe("Add Login Flow");
+	expect(worktrees()[0]?.name).toBe("Add Login Flow");
 });
 
 test("a renamed workspace is never touched again", async () => {
@@ -106,7 +111,7 @@ test("a failed suggestion leaves the flag unset so a later turn retries", async 
 	fakeRunner("!!! ???"); // slugs to nothing → suggestion degrades to null
 
 	expect(await maybeAutoRenameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 
 	fakeRunner("Fix The Parser");
 	const retried = await maybeAutoRenameWorkspace("s1", ws.id, firstTurn);
@@ -120,7 +125,7 @@ test("a throwing runner degrades to null", async () => {
 	});
 
 	expect(await maybeAutoRenameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 });
 
 test("an errored or aborted run never names the workspace", async () => {
@@ -169,7 +174,7 @@ test("a workspace archived during the one-shot is not renamed or resurrected", a
 	release();
 
 	expect(await pending).toBeNull();
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 });
 
 test("a user rename landing during the one-shot wins; the late suggestion is dropped", async () => {
@@ -188,7 +193,7 @@ test("a user rename landing during the one-shot wins; the late suggestion is dro
 	release();
 
 	expect(await pending).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("user picked this");
+	expect(worktrees()[0]?.name).toBe("user picked this");
 });
 
 test("naive-rename names the workspace instantly from the first prompt, provisionally", async () => {
@@ -202,7 +207,7 @@ test("naive-rename names the workspace instantly from the first prompt, provisio
 	expect(named?.worktreePath).toBe(ws.worktreePath); // dir never moves
 	// Provisional: `renamed` stays unset so the agentic pass still refines it.
 	expect(named?.renamed).toBeUndefined();
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 });
 
 test("naive-rename fires only while the name is pristine (workspace-N)", async () => {
@@ -211,14 +216,14 @@ test("naive-rename fires only while the name is pristine (workspace-N)", async (
 
 	// Second turn start: the branch is no longer `workspace-N`, so it never re-fires.
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("Add A Login Form To");
+	expect(worktrees()[0]?.name).toBe("Add A Login Form To");
 });
 
 test("naive-rename never touches a user-named workspace", async () => {
 	const ws = await createWorkspace("p1", "chosen name");
 
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("chosen name");
+	expect(worktrees()[0]?.name).toBe("chosen name");
 });
 
 test("the agentic pass refines a provisional naive name and locks it", async () => {
@@ -236,7 +241,7 @@ test("the agentic pass refines a provisional naive name and locks it", async () 
 
 	// And the now-locked name is inert to a further turn start.
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("Add Login Flow");
+	expect(worktrees()[0]?.name).toBe("Add Login Flow");
 });
 
 test("naive-rename resolves null when the first prompt is blank or unusable", async () => {
@@ -244,7 +249,7 @@ test("naive-rename resolves null when the first prompt is blank or unusable", as
 	const punctOnly = async (): Promise<Message[]> => [user("!!! ??? ..."), assistant("hm")];
 
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, punctOnly)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("workspace-1");
+	expect(worktrees()[0]?.name).toBe("workspace-1");
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, async () => [])).toBeNull();
 });
 

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -83,6 +83,7 @@ import { addTodo, listTodos, removeTodo, updateTodo } from "../todos";
 import { ensureWatch, stopWatch } from "../watch";
 import {
 	createWorkspace,
+	ensureWorkspaceScratchDir,
 	forgetWorkspace,
 	getWorkspace,
 	listWorkspaceRecords,
@@ -304,6 +305,9 @@ const handlers: Record<string, Handler> = {
 			thinkingLevel?: ThinkingLevel;
 		};
 		const ws = getWorkspace(p.workspaceId);
+		// Chat start is what seeds the gitignored scratch dir — for the Default workspace this is the one
+		// moment ThinkRail may write into the user's repo (worktrees self-heal a deleted dir the same way).
+		ensureWorkspaceScratchDir(ws);
 		const created = await createSession({
 			cwd: ws.worktreePath,
 			workspaceId: p.workspaceId,

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -15,6 +15,10 @@ chats. Its **display `name` is decoupled from its git `branch`**: `name` is a hu
 (Title Case, spaces) and `branch` is a kebab slug derived from it — they were once held equal, and still
 coincide for the auto `workspace-N` placeholder, but a named workspace carries both distinctly.
 
+Every project also carries **exactly one built-in Default workspace** (`kind: "default"`) whose
+`worktreePath` is the project folder itself (git's *main working tree*) — the "just work in my project
+folder" anchor, ensured lazily, **non-removable and non-renamable**.
+
 ## Boundary
 
 - **Owns:** `createWorkspace` (**async**; off `baseRef` when given — branched with `worktree add -b`, never a detached
@@ -56,6 +60,26 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   `listWorkspaces` immediately), `reclaimWorktree(ws)` (the slow half — `git worktree remove --force`,
   keeps the branch; hardened: rm + `prune` if git fails), and `removeWorkspace(id)` (the synchronous
   composition of the two, kept for callers/tests that want the whole archive in one call).
+- **Default workspace (`kind: "default"`):** exactly one per project. `listWorkspaces` **ensures** it
+  — find-or-create by `projectId`+`kind` (id a plain `randomUUID`; the `kind` field is the marker,
+  never an id convention), **collapsing duplicates** defensively if out-of-band state churn ever
+  produced two — and returns it **pinned first**. No `git worktree add` (the folder already is the
+  main working tree) and **no scratch-dir seeding at ensure** — merely listing a project must never
+  write into the user's repo (see `ensureWorkspaceScratchDir`). Fields are folder-truth, refreshed
+  quietly at list time when drifted (no lifecycle event — membership didn't change): `branch` = the
+  folder's current HEAD (`symbolic-ref --short`, unborn-safe; detached → literal `HEAD`), `baseBranch`
+  = the repo's default branch via `git`'s `resolveDefaultBranch` — so Default's Changes measure like
+  any workspace, degenerating to uncommitted work when the folder sits on the default branch itself.
+  First materialization emits `created` (idempotent for stores). **Non-removable + non-renamable,
+  enforced here, not just hidden in the UI:** `forgetWorkspace` and `renameWorkspace` **throw** on
+  `kind: "default"` — forget would hand the archive teardown's `rm -rf` fallback the project folder,
+  rename would `git branch -m` the user's real branch; the record carries `renamed: true` so both
+  auto-rename passes stay away as belt-and-suspenders.
+- **`ensureWorkspaceScratchDir(ws)`** — idempotent seed of the gitignored `WORKSPACE_CONTEXT_DIR`
+  scratch dir (mkdir + self-ignoring `*` `.gitignore`); the host calls it on **session create** for
+  every workspace, so the Default workspace writes into the user's repo only when a chat actually
+  starts there (worktree creation still seeds eagerly at create; this also self-heals a worktree
+  whose scratch dir was deleted).
 - **Lifecycle events:** every membership mutation — `createWorkspace` (`created`), `renameWorkspace`
   (`updated`, both the naive and agentic auto-rename passes since both go through it), `forgetWorkspace`
   (`removed`) — emits a `WorkspaceLifecycleEvent` through an **injected publisher** (`setWorkspacePublisher`,
@@ -66,6 +90,7 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   self-publishes), so registry membership stays shared domain state across every client (architecture #9).
 - **Public surface (barrel):** `createWorkspace`, `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`,
   `reclaimWorktree`, `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`,
+  `ensureWorkspaceScratchDir`,
   `setWorkspacePublisher`, `WorkspaceLifecycleEvent`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	createWorkspace,
+	ensureWorkspaceScratchDir,
 	forgetWorkspace,
 	listWorkspaces,
 	reclaimWorktree,
@@ -25,6 +26,11 @@ const savedDataDir = process.env.THINKRAIL_DATA_DIR;
 function git(cwd: string, ...args: string[]): void {
 	const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "ignore", stderr: "ignore" });
 	if (!result.success) throw new Error(`git ${args.join(" ")} failed`);
+}
+
+/** The project's worktree workspaces — `listWorkspaces` minus the always-ensured Default. */
+function worktrees(projectId = "p1") {
+	return listWorkspaces(projectId).filter((w) => w.kind !== "default");
 }
 
 beforeEach(() => {
@@ -127,8 +133,8 @@ test("renameWorkspace moves the branch in place: record + git follow, the worktr
 		"workspace-1",
 	);
 	// And the record on disk agrees.
-	expect(listWorkspaces("p1")[0]?.name).toBe("add login flow");
-	expect(listWorkspaces("p1")[0]?.branch).toBe("add-login-flow");
+	expect(worktrees()[0]?.name).toBe("add login flow");
+	expect(worktrees()[0]?.branch).toBe("add-login-flow");
 });
 
 test("renameWorkspace with lock:false renames name + branch but leaves renamed unset (provisional)", async () => {
@@ -139,7 +145,7 @@ test("renameWorkspace with lock:false renames name + branch but leaves renamed u
 	expect(renamed.branch).toBe("add-login-flow");
 	expect(renamed.renamed).toBeUndefined(); // still eligible for the agentic refinement
 	expect(gitOut(ws.worktreePath, "rev-parse", "--abbrev-ref", "HEAD")).toBe("add-login-flow");
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 
 	// A later default (lock) rename still moves the branch and now locks it.
 	const locked = renameWorkspace(ws.id, "final name");
@@ -197,12 +203,12 @@ test("creating after a rename skips the freed name whose worktree dir is still o
 
 test("forgetWorkspace drops the record + returns it, but leaves the worktree for a separate reclaim", async () => {
 	const ws = await createWorkspace("p1");
-	expect(listWorkspaces("p1")).toHaveLength(1);
+	expect(worktrees()).toHaveLength(1);
 
 	// forgetWorkspace removes the record synchronously (gone from the list) and hands back the record…
 	const forgotten = forgetWorkspace(ws.id);
 	expect(forgotten?.id).toBe(ws.id);
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 	// …but the worktree is still registered with git (the slow reclaim runs separately, e.g. backgrounded).
 	const before = Bun.spawnSync(["git", "-C", repo, "worktree", "list"], { stdout: "pipe" });
 	expect(new TextDecoder().decode(before.stdout)).toContain(ws.worktreePath);
@@ -238,20 +244,117 @@ test("a null publisher makes lifecycle emits silent no-ops", async () => {
 	setWorkspacePublisher(null);
 	const ws = await createWorkspace("p1");
 	expect(() => removeWorkspace(ws.id)).not.toThrow();
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 });
 
 test("removeWorkspace cleans up even when the worktree dir is already gone", async () => {
 	const ws = await createWorkspace("p1");
-	expect(listWorkspaces("p1")).toHaveLength(1);
+	expect(worktrees()).toHaveLength(1);
 
 	// Simulate drift: delete the worktree dir behind git's back so `git worktree remove` can't.
 	rmSync(ws.worktreePath, { recursive: true, force: true });
 
 	expect(() => removeWorkspace(ws.id)).not.toThrow();
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 
 	// git's worktree registration is pruned — no orphan left behind.
 	const list = Bun.spawnSync(["git", "-C", repo, "worktree", "list"], { stdout: "pipe" });
 	expect(new TextDecoder().decode(list.stdout)).not.toContain(ws.worktreePath);
+});
+
+// ─── The built-in Default workspace (kind: "default") ────────────────────────────────────────────
+
+test("listWorkspaces ensures exactly one Default workspace, pinned first, with folder-truth fields", async () => {
+	const first = listWorkspaces("p1");
+	const def = first[0];
+	expect(def?.kind).toBe("default");
+	expect(def?.name).toBe("Default");
+	expect(def?.worktreePath).toBe(repo); // the project folder itself — no worktree was added
+	expect(def?.branch).toBe("main");
+	expect(def?.baseBranch).toBe("main"); // no remote → the repo HEAD branch
+	expect(def?.renamed).toBe(true); // the auto-namer must never touch it
+
+	// Idempotent: repeated lists neither duplicate it nor mint a new id.
+	const again = listWorkspaces("p1");
+	expect(again.filter((w) => w.kind === "default")).toHaveLength(1);
+	expect(again[0]?.id).toBe(def?.id);
+
+	// A later worktree create stays behind the pinned Default.
+	await createWorkspace("p1");
+	const rows = listWorkspaces("p1");
+	expect(rows[0]?.kind).toBe("default");
+	expect(rows).toHaveLength(2);
+});
+
+test("the Default workspace's branch and base refresh from the folder on each list", async () => {
+	// A bare remote with main pushed: the default branch resolves to origin/main from here on.
+	const remoteRepo = join(dataDir, "remote.git");
+	git(repo, "init", "--bare", remoteRepo);
+	git(repo, "remote", "add", "origin", remoteRepo);
+	git(repo, "push", "origin", "main");
+	git(repo, "fetch", "origin");
+
+	expect(listWorkspaces("p1")[0]?.baseBranch).toBe("origin/main");
+
+	// The user switches branches in a terminal — the next list reflects the folder, quietly.
+	git(repo, "switch", "-c", "feature/x");
+	const def = listWorkspaces("p1")[0];
+	expect(def?.branch).toBe("feature/x");
+	expect(def?.baseBranch).toBe("origin/main");
+
+	// Committed work on the branch counts against the default branch (the Changes semantics).
+	writeFileSync(join(repo, "new.txt"), "one\ntwo\n");
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "feature work");
+	expect(listWorkspaces("p1")[0]?.diffStats?.added).toBe(2);
+});
+
+test("the Default workspace is non-removable and non-renamable — loud server-side guards", () => {
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+
+	expect(() => forgetWorkspace(def.id)).toThrow("The Default workspace cannot be removed");
+	expect(() => removeWorkspace(def.id)).toThrow("The Default workspace cannot be removed");
+	expect(() => renameWorkspace(def.id, "anything")).toThrow(
+		"The Default workspace cannot be renamed",
+	);
+	// Defense in depth: even handed the record directly, reclaim must never touch the project folder.
+	reclaimWorktree(def);
+	expect(existsSync(join(repo, "README.md"))).toBe(true);
+	// And the record survived every attempt.
+	expect(listWorkspaces("p1")[0]?.id).toBe(def.id);
+});
+
+test("duplicate Default records (out-of-band corruption) collapse to the oldest", () => {
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+
+	// Simulate corruption: a second default record appears behind the module's back.
+	const raw = JSON.parse(readFileSync(join(dataDir, "workspaces.json"), "utf8"));
+	raw.push({ ...def, id: "dupe" });
+	writeFileSync(join(dataDir, "workspaces.json"), JSON.stringify(raw));
+
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
+	const rows = listWorkspaces("p1");
+	expect(rows.filter((w) => w.kind === "default")).toHaveLength(1);
+	expect(rows[0]?.id).toBe(def.id); // the oldest record wins
+	expect(events).toEqual([{ kind: "removed", projectId: "p1", id: "dupe" }]);
+});
+
+test("ensuring the Default emits created once; listing never writes into the project folder", () => {
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
+
+	listWorkspaces("p1");
+	listWorkspaces("p1");
+	expect(events.map((e) => e.kind)).toEqual(["created"]); // once, not per list
+
+	// Listing/entering must not seed the scratch dir in the user's repo — only a chat start does.
+	expect(existsSync(join(repo, ".thinkrail"))).toBe(false);
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+	ensureWorkspaceScratchDir(def); // what the host runs on session.create
+	expect(readFileSync(join(repo, ".thinkrail", "context", ".gitignore"), "utf8")).toBe("*\n");
+	expect(gitOut(repo, "status", "--porcelain")).not.toContain(".thinkrail");
 });

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { DiffStats, Project, Workspace } from "@thinkrail/contracts";
 import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
-import { git, gitAsync } from "../git";
+import { currentBranch, git, gitAsync, resolveDefaultBranch } from "../git";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
 import { getProjects } from "../projects";
 
@@ -147,13 +147,6 @@ export async function createWorkspace(
 	const added = git(project.path, ["worktree", "add", worktreePath, "-b", branch, baseBranch]);
 	if (!added.ok) throw new Error(`git worktree add failed: ${added.err}`);
 
-	// Ephemeral per-workspace scratch dir for temp docs (task-specs / working files). Its `.gitignore` is
-	// a lone `*` — which matches the `.gitignore` itself — so the whole dir has zero git footprint yet
-	// stays scannable by the spec tools (they ignore only node_modules/.git/dist/build, not .gitignore).
-	const contextDir = join(worktreePath, WORKSPACE_CONTEXT_DIR);
-	mkdirSync(contextDir, { recursive: true });
-	writeFileSync(join(contextDir, ".gitignore"), "*\n");
-
 	const workspace: Workspace = {
 		id: randomUUID(),
 		projectId,
@@ -164,6 +157,77 @@ export async function createWorkspace(
 		// A user-chosen name is a deliberate one — the auto-namer must never touch it. Auto `workspace-N`
 		// leaves the flag unset: eligible for one assist rename.
 		...(displayName ? { renamed: true } : {}),
+	};
+	ensureWorkspaceScratchDir(workspace);
+	all.push(workspace);
+	saveWorkspaces(all);
+	emit({ kind: "created", workspace });
+	return workspace;
+}
+
+/**
+ * Idempotently seed a workspace's ephemeral scratch dir (`WORKSPACE_CONTEXT_DIR`) for temp docs
+ * (task-specs / working files). Its `.gitignore` is a lone `*` — which matches the `.gitignore`
+ * itself — so the whole dir has zero git footprint yet stays scannable by the spec tools (they ignore
+ * only node_modules/.git/dist/build, not .gitignore). Worktree creation seeds eagerly; the host also
+ * calls this on session create, which is what seeds the **Default** workspace — merely listing or
+ * entering it must never write into the user's repo, starting a chat there may.
+ */
+export function ensureWorkspaceScratchDir(ws: Workspace): void {
+	const contextDir = join(ws.worktreePath, WORKSPACE_CONTEXT_DIR);
+	mkdirSync(contextDir, { recursive: true });
+	writeFileSync(join(contextDir, ".gitignore"), "*\n");
+}
+
+/**
+ * Ensure the project's built-in **Default workspace** (`kind: "default"`) — the project folder itself
+ * (git's main working tree) surfaced as a workspace. Exactly one per project: find-or-create keyed by
+ * `projectId` + `kind` (the id is a plain `randomUUID` — the `kind` field is the marker, never an id
+ * convention), collapsing duplicates defensively if out-of-band state churn ever produced two (keep
+ * the oldest, emit `removed` for the rest so clients converge). No `git worktree add` (the folder
+ * already is a working tree) and no scratch-dir seeding (see `ensureWorkspaceScratchDir`).
+ *
+ * Fields are folder-truth: `branch` = whatever the folder has checked out, `baseBranch` = the repo's
+ * default branch — both refreshed **quietly** when they drifted out-of-band (no lifecycle event;
+ * membership didn't change). `renamed: true` keeps the auto-rename passes away, belt-and-suspenders on
+ * top of the hard guards in `renameWorkspace`/`forgetWorkspace`.
+ */
+function ensureDefaultWorkspace(project: Project): Workspace {
+	const all = loadWorkspaces();
+	const defaults = all.filter((w) => w.projectId === project.id && w.kind === "default");
+	const branch = currentBranch(project.path);
+	const baseBranch = resolveDefaultBranch(project.path);
+
+	const existing = defaults[0];
+	if (existing) {
+		let dirty = false;
+		if (defaults.length > 1) {
+			// Duplicates are corruption (the ensure is the only writer) — collapse to the oldest record.
+			const extras = defaults.slice(1);
+			const keep = all.filter((w) => !extras.includes(w));
+			all.length = 0;
+			all.push(...keep);
+			dirty = true;
+			for (const extra of extras) emit({ kind: "removed", projectId: project.id, id: extra.id });
+		}
+		if (existing.branch !== branch || existing.baseBranch !== baseBranch) {
+			existing.branch = branch;
+			existing.baseBranch = baseBranch;
+			dirty = true;
+		}
+		if (dirty) saveWorkspaces(all);
+		return existing;
+	}
+
+	const workspace: Workspace = {
+		id: randomUUID(),
+		projectId: project.id,
+		kind: "default",
+		name: "Default",
+		branch,
+		worktreePath: project.path,
+		baseBranch,
+		renamed: true,
 	};
 	all.push(workspace);
 	saveWorkspaces(all);
@@ -197,6 +261,8 @@ export function renameWorkspace(
 	const project = getProjects().find((p) => p.id === ws.projectId);
 	if (!project) throw new Error(`Unknown project: ${ws.projectId}`);
 
+	// The Default workspace's branch is the user's real branch — renaming would `git branch -m` it.
+	if (ws.kind === "default") throw new Error("The Default workspace cannot be renamed");
 	const displayName = toDisplayName(requestedName);
 	if (!displayName) throw new Error(`Invalid workspace name: ${requestedName}`);
 	const wanted = toBranch(displayName);
@@ -246,9 +312,15 @@ export function setWorkspaceSkillOverride(
 }
 
 export function listWorkspaces(projectId: string): Workspace[] {
-	return loadWorkspaces()
-		.filter((w) => w.projectId === projectId)
-		.map((w) => ({ ...w, diffStats: diffStats(w.worktreePath, w.baseBranch) }));
+	// Lazily ensure the built-in Default workspace on every list: find-or-create is idempotent, backfills
+	// projects opened before the feature existed, and self-heals out-of-band state churn (the e2e reset
+	// rewrites workspaces.json mid-run). Unknown project → no ensure, the filter returns [] as before.
+	const project = getProjects().find((p) => p.id === projectId);
+	if (project) ensureDefaultWorkspace(project);
+	const rows = loadWorkspaces().filter((w) => w.projectId === projectId);
+	// Pin the Default workspace first (creation order would put a backfilled one last).
+	rows.sort((a, b) => (a.kind === "default" ? -1 : 0) - (b.kind === "default" ? -1 : 0));
+	return rows.map((w) => ({ ...w, diffStats: diffStats(w.worktreePath, w.baseBranch) }));
 }
 
 /**
@@ -269,6 +341,10 @@ export function forgetWorkspace(id: string): Workspace | null {
 	const all = loadWorkspaces();
 	const ws = all.find((w) => w.id === id);
 	if (!ws) return null;
+	// Loud, before any side-effect: the record's worktreePath is the project folder — forgetting it
+	// would hand the archive teardown's `rm -rf` fallback the user's repo. The UI offers no Remove for
+	// it; this guard is for buggy/rogue clients.
+	if (ws.kind === "default") throw new Error("The Default workspace cannot be removed");
 	saveWorkspaces(all.filter((w) => w.id !== id));
 	emit({ kind: "removed", projectId: ws.projectId, id: ws.id });
 	return ws;
@@ -280,6 +356,9 @@ export function forgetWorkspace(id: string): Workspace | null {
  * dir if it lingers then `prune` the stale registration so `git worktree list` never orphans it.
  */
 export function reclaimWorktree(ws: Workspace): void {
+	// Defense in depth: never reclaim the project folder itself (`git worktree remove` would refuse the
+	// main working tree, but the hardened rm-fallback below would not).
+	if (ws.kind === "default") return;
 	const project = loadProjects().find((p) => p.id === ws.projectId);
 	if (!project) return;
 	const removed = git(project.path, ["worktree", "remove", "--force", ws.worktreePath]);


### PR DESCRIPTION
> **Stacked on #134** (the copy-only quick win) — this PR targets `welcome-copy-setup-note`, so its diff shows only the Default-workspace work. It retargets to `main` automatically once #134 merges.

## What

People were getting lost in the project → workspace (git worktree) model: opening a project landed on a Welcome screen with zero workspaces, and nothing represented "just work in my project folder."

Every project now carries exactly one built-in **Default workspace** (`Workspace.kind: "default"`) whose cwd is the **project folder itself** (git's *main working tree*) — **non-removable and non-renamable**, enforced server-side, not just hidden in the UI.

And the two working modes are now an **explicit choice** rather than a hidden default (second commit, after testing feedback): opening a project lands on its **Welcome**, where *Start building* (isolated worktree) sits beside *Work in project folder* (enters the Default), and the New-Workspace dialog carries a **target control** with a mode-aware header.

## Decisions (user-confirmed in the design rounds)

- **Label "Default"**, live current branch beneath it (the folder can be on any branch, so the label must not claim "main"), pinned first with a House icon.
- ~~Auto-enter on open~~ → **superseded**: opening a project lands on **Welcome**, the mode fork. Auto-enter hid that a choice existed.
- **Dialog target control** — *Isolated workspace* ↔ *Project folder*, always both visible; folder mode creates nothing (submit **enters** the Default), hides the base-branch picker + naming hint, and the button reads **Start**.
- **"Set up project"** keeps the full dialog, preselects **Project folder** (specs are ground truth — they land in place, no merge dance) and carries the explanatory note (the note itself ships in #134).
- **Changes = diff vs the repo's default branch** (`origin/HEAD` → `origin/main` → repo HEAD), same semantics as worktree workspaces.
- **Invariants:** exactly one per project · non-renamable · non-removable.

## How

- **contracts** — `Workspace.kind?: "default"` (explicit wire field, never an id convention); `PROTOCOL_VERSION` **17**.
- **server/workspaces** — lazily **ensured in `listWorkspaces`** (find-or-create: backfills existing projects, self-heals out-of-band state churn, collapses duplicate records); `branch`/`baseBranch` are folder-truth, refreshed quietly on drift; `forgetWorkspace`/`renameWorkspace` **throw** on it and `reclaimWorktree` refuses it — the archive teardown's `rm -rf` fallback must never see the project folder; `ensureWorkspaceScratchDir` extracted.
- **server/git** — `resolveDefaultBranch` factored (shared by the base picker + the ensure); `currentBranch` (unborn-HEAD-safe); `gitStatus` reports the Default's branch **live** so the Changes header never lags a terminal `git checkout`.
- **server/host** — `workspace.remove` rejects the Default loudly **before any side-effect**; `session.create` seeds the gitignored `.thinkrail/context/` scratch dir — merely opening a project never writes into the user's repo, starting a chat there does (zero git footprint via the self-ignoring gitignore).
- **web** — pinned Default row (House icon, no Remove button, `data-kind` hook); Welcome fork card + dialog target segment; new shared `panels/defaultWorkspace.ts` (`resolveDefaultWorkspace` — one resolve+degrade path for both); truthful empty-center receipt ("Chats, changes, and terminals run directly in your project folder").
- **specs first** — `workspaces`/`git`/`host`/`contracts`/`panels` SPECs, the `architecture.md` decision #6 exception, and `goal-and-requirements.md` updated as part of the change.

## Verification

- `bun run test` — **335 pass** (10 new workspaces tests: ensure idempotence, drift refresh, duplicate collapse, guards incl. `reclaimWorktree` refusing the project folder, scratch-dir laziness; 1 new git test: live status branch).
- `bun run e2e` — **101/101**, incl. `e2e/default-workspace.spec.ts` (fork card → Default, folder-cwd proof via terminal `pwd`, pin-first, no-Remove, uniqueness across re-opens, project-home gesture). Specs that landed on `main` meanwhile (`history-jump`, `history-search`, `templates.live`, `new-workspace`) were migrated to the `worktreeRows` fixture so the always-present Default row can't be mistaken for a worktree.
- `check:deps` / `lint` / `typecheck` clean; no suppressions added. Rebased onto fresh `main` (pi 0.82.1) — protocol 9 → 17, `DiffStatBadge`, slash-command completion and the skills/trust surfaces all reconciled.
