### PR TITLE
feat(server): background model-catalog refresh on model.list (#98)

### DIFF
--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -29,8 +29,18 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     one untouched — pinned by `piRuntime.test.ts`): catalog reads stay local (builtins + models.json +
     the persisted models-store), because `reloadConfig()`/`refresh()` await remote pi.dev catalog
     checks with no timeout — on the `provider.status` and jbcentral-connect paths that stalls wherever
-    egress is slow or blocked. Live catalog refresh is a
-    deliberate, detached opt-in (`refresh({ allowNetwork: true })`) tracked as a follow-up (issue #98). The **provider-credential surface** over this runtime —
+    egress is slow or blocked. The one deliberate opt-in to
+    live catalogs is **`refreshCatalogsDetached(runtime)`** (issue #98, mirroring pi's own `/model`):
+    **triggered by `model.list` only** (`listAvailableModels` fires it, then serves the current snapshot
+    — the picker read never awaits the network; a later read picks up what landed; broader triggers —
+    `model.default`, host boot — were considered and declined). Fire-and-forget semantics: per-call
+    `refresh({ allowNetwork: true })` — **no `force`**, so pi's provider freshness throttle decides
+    whether anything is fetched; **single-flight per runtime instance** (pi's `refresh()` doesn't dedupe
+    concurrent calls) with a **15s abort** (pi's model-selector budget — a hung refresh must self-expire
+    or single-flight would wedge) on an **unref'd** timer (must not hold a shutting-down host or a test
+    process open); failures `console.warn` + swallowed, never the picker's problem; **`PI_OFFLINE`**
+    (pi's env convention) disables it — the e2e webServer env and the manager's unit suite set it for
+    hermeticity. The **provider-credential surface** over this runtime —
     `provider.status` + in-app login — lives in the sibling `auth` module (which consumes `getPiRuntime`),
     **not** here.
   - `agentSessionManager` — sessions keyed by `session.sessionId` (each `Entry` also tracks its

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { InMemoryCredentialStore, type ModelsRefreshResult } from "@earendil-works/pi-ai";
 import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type { ExtUiRequest } from "@thinkrail/contracts";
@@ -56,6 +56,22 @@ const fauxB = createFauxCore({
 	models: [modelDef("fauxb")],
 	tokensPerSecond: 2000,
 });
+// Registered only DURING the catalog-refresh test below — the "newly shipped" model a refresh delivers.
+const fauxC = createFauxCore({
+	provider: "fauxc",
+	api: "fauxc",
+	models: [modelDef("fauxc")],
+	tokensPerSecond: 2000,
+});
+
+/** Provider config for `registerProvider` (baseUrl + apiKey are required when models are defined). */
+const cfg = (faux: typeof fauxA, id: string) => ({
+	api: faux.api,
+	baseUrl: "http://faux.local",
+	apiKey: "faux",
+	streamSimple: faux.streamSimple,
+	models: [{ ...modelDef(id), api: faux.api }],
+});
 
 const events = new Map<string, unknown[]>();
 const seen = (id: string) => JSON.stringify(events.get(id) ?? []);
@@ -68,26 +84,25 @@ function tmpCwd(prefix: string): string {
 }
 
 let priorAgentDir: string | undefined;
+let priorOffline: string | undefined;
+let runtime: ModelRuntime;
 
 beforeAll(async () => {
 	// Isolate pi's on-disk session files to a throwaway dir — the disk-reopen test writes real ones.
 	priorAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = tmpCwd("trpi-agentdir-");
 
+	// `listAvailableModels` fires a detached network catalog refresh (issue #98) — keep this suite
+	// hermetic the same way e2e is, via pi's own PI_OFFLINE convention. The refresh tests lift it locally.
+	priorOffline = process.env.PI_OFFLINE;
+	process.env.PI_OFFLINE = "1";
+
 	// A REAL runtime (in-memory credentials, no models.json, no network) with the faux providers
 	// registered as extension providers — their `streamSimple` does the real (in-process) work.
-	const runtime = await ModelRuntime.create({
+	runtime = await ModelRuntime.create({
 		credentials: new InMemoryCredentialStore(),
 		modelsPath: null,
 		allowModelNetwork: false,
-	});
-	const cfg = (faux: typeof fauxA, id: string) => ({
-		api: faux.api,
-		// baseUrl + apiKey are required when models are defined.
-		baseUrl: "http://faux.local",
-		apiKey: "faux",
-		streamSimple: faux.streamSimple,
-		models: [{ ...modelDef(id), api: faux.api }],
 	});
 	runtime.registerProvider("fauxa", cfg(fauxA, "fauxa"));
 	runtime.registerProvider("fauxb", cfg(fauxB, "fauxb"));
@@ -106,6 +121,8 @@ afterAll(() => {
 	for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
 	if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 	else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+	if (priorOffline === undefined) delete process.env.PI_OFFLINE;
+	else process.env.PI_OFFLINE = priorOffline;
 });
 
 test("two sessions in two worktrees stream independently; disposing one leaves the other working", async () => {
@@ -153,6 +170,65 @@ test("listAvailableModels returns the configured (faux) models", async () => {
 	const ids = (await listAvailableModels()).map((m) => m.id);
 	expect(ids).toContain("fauxa");
 	expect(ids).toContain("fauxb");
+});
+
+/** Let a detached refresh task's `.then/.finally` chain settle (macrotask — nothing sleeps). */
+const refreshSettled = () => new Promise<void>((r) => setTimeout(r, 0));
+
+test("model.list is never blocked by a hanging catalog refresh (fire-and-forget, issue #98)", async () => {
+	delete process.env.PI_OFFLINE;
+	const originalRefresh = runtime.refresh.bind(runtime);
+	let releaseHang = () => {};
+	try {
+		runtime.refresh = () =>
+			new Promise<ModelsRefreshResult>((resolve) => {
+				releaseHang = () => resolve({ aborted: false, errors: new Map() });
+			});
+		// Resolves immediately from the snapshot while the "network" refresh hangs unresolved.
+		const ids = (await listAvailableModels()).map((m) => m.id);
+		expect(ids).toContain("fauxa");
+	} finally {
+		releaseHang(); // frees the single-flight slot so this test leaves no pending state behind
+		await refreshSettled();
+		runtime.refresh = originalRefresh;
+		process.env.PI_OFFLINE = "1";
+	}
+});
+
+test("a newly-shipped catalog model appears on a later model.list without a restart (issue #98)", async () => {
+	delete process.env.PI_OFFLINE;
+	const originalRefresh = runtime.refresh.bind(runtime);
+	let landRefresh = () => {};
+	let refreshCalls = 0;
+	try {
+		// The first "network" refresh delivers a new provider+model when it lands — deferred, so the first
+		// read provably serves the pre-refresh snapshot. Any later trigger settles instantly and delivers
+		// nothing, mirroring pi's freshness throttle.
+		runtime.refresh = () => {
+			refreshCalls += 1;
+			if (refreshCalls > 1) return Promise.resolve({ aborted: false, errors: new Map() });
+			return new Promise<ModelsRefreshResult>((resolve) => {
+				landRefresh = () => {
+					runtime.registerProvider("fauxc", cfg(fauxC, "fauxc"));
+					resolve({ aborted: false, errors: new Map() });
+				};
+			});
+		};
+
+		const before = (await listAvailableModels()).map((m) => m.id); // triggers the detached refresh
+		expect(before).not.toContain("fauxc");
+
+		landRefresh();
+		await refreshSettled();
+
+		const after = (await listAvailableModels()).map((m) => m.id);
+		expect(after).toContain("fauxc");
+	} finally {
+		await refreshSettled(); // let the second trigger's instant refresh settle before restoring
+		runtime.unregisterProvider("fauxc");
+		runtime.refresh = originalRefresh;
+		process.env.PI_OFFLINE = "1";
+	}
 });
 
 test("wire models expose only the allowlisted fields (no baseUrl/headers/other Model fields)", async () => {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -20,7 +20,7 @@ import type {
 } from "@thinkrail/contracts";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import { buildResourceLoader } from "./extensions";
-import { getPiRuntime } from "./piRuntime";
+import { getPiRuntime, refreshCatalogsDetached } from "./piRuntime";
 import { repairDanglingToolCalls } from "./sessionRepair";
 import { cancelExtUiForSession, createWebUiContext, notifyExtUi } from "./webUiContext";
 
@@ -408,9 +408,13 @@ export function getSessionCommands(sessionId: string): SlashCommandInfo[] {
 }
 
 /** Models with configured auth, for the model picker (cheap win #1). Redacted to `WireModel` — the raw
- * `Model.baseUrl` carries the jbcentral proxy secret when wired, and the picker only reads id/name/provider. */
+ * `Model.baseUrl` carries the jbcentral proxy secret when wired, and the picker only reads id/name/provider.
+ * Also fires the detached catalog refresh (issue #98): the read below returns the current snapshot
+ * immediately — never awaiting the network — and a later `model.list` picks up whatever the refresh landed. */
 export async function listAvailableModels(): Promise<WireModel[]> {
-	const available = await (await getPiRuntime()).getAvailable();
+	const runtime = await getPiRuntime();
+	refreshCatalogsDetached(runtime);
+	const available = await runtime.getAvailable();
 	return available.map((m) => toWireModel(m as unknown as Model<string>));
 }
 

--- a/packages/server/src/agent/piRuntime.test.ts
+++ b/packages/server/src/agent/piRuntime.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
-import { configurePiRuntime, getPiRuntime } from "./piRuntime";
+import {
+	type CatalogRefreshRuntime,
+	configurePiRuntime,
+	getPiRuntime,
+	refreshCatalogsDetached,
+} from "./piRuntime";
 
 let priorOffline: string | undefined;
 beforeEach(() => {
@@ -70,4 +75,91 @@ test("a user-set PI_OFFLINE survives runtime creation untouched", async () => {
 	} finally {
 		cleanup(agentDir);
 	}
+});
+
+// ---- refreshCatalogsDetached (issue #98): detached, single-flight, throttle-respecting, offline-aware ----
+
+const OK: ModelsRefreshResult = { aborted: false, errors: new Map() };
+
+/** A fake runtime whose `refresh` is fully controlled by the test — settles only when told to. */
+function fakeRuntime() {
+	const calls: ModelsRefreshOptions[] = [];
+	let settle = { resolve: (_: ModelsRefreshResult) => {}, reject: (_: unknown) => {} };
+	const runtime: CatalogRefreshRuntime = {
+		refresh: (options?: ModelsRefreshOptions) => {
+			calls.push(options ?? {});
+			return new Promise<ModelsRefreshResult>((resolve, reject) => {
+				settle = { resolve, reject };
+			});
+		},
+	};
+	return {
+		runtime,
+		calls,
+		resolve: (result: ModelsRefreshResult = OK) => settle.resolve(result),
+		reject: (err: unknown) => settle.reject(err),
+	};
+}
+
+/** Let the refresh task's `.then/.catch/.finally` chain run (microtasks only — nothing sleeps). */
+const settled = () => new Promise<void>((r) => setTimeout(r, 0));
+
+test("opts into the network per-call but never forces past pi's freshness throttle", () => {
+	const { runtime, calls } = fakeRuntime();
+	refreshCatalogsDetached(runtime);
+	expect(calls.length).toBe(1);
+	const options = calls[0];
+	expect(options?.allowNetwork).toBe(true);
+	expect(options?.force).toBeUndefined();
+	expect(options?.signal).toBeInstanceOf(AbortSignal);
+});
+
+test("single-flight: repeated triggers while one refresh is pending don't stack network tasks", async () => {
+	const { runtime, calls, resolve } = fakeRuntime();
+	refreshCatalogsDetached(runtime);
+	refreshCatalogsDetached(runtime);
+	refreshCatalogsDetached(runtime);
+	expect(calls.length).toBe(1);
+
+	resolve();
+	await settled();
+	refreshCatalogsDetached(runtime); // the slot is free again once the previous refresh settled
+	expect(calls.length).toBe(2);
+});
+
+test("a rejected refresh is swallowed and does not wedge future refreshes", async () => {
+	const { runtime, calls, reject } = fakeRuntime();
+	refreshCatalogsDetached(runtime);
+	reject(new Error("pi.dev unreachable"));
+	await settled();
+
+	refreshCatalogsDetached(runtime);
+	expect(calls.length).toBe(2);
+});
+
+test("an aborted (timed-out) refresh is tolerated and frees the single-flight slot", async () => {
+	const { runtime, calls, resolve } = fakeRuntime();
+	refreshCatalogsDetached(runtime);
+	resolve({ aborted: true, errors: new Map() }); // what pi returns when our 15s signal fires
+	await settled();
+
+	refreshCatalogsDetached(runtime);
+	expect(calls.length).toBe(2);
+});
+
+test("per-provider failures in a completed refresh are tolerated (result is only logged)", async () => {
+	const { runtime, calls, resolve } = fakeRuntime();
+	refreshCatalogsDetached(runtime);
+	resolve({ aborted: false, errors: new Map([["someprovider", new Error("boom")]]) });
+	await settled();
+
+	refreshCatalogsDetached(runtime);
+	expect(calls.length).toBe(2);
+});
+
+test("PI_OFFLINE disables the refresh entirely", () => {
+	process.env.PI_OFFLINE = "1";
+	const { runtime, calls } = fakeRuntime();
+	refreshCatalogsDetached(runtime);
+	expect(calls.length).toBe(0);
 });

--- a/packages/server/src/agent/piRuntime.ts
+++ b/packages/server/src/agent/piRuntime.ts
@@ -20,8 +20,8 @@ export function configurePiRuntime(rt: ModelRuntime | null): void {
  * matching the pre-0.80.8 behavior. Without that, every `reloadConfig()`/`refresh()` — i.e. every
  * `provider.status` read and jbcentral connect — would await remote pi.dev catalog checks with **no
  * timeout** (the catalog fetch takes only the caller's signal, and `reloadConfig` passes none),
- * stalling those paths wherever that egress is slow or blocked (CI, offline). A deliberate, detached
- * catalog refresh (explicit `refresh({ allowNetwork: true })`) is tracked in issue #98.
+ * stalling those paths wherever that egress is slow or blocked (CI, offline). The one deliberate
+ * opt-in to live catalogs is `refreshCatalogsDetached` below (issue #98).
  *
  * HOW it stays local changed under us in pi 0.81: `allowModelNetwork: false` now gates only the
  * create-time refresh, while the runtime's ambient-network default (`modelNetworkEnabled`, what
@@ -54,4 +54,56 @@ export function getPiRuntime(): Promise<ModelRuntime> {
 		});
 	}
 	return runtime;
+}
+
+/** The slice of `ModelRuntime` the detached refresh needs — tests fake this, no cast required. */
+export type CatalogRefreshRuntime = Pick<ModelRuntime, "refresh">;
+
+// One in-flight refresh per runtime instance: pi's `refresh()` does NOT single-flight itself (verified
+// vs 0.81.1 — only the availability sub-refresh is queued), and each picker open triggers us again.
+const inflightCatalogRefresh = new WeakMap<CatalogRefreshRuntime, Promise<void>>();
+
+// pi's own model-selector refresh budget. With single-flight, a hung refresh must self-expire or it
+// would block every future refresh for the host's lifetime.
+const CATALOG_REFRESH_TIMEOUT_MS = 15_000;
+
+/**
+ * Fire-and-forget model-catalog refresh (issue #98) — the deliberate, detached opt-in to live catalogs
+ * over the shared ambient-network-OFF runtime (the per-call `allowNetwork: true` overrides its default).
+ * Triggered by `model.list` (the picker read) and nothing else — the caller returns the current
+ * snapshot immediately; a later read picks up whatever landed. Mirrors pi's own `/model`.
+ *
+ * Never awaited, never throws: pi's provider freshness throttle decides whether anything is fetched
+ * (no `force`), failures are logged and swallowed, and `PI_OFFLINE` (pi's env convention, also set by
+ * the e2e harness for hermeticity) disables it entirely.
+ */
+export function refreshCatalogsDetached(runtime: CatalogRefreshRuntime): void {
+	if (process.env.PI_OFFLINE) return;
+	if (inflightCatalogRefresh.has(runtime)) return;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), CATALOG_REFRESH_TIMEOUT_MS);
+	// The pending abort timer must keep neither a shutting-down host nor a test process alive.
+	timer.unref?.();
+	const task = runtime
+		.refresh({ allowNetwork: true, signal: controller.signal })
+		.then((result) => {
+			if (result.aborted) {
+				// Only our own timeout aborts this signal — say so, or a stuck egress looks like "all fresh".
+				console.warn(
+					`model catalog refresh timed out after ${CATALOG_REFRESH_TIMEOUT_MS}ms; serving cached catalogs`,
+				);
+			} else if (result.errors.size > 0) {
+				console.warn(
+					`model catalog refresh: provider(s) failed: ${[...result.errors.keys()].join(", ")}`,
+				);
+			}
+		})
+		.catch((err) => {
+			console.warn(`model catalog refresh failed: ${err}`);
+		})
+		.finally(() => {
+			clearTimeout(timer);
+			inflightCatalogRefresh.delete(runtime);
+		});
+	inflightCatalogRefresh.set(runtime, task);
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,6 +56,9 @@ export default defineConfig({
 			// @agent suite uses a real provider yet `setModel`/`setThinkingLevel` persist here — never the
 			// user's real `~/.pi/agent`. (Provider env vars in the inherited env still resolve auth too.)
 			PI_CODING_AGENT_DIR: E2E_PI_AGENT_DIR,
+			// Keep the suite hermetic: `model.list` fires a detached pi.dev catalog refresh (issue #98) that
+			// must never leave the machine in tests — PI_OFFLINE is pi's own convention and our guard honors it.
+			PI_OFFLINE: "1",
 			// Put the stub `central` first on PATH (see fakeBinDir), and pin the proxy port so wiring is
 			// deterministic and never reads the dev machine's real ~/.wire/config.json.
 			PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,


### PR DESCRIPTION
## What

Implements #98: `model.list` returns the current catalog snapshot **immediately** and fires a **detached** `runtime.refresh({ allowNetwork: true })`; a later read picks up whatever landed — newly-shipped catalog models appear in the picker **without a host restart**. Mirrors pi's own `/model`.

Builds on the pi-0.81 offline-construction fix (#104, merged): the shared runtime keeps ambient network OFF; this helper is the one deliberate, per-call opt-in.

## Design (task-spec'd, scope approved)

- **Trigger: `model.list` only.** Broader triggers (`model.default`, host boot) considered and declined — recorded in `packages/server/src/agent/SPEC.md` (piRuntime bullet, promoted from the old "tracked as follow-up" note).
- **`refreshCatalogsDetached(runtime)`** in `agent/piRuntime.ts`:
  - per-call `allowNetwork: true`, **never `force`** → pi's provider freshness throttle (~4h) decides whether anything is actually fetched;
  - **single-flight per runtime** — pi's `refresh()` doesn't dedupe concurrent calls (verified vs 0.81.1 source), and every picker open triggers us;
  - **15s abort** (pi's own model-selector budget) on an **unref'd** timer — a hung refresh must self-expire without wedging single-flight or holding a shutting-down host / test process open; a timed-out refresh is **logged** ("serving cached catalogs"), so stuck egress never masquerades as freshness;
  - failures `console.warn` + swallowed — never the picker request's problem;
  - **`PI_OFFLINE`** (pi's env convention) disables it — now also set in the e2e webServer env and the agent unit suite for hermeticity. (Verified against pi source: `PI_OFFLINE` never gates provider/OAuth auth, so the `@agent` suite is unaffected.)

## Acceptance criteria → tests

- `model.list` never awaits the network → *"model.list is never blocked by a hanging catalog refresh"* (agentSessionManager.test.ts)
- respects pi's throttle, failures logged not thrown → *"opts into the network per-call but never forces…"* + rejection / per-provider-error / aborted-timeout tests (piRuntime.test.ts)
- new model appears on a later read, no restart → *"a newly-shipped catalog model appears on a later model.list…"* (deferred refresh delivers a new faux provider)
- fire-and-forget, single-flight, offline guard — all pinned
- SPEC notes the refresh trigger ✓

## Verification

`check:deps` ✓ · lint ✓ · typecheck 9/9 ✓ · server unit suite **186/186** ✓ · `bun run e2e` **46/46** ✓ · suppression audit clean