### PR TITLE
feat(chat): Ctrl+R history search

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -52,7 +52,8 @@ screen, not a blank root).
 
 - `shell` → `panels`, `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`, `themes` (the single owner of the atomic `applyTheme` DOM effect, driven by `store.theme`)
 - `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` — `CenterTabs`'s per-tab boundary), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector` — these are shiki-free, so the eager import stays split-safe), `auth` (`ProvidersSettings` mounts `auth/LoginDialog`), `themes` (`AppearanceSettings` consumes the live catalog; code surfaces consume generic theme variables/syntax mapping)
-- `chat` → `contracts` (pi message types, **type-only**), `components/ui`, `lib`; `store` + `transport` (**`ChatView` only** — the renderers are store-free)
+- `chat` → `contracts` (pi message types, **type-only**), `components/ui`, `lib`; `store` + `transport`
+  (**`ChatView` + `useHistorySearch.ts` only** — the renderers stay store-free)
 - `auth` → `components/ui` (the dialog is store/transport-free — the panel integrates it; the state types need no imports)
 - `store` → `transport` (**type-only** — `ConnectionStatus`), `chat` (**type-only** — `ChatTurn`/`ToolResultState`), `auth` (**type-only** — `LoginState`; the `foldLoginFrame` reducer lives in `store`, like `reduceExtUi`), `contracts`
 - `transport` → `contracts`, `store` (welcome routing; the `store → transport` back-edge is type-only, so

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -329,10 +329,14 @@ export default function ChatView({
 		const prefix = anchorText.slice(0, 40);
 		const mappedId = runtime.turnIdByMessageIndex?.[messageIndex];
 		const mapped = mappedId ? turns.find((t) => t.id === mappedId) : undefined;
+		// Fall back to the NEWEST turn whose text matches the anchor (`findLast`, not `find`): a hit is
+		// deduped to its newest occurrence, so when there's no exact index map (a never-hydrated live chat)
+		// or the mapped turn's text no longer matches, the newest match is the right target — matching the
+		// oldest would jump repeated prompts to a stale earlier turn.
 		const target =
 			mapped && turnAnchorText(mapped).includes(prefix)
 				? mapped
-				: turns.find((t) => turnAnchorText(t).includes(prefix));
+				: turns.findLast((t) => turnAnchorText(t).includes(prefix));
 		const index = target ? rowIndexForTurn(rows, target.id) : -1;
 		if (index === -1) {
 			toast.error("couldn't locate the message — the session may have changed");

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -307,11 +307,12 @@ export default function ChatView({
 		closeHistory();
 	};
 
-	// Cmd/Ctrl+Enter on a prompt hit: reuse the exact `onSubmit` path a normal composer send takes, then
-	// clear the draft the same way `Composer`'s own `submit()` does after sending.
+	// Cmd/Ctrl+Enter on a prompt hit: send through the composer's own submit seam (its imperative
+	// handle), never a ChatView-side `onSubmit` call — the composer privately holds pending image
+	// attachments, and only its own path sends them with the text and clears them with the draft
+	// (which also resets the store draft via the composer's `onChange("")`).
 	const onInsertAndSendHit = (hit: PromptHit) => {
-		onSubmit(hit.text, [], isStreaming ? "followUp" : "send");
-		useAppStore.getState().setChatDraft(sessionId, "");
+		composerRef.current?.insertAndSubmit(hit.text, isStreaming ? "followUp" : "send");
 		closeHistory();
 	};
 

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -1,6 +1,7 @@
 import type {
 	AskUserQuestionResult,
 	ImageContent,
+	PromptHit,
 	ThinkingLevel,
 	WireModel,
 } from "@thinkrail/contracts";
@@ -8,21 +9,55 @@ import { ArrowDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { Popover, PopoverAnchor, PopoverTrigger } from "@/components/ui/popover";
-import { EMPTY_RUNTIME, selectSkillsStale, useAppStore } from "@/store";
+import { EMPTY_RUNTIME, selectSkillsStale, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { type ChatActions, ChatActionsContext } from "./ChatActions";
 import { ChatHeader } from "./ChatHeader";
 import { ChatPlanContent, ChatPlanStripContent } from "./ChatPlan";
-import { Composer, type MentionCandidate, type SubmitBehavior } from "./Composer";
+import {
+	Composer,
+	type ComposerHandle,
+	type MentionCandidate,
+	type SubmitBehavior,
+} from "./Composer";
 import { ExtUiDialog } from "./ExtUiDialog";
-import { type ChatRow, deriveRows } from "./rows";
+import { HistoryOverlay } from "./HistoryOverlay";
+import { type ChatRow, deriveRows, rowIndexForTurn } from "./rows";
 import { SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
 import "./tools/register"; // side-effect: register the built-in pi tool renderers (bash/read/edit/write)
 import { ChatTurnView } from "./turns";
+import type { ChatTurn } from "./types";
 import { useChatScroll } from "./useChatScroll";
 import { useChatTodos } from "./useChatTodos";
+import { useHistorySearch } from "./useHistorySearch";
+
+/**
+ * Best-effort plain text for a turn — user: `message.content` (a plain string, or text/image blocks);
+ * assistant: joined text blocks. `system`/`error`/`retry` turns fall through to `""`. Two consumers:
+ * anchor-matching a `chatLocationRequest` jump target (`turnIdByMessageIndex` only maps user/assistant
+ * messages, so a non-anchor turn's `""` never matches and is never wrongly selected by the fallback scan),
+ * and `recentPrompts` below (user turns only, so the assistant/`""` branches never surface there).
+ */
+function turnAnchorText(turn: ChatTurn): string {
+	if (turn.kind === "user") {
+		const { content } = turn.message;
+		return typeof content === "string"
+			? content
+			: content
+					.filter((b) => b.type === "text")
+					.map((b) => b.text)
+					.join("\n");
+	}
+	if (turn.kind === "assistant") {
+		return turn.message.content
+			.filter((b) => b.type === "text")
+			.map((b) => b.text)
+			.join("\n");
+	}
+	return "";
+}
 
 /** Context threaded to the Virtuoso footer so the streaming loader lives at the end of the conversation. */
 type ChatListContext = { status: StreamStatus | null };
@@ -57,12 +92,13 @@ export default function ChatView({
 	// chat streaming into its own runtime never re-renders the foreground one.
 	const runtime = useAppStore((s) => s.sessions[sessionId]) ?? EMPTY_RUNTIME;
 	const models = useAppStore((s) => s.models);
-	// This chat's owning project (workspaces are keyed by project) — for the Skills manager's trust ops.
+	// This chat's owning project (workspaces are keyed by project) — for the Skills manager's trust ops
+	// and the "project" / "all" history-search scopes.
 	const projectId = useAppStore(
 		(s) =>
 			Object.values(s.workspaces)
 				.flat()
-				.find((w) => w.id === workspaceId)?.projectId ?? null,
+				.find((w) => w.id === workspaceId)?.projectId,
 	);
 	const [skillsOpen, setSkillsOpen] = useState(false);
 	// Auto-detect: a skill dir changed on disk (pull/branch/edit) after this session loaded — flag a manual
@@ -76,6 +112,17 @@ export default function ChatView({
 		}
 		return undefined;
 	});
+	// The raw record is a stable reference from zustand's perspective (unlike a fresh object/array
+	// literal, which would re-render this view on every unrelated store update); the workspaceId →
+	// display-name map the history overlay's cross-workspace chip needs is derived below in a `useMemo`.
+	const workspaces = useAppStore((s) => s.workspaces);
+	const workspaceNames = useMemo(() => {
+		const map: Record<string, string> = {};
+		for (const list of Object.values(workspaces)) {
+			for (const w of list) map[w.id] = w.name;
+		}
+		return map;
+	}, [workspaces]);
 	const {
 		turns,
 		toolResults,
@@ -108,6 +155,20 @@ export default function ChatView({
 		return { status };
 	}, [turns, isStreaming, currentAssistantId]);
 
+	// The plain `↑`-recall list (`Composer`'s `recentPrompts` prop): this chat's own user-turn texts,
+	// newest first, deduped keeping the NEWEST occurrence — the same recency-first ranking rule as the
+	// server history index (and the atuin/fzf convention it follows). Reuses `turnAnchorText`'s
+	// user-content extraction (string, or joined text blocks) rather than re-deriving it. Reverse to
+	// newest→oldest *before* deduping: `Set` keeps each string's first-seen entry, so reversing first
+	// makes that first-seen entry the newest one, not the oldest (see `chat/SPEC.md`).
+	const recentPrompts = useMemo(() => {
+		const texts = turns
+			.filter((t) => t.kind === "user")
+			.map((t) => turnAnchorText(t))
+			.filter(Boolean);
+		return [...new Set(texts.reverse())];
+	}, [turns]);
+
 	const [mentionQuery, setMentionQuery] = useState<string | null>(null);
 	const [mentionCandidates, setMentionCandidates] = useState<MentionCandidate[]>([]);
 	// The chat's TODO plan, surfaced inline via a header strip that opens a popup over the chat (SPEC §Chat TODO plan).
@@ -117,6 +178,28 @@ export default function ChatView({
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
 	const { followOutput, handleAtBottom, showScrollButton, scrollToBottom, containerProps } =
 		useChatScroll(virtuosoRef);
+	const composerRef = useRef<ComposerHandle>(null);
+
+	// The Ctrl+R history-recall overlay's integration edge (store/transport) — see `chat/SPEC.md`'s
+	// boundary section for why this hook, not this component's body, owns that edge.
+	const {
+		state: historyState,
+		openOverlay,
+		close: closeHistory,
+		setQuery,
+		cycleScope,
+		setScope,
+		toggleStage,
+		moveSelection,
+		openMessage,
+	} = useHistorySearch(sessionId, workspaceId, projectId);
+
+	// The history-search "jump to message" deep link this session is the target of, if any — cleared by
+	// this effect below once it has resolved (or failed to resolve) a row to scroll to. `CenterTabs` is the
+	// other consumer: it opens/hydrates the target chat's tab but never clears the request (see its own
+	// effect's jsdoc).
+	const chatLocationRequest = useAppStore((s) => s.chatLocationRequest);
+	const [flashRowId, setFlashRowId] = useState<string | null>(null);
 
 	// Models are global to the host — fetch once, then every chat's picker shares them.
 	useEffect(() => {
@@ -214,6 +297,64 @@ export default function ChatView({
 			.catch(() => {});
 	};
 
+	// Ctrl+R in the composer seeds the overlay with the current draft (never a stale store value) —
+	// `useHistorySearch` owns everything from here (debounce, scope cycling, stale-response drop).
+	const onHistoryOpen = () => openOverlay(draft);
+
+	// Enter on a prompt hit: replace the draft, focus, caret at end, close — no submit.
+	const onInsertHit = (hit: PromptHit) => {
+		composerRef.current?.insertText(hit.text);
+		closeHistory();
+	};
+
+	// Cmd/Ctrl+Enter on a prompt hit: reuse the exact `onSubmit` path a normal composer send takes, then
+	// clear the draft the same way `Composer`'s own `submit()` does after sending.
+	const onInsertAndSendHit = (hit: PromptHit) => {
+		onSubmit(hit.text, [], isStreaming ? "followUp" : "send");
+		useAppStore.getState().setChatDraft(sessionId, "");
+		closeHistory();
+	};
+
+	// Consume a `chatLocationRequest` targeting this session: resolve its `messageIndex` to a turn (via
+	// `turnIdByMessageIndex`, falling back to scanning by `anchorText` when the map entry is absent —
+	// e.g. this runtime came from an already-live `hydrateSession` no-op, or the index is stale after
+	// compaction — or when the mapped turn's own text no longer contains the anchor), scroll its row into
+	// view, and flash it briefly. `rows.length > 0` guards against running before the transcript is ready
+	// (a fresh tab renders zero rows for one tick). Always clears the request — this is its only consumer.
+	useEffect(() => {
+		if (!chatLocationRequest || chatLocationRequest.sessionId !== sessionId || rows.length === 0) {
+			return;
+		}
+		const { messageIndex, anchorText } = chatLocationRequest;
+		const prefix = anchorText.slice(0, 40);
+		const mappedId = runtime.turnIdByMessageIndex?.[messageIndex];
+		const mapped = mappedId ? turns.find((t) => t.id === mappedId) : undefined;
+		const target =
+			mapped && turnAnchorText(mapped).includes(prefix)
+				? mapped
+				: turns.find((t) => turnAnchorText(t).includes(prefix));
+		const index = target ? rowIndexForTurn(rows, target.id) : -1;
+		if (index === -1) {
+			toast.error("couldn't locate the message — the session may have changed");
+			useAppStore.getState().clearChatLocation();
+			return;
+		}
+		virtuosoRef.current?.scrollToIndex({ index, align: "center" });
+		setFlashRowId(rows[index]?.id ?? null);
+		useAppStore.getState().clearChatLocation();
+	}, [chatLocationRequest, sessionId, rows, runtime.turnIdByMessageIndex, turns]);
+
+	// Auto-clear the flash, decoupled from the effect above: `clearChatLocation()` there flips
+	// `chatLocationRequest` to null, which is one of that effect's own deps — if the timeout lived there,
+	// the re-run's cleanup would cancel it (and the re-run bails on `!chatLocationRequest` before
+	// scheduling a replacement), so `flashRowId` would never reset. Keying solely on `flashRowId` avoids
+	// that churn: this effect only fires when a flash actually starts or ends.
+	useEffect(() => {
+		if (flashRowId === null) return;
+		const timer = setTimeout(() => setFlashRowId(null), 1600);
+		return () => clearTimeout(timer);
+	}, [flashRowId]);
+
 	// A turn-divider's "files changed" chip → deep-link the right panel to the first changed file (flip to
 	// Changes + highlight its row; the diff opens only on an explicit click). This is the one chat touch of
 	// the store outside the renderers, kept here in the integration layer.
@@ -307,7 +448,10 @@ export default function ChatView({
 							// Row ids are stable across streaming snapshots (rows.ts), so items never remount mid-stream.
 							computeItemKey={(_, row) => row.id}
 							itemContent={(_, row) => (
-								<div className="mx-auto max-w-3xl px-md py-xs">
+								<div
+									data-flash={row.id === flashRowId || undefined}
+									className="mx-auto max-w-3xl rounded-[var(--radius-md)] px-md py-xs transition-colors data-[flash]:bg-[var(--primary-10)]"
+								>
 									<ChatTurnView
 										row={row}
 										workspaceRoot={workspaceRoot}
@@ -335,21 +479,39 @@ export default function ChatView({
 							))}
 						</div>
 					) : null}
-					<Composer
-						value={draft}
-						onChange={(v) => useAppStore.getState().setChatDraft(sessionId, v)}
-						isStreaming={isStreaming}
-						commands={commands}
-						mentionCandidates={mentionCandidates}
-						models={models}
-						currentModel={currentModel}
-						thinkingLevel={thinkingLevel}
-						onMentionQuery={onMentionQuery}
-						onSelectModel={onSelectModel}
-						onSelectThinking={onSelectThinking}
-						onSubmit={onSubmit}
-						onAbort={onAbort}
-					/>
+					<div className="relative shrink-0">
+						<HistoryOverlay
+							state={historyState}
+							workspaceNames={workspaceNames}
+							onQueryChange={setQuery}
+							onCycleScope={cycleScope}
+							onSetScope={setScope}
+							onToggleStage={toggleStage}
+							onMoveSelection={moveSelection}
+							onClose={closeHistory}
+							onInsert={onInsertHit}
+							onInsertAndSend={onInsertAndSendHit}
+							onOpenMessage={openMessage}
+						/>
+						<Composer
+							ref={composerRef}
+							value={draft}
+							onChange={(v) => useAppStore.getState().setChatDraft(sessionId, v)}
+							isStreaming={isStreaming}
+							commands={commands}
+							mentionCandidates={mentionCandidates}
+							recentPrompts={recentPrompts}
+							models={models}
+							currentModel={currentModel}
+							thinkingLevel={thinkingLevel}
+							onMentionQuery={onMentionQuery}
+							onSelectModel={onSelectModel}
+							onSelectThinking={onSelectThinking}
+							onSubmit={onSubmit}
+							onAbort={onAbort}
+							onHistoryOpen={onHistoryOpen}
+						/>
+					</div>
 					{pendingExtUi ? (
 						<ExtUiDialog key={pendingExtUi.id} request={pendingExtUi} onReply={onExtUiReply} />
 					) : null}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -169,15 +169,25 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	/** Place a collapsed caret at `pos` (after the current commit — see `pendingCaret` above). */
 	const focusCaret = useCallback((pos: number) => setPendingCaret(pos), []);
 
+	// The single seam for replacing the draft programmatically (history recall, mention, slash). Sets the
+	// value, places the caret, and — crucially — exits any active `↑`-recall session: these paths set the
+	// controlled `value` directly (not via the textarea's `onChange`), so the diverging-edit reset there
+	// never fires, and a leftover `recallIdx` would let a subsequent `↓` overwrite what was just inserted.
+	const replaceDraft = useCallback(
+		(text: string, caret: number = text.length) => {
+			setRecallIdx(null);
+			onChange(text);
+			focusCaret(caret);
+		},
+		[onChange, focusCaret],
+	);
+
 	useImperativeHandle(
 		handleRef,
 		() => ({
-			insertText: (text: string) => {
-				onChange(text);
-				focusCaret(text.length);
-			},
+			insertText: (text: string) => replaceDraft(text),
 		}),
-		[onChange, focusCaret],
+		[replaceDraft],
 	);
 
 	const pickMention = (c: MentionCandidate) => {
@@ -185,19 +195,26 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		const after = value.slice(caret);
 		const insert = c.kind === "dir" ? `@${c.path}/` : `@${c.path}`;
 		const suffix = c.kind === "dir" ? "" : " ";
-		onChange(`${before}${insert}${suffix}${after}`);
-		focusCaret(before.length + insert.length + suffix.length);
+		replaceDraft(
+			`${before}${insert}${suffix}${after}`,
+			before.length + insert.length + suffix.length,
+		);
 	};
 
 	const slashCompletion = useSlashCommandCompletion({
 		value,
 		commands,
-		onSelect: (command) => {
-			const next = selectedSlashCommandValue(command);
-			onChange(next);
-			focusCaret(next.length);
-		},
+		onSelect: (command) => replaceDraft(selectedSlashCommandValue(command)),
 	});
+
+	// The single entry point to the history overlay — both the `Ctrl+R` chord and the always-rendered
+	// history button go through here, so both dismiss any open mention/slash menu first (the two floating
+	// panels share the composer's anchor rect; leaving one open would paint both at once).
+	const openHistory = () => {
+		setMentionDismissed(true);
+		slashCompletion.dismiss();
+		onHistoryOpen?.();
+	};
 
 	const addFiles = async (files: File[]) => {
 		const picked = files.filter((f) => f.type.startsWith("image/"));
@@ -230,9 +247,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		// both at once (mutual exclusion between the composer's floating panels).
 		if (e.key === "r" && e.ctrlKey && !e.metaKey && !e.altKey) {
 			e.preventDefault();
-			setMentionDismissed(true);
-			slashCompletion.dismiss();
-			onHistoryOpen?.();
+			openHistory();
 			return;
 		}
 		if (mentionOpen) {
@@ -409,7 +424,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							type="button"
 							data-testid="history-open"
 							aria-label="Search history"
-							onClick={() => onHistoryOpen?.()}
+							onClick={openHistory}
 							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border2 bg-elevated text-text hover:bg-hover"
 						>
 							<History className="size-3.5" />

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -4,12 +4,16 @@ import type {
 	ThinkingLevel,
 	WireModel,
 } from "@thinkrail/contracts";
-import { ArrowUp, FileIcon, FolderIcon, Square, X } from "lucide-react";
+import { ArrowUp, FileIcon, FolderIcon, History, Square, X } from "lucide-react";
 import {
 	type ClipboardEvent,
 	type DragEvent,
+	forwardRef,
 	type KeyboardEvent,
+	useCallback,
 	useEffect,
+	useImperativeHandle,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";
@@ -60,32 +64,15 @@ function activeToken(value: string, caret: number): { token: string; start: numb
 	return { token: match[0], start: caret - match[0].length };
 }
 
-/**
- * The chat composer (props-driven, no store/transport). Enter sends (or **steers** mid-stream);
- * Cmd/Ctrl+Enter queues a **follow-up**; a Stop button **aborts**. The model + effort controls sit in
- * the row under the tall prompt field, mirroring the New-Workspace dialog's layout. `@` opens worktree
- * file completion, a leading `/` opens the skill/command menu, and images can be pasted or dropped in.
- */
-export function Composer({
-	value,
-	onChange,
-	isStreaming,
-	commands,
-	mentionCandidates,
-	models,
-	currentModel,
-	thinkingLevel,
-	onMentionQuery,
-	onSelectModel,
-	onSelectThinking,
-	onSubmit,
-	onAbort,
-}: {
+interface ComposerProps {
 	value: string;
 	onChange: (value: string) => void;
 	isStreaming: boolean;
 	commands: SlashCommandInfo[];
 	mentionCandidates: MentionCandidate[];
+	/** This chat's own prior user-turn texts (newest first, deduped) — backs the plain `↑` recall session
+	 * below; `ChatView` derives it from `turns` via `turnAnchorText`. */
+	recentPrompts: string[];
 	models: WireModel[];
 	currentModel: WireModel | null;
 	thinkingLevel: ThinkingLevel;
@@ -94,12 +81,55 @@ export function Composer({
 	onSelectThinking: (level: ThinkingLevel) => void;
 	onSubmit: (text: string, images: ImageContent[], behavior: SubmitBehavior) => void;
 	onAbort: () => void;
-}) {
+	/** `Ctrl+R` — opens the history-recall overlay (`ChatView` seeds it with the current draft). Optional
+	 * so a standalone/storybook-style render of `Composer` doesn't need to wire it. */
+	onHistoryOpen?: () => void;
+}
+
+/** Imperative handle so `ChatView` can insert a recalled prompt without reaching into the DOM itself. */
+export interface ComposerHandle {
+	/** Replace the draft, focus the textarea, and place the caret at the end. */
+	insertText: (text: string) => void;
+}
+
+/**
+ * The chat composer (props-driven, no store/transport). Enter sends (or **steers** mid-stream);
+ * Cmd/Ctrl+Enter queues a **follow-up**; a Stop button **aborts**. The model + effort controls sit in
+ * the row under the tall prompt field, mirroring the New-Workspace dialog's layout. `@` opens worktree
+ * file completion, a leading `/` opens the skill/command menu, `Ctrl+R` opens history recall (also
+ * reachable via the always-rendered `history-open` button), plain `↑`/`↓` recall step through
+ * `recentPrompts` when the field is empty or a recall session is already active, and images can be pasted
+ * or dropped in.
+ */
+export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer(
+	{
+		value,
+		onChange,
+		isStreaming,
+		commands,
+		mentionCandidates,
+		recentPrompts,
+		models,
+		currentModel,
+		thinkingLevel,
+		onMentionQuery,
+		onSelectModel,
+		onSelectThinking,
+		onSubmit,
+		onAbort,
+		onHistoryOpen,
+	},
+	handleRef,
+) {
 	const ref = useRef<HTMLTextAreaElement>(null);
 	const [caret, setCaret] = useState(0);
 	const [images, setImages] = useState<PendingImage[]>([]);
 	const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
 	const [mentionDismissed, setMentionDismissed] = useState(false);
+	// The plain `↑`-recall session: `null` when inactive; otherwise an index into `recentPrompts` (0 =
+	// newest). Reset on a diverging edit (the textarea's `onChange` below) or a submit — see `onKeyDown`'s
+	// recall block (after the mention/slash menu) for the stepping rules.
+	const [recallIdx, setRecallIdx] = useState<number | null>(null);
 
 	const { token, start } = activeToken(value, caret);
 	const mentionQuery = token.startsWith("@") ? token.slice(1) : null;
@@ -113,15 +143,42 @@ export function Composer({
 
 	const mentionOpen = !mentionDismissed && mentionQuery !== null && mentionCandidates.length > 0;
 
-	const focusCaret = (pos: number) => {
-		requestAnimationFrame(() => {
-			const el = ref.current;
-			if (!el) return;
+	// A one-shot imperative caret move requested by `focusCaret`, applied in `useLayoutEffect` below rather
+	// than a `requestAnimationFrame`: RAF only guarantees "before the next paint", leaving a gap *after the
+	// current task ends* where another actor touching the same textarea's selection (a fast follow-up
+	// keystroke, Playwright's `fill()`, a paste) can run first — a stale RAF then collapses *that* selection
+	// instead of the one it was scheduled for. Concretely: `fill()` does select-all then insert-text as
+	// separate steps; if a stale RAF's `setSelectionRange(pos, pos)` fires in the gap between them, it
+	// collapses the select-all to a bare caret, so the subsequent insert appends at `pos` instead of
+	// replacing — producing a doubled `oldValue + newValue` (this is the exact mechanism behind the flake
+	// once seen on the recall test below). `useLayoutEffect` runs synchronously in React's commit phase, in
+	// the same task as the keystroke that triggered it, so there is no gap for anything else to interleave.
+	const [pendingCaret, setPendingCaret] = useState<number | null>(null);
+
+	useLayoutEffect(() => {
+		if (pendingCaret === null) return;
+		const el = ref.current;
+		if (el) {
 			el.focus();
-			el.setSelectionRange(pos, pos);
-			setCaret(pos);
-		});
-	};
+			el.setSelectionRange(pendingCaret, pendingCaret);
+		}
+		setCaret(pendingCaret);
+		setPendingCaret(null);
+	}, [pendingCaret]);
+
+	/** Place a collapsed caret at `pos` (after the current commit — see `pendingCaret` above). */
+	const focusCaret = useCallback((pos: number) => setPendingCaret(pos), []);
+
+	useImperativeHandle(
+		handleRef,
+		() => ({
+			insertText: (text: string) => {
+				onChange(text);
+				focusCaret(text.length);
+			},
+		}),
+		[onChange, focusCaret],
+	);
 
 	const pickMention = (c: MentionCandidate) => {
 		const before = value.slice(0, start);
@@ -162,9 +219,22 @@ export function Composer({
 		);
 		onChange("");
 		setImages([]);
+		setRecallIdx(null);
 	};
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+		// Ctrl+R opens history recall — guarded at the very top, before the mention/slash menu, and before
+		// Enter-to-send. Ctrl+R is the browser-reload chord on Windows/Linux, so this must preventDefault
+		// unconditionally; Cmd+R (mac reload) and Alt+R are left alone. Dismiss any open mention/slash menu
+		// first — the two floating panels share the same anchor rect, so leaving the menu open would paint
+		// both at once (mutual exclusion between the composer's floating panels).
+		if (e.key === "r" && e.ctrlKey && !e.metaKey && !e.altKey) {
+			e.preventDefault();
+			setMentionDismissed(true);
+			slashCompletion.dismiss();
+			onHistoryOpen?.();
+			return;
+		}
 		if (mentionOpen) {
 			const menuLen = mentionCandidates.length;
 			if (e.key === "ArrowDown") {
@@ -190,6 +260,36 @@ export function Composer({
 			}
 		}
 		if (slashCompletion.handleKeyDown(e)) return;
+		// Plain `↑`/`↓` recall — reached only once the mention/slash menu is closed (every menu-open branch
+		// above returns before falling through, and `slashCompletion.handleKeyDown` consumes its keys while
+		// its menu is open). `↑` steps in only when there's nothing to lose (an empty field) or a recall
+		// session is already active, so it can never eat a draft; `↓` only steps while a session is active.
+		// Both place the caret at the recalled text's end, matching `insertText`/`pickMention`/the slash
+		// completion's own focus-after-change pattern.
+		if (e.key === "ArrowUp" && (value === "" || recallIdx !== null) && recentPrompts.length > 0) {
+			e.preventDefault();
+			const next = recallIdx === null ? 0 : Math.min(recallIdx + 1, recentPrompts.length - 1);
+			const text = recentPrompts[next] ?? "";
+			setRecallIdx(next);
+			onChange(text);
+			focusCaret(text.length);
+			return;
+		}
+		if (e.key === "ArrowDown" && recallIdx !== null) {
+			e.preventDefault();
+			if (recallIdx === 0) {
+				setRecallIdx(null);
+				onChange("");
+				focusCaret(0);
+			} else {
+				const next = recallIdx - 1;
+				const text = recentPrompts[next] ?? "";
+				setRecallIdx(next);
+				onChange(text);
+				focusCaret(text.length);
+			}
+			return;
+		}
 		if (e.key === "Enter" && !e.shiftKey) {
 			e.preventDefault();
 			const behavior: SubmitBehavior = isStreaming
@@ -276,7 +376,12 @@ export function Composer({
 					data-testid="chat-input"
 					value={value}
 					onChange={(e) => {
-						onChange(e.target.value);
+						const next = e.target.value;
+						// A genuine user edit (typing/pasting/deleting — never fired by the recall/insert paths
+						// themselves, since those set the controlled `value` prop directly rather than mutating the
+						// DOM node) that diverges from the recalled entry exits the recall session.
+						if (recallIdx !== null && next !== recentPrompts[recallIdx]) setRecallIdx(null);
+						onChange(next);
 						setCaret(e.target.selectionStart);
 					}}
 					onKeyUp={(e) => setCaret(e.currentTarget.selectionStart)}
@@ -298,6 +403,17 @@ export function Composer({
 						<ThinkingSelector level={thinkingLevel} onSelect={onSelectThinking} />
 					</div>
 					<div className="flex shrink-0 items-center gap-sm">
+						{/* Always rendered — the tap path to history recall on mobile, and a discoverability
+						 * affordance for `Ctrl+R` on desktop; both open the exact same overlay via `onHistoryOpen`. */}
+						<button
+							type="button"
+							data-testid="history-open"
+							aria-label="Search history"
+							onClick={() => onHistoryOpen?.()}
+							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border2 bg-elevated text-text hover:bg-hover"
+						>
+							<History className="size-3.5" />
+						</button>
 						{isStreaming ? (
 							<button
 								type="button"
@@ -324,4 +440,4 @@ export function Composer({
 			</div>
 		</div>
 	);
-}
+});

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -90,6 +90,11 @@ interface ComposerProps {
 export interface ComposerHandle {
 	/** Replace the draft, focus the textarea, and place the caret at the end. */
 	insertText: (text: string) => void;
+	/** Replace the draft and send it through the composer's own submit seam — pending image attachments
+	 * travel with the text and are cleared with the draft, exactly like a keyboard send. This is the
+	 * history overlay's ⌘/Ctrl+Enter path; a caller-side `onSubmit` would strand the composer-private
+	 * `images` state (sent without them, stale thumbnails left attached to the next message). */
+	insertAndSubmit: (text: string, behavior: SubmitBehavior) => void;
 }
 
 /**
@@ -182,13 +187,29 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		[onChange, focusCaret],
 	);
 
-	useImperativeHandle(
-		handleRef,
-		() => ({
-			insertText: (text: string) => replaceDraft(text),
-		}),
-		[replaceDraft],
-	);
+	// The one submit seam — the composer's own send gestures (`submit` below) and the imperative
+	// `insertAndSubmit` both land here, so whatever initiated the send, pending images always travel
+	// with the text and are cleared with the draft in the same step. No-op when both the (trimmed)
+	// text and the image list are empty.
+	const submitText = (raw: string, behavior: SubmitBehavior) => {
+		const text = raw.trim();
+		if (!text && images.length === 0) return;
+		onSubmit(
+			text,
+			images.map((i) => i.content),
+			behavior,
+		);
+		onChange("");
+		setImages([]);
+		setRecallIdx(null);
+	};
+
+	// No dependency array: `submitText` closes over the live draft/images on purpose, so the handle is
+	// refreshed every render — memoizing it against stale closures is exactly the bug this avoids.
+	useImperativeHandle(handleRef, () => ({
+		insertText: (text: string) => replaceDraft(text),
+		insertAndSubmit: (text: string, behavior: SubmitBehavior) => submitText(text, behavior),
+	}));
 
 	const pickMention = (c: MentionCandidate) => {
 		const before = value.slice(0, start);
@@ -226,18 +247,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		]);
 	};
 
-	const submit = (behavior: SubmitBehavior) => {
-		const text = value.trim();
-		if (!text && images.length === 0) return;
-		onSubmit(
-			text,
-			images.map((i) => i.content),
-			behavior,
-		);
-		onChange("");
-		setImages([]);
-		setRecallIdx(null);
-	};
+	const submit = (behavior: SubmitBehavior) => submitText(value, behavior);
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
 		// Ctrl+R opens history recall — guarded at the very top, before the mention/slash menu, and before

--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -1,0 +1,560 @@
+import type { HistoryScope, MessageHit, PromptHit } from "@thinkrail/contracts";
+import { Check, CornerUpRight } from "lucide-react";
+import { type KeyboardEvent, useEffect, useRef } from "react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	type ChatLocationRequest,
+	type HistorySearchState,
+	type HistorySelection,
+	jumpTarget,
+	resolveHistorySelection,
+	SCOPE_ORDER,
+} from "./useHistorySearch";
+
+const SCOPE_LABELS: Record<HistoryScope["kind"], string> = {
+	chat: "Chat",
+	workspace: "Workspace",
+	project: "Project",
+	all: "All",
+};
+
+/** The scope picker's dropdown labels (R2) — fuller than the terse badge label above (a menu has room a
+ * pill doesn't), matching the design doc's prose exactly: "This chat / Workspace / Project / Everywhere". */
+const SCOPE_MENU_LABELS: Record<HistoryScope["kind"], string> = {
+	chat: "This chat",
+	workspace: "Workspace",
+	project: "Project",
+	all: "Everywhere",
+};
+
+/** Tiny relative-time formatter — `panels/CenterTabs.tsx` has a private twin; `chat/` can't import from
+ * `panels/` (wrong dependency direction), and this is too small to promote to a shared lib. */
+function relativeTime(ms: number): string {
+	const s = Math.floor((Date.now() - ms) / 1000);
+	if (s < 60) return "just now";
+	const m = Math.floor(s / 60);
+	if (m < 60) return `${m}m ago`;
+	const h = Math.floor(m / 60);
+	if (h < 24) return `${h}h ago`;
+	return `${Math.floor(h / 24)}d ago`;
+}
+
+function escapeRegExp(term: string): string {
+	return term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Wraps every case-insensitive occurrence of a `query` term in `text`. Term split matches the server
+ * matcher exactly (`query.toLowerCase().split(/\s+/)`, see `packages/server/src/history/historyIndex.ts`)
+ * so highlighted spans always line up with why a row matched; terms sort longest-first so overlapping
+ * terms prefer the longer alternative.
+ */
+function Highlight({ text, query }: { text: string; query: string }) {
+	const terms = [...new Set(query.toLowerCase().split(/\s+/).filter(Boolean))].sort(
+		(a, b) => b.length - a.length,
+	);
+	if (terms.length === 0) return <>{text}</>;
+	const pattern = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+	// Key on each part's own start offset in `text` (not the array index) — parts are consecutive,
+	// non-overlapping substrings, so `start` alone would collide only for two same-offset zero-length
+	// gaps either side of back-to-back matches; pairing it with the part's own text rules that out too.
+	let offset = 0;
+	const parts = text.split(pattern).map((part) => {
+		const start = offset;
+		offset += part.length;
+		return { text: part, key: `${start}:${part}` };
+	});
+	return (
+		<>
+			{parts.map(({ text: part, key }) =>
+				terms.includes(part.toLowerCase()) ? (
+					<mark key={key} className="rounded-[2px] bg-[var(--primary-20)] text-text">
+						{part}
+					</mark>
+				) : (
+					<span key={key}>{part}</span>
+				),
+			)}
+		</>
+	);
+}
+
+function PromptRow({
+	hit,
+	query,
+	scope,
+	workspaceName,
+	isSelected,
+	onPick,
+	onOpenMessage,
+}: {
+	hit: PromptHit;
+	query: string;
+	scope: HistoryScope;
+	workspaceName: string | undefined;
+	isSelected: boolean;
+	onPick: () => void;
+	onOpenMessage: (target: ChatLocationRequest) => void;
+}) {
+	const firstLine = hit.text.split("\n")[0] ?? hit.text;
+	const showChip = (scope.kind === "project" || scope.kind === "all") && !!hit.workspaceId;
+	// jumpable once the hit carries its jump anchor (absent for an unmapped cwd, or a host that
+	// doesn't populate those fields) — the same rule the overlay's `Shift+Enter` handler gates on, so
+	// the icon and the shortcut can never disagree.
+	const target = jumpTarget(hit);
+	return (
+		<div
+			data-testid="history-item"
+			data-kind="prompt"
+			data-selected={isSelected}
+			className={`group flex w-full items-center gap-xs rounded-[var(--radius-sm)] border-l-2 py-xs pl-sm pr-xs text-left text-sm ${
+				isSelected ? "border-l-primary bg-hover text-text" : "border-l-transparent text-muted"
+			}`}
+		>
+			<button
+				type="button"
+				onClick={onPick}
+				className="flex min-w-0 flex-1 items-center gap-sm overflow-hidden text-left"
+			>
+				<span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap text-ellipsis">
+					<Highlight text={firstLine} query={query} />
+				</span>
+				{showChip ? (
+					<span className="shrink-0 rounded-full border border-border2 bg-bg px-xs text-[10px] text-hint">
+						{workspaceName ?? "workspace"}
+					</span>
+				) : null}
+				<span className="shrink-0 text-hint text-xs">{relativeTime(hit.timestamp)}</span>
+			</button>
+			{target ? (
+				<>
+					{isSelected ? (
+						<span data-testid="history-jump-shortcut" className="shrink-0 text-[10px] text-hint">
+							⇧⏎
+						</span>
+					) : null}
+					<button
+						type="button"
+						data-testid="history-jump"
+						aria-label="Go to chat"
+						title="⇧⏎ go to chat"
+						onClick={(e) => {
+							e.stopPropagation();
+							onOpenMessage(target);
+						}}
+						className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-xs text-muted opacity-0 transition hover:bg-elevated hover:text-text group-hover:opacity-100 ${
+							isSelected ? "opacity-100" : ""
+						}`}
+					>
+						<CornerUpRight className="size-3.5" />
+					</button>
+				</>
+			) : null}
+		</div>
+	);
+}
+
+function MessageRow({
+	hit,
+	query,
+	isSelected,
+	onPick,
+}: {
+	hit: MessageHit;
+	query: string;
+	isSelected: boolean;
+	onPick: () => void;
+}) {
+	const unmapped = !hit.workspaceId;
+	return (
+		<button
+			type="button"
+			data-testid="history-item"
+			data-kind="message"
+			data-selected={isSelected}
+			onClick={onPick}
+			disabled={unmapped}
+			className={`flex w-full flex-col gap-0.5 rounded-[var(--radius-sm)] border-l-2 px-sm py-xs text-left text-sm disabled:cursor-default ${
+				isSelected ? "border-l-primary bg-hover text-text" : "border-l-transparent text-muted"
+			}`}
+		>
+			<span className="flex items-center gap-xs text-hint text-xs">
+				<span className="truncate">
+					{hit.sessionTitle || hit.cwd.split("/").pop() || "session"}
+				</span>
+				<span>·</span>
+				<span>{hit.role}</span>
+				<span>·</span>
+				<span>{relativeTime(hit.timestamp)}</span>
+				{unmapped ? <span>· not a ThinkRail workspace</span> : null}
+			</span>
+			<span className="overflow-hidden whitespace-nowrap text-ellipsis">
+				<Highlight text={hit.snippet} query={query} />
+			</span>
+		</button>
+	);
+}
+
+/** A prompt hit's preview footer: chat title (when set) / a workspace chip whenever the hit has a
+ * `workspaceId` — unlike `PromptRow`'s chip, never scope-gated, since a single detail pane has room a
+ * dense list row doesn't — / relative time, `·`-joined like every other crumb in this file. */
+function PromptPreviewFooter({
+	hit,
+	workspaceName,
+}: {
+	hit: PromptHit;
+	workspaceName: string | undefined;
+}) {
+	const parts = [
+		hit.sessionTitle,
+		hit.workspaceId ? (workspaceName ?? "workspace") : undefined,
+		relativeTime(hit.timestamp),
+	].filter((part): part is string => !!part);
+	return <>{parts.join(" · ")}</>;
+}
+
+/**
+ * The zoomed stage's right-hand pane (R1) — a full-text preview of the flat-list keyboard-selected item.
+ * Always mounted while `stage === "zoomed"` (never in `compact`), so `data-testid="history-preview"`'s
+ * mere presence in the DOM doubles as the zoomed/compact signal. `item` is `null` when there's nothing
+ * selected (an empty result set) — renders an empty panel then, never a crash. Body reuses `Highlight`
+ * **verbatim** (the same helper `PromptRow`/`MessageRow` use for their truncated text) over the hit's
+ * full `text` — never a row's first-line/snippet truncation — so a long prompt's tail, cut off in the
+ * list, reads in full here.
+ */
+function HistoryPreview({
+	item,
+	query,
+	workspaceName,
+	className,
+}: {
+	item: HistorySelection | null;
+	query: string;
+	workspaceName: string | undefined;
+	className: string;
+}) {
+	return (
+		<div data-testid="history-preview" className={`flex flex-col overflow-hidden ${className}`}>
+			{item ? (
+				<>
+					<div className="min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap break-words p-sm text-sm text-text">
+						<Highlight text={item.hit.text} query={query} />
+					</div>
+					<div className="shrink-0 border-t border-border2 px-sm py-xs text-[11px] text-hint">
+						{item.kind === "prompt" ? (
+							<PromptPreviewFooter hit={item.hit} workspaceName={workspaceName} />
+						) : (
+							messageCrumb(item.hit)
+						)}
+					</div>
+				</>
+			) : null}
+		</div>
+	);
+}
+
+/** A message hit's preview footer — the literal `sessionTitle · role · relative time` crumb (R1 spec),
+ * deliberately simpler than `MessageRow`'s own header (which also flags an unmapped session): the row
+ * immediately to this preview's left already carries that flag, so the preview isn't the only place it
+ * shows. */
+function messageCrumb(hit: MessageHit): string {
+	return `${hit.sessionTitle || hit.cwd.split("/").pop() || "session"} · ${hit.role} · ${relativeTime(hit.timestamp)}`;
+}
+
+export interface HistoryOverlayProps {
+	state: HistorySearchState;
+	/** `workspaceId → display name` for every known workspace, so the "project"/"all" scope's cross-
+	 * workspace chip can show a human label without this presentational component touching the store. */
+	workspaceNames: Record<string, string>;
+	onQueryChange: (query: string) => void;
+	onCycleScope: () => void;
+	onToggleStage: () => void;
+	onMoveSelection: (delta: number) => void;
+	onClose: () => void;
+	/** Enter on a prompt hit — replace the draft, focus, caret at end, close. */
+	onInsert: (hit: PromptHit) => void;
+	/** Cmd/Ctrl+Enter on a prompt hit — insert then submit via the composer's own submit path. */
+	onInsertAndSend: (hit: PromptHit) => void;
+	/** Jump to an already-resolved target — `Enter`/click on a mapped message hit, or the
+	 * go-to-chat icon / `Shift+Enter` on a jumpable prompt hit. Every call site resolves its hit through
+	 * the shared `jumpTarget` helper first and only calls this when it returns non-null, so an unmapped
+	 * hit (or a prompt hit missing its anchor) never reaches here — belt-and-suspenders, not a
+	 * redundant guard inside `useHistorySearch`'s `openMessage`. */
+	onOpenMessage: (target: ChatLocationRequest) => void;
+	/** R2's mouse path: a direct scope pick from the badge's dropdown menu. `onCycleScope` stays the
+	 * `Ctrl+R` keyboard path, unaffected — both just set the same underlying scope state
+	 * (`useHistorySearch.ts`'s `setScope`/`cycleScope` reset the results selection identically). */
+	onSetScope: (kind: HistoryScope["kind"]) => void;
+}
+
+/**
+ * The Ctrl+R history-recall overlay (props-driven, no store/transport — `useHistorySearch` owns that
+ * edge). Anchored above the composer exactly like its mention menu (`Composer.tsx:224-263`): `compact`
+ * shows prompts only (~40vh); `Tab` zooms to ~75vh with both the Prompts and Messages sections.
+ */
+export function HistoryOverlay({
+	state,
+	workspaceNames,
+	onQueryChange,
+	onCycleScope,
+	onToggleStage,
+	onMoveSelection,
+	onClose,
+	onInsert,
+	onInsertAndSend,
+	onOpenMessage,
+	onSetScope,
+}: HistoryOverlayProps) {
+	const { open, stage, query, scope, result, selected, error } = state;
+	const inputRef = useRef<HTMLInputElement>(null);
+	const resultsRef = useRef<HTMLDivElement>(null);
+
+	// Auto-focus with the seeded text selected, the instant the overlay opens — not on every keystroke.
+	useEffect(() => {
+		if (!open) return;
+		const el = inputRef.current;
+		if (!el) return;
+		el.focus();
+		el.select();
+	}, [open]);
+
+	// Arrow-key navigation moves `selected` past the edge of what's currently scrolled into view — the
+	// container itself scrolls (mouse wheel, drag), but a keyboard-only selection change never does on its
+	// own. `block: "nearest"` is the minimal scroll: it only moves the container when the selected row is
+	// actually outside the visible range, never re-centers a row that's already visible. `selected`/
+	// `stage`/`result` are all trigger-only — the body reaches the selected row through the DOM (via
+	// `data-selected`), not through these values directly — but a stage toggle or a fresh result can change
+	// which row `selected`'s index now points at without the index itself changing, so all three must
+	// re-run the effect.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: selected/stage/result are re-render triggers, not body inputs — the row is found via the DOM, not these values
+	useEffect(() => {
+		resultsRef.current
+			?.querySelector('[data-selected="true"]')
+			?.scrollIntoView({ block: "nearest" });
+	}, [selected, stage, result]);
+
+	if (!open) return null;
+
+	const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "r" && e.ctrlKey && !e.metaKey && !e.altKey) {
+			e.preventDefault();
+			onCycleScope();
+			return;
+		}
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			onMoveSelection(1);
+			return;
+		}
+		if (e.key === "ArrowUp") {
+			e.preventDefault();
+			onMoveSelection(-1);
+			return;
+		}
+		if (e.key === "Tab") {
+			e.preventDefault();
+			onToggleStage();
+			return;
+		}
+		if (e.key === "Escape") {
+			e.preventDefault();
+			onClose();
+			return;
+		}
+		if (e.key === "Enter") {
+			e.preventDefault();
+			const item = resolveHistorySelection(stage, result, selected);
+			if (!item) return;
+			// Shift+Enter on a prompt row jumps to its chat location instead of inserting — the
+			// same target its go-to-chat icon resolves via `jumpTarget`. A message row has no separate
+			// insert action, so Shift+Enter there just falls through to the same jump Enter already did.
+			if (item.kind === "prompt" && !e.shiftKey) {
+				if (e.metaKey || e.ctrlKey) onInsertAndSend(item.hit);
+				else onInsert(item.hit);
+				return;
+			}
+			const target = jumpTarget(item.hit);
+			if (target) onOpenMessage(target);
+		}
+	};
+
+	const promptCount = result ? Math.min(result.prompts.length, result.promptTotal) : 0;
+	const messageCount = result ? Math.min(result.messages.length, result.messageTotal) : 0;
+	// A cold-build partial (`result.indexing`) can still carry real hits — whatever the server's budget
+	// managed to parse before it gave up and returned early. `hasResults` is checked independently of
+	// `indexing` so those partials render instead of being suppressed behind the indexing message; `isEmpty`
+	// only ever fires once indexing is done, so a partial's "nothing found yet" moment never flashes "no
+	// matches" while the index is still filling in.
+	const hasResults =
+		!!result && (result.prompts.length > 0 || (stage === "zoomed" && result.messages.length > 0));
+	const isEmpty = !!result && !result.indexing && !hasResults;
+
+	// The zoomed stage's preview (R1) mirrors whatever the flat-list `selected` index currently resolves
+	// to — the same resolution `Enter`/Cmd/Ctrl+S already use above, so the preview and the keyboard
+	// actions can never disagree on "the selected item." `null` (no result yet, or an empty result set)
+	// renders an empty panel, never a crash — see `HistoryPreview`.
+	const selectedItem = resolveHistorySelection(stage, result, selected);
+	const selectedWorkspaceName = selectedItem?.hit.workspaceId
+		? workspaceNames[selectedItem.hit.workspaceId]
+		: undefined;
+
+	const resultsBody = error ? (
+		<div data-testid="history-error" className="p-md text-center text-red text-sm">
+			search unavailable
+		</div>
+	) : !result ? null : (
+		<>
+			{result.indexing ? (
+				<div
+					data-testid="history-indexing"
+					className="px-sm py-1 text-center text-hint text-[11px]"
+				>
+					indexing history…
+				</div>
+			) : null}
+			{hasResults ? (
+				<div className="flex flex-col gap-xs p-xs">
+					{result.prompts.length > 0 ? (
+						<div className="flex flex-col gap-0.5">
+							<div className="flex items-center justify-between px-sm py-0.5 text-hint text-xs uppercase tracking-wide">
+								<span>Prompts</span>
+								<span data-testid="history-counts">
+									{promptCount}/{result.promptTotal}
+								</span>
+							</div>
+							{result.prompts.map((hit, i) => (
+								<PromptRow
+									key={`${hit.sessionId}:${hit.timestamp}`}
+									hit={hit}
+									query={query}
+									scope={scope}
+									workspaceName={hit.workspaceId ? workspaceNames[hit.workspaceId] : undefined}
+									isSelected={i === selected}
+									onPick={() => onInsert(hit)}
+									onOpenMessage={onOpenMessage}
+								/>
+							))}
+						</div>
+					) : null}
+					{stage === "zoomed" && result.messages.length > 0 ? (
+						<div className="flex flex-col gap-0.5">
+							<div className="flex items-center justify-between px-sm py-0.5 text-hint text-xs uppercase tracking-wide">
+								<span>Messages</span>
+								<span data-testid="history-counts">
+									{messageCount}/{result.messageTotal}
+								</span>
+							</div>
+							{result.messages.map((hit, i) => (
+								<MessageRow
+									key={`${hit.sessionId}:${hit.messageIndex}`}
+									hit={hit}
+									query={query}
+									isSelected={result.prompts.length + i === selected}
+									onPick={() => {
+										const target = jumpTarget(hit);
+										if (target) onOpenMessage(target);
+									}}
+								/>
+							))}
+						</div>
+					) : null}
+				</div>
+			) : isEmpty ? (
+				<div className="p-md text-center text-muted text-sm">no matches</div>
+			) : null}
+		</>
+	);
+
+	return (
+		<div
+			data-testid="history-overlay"
+			data-stage={stage}
+			className="absolute bottom-full left-sm right-sm mb-xs flex flex-col overflow-hidden rounded-[var(--radius-md)] border border-border2 bg-elevated shadow-[var(--shadow-md)]"
+		>
+			<div className="flex items-center gap-sm border-b border-border2 p-sm">
+				<input
+					ref={inputRef}
+					data-testid="history-query"
+					value={query}
+					onChange={(e) => onQueryChange(e.target.value)}
+					onKeyDown={onKeyDown}
+					placeholder="Search prompts and conversations…"
+					className="min-w-0 flex-1 bg-transparent text-sm text-text outline-none placeholder:text-hint"
+				/>
+				<DropdownMenu>
+					<DropdownMenuTrigger
+						data-testid="history-scope"
+						data-scope={scope.kind}
+						className="flex shrink-0 items-center gap-xs rounded-full border border-border2 bg-bg px-sm py-0.5 text-[11px] text-muted outline-none hover:bg-hover"
+					>
+						<span>{SCOPE_LABELS[scope.kind]}</span>
+						<span className="text-hint">⌃R</span>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						align="end"
+						// Radix's default on close is to return focus to the trigger — override it so focus
+						// lands back on the query input instead, the same place it is right after `Enter`
+						// inserts a prompt. `Ctrl+R` cycling only fires from the input's own `onKeyDown`, so
+						// this is also what keeps it working right after a mouse pick.
+						onCloseAutoFocus={(e) => {
+							e.preventDefault();
+							inputRef.current?.focus();
+						}}
+					>
+						{SCOPE_ORDER.map((kind) => (
+							<DropdownMenuItem
+								key={kind}
+								data-testid="history-scope-option"
+								data-scope={kind}
+								onSelect={() => onSetScope(kind)}
+							>
+								<Check className={kind === scope.kind ? "size-3.5" : "size-3.5 invisible"} />
+								<span>{SCOPE_MENU_LABELS[kind]}</span>
+							</DropdownMenuItem>
+						))}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+			{stage === "zoomed" ? (
+				<div className="flex flex-col overflow-hidden md:flex-row">
+					<div
+						ref={resultsRef}
+						data-testid="history-results"
+						className="max-h-[37.5vh] overflow-y-auto md:max-h-[75vh] md:w-[55%]"
+					>
+						{resultsBody}
+					</div>
+					<HistoryPreview
+						item={selectedItem}
+						query={query}
+						workspaceName={selectedWorkspaceName}
+						className="max-h-[37.5vh] border-border2 border-t md:max-h-[75vh] md:w-[45%] md:border-t-0 md:border-l"
+					/>
+				</div>
+			) : (
+				<div
+					ref={resultsRef}
+					data-testid="history-results"
+					className="max-h-[40vh] overflow-y-auto"
+				>
+					{resultsBody}
+				</div>
+			)}
+			{stage === "compact" && !error && result && !result.indexing && result.messageTotal > 0 ? (
+				<button
+					type="button"
+					data-testid="history-expand-hint"
+					onClick={onToggleStage}
+					className="border-t border-border2 p-xs text-center text-hint text-xs hover:bg-hover"
+				>
+					{result.messageTotal} matches in conversations · ⇥ expand
+				</button>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -1,6 +1,6 @@
 import type { HistoryScope, MessageHit, PromptHit } from "@thinkrail/contracts";
 import { Check, CornerUpRight } from "lucide-react";
-import { type KeyboardEvent, useEffect, useRef } from "react";
+import { type KeyboardEvent, useEffect, useMemo, useRef } from "react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -323,20 +323,30 @@ export function HistoryOverlay({
 		el.select();
 	}, [open]);
 
-	// Arrow-key navigation moves `selected` past the edge of what's currently scrolled into view — the
-	// container itself scrolls (mouse wheel, drag), but a keyboard-only selection change never does on its
-	// own. `block: "nearest"` is the minimal scroll: it only moves the container when the selected row is
-	// actually outside the visible range, never re-centers a row that's already visible. `selected`/
-	// `stage`/`result` are all trigger-only — the body reaches the selected row through the DOM (via
-	// `data-selected`), not through these values directly — but a stage toggle or a fresh result can change
-	// which row `selected`'s index now points at without the index itself changing, so all three must
-	// re-run the effect.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: selected/stage/result are re-render triggers, not body inputs — the row is found via the DOM, not these values
+	// A stable identity for the currently-selected row, derived from stage/result/selected. It changes
+	// exactly when the selection lands on a different row — including when a stage toggle or a fresh result
+	// makes the same `selected` index point at a different hit (or none) — so the scroll effect below can
+	// depend on it alone and stay honestly exhaustive. `null` when nothing is selected.
+	const selectedKey = useMemo(() => {
+		const sel = resolveHistorySelection(stage, result, selected);
+		if (!sel) return null;
+		return sel.kind === "prompt"
+			? `p:${sel.hit.sessionId}:${sel.hit.messageIndex ?? sel.hit.timestamp}`
+			: `m:${sel.hit.sessionId}:${sel.hit.messageIndex}`;
+	}, [stage, result, selected]);
+
+	// Arrow-key navigation moves the selection past the edge of what's scrolled into view — the container
+	// itself scrolls (mouse wheel, drag), but a keyboard-only selection change never does on its own.
+	// `block: "nearest"` is the minimal scroll: it only moves the container when the selected row is
+	// actually outside the visible range, never re-centering a row that's already visible. The row is
+	// reached through the DOM (`data-selected`); `selectedKey` is the sole dependency because it's the
+	// thing that changes when "which row is selected" changes.
 	useEffect(() => {
+		if (selectedKey === null) return;
 		resultsRef.current
 			?.querySelector('[data-selected="true"]')
 			?.scrollIntoView({ block: "nearest" });
-	}, [selected, stage, result]);
+	}, [selectedKey]);
 
 	if (!open) return null;
 

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -91,14 +91,35 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   so "answered / superseded / awaiting" is a fact about the transcript, not a tool status — derived once
   per runtime snapshot and consumed by the card via context, keeping it props-driven everywhere else.
 - **Hydration** (`hydrate.ts`) — the pure `messagesToRuntime(TranscriptMessage[])` converter (read-side
-  counterpart of the event reducer): rebuilds `{ turns, toolResults, askAnswers }` (a `HydratedRuntime`)
-  from a persisted transcript so a reconnecting/second client renders identically to the live path (same
-  `raw` result shape, same error-turn surfacing for `stopReason: "error"`). `custom` messages never
-  become turns: known ones (`ask-user-answers`) index into `askAnswers`; unknown customTypes are
-  ignored. No store/transport/shiki.
+  counterpart of the event reducer): rebuilds `{ turns, toolResults, askAnswers, turnIdByMessageIndex }`
+  (a `HydratedRuntime`) from a persisted transcript so a reconnecting/second client renders identically to
+  the live path (same `raw` result shape, same error-turn surfacing for `stopReason: "error"`). It also
+  returns `turnIdByMessageIndex` (message-position → minted turn id) — the jump anchor map a
+  history-search "jump to message" deep link (`chatLocationRequest`, see `store/SPEC.md`) resolves
+  against; entries are `null` for a `toolResult`/`custom` message (never its own turn), and a message that
+  ended in `stopReason: "error"` maps to its own assistant turn's id, never the synthesized error turn's.
+  `custom` messages never become turns: known ones (`ask-user-answers`) index into `askAnswers`; unknown
+  customTypes are ignored. No store/transport/shiki.
+- **Jump-to-message** (`chatLocationRequest` — set by `useHistorySearch.ts`'s `openMessage` on Enter over
+  a mapped message hit; see `store/SPEC.md` for the store-level request/clear contract and
+  `CenterTabs.tsx`'s open/reopen/hydrate half) — `ChatView` is the sole consumer. Once `rows.length > 0`,
+  it resolves the request's `messageIndex` via `runtime.turnIdByMessageIndex` (present only on a
+  *hydrated* runtime — a live/already-open session's runtime, built by the event reducer, never carries
+  one), falling back to scanning `turns` for the first whose own text contains `anchorText`'s prefix — the
+  same fallback also covers a hydrated map entry whose turn no longer contains the anchor (e.g. the
+  transcript changed underneath it). The resolved turn maps to a row via the pure **`rowIndexForTurn(rows,
+  turnId)`** (`rows.ts`) — a turn's own row for `user`/`system`/`error`/`retry`, or its first `:text:` row
+  for `assistant` (whose turns dissolve into `markdown`/`tool`/`activity` rows, never a row of their own)
+  — then `virtuosoRef.scrollToIndex({ align: "center" })` plus a transient `flashRowId` (rendered as
+  `data-flash` + a `bg-[var(--primary-10)]` transition on the row wrapper, cleared after 1600ms) draw the
+  eye to it. Either resolving a row or giving up (toasted as "couldn't locate the message") always clears
+  the request — `ChatView` is its only consumer, so an unresolved request must never linger.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
-  commands, image paste/drop) plus its props-driven **slash-completion primitive** (filter/menu/caret +
-  Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so the two inputs cannot drift;
+  commands, image paste/drop, `Ctrl+R` → `onHistoryOpen`) plus its props-driven **slash-completion
+  primitive** (filter/menu/caret + Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so
+  the two inputs cannot drift; `HistoryOverlay` (the history-recall/search overlay `Composer` opens —
+  presentational, driven entirely by `useHistorySearch.ts`'s state + callbacks, plus a **zoomed-stage
+  preview pane** + **scope picker** — see the next bullet),
   `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip; its **Skills** button is the presentational **`SkillsButton`**
@@ -112,6 +133,65 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   skill overrides, + a **Reload** that applies changes to this chat's session via `session.reloadResources`,
   disabled while streaming) or project (`project.skills`, per-project-baseline toggles, no session) — the
   latter reused by `panels` pre-session). All props-driven; behavior detail lives in the components' jsdoc.
+- **History overlay: zoomed preview pane + scope picker** (`HistoryOverlay.tsx`) — `Tab` grows the
+  compact single-column overlay into a **two-pane** `zoomed` layout: the existing Prompts/Messages
+  sections list stays on the left (~55% width, `data-testid="history-results"` — keyboard nav,
+  `scrollIntoView`, and counts are all unchanged), and a preview of the
+  flat-list **keyboard-selected** item renders on the right (~45%, `data-testid="history-preview"`,
+  resolved via the same `resolveHistorySelection` that `Enter` already uses — the preview and
+  the keyboard actions can never disagree on "the selected item"). The `compact` stage is untouched: no
+  preview pane exists in the DOM at all until `Tab` (not merely hidden), so `history-preview`'s bare
+  presence doubles as the zoomed/compact signal. **Preview body:** the hit's full `text` — never the
+  row's truncated first line (`PromptRow`) or snippet (`MessageRow`) — is what makes the preview worth
+  having: a long prompt's tail, cut off in the list, reads in full here. `whitespace-pre-wrap
+  break-words`, scrollable (`overflow-y-auto`), query terms highlighted via `Highlight` reused
+  **verbatim** (the same helper the rows use) so highlighting can never drift between a row and its own
+  preview. **Preview footer** (muted, small): for a prompt hit, chat title (when set) / a workspace chip
+  whenever `workspaceId` is present (unlike `PromptRow`'s chip, never scope-gated — a single detail pane
+  has room a dense list row doesn't) / relative time, `·`-joined; for a message hit,
+  `sessionTitle · role · relative time`. No selection (an empty result set) renders an empty panel —
+  never a crash. **Narrow widths** (below the `md` breakpoint): the preview collapses **below** the
+  list instead of beside it (list first in source order, so a column flex stack already places it
+  there), each pane independently scrollable within its own height budget. The **scope badge**
+  (`data-testid="history-scope"`, unchanged `<scope> ⌃R` label + `data-scope`) is now also a
+  `components/ui/dropdown-menu` trigger: its content lists all four scopes in cycle order
+  (`data-testid="history-scope-option"` + `data-scope`, fuller labels than the badge itself — "This
+  chat" / "Workspace" / "Project" / "Everywhere" — with the current one check-marked). Picking one
+  calls `useHistorySearch.ts`'s new `setScope(kind)`, which resets the results selection exactly like
+  `cycleScope` — the unchanged `Ctrl+R` keyboard path, since both just set the same underlying scope
+  state. Radix's default on close is to return focus to the trigger; `onCloseAutoFocus` is overridden
+  (`preventDefault` + focus the query input) so a mouse pick hands focus back to the query input
+  instead — typing (and `Ctrl+R` cycling) resumes immediately, no extra click needed. The menu never
+  fights the overlay's own `ArrowUp`/`ArrowDown`/`Enter` handling: that handler is bound to the query
+  `<input>` element itself, and Radix's portaled dropdown content is a **sibling** subtree — never a
+  descendant of the input — so a keydown while the menu holds focus cannot reach the input's handler by
+  construction, not by a case-by-case guard.
+- **History overlay: assistant-only messages + jumpable prompts** (`HistoryOverlay.tsx`,
+  `useHistorySearch.ts`) — `MESSAGES` only ever contains assistant-role hits (the server
+  filters; see `packages/server/src/history/SPEC.md`): a user-role hit is always a textual duplicate of
+  its own `PromptHit` entry, so the location it used to add moved onto the prompt row instead. Every
+  prompt row renders a go-to-chat icon (`data-testid="history-jump"`, `aria-label="Go to chat"`,
+  `title="⇧⏎ go to chat"`) **when jumpable** — `workspaceId` present and `messageIndex != null` (absent
+  for an unmapped-cwd hit, or a host that never populated the prompt's anchor fields). Clicking it, or
+  **`Shift+Enter`** while a prompt row is the keyboard selection, routes through the exact same
+  `onOpenMessage` path a message hit's `Enter`/click already used — both go through the shared
+  **`jumpTarget(hit)`** helper (`useHistorySearch.ts`, exported pure), which resolves either hit shape to
+  a `ChatLocationRequest` or `null`, so the icon's render gate, the `Shift+Enter` handler, and the
+  message-hit gate can never disagree on "is this jumpable." An unmapped/legacy prompt row shows no icon
+  and `Shift+Enter` is a no-op (overlay stays open) — the same belt-and-suspenders gating the message-hit
+  path already had. The icon itself stays hover-revealed (`group-hover`/`isSelected` opacity), but its
+  shortcut glyph (`data-testid="history-jump-shortcut"`, literal `⇧⏎`) is a **selected-only**, not
+  hover-only, persistent `<span>` — the same precedent as the scope badge's `⌃R` (always next to its
+  label) — since a keyboard-only user, `Shift+Enter`'s own audience, never triggers `:hover`.
+- **Plain `↑` recall + history button** — `Composer`'s `recentPrompts` prop (`ChatView`: this chat's own
+  user-turn texts via `turnAnchorText`, newest first, deduped **keeping the newest occurrence** — the same
+  recency-first ranking rule as the server history index, the atuin/fzf convention) backs a lightweight
+  recall session (`recallIdx`) gated so it can never eat a draft: `↑` only steps in when the field is
+  **empty** or a recall is already active (older → higher index), `↓` steps newer (past the newest
+  restores `""`), any diverging edit or a submit exits the session, and the recalled text lands with the
+  caret at its end. A `History`-icon button (`data-testid="history-open"`, `aria-label="Search history"`,
+  always rendered next to send) calls the same `onHistoryOpen` as `Ctrl+R` — the tap path on mobile, a
+  discoverability affordance on desktop.
 - **Chat TODO plan** — the chat's `pi-todos` list surfaced **only in the chat** (engine:
   [[module-pi-todos]]; host read/write: [[submodule-server-todos]]):
   `useChatTodos` (the `todo.*` data hook — fetch + live `pi.event` refetch + edits + the add-nudge + the
@@ -140,16 +220,18 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   **No `index.ts` barrel** — chat pulls **shiki**, so per the code-splitting exception imports stay
   **per-file**; the registry is importable from `chat/toolRegistry` **without** pulling shiki.
 - **Allowed deps:** `contracts` (pi message/content-block types, **type-only**); `store` + `transport`
-  (**`ChatView` only** — the app-integration edge); `react-markdown` / `remark-gfm` / `shiki` (via
-  `lib/highlighter`); `mermaid` (**lazy, `tools/visualize` only**); `react-virtuoso`; `lucide-react`;
-  `components/ui`; `lib`.
+  (**`ChatView` + its integration hook `useHistorySearch.ts` only** — the
+  app-integration edge); `react-markdown` / `remark-gfm` / `shiki` (via `lib/highlighter`); `mermaid`
+  (**lazy, `tools/visualize` only**); `react-virtuoso`; `lucide-react`; `components/ui`; `lib`.
 - **Forbidden:** value-importing any `pi` package; a **presentational** renderer importing
-  `store`/`transport` (only `ChatView` may — keep the renderers reusable).
-- **`ChatView`** is the one app-integration file: wires this session's runtime
+  `store`/`transport` (only `ChatView` and its integration hook `useHistorySearch.ts` may — keep the
+  renderers reusable).
+- **`ChatView`** is the primary app-integration file: wires this session's runtime
   (`store.sessions[sessionId]`), the transport calls, the `ChatActions` + `AskStates` contexts, and the
-  divider's "files changed" → `requestChangesView` deep link. A **rejected** send (`prompt`/`steer`/`followUp`)
-  lands in the chat via the store's `appendErrorTurn` — never swallowed; *streaming* faults arrive as pi
-  events instead.
+  divider's "files changed" → `requestChangesView` deep link — together with **`useHistorySearch.ts`**
+  (the Ctrl+R history-recall overlay's store/transport edge), the other integration point. A
+  **rejected** send (`prompt`/`steer`/`followUp`) lands in the chat via the store's `appendErrorTurn` —
+  never swallowed; *streaming* faults arrive as pi events instead.
 
 ## Streaming model
 

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -54,6 +54,39 @@ test("an assistant turn that ended in a provider error hydrates a following erro
 	expect(err?.kind === "error" && err.text).toContain("gpt-5.5");
 });
 
+test("turnIdByMessageIndex maps each message's position to its own turn id, null for non-turn messages, and the assistant's id (not the injected error turn's) when the message ended in an error", () => {
+	const { turns, turnIdByMessageIndex } = messagesToRuntime([
+		{ role: "user", content: "hi", timestamp: 1 },
+		{ role: "assistant", content: [], stopReason: "error", errorMessage: "boom" },
+		{
+			role: "toolResult",
+			toolCallId: "x",
+			toolName: "bash",
+			content: [],
+			isError: false,
+			timestamp: 2,
+		},
+		{
+			role: "custom",
+			customType: "someone-elses-extension",
+			content: "hello",
+			display: true,
+			timestamp: 3,
+		},
+		{ role: "user", content: "again", timestamp: 4 },
+	] as unknown as Message[]);
+
+	// [user, assistant, error, user] — the injected error turn has no message index of its own.
+	expect(turns.map((t) => t.kind)).toEqual(["user", "assistant", "error", "user"]);
+	expect(turnIdByMessageIndex).toHaveLength(5);
+	expect(turnIdByMessageIndex[0]).toBe(turns[0]?.id);
+	expect(turnIdByMessageIndex[1]).toBe(turns[1]?.id); // the assistant turn itself...
+	expect(turnIdByMessageIndex[1]).not.toBe(turns[2]?.id); // ...never the synthesized error turn
+	expect(turnIdByMessageIndex[2]).toBeNull(); // toolResult never becomes a turn
+	expect(turnIdByMessageIndex[3]).toBeNull(); // custom never becomes a turn
+	expect(turnIdByMessageIndex[4]).toBe(turns[3]?.id); // the trailing user turn
+});
+
 test("a failed tool result maps to error status", () => {
 	const { toolResults } = messagesToRuntime([
 		{

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -20,6 +20,14 @@ export interface HydratedRuntime {
 	toolResults: Record<string, ToolResultState>;
 	/** `ask_user_question` replies keyed by tool call id (from `ask-user-answers` custom messages). */
 	askAnswers: Record<string, AskUserAnswersDetails["result"]>;
+	/**
+	 * Parallel to `messages`: `turnIdByMessageIndex[i]` is the turn id minted for `messages[i]` (`null` for
+	 * a `toolResult`/`custom` message, which never becomes its own turn) — the jump anchor map a
+	 * history-search "jump to message" deep link (`chatLocationRequest`) resolves against. A message that
+	 * ended in `stopReason: "error"` maps to its own assistant turn's id, never the synthesized error
+	 * turn's (the error turn has no message index of its own).
+	 */
+	turnIdByMessageIndex: (string | null)[];
 }
 
 /**
@@ -34,15 +42,26 @@ export function messagesToRuntime(messages: TranscriptMessage[]): HydratedRuntim
 	const turns: ChatTurn[] = [];
 	const toolResults: Record<string, ToolResultState> = {};
 	const askAnswers: HydratedRuntime["askAnswers"] = {};
+	const turnIdByMessageIndex: HydratedRuntime["turnIdByMessageIndex"] = [];
 	for (const message of messages) {
+		// Exactly one push per message, in order — keeps the map aligned to `messages` regardless of which
+		// branch below fires (a user/assistant message sets it to its own turn's id; every other message
+		// leaves it `null`).
+		let turnId: string | null = null;
 		if (message.role === "user") {
-			if (userText(message.content).startsWith(TODO_NUDGE_PREFIX)) continue; // hidden nudge
-			turns.push({ kind: "user", id: crypto.randomUUID(), message });
+			// A pi-todos hidden nudge renders no turn, but still consumes its positional slot below
+			// (turnId stays null) so turnIdByMessageIndex stays aligned with the server's messageIndex.
+			if (!userText(message.content).startsWith(TODO_NUDGE_PREFIX)) {
+				turnId = crypto.randomUUID();
+				turns.push({ kind: "user", id: turnId, message });
+			}
 		} else if (message.role === "assistant") {
-			turns.push({ kind: "assistant", id: crypto.randomUUID(), message, streaming: false });
+			turnId = crypto.randomUUID();
+			turns.push({ kind: "assistant", id: turnId, message, streaming: false });
 			// A persisted turn that ended in a provider/model error carries `stopReason: "error"` + the
 			// provider's `errorMessage`. Re-surface it as an error turn so a reopened chat shows the failure,
-			// matching the live path (the reducer's terminal-error `agent_end`).
+			// matching the live path (the reducer's terminal-error `agent_end`). `turnId` stays the
+			// assistant message's own id — the error turn below is synthesized, not a message of its own.
 			if (message.stopReason === "error") {
 				turns.push({
 					kind: "error",
@@ -62,6 +81,7 @@ export function messagesToRuntime(messages: TranscriptMessage[]): HydratedRuntim
 			// The shared guard validates the details shape (not just the tag) — a malformed reply is ignored.
 			askAnswers[message.details.toolCallId] = message.details.result;
 		}
+		turnIdByMessageIndex.push(turnId);
 	}
-	return { turns, toolResults, askAnswers };
+	return { turns, toolResults, askAnswers, turnIdByMessageIndex };
 }

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -1,9 +1,6 @@
 import type { AskUserAnswersDetails, TranscriptMessage, UserMessage } from "@thinkrail/contracts";
-import { isAskUserAnswersMessage } from "@thinkrail/contracts";
+import { isAskUserAnswersMessage, TODO_NUDGE_PREFIX } from "@thinkrail/contracts";
 import type { ChatTurn, ToolResultState } from "./types";
-
-/** Prefix on the wake-the-agent nudge sent when a TODO is added; hidden from the transcript (never appended live, skipped on hydrate). */
-export const TODO_NUDGE_PREFIX = "[thinkrail:todo-nudge] ";
 
 /** The leading text of a user message (string or text blocks). */
 function userText(content: UserMessage["content"]): string {

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -218,3 +218,9 @@ export function turnDivider(turns: ChatTurn[], endIndex: number): TurnDividerDat
 
 	return { elapsedMs, toolCount, changedFiles };
 }
+
+/** The first row rendering the turn a jump targets: the turn's own row (user/system/…) or its first
+ * text row (assistant messages dissolve; a matched assistant message always has a text block). */
+export function rowIndexForTurn(rows: ChatRow[], turnId: string): number {
+	return rows.findIndex((r) => r.id === turnId || r.id.startsWith(`${turnId}:text:`));
+}

--- a/apps/web/src/chat/useChatTodos.ts
+++ b/apps/web/src/chat/useChatTodos.ts
@@ -1,9 +1,9 @@
 import type { SessionEventPayload, TodoPlan } from "@thinkrail/contracts";
-import { WS_CHANNELS } from "@thinkrail/contracts";
+import { TODO_NUDGE_PREFIX, WS_CHANNELS } from "@thinkrail/contracts";
 import { useEffect, useState } from "react";
 import { selectWorkspaceTick, useAppStore } from "../store";
 import { errorText, getTransport } from "../transport";
-import { messagesToRuntime, TODO_NUDGE_PREFIX } from "./hydrate";
+import { messagesToRuntime } from "./hydrate";
 import { planToMarkdown } from "./planMarkdown";
 
 export interface ChatTodos {

--- a/apps/web/src/chat/useHistorySearch.ts
+++ b/apps/web/src/chat/useHistorySearch.ts
@@ -99,9 +99,14 @@ export function resolveHistorySelection(
  * three gate on the exact same rule and can never disagree on "is this jumpable."
  */
 export function jumpTarget(hit: PromptHit | MessageHit): ChatLocationRequest | null {
-	if (!hit.workspaceId || hit.messageIndex == null || hit.anchorText == null) return null;
+	// `workspaceId` and `projectId` are populated together by the host's `buildHistoryScope` labeler (both
+	// from the same registry entry), so an unmapped-cwd hit lacks both; gate on both to be explicit.
+	if (!hit.workspaceId || !hit.projectId || hit.messageIndex == null || hit.anchorText == null) {
+		return null;
+	}
 	return {
 		workspaceId: hit.workspaceId,
+		projectId: hit.projectId,
 		sessionId: hit.sessionId,
 		messageIndex: hit.messageIndex,
 		anchorText: hit.anchorText,
@@ -220,25 +225,41 @@ export function useHistorySearch(
 
 	const close = useCallback(() => setOpen(false), []);
 
-	const setQuery = useCallback((q: string) => {
-		setQueryState(q);
+	// A query or scope change makes the current result stale. Clear it — not just the selection — so
+	// nothing (Enter / Ctrl+Enter / a row click) can act on a hit that no longer matches what the input
+	// now shows, during the ~100ms debounce + request round-trip before fresh results land. Any prior
+	// error clears too, since a fresh request is on its way.
+	const resetForParamsChange = useCallback(() => {
 		setSelected(0);
+		setResult(null);
+		setError(false);
 	}, []);
+
+	const setQuery = useCallback(
+		(q: string) => {
+			setQueryState(q);
+			resetForParamsChange();
+		},
+		[resetForParamsChange],
+	);
 
 	const cycleScope = useCallback(() => {
 		// The modulo always lands in range given `k` is itself a SCOPE_ORDER member — `?? k` is just to
 		// satisfy noUncheckedIndexedAccess, never an actual fallback in practice.
 		setScopeKind((k) => SCOPE_ORDER[(SCOPE_ORDER.indexOf(k) + 1) % SCOPE_ORDER.length] ?? k);
-		setSelected(0);
-	}, []);
+		resetForParamsChange();
+	}, [resetForParamsChange]);
 
 	// R2's mouse path: the scope picker's dropdown items pick a scope directly rather than stepping
-	// through `cycleScope` — `Ctrl+R` keeps calling `cycleScope` above, unchanged. Resets `selected` the
-	// same way cycling does, for the same reason (a scope change reshapes the flat list under it).
-	const setScope = useCallback((kind: ScopeKind) => {
-		setScopeKind(kind);
-		setSelected(0);
-	}, []);
+	// through `cycleScope` — `Ctrl+R` keeps calling `cycleScope` above, unchanged. Clears the stale result
+	// the same way cycling does, for the same reason (a scope change reshapes the results under it).
+	const setScope = useCallback(
+		(kind: ScopeKind) => {
+			setScopeKind(kind);
+			resetForParamsChange();
+		},
+		[resetForParamsChange],
+	);
 
 	const toggleStage = useCallback(() => {
 		setStage((s) => (s === "compact" ? "zoomed" : "compact"));
@@ -258,10 +279,25 @@ export function useHistorySearch(
 	// Jump to an already-resolved target (see `jumpTarget` above) via the store's `chatLocationRequest`
 	// deep link (see `store/SPEC.md`), then close the overlay. Callers only ever pass a target `jumpTarget`
 	// produced, so there's nothing left to gate here — the "is this jumpable" check happened at the call
-	// site (the icon's render gate / `Shift+Enter` handler / message-hit click), belt-and-suspenders by
-	// construction rather than a redundant guard here.
+	// site (the icon's render gate / `Shift+Enter` handler / message-hit click).
+	//
+	// A jump can cross into a project the user hasn't opened this session, whose workspace list the store
+	// loads lazily (on project expansion). Fetch it first when absent so the atomic
+	// `requestChatLocation` below leaves a resolvable `activeWorkspaceId` — otherwise `selectActiveWorkspace`
+	// would return null and the destination would render blank. A failed fetch still records the request;
+	// `ChatView`'s consumer surfaces "couldn't locate" if the workspace truly can't be resolved.
 	const openMessage = useCallback(
-		(target: ChatLocationRequest) => {
+		async (target: ChatLocationRequest) => {
+			if (!useAppStore.getState().workspaces[target.projectId]?.length) {
+				try {
+					const list = await getTransport().request("workspace.list", {
+						projectId: target.projectId,
+					});
+					useAppStore.getState().setWorkspaces(target.projectId, list);
+				} catch {
+					// fall through — record the request anyway; the consumer handles an unresolved target
+				}
+			}
 			useAppStore.getState().requestChatLocation(target);
 			close();
 		},

--- a/apps/web/src/chat/useHistorySearch.ts
+++ b/apps/web/src/chat/useHistorySearch.ts
@@ -1,0 +1,287 @@
+import type {
+	HistoryScope,
+	HistorySearchResult,
+	MessageHit,
+	PromptHit,
+} from "@thinkrail/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ChatLocationRequest, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+
+// Re-exported so `HistoryOverlay.tsx` (props-driven, no store/transport of its own — see `chat/SPEC.md`'s
+// boundary section) can type its `onOpenMessage` prop and call `jumpTarget` without importing `@/store`
+// directly; this hook stays the one seam that does.
+export type { ChatLocationRequest };
+
+/** `compact` shows prompts only (a few rows); `Tab` zooms to both sections. */
+export type HistoryStage = "compact" | "zoomed";
+
+/** The Ctrl+R history-recall overlay's full state — owned by `useHistorySearch`, rendered by the
+ * presentational `HistoryOverlay`. */
+export interface HistorySearchState {
+	open: boolean;
+	stage: HistoryStage;
+	query: string;
+	scope: HistoryScope;
+	result: HistorySearchResult | null;
+	selected: number;
+	error: boolean;
+}
+
+/** One flat-list selection: a prompt hit (insertable) or a message hit (a jump target — see `openMessage`). */
+export type HistorySelection =
+	| { kind: "prompt"; hit: PromptHit }
+	| { kind: "message"; hit: MessageHit };
+
+/** Exported so the scope picker (`HistoryOverlay`'s dropdown menu, R2) can render its four options in
+ * this exact cycle order — the same order `Ctrl+R`'s `cycleScope` advances through. */
+export const SCOPE_ORDER = ["chat", "workspace", "project", "all"] as const;
+export type ScopeKind = (typeof SCOPE_ORDER)[number];
+
+function buildScope(
+	kind: ScopeKind,
+	sessionId: string,
+	workspaceId: string,
+	projectId: string | undefined,
+): HistoryScope {
+	switch (kind) {
+		case "chat":
+			return { kind: "chat", sessionId };
+		case "workspace":
+			return { kind: "workspace", workspaceId };
+		case "project":
+			// An unresolved owning project (store not hydrated yet) falls back to an id that can never
+			// match — the host's `buildHistoryScope` treats an unknown project id as "no results," never a
+			// throw — rather than sending a scope shape the caller can't actually have intended.
+			return { kind: "project", projectId: projectId ?? "" };
+		case "all":
+			return { kind: "all" };
+	}
+}
+
+/** How many items the current stage exposes as a flat, arrow-key-navigable list — prompts only in
+ * `compact`; prompts then messages in `zoomed` (same order `resolveHistorySelection` resolves against). */
+function flatListLength(stage: HistoryStage, result: HistorySearchResult | null): number {
+	if (!result) return 0;
+	return stage === "compact"
+		? result.prompts.length
+		: result.prompts.length + result.messages.length;
+}
+
+/**
+ * Pure resolution of the flat-list `selected` index into the hit it points at (or `null` when the index
+ * is out of range for the current stage — e.g. the instant `Tab` collapses `zoomed` back to `compact` and
+ * the selection had been sitting in the messages section). Exported so the presentational
+ * `HistoryOverlay` can resolve the same index for row highlighting and `Enter` handling without
+ * duplicating the prompts-then-messages ordering rule.
+ */
+export function resolveHistorySelection(
+	stage: HistoryStage,
+	result: HistorySearchResult | null,
+	selected: number,
+): HistorySelection | null {
+	if (!result) return null;
+	if (selected < result.prompts.length) {
+		const hit = result.prompts[selected];
+		return hit ? { kind: "prompt", hit } : null;
+	}
+	if (stage !== "zoomed") return null;
+	const hit = result.messages[selected - result.prompts.length];
+	return hit ? { kind: "message", hit } : null;
+}
+
+/**
+ * The `ChatLocationRequest` a hit resolves to, or `null` when it isn't jumpable. A `MessageHit` is
+ * jumpable once mapped to a workspace (`workspaceId` present) — unchanged from before. A `PromptHit` is
+ * jumpable once it also carries its kept-newest occurrence's `messageIndex`/`anchorText` — absent for an
+ * unmapped-cwd hit, or a host that doesn't populate those two fields. Shared by `PromptRow`'s
+ * go-to-chat icon, the overlay's `Shift+Enter` handler, and `MessageRow`'s click/`Enter` handler, so all
+ * three gate on the exact same rule and can never disagree on "is this jumpable."
+ */
+export function jumpTarget(hit: PromptHit | MessageHit): ChatLocationRequest | null {
+	if (!hit.workspaceId || hit.messageIndex == null || hit.anchorText == null) return null;
+	return {
+		workspaceId: hit.workspaceId,
+		sessionId: hit.sessionId,
+		messageIndex: hit.messageIndex,
+		anchorText: hit.anchorText,
+	};
+}
+
+/**
+ * The Ctrl+R history-recall overlay's integration edge — the one hook (besides `ChatView` itself)
+ * sanctioned to touch store/transport (see `chat/SPEC.md`'s boundary section). Owns the overlay's
+ * open/stage/query/scope/selection state, debounces `history.search` 100ms per query/scope change, and
+ * drops stale responses via a sequence token so a slow earlier request can never clobber a faster later
+ * one.
+ */
+export function useHistorySearch(
+	sessionId: string,
+	workspaceId: string,
+	projectId: string | undefined,
+): {
+	state: HistorySearchState;
+	openOverlay: (seedQuery: string) => void;
+	close: () => void;
+	setQuery: (q: string) => void;
+	cycleScope: () => void;
+	setScope: (kind: ScopeKind) => void;
+	toggleStage: () => void;
+	moveSelection: (delta: number) => void;
+	openMessage: (target: ChatLocationRequest) => void;
+} {
+	const [open, setOpen] = useState(false);
+	const [stage, setStage] = useState<HistoryStage>("compact");
+	const [query, setQueryState] = useState("");
+	const [scopeKind, setScopeKind] = useState<ScopeKind>("workspace");
+	const [result, setResult] = useState<HistorySearchResult | null>(null);
+	const [selected, setSelected] = useState(0);
+	const [error, setError] = useState(false);
+
+	const scope = useMemo(
+		() => buildScope(scopeKind, sessionId, workspaceId, projectId),
+		[scopeKind, sessionId, workspaceId, projectId],
+	);
+
+	// Debounce 100ms per query/scope change; a sequence token drops stale responses (a slow earlier
+	// request resolving after a faster later one must never overwrite it). The token bumps unconditionally
+	// (even while closed) so a response in flight at close time can never land after reopening.
+	const tokenRef = useRef(0);
+	useEffect(() => {
+		const token = ++tokenRef.current;
+		if (!open) return;
+		const timer = setTimeout(() => {
+			getTransport()
+				.request("history.search", { query, scope, limit: 50 })
+				.then((res) => {
+					if (tokenRef.current !== token) return;
+					setResult(res);
+					setError(false);
+				})
+				.catch(() => {
+					if (tokenRef.current !== token) return;
+					setError(true);
+				});
+		}, 100);
+		return () => clearTimeout(timer);
+	}, [open, query, scope]);
+
+	// A cold (first-ever) build returns a partial result with `indexing: true` once its budget expires —
+	// otherwise correct, just not yet complete. Retry every 300ms for as long as the overlay stays open
+	// and the latest result keeps reporting `indexing`, using a token of its own — never the debounce
+	// effect's `tokenRef` above. Sharing one counter between two independently-triggered schedulers would
+	// mean whichever fires *second* within the same render invalidates the other's already-in-flight
+	// request even when that one is the more relevant of the two (e.g. a query edit arriving while a
+	// retry happens to also be due: both effects would fire in the same pass, and a shared token would let
+	// the retry's bump silently drop the fresh debounced response for the new query). Bumping
+	// unconditionally before the early return mirrors the debounce effect's own token discipline, for the
+	// same reason: a retry in flight when the overlay closes must never land after it reopens. Keyed on
+	// `result` itself, not `result.indexing` — a same-valued `indexing: true` on every retry still
+	// produces a *new* result object each `search()` call, which is what makes this effect re-fire and
+	// reschedule the next retry; a boolean dep would fire once and never repeat.
+	const retryTokenRef = useRef(0);
+	useEffect(() => {
+		const token = ++retryTokenRef.current;
+		if (!open || !result?.indexing) return;
+		const timer = setTimeout(() => {
+			getTransport()
+				.request("history.search", { query, scope, limit: 50 })
+				.then((res) => {
+					if (retryTokenRef.current !== token) return;
+					setResult(res);
+					setError(false);
+				})
+				.catch(() => {
+					if (retryTokenRef.current !== token) return;
+					setError(true);
+				});
+		}, 300);
+		return () => clearTimeout(timer);
+	}, [open, result, query, scope]);
+
+	// Keep `selected` in range as the visible flat list changes shape (a narrower result set, or a stage
+	// toggle that changes which sections are visible).
+	useEffect(() => {
+		setSelected((s) => {
+			const len = flatListLength(stage, result);
+			return len === 0 ? 0 : Math.min(s, len - 1);
+		});
+	}, [stage, result]);
+
+	const openOverlay = useCallback((seedQuery: string) => {
+		setOpen(true);
+		setStage("compact");
+		setScopeKind("workspace");
+		setQueryState(seedQuery);
+		setSelected(0);
+		setResult(null);
+		setError(false);
+	}, []);
+
+	const close = useCallback(() => setOpen(false), []);
+
+	const setQuery = useCallback((q: string) => {
+		setQueryState(q);
+		setSelected(0);
+	}, []);
+
+	const cycleScope = useCallback(() => {
+		// The modulo always lands in range given `k` is itself a SCOPE_ORDER member — `?? k` is just to
+		// satisfy noUncheckedIndexedAccess, never an actual fallback in practice.
+		setScopeKind((k) => SCOPE_ORDER[(SCOPE_ORDER.indexOf(k) + 1) % SCOPE_ORDER.length] ?? k);
+		setSelected(0);
+	}, []);
+
+	// R2's mouse path: the scope picker's dropdown items pick a scope directly rather than stepping
+	// through `cycleScope` — `Ctrl+R` keeps calling `cycleScope` above, unchanged. Resets `selected` the
+	// same way cycling does, for the same reason (a scope change reshapes the flat list under it).
+	const setScope = useCallback((kind: ScopeKind) => {
+		setScopeKind(kind);
+		setSelected(0);
+	}, []);
+
+	const toggleStage = useCallback(() => {
+		setStage((s) => (s === "compact" ? "zoomed" : "compact"));
+	}, []);
+
+	const moveSelection = useCallback(
+		(delta: number) => {
+			setSelected((s) => {
+				const len = flatListLength(stage, result);
+				if (len === 0) return 0;
+				return (s + delta + len) % len;
+			});
+		},
+		[stage, result],
+	);
+
+	// Jump to an already-resolved target (see `jumpTarget` above) via the store's `chatLocationRequest`
+	// deep link (see `store/SPEC.md`), then close the overlay. Callers only ever pass a target `jumpTarget`
+	// produced, so there's nothing left to gate here — the "is this jumpable" check happened at the call
+	// site (the icon's render gate / `Shift+Enter` handler / message-hit click), belt-and-suspenders by
+	// construction rather than a redundant guard here.
+	const openMessage = useCallback(
+		(target: ChatLocationRequest) => {
+			useAppStore.getState().requestChatLocation(target);
+			close();
+		},
+		[close],
+	);
+
+	const state = useMemo<HistorySearchState>(
+		() => ({ open, stage, query, scope, result, selected, error }),
+		[open, stage, query, scope, result, selected, error],
+	);
+
+	return {
+		state,
+		openOverlay,
+		close,
+		setQuery,
+		cycleScope,
+		setScope,
+		toggleStage,
+		moveSelection,
+		openMessage,
+	};
+}

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -98,6 +98,7 @@ export function CenterTabs() {
 	const tabsByWorkspace = useAppStore((s) => s.tabsByWorkspace);
 	const activeTabByWorkspace = useAppStore((s) => s.activeTabByWorkspace);
 	const closedChatsByWorkspace = useAppStore((s) => s.closedChatsByWorkspace);
+	const chatLocationRequest = useAppStore((s) => s.chatLocationRequest);
 	const setActiveTab = useAppStore((s) => s.setActiveTab);
 	const closeTab = useAppStore((s) => s.closeTab);
 
@@ -147,6 +148,47 @@ export function CenterTabs() {
 			cancelled = true;
 		};
 	}, [activeWorkspaceId]);
+
+	// Jump-to-message deep link from history search (`chatLocationRequest`, see `store/SPEC.md`): open,
+	// reopen, or activate the target chat in this workspace. `requestChatLocation` already set
+	// `activeWorkspaceId` to the request's own workspace, so this only has to place/focus the tab; it
+	// deliberately never clears the request — `ChatView` (mounted once its tab is active) consumes it to
+	// scroll + flash, and clears it once it has resolved a row (or given up and toasted).
+	useEffect(() => {
+		if (!chatLocationRequest || chatLocationRequest.workspaceId !== activeWorkspaceId) return;
+		const { sessionId } = chatLocationRequest;
+		// (a) Already open in a tab — just focus it, the exact action its own tab button calls.
+		const tab = openTabs.find((t) => t.kind === "chat" && t.sessionId === sessionId);
+		if (tab) {
+			setActiveTab(tab.id);
+			return;
+		}
+		const store = useAppStore.getState();
+		// (b) Closed to history but its runtime is still live (`closeChatToHistory`, not a restart) —
+		// `reopenChat` just re-attaches the tab; no fetch needed.
+		if (store.sessions[sessionId]) {
+			store.reopenChat(sessionId);
+			return;
+		}
+		// (c) Neither — the same fetch + hydrate `onReopenChat` below does for a disk-only history entry.
+		let cancelled = false;
+		void getTransport()
+			.request("session.getMessages", { sessionId, workspaceId: chatLocationRequest.workspaceId })
+			.then(({ summary, messages }) => {
+				if (cancelled) return;
+				useAppStore.getState().hydrateSession(summary, messagesToRuntime(messages), true);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				// The request would otherwise sit unconsumed forever (its only other consumer, `ChatView`,
+				// never mounts for a session whose tab never opens) — say why the jump did nothing.
+				toast.error(errorText(err), "Couldn't open the chat");
+				useAppStore.getState().clearChatLocation();
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [chatLocationRequest, activeWorkspaceId, openTabs, setActiveTab]);
 
 	// Reopen a chat from history: a live runtime just restores its tab; a disk-only one is re-opened on the
 	// host, its transcript fetched, then hydrated + focused (hydrateSession drops it from history, keyed to

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -166,7 +166,12 @@ a project picker, the prompt hero, and the reused
   via `store.noteClosedChats`. Reopening restores a live runtime's tab, or for a disk-only chat re-opens it
   on the host (`getMessages`) + hydrates — so a reload, a second tab, or a host restart all rebuild from the
   host. A rejected new-chat `session.create` or history-reopen `getMessages` raises a `store.toast.error`
-  (the click would otherwise do nothing, silently; a failed reopen stays in history for a retry). **`Toaster`** is the app-wide toast host the shell mounts once: it subscribes to `store.toasts` and
+  (the click would otherwise do nothing, silently; a failed reopen stays in history for a retry).
+  `CenterTabs` also resolves the history-search **`chatLocationRequest`** deep link (see `store/SPEC.md`):
+  once its workspace is active, it focuses an already-open tab, `reopenChat`s a live-but-closed one, or
+  fetches + hydrates a disk-only one — the reopen flow's two cases above, plus a third case for an
+  already-open tab — leaving `ChatView` to consume the request for the scroll + flash (`chat/SPEC.md`'s
+  Jump-to-message bullet). **`Toaster`** is the app-wide toast host the shell mounts once: it subscribes to `store.toasts` and
   renders each via the `components/ui/toast` primitives, letting Radix own the auto-timeout + swipe/hover-pause
   and routing every close back through `store.dismissToast` (so the store stays the single source of truth).
   Errors persist until dismissed; success/info time out. The **integration piece** — the primitives stay

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -129,13 +129,14 @@ changed file vs the workspace's base branch (id `${workspaceId}:diff:${path}` �
 `view` split|inline via **`setDiffTabView`**, split the default; a markdown diff's `rendered` flag via
 **`setDiffTabRendered`** swaps raw lines for compiled documents — `DiffPane` offers it for markdown
 paths only; opened by `ChangesPanel`). The transient **`chatLocationRequest`** — the history-search jump
-  deep link; the requester switches the active workspace, `CenterTabs` opens/hydrates the target chat,
-  `ChatView` consumes + clears — is **`ChatLocationRequest { workspaceId, sessionId, messageIndex,
-  anchorText }`**, set by **`requestChatLocation(req)`** (which also sets `activeWorkspaceId:
-  req.workspaceId`, since the target chat can live in a different workspace than the one the search ran
-  from) and cleared by **`clearChatLocation()`**; the target's anchor resolves against the runtime's
-  `turnIdByMessageIndex` (see `chat/SPEC.md`'s hydration bullet), falling back to `anchorText` when
-  absent. The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
+  deep link; the requester activates the target project+workspace, `CenterTabs` opens/hydrates the target
+  chat, `ChatView` consumes + clears — is **`ChatLocationRequest { workspaceId, projectId, sessionId,
+  messageIndex, anchorText }`**, set by **`requestChatLocation(req)`** (which sets `selectedProjectId` +
+  `activeWorkspaceId` **atomically**, the same invariant `activateWorkspace` upholds, since the target chat
+  can live in a different project/workspace than the one the search ran from — the caller
+  `useHistorySearch.openMessage` loads the destination project's workspaces first when absent) and cleared
+  by **`clearChatLocation()`**; the target's anchor resolves against the runtime's `turnIdByMessageIndex`
+  (see `chat/SPEC.md`'s hydration bullet), falling back to the newest `anchorText` match when absent. The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
   `SessionRuntime` types. (Chat *render* types + renderers live in the `chat` module.) The pure context
   selectors in `selectors.ts` resolve the active `Workspace`, its owning project id, and the shell's context
   project from those canonical ids and collections; derived active-project state is never stored separately.

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -128,8 +128,14 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
 changed file vs the workspace's base branch (id `${workspaceId}:diff:${path}` — one tab per file;
 `view` split|inline via **`setDiffTabView`**, split the default; a markdown diff's `rendered` flag via
 **`setDiffTabRendered`** swaps raw lines for compiled documents — `DiffPane` offers it for markdown
-paths only; opened by `ChangesPanel`).
-The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
+paths only; opened by `ChangesPanel`). The transient **`chatLocationRequest`** — the history-search jump
+  deep link; the requester switches the active workspace, `CenterTabs` opens/hydrates the target chat,
+  `ChatView` consumes + clears — is **`ChatLocationRequest { workspaceId, sessionId, messageIndex,
+  anchorText }`**, set by **`requestChatLocation(req)`** (which also sets `activeWorkspaceId:
+  req.workspaceId`, since the target chat can live in a different workspace than the one the search ran
+  from) and cleared by **`clearChatLocation()`**; the target's anchor resolves against the runtime's
+  `turnIdByMessageIndex` (see `chat/SPEC.md`'s hydration bullet), falling back to `anchorText` when
+  absent. The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
   `SessionRuntime` types. (Chat *render* types + renderers live in the `chat` module.) The pure context
   selectors in `selectors.ts` resolve the active `Workspace`, its owning project id, and the shell's context
   project from those canonical ids and collections; derived active-project state is never stored separately.
@@ -138,7 +144,7 @@ The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` +
   sync-baseline snapshot; + the `isSkillPath` path predicate it shares with `noteFsChanged`); `toast` (the
   fire-from-anywhere helper),
   `Toast` (type), `EditorTab` (`FileTab`/`ChatTab`/`DocTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` +
-  `EMPTY_RUNTIME` (ChatView's pre-creation fallback), `reduceSessionEvent`.
+  `EMPTY_RUNTIME` (ChatView's pre-creation fallback), `ChatLocationRequest` (type), `reduceSessionEvent`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/
   `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`/`AppConfig`/`ThemeId`;
   `DEFAULT_CONFIG` for the pre-welcome default; `PiEvent`/`LoginFrame`, **type-only**); `chat`

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -542,12 +542,13 @@ test("clearWorkspaceTabs drops both open and closed chat runtimes + clears histo
 	expect(st.tabsByWorkspace.ws1).toBeUndefined();
 });
 
-test("requestChatLocation sets the jump deep link AND switches the active workspace; clearChatLocation drops it", () => {
+test("requestChatLocation sets the jump deep link AND switches project+workspace atomically; clearChatLocation drops it", () => {
 	const store = useAppStore.getState();
-	useAppStore.setState({ activeWorkspaceId: "ws1" });
+	useAppStore.setState({ selectedProjectId: "p1", activeWorkspaceId: "ws1" });
 
 	store.requestChatLocation({
 		workspaceId: "ws2",
+		projectId: "p2",
 		sessionId: "s1",
 		messageIndex: 3,
 		anchorText: "deploy the docs",
@@ -555,16 +556,20 @@ test("requestChatLocation sets the jump deep link AND switches the active worksp
 	let st = useAppStore.getState();
 	expect(st.chatLocationRequest).toEqual({
 		workspaceId: "ws2",
+		projectId: "p2",
 		sessionId: "s1",
 		messageIndex: 3,
 		anchorText: "deploy the docs",
 	});
-	expect(st.activeWorkspaceId).toBe("ws2"); // the hit's chat can live in a different workspace
+	// A cross-project jump activates BOTH ids together — never leaving selectedProjectId on the source.
+	expect(st.activeWorkspaceId).toBe("ws2");
+	expect(st.selectedProjectId).toBe("p2");
 
 	store.clearChatLocation();
 	st = useAppStore.getState();
 	expect(st.chatLocationRequest).toBeNull();
-	expect(st.activeWorkspaceId).toBe("ws2"); // clearing the request never reverts the workspace switch
+	expect(st.activeWorkspaceId).toBe("ws2"); // clearing the request never reverts the navigation
+	expect(st.selectedProjectId).toBe("p2");
 });
 
 // ---- updateWorkspace: the workspace.updated push folds in without losing local computed state ----

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -464,15 +464,17 @@ test("hydrateSession rebuilds a runtime + tab on connect, and never clobbers a l
 		turns: [{ kind: "user", id: "u1", message: { role: "user", content: "hi", timestamp: 0 } }],
 		toolResults: {},
 		askAnswers: {},
+		turnIdByMessageIndex: ["u1"],
 	});
 	const st = useAppStore.getState();
 	expect(st.sessions.h1?.turns).toHaveLength(1);
+	expect(st.sessions.h1?.turnIdByMessageIndex).toEqual(["u1"]); // the anchor map copies through
 	expect(st.tabsByWorkspace.ws1?.some((t) => t.kind === "chat" && t.sessionId === "h1")).toBe(true);
 
 	// A second hydrate (e.g. stale list) must NOT overwrite the now-live runtime.
 	store.hydrateSession(
 		{ ...summary, messageCount: 99 },
-		{ turns: [], toolResults: {}, askAnswers: {} },
+		{ turns: [], toolResults: {}, askAnswers: {}, turnIdByMessageIndex: [] },
 	);
 	expect(useAppStore.getState().sessions.h1?.turns).toHaveLength(1);
 });
@@ -513,7 +515,11 @@ test("hydrateSession(activate) reopens a disk-only chat: builds it, focuses it, 
 		updatedAt: 1,
 		live: true,
 	};
-	store.hydrateSession(summary, { turns: [], toolResults: {}, askAnswers: {} }, true);
+	store.hydrateSession(
+		summary,
+		{ turns: [], toolResults: {}, askAnswers: {}, turnIdByMessageIndex: [] },
+		true,
+	);
 
 	const st = useAppStore.getState();
 	expect(st.sessions.disk1).toBeDefined(); // runtime built from the re-opened session
@@ -534,6 +540,31 @@ test("clearWorkspaceTabs drops both open and closed chat runtimes + clears histo
 	expect(st.sessions.b).toBeUndefined();
 	expect(st.closedChatsByWorkspace.ws1).toBeUndefined();
 	expect(st.tabsByWorkspace.ws1).toBeUndefined();
+});
+
+test("requestChatLocation sets the jump deep link AND switches the active workspace; clearChatLocation drops it", () => {
+	const store = useAppStore.getState();
+	useAppStore.setState({ activeWorkspaceId: "ws1" });
+
+	store.requestChatLocation({
+		workspaceId: "ws2",
+		sessionId: "s1",
+		messageIndex: 3,
+		anchorText: "deploy the docs",
+	});
+	let st = useAppStore.getState();
+	expect(st.chatLocationRequest).toEqual({
+		workspaceId: "ws2",
+		sessionId: "s1",
+		messageIndex: 3,
+		anchorText: "deploy the docs",
+	});
+	expect(st.activeWorkspaceId).toBe("ws2"); // the hit's chat can live in a different workspace
+
+	store.clearChatLocation();
+	st = useAppStore.getState();
+	expect(st.chatLocationRequest).toBeNull();
+	expect(st.activeWorkspaceId).toBe("ws2"); // clearing the request never reverts the workspace switch
 });
 
 // ---- updateWorkspace: the workspace.updated push folds in without losing local computed state ----

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -118,6 +118,18 @@ export interface ClosedChat {
 }
 
 /**
+ * A history-search "jump to message" deep link: which workspace/session/message to open and scroll to.
+ * `anchorText` (a prefix of the hit's message text, from `MessageHit`) lets the consumer validate/fall
+ * back if the live transcript drifted from the indexed hit (e.g. after compaction).
+ */
+export interface ChatLocationRequest {
+	workspaceId: string;
+	sessionId: string;
+	messageIndex: number;
+	anchorText: string;
+}
+
+/**
  * The live state of one chat session, keyed by its `sessionId` in `store.sessions`. The host already runs
  * N independent `AgentSession`s, so each gets its own runtime here — events route to it by id, letting
  * several chats stream concurrently while switching tabs is an instant in-memory swap.
@@ -125,6 +137,13 @@ export interface ClosedChat {
 export interface SessionRuntime {
 	/** Conversation as pi-canonical turns (user/assistant messages + web-local system notices). */
 	turns: ChatTurn[];
+	/**
+	 * Message-position → turn id, from hydration (`hydrate.ts`'s `HydratedRuntime`); absent until this
+	 * chat has been hydrated (a freshly created session never sets it). The `chatLocationRequest`
+	 * jump-to-message deep link resolves its `messageIndex` against this map, falling back to the
+	 * request's `anchorText` when absent (e.g. an already-live chat `hydrateSession` no-op'd on).
+	 */
+	turnIdByMessageIndex?: (string | null)[];
 	/** Live tool state keyed by toolCallId; paired with the toolCall block inside an assistant turn. */
 	toolResults: Record<string, ToolResultState>;
 	/** `ask_user_question` replies keyed by tool call id (from `ask-user-answers` custom messages). */
@@ -423,6 +442,13 @@ interface AppState {
 	 */
 	changesRequest: { workspaceId: string; path: string } | null;
 	/**
+	 * A history-search "jump to message" deep link, set by `requestChatLocation` and consumed by
+	 * `CenterTabs` (open/hydrate the target chat tab) then `ChatView` (scroll to the anchored turn, then
+	 * clear it) — a fresh object each call so identical re-requests (e.g. the same hit clicked twice)
+	 * still fire.
+	 */
+	chatLocationRequest: ChatLocationRequest | null;
+	/**
 	 * The live-refresh signal, per workspace: `tick` increments on every `workspace.fsChanged` push (the
 	 * host's debounced worktree change notifier); `paths`/`truncated` are the LAST batch only. Panels
 	 * select their workspace's entry and silently refetch on `tick` change — the store holds only the
@@ -590,6 +616,13 @@ interface AppState {
 	applyConfig: (config: AppConfig) => void;
 	/** Ask the right panel to open `path`'s diff in its Changes view (deep-link from chat). */
 	requestChangesView: (workspaceId: string, path: string) => void;
+	/**
+	 * Open a history-search hit: sets `chatLocationRequest` AND switches `activeWorkspaceId` (the hit's
+	 * chat can live in a different workspace than the one the search ran from).
+	 */
+	requestChatLocation: (req: ChatLocationRequest) => void;
+	/** Dismiss the jump deep link once `ChatView` has consumed it (scrolled to the anchored turn). */
+	clearChatLocation: () => void;
 	/** Enqueue a toast; returns its id so a caller can dismiss it early. An identical live toast (same
 	 * variant/title/message — e.g. a retried failure) coalesces: no twin is added, the existing id returns.
 	 * The queue caps at `MAX_TOASTS` (oldest drop). Prefer the `toast` helper. */
@@ -683,6 +716,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	models: [],
 	changesRequest: null,
 	changesView: "list",
+	chatLocationRequest: null,
 	fsChangesByWorkspace: {},
 	skillChangeTickByWorkspace: {},
 	skillsSyncedTickBySession: {},
@@ -1074,6 +1108,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 				toolResults: hydrated.toolResults,
 				askAnswers: hydrated.askAnswers,
 				isStreaming: summary.isStreaming,
+				...(hydrated.turnIdByMessageIndex
+					? { turnIdByMessageIndex: hydrated.turnIdByMessageIndex }
+					: {}),
 			};
 			const id = `${wsId}:${summary.sessionId}`;
 			const tab: ChatTab = {
@@ -1215,6 +1252,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 	setSettingsSection: (section) => set({ settingsSection: section }),
 	applyConfig: (config) => set({ theme: config.theme }),
 	requestChangesView: (workspaceId, path) => set({ changesRequest: { workspaceId, path } }),
+	requestChatLocation: (req) =>
+		set({ chatLocationRequest: req, activeWorkspaceId: req.workspaceId }),
+	clearChatLocation: () => set({ chatLocationRequest: null }),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(
 			(t) => t.variant === toast.variant && t.title === toast.title && t.message === toast.message,

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -123,7 +123,11 @@ export interface ClosedChat {
  * back if the live transcript drifted from the indexed hit (e.g. after compaction).
  */
 export interface ChatLocationRequest {
+	/** The workspace that owns the target chat. */
 	workspaceId: string;
+	/** The project that owns `workspaceId` — carried so a cross-project jump can activate both IDs
+	 * atomically (and load the destination project's workspaces first if it hasn't been opened yet). */
+	projectId: string;
 	sessionId: string;
 	messageIndex: number;
 	anchorText: string;
@@ -1252,8 +1256,16 @@ export const useAppStore = create<AppState>((set, get) => ({
 	setSettingsSection: (section) => set({ settingsSection: section }),
 	applyConfig: (config) => set({ theme: config.theme }),
 	requestChangesView: (workspaceId, path) => set({ changesRequest: { workspaceId, path } }),
+	// Activate project + workspace together (the same atomicity `activateWorkspace` upholds) so a jump into
+	// another project can never leave `selectedProjectId` on the source while `activeWorkspaceId` points
+	// elsewhere. The caller (`useHistorySearch.openMessage`) ensures the target project's workspaces are
+	// loaded first, so `selectActiveWorkspace` can resolve `activeWorkspaceId`.
 	requestChatLocation: (req) =>
-		set({ chatLocationRequest: req, activeWorkspaceId: req.workspaceId }),
+		set({
+			chatLocationRequest: req,
+			selectedProjectId: req.projectId,
+			activeWorkspaceId: req.workspaceId,
+		}),
 	clearChatLocation: () => set({ chatLocationRequest: null }),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(

--- a/e2e/fixtures/sessions.ts
+++ b/e2e/fixtures/sessions.ts
@@ -1,14 +1,12 @@
 // Seeds real, pi-parseable session JSONL files into the e2e host's isolated agent dir so `history.search`
-// has something to find. Reuses `writeFixtureSession`/`defaultSessionDirFor` from
-// `packages/server/src/history/testFixtures.ts` (a cross-package source import — this file runs under
-// node via Playwright's own TS loading, same as the rest of `global-setup.ts`, and `testFixtures.ts` only
-// imports `node:fs`/`node:path`, so this resolves cleanly with no bundler involved). Those two helpers are
-// pinned against pi's real `SessionManager` by `packages/server/src/history/testFixtures.test.ts` — if
-// pi's on-disk format or default-layout encoding ever shifts, that test fails, not this seeder silently.
-import {
-	defaultSessionDirFor,
-	writeFixtureSession,
-} from "../../packages/server/src/history/testFixtures";
+// has something to find. Reuses `writeFixtureSession`/`defaultSessionDirFor` via the server package's
+// declared test-only subpath export `@thinkrail/server/history-test-fixtures` (the sanctioned boundary —
+// same pattern as `@thinkrail/server/agent`; it maps to `testFixtures.ts`, which imports only
+// `node:crypto`/`node:fs`/`node:path`, so it resolves cleanly under Playwright's node TS loading and never
+// drags in the Bun-only host). Those two helpers are pinned against pi's real `SessionManager` by
+// `packages/server/src/history/testFixtures.test.ts` — if pi's on-disk format or default-layout encoding
+// ever shifts, that test fails, not this seeder silently.
+import { defaultSessionDirFor, writeFixtureSession } from "@thinkrail/server/history-test-fixtures";
 import { E2E_PI_AGENT_DIR } from "./paths";
 
 /** Deliberately **unmapped** cwd — no project/workspace record in the e2e fixtures maps to this path, so

--- a/e2e/fixtures/sessions.ts
+++ b/e2e/fixtures/sessions.ts
@@ -19,7 +19,7 @@ const BASE_TS = 1_700_000_000_000;
 
 /**
  * Seeds two sessions for `E2E_EXTERNAL_CWD` under `agentDir`'s default per-cwd layout — the same layout
- * production `HistoryIndex` discovers via no-arg `SessionManager.listAll()` (see
+ * a no-arg production `HistoryIndex` discovers with its own walk (see
  * `packages/server/src/history/SPEC.md`'s "pi file format" section), and the layout the e2e host actually
  * runs against (`PI_CODING_AGENT_DIR=E2E_PI_AGENT_DIR`, `playwright.config.ts`).
  *

--- a/e2e/fixtures/sessions.ts
+++ b/e2e/fixtures/sessions.ts
@@ -1,0 +1,86 @@
+// Seeds real, pi-parseable session JSONL files into the e2e host's isolated agent dir so `history.search`
+// has something to find. Reuses `writeFixtureSession`/`defaultSessionDirFor` from
+// `packages/server/src/history/testFixtures.ts` (a cross-package source import — this file runs under
+// node via Playwright's own TS loading, same as the rest of `global-setup.ts`, and `testFixtures.ts` only
+// imports `node:fs`/`node:path`, so this resolves cleanly with no bundler involved). Those two helpers are
+// pinned against pi's real `SessionManager` by `packages/server/src/history/testFixtures.test.ts` — if
+// pi's on-disk format or default-layout encoding ever shifts, that test fails, not this seeder silently.
+import {
+	defaultSessionDirFor,
+	writeFixtureSession,
+} from "../../packages/server/src/history/testFixtures";
+import { E2E_PI_AGENT_DIR } from "./paths";
+
+/** Deliberately **unmapped** cwd — no project/workspace record in the e2e fixtures maps to this path, so
+ * search hits against it exercise `history.search`'s "no workspace/project scope labels" branch. */
+export const E2E_EXTERNAL_CWD = "/tmp/thinkrail-e2e-external";
+
+/** Deterministic base timestamp (ms since epoch) so recency order across the seeded fixtures is
+ * assertable rather than depending on wall-clock write order. */
+const BASE_TS = 1_700_000_000_000;
+
+/**
+ * Seeds two sessions for `E2E_EXTERNAL_CWD` under `agentDir`'s default per-cwd layout — the same layout
+ * production `HistoryIndex` discovers via no-arg `SessionManager.listAll()` (see
+ * `packages/server/src/history/SPEC.md`'s "pi file format" section), and the layout the e2e host actually
+ * runs against (`PI_CODING_AGENT_DIR=E2E_PI_AGENT_DIR`, `playwright.config.ts`).
+ *
+ * Deterministic timestamps make recency order assertable — newest first:
+ *  1. "update dependency pins" (its own session, `BASE_TS + 10_000`)
+ *  2. "fix the flaky watcher test" (`BASE_TS + 2_000`)
+ *  3. "deploy the docs site" (`BASE_TS`)
+ *
+ * The first session's second assistant reply contains the exact phrase "the debounce window overlaps" —
+ * a fixed string later message-search specs can match on.
+ */
+export function seedExternalCwdSessions(agentDir: string = E2E_PI_AGENT_DIR): void {
+	const dir = defaultSessionDirFor(agentDir, E2E_EXTERNAL_CWD);
+
+	writeFixtureSession(dir, {
+		id: "e2e-fixture-deploy-docs",
+		cwd: E2E_EXTERNAL_CWD,
+		messages: [
+			{ role: "user", text: "deploy the docs site", timestamp: BASE_TS },
+			{
+				role: "assistant",
+				text: "Deployed the docs site — all checks green.",
+				timestamp: BASE_TS + 1_000,
+			},
+			{ role: "user", text: "fix the flaky watcher test", timestamp: BASE_TS + 2_000 },
+			{
+				role: "assistant",
+				text: "Fixed it: the debounce window overlaps with the poll interval, so I widened it.",
+				timestamp: BASE_TS + 3_000,
+			},
+		],
+	});
+
+	writeFixtureSession(dir, {
+		id: "e2e-fixture-dependency-pins",
+		cwd: E2E_EXTERNAL_CWD,
+		messages: [{ role: "user", text: "update dependency pins", timestamp: BASE_TS + 10_000 }],
+	});
+}
+
+/**
+ * Seeds a session for a real workspace worktree cwd created during a test, using the same default-layout
+ * encoding the e2e host's `HistoryIndex` discovers — for later tasks (A6+) that need searchable history
+ * scoped to an actual workspace rather than the unmapped `E2E_EXTERNAL_CWD`.
+ *
+ * `opts.id` is optional and defaults (via `writeFixtureSession`) to a fresh `sess-<uuid>` per call — the
+ * right choice for most tests, since it's what lets the *same* server process (one `webServer` lifetime
+ * spans the whole Playwright run, including every `--repeat-each` repeat) attach each seeded session
+ * without the "Unknown session" collision a fixed literal id causes once a second repeat's differently-
+ * `workspaceId`'d attempt reuses it (see `AgentSessionManager`'s in-memory `sessions` map). Pass an
+ * explicit `id` only when a test asserts against the literal id or otherwise needs it deterministic.
+ *
+ * @returns the resolved `id` and the written file's `path` (appendable, like `writeFixtureSession`
+ * itself, e.g. to exercise mtime revalidation).
+ */
+export function seedWorkspaceSession(
+	worktreePath: string,
+	opts: Omit<Parameters<typeof writeFixtureSession>[1], "cwd">,
+): { id: string; path: string } {
+	const dir = defaultSessionDirFor(E2E_PI_AGENT_DIR, worktreePath);
+	return writeFixtureSession(dir, { ...opts, cwd: worktreePath });
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -10,6 +10,7 @@ import {
 	E2E_PICK_DIR_POINTER,
 } from "./fixtures/paths";
 import { seedFixtureRepo } from "./fixtures/repo";
+import { seedExternalCwdSessions } from "./fixtures/sessions";
 
 /** Fresh, isolated state dir + a throwaway git repo to open as a project. (Runs under node, not bun.) */
 export default function globalSetup(): void {
@@ -43,6 +44,11 @@ export default function globalSetup(): void {
 		join(E2E_PI_AGENT_DIR, "settings.json"),
 		`${JSON.stringify({ defaultProvider: provider, defaultModel: idParts.join("/"), defaultThinkingLevel: "low" }, null, 2)}\n`,
 	);
+
+	// Seed two deterministic pi sessions for a deliberately unmapped cwd, under the SAME default per-cwd
+	// layout production `HistoryIndex` discovers (see fixtures/sessions.ts + history/SPEC.md's "pi file
+	// format" section) — so `history.search` has real, searchable history the moment the host boots.
+	seedExternalCwdSessions();
 
 	// Seed the shared fixture repo (git init + seed files + commit). Shared with per-test `resetState`, which
 	// re-seeds it if a flaky @agent spec damages the repo (see fixtures/repo.ts).

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -1,0 +1,337 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
+
+// Selecting a message hit in the Ctrl+R history overlay (A7) jumps to it: `useHistorySearch`'s
+// `openMessage` sets the store's `chatLocationRequest`; `CenterTabs` opens/hydrates the target chat;
+// `ChatView` scrolls to the matched row and flashes it (`[data-flash]`), then clears the request. This
+// file drives that whole path against real, disk-only (never-opened) seeded sessions — the "come back to
+// a workspace later and jump to something you remember" case the feature targets.
+//
+// `HistoryIndex` (packages/server/src/history/historyIndex.ts) is a process-wide singleton shared by the
+// entire e2e run and throttles revalidation to `REVALIDATE_MS` (2s): once warm, a `history.search` call
+// only rescans disk if it's been >2s since the *last* rescan anywhere in the process, otherwise it serves
+// the previous scan's (possibly stale) results with no signal that they're stale. Every seed below is
+// followed by an explicit `waitForTimeout(2_100)` before the first search this test fires, so the
+// just-written file is guaranteed to be on disk long enough that the very next search is forced to
+// rescan and pick it up — mirroring the unit-test workaround at `historyIndex.test.ts:173`.
+
+test("selecting a same-workspace message hit opens the chat and flashes the matched row", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspaceA = await createWorkspaceViaDialog(page);
+
+	// `worktreePath` is the seed target because it's the exact server-side session `cwd`: `workspaces.ts`
+	// builds it as `join(dataDir(), "worktrees", slug, branch)`, and every session opened for this
+	// workspace runs with that same cwd — so a fixture written there is indistinguishable from a session a
+	// real chat would have produced.
+	// No explicit `id`: this test never references the seeded session by id (the jump below is driven by
+	// `history.search`'s text match, not the id), so the default fresh-per-call id is enough — and,
+	// unlike a fixed literal id, survives a Playwright retry within the same `webServer` lifetime (see
+	// `seedWorkspaceSession`'s jsdoc for the "Unknown session" collision a fixed id causes there).
+	seedWorkspaceSession(workspaceA.worktreePath, {
+		messages: [
+			{ role: "user", text: "audit the retry backoff", timestamp: 1_700_100_000_000 },
+			{
+				role: "assistant",
+				text: "Audited the retry backoff and added a jittered ceiling so it never spins forever.",
+				timestamp: 1_700_100_001_000,
+			},
+		],
+	});
+	await page.waitForTimeout(2_100);
+
+	// A reload doesn't auto-restore the active project/workspace (see `ask-restart.live.spec.ts`) — re-pick
+	// both, so `CenterTabs`' hydrate-on-connect effect re-lists workspace A's sessions from a cold client,
+	// the realistic "come back later" path. (Not load-bearing for the jump itself — case (c) below fetches
+	// the target session directly by id regardless of whether `session.list` ever ran for it — but this
+	// keeps the scenario honest to the brief and exercises the full reload path.)
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("project-item").first().click();
+	await page.getByTestId("workspace-item").first().click();
+	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+
+	// A fresh chat (not the seeded one) so a composer exists; the seeded session stays unopened — jumping
+	// to it must open a *second* tab, not reuse this one.
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+
+	await page.getByTestId("chat-input").press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	await query.fill("jittered ceiling");
+	const hit = page
+		.locator('[data-testid="history-item"][data-kind="message"]')
+		.filter({ hasText: "jittered ceiling" });
+	// Compact stage only lists prompts; the message hit lives behind the expand hint (no prompt matches
+	// "jittered ceiling", so it's the sole match, but only visible once zoomed).
+	await expect(page.getByTestId("history-expand-hint")).toBeVisible();
+	await query.press("Tab");
+	await expect(overlay).toHaveAttribute("data-stage", "zoomed");
+	await expect(hit).toBeVisible();
+	// Zero prompts matched "jittered ceiling", so the flat list's only entry (index 0) is this message hit
+	// — Enter selects it with no arrow-key navigation needed.
+	await query.press("Enter");
+
+	await expect(overlay).toBeHidden();
+	// The seeded session opened as a second tab and is now active.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(2);
+	const flashRow = page.locator("[data-flash]");
+	await expect(flashRow).toBeVisible();
+	await expect(flashRow).toContainText("jittered ceiling");
+	// The flash is transient (cleared 1600ms after it starts, decoupled from the location-request effect
+	// so clearing the request doesn't cancel the timer) — confirm it actually turns off, not just on.
+	await expect(page.locator("[data-flash]")).toHaveCount(0, { timeout: 5_000 });
+});
+
+test("selecting a cross-workspace message hit switches the active workspace and flashes the row", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspaceA = await createWorkspaceViaDialog(page);
+	// No explicit `id` — same reasoning as the same-workspace jump test above.
+	seedWorkspaceSession(workspaceA.worktreePath, {
+		messages: [
+			{ role: "user", text: "review the changelog draft", timestamp: 1_700_200_000_000 },
+			{
+				role: "assistant",
+				text: "Reviewed the changelog draft and tightened the wording on the migration notes.",
+				timestamp: 1_700_200_001_000,
+			},
+		],
+	});
+	await page.waitForTimeout(2_100);
+
+	// Workspace B: created second, so it's the active one — the search below runs from *its* chat, not A's.
+	await createWorkspaceViaDialog(page);
+	const workspaces = page.getByTestId("workspace-item");
+	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+
+	await page.getByTestId("chat-input").press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	// Default scope is "workspace" (scoped to B, which has no history of its own) — cycle to "all"
+	// (workspace → project → all, 2 presses) so workspace A's session is in scope.
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await expect(page.getByTestId("history-scope")).toHaveAttribute("data-scope", "all");
+	await query.fill("migration notes");
+	const hit = page
+		.locator('[data-testid="history-item"][data-kind="message"]')
+		.filter({ hasText: "migration notes" });
+	await expect(page.getByTestId("history-expand-hint")).toBeVisible();
+	await query.press("Tab");
+	await expect(hit).toBeVisible();
+	await query.press("Enter");
+
+	await expect(overlay).toBeHidden();
+	// Active workspace switched from B (index 1) to A (index 0).
+	await expect(workspaces.nth(0)).toHaveAttribute("data-active", "true");
+	await expect(workspaces.nth(1)).not.toHaveAttribute("data-active", "true");
+	// Workspace A's tab strip now shows only the just-opened seeded chat (B's own started-but-empty chat is
+	// a different workspace's tab list, hidden now that A is active).
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	const flashRow = page.locator("[data-flash]");
+	await expect(flashRow).toBeVisible();
+	await expect(flashRow).toContainText("migration notes");
+});
+
+test("an unmapped message hit is a no-op — the overlay stays open and the active workspace is untouched", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page); // workspace A
+	await createWorkspaceViaDialog(page); // workspace B — active
+	// Deliberately-unmapped external-cwd fixture (see fixtures/sessions.ts): no project/workspace maps to
+	// its cwd, so its message hits carry no `workspaceId`.
+	seedExternalCwdSessions();
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+
+	await page.getByTestId("chat-input").press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await expect(page.getByTestId("history-scope")).toHaveAttribute("data-scope", "all");
+	await query.fill("debounce window overlaps");
+	const hit = page
+		.locator('[data-testid="history-item"][data-kind="message"]')
+		.filter({ hasText: "debounce window overlaps" });
+	await expect(page.getByTestId("history-expand-hint")).toBeVisible();
+	await query.press("Tab");
+	await expect(hit).toBeVisible();
+	await expect(hit).toContainText("not a ThinkRail workspace");
+	await query.press("Enter");
+
+	// No-op: overlay stays open, no new tab, active workspace unchanged (still B).
+	await expect(overlay).toBeVisible();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	const workspaces = page.getByTestId("workspace-item");
+	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
+	await expect(workspaces.nth(0)).not.toHaveAttribute("data-active", "true");
+});
+
+// MESSAGES is assistant-only, and a `PromptHit` carries the same jump anchor a `MessageHit` always had
+// (`messageIndex`/`anchorText`, populated from the entry's own occurrence) — so the prompt row itself is
+// jumpable via a go-to-chat icon and `Shift+Enter`. The three tests below pin: (1) the messages section
+// drops the user-role duplicate it would otherwise show, while the prompt row gains the icon; (2) the
+// jump itself, via `Shift+Enter`, lands on the USER turn (not the assistant's); (3) an unmapped prompt
+// hit — same rule a `MessageHit` already followed — gets neither the icon nor a working shortcut.
+
+test("searching a prompt's own words that an assistant reply also echoes shows only an assistant crumb in MESSAGES, and the prompt row gets a jump icon", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspaceA = await createWorkspaceViaDialog(page);
+	// The assistant reply deliberately echoes the user's own words ("auth middleware"): the user-role
+	// entry itself is NOT also surfaced here as a second, textually-duplicate message hit (see
+	// `historyIndex.test.ts`'s test (a)) — the location it would carry lives on the prompt hit's
+	// `messageIndex`/`anchorText` instead.
+	seedWorkspaceSession(workspaceA.worktreePath, {
+		messages: [
+			{ role: "user", text: "refactor the auth middleware", timestamp: 1_700_700_000_000 },
+			{
+				role: "assistant",
+				text: "Refactored the auth middleware to extract the token check into its own helper.",
+				timestamp: 1_700_700_001_000,
+			},
+		],
+	});
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+
+	await page.getByTestId("chat-input").press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	await query.fill("auth middleware");
+	await query.press("Tab");
+	await expect(overlay).toHaveAttribute("data-stage", "zoomed");
+
+	// PROMPTS: the user's own line — mapped to a real workspace, so it carries a go-to-chat icon.
+	const promptRow = page
+		.locator('[data-testid="history-item"][data-kind="prompt"]')
+		.filter({ hasText: "refactor the auth middleware" });
+	await expect(promptRow).toBeVisible();
+	await expect(promptRow.getByTestId("history-jump")).toBeVisible();
+	// It's also the default (index-0) keyboard selection, so its shortcut glyph is visible without a
+	// mouse hover — the whole point of a keyboard-discoverable shortcut.
+	await expect(promptRow.getByTestId("history-jump-shortcut")).toHaveText("⇧⏎");
+
+	// MESSAGES: only the assistant's own line — no user-role row duplicates it.
+	const messageRows = page.locator('[data-testid="history-item"][data-kind="message"]');
+	await expect(messageRows).toHaveCount(1);
+	await expect(messageRows.filter({ hasText: "assistant" })).toHaveCount(1);
+	await expect(messageRows).toContainText("Refactored the auth middleware");
+});
+
+test("Shift+Enter on the selected prompt row jumps to the chat and flashes the matching USER turn", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspaceA = await createWorkspaceViaDialog(page);
+	seedWorkspaceSession(workspaceA.worktreePath, {
+		messages: [
+			{
+				role: "user",
+				text: "investigate the zephyr7000 regression",
+				timestamp: 1_700_800_000_000,
+			},
+			{
+				role: "assistant",
+				text: "Looked into it — turned out to be a stale cache entry.",
+				timestamp: 1_700_800_001_000,
+			},
+		],
+	});
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+
+	await page.getByTestId("chat-input").press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	await query.fill("zephyr7000");
+	const hit = page
+		.locator('[data-testid="history-item"][data-kind="prompt"]')
+		.filter({ hasText: "zephyr7000" });
+	await expect(hit).toBeVisible();
+	await expect(hit.getByTestId("history-jump")).toBeVisible();
+	// The only match is this prompt hit (default selection, index 0), so its shortcut glyph is already
+	// visible — no hover needed — confirming a keyboard-only user can discover Shift+Enter before
+	// pressing it, not just after the fact.
+	await expect(hit.getByTestId("history-jump-shortcut")).toHaveText("⇧⏎");
+
+	// Shift+Enter jumps it, rather than inserting it the way plain Enter / Cmd+Enter do (see
+	// history-search.spec.ts).
+	await query.press("Shift+Enter");
+
+	await expect(overlay).toBeHidden();
+	// The seeded session opened as a second tab and is now active.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(2);
+	const flashRow = page.locator("[data-flash]");
+	await expect(flashRow).toBeVisible();
+	// Flashes the USER turn the prompt hit's anchor points at — not the assistant reply.
+	await expect(flashRow).toContainText("investigate the zephyr7000 regression");
+	// The flash is transient — confirm it actually turns off, not just on (see the same-workspace jump
+	// test above for why this is decoupled from the location-request effect).
+	await expect(page.locator("[data-flash]")).toHaveCount(0, { timeout: 5_000 });
+});
+
+test("an unmapped prompt hit shows no jump icon, and Shift+Enter on it is a no-op", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page); // workspace A
+	await createWorkspaceViaDialog(page); // workspace B — active
+	// Deliberately-unmapped external-cwd fixture (see fixtures/sessions.ts): no project/workspace maps to
+	// its cwd, so its prompt hits carry no `workspaceId` — and therefore no jump anchor (`jumpTarget`
+	// requires one), the same rule an unmapped message hit already followed.
+	seedExternalCwdSessions();
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+
+	await page.getByTestId("chat-input").press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await expect(page.getByTestId("history-scope")).toHaveAttribute("data-scope", "all");
+	await query.fill("flaky watcher");
+	const hit = page
+		.locator('[data-testid="history-item"][data-kind="prompt"]')
+		.filter({ hasText: "flaky watcher" });
+	await expect(hit).toBeVisible();
+	await expect(hit.getByTestId("history-jump")).toHaveCount(0);
+	// Selected (default index 0, only match) but unmapped — no shortcut glyph either, same rule as the
+	// icon it sits beside.
+	await expect(hit.getByTestId("history-jump-shortcut")).toHaveCount(0);
+
+	await query.press("Shift+Enter");
+
+	// No-op: overlay stays open, no new tab, active workspace unchanged (still B).
+	await expect(overlay).toBeVisible();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	const workspaces = page.getByTestId("workspace-item");
+	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
+	await expect(workspaces.nth(0)).not.toHaveAttribute("data-active", "true");
+});

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -1,0 +1,622 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject, openWorkspaceChat } from "./fixtures/app";
+import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
+
+// No-agent (see composer.live.spec.ts for the @agent-tagged composer suite): the Ctrl+R history-recall
+// overlay never touches the agent — `openWorkspaceChat` creates a chat session but sends nothing to it.
+// `history.search` runs against the two deterministic sessions `seedExternalCwdSessions` seeds for the
+// deliberately unmapped `E2E_EXTERNAL_CWD` (see fixtures/sessions.ts): "deploy the docs site" / "fix the
+// flaky watcher test" (+ an assistant reply containing "the debounce window overlaps") and, in a second
+// session, "update dependency pins".
+//
+// Deviation from the brief's literal wording: Step 2 describes querying "flaky" and expecting BOTH a
+// prompt hit ("fix the flaky watcher test") and a message hit ("...debounce window overlaps...") to
+// surface for the same query. That pair isn't reachable — `historyIndex.ts`'s `matchesTerms` matches each
+// transcript entry independently, and "flaky" only appears in the user prompt, never in the assistant
+// reply. Querying "fix" instead matches both entries (a direct substring of the prompt, and a
+// case-insensitive substring of "Fixed" in the reply) and otherwise exercises the exact same scenario the
+// brief describes — see task-A7-report.md for the full writeup.
+
+test("Ctrl+R opens history recall, cycles scope to all, zooms to messages, inserts a prompt, and Esc preserves the draft", async ({
+	page,
+}) => {
+	await openWorkspaceChat(page);
+	// `openWorkspaceChat` → `openAppFresh` → `resetState()` unconditionally wipes `E2E_PI_AGENT_DIR/sessions`
+	// (see its jsdoc: stale sessions must be cleared so they don't resurface in a reused worktree) — which
+	// also empties the external-cwd fixture `globalSetup` seeded once for the whole run. Re-seed per-test,
+	// the same way `seedWorkspaceSession`'s own doc comment describes doing "during a test"; the write is
+	// idempotent (same ids/timestamps every call), so re-seeding here never duplicates or drifts the fixture.
+	seedExternalCwdSessions();
+
+	const input = page.getByTestId("chat-input");
+	const overlay = page.getByTestId("history-overlay");
+	const query = page.getByTestId("history-query");
+	const scopeBadge = page.getByTestId("history-scope");
+	const promptItems = page.locator('[data-testid="history-item"][data-kind="prompt"]');
+	const messageItems = page.locator('[data-testid="history-item"][data-kind="message"]');
+
+	// Ctrl+R from the composer opens the overlay in `compact` stage, focused on the (seeded-empty) query,
+	// defaulted to `workspace` scope.
+	await input.press("Control+r");
+	await expect(overlay).toBeVisible();
+	await expect(overlay).toHaveAttribute("data-stage", "compact");
+	await expect(query).toBeFocused();
+	await expect(scopeBadge).toHaveAttribute("data-scope", "workspace");
+
+	// Query "fix" (see file-header deviation note), then cycle scope workspace → project → all (2 presses)
+	// so the deliberately-unmapped external-cwd fixture sessions are in scope.
+	await query.fill("fix");
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await expect(scopeBadge).toHaveAttribute("data-scope", "all");
+	await expect(scopeBadge).toContainText("All");
+	await expect(promptItems.filter({ hasText: "fix the flaky watcher test" })).toBeVisible();
+	// Exactly one prompt matches "fix" across the seeded fixtures — the Prompts counter is "shown/total".
+	await expect(page.getByTestId("history-counts")).toHaveText("1/1");
+
+	// Tab zooms to `zoomed` (both sections); the assistant reply surfaces as a message hit, flagged as not
+	// belonging to a ThinkRail workspace (the fixture's cwd is deliberately unmapped — see the file header).
+	await query.press("Tab");
+	await expect(overlay).toHaveAttribute("data-stage", "zoomed");
+	const debounceHit = messageItems.filter({ hasText: "debounce window overlaps" });
+	await expect(debounceHit).toBeVisible();
+	await expect(debounceHit).toContainText("not a ThinkRail workspace");
+	// messages is assistant-only — "fix the flaky watcher test" (user-role) no longer reappears as a
+	// message (its jump anchor lives on the prompt hit above instead); only the assistant reply
+	// matches "fix" (via "Fixed"). The Messages counter is the second `history-counts` (Prompts renders
+	// first).
+	await expect(page.getByTestId("history-counts").last()).toHaveText("1/1");
+
+	// ↓ moves the flat-list selection off the prompt and onto that (unmapped) message hit; Enter on an
+	// unmapped message hit is a deliberate no-op — the overlay stays open and the draft is untouched.
+	await query.press("ArrowDown");
+	await query.press("Enter");
+	await expect(overlay).toBeVisible();
+	await expect(input).toHaveValue("");
+
+	// ↑ moves the selection back onto the prompt hit. Enter now inserts it into the composer, focuses it,
+	// and closes the overlay.
+	await query.press("ArrowUp");
+	await query.press("Enter");
+	await expect(overlay).toBeHidden();
+	await expect(input).toHaveValue("fix the flaky watcher test");
+	await expect(input).toBeFocused();
+
+	// Draft preservation: a fresh draft survives Ctrl+R → mutating the query → Esc leaves it untouched.
+	await input.fill("my draft");
+	await input.press("Control+r");
+	await expect(overlay).toBeVisible();
+	await expect(query).toHaveValue("my draft");
+	await query.fill("nothing matches this");
+	await query.press("Escape");
+	await expect(overlay).toBeHidden();
+	await expect(input).toHaveValue("my draft");
+
+	// Cmd/Ctrl+Enter on a selected prompt hit inserts AND submits, reusing the composer's own send path —
+	// cheap to cover with no agent: `onSubmit` appends the user message optimistically *before* the (here,
+	// rejected — no auth in this suite) transport call, so the sent text lands in the transcript regardless
+	// of what the host does next. Re-open + re-navigate to the same prompt hit rather than reusing the
+	// overlay instance closed by the Enter-insert above. `ControlOrMeta` is Playwright's cross-platform
+	// modifier alias (Meta on macOS, Control elsewhere) — it matches the app's own check on both the
+	// Composer's and the overlay's key handlers (`e.metaKey || e.ctrlKey`), so this exercises the same
+	// gesture a real user would make on either platform.
+	await input.press("Control+r");
+	await query.fill("fix");
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await expect(scopeBadge).toHaveAttribute("data-scope", "all");
+	await expect(promptItems.filter({ hasText: "fix the flaky watcher test" })).toBeVisible();
+	await query.press("ControlOrMeta+Enter");
+	await expect(overlay).toBeHidden();
+	await expect(input).toHaveValue("");
+	await expect(
+		page
+			.locator('[data-testid="chat-message"][data-role="user"]')
+			.filter({ hasText: "fix the flaky watcher test" }),
+	).toBeVisible();
+});
+
+test("empty query in chat scope shows the empty state for a session with no history yet", async ({
+	page,
+}) => {
+	await openWorkspaceChat(page);
+
+	const input = page.getByTestId("chat-input");
+	const overlay = page.getByTestId("history-overlay");
+	const query = page.getByTestId("history-query");
+	const scopeBadge = page.getByTestId("history-scope");
+
+	await input.press("Control+r");
+	await expect(overlay).toBeVisible();
+
+	// `openOverlay` always resets scope to `workspace`; reaching `chat` takes 3 forward cycles:
+	// workspace → project → all → chat.
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await expect(scopeBadge).toHaveAttribute("data-scope", "chat");
+
+	// This chat session was just created and never sent to — no prompts/messages of its own, so an empty
+	// query (which otherwise matches everything) still turns up nothing.
+	await expect(overlay).toContainText("no matches");
+});
+
+test("Ctrl+R dismisses an open mention menu instead of overlapping it", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const input = page.getByTestId("chat-input");
+	const overlay = page.getByTestId("history-overlay");
+	const mentionMenu = page.getByTestId("mention-menu");
+
+	// `@` alone matches every root-level entry (`fs.readDir` with an empty prefix) — the fixture repo
+	// always has files at its root, so the mention menu is guaranteed to have candidates to show.
+	await input.fill("@");
+	await expect(mentionMenu).toBeVisible();
+
+	// Regression: both floating panels anchor at the same `bottom-full` rect above the composer, so Ctrl+R
+	// must dismiss the mention menu rather than paint the history overlay on top of it
+	// (`Composer.tsx`'s Ctrl+R guard calls `setDismissed(true)` before `onHistoryOpen()`).
+	await input.press("Control+r");
+	await expect(overlay).toBeVisible();
+	await expect(mentionMenu).not.toBeVisible();
+});
+
+// A9: plain `↑`/`↓` recall (no Ctrl+R, no query typing) steps through *this chat's own* prior prompts — it
+// needs a chat whose runtime actually has prior user turns, so `openWorkspaceChat`'s brand-new session
+// (never sent to) doesn't do; seed one via `seedWorkspaceSession` on a real workspace `worktreePath` (see
+// the comment at its first use in `history-jump.spec.ts` for why that path, not some arbitrary string, is
+// the seed target) and open it. Simplest way in: the `chat-history` / `closed-chat-item` reopen flow
+// (`CenterTabs.tsx`) rather than the search-and-jump flow `history-jump.spec.ts` already covers — a
+// disk-only session surfaces there the moment its workspace becomes active. No `historyIndex` revalidation
+// wait is needed here (contrast the 2.1s waits in `history-jump.spec.ts`): `session.list` reads pi's
+// `SessionManager.list` straight off disk on every call, it isn't behind the throttled `HistoryIndex`
+// singleton that backs `history.search`.
+test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts, a diverging edit exits the session, and the history button opens the overlay", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	// No explicit `id`: this test never references the seeded session by id again (it reopens via the
+	// `chat-history` → `closed-chat-item` UI flow below), so the default fresh-per-call id is enough —
+	// and, unlike a fixed literal id, survives a Playwright retry within the same `webServer` lifetime.
+	seedWorkspaceSession(workspace.worktreePath, {
+		messages: [
+			{ role: "user", text: "audit the retry backoff", timestamp: 1_700_400_000_000 },
+			{ role: "assistant", text: "Audited it — looks fine.", timestamp: 1_700_400_001_000 },
+			{
+				role: "user",
+				text: "add a jittered ceiling to the backoff",
+				timestamp: 1_700_400_002_000,
+			},
+			{ role: "assistant", text: "Added the ceiling.", timestamp: 1_700_400_003_000 },
+			{ role: "user", text: "write a test for the jitter", timestamp: 1_700_400_004_000 },
+			{ role: "assistant", text: "Added a test.", timestamp: 1_700_400_005_000 },
+		],
+	});
+
+	// A reload doesn't auto-restore the active project/workspace (see `history-jump.spec.ts`) — re-pick both
+	// so `CenterTabs`'s hydrate-on-connect effect re-lists this workspace's sessions from a cold client and
+	// discovers the disk-only seeded one.
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("project-item").first().click();
+	await page.getByTestId("workspace-item").first().click();
+	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+
+	await page.getByTestId("chat-history").click();
+	await page.getByTestId("closed-chat-item").first().click();
+	const input = page.getByTestId("chat-input");
+	await expect(input).toBeVisible();
+	// The reopened chat's transcript is restored, but its *draft* is fresh — recall must start from empty.
+	await expect(input).toHaveValue("");
+
+	// Newest first: ArrowUp on the empty field recalls the latest prompt, then steps older.
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("write a test for the jitter");
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("add a jittered ceiling to the backoff");
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("audit the retry backoff");
+	// Clamped at the oldest entry — one more ArrowUp doesn't wrap around.
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("audit the retry backoff");
+
+	// ArrowDown steps back newer; past the newest restores the empty draft.
+	await input.press("ArrowDown");
+	await expect(input).toHaveValue("add a jittered ceiling to the backoff");
+	await input.press("ArrowDown");
+	await expect(input).toHaveValue("write a test for the jitter");
+	await input.press("ArrowDown");
+	await expect(input).toHaveValue("");
+
+	// A diverging edit (the composer's own `fill`, exactly like a real keystroke — Playwright's `fill`
+	// dispatches a native `input` event React's controlled `onChange` reacts to) exits the recall session:
+	// the next ArrowUp must not step — the value is unchanged besides the edit itself.
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("write a test for the jitter");
+	await input.fill("write a test for the jitter!");
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("write a test for the jitter!");
+
+	// The history button — the tap path on mobile, a discoverability affordance on desktop — opens the
+	// exact same overlay `Ctrl+R` does.
+	await page.getByTestId("history-open").click();
+	await expect(page.getByTestId("history-overlay")).toBeVisible();
+});
+
+// Regression for a real flake caught in the test above: `Composer`'s `focusCaret` used to move the caret
+// via a bare `requestAnimationFrame`, which only guarantees "before the next paint" — leaving a gap after
+// the triggering keystroke's task ends where another actor touching the same textarea's selection (e.g.
+// Playwright's `fill`, which does select-all then insert-text as separate steps) could run first. If that
+// stale RAF fired between `fill`'s select-all and insert steps, its `setSelectionRange(pos, pos)` collapsed
+// the select-all to a bare caret, so the insert appended instead of replacing — producing a doubled
+// `oldValue + newValue` (seen as `"write a test for the jitterwrite a test for the jitter!"` under
+// parallel-worker contention). `focusCaret` now moves the caret from a `useLayoutEffect`, which commits
+// synchronously in the same task as the triggering keystroke — there's no longer a gap for `fill` (or any
+// other follow-up interaction) to land in. This mechanism doesn't depend on Playwright specifically — any
+// fast selection-replacing interaction right after a recall step could have raced the old stale RAF — so
+// this is a real feature fix, not test-only synchronization; CPU-throttling below only makes an already-
+// closed race window observable within a short, deterministic test rather than needing rare real-world
+// timing (see `Composer.tsx`'s `focusCaret` comment for the fuller mechanism writeup).
+test("a recall step immediately followed by a full-value replace never doubles the value, even under CPU contention", async ({
+	page,
+}) => {
+	test.setTimeout(60_000);
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	// No explicit `id`: this test loops many repeated recall/replace cycles and is meant to be re-run
+	// under `--repeat-each` to prove the race stays closed. A fixed literal id would collide with an
+	// in-memory session entry from an earlier repeat's (differently-`workspaceId`'d) run within the same
+	// shared webServer lifetime, failing with "Unknown session" before ever reaching the code path this
+	// test exists to exercise — the default fresh-per-call id (`seedWorkspaceSession`) sidesteps that.
+	seedWorkspaceSession(workspace.worktreePath, {
+		messages: [
+			{ role: "user", text: "write a test for the jitter", timestamp: 1_700_500_000_000 },
+			{ role: "assistant", text: "Added a test.", timestamp: 1_700_500_001_000 },
+		],
+	});
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("project-item").first().click();
+	await page.getByTestId("workspace-item").first().click();
+	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+
+	await page.getByTestId("chat-history").click();
+	await page.getByTestId("closed-chat-item").first().click();
+	const input = page.getByTestId("chat-input");
+	await expect(input).toBeVisible();
+	await expect(input).toHaveValue("");
+
+	// Throttle the main thread so any reintroduced deferred-callback gap (RAF or otherwise) would widen
+	// enough to be caught reliably within a handful of iterations — this is what let the old RAF-based
+	// code reproduce the doubled value in ~3% of iterations during root-cause diagnosis. `press` and
+	// `fill` still auto-wait/retry as usual; only real wall-clock CPU speed is reduced.
+	const client = await page.context().newCDPSession(page);
+	await client.send("Emulation.setCPUThrottlingRate", { rate: 4 });
+
+	for (let i = 0; i < 200; i++) {
+		await input.press("ArrowUp");
+		await expect(input).toHaveValue("write a test for the jitter");
+		const replacement = `edit ${i}`;
+		await input.fill(replacement);
+		// A snapshot read, not the auto-retrying `toHaveValue` matcher: the corruption this pins is an
+		// immediate, permanent doubling at `fill`-completion time, not a transient state that later
+		// settles — polling could mask a regression that briefly shows the wrong value.
+		expect(await input.inputValue()).toBe(replacement);
+		await input.fill("");
+	}
+});
+
+// Regression: `recentPrompts`'s dedup must keep a repeated prompt's NEWEST occurrence (recency-first,
+// matching the server history index's own ranking rule and the atuin/fzf convention) — not its oldest.
+// "alpha" is said twice, "beta" once, in between: the first ArrowUp must recall "alpha" (the most recent
+// prompt), the second must recall "beta", and a third must stay clamped on "beta" — proving "alpha" backs
+// exactly one recall slot (its newest), not two.
+test("a prompt repeated earlier in the chat recalls at its most recent position, deduped to one entry", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	// No explicit `id` — same reasoning as the recall test above: this test never references the seeded
+	// session by id, so the default fresh-per-call id (survives a same-process retry) is enough.
+	seedWorkspaceSession(workspace.worktreePath, {
+		messages: [
+			{ role: "user", text: "alpha", timestamp: 1_700_450_000_000 },
+			{ role: "assistant", text: "ok", timestamp: 1_700_450_001_000 },
+			{ role: "user", text: "beta", timestamp: 1_700_450_002_000 },
+			{ role: "assistant", text: "ok", timestamp: 1_700_450_003_000 },
+			{ role: "user", text: "alpha", timestamp: 1_700_450_004_000 },
+			{ role: "assistant", text: "ok", timestamp: 1_700_450_005_000 },
+		],
+	});
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("project-item").first().click();
+	await page.getByTestId("workspace-item").first().click();
+	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+
+	await page.getByTestId("chat-history").click();
+	await page.getByTestId("closed-chat-item").first().click();
+	const input = page.getByTestId("chat-input");
+	await expect(input).toBeVisible();
+	await expect(input).toHaveValue("");
+
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("alpha");
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("beta");
+	// Clamped at "beta" — if the earlier "alpha" occurrence were a distinct entry, this would step to it.
+	await input.press("ArrowUp");
+	await expect(input).toHaveValue("beta");
+});
+
+// A9's mobile-discoverability half: `HistoryOverlay` sizes itself with `left-sm right-sm` insets (see
+// `HistoryOverlay.tsx`) rather than a fixed pixel width, specifically so it can't overflow a narrow
+// container. The app's three-pane layout (`shell/Shell.tsx`) isn't itself the "mobile single-view shell"
+// `architecture.md` describes — that's a separate, not-yet-built concern — so this only isolates what IS
+// this task's concern: the overlay's own sizing at a narrow (~390px, a small-phone width) viewport. Resize
+// only for the check itself (after the normal desktop-sized setup) so a squeezed three-pane layout can't
+// make the setup flow itself flaky.
+test("the history overlay stays inside the viewport and its query stays focusable at a narrow (~390px) width", async ({
+	page,
+}) => {
+	await openWorkspaceChat(page);
+	await page.setViewportSize({ width: 390, height: 844 });
+
+	const input = page.getByTestId("chat-input");
+	const overlay = page.getByTestId("history-overlay");
+	await input.press("Control+r");
+	await expect(overlay).toBeVisible();
+
+	const viewportSize = page.viewportSize();
+	const box = await overlay.boundingBox();
+	expect(box).not.toBeNull();
+	expect(viewportSize).not.toBeNull();
+	if (box && viewportSize) {
+		expect(box.x).toBeGreaterThanOrEqual(0);
+		expect(box.x + box.width).toBeLessThanOrEqual(viewportSize.width);
+	}
+
+	const query = page.getByTestId("history-query");
+	await expect(query).toBeVisible();
+	await expect(query).toBeFocused();
+});
+
+// Reviewer-flagged regression: the results list itself scrolls (mouse wheel, drag), but before this fix
+// keyboard-only navigation never moved that scroll position on its own — repeatedly pressing ArrowDown
+// could walk `selected` well past the bottom of what's currently visible, leaving the highlighted row
+// entirely offscreen inside the `overflow-y-auto` results container. `HistoryOverlay` now scrolls the
+// selected row into view (`Element.scrollIntoView({ block: "nearest" })`) whenever the selection changes.
+test("ArrowDown repeatedly scrolls the keyboard-selected row into view inside the results container", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	// 30 distinct prompts, all in this workspace's own cwd — comfortably more than fit inside the compact
+	// stage's `max-h-[40vh]`. An empty query in the default "workspace" scope (no scope cycling needed)
+	// surfaces every one of them as a recent prompt (see `historyIndex.test.ts`'s "(d) empty query returns
+	// recent prompts"), well under the 50-item server cap, so none get paged out.
+	seedWorkspaceSession(workspace.worktreePath, {
+		messages: Array.from({ length: 30 }, (_, i) => ({
+			role: "user" as const,
+			text: `prompt number ${String(i).padStart(2, "0")}`,
+			timestamp: 1_700_600_000_000 + i * 1_000,
+		})),
+	});
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	const input = page.getByTestId("chat-input");
+	await expect(input).toBeVisible();
+
+	await input.press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	await expect(page.locator('[data-testid="history-item"][data-kind="prompt"]')).toHaveCount(30);
+
+	const query = page.getByTestId("history-query");
+	const results = page.getByTestId("history-results");
+	const selectedRow = page.locator('[data-testid="history-item"][data-selected="true"]');
+
+	// Walk the selection deep into the list — well past what the compact stage can show without scrolling.
+	for (let i = 0; i < 25; i++) {
+		await query.press("ArrowDown");
+	}
+	await expect(selectedRow).toHaveCount(1);
+
+	// The selected row's own layout box (real position, regardless of the container's overflow-clipping)
+	// must sit entirely within the results container's box — i.e. the container actually scrolled to bring
+	// it into view, rather than leaving it below the visible range.
+	const resultsBox = await results.boundingBox();
+	const rowBox = await selectedRow.boundingBox();
+	expect(resultsBox).not.toBeNull();
+	expect(rowBox).not.toBeNull();
+	if (resultsBox && rowBox) {
+		expect(rowBox.y).toBeGreaterThanOrEqual(resultsBox.y);
+		expect(rowBox.y + rowBox.height).toBeLessThanOrEqual(resultsBox.y + resultsBox.height);
+	}
+});
+
+// R1: the zoomed stage's two-pane preview (`data-testid="history-preview"`) shows the keyboard-selected
+// item's FULL text — never the row's truncated first line — with query terms highlighted the same way a
+// row highlights its own text (`Highlight` is reused verbatim, never forked). The compact stage has no
+// preview pane in the DOM at all (not merely hidden), and moving the keyboard selection swaps the preview
+// to match the newly-selected item.
+test("the zoomed stage's preview pane shows the selected item's full text, including a tail truncated in its row, and updates on ArrowDown; the compact stage has no preview at all", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	// A 3-line, >200-char prompt whose FIRST line never mentions the tail marker "zephyr9000" —
+	// `PromptRow` shows only `hit.text.split("\n")[0]`, so a hit whose full text matched the query can
+	// still show a row whose visible first line doesn't contain the very term that matched. That's the
+	// "truncated in the row" case R1's preview pane exists for.
+	const longPrompt = [
+		"Investigate the deployment pipeline failure end to end before the next release window opens.",
+		"Check the retry policy, the queue backlog depth, and every healthcheck threshold across all services.",
+		"Root cause found: the zephyr9000 rollback trigger misfired under load and needs a guard added.",
+	].join("\n");
+	expect(longPrompt.length).toBeGreaterThan(200);
+	seedWorkspaceSession(workspace.worktreePath, {
+		messages: [
+			{ role: "user", text: longPrompt, timestamp: 1_700_900_000_000 },
+			{ role: "user", text: "a shorter unrelated prompt", timestamp: 1_700_900_001_000 },
+		],
+	});
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	const input = page.getByTestId("chat-input");
+	await expect(input).toBeVisible();
+
+	await input.press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	const preview = page.getByTestId("history-preview");
+
+	// Compact stage: the preview pane doesn't exist in the DOM at all, not merely hidden.
+	await expect(preview).toHaveCount(0);
+
+	await query.fill("zephyr9000");
+	const longRow = page
+		.locator('[data-testid="history-item"][data-kind="prompt"]')
+		.filter({ hasText: "Investigate the deployment pipeline" });
+	await expect(longRow).toBeVisible();
+	// The row shows only the truncated first line — the tail term that actually matched never appears.
+	await expect(longRow).not.toContainText("zephyr9000");
+
+	await query.press("Tab");
+	await expect(overlay).toHaveAttribute("data-stage", "zoomed");
+	await expect(preview).toBeVisible();
+	// The preview shows the FULL text, including the tail the row truncated away.
+	await expect(preview).toContainText("zephyr9000");
+	await expect(preview).toContainText("Investigate the deployment pipeline failure");
+
+	// Broaden to an empty query so both seeded prompts are in the flat list; newest first ("a shorter
+	// unrelated prompt", seeded one second later) is selected initially — the preview follows.
+	await query.fill("");
+	await expect(page.locator('[data-testid="history-item"][data-kind="prompt"]')).toHaveCount(2);
+	await expect(preview).toContainText("a shorter unrelated prompt");
+	await expect(preview).not.toContainText("zephyr9000");
+
+	// ArrowDown moves the keyboard selection onto the long prompt — the preview updates to match.
+	await query.press("ArrowDown");
+	await expect(preview).toContainText("zephyr9000");
+	await expect(preview).toContainText("Investigate the deployment pipeline failure");
+});
+
+// R1: at a narrow (~390px) viewport, the zoomed stage's preview pane stacks BELOW the results list
+// instead of beside it — the two-pane wrapper switches to a column flex layout under the `md` breakpoint
+// (the same convention `SettingsDialog`'s own two-pane shell uses). Keeps the existing 390px overlay-
+// sizing e2e (above) passing unmodified — this is a separate assertion about the *zoomed* stage only.
+test("at a narrow (~390px) viewport, the zoomed stage's preview pane stacks below the results list, both visible", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	seedWorkspaceSession(workspace.worktreePath, {
+		messages: [
+			{
+				role: "user",
+				text: "a narrow-viewport preview stacking test prompt",
+				timestamp: 1_701_000_000_000,
+			},
+		],
+	});
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	const input = page.getByTestId("chat-input");
+	await expect(input).toBeVisible();
+	await page.setViewportSize({ width: 390, height: 844 });
+
+	await input.press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	await query.press("Tab");
+	await expect(overlay).toHaveAttribute("data-stage", "zoomed");
+	const results = page.getByTestId("history-results");
+	const preview = page.getByTestId("history-preview");
+	await expect(results).toBeVisible();
+	await expect(preview).toBeVisible();
+
+	const resultsBox = await results.boundingBox();
+	const previewBox = await preview.boundingBox();
+	expect(resultsBox).not.toBeNull();
+	expect(previewBox).not.toBeNull();
+	if (resultsBox && previewBox) {
+		// Stacked, list first: the preview's top sits at or below the list's own bottom edge.
+		expect(previewBox.y).toBeGreaterThanOrEqual(resultsBox.y + resultsBox.height - 1);
+	}
+});
+
+// R2: the scope badge is now a dropdown picker (the discoverable mouse path — atuin's "cycling is
+// invisible" lesson) alongside the unchanged `Ctrl+R` cycle. Also proves the brief's sharp edge: while
+// the picker is open, ArrowDown belongs to the menu, never to the overlay's own results selection —
+// Radix's portaled content is a sibling of the query `<input>` the overlay's key handler is bound to,
+// never its descendant, so there's nothing for the two handlers to double up on; this test is the proof.
+test("the scope badge opens a picker that selects a scope directly without disturbing the results selection, returns focus to the query input, and Ctrl+R still cycles afterward", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	seedWorkspaceSession(workspace.worktreePath, {
+		messages: [
+			{
+				role: "user",
+				text: "alpha prompt for the scope picker test",
+				timestamp: 1_701_100_000_000,
+			},
+			{ role: "user", text: "beta prompt for the scope picker test", timestamp: 1_701_100_001_000 },
+		],
+	});
+	seedExternalCwdSessions();
+	await page.waitForTimeout(2_100);
+
+	await page.getByTestId("start-chat").click();
+	const input = page.getByTestId("chat-input");
+	await expect(input).toBeVisible();
+
+	await input.press("Control+r");
+	const overlay = page.getByTestId("history-overlay");
+	await expect(overlay).toBeVisible();
+	const query = page.getByTestId("history-query");
+	const scopeBadge = page.getByTestId("history-scope");
+	const scopeOptions = page.getByTestId("history-scope-option");
+	const selectedRow = page.locator('[data-testid="history-item"][data-selected="true"]');
+
+	// Default "workspace" scope, empty query: both seeded prompts, newest ("beta…") first and selected.
+	await expect(page.locator('[data-testid="history-item"][data-kind="prompt"]')).toHaveCount(2);
+	await expect(selectedRow).toContainText("beta prompt for the scope picker test");
+
+	// Click the badge → 4 options, correct data-scopes, in cycle order.
+	await scopeBadge.click();
+	await expect(scopeOptions).toHaveCount(4);
+	await expect(scopeOptions.nth(0)).toHaveAttribute("data-scope", "chat");
+	await expect(scopeOptions.nth(1)).toHaveAttribute("data-scope", "workspace");
+	await expect(scopeOptions.nth(2)).toHaveAttribute("data-scope", "project");
+	await expect(scopeOptions.nth(3)).toHaveAttribute("data-scope", "all");
+
+	// Sharp edge: ArrowDown while the menu is open belongs to the menu, not the overlay's results list.
+	await page.keyboard.press("ArrowDown");
+	await expect(selectedRow).toContainText("beta prompt for the scope picker test");
+
+	// Click "Everywhere" selects it directly (no Ctrl+R needed), closes the menu, and returns focus to
+	// the query input.
+	await scopeOptions.filter({ hasText: "Everywhere" }).click();
+	await expect(scopeBadge).toHaveAttribute("data-scope", "all");
+	await expect(query).toBeFocused();
+	await expect(
+		page
+			.locator('[data-testid="history-item"][data-kind="prompt"]')
+			.filter({ hasText: "deploy the docs site" }),
+	).toBeVisible();
+
+	// Ctrl+R still cycles after the mouse pick — from "all" it wraps forward to "chat".
+	await query.press("Control+r");
+	await expect(scopeBadge).toHaveAttribute("data-scope", "chat");
+});

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -116,6 +116,79 @@ test("Ctrl+R opens history recall, cycles scope to all, zooms to messages, inser
 	).toBeVisible();
 });
 
+test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the recalled prompt and clears them", async ({
+	page,
+}) => {
+	// Regression (Air review): the overlay's insert-and-send used to call ChatView's `onSubmit` directly,
+	// bypassing the composer's own submit seam — the pending image was silently dropped from the send and
+	// its stale thumbnail stayed attached to the next message. Tap the app's WebSocket before it connects
+	// (the live-refresh spec's pattern, `framesent` side) so the assertion covers the actual wire payload
+	// — a `session.prompt` request carrying `images` — not just the thumbnails' visible state.
+	const sentFrames: string[] = [];
+	page.on("websocket", (ws) => {
+		ws.on("framesent", (frame) => {
+			sentFrames.push(typeof frame.payload === "string" ? frame.payload : frame.payload.toString());
+		});
+	});
+
+	await openWorkspaceChat(page);
+	seedExternalCwdSessions(); // re-seed after resetState — see the first test's note
+
+	const input = page.getByTestId("chat-input");
+	const overlay = page.getByTestId("history-overlay");
+	const query = page.getByTestId("history-query");
+	const thumbnails = page.getByTestId("composer-images");
+
+	// Attach an image the way a user does — paste. A constructed ClipboardEvent must be dispatched in
+	// page context (Playwright's keyboard can't carry files); React's onPaste reads `e.clipboardData`.
+	await input.evaluate((el) => {
+		const dt = new DataTransfer();
+		dt.items.add(
+			new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], "pixel.png", { type: "image/png" }),
+		);
+		el.dispatchEvent(
+			new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }),
+		);
+	});
+	await expect(thumbnails).toBeVisible();
+	await expect(thumbnails).toContainText("image/png");
+
+	// Recall a prompt (same navigation as above: query "fix", cycle scope to `all`) and insert-and-send.
+	await input.press("Control+r");
+	await query.fill("fix");
+	await query.press("Control+r");
+	await query.press("Control+r");
+	await expect(
+		page
+			.locator('[data-testid="history-item"][data-kind="prompt"]')
+			.filter({ hasText: "fix the flaky watcher test" }),
+	).toBeVisible();
+	await query.press("ControlOrMeta+Enter");
+	await expect(overlay).toBeHidden();
+
+	// The send went through the composer's own seam: the text is in the transcript, the draft is empty,
+	// and the thumbnail strip is cleared with it — nothing stale left attached to the next message.
+	await expect(
+		page
+			.locator('[data-testid="chat-message"][data-role="user"]')
+			.filter({ hasText: "fix the flaky watcher test" }),
+	).toBeVisible();
+	await expect(input).toHaveValue("");
+	await expect(thumbnails).toBeHidden();
+
+	// And the wire request really carried the attachment (the frame may land a beat after the UI
+	// updates — poll). The request itself is rejected by the unauthenticated host, which is fine: the
+	// payload already proves the image went with the text.
+	await expect(() => {
+		const prompt = sentFrames.find(
+			(f) => f.includes('"session.prompt"') && f.includes("fix the flaky watcher test"),
+		);
+		expect(prompt).toBeDefined();
+		expect(prompt).toContain('"images"');
+		expect(prompt).toContain('"image/png"');
+	}).toPass({ timeout: 5000 });
+});
+
 test("empty query in chat scope shows the empty state for a session with no history yet", async ({
 	page,
 }) => {

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -119,6 +119,13 @@ of the host.
   carries only what the panel renders (`type`/`status` stay `string`: tolerate whatever is on disk);
   **`TodoItem`/`TodoGroupItem`/`TodoPlan`** + the **`TodoStatus`/`TodoOrigin`** unions — the in-chat plan
   DTOs, **mirrored** from `pi-todos/core` (never imported), carrying the chat's per-session TODO list.
+  **history-search read DTOs** — **`HistoryScope`** (the overlay's cycle: this chat → workspace →
+  project → everywhere); **`PromptHit`** (a recalled prompt; carries optional `messageIndex` +
+  `anchorText` — the kept-newest occurrence's jump anchor) and **`MessageHit`** (a full-text
+  conversation match; assistant-only — a user-role hit only ever duplicates its own `PromptHit`'s text,
+  so the jump affordance lives there instead; `messageIndex` anchors jump-to-message into
+  `session.getMessages` order, `anchorText` makes the anchor drift-tolerant), and
+  **`HistorySearchResult`** (the prompts + full-text messages sections, with totals and indexing status).
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.inspect`** (classify a path) +
   **`project.init`** (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "has any
   registered spec?" for the Welcome screen — a full-tree walk, so requested only for the shown project,
@@ -148,7 +155,10 @@ of the host.
   `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
-  read side) / **`settings.update`** (merge + persist a partial `AppConfig`, returns the merged config)),
+  read side) / **`settings.update`** (merge + persist a partial `AppConfig`, returns the merged
+  config) / **`history.search`** (the prompt-recall + conversation-search read; results capped,
+  recency-ordered; the messages section is assistant-only — a user-role hit surfaces as a jumpable
+  `PromptHit` instead, never a separate `MessageHit`)),
   `WS_CHANNELS` (`server.welcome` — which carries the initial `config: AppConfig` alongside `projects` /
   `pi.event` / `pi.extensionUi` / **`settings.changed`** (the full `AppConfig`, broadcast so every client
   converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -331,3 +331,53 @@ export interface AppConfig {
 
 /** The config a fresh host (no `config.json` yet) falls back to. */
 export const DEFAULT_CONFIG: AppConfig = { theme: "dark" };
+
+/** History-search scope — the overlay's cycle: this chat → workspace → project → everywhere. */
+export type HistoryScope =
+	| { kind: "chat"; sessionId: string }
+	| { kind: "workspace"; workspaceId: string }
+	| { kind: "project"; projectId: string }
+	| { kind: "all" };
+
+/** One recalled prompt (prompts section: deduped by normalized text, newest kept, recency-ordered). */
+export interface PromptHit {
+	text: string;
+	timestamp: number;
+	sessionId: string;
+	/** pi's session display name, when set. */
+	sessionTitle?: string;
+	/** Mapped from the session's cwd via the workspace registry; absent for unmapped (pi-CLI) cwds. */
+	workspaceId?: string;
+	projectId?: string;
+	cwd: string;
+	/**
+	 * The kept-newest occurrence's position in `session.getMessages` order — the same jump anchor a
+	 * `MessageHit` carries, letting the prompt row itself be jumped to. Optional for tolerance; a v10+
+	 * host always sets it alongside `anchorText`.
+	 */
+	messageIndex?: number;
+	/**
+	 * The kept-newest occurrence's message-text prefix — the same drift-tolerant jump validation a
+	 * `MessageHit` carries. Optional for tolerance; a v10+ host always sets it alongside `messageIndex`.
+	 */
+	anchorText?: string;
+}
+
+/** One full-text conversation match. `messageIndex` is the position in the `session.getMessages`
+ * transcript; `anchorText` (a prefix of the message text) lets the client validate/fall back if the
+ * live transcript drifted from the indexed file (e.g. after compaction). */
+export interface MessageHit extends PromptHit {
+	role: "user" | "assistant";
+	snippet: string;
+	messageIndex: number;
+	anchorText: string;
+}
+
+/** `history.search` result. `indexing` = the one-time cold build is still running (show "indexing…"). */
+export interface HistorySearchResult {
+	prompts: PromptHit[];
+	messages: MessageHit[];
+	promptTotal: number;
+	messageTotal: number;
+	indexing: boolean;
+}

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -332,6 +332,14 @@ export interface AppConfig {
 /** The config a fresh host (no `config.json` yet) falls back to. */
 export const DEFAULT_CONFIG: AppConfig = { theme: "dark" };
 
+/**
+ * Prefix on the internal "wake the agent" nudge the client sends when a TODO is added. It is control
+ * traffic, not conversation: hidden from the rendered transcript (never appended live, skipped on
+ * hydrate) and excluded from history search. Lives on the wire so both the web client (which authors and
+ * hides it) and the host history indexer (which must skip it) agree on the exact marker.
+ */
+export const TODO_NUDGE_PREFIX = "[thinkrail:todo-nudge] ";
+
 /** History-search scope — the overlay's cycle: this chat → workspace → project → everywhere. */
 export type HistoryScope =
 	| { kind: "chat"; sessionId: string }
@@ -373,7 +381,19 @@ export interface MessageHit extends PromptHit {
 	anchorText: string;
 }
 
-/** `history.search` result. `indexing` = the one-time cold build is still running (show "indexing…"). */
+/**
+ * Protocol maximum for `history.search`'s `limit`. The client asks for far fewer; this is the hard
+ * ceiling the host clamps a request to (defense in depth), so a malformed/oversized/negative `limit`
+ * can neither defeat the cap nor hit `Array.slice`'s negative-index semantics.
+ */
+export const MAX_HISTORY_LIMIT = 200;
+
+/** Protocol maximum for a `history.search` `query`, in characters — bounds worst-case matching work. */
+export const MAX_HISTORY_QUERY_LENGTH = 200;
+
+/** `history.search` result. `indexing` = a build is still in flight — the one-time cold build, or a
+ * background warm revalidation — so results may not yet be complete/current; the client keeps re-querying
+ * (and may show "indexing…") until it clears. */
 export interface HistorySearchResult {
 	prompts: PromptHit[];
 	messages: MessageHit[];

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,14 @@
-// The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol) and
-// the app-config default (`DEFAULT_CONFIG`). Theme catalogs stay browser-side; the wire carries an opaque id.
+// The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol), the
+// app-config default (`DEFAULT_CONFIG`), the history-search caps (`MAX_HISTORY_LIMIT`,
+// `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX`) — small
+// plain constants both sides must agree on. Theme catalogs stay browser-side; the wire carries an opaque id.
 
 export type * from "./domain";
-export { DEFAULT_CONFIG } from "./domain";
+export {
+	DEFAULT_CONFIG,
+	MAX_HISTORY_LIMIT,
+	MAX_HISTORY_QUERY_LENGTH,
+	TODO_NUDGE_PREFIX,
+} from "./domain";
 export type * from "./piProtocol";
 export * from "./wsProtocol";

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -7,6 +7,8 @@ import type {
 	FileNode,
 	GithubAuthStatus,
 	GitStatus,
+	HistoryScope,
+	HistorySearchResult,
 	JbcentralConnectResult,
 	LoginReply,
 	Project,
@@ -61,7 +63,12 @@ import type {
 // v14: group/source toggles + pre-session manager — `project.setGroupEnabled` (turn a plugin or source tier,
 // incl. `@plugins`, on/off at the project baseline) + `project.skills` (project-scoped catalog for Welcome /
 // New Workspace); `Project` gains `disabledGroups`, `SkillCatalogEntry` gains `group`.
-export const PROTOCOL_VERSION = 14;
+// v15: chat-history search — `history.search` reads a lazy in-memory index over pi's session files
+// (prompt recall + full-conversation matches, scoped chat/workspace/project/all, recency-ordered). The
+// messages section is assistant-only (a user-role hit only ever duplicates its own prompt's text);
+// `PromptHit` carries optional `messageIndex`/`anchorText` so the prompt row itself is jumpable — the
+// location a dropped user-role message hit used to carry.
+export const PROTOCOL_VERSION = 15;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -189,6 +196,7 @@ export const WS_METHODS = {
 	// Persist a partial change to the server-synced app settings (e.g. the theme). The host merges, saves
 	// `config.json`, and broadcasts `settings.changed` — the caller converges on that push, not optimism.
 	settingsUpdate: "settings.update",
+	historySearch: "history.search",
 } as const;
 
 /** Server→client push channels. */
@@ -428,6 +436,12 @@ export interface WsMethodMap {
 	// Merge a partial into the server-synced app settings, persist it, and broadcast `settings.changed`.
 	// Returns the merged, persisted `AppConfig`.
 	"settings.update": { params: { config: Partial<AppConfig> }; result: AppConfig };
+	// Prompt recall + full-text conversation search over pi's persisted sessions (and live ones — pi
+	// appends as messages complete). Server-side index; results capped (default 50/section), true totals.
+	"history.search": {
+		params: { query: string; scope: HistoryScope; limit?: number };
+		result: HistorySearchResult;
+	};
 }
 
 export type WsMethodName = keyof WsMethodMap;

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -60,6 +60,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `auth` | provider status (`provider.status`) + in-app login (OAuth / API key / logout) | [auth/SPEC.md](src/auth/SPEC.md) |
 | `assist` | ad-hoc one-shot tasks (workspace naming, …) on a cheap model, best-effort | [assist/SPEC.md](src/assist/SPEC.md) |
 | `dialog` | the host's native folder picker | [dialog/SPEC.md](src/dialog/SPEC.md) |
+| `history` | prompt recall + conversation search over pi's session files | [history/SPEC.md](src/history/SPEC.md) |
 
 `src/index.ts` re-exports `host` + the `agent` barrel's `registerBundledRuntime` seam; `src/dev.ts` boots
 the host from env via `bootHost` for dev/e2e.
@@ -68,7 +69,7 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`
+- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`, `history`
 - `workspaces` → `projects`, `git`, `persistence`
 - `projects` → `git` (shared runner), `persistence`
 - `git`, `fs`, `spec`, `watch`, `terminal`, `settings` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
@@ -76,7 +77,7 @@ the host from env via `bootHost` for dev/e2e.
 - `assist` → `agent` (the one-shot completion primitive)
 - `auth` → `agent` (`getPiRuntime` — the shared `AuthStorage` + `ModelRegistry`; one-way, `agent` never imports `auth`)
 - `agent` → (no internal deps — only the pi runtime)
-- `persistence`, `dialog`, `github` → (leaves)
+- `persistence`, `dialog`, `github`, `history` → (leaves)
 
 Rules: features never import `host`, and never each other except the edges above. The graph is acyclic.
 `agent`'s WS surface (`session.*` + `pi.event` forwarding) attaches to `host`. Features that push on their
@@ -84,6 +85,8 @@ own never import `host` either: they expose a **publisher-injection seam** (`set
 `setSessionPublisher`, `setLoginPublisher`, `workspaces`' `setWorkspacePublisher` for the
 `workspace.created`/`updated`/`removed` lifecycle trio, and `settings`' `setSettingsPublisher` for
 `settings.changed`) that `host` installs at `createServer` — so the channel wiring lives only in `host`.
+`history` stays registry-free (never imports `projects`/`workspaces`); `host` injects the scope filter
++ labels from the registries at the handler layer (`history.search` handler).
 
 ## Get right
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",
-		"./agent": "./src/agent/index.ts"
+		"./agent": "./src/agent/index.ts",
+		"./history-test-fixtures": "./src/history/testFixtures.ts"
 	},
 	"scripts": {
 		"dev": "bun run --watch src/dev.ts",

--- a/packages/server/src/history/SPEC.md
+++ b/packages/server/src/history/SPEC.md
@@ -1,0 +1,94 @@
+---
+id: submodule-server-history
+type: submodule-design
+status: active
+title: history — chat-history search index
+parent: module-server
+depends-on: [module-contracts]
+tags: [v1, history]
+---
+
+## Responsibility
+The `history.search` backend: a **lazy in-memory index** over pi's session JSONL files (prompt recall +
+full-conversation matches). Reads via pi's `SessionManager.listAll()`; **never writes** session files.
+Because `listAll()` walks every pi session on disk, the host handler's `all` scope (`host/historyScope.ts`'s
+`filter = () => true`) deliberately surfaces pi-CLI sessions outside any registered ThinkRail workspace
+too — a bit more than `session.getMessages` itself ever exposes for a single session, but consistent with
+an owner-scoped host (no multi-tenant isolation to preserve).
+
+## Design
+- `extract.ts` — pure JSONL→`HistoryEntry[]`; `messageIndex` counts user/assistant/toolResult/custom in
+  file order (the `getSessionMessages` filter), so it anchors into the transcript the client renders.
+  Searchable text capped (`MAX_SEARCHABLE`); tool results/thinking not indexed (V1).
+- `historyIndex.ts` — `HistoryIndex`: cold build on first search (batched, yields the event loop);
+  freshness = mtime revalidation throttled to ~2 s (pi appends live messages to the file, so the file IS
+  the live feed — no agent-module hook). Matching: case-insensitive substring AND over whitespace terms;
+  strict recency order; prompts deduped by normalized text keeping newest; caps + true totals.
+  The messages section (and `messageTotal`) is filtered to `role === "assistant"` only — a user-role hit
+  is always a textual duplicate of its own prompt entry (user text IS a prompt in this extraction), so it
+  would add no text, only a location; that location moves onto the prompt hit instead, via the two
+  fields below.
+- Jump anchors are drift-tolerant: hits carry `anchorText` (message-text prefix) the client validates.
+  Every prompt hit now also carries its kept-newest occurrence's `messageIndex`/`anchorText` —
+  the same two fields `MessageHit` always had — making the prompt row itself jumpable. Both fields are
+  optional on `PromptHit` (absent only when the host predates this feature).
+- `testFixtures.ts` — test-only session-file builders (pinned by A5): `writeFixtureSession` writes a
+  minimal but real pi-shaped JSONL, one flat file per session, that `historyIndex` tests, the e2e fixture
+  seeder, and its own format-pinning test (`testFixtures.test.ts`) drive against; `defaultSessionDirFor`
+  replicates pi's private default-layout directory encoding (not importable — see "pi file format" below)
+  so fixtures can land where a real no-arg `listAll()` would actually look.
+
+## On-disk JSONL structure (observed from pi session files)
+- **`message` entries:** `{ type: "message", ..., message: { role: "user"|"assistant"|"toolResult", content: string|array, timestamp: ms-number } }`
+  — `message.role` determines renderability; `message.timestamp` is milliseconds since epoch.
+- **`custom_message` entries:** `{ type: "custom_message", customType: string, content: string|array, timestamp: ISO-string, display: boolean, ... }`
+  — top-level structure (no `message` wrapper); always renderable as role "custom"; `timestamp` is ISO 8601 string at entry level.
+
+## pi file format (pinned v0.80.6 — `@earendil-works/pi-coding-agent`)
+Verified by reading `dist/core/session-manager.{js,d.ts}` in the installed package (source of truth over
+any assumption — re-verify on a pi version bump):
+- **Header line** (always line 1, `SessionHeader`): `{ type: "session", version?: number, id: string,
+  timestamp: string /* ISO */, cwd: string, parentSession?: string }`. `readSessionHeader`/`buildSessionInfo`
+  reject the file (return `null`/`[]`) unless the first line parses as JSON with `type === "session"` and a
+  string `id`. `CURRENT_SESSION_VERSION = 3`; pi's own writer stamps `version: 3` — fixtures should too, so
+  a real `SessionManager` that later opens one never runs migration.
+- **File naming:** discovery is driven **purely by the `.jsonl` suffix** — `listSessionsFromDir` does
+  `readdir(dir).filter(f => f.endsWith(".jsonl"))`; nothing parses the filename. pi's own writer names new
+  files `<isoTimestamp-with-:-and-.-replaced-by-'-'>_<sessionId>.jsonl`, but any `*.jsonl` name works for
+  discovery — fixtures don't need to match that exact pattern.
+- **`cwd` recovery — and the non-recursive-custom-dir trap:** `cwd` always comes from the header's `cwd`
+  field (`header.cwd`), never from directory placement. But *directory structure interacts with discovery*:
+  `SessionManager.listAll()` (no args) walks pi's real default root (`~/.pi/agent/sessions/`) **one level of
+  subdirectories** — one dir per encoded cwd (`getDefaultSessionDirPath`: `--<cwd, / and \ and : → '-'>--`)
+  — and flattens the `.jsonl` files found inside each. But `listAll(sessionDir)` / `list(cwd, sessionDir)`
+  — the path taken whenever a **custom** `sessionDir` string is passed (exactly what `HistoryIndex`'s
+  constructor and this module's tests do) — calls `listSessionsFromDir(customDir)`, which does a **flat,
+  non-recursive** `readdir(customDir)`. Files placed in subdirectories of a custom `sessionDir` are invisible
+  to `listAll`. Consequence for fixtures: multi-session, multi-cwd test fixtures must write all `.jsonl`
+  files **flat, directly under** the given dir; different `cwd`s are expressed via each file's own header
+  `cwd` field, never via subdirectory nesting.
+- **Default-layout encoding is not importable — fixtures replicate it (pinned by A5):** the per-cwd
+  subdirectory name above is computed by `getDefaultSessionDirPath`, a *private* (unexported) helper inside
+  `core/session-manager.js`. The mkdir-ing wrapper that IS exported from that module (`getDefaultSessionDir`)
+  is not re-exported from the package root `@earendil-works/pi-coding-agent` index either (checked
+  `dist/index.js`: only `SessionManager` + a handful of pure tree-traversal helpers cross that boundary) —
+  so nothing importable computes this path. `testFixtures.ts` exports `defaultSessionDirFor(agentDir, cwd)`,
+  a from-scratch replica of the exact regex (`--<cwd, / and \ and : → '-'>--`), pinned in
+  `testFixtures.test.ts` against a real `SessionManager.list(cwd)` / `listAll()` call — re-verify against
+  `dist/core/session-manager.js` on a pi version bump.
+- **`PI_CODING_AGENT_DIR` is read live, not cached (pinned by A5):** `getAgentDir()` (`config.js`) reads
+  `process.env.PI_CODING_AGENT_DIR` directly in its function body on every call — there is no top-level
+  capture at module load. So a same-process test (or the e2e seeder) can set the env var immediately before
+  the `SessionManager` call it needs to affect and restore it in a `finally`/`afterAll`; no subprocess is
+  needed to observe a "live" env read. (Existing precedent: `agent/agentSessionManager.test.ts` already
+  does this for its disk-reopen case.)
+
+## Boundary
+- **Public surface (`index.ts`):** `HistoryIndex`, `getHistoryIndex()`, `matchesTerms`, `makeSnippet`,
+  `extractEntries`, `writeFixtureSession`, `defaultSessionDirFor` (test-only; re-exported for A5's e2e
+  fixture seeder), types.
+- **Allowed deps:** `@earendil-works/pi-coding-agent` (`SessionManager`), `@thinkrail/contracts`, `node:fs`,
+  `node:path`.
+- **Forbidden:** importing `agent`/`workspaces`/`projects` (scope mapping is injected by the host handler
+  via the `filter`/`labels` callbacks passed into `search()`); writing anything to disk (`writeFixtureSession`
+  is test-only, never called from production code paths).

--- a/packages/server/src/history/SPEC.md
+++ b/packages/server/src/history/SPEC.md
@@ -17,12 +17,26 @@ too — a bit more than `session.getMessages` itself ever exposes for a single s
 an owner-scoped host (no multi-tenant isolation to preserve).
 
 ## Design
-- `extract.ts` — pure JSONL→`HistoryEntry[]`; `messageIndex` counts user/assistant/toolResult/custom in
-  file order (the `getSessionMessages` filter), so it anchors into the transcript the client renders.
-  Searchable text capped (`MAX_SEARCHABLE`); tool results/thinking not indexed (V1).
-- `historyIndex.ts` — `HistoryIndex`: cold build on first search (batched, yields the event loop);
-  freshness = mtime revalidation throttled to ~2 s (pi appends live messages to the file, so the file IS
-  the live feed — no agent-module hook). Matching: case-insensitive substring AND over whitespace terms;
+- `extract.ts` — pure JSONL→`HistoryEntry[]`. Pi session files are **trees** (abandoned branches) that
+  compaction rewrites, so it resolves the file the way pi does before the client renders it —
+  `parseSessionEntries` → `migrateSessionEntries` → `buildSessionContext` (follow the current leaf, apply
+  the latest compaction, drop summarized/abandoned entries) — then indexes the resolved messages, filtered
+  to the same renderable roles `getSessionMessages` sends. So `messageIndex` matches the client's
+  `turnIdByMessageIndex` exactly (no raw-file-order drift), and abandoned/summarized text never becomes a
+  hit. The internal `TODO_NUDGE_PREFIX` control message (hidden from the transcript on hydrate) is skipped
+  after its index slot is consumed, so alignment holds. Searchable text capped (`MAX_SEARCHABLE`); tool
+  results/thinking not indexed (V1).
+- `historyIndex.ts` — `HistoryIndex`: cold build on first search (batched, yields the event loop; blocks
+  the search up to a budget, then returns partial with `indexing: true`). Freshness = `(mtime, size)`
+  revalidation throttled to ~2 s (pi appends live messages to the file, so the file IS the live feed — no
+  agent-module hook; size is compared alongside mtime so an append landing in the same coarse mtime tick
+  still reloads). A warm revalidation runs in the **background** — `SessionManager.listAll()` re-parses the
+  whole corpus, so a search never blocks on it; results are at most one cycle stale, and the background
+  refresh swallows its own errors (an unhandled rejection could crash the in-process host). `indexing` is
+  reported whenever any build is in flight (cold OR a background revalidation), so the client's retry loop
+  polls until a just-written session lands — read-your-writes without blocking the search. Matching:
+  case-insensitive substring AND over whitespace terms (query length + result `limit` clamped to the
+  protocol caps, `MAX_HISTORY_QUERY_LENGTH`/`MAX_HISTORY_LIMIT`, at both the handler and `search()`);
   strict recency order; prompts deduped by normalized text keeping newest; caps + true totals.
   The messages section (and `messageTotal`) is filtered to `role === "assistant"` only — a user-role hit
   is always a textual duplicate of its own prompt entry (user text IS a prompt in this extraction), so it
@@ -85,10 +99,14 @@ any assumption — re-verify on a pi version bump):
 
 ## Boundary
 - **Public surface (`index.ts`):** `HistoryIndex`, `getHistoryIndex()`, `matchesTerms`, `makeSnippet`,
-  `extractEntries`, `writeFixtureSession`, `defaultSessionDirFor` (test-only; re-exported for A5's e2e
-  fixture seeder), types.
-- **Allowed deps:** `@earendil-works/pi-coding-agent` (`SessionManager`), `@thinkrail/contracts`, `node:fs`,
-  `node:path`.
+  `clampLimit`, `extractEntries`, types. **No test helpers** — `writeFixtureSession`/`defaultSessionDirFor`
+  are disk-writing test-only builders and must not enter the runtime module graph; they're reachable only
+  through the server package's dedicated **`@thinkrail/server/history-test-fixtures`** subpath export
+  (package.json), the sanctioned test boundary — same pattern as `@thinkrail/server/agent`. In-package
+  tests import them relatively (`./testFixtures`); the e2e seeder imports the subpath.
+- **Allowed deps:** `@earendil-works/pi-coding-agent` (`SessionManager`, plus the exported session-tree
+  helpers `parseSessionEntries`/`migrateSessionEntries`/`buildSessionContext` used by `extract.ts`),
+  `@thinkrail/contracts`, `node:fs`, `node:path`.
 - **Forbidden:** importing `agent`/`workspaces`/`projects` (scope mapping is injected by the host handler
   via the `filter`/`labels` callbacks passed into `search()`); writing anything to disk (`writeFixtureSession`
   is test-only, never called from production code paths).

--- a/packages/server/src/history/SPEC.md
+++ b/packages/server/src/history/SPEC.md
@@ -10,28 +10,47 @@ tags: [v1, history]
 
 ## Responsibility
 The `history.search` backend: a **lazy in-memory index** over pi's session JSONL files (prompt recall +
-full-conversation matches). Reads via pi's `SessionManager.listAll()`; **never writes** session files.
-Because `listAll()` walks every pi session on disk, the host handler's `all` scope (`host/historyScope.ts`'s
-`filter = () => true`) deliberately surfaces pi-CLI sessions outside any registered ThinkRail workspace
-too — a bit more than `session.getMessages` itself ever exposes for a single session, but consistent with
-an owner-scoped host (no multi-tenant isolation to preserve).
+full-conversation matches). Enumerates and reads session files **itself** (async `readdir`/`stat`/
+`readFile`, replicating pi's pinned discovery layout below) — it must **never call
+`SessionManager.listAll()`** on any search/refresh path: `listAll` reads and JSON-parses *every session
+file in full* just to build its `SessionInfo`s (`messageCount`/`allMessagesText` we never use), so an
+index refresh through it costs the whole corpus even when nothing changed, on the event loop every live
+session shares. **Never writes** session files. Because discovery walks every pi session on disk, the
+host handler's `all` scope (`host/historyScope.ts`'s `filter = () => true`) deliberately surfaces pi-CLI
+sessions outside any registered ThinkRail workspace too — a bit more than `session.getMessages` itself
+ever exposes for a single session, but consistent with an owner-scoped host (no multi-tenant isolation
+to preserve).
 
 ## Design
-- `extract.ts` — pure JSONL→`HistoryEntry[]`. Pi session files are **trees** (abandoned branches) that
-  compaction rewrites, so it resolves the file the way pi does before the client renders it —
-  `parseSessionEntries` → `migrateSessionEntries` → `buildSessionContext` (follow the current leaf, apply
-  the latest compaction, drop summarized/abandoned entries) — then indexes the resolved messages, filtered
-  to the same renderable roles `getSessionMessages` sends. So `messageIndex` matches the client's
-  `turnIdByMessageIndex` exactly (no raw-file-order drift), and abandoned/summarized text never becomes a
-  hit. The internal `TODO_NUDGE_PREFIX` control message (hidden from the transcript on hydrate) is skipped
-  after its index slot is consumed, so alignment holds. Searchable text capped (`MAX_SEARCHABLE`); tool
+- `extract.ts` — pure JSONL→`ExtractedSession | null` (`extractSession`): the session's identity
+  (`id`/`cwd` from the header, mirroring pi's own rejection rule — the first parseable entry must be a
+  `type: "session"` header with a string `id`, else `null`), its `title` (the **latest** `session_info`
+  entry's name, including explicit clears — the same latest-wins rule as pi's `buildSessionInfo`), and its
+  `HistoryEntry[]` — all from **one parse**, so the index never needs a second source (`listAll`) for
+  metadata. Pi session files are **trees** (abandoned branches) that compaction rewrites, so it resolves
+  the file the way pi does before the client renders it — `parseSessionEntries` →
+  `migrateSessionEntries` → `buildSessionContext` (follow the current leaf, apply the latest compaction,
+  drop summarized/abandoned entries) — then indexes the resolved messages, filtered to the same renderable
+  roles `getSessionMessages` sends. So `messageIndex` matches the client's `turnIdByMessageIndex` exactly
+  (no raw-file-order drift), and abandoned/summarized text never becomes a hit. The internal
+  `TODO_NUDGE_PREFIX` control message (hidden from the transcript on hydrate) is skipped after its index
+  slot is consumed, so alignment holds. Entry text is **full, never truncated** — a hit's `text` is what
+  recall inserts and what the overlay's preview presents as the whole prompt, so a cap would silently
+  corrupt recall of long pasted-log prompts and make terms past the cutoff unsearchable (the memory
+  precedent is pi itself: `SessionInfo.allMessagesText` holds every session's full text in memory). Tool
   results/thinking not indexed (V1).
-- `historyIndex.ts` — `HistoryIndex`: cold build on first search (batched, yields the event loop; blocks
-  the search up to a budget, then returns partial with `indexing: true`). Freshness = `(mtime, size)`
+- `historyIndex.ts` — `HistoryIndex`: cold build on first search (async per-file IO yields the event loop;
+  blocks the search up to a budget, then returns partial with `indexing: true`). Discovery is its own
+  async enumeration (see "pi file format" below for the pinned layout): a custom `sessionDir` is a flat,
+  non-recursive dir of `.jsonl` files; the default root is `<agentDir>/sessions` — agent dir resolved
+  **per refresh** via pi's exported `getAgentDir()`, which reads `PI_CODING_AGENT_DIR` live — holding one
+  level of per-cwd subdirectories. Freshness = `(mtime, size)`
   revalidation throttled to ~2 s (pi appends live messages to the file, so the file IS the live feed — no
   agent-module hook; size is compared alongside mtime so an append landing in the same coarse mtime tick
-  still reloads). A warm revalidation runs in the **background** — `SessionManager.listAll()` re-parses the
-  whole corpus, so a search never blocks on it; results are at most one cycle stale, and the background
+  still reloads); only a **new or changed** file is read (once, `readFile`) and re-parsed — an unchanged
+  corpus costs one `readdir` walk + one `stat` per file, no reads, no parses. A warm revalidation runs in
+  the **background** — a bulk change (first refresh after restart, a git checkout) can still mean many
+  parses, so a search never blocks on it; results are at most one cycle stale, and the background
   refresh swallows its own errors (an unhandled rejection could crash the in-process host). `indexing` is
   reported whenever any build is in flight (cold OR a background revalidation), so the client's retry loop
   polls until a just-written session lands — read-your-writes without blocking the search. Matching:
@@ -60,7 +79,9 @@ an owner-scoped host (no multi-tenant isolation to preserve).
 
 ## pi file format (pinned v0.80.6 — `@earendil-works/pi-coding-agent`)
 Verified by reading `dist/core/session-manager.{js,d.ts}` in the installed package (source of truth over
-any assumption — re-verify on a pi version bump):
+any assumption — re-verify on a pi version bump). These facts now pin **two** consumers: the fixtures
+below, and `historyIndex.ts`'s own discovery walk (which must see exactly the files pi's `SessionManager`
+would):
 - **Header line** (always line 1, `SessionHeader`): `{ type: "session", version?: number, id: string,
   timestamp: string /* ISO */, cwd: string, parentSession?: string }`. `readSessionHeader`/`buildSessionInfo`
   reject the file (return `null`/`[]`) unless the first line parses as JSON with `type === "session"` and a
@@ -99,14 +120,16 @@ any assumption — re-verify on a pi version bump):
 
 ## Boundary
 - **Public surface (`index.ts`):** `HistoryIndex`, `getHistoryIndex()`, `matchesTerms`, `makeSnippet`,
-  `clampLimit`, `extractEntries`, types. **No test helpers** — `writeFixtureSession`/`defaultSessionDirFor`
+  `clampLimit`, `extractSession`, types. **No test helpers** — `writeFixtureSession`/`defaultSessionDirFor`
   are disk-writing test-only builders and must not enter the runtime module graph; they're reachable only
   through the server package's dedicated **`@thinkrail/server/history-test-fixtures`** subpath export
   (package.json), the sanctioned test boundary — same pattern as `@thinkrail/server/agent`. In-package
   tests import them relatively (`./testFixtures`); the e2e seeder imports the subpath.
-- **Allowed deps:** `@earendil-works/pi-coding-agent` (`SessionManager`, plus the exported session-tree
-  helpers `parseSessionEntries`/`migrateSessionEntries`/`buildSessionContext` used by `extract.ts`),
-  `@thinkrail/contracts`, `node:fs`, `node:path`.
+- **Allowed deps:** `@earendil-works/pi-coding-agent` (`getAgentDir` — the default sessions root — plus
+  the exported session-tree helpers `parseSessionEntries`/`migrateSessionEntries`/`buildSessionContext`
+  used by `extract.ts`; **not `SessionManager`** in production code — see Responsibility. Tests may use
+  `SessionManager` to *pin* layout/format facts against the real thing), `@thinkrail/contracts`,
+  `node:fs`, `node:fs/promises`, `node:path`.
 - **Forbidden:** importing `agent`/`workspaces`/`projects` (scope mapping is injected by the host handler
   via the `filter`/`labels` callbacks passed into `search()`); writing anything to disk (`writeFixtureSession`
   is test-only, never called from production code paths).

--- a/packages/server/src/history/extract.test.ts
+++ b/packages/server/src/history/extract.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { extractEntries } from "./extract";
+
+const line = (obj: unknown) => JSON.stringify(obj);
+
+describe("extractEntries", () => {
+	test("extracts user + assistant text with getMessages-aligned messageIndex", () => {
+		const jsonl = [
+			line({ type: "session_info", id: "a", name: "My chat" }), // not a message — no index
+			line({
+				type: "message",
+				id: "b",
+				message: { role: "user", content: "fix the flaky test", timestamp: 100 },
+			}),
+			line({
+				type: "message",
+				id: "c",
+				message: {
+					role: "assistant",
+					timestamp: 200,
+					content: [
+						{ type: "thinking", thinking: "hmm" },
+						{ type: "text", text: "It fails because of the debounce." },
+						{ type: "toolCall", id: "t1", name: "bash", arguments: {} },
+					],
+				},
+			}),
+			line({
+				type: "message",
+				id: "d",
+				message: { role: "toolResult", toolCallId: "t1", content: [], timestamp: 300 },
+			}),
+			line({
+				type: "custom_message",
+				id: "e",
+				customType: "x",
+				content: "ignored",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				display: false,
+			}),
+			line({
+				type: "message",
+				id: "f",
+				message: { role: "user", content: [{ type: "text", text: "try again" }], timestamp: 500 },
+			}),
+			"not json at all",
+		].join("\n");
+		const entries = extractEntries(jsonl);
+		expect(entries).toEqual([
+			{ text: "fix the flaky test", role: "user", timestamp: 100, messageIndex: 0 },
+			{
+				text: "It fails because of the debounce.",
+				role: "assistant",
+				timestamp: 200,
+				messageIndex: 1,
+			},
+			// toolResult = index 2, custom = index 3 (counted, not extracted)
+			{ text: "try again", role: "user", timestamp: 500, messageIndex: 4 },
+		]);
+	});
+
+	test("caps searchable text and skips empty text", () => {
+		const big = "x".repeat(10_000);
+		const jsonl = [
+			line({
+				type: "message",
+				id: "a",
+				message: { role: "user", content: big, timestamp: 1 },
+			}),
+			line({
+				type: "message",
+				id: "b",
+				message: { role: "assistant", content: [{ type: "text", text: "   " }], timestamp: 2 },
+			}),
+		].join("\n");
+		const entries = extractEntries(jsonl);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.text.length).toBe(4000);
+	});
+
+	test("ignores message entries with role='custom' (custom-role arrives only as custom_message type)", () => {
+		const jsonl = [
+			line({
+				type: "message",
+				id: "a",
+				message: { role: "user", content: "real user msg", timestamp: 100 },
+			}),
+			line({
+				type: "message",
+				id: "b",
+				message: { role: "custom", content: "should not appear", timestamp: 200 },
+			}),
+			line({
+				type: "custom_message",
+				id: "c",
+				customType: "x",
+				content: "custom via type",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				display: false,
+			}),
+		].join("\n");
+		const entries = extractEntries(jsonl);
+		// Only the user message should be extracted; the message with role="custom" is skipped,
+		// and the custom_message is counted in messageIndex (index 2) but not extracted.
+		expect(entries).toEqual([
+			{ text: "real user msg", role: "user", timestamp: 100, messageIndex: 0 },
+		]);
+	});
+
+	test("a mid-file garbage line and a message entry with no message object don't disturb messageIndex continuity", () => {
+		const jsonl = [
+			line({
+				type: "message",
+				id: "a",
+				message: { role: "user", content: "first", timestamp: 100 },
+			}),
+			"not json at all, sitting mid-file",
+			line({ type: "message", id: "b" }), // `type: "message"` but no `message` object at all
+			line({
+				type: "message",
+				id: "c",
+				message: { role: "assistant", content: "second", timestamp: 200 },
+			}),
+		].join("\n");
+		const entries = extractEntries(jsonl);
+		// Both the unparseable line and the message-shaped-but-message-less entry are pure no-ops: neither
+		// extracts an entry NOR advances messageIndex (the role check that discards them runs before the
+		// `messageIndex++`), so "second" lands at messageIndex 1, right behind "first" at 0 — no gap opened
+		// by the two lines in between.
+		expect(entries).toEqual([
+			{ text: "first", role: "user", timestamp: 100, messageIndex: 0 },
+			{ text: "second", role: "assistant", timestamp: 200, messageIndex: 1 },
+		]);
+	});
+});

--- a/packages/server/src/history/extract.test.ts
+++ b/packages/server/src/history/extract.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { TODO_NUDGE_PREFIX } from "@thinkrail/contracts";
 import { extractEntries } from "./extract";
 
 const line = (obj: unknown) => JSON.stringify(obj);
+
+/** A v3 session header — present so `migrateSessionEntries` treats the fixture as current (no migration)
+ * and the hand-written `id`/`parentId` tree below is used verbatim. */
+const header = (cwd = "/tmp/x") =>
+	line({ type: "session", version: 3, id: "s1", timestamp: "2026-01-01T00:00:00.000Z", cwd });
 
 describe("extractEntries", () => {
 	test("extracts user + assistant text with getMessages-aligned messageIndex", () => {
@@ -54,7 +60,7 @@ describe("extractEntries", () => {
 				timestamp: 200,
 				messageIndex: 1,
 			},
-			// toolResult = index 2, custom = index 3 (counted, not extracted)
+			// toolResult = index 2, custom = index 3 (renderable, counted but not extracted)
 			{ text: "try again", role: "user", timestamp: 500, messageIndex: 4 },
 		]);
 	});
@@ -78,13 +84,15 @@ describe("extractEntries", () => {
 		expect(entries[0]?.text.length).toBe(4000);
 	});
 
-	test("ignores message entries with role='custom' (custom-role arrives only as custom_message type)", () => {
+	test("a message entry with role='custom' is counted (renderable) but never extracted", () => {
 		const jsonl = [
 			line({
 				type: "message",
 				id: "a",
 				message: { role: "user", content: "real user msg", timestamp: 100 },
 			}),
+			// A v2 `hookMessage` migrates to role "custom" on a `message` entry — the host surfaces it as a
+			// renderable "custom" message, so it consumes an index slot (index 1) but carries no prompt text.
 			line({
 				type: "message",
 				id: "b",
@@ -100,14 +108,12 @@ describe("extractEntries", () => {
 			}),
 		].join("\n");
 		const entries = extractEntries(jsonl);
-		// Only the user message should be extracted; the message with role="custom" is skipped,
-		// and the custom_message is counted in messageIndex (index 2) but not extracted.
 		expect(entries).toEqual([
 			{ text: "real user msg", role: "user", timestamp: 100, messageIndex: 0 },
 		]);
 	});
 
-	test("a mid-file garbage line and a message entry with no message object don't disturb messageIndex continuity", () => {
+	test("a mid-file garbage line doesn't disturb messageIndex continuity", () => {
 		const jsonl = [
 			line({
 				type: "message",
@@ -115,7 +121,6 @@ describe("extractEntries", () => {
 				message: { role: "user", content: "first", timestamp: 100 },
 			}),
 			"not json at all, sitting mid-file",
-			line({ type: "message", id: "b" }), // `type: "message"` but no `message` object at all
 			line({
 				type: "message",
 				id: "c",
@@ -123,13 +128,166 @@ describe("extractEntries", () => {
 			}),
 		].join("\n");
 		const entries = extractEntries(jsonl);
-		// Both the unparseable line and the message-shaped-but-message-less entry are pure no-ops: neither
-		// extracts an entry NOR advances messageIndex (the role check that discards them runs before the
-		// `messageIndex++`), so "second" lands at messageIndex 1, right behind "first" at 0 — no gap opened
-		// by the two lines in between.
+		// The unparseable line is skipped by pi's own parser; "second" lands at messageIndex 1, right behind
+		// "first" at 0 — no gap opened by the line in between.
 		expect(entries).toEqual([
 			{ text: "first", role: "user", timestamp: 100, messageIndex: 0 },
 			{ text: "second", role: "assistant", timestamp: 200, messageIndex: 1 },
+		]);
+	});
+
+	test("indexes only the active branch — abandoned-branch messages are neither indexed nor counted", () => {
+		// Tree: u0 → a0 → {abandoned: u1x → a1x}, and the live branch u1 → a1 (both children of a0). The
+		// leaf is the last physical entry (a1), so pi resolves the path u0 → a0 → u1 → a1. The abandoned
+		// edit/reply must not appear, and the live follow-up must land at index 2 — NOT index 4 (its raw
+		// file position) — matching what the client's hydrated transcript renders.
+		const jsonl = [
+			header(),
+			line({
+				type: "message",
+				id: "u0",
+				parentId: null,
+				message: { role: "user", content: "first question", timestamp: 100 },
+			}),
+			line({
+				type: "message",
+				id: "a0",
+				parentId: "u0",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "first answer" }],
+					timestamp: 200,
+				},
+			}),
+			line({
+				type: "message",
+				id: "u1x",
+				parentId: "a0",
+				message: { role: "user", content: "abandoned edit", timestamp: 300 },
+			}),
+			line({
+				type: "message",
+				id: "a1x",
+				parentId: "u1x",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "abandoned reply" }],
+					timestamp: 400,
+				},
+			}),
+			line({
+				type: "message",
+				id: "u1",
+				parentId: "a0",
+				message: { role: "user", content: "real followup", timestamp: 500 },
+			}),
+			line({
+				type: "message",
+				id: "a1",
+				parentId: "u1",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "real reply" }],
+					timestamp: 600,
+				},
+			}),
+		].join("\n");
+		const entries = extractEntries(jsonl);
+		expect(entries).toEqual([
+			{ text: "first question", role: "user", timestamp: 100, messageIndex: 0 },
+			{ text: "first answer", role: "assistant", timestamp: 200, messageIndex: 1 },
+			{ text: "real followup", role: "user", timestamp: 500, messageIndex: 2 },
+			{ text: "real reply", role: "assistant", timestamp: 600, messageIndex: 3 },
+		]);
+	});
+
+	test("respects compaction — summarized-away messages are dropped and the summary isn't indexed", () => {
+		// u0/a0 precede firstKeptEntryId (u1) so compaction drops them; the compaction summary is a
+		// non-renderable message (no index slot); the kept question + post-compaction answer index from 0,
+		// matching the client's post-compaction transcript.
+		const jsonl = [
+			header(),
+			line({
+				type: "message",
+				id: "u0",
+				parentId: null,
+				message: { role: "user", content: "dropped question", timestamp: 100 },
+			}),
+			line({
+				type: "message",
+				id: "a0",
+				parentId: "u0",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "dropped answer" }],
+					timestamp: 200,
+				},
+			}),
+			line({
+				type: "message",
+				id: "u1",
+				parentId: "a0",
+				message: { role: "user", content: "kept question", timestamp: 300 },
+			}),
+			line({
+				type: "compaction",
+				id: "c0",
+				parentId: "u1",
+				firstKeptEntryId: "u1",
+				summary: "earlier conversation summarized",
+				tokensBefore: 1000,
+				timestamp: "2026-01-01T00:00:01.000Z",
+			}),
+			line({
+				type: "message",
+				id: "a1",
+				parentId: "c0",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "post-compaction answer" }],
+					timestamp: 400,
+				},
+			}),
+		].join("\n");
+		const entries = extractEntries(jsonl);
+		expect(entries).toEqual([
+			{ text: "kept question", role: "user", timestamp: 300, messageIndex: 0 },
+			{ text: "post-compaction answer", role: "assistant", timestamp: 400, messageIndex: 1 },
+		]);
+	});
+
+	test("excludes the internal todo-nudge prompt but still consumes its index slot", () => {
+		const jsonl = [
+			header(),
+			line({
+				type: "message",
+				id: "u0",
+				parentId: null,
+				message: { role: "user", content: "real prompt", timestamp: 100 },
+			}),
+			line({
+				type: "message",
+				id: "n0",
+				parentId: "u0",
+				message: {
+					role: "user",
+					content: `${TODO_NUDGE_PREFIX}A TODO was added to the list: "x".`,
+					timestamp: 200,
+				},
+			}),
+			line({
+				type: "message",
+				id: "u1",
+				parentId: "n0",
+				message: { role: "user", content: "next prompt", timestamp: 300 },
+			}),
+		].join("\n");
+		const entries = extractEntries(jsonl);
+		// The nudge (index 1) is not surfaced, but its slot is still consumed so "next prompt" keeps its
+		// real position (index 2) — the same index the client's turnIdByMessageIndex assigns it.
+		expect(entries).toEqual([
+			{ text: "real prompt", role: "user", timestamp: 100, messageIndex: 0 },
+			{ text: "next prompt", role: "user", timestamp: 300, messageIndex: 2 },
 		]);
 	});
 });

--- a/packages/server/src/history/extract.test.ts
+++ b/packages/server/src/history/extract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { TODO_NUDGE_PREFIX } from "@thinkrail/contracts";
-import { extractEntries } from "./extract";
+import { extractSession } from "./extract";
 
 const line = (obj: unknown) => JSON.stringify(obj);
 
@@ -9,18 +9,28 @@ const line = (obj: unknown) => JSON.stringify(obj);
 const header = (cwd = "/tmp/x") =>
 	line({ type: "session", version: 3, id: "s1", timestamp: "2026-01-01T00:00:00.000Z", cwd });
 
-describe("extractEntries", () => {
+/** Unwrap the entries of a fixture that must parse (the header-shape cases assert on `null` directly). */
+const entriesOf = (jsonl: string) => {
+	const session = extractSession(jsonl);
+	expect(session).not.toBeNull();
+	return session?.entries;
+};
+
+describe("extractSession", () => {
 	test("extracts user + assistant text with getMessages-aligned messageIndex", () => {
 		const jsonl = [
-			line({ type: "session_info", id: "a", name: "My chat" }), // not a message — no index
+			header(),
+			line({ type: "session_info", id: "a", parentId: null, name: "My chat" }), // not a message — no index
 			line({
 				type: "message",
 				id: "b",
+				parentId: "a",
 				message: { role: "user", content: "fix the flaky test", timestamp: 100 },
 			}),
 			line({
 				type: "message",
 				id: "c",
+				parentId: "b",
 				message: {
 					role: "assistant",
 					timestamp: 200,
@@ -34,11 +44,13 @@ describe("extractEntries", () => {
 			line({
 				type: "message",
 				id: "d",
+				parentId: "c",
 				message: { role: "toolResult", toolCallId: "t1", content: [], timestamp: 300 },
 			}),
 			line({
 				type: "custom_message",
 				id: "e",
+				parentId: "d",
 				customType: "x",
 				content: "ignored",
 				timestamp: "2026-01-01T00:00:00.000Z",
@@ -47,12 +59,12 @@ describe("extractEntries", () => {
 			line({
 				type: "message",
 				id: "f",
+				parentId: "e",
 				message: { role: "user", content: [{ type: "text", text: "try again" }], timestamp: 500 },
 			}),
 			"not json at all",
 		].join("\n");
-		const entries = extractEntries(jsonl);
-		expect(entries).toEqual([
+		expect(entriesOf(jsonl)).toEqual([
 			{ text: "fix the flaky test", role: "user", timestamp: 100, messageIndex: 0 },
 			{
 				text: "It fails because of the debounce.",
@@ -65,30 +77,92 @@ describe("extractEntries", () => {
 		]);
 	});
 
-	test("caps searchable text and skips empty text", () => {
-		const big = "x".repeat(10_000);
+	test("carries the header's identity and the latest session_info name (a clear wins too)", () => {
 		const jsonl = [
+			line({
+				type: "session",
+				version: 3,
+				id: "sess-42",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: "/repo/a",
+			}),
+			line({ type: "session_info", id: "i0", parentId: null, name: "First name" }),
+			line({ type: "session_info", id: "i1", parentId: "i0", name: "Renamed chat" }),
+			line({
+				type: "message",
+				id: "m0",
+				parentId: "i1",
+				message: { role: "user", content: "hello", timestamp: 100 },
+			}),
+		].join("\n");
+		expect(extractSession(jsonl)).toMatchObject({
+			id: "sess-42",
+			cwd: "/repo/a",
+			title: "Renamed chat",
+		});
+
+		// An explicit clear (empty name) after a set name means no title — pi's latest-wins rule.
+		const cleared = [
+			line({
+				type: "session",
+				version: 3,
+				id: "sess-43",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: "/repo/a",
+			}),
+			line({ type: "session_info", id: "i0", parentId: null, name: "Named" }),
+			line({ type: "session_info", id: "i1", parentId: "i0", name: "" }),
+		].join("\n");
+		expect(extractSession(cleared)?.title).toBeUndefined();
+	});
+
+	test("rejects a file whose first parseable entry is not a session header (pi's own rule)", () => {
+		// No header at all.
+		expect(
+			extractSession(
+				line({ type: "message", id: "a", message: { role: "user", content: "x", timestamp: 1 } }),
+			),
+		).toBeNull();
+		// A header-shaped line without a string id.
+		expect(
+			extractSession(line({ type: "session", version: 3, timestamp: "2026-01-01T00:00:00.000Z" })),
+		).toBeNull();
+		// Malformed leading lines are skipped (pi's parser drops them) — the header is still found.
+		const afterGarbage = ["not json at all", header()].join("\n");
+		expect(extractSession(afterGarbage)).toMatchObject({ id: "s1", cwd: "/tmp/x" });
+	});
+
+	test("preserves full text — a prompt far beyond 4k chars is never truncated — and skips empty text", () => {
+		const big = `${"x".repeat(10_000)} needle-at-the-end`;
+		const jsonl = [
+			header(),
 			line({
 				type: "message",
 				id: "a",
+				parentId: null,
 				message: { role: "user", content: big, timestamp: 1 },
 			}),
 			line({
 				type: "message",
 				id: "b",
+				parentId: "a",
 				message: { role: "assistant", content: [{ type: "text", text: "   " }], timestamp: 2 },
 			}),
 		].join("\n");
-		const entries = extractEntries(jsonl);
+		const entries = entriesOf(jsonl);
 		expect(entries).toHaveLength(1);
-		expect(entries[0]?.text.length).toBe(4000);
+		// The whole prompt round-trips: recall inserts `text` verbatim, and a term past any would-be
+		// cutoff must stay searchable.
+		expect(entries?.[0]?.text).toBe(big);
 	});
 
 	test("a message entry with role='custom' is counted (renderable) but never extracted", () => {
 		const jsonl = [
+			header(),
 			line({
 				type: "message",
 				id: "a",
+				parentId: null,
 				message: { role: "user", content: "real user msg", timestamp: 100 },
 			}),
 			// A v2 `hookMessage` migrates to role "custom" on a `message` entry — the host surfaces it as a
@@ -96,41 +170,44 @@ describe("extractEntries", () => {
 			line({
 				type: "message",
 				id: "b",
+				parentId: "a",
 				message: { role: "custom", content: "should not appear", timestamp: 200 },
 			}),
 			line({
 				type: "custom_message",
 				id: "c",
+				parentId: "b",
 				customType: "x",
 				content: "custom via type",
 				timestamp: "2026-01-01T00:00:00.000Z",
 				display: false,
 			}),
 		].join("\n");
-		const entries = extractEntries(jsonl);
-		expect(entries).toEqual([
+		expect(entriesOf(jsonl)).toEqual([
 			{ text: "real user msg", role: "user", timestamp: 100, messageIndex: 0 },
 		]);
 	});
 
 	test("a mid-file garbage line doesn't disturb messageIndex continuity", () => {
 		const jsonl = [
+			header(),
 			line({
 				type: "message",
 				id: "a",
+				parentId: null,
 				message: { role: "user", content: "first", timestamp: 100 },
 			}),
 			"not json at all, sitting mid-file",
 			line({
 				type: "message",
 				id: "c",
+				parentId: "a",
 				message: { role: "assistant", content: "second", timestamp: 200 },
 			}),
 		].join("\n");
-		const entries = extractEntries(jsonl);
 		// The unparseable line is skipped by pi's own parser; "second" lands at messageIndex 1, right behind
 		// "first" at 0 — no gap opened by the line in between.
-		expect(entries).toEqual([
+		expect(entriesOf(jsonl)).toEqual([
 			{ text: "first", role: "user", timestamp: 100, messageIndex: 0 },
 			{ text: "second", role: "assistant", timestamp: 200, messageIndex: 1 },
 		]);
@@ -192,8 +269,7 @@ describe("extractEntries", () => {
 				},
 			}),
 		].join("\n");
-		const entries = extractEntries(jsonl);
-		expect(entries).toEqual([
+		expect(entriesOf(jsonl)).toEqual([
 			{ text: "first question", role: "user", timestamp: 100, messageIndex: 0 },
 			{ text: "first answer", role: "assistant", timestamp: 200, messageIndex: 1 },
 			{ text: "real followup", role: "user", timestamp: 500, messageIndex: 2 },
@@ -249,8 +325,7 @@ describe("extractEntries", () => {
 				},
 			}),
 		].join("\n");
-		const entries = extractEntries(jsonl);
-		expect(entries).toEqual([
+		expect(entriesOf(jsonl)).toEqual([
 			{ text: "kept question", role: "user", timestamp: 300, messageIndex: 0 },
 			{ text: "post-compaction answer", role: "assistant", timestamp: 400, messageIndex: 1 },
 		]);
@@ -282,10 +357,9 @@ describe("extractEntries", () => {
 				message: { role: "user", content: "next prompt", timestamp: 300 },
 			}),
 		].join("\n");
-		const entries = extractEntries(jsonl);
 		// The nudge (index 1) is not surfaced, but its slot is still consumed so "next prompt" keeps its
 		// real position (index 2) — the same index the client's turnIdByMessageIndex assigns it.
-		expect(entries).toEqual([
+		expect(entriesOf(jsonl)).toEqual([
 			{ text: "real prompt", role: "user", timestamp: 100, messageIndex: 0 },
 			{ text: "next prompt", role: "user", timestamp: 300, messageIndex: 2 },
 		]);

--- a/packages/server/src/history/extract.ts
+++ b/packages/server/src/history/extract.ts
@@ -1,0 +1,74 @@
+/** One searchable message from a session transcript (see SPEC.md for the messageIndex invariant). */
+export interface HistoryEntry {
+	text: string;
+	role: "user" | "assistant";
+	timestamp: number;
+	/** Position among renderable messages (user/assistant/toolResult/custom) — `session.getMessages` order. */
+	messageIndex: number;
+}
+
+/** Cap per-entry searchable text — huge pasted-log prompts truncate for matching (recall shows the hit;
+ * insert re-reads nothing, the capped text is what's inserted, which V1 accepts for >4k prompts). */
+export const MAX_SEARCHABLE = 4000;
+
+const MESSAGE_ROLES = new Set(["user", "assistant", "toolResult"]);
+
+function textOf(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((b) =>
+			b && typeof b === "object" && (b as { type?: string }).type === "text"
+				? String((b as { text?: unknown }).text ?? "")
+				: "",
+		)
+		.filter(Boolean)
+		.join("\n");
+}
+
+/** Parse one pi session JSONL file into searchable entries. Tolerant: non-JSON / unknown lines skip
+ * without disturbing the renderable-message count. Pure. */
+export function extractEntries(jsonl: string): HistoryEntry[] {
+	const entries: HistoryEntry[] = [];
+	let messageIndex = 0;
+	for (const raw of jsonl.split("\n")) {
+		const lineText = raw.trim();
+		if (!lineText) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(lineText);
+		} catch {
+			continue;
+		}
+
+		const entry = parsed as {
+			type?: unknown;
+			message?: { role?: unknown; content?: unknown; timestamp?: unknown };
+		};
+
+		// custom_message entries: top-level, no message wrapper, always renderable.
+		if (entry.type === "custom_message") {
+			messageIndex++;
+			continue;
+		}
+
+		// message entries: require message.role to be a known type.
+		if (entry.type !== "message") continue;
+		const role = entry.message?.role;
+		if (typeof role !== "string" || !MESSAGE_ROLES.has(role)) continue;
+		const index = messageIndex++;
+
+		// Extract text only from user/assistant roles.
+		if (role !== "user" && role !== "assistant") continue;
+		const text = textOf(entry.message?.content);
+		if (!text.trim()) continue;
+		const ts = entry.message?.timestamp;
+		entries.push({
+			text: text.slice(0, MAX_SEARCHABLE),
+			role,
+			timestamp: typeof ts === "number" ? ts : 0,
+			messageIndex: index,
+		});
+	}
+	return entries;
+}

--- a/packages/server/src/history/extract.ts
+++ b/packages/server/src/history/extract.ts
@@ -15,9 +15,15 @@ export interface HistoryEntry {
 	messageIndex: number;
 }
 
-/** Cap per-entry searchable text — huge pasted-log prompts truncate for matching (recall shows the hit;
- * insert re-reads nothing, the capped text is what's inserted, which V1 accepts for >4k prompts). */
-export const MAX_SEARCHABLE = 4000;
+/** One resolved session file: its identity + searchable entries, all from a single parse — so the index
+ * never needs a second metadata source (`SessionManager.listAll` re-parses the whole corpus; see SPEC.md). */
+export interface ExtractedSession {
+	id: string;
+	cwd: string;
+	/** The latest `session_info` name (latest wins, including explicit clears) — pi's own rule. */
+	title?: string;
+	entries: HistoryEntry[];
+}
 
 /** The roles the host surfaces to the client (`getSessionMessages`'s filter) — the exact set the client's
  * `messagesToRuntime` folds into `turnIdByMessageIndex`. Indexing against the same set is what keeps a
@@ -38,7 +44,13 @@ function textOf(content: unknown): string {
 }
 
 /**
- * Parse one pi session JSONL file into searchable entries. Pure.
+ * Parse one pi session JSONL file into its identity + searchable entries. Pure.
+ *
+ * Returns `null` unless the first parseable entry is a `type: "session"` header with a string `id` —
+ * the same rejection rule pi's own `buildSessionInfo` applies, so a stray non-session `.jsonl` in a
+ * sessions dir is skipped exactly like pi would skip it. `id`/`cwd` come from that header (`cwd` is
+ * **never** inferred from directory placement — see SPEC.md), `title` from the latest `session_info`
+ * entry (including explicit clears).
  *
  * Pi session files are trees, not flat logs: a file can hold abandoned branches, and compaction rewrites
  * which messages are "live". So we resolve the file the same way pi does before the client ever renders
@@ -47,16 +59,24 @@ function textOf(content: unknown): string {
  * `leafId` is left undefined so pi picks the current leaf as the last entry, exactly as
  * `SessionManager._buildIndex` does on load — and the resolved array is filtered to the same
  * `RENDERABLE_ROLES` the host's `getSessionMessages` sends, so every entry's `messageIndex` lines up with
- * the client's `turnIdByMessageIndex` (the jump anchor). Tolerant: `parseSessionEntries` skips
- * non-JSON/malformed lines; a v1/v2 file is migrated first so it resolves like any current session.
+ * the client's `turnIdByMessageIndex` (the jump anchor). Entry text is full, never truncated — it's what
+ * recall inserts and what the overlay presents as the whole prompt (see SPEC.md). Tolerant:
+ * `parseSessionEntries` skips non-JSON/malformed lines; a v1/v2 file is migrated first so it resolves
+ * like any current session.
  */
-export function extractEntries(jsonl: string): HistoryEntry[] {
+export function extractSession(jsonl: string): ExtractedSession | null {
 	const parsed = parseSessionEntries(jsonl);
+	const header = parsed[0];
+	if (header?.type !== "session" || typeof header.id !== "string") return null;
 	migrateSessionEntries(parsed);
 	// `parseSessionEntries` returns `FileEntry[]` (the session header included); `buildSessionContext`
 	// wants `SessionEntry[]`. The header carries no id any message's `parentId` points at, so dropping it
 	// changes nothing about the resolved path — it just satisfies the type without a cast.
 	const entries = parsed.filter((e): e is SessionEntry => e.type !== "session");
+	let title: string | undefined;
+	for (const entry of entries) {
+		if (entry.type === "session_info") title = entry.name?.trim() || undefined;
+	}
 	const { messages } = buildSessionContext(entries);
 
 	const out: HistoryEntry[] = [];
@@ -74,11 +94,16 @@ export function extractEntries(jsonl: string): HistoryEntry[] {
 		// skipping only the text keeps every later hit's anchor aligned.
 		if (message.role === "user" && text.startsWith(TODO_NUDGE_PREFIX)) continue;
 		out.push({
-			text: text.slice(0, MAX_SEARCHABLE),
+			text,
 			role: message.role,
 			timestamp: message.timestamp,
 			messageIndex: index,
 		});
 	}
-	return out;
+	return {
+		id: header.id,
+		cwd: typeof header.cwd === "string" ? header.cwd : "",
+		...(title !== undefined ? { title } : {}),
+		entries: out,
+	};
 }

--- a/packages/server/src/history/extract.ts
+++ b/packages/server/src/history/extract.ts
@@ -1,3 +1,11 @@
+import {
+	buildSessionContext,
+	migrateSessionEntries,
+	parseSessionEntries,
+	type SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import { TODO_NUDGE_PREFIX } from "@thinkrail/contracts";
+
 /** One searchable message from a session transcript (see SPEC.md for the messageIndex invariant). */
 export interface HistoryEntry {
 	text: string;
@@ -11,7 +19,10 @@ export interface HistoryEntry {
  * insert re-reads nothing, the capped text is what's inserted, which V1 accepts for >4k prompts). */
 export const MAX_SEARCHABLE = 4000;
 
-const MESSAGE_ROLES = new Set(["user", "assistant", "toolResult"]);
+/** The roles the host surfaces to the client (`getSessionMessages`'s filter) — the exact set the client's
+ * `messagesToRuntime` folds into `turnIdByMessageIndex`. Indexing against the same set is what keeps a
+ * hit's `messageIndex` aligned with the jump anchor the client resolves it against. */
+const RENDERABLE_ROLES = new Set(["user", "assistant", "toolResult", "custom"]);
 
 function textOf(content: unknown): string {
 	if (typeof content === "string") return content;
@@ -26,49 +37,48 @@ function textOf(content: unknown): string {
 		.join("\n");
 }
 
-/** Parse one pi session JSONL file into searchable entries. Tolerant: non-JSON / unknown lines skip
- * without disturbing the renderable-message count. Pure. */
+/**
+ * Parse one pi session JSONL file into searchable entries. Pure.
+ *
+ * Pi session files are trees, not flat logs: a file can hold abandoned branches, and compaction rewrites
+ * which messages are "live". So we resolve the file the same way pi does before the client ever renders
+ * it — `parseSessionEntries` → `migrateSessionEntries` → `buildSessionContext` (follow the current leaf,
+ * apply the latest compaction, drop summarized/abandoned entries), then index the resolved messages.
+ * `leafId` is left undefined so pi picks the current leaf as the last entry, exactly as
+ * `SessionManager._buildIndex` does on load — and the resolved array is filtered to the same
+ * `RENDERABLE_ROLES` the host's `getSessionMessages` sends, so every entry's `messageIndex` lines up with
+ * the client's `turnIdByMessageIndex` (the jump anchor). Tolerant: `parseSessionEntries` skips
+ * non-JSON/malformed lines; a v1/v2 file is migrated first so it resolves like any current session.
+ */
 export function extractEntries(jsonl: string): HistoryEntry[] {
-	const entries: HistoryEntry[] = [];
+	const parsed = parseSessionEntries(jsonl);
+	migrateSessionEntries(parsed);
+	// `parseSessionEntries` returns `FileEntry[]` (the session header included); `buildSessionContext`
+	// wants `SessionEntry[]`. The header carries no id any message's `parentId` points at, so dropping it
+	// changes nothing about the resolved path — it just satisfies the type without a cast.
+	const entries = parsed.filter((e): e is SessionEntry => e.type !== "session");
+	const { messages } = buildSessionContext(entries);
+
+	const out: HistoryEntry[] = [];
 	let messageIndex = 0;
-	for (const raw of jsonl.split("\n")) {
-		const lineText = raw.trim();
-		if (!lineText) continue;
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(lineText);
-		} catch {
-			continue;
-		}
-
-		const entry = parsed as {
-			type?: unknown;
-			message?: { role?: unknown; content?: unknown; timestamp?: unknown };
-		};
-
-		// custom_message entries: top-level, no message wrapper, always renderable.
-		if (entry.type === "custom_message") {
-			messageIndex++;
-			continue;
-		}
-
-		// message entries: require message.role to be a known type.
-		if (entry.type !== "message") continue;
-		const role = entry.message?.role;
-		if (typeof role !== "string" || !MESSAGE_ROLES.has(role)) continue;
+	for (const message of messages) {
+		// Non-renderable context messages (compaction/branch summaries) are stripped by the host before
+		// the client sees them, so they must not consume an index slot here either.
+		if (!RENDERABLE_ROLES.has(message.role)) continue;
 		const index = messageIndex++;
-
-		// Extract text only from user/assistant roles.
-		if (role !== "user" && role !== "assistant") continue;
-		const text = textOf(entry.message?.content);
+		if (message.role !== "user" && message.role !== "assistant") continue;
+		const text = textOf(message.content);
 		if (!text.trim()) continue;
-		const ts = entry.message?.timestamp;
-		entries.push({
+		// Internal control traffic: the pi-todos wake-nudge is hidden from the transcript on hydrate, so it
+		// must not surface as a recallable/insertable prompt. The index was already consumed above, so
+		// skipping only the text keeps every later hit's anchor aligned.
+		if (message.role === "user" && text.startsWith(TODO_NUDGE_PREFIX)) continue;
+		out.push({
 			text: text.slice(0, MAX_SEARCHABLE),
-			role,
-			timestamp: typeof ts === "number" ? ts : 0,
+			role: message.role,
+			timestamp: message.timestamp,
 			messageIndex: index,
 		});
 	}
-	return entries;
+	return out;
 }

--- a/packages/server/src/history/historyIndex.test.ts
+++ b/packages/server/src/history/historyIndex.test.ts
@@ -3,7 +3,7 @@ import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getHistoryIndex, HistoryIndex, makeSnippet, matchesTerms } from "./historyIndex";
-import { writeFixtureSession } from "./testFixtures";
+import { defaultSessionDirFor, writeFixtureSession } from "./testFixtures";
 
 const allowAll = () => true;
 const noLabels = () => ({});
@@ -221,7 +221,7 @@ describe("HistoryIndex.search", () => {
 	// text, not its truncated `snippet`. `search()`'s message-hit construction spreads the same `hit`
 	// object it builds for prompts (`{ ...hit, role, snippet, messageIndex, anchorText }`) — `text` is
 	// never overwritten in that spread, so it already carries `entry.text` (the extractor's full,
-	// 4000-char-capped text) unchanged. This pins that invariant with an **assistant**-role message,
+	// uncapped text) unchanged. This pins that invariant with an **assistant**-role message,
 	// deliberately: an assistant entry can never become a `promptCandidate` (only `role === "user"`
 	// does), so a passing assertion here can only be explained by the message-hit-specific construction
 	// path itself carrying the full text — not by some accidental aliasing with the prompts branch.
@@ -252,6 +252,62 @@ describe("HistoryIndex.search", () => {
 		// Confirms the fixture's assistant-only setup: no prompt hit exists to have accidentally supplied
 		// `.text` instead.
 		expect(result.prompts).toHaveLength(0);
+	});
+
+	// Pins the fix for the truncation finding: a hit's `text` IS what recall inserts and what the
+	// overlay's preview shows as the whole prompt, so a long pasted-log prompt must round-trip in full
+	// and a term past any would-be cutoff must stay searchable.
+	test("(i) a prompt far beyond 4k chars round-trips in full, and its tail is searchable", async () => {
+		const big = `${"log-line ".repeat(1000)}rare-tail-needle`; // ~9k chars, needle at the very end
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [{ role: "user", text: big, timestamp: 1000 }],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({
+			query: "rare-tail-needle",
+			filter: allowAll,
+			labels: noLabels,
+		});
+
+		expect(result.prompts).toHaveLength(1);
+		expect(result.prompts[0]?.text).toBe(big);
+	});
+
+	// Pins the rewritten discovery walk (no `SessionManager.listAll()`): a no-arg index must find files
+	// in pi's real default layout — `<agentDir>/sessions/<encoded-cwd>/*.jsonl`, one subdir level — with
+	// the agent dir resolved live from `PI_CODING_AGENT_DIR` (the same live-read `getAgentDir()` behavior
+	// the e2e host relies on; see SPEC.md).
+	test("(j) default layout: a no-arg index discovers per-cwd subdirectories under the agent dir", async () => {
+		const prev = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = dir; // `dir` acts as the agent dir, not a flat session dir
+		try {
+			writeFixtureSession(defaultSessionDirFor(dir, "/repo/a"), {
+				id: "sess-a",
+				cwd: "/repo/a",
+				messages: [{ role: "user", text: "default layout prompt", timestamp: 1000 }],
+			});
+			writeFixtureSession(defaultSessionDirFor(dir, "/repo/b"), {
+				id: "sess-b",
+				cwd: "/repo/b",
+				messages: [{ role: "user", text: "default layout other", timestamp: 2000 }],
+			});
+
+			const index = new HistoryIndex();
+			const result = await index.search({
+				query: "default layout",
+				filter: allowAll,
+				labels: noLabels,
+			});
+
+			expect(result.prompts.map((p) => p.sessionId).sort()).toEqual(["sess-a", "sess-b"]);
+			expect(result.prompts.map((p) => p.cwd).sort()).toEqual(["/repo/a", "/repo/b"]);
+		} finally {
+			if (prev === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = prev;
+		}
 	});
 
 	test("scope labels (workspaceId/projectId) are merged onto every hit", async () => {

--- a/packages/server/src/history/historyIndex.test.ts
+++ b/packages/server/src/history/historyIndex.test.ts
@@ -179,11 +179,22 @@ describe("HistoryIndex.search", () => {
 			})}\n`,
 		);
 
-		// Pass the 2000ms revalidation throttle so the next search re-lists and re-parses.
+		// Pass the 2000ms revalidation throttle so the next search triggers a re-list/re-parse.
 		await Bun.sleep(2100);
 
+		// Warm revalidation is non-blocking: this search kicks off the background refresh but returns the
+		// still-current index, so the freshly appended line hasn't landed yet.
 		const second = await index.search({ query: "prompt", filter: allowAll, labels: noLabels });
-		expect(second.prompts.map((p) => p.text)).toEqual(["fresh prompt two", "original prompt one"]);
+		expect(second.prompts.map((p) => p.text)).toEqual(["original prompt one"]);
+
+		// Once the background refresh settles, a follow-up search reflects the appended line. Poll rather
+		// than sleep a fixed amount, since the refresh completes off the search's critical path.
+		let third = second;
+		for (let i = 0; i < 100 && third.prompts.length < 2; i++) {
+			await Bun.sleep(20);
+			third = await index.search({ query: "prompt", filter: allowAll, labels: noLabels });
+		}
+		expect(third.prompts.map((p) => p.text)).toEqual(["fresh prompt two", "original prompt one"]);
 	});
 
 	test("(g) a user-text match produces a jumpable prompt hit (messageIndex + 120-char anchorText) and no message hit", async () => {

--- a/packages/server/src/history/historyIndex.test.ts
+++ b/packages/server/src/history/historyIndex.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getHistoryIndex, HistoryIndex, makeSnippet, matchesTerms } from "./historyIndex";
+import { writeFixtureSession } from "./testFixtures";
+
+const allowAll = () => true;
+const noLabels = () => ({});
+
+describe("HistoryIndex.search", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "trpi-history-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("(a) AND-matches terms and orders hits by recency across sessions", async () => {
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [
+				{ role: "user", text: "deploy the frontend service", timestamp: 1000 },
+				{ role: "assistant", text: "the frontend service deployed cleanly", timestamp: 3000 },
+			],
+		});
+		writeFixtureSession(dir, {
+			id: "sess-b",
+			cwd: "/repo/b",
+			messages: [
+				{ role: "user", text: "deploy the backend service", timestamp: 2000 },
+				{ role: "user", text: "unrelated note about lunch", timestamp: 4000 },
+			],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({
+			query: "deploy service",
+			filter: allowAll,
+			labels: noLabels,
+		});
+
+		// AND matching: "unrelated note about lunch" (no "deploy") never appears.
+		// messages is assistant-only, so only sess-a's assistant line qualifies; the two
+		// user-role "deploy ... service" hits surface as prompts instead.
+		expect(result.messages.map((m) => m.timestamp)).toEqual([3000]);
+		expect(result.messages.map((m) => m.sessionId)).toEqual(["sess-a"]);
+		// Cross-session recency still holds for prompts: sess-b's t=2000 sorts ahead of sess-a's
+		// t=1000, even though sess-a's file was written first — proves the merge is global, not
+		// grouped per session.
+		expect(result.prompts.map((p) => p.timestamp)).toEqual([2000, 1000]);
+		expect(result.prompts.map((p) => p.sessionId)).toEqual(["sess-b", "sess-a"]);
+		// Tiny fixture — the cold build finishes well inside the 150ms budget.
+		expect(result.indexing).toBe(false);
+	});
+
+	test("(b) dedups prompts by normalized text, keeping the newest", async () => {
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [{ role: "user", text: "fix   the bug", timestamp: 1000 }],
+		});
+		writeFixtureSession(dir, {
+			id: "sess-b",
+			cwd: "/repo/b",
+			messages: [{ role: "user", text: "fix the bug", timestamp: 5000 }],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({ query: "fix bug", filter: allowAll, labels: noLabels });
+
+		expect(result.prompts).toHaveLength(1);
+		expect(result.prompts[0]?.timestamp).toBe(5000);
+		expect(result.prompts[0]?.sessionId).toBe("sess-b");
+		expect(result.promptTotal).toBe(1);
+	});
+
+	test("(c) scope filter by cwd excludes the other session's hits", async () => {
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [{ role: "user", text: "alpha message about widgets", timestamp: 1000 }],
+		});
+		writeFixtureSession(dir, {
+			id: "sess-b",
+			cwd: "/repo/b",
+			messages: [{ role: "user", text: "beta message about widgets", timestamp: 2000 }],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({
+			query: "widgets",
+			filter: (cwd) => cwd === "/repo/a",
+			labels: noLabels,
+		});
+
+		expect(result.prompts).toHaveLength(1);
+		expect(result.prompts[0]?.sessionId).toBe("sess-a");
+		expect(result.promptTotal).toBe(1);
+	});
+
+	test("(d) empty query returns recent prompts but zero messages", async () => {
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [
+				{ role: "user", text: "hello there", timestamp: 1000 },
+				{ role: "assistant", text: "hi, how can I help", timestamp: 2000 },
+			],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({ query: "", filter: allowAll, labels: noLabels });
+
+		expect(result.messages).toEqual([]);
+		expect(result.messageTotal).toBe(0);
+		expect(result.prompts).toHaveLength(1);
+		expect(result.prompts[0]?.text).toBe("hello there");
+		expect(result.promptTotal).toBe(1);
+	});
+
+	test("(e) totals are pre-cap counts, filtered per section — they exceed the returned page when limit is smaller", async () => {
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [
+				{ role: "user", text: "widget one", timestamp: 1000 },
+				{ role: "user", text: "widget two", timestamp: 2000 },
+				{ role: "user", text: "widget three", timestamp: 3000 },
+				{ role: "assistant", text: "widget four report", timestamp: 4000 },
+				{ role: "assistant", text: "widget five report", timestamp: 5000 },
+				{ role: "assistant", text: "widget six report", timestamp: 6000 },
+			],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({
+			query: "widget",
+			limit: 2,
+			filter: allowAll,
+			labels: noLabels,
+		});
+
+		// prompts (user-role) and messages (assistant-role) are counted/capped independently —
+		// 3 of each match "widget", so each section's total is 3 (not 6), and each cap keeps its own
+		// newest 2, proving the role filter and the pagination cap compose correctly.
+		expect(result.prompts).toHaveLength(2);
+		expect(result.promptTotal).toBe(3);
+		expect(result.prompts.map((p) => p.timestamp)).toEqual([3000, 2000]);
+		expect(result.messages).toHaveLength(2);
+		expect(result.messageTotal).toBe(3);
+		expect(result.messages.map((m) => m.timestamp)).toEqual([6000, 5000]);
+	});
+
+	test("(f) revalidates after the 2s throttle and picks up an appended line", async () => {
+		const path = writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [{ role: "user", text: "original prompt one", timestamp: 1000 }],
+		}).path;
+
+		const index = new HistoryIndex(dir);
+		const first = await index.search({ query: "prompt", filter: allowAll, labels: noLabels });
+		expect(first.prompts.map((p) => p.text)).toEqual(["original prompt one"]);
+
+		// Append a new message entry onto the same file — mtime naturally bumps on write.
+		appendFileSync(
+			path,
+			`${JSON.stringify({
+				type: "message",
+				id: "sess-a-m1",
+				parentId: "sess-a-m0",
+				timestamp: new Date(9000).toISOString(),
+				message: { role: "user", content: "fresh prompt two", timestamp: 9000 },
+			})}\n`,
+		);
+
+		// Pass the 2000ms revalidation throttle so the next search re-lists and re-parses.
+		await Bun.sleep(2100);
+
+		const second = await index.search({ query: "prompt", filter: allowAll, labels: noLabels });
+		expect(second.prompts.map((p) => p.text)).toEqual(["fresh prompt two", "original prompt one"]);
+	});
+
+	test("(g) a user-text match produces a jumpable prompt hit (messageIndex + 120-char anchorText) and no message hit", async () => {
+		const longText = `${"x".repeat(150)} needle ${"y".repeat(150)}`;
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [{ role: "user", text: longText, timestamp: 1000 }],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({ query: "needle", filter: allowAll, labels: noLabels });
+
+		expect(result.prompts).toHaveLength(1);
+		expect(result.prompts[0]?.messageIndex).toBe(0);
+		expect(result.prompts[0]?.anchorText).toBe(longText.slice(0, 120));
+		// messages is assistant-only — a user-role hit never gets a separate message hit; the
+		// location it used to carry now lives on the prompt hit above instead.
+		expect(result.messages).toHaveLength(0);
+		expect(result.messageTotal).toBe(0);
+	});
+
+	// R1 step 0 (task-R1R2-brief.md): the web zoomed-stage preview pane renders a message hit's FULL
+	// text, not its truncated `snippet`. `search()`'s message-hit construction spreads the same `hit`
+	// object it builds for prompts (`{ ...hit, role, snippet, messageIndex, anchorText }`) — `text` is
+	// never overwritten in that spread, so it already carries `entry.text` (the extractor's full,
+	// 4000-char-capped text) unchanged. This pins that invariant with an **assistant**-role message,
+	// deliberately: an assistant entry can never become a `promptCandidate` (only `role === "user"`
+	// does), so a passing assertion here can only be explained by the message-hit-specific construction
+	// path itself carrying the full text — not by some accidental aliasing with the prompts branch.
+	test("(h) an assistant-text match produces a message hit — full text, snippet, anchorText", async () => {
+		const longText = `intro ${"padding ".repeat(40)}needle-marker ${"more-padding ".repeat(40)}`;
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			messages: [{ role: "assistant", text: longText, timestamp: 1000 }],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({
+			query: "needle-marker",
+			filter: allowAll,
+			labels: noLabels,
+		});
+
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0]?.role).toBe("assistant");
+		expect(result.messages[0]?.text).toBe(longText);
+		expect(result.messages[0]?.anchorText).toBe(longText.slice(0, 120));
+		expect(result.messages[0]?.snippet).toContain("needle-marker");
+		expect(result.messages[0]?.snippet.length).toBeLessThan(longText.length);
+		expect(result.messages[0]?.text.length).toBeGreaterThan(
+			result.messages[0]?.snippet.length ?? 0,
+		);
+		// Confirms the fixture's assistant-only setup: no prompt hit exists to have accidentally supplied
+		// `.text` instead.
+		expect(result.prompts).toHaveLength(0);
+	});
+
+	test("scope labels (workspaceId/projectId) are merged onto every hit", async () => {
+		writeFixtureSession(dir, {
+			id: "sess-a",
+			cwd: "/repo/a",
+			name: "My chat",
+			messages: [{ role: "user", text: "labelled prompt", timestamp: 1000 }],
+		});
+
+		const index = new HistoryIndex(dir);
+		const result = await index.search({
+			query: "labelled",
+			filter: allowAll,
+			labels: () => ({ workspaceId: "ws1", projectId: "proj1" }),
+		});
+
+		expect(result.prompts[0]).toMatchObject({
+			workspaceId: "ws1",
+			projectId: "proj1",
+			cwd: "/repo/a",
+			sessionTitle: "My chat",
+		});
+	});
+});
+
+describe("getHistoryIndex", () => {
+	test("is a lazy singleton", () => {
+		expect(getHistoryIndex()).toBe(getHistoryIndex());
+	});
+});
+
+describe("matchesTerms", () => {
+	test("requires every term to be a case-insensitive substring", () => {
+		expect(matchesTerms("Fix the Bug", ["fix", "bug"])).toBe(true);
+		expect(matchesTerms("fix the bug", ["fix", "typo"])).toBe(false);
+	});
+
+	test("an empty term is vacuously true (empty-query semantics)", () => {
+		expect(matchesTerms("anything at all", [""])).toBe(true);
+	});
+});
+
+describe("makeSnippet", () => {
+	test("windows around the first case-insensitive match", () => {
+		expect(makeSnippet("aaa NEEDLE bbb", "needle")).toBe("aaa NEEDLE bbb");
+	});
+
+	test("truncates with ellipses when the match is far from either edge", () => {
+		const text = `${"a".repeat(200)} needle ${"b".repeat(200)}`;
+		const snippet = makeSnippet(text, "needle", 10);
+		expect(snippet).toContain("needle");
+		expect(snippet.startsWith("…")).toBe(true);
+		expect(snippet.endsWith("…")).toBe(true);
+		expect(snippet.length).toBeLessThan(text.length);
+	});
+});

--- a/packages/server/src/history/historyIndex.ts
+++ b/packages/server/src/history/historyIndex.ts
@@ -1,6 +1,7 @@
 import { readFileSync, statSync } from "node:fs";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import type { HistorySearchResult, MessageHit, PromptHit } from "@thinkrail/contracts";
+import { MAX_HISTORY_LIMIT, MAX_HISTORY_QUERY_LENGTH } from "@thinkrail/contracts";
 import { extractEntries, type HistoryEntry } from "./extract";
 
 interface SessionRecord {
@@ -9,17 +10,31 @@ interface SessionRecord {
 	title?: string;
 	path: string;
 	mtimeMs: number;
+	/** File size — paired with `mtimeMs` for change detection so an append that lands in the same coarse
+	 * mtime tick as the last read (the file always grows) still triggers a reload. */
+	size: number;
 	entries: HistoryEntry[];
 }
 
 const REVALIDATE_MS = 2000;
 const BATCH = 20;
 /** Cold (first-ever) build budget: block `search()` this long, then return whatever's parsed so far
- * with `indexing: true`. Warm revalidations (only new/mtime-changed files) are always awaited in full —
- * they're bounded by the mtime diff, so search results are only ever as stale as the last file write. */
+ * with `indexing: true`. A warm revalidation is NOT awaited — `SessionManager.listAll()` re-reads and
+ * parses every session file (cost scales with the whole corpus, not the mtime diff), so blocking a search
+ * on it would tax every query; instead it runs in the background and results are at most one revalidation
+ * cycle stale (the same tolerance the cold path's `indexing` flag already relies on). */
 const COLD_BUILD_BUDGET_MS = 150;
 /** Default snippet half-window, in chars, on either side of the matched term. */
 const SNIPPET_RADIUS = 60;
+
+/** Clamp a client-supplied `limit` to a finite, non-negative integer within the protocol cap — so a
+ * missing/negative/oversized value can neither defeat the cap nor hit `Array.slice`'s negative-index
+ * semantics (`slice(0, -1)` would silently drop the last item). Applied at both the `history.search`
+ * handler boundary and inside `search()` (defense in depth). */
+export function clampLimit(limit: number | undefined): number {
+	if (typeof limit !== "number" || !Number.isFinite(limit)) return 50;
+	return Math.max(0, Math.min(MAX_HISTORY_LIMIT, Math.floor(limit)));
+}
 
 /** `query.toLowerCase().split(/\s+/)` AND-matching: every term must be a case-insensitive substring of
  * `text`. An empty term (from an empty/whitespace-only query) is vacuously true for any text — this is
@@ -56,13 +71,14 @@ export class HistoryIndex {
 
 	private loadRecord(info: { path: string; id: string; cwd: string; name?: string }): void {
 		try {
-			const mtimeMs = statSync(info.path).mtimeMs;
+			const { mtimeMs, size } = statSync(info.path);
 			const entries = extractEntries(readFileSync(info.path, "utf8"));
 			this.records.set(info.path, {
 				sessionId: info.id,
 				cwd: info.cwd,
 				path: info.path,
 				mtimeMs,
+				size,
 				entries,
 				...(info.name ? { title: info.name } : {}),
 			});
@@ -80,12 +96,15 @@ export class HistoryIndex {
 			seen.add(info.path);
 			const rec = this.records.get(info.path);
 			let mtimeMs = 0;
+			let size = 0;
 			try {
-				mtimeMs = statSync(info.path).mtimeMs;
+				({ mtimeMs, size } = statSync(info.path));
 			} catch {
 				continue;
 			}
-			if (rec && rec.mtimeMs === mtimeMs) continue;
+			// Skip only when BOTH mtime and size are unchanged — an append can land in the same coarse
+			// mtime tick as the last read, but it always changes the size.
+			if (rec && rec.mtimeMs === mtimeMs && rec.size === size) continue;
 			this.loadRecord(info);
 			if (++inBatch % BATCH === 0) await new Promise((r) => setImmediate(r));
 		}
@@ -97,17 +116,24 @@ export class HistoryIndex {
 		const now = Date.now();
 		if (!this.building && (!this.built || now - this.lastCheck > REVALIDATE_MS)) {
 			this.lastCheck = now;
-			this.building = this.refresh().finally(() => {
-				this.building = null;
-			});
+			// A warm revalidation isn't awaited by `search()`, so swallow its errors here — an unhandled
+			// rejection would otherwise be able to take down the in-process host. A failed refresh just
+			// leaves the current index in place; the next cycle retries. (A cold build's error is caught the
+			// same way, leaving `built` false so `indexing: true` keeps being reported until it succeeds.)
+			this.building = this.refresh()
+				.catch(() => {})
+				.finally(() => {
+					this.building = null;
+				});
 		}
 	}
 
 	/**
 	 * Search the index. Blocks on a cold (first-ever) build up to `COLD_BUILD_BUDGET_MS`, then returns
 	 * partial results with `indexing: true` if the build is still running. A warm revalidation (mtime
-	 * throttled to `REVALIDATE_MS`) is always awaited fully — it only touches new/changed files, so it's
-	 * bounded and search results should never lag behind an on-disk write by more than the throttle.
+	 * throttled to `REVALIDATE_MS`) runs in the background and is **not** awaited — it re-parses the whole
+	 * corpus via `listAll()`, so blocking on it would tax every search; results are instead at most one
+	 * revalidation cycle stale.
 	 */
 	async search(input: {
 		query: string;
@@ -117,16 +143,25 @@ export class HistoryIndex {
 	}): Promise<HistorySearchResult> {
 		const wasCold = !this.built;
 		this.ensureFresh();
-		if (this.building) {
-			if (wasCold) await Promise.race([this.building, Bun.sleep(COLD_BUILD_BUDGET_MS)]);
-			else await this.building;
+		// Only a cold build blocks the search (up to the budget); a warm revalidation runs in the
+		// background — see `COLD_BUILD_BUDGET_MS`.
+		if (this.building && wasCold) {
+			await Promise.race([this.building, Bun.sleep(COLD_BUILD_BUDGET_MS)]);
 		}
-		const indexing = !this.built;
+		// `indexing` is reported while ANY build is in flight — the first cold build OR a background warm
+		// revalidation — not just the cold one. A warm revalidation returns the current (possibly
+		// one-cycle-stale) records immediately without blocking, but flagging `indexing` keeps the client's
+		// retry loop polling until `this.building` settles, so a just-written session still surfaces without
+		// the search ever having to wait on the full-corpus re-parse (read-your-writes without blocking).
+		const indexing = !this.built || this.building !== null;
 
-		const limit = input.limit ?? 50;
-		const terms = input.query.toLowerCase().split(/\s+/);
+		const limit = clampLimit(input.limit);
+		// Cap the query length as defense against pathological matching work; truncation can't turn a
+		// non-empty query empty, so the "empty query matches everything" branch is unaffected.
+		const query = input.query.slice(0, MAX_HISTORY_QUERY_LENGTH);
+		const terms = query.toLowerCase().split(/\s+/);
 		const primaryTerm = terms.find((t) => t.length > 0) ?? "";
-		const emptyQuery = input.query.trim().length === 0;
+		const emptyQuery = query.trim().length === 0;
 
 		const promptCandidates: PromptHit[] = [];
 		const messageCandidates: MessageHit[] = [];

--- a/packages/server/src/history/historyIndex.ts
+++ b/packages/server/src/history/historyIndex.ts
@@ -1,0 +1,199 @@
+import { readFileSync, statSync } from "node:fs";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import type { HistorySearchResult, MessageHit, PromptHit } from "@thinkrail/contracts";
+import { extractEntries, type HistoryEntry } from "./extract";
+
+interface SessionRecord {
+	sessionId: string;
+	cwd: string;
+	title?: string;
+	path: string;
+	mtimeMs: number;
+	entries: HistoryEntry[];
+}
+
+const REVALIDATE_MS = 2000;
+const BATCH = 20;
+/** Cold (first-ever) build budget: block `search()` this long, then return whatever's parsed so far
+ * with `indexing: true`. Warm revalidations (only new/mtime-changed files) are always awaited in full —
+ * they're bounded by the mtime diff, so search results are only ever as stale as the last file write. */
+const COLD_BUILD_BUDGET_MS = 150;
+/** Default snippet half-window, in chars, on either side of the matched term. */
+const SNIPPET_RADIUS = 60;
+
+/** `query.toLowerCase().split(/\s+/)` AND-matching: every term must be a case-insensitive substring of
+ * `text`. An empty term (from an empty/whitespace-only query) is vacuously true for any text — this is
+ * what makes "empty query matches everything" fall out of the same code path as a real search. */
+export function matchesTerms(text: string, terms: string[]): boolean {
+	const lower = text.toLowerCase();
+	return terms.every((term) => lower.includes(term.toLowerCase()));
+}
+
+/** A window of `text` around the first case-insensitive occurrence of `term`, ellipsized on whichever
+ * edge got truncated. Falls back to a plain prefix if `term` isn't found (callers only snippet entries
+ * that already passed `matchesTerms`, so this is defensive, not a normal path). Pure. */
+export function makeSnippet(text: string, term: string, radius = SNIPPET_RADIUS): string {
+	const idx = term ? text.toLowerCase().indexOf(term.toLowerCase()) : -1;
+	if (idx === -1) return text.slice(0, radius * 2);
+	const start = Math.max(0, idx - radius);
+	const end = Math.min(text.length, idx + term.length + radius);
+	const prefix = start > 0 ? "…" : "";
+	const suffix = end < text.length ? "…" : "";
+	return `${prefix}${text.slice(start, end)}${suffix}`;
+}
+
+export class HistoryIndex {
+	private records = new Map<string, SessionRecord>(); // keyed by file path
+	private building: Promise<void> | null = null;
+	private built = false;
+	private lastCheck = 0;
+
+	constructor(private sessionDir?: string) {}
+
+	private async listInfos() {
+		return this.sessionDir ? SessionManager.listAll(this.sessionDir) : SessionManager.listAll();
+	}
+
+	private loadRecord(info: { path: string; id: string; cwd: string; name?: string }): void {
+		try {
+			const mtimeMs = statSync(info.path).mtimeMs;
+			const entries = extractEntries(readFileSync(info.path, "utf8"));
+			this.records.set(info.path, {
+				sessionId: info.id,
+				cwd: info.cwd,
+				path: info.path,
+				mtimeMs,
+				entries,
+				...(info.name ? { title: info.name } : {}),
+			});
+		} catch {
+			this.records.delete(info.path); // vanished/unreadable mid-walk — drop it
+		}
+	}
+
+	/** Cold build / revalidation. Batched so it never starves the event loop live sessions share. */
+	private async refresh(): Promise<void> {
+		const infos = await this.listInfos();
+		const seen = new Set<string>();
+		let inBatch = 0;
+		for (const info of infos) {
+			seen.add(info.path);
+			const rec = this.records.get(info.path);
+			let mtimeMs = 0;
+			try {
+				mtimeMs = statSync(info.path).mtimeMs;
+			} catch {
+				continue;
+			}
+			if (rec && rec.mtimeMs === mtimeMs) continue;
+			this.loadRecord(info);
+			if (++inBatch % BATCH === 0) await new Promise((r) => setImmediate(r));
+		}
+		for (const path of this.records.keys()) if (!seen.has(path)) this.records.delete(path);
+		this.built = true;
+	}
+
+	private ensureFresh(): void {
+		const now = Date.now();
+		if (!this.building && (!this.built || now - this.lastCheck > REVALIDATE_MS)) {
+			this.lastCheck = now;
+			this.building = this.refresh().finally(() => {
+				this.building = null;
+			});
+		}
+	}
+
+	/**
+	 * Search the index. Blocks on a cold (first-ever) build up to `COLD_BUILD_BUDGET_MS`, then returns
+	 * partial results with `indexing: true` if the build is still running. A warm revalidation (mtime
+	 * throttled to `REVALIDATE_MS`) is always awaited fully — it only touches new/changed files, so it's
+	 * bounded and search results should never lag behind an on-disk write by more than the throttle.
+	 */
+	async search(input: {
+		query: string;
+		limit?: number;
+		filter: (cwd: string, sessionId: string) => boolean;
+		labels: (cwd: string) => { workspaceId?: string; projectId?: string };
+	}): Promise<HistorySearchResult> {
+		const wasCold = !this.built;
+		this.ensureFresh();
+		if (this.building) {
+			if (wasCold) await Promise.race([this.building, Bun.sleep(COLD_BUILD_BUDGET_MS)]);
+			else await this.building;
+		}
+		const indexing = !this.built;
+
+		const limit = input.limit ?? 50;
+		const terms = input.query.toLowerCase().split(/\s+/);
+		const primaryTerm = terms.find((t) => t.length > 0) ?? "";
+		const emptyQuery = input.query.trim().length === 0;
+
+		const promptCandidates: PromptHit[] = [];
+		const messageCandidates: MessageHit[] = [];
+
+		for (const rec of this.records.values()) {
+			if (!input.filter(rec.cwd, rec.sessionId)) continue;
+			const scope = input.labels(rec.cwd);
+			for (const entry of rec.entries) {
+				if (!matchesTerms(entry.text, terms)) continue;
+				// every prompt hit carries its own jump anchor (the same two fields a MessageHit
+				// always had) — populated from this entry, so dedup (below) naturally keeps the
+				// kept-newest occurrence's anchor along with its text.
+				const hit: PromptHit = {
+					text: entry.text,
+					timestamp: entry.timestamp,
+					sessionId: rec.sessionId,
+					cwd: rec.cwd,
+					messageIndex: entry.messageIndex,
+					anchorText: entry.text.slice(0, 120),
+					...(rec.title ? { sessionTitle: rec.title } : {}),
+					...(scope.workspaceId ? { workspaceId: scope.workspaceId } : {}),
+					...(scope.projectId ? { projectId: scope.projectId } : {}),
+				};
+				if (entry.role === "user") promptCandidates.push(hit);
+				// messages section is assistant-only — a user-role hit is always a textual
+				// duplicate of its own prompt entry above, so it would add no text, only a location;
+				// that location now lives on the prompt hit's messageIndex/anchorText instead.
+				if (!emptyQuery && entry.role === "assistant") {
+					messageCandidates.push({
+						...hit,
+						role: entry.role,
+						snippet: makeSnippet(entry.text, primaryTerm),
+						messageIndex: entry.messageIndex,
+						anchorText: entry.text.slice(0, 120),
+					});
+				}
+			}
+		}
+
+		promptCandidates.sort((a, b) => b.timestamp - a.timestamp);
+		messageCandidates.sort((a, b) => b.timestamp - a.timestamp);
+
+		// Dedup by normalized text, keeping the newest: since candidates are already sorted by
+		// recency desc, keeping the first occurrence of each key keeps the newest one.
+		const seenKeys = new Set<string>();
+		const dedupedPrompts: PromptHit[] = [];
+		for (const p of promptCandidates) {
+			const key = p.text.trim().replace(/\s+/g, " ");
+			if (seenKeys.has(key)) continue;
+			seenKeys.add(key);
+			dedupedPrompts.push(p);
+		}
+
+		return {
+			prompts: dedupedPrompts.slice(0, limit),
+			messages: messageCandidates.slice(0, limit),
+			promptTotal: dedupedPrompts.length,
+			messageTotal: messageCandidates.length,
+			indexing,
+		};
+	}
+}
+
+let instance: HistoryIndex | null = null;
+
+/** Lazy process-wide singleton — one in-memory index shared by every `history.search` call. */
+export function getHistoryIndex(): HistoryIndex {
+	if (!instance) instance = new HistoryIndex();
+	return instance;
+}

--- a/packages/server/src/history/historyIndex.ts
+++ b/packages/server/src/history/historyIndex.ts
@@ -1,8 +1,9 @@
-import { readFileSync, statSync } from "node:fs";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { HistorySearchResult, MessageHit, PromptHit } from "@thinkrail/contracts";
 import { MAX_HISTORY_LIMIT, MAX_HISTORY_QUERY_LENGTH } from "@thinkrail/contracts";
-import { extractEntries, type HistoryEntry } from "./extract";
+import { extractSession, type HistoryEntry } from "./extract";
 
 interface SessionRecord {
 	sessionId: string;
@@ -17,12 +18,13 @@ interface SessionRecord {
 }
 
 const REVALIDATE_MS = 2000;
-const BATCH = 20;
 /** Cold (first-ever) build budget: block `search()` this long, then return whatever's parsed so far
- * with `indexing: true`. A warm revalidation is NOT awaited — `SessionManager.listAll()` re-reads and
- * parses every session file (cost scales with the whole corpus, not the mtime diff), so blocking a search
- * on it would tax every query; instead it runs in the background and results are at most one revalidation
- * cycle stale (the same tolerance the cold path's `indexing` flag already relies on). */
+ * with `indexing: true`. A warm revalidation is NOT awaited — an unchanged corpus revalidates for just a
+ * `readdir` walk + one `stat` per file, but a bulk change (the first refresh after a restart, a git
+ * checkout touching many sessions) still re-parses every changed file, so blocking a search on it would
+ * tax exactly the queries that hit the worst case; instead it runs in the background and results are at
+ * most one revalidation cycle stale (the same tolerance the cold path's `indexing` flag already relies
+ * on). */
 const COLD_BUILD_BUDGET_MS = 150;
 /** Default snippet half-window, in chars, on either side of the matched term. */
 const SNIPPET_RADIUS = 60;
@@ -57,6 +59,16 @@ export function makeSnippet(text: string, term: string, radius = SNIPPET_RADIUS)
 	return `${prefix}${text.slice(start, end)}${suffix}`;
 }
 
+/** The `.jsonl` files directly inside `dir` (non-recursive — pi's own rule for a flat session dir);
+ * a missing/unreadable dir is an empty list, matching pi's tolerance for a vanished dir mid-walk. */
+async function listJsonl(dir: string): Promise<string[]> {
+	try {
+		return (await readdir(dir)).filter((f) => f.endsWith(".jsonl")).map((f) => join(dir, f));
+	} catch {
+		return [];
+	}
+}
+
 export class HistoryIndex {
 	private records = new Map<string, SessionRecord>(); // keyed by file path
 	private building: Promise<void> | null = null;
@@ -65,48 +77,74 @@ export class HistoryIndex {
 
 	constructor(private sessionDir?: string) {}
 
-	private async listInfos() {
-		return this.sessionDir ? SessionManager.listAll(this.sessionDir) : SessionManager.listAll();
+	/**
+	 * Enumerate candidate session files WITHOUT reading their contents — never via
+	 * `SessionManager.listAll()`, which reads and JSON-parses every session in full just to list it (see
+	 * SPEC.md). Mirrors pi's pinned discovery rules: a custom `sessionDir` is a flat, non-recursive dir of
+	 * `.jsonl` files; the default root (`<agentDir>/sessions` — agent dir resolved per call via pi's
+	 * `getAgentDir()`, which reads `PI_CODING_AGENT_DIR` live) holds one level of per-cwd subdirectories.
+	 * A missing dir is an empty corpus, not an error.
+	 */
+	private async listFiles(): Promise<string[]> {
+		if (this.sessionDir) return listJsonl(this.sessionDir);
+		const root = join(getAgentDir(), "sessions");
+		let subdirs: string[] = [];
+		try {
+			subdirs = (await readdir(root, { withFileTypes: true }))
+				.filter((entry) => entry.isDirectory())
+				.map((entry) => join(root, entry.name));
+		} catch {
+			return [];
+		}
+		const files: string[] = [];
+		for (const dir of subdirs) files.push(...(await listJsonl(dir)));
+		return files;
 	}
 
-	private loadRecord(info: { path: string; id: string; cwd: string; name?: string }): void {
+	/** One async read + parse; identity (id/cwd/title) comes from the same parse (`extractSession`).
+	 * `mtimeMs`/`size` are the values statted BEFORE the read — if an append lands between the stat and
+	 * the read, the stored pair is older than the stored content, so the next cycle just re-reads (the
+	 * safe direction; recording a post-read stat could mask an append that slipped in between). */
+	private async loadRecord(path: string, mtimeMs: number, size: number): Promise<void> {
 		try {
-			const { mtimeMs, size } = statSync(info.path);
-			const entries = extractEntries(readFileSync(info.path, "utf8"));
-			this.records.set(info.path, {
-				sessionId: info.id,
-				cwd: info.cwd,
-				path: info.path,
+			const session = extractSession(await readFile(path, "utf8"));
+			if (!session) {
+				this.records.delete(path); // a stray non-session .jsonl — pi would skip it too
+				return;
+			}
+			this.records.set(path, {
+				sessionId: session.id,
+				cwd: session.cwd,
+				path,
 				mtimeMs,
 				size,
-				entries,
-				...(info.name ? { title: info.name } : {}),
+				entries: session.entries,
+				...(session.title ? { title: session.title } : {}),
 			});
 		} catch {
-			this.records.delete(info.path); // vanished/unreadable mid-walk — drop it
+			this.records.delete(path); // vanished/unreadable mid-walk — drop it
 		}
 	}
 
-	/** Cold build / revalidation. Batched so it never starves the event loop live sessions share. */
+	/** Cold build / revalidation. Only new/changed files are read and parsed; every file boundary has an
+	 * `await` (stat/read), so the walk never starves the event loop live sessions share — the longest
+	 * uninterrupted stretch is one file's parse. */
 	private async refresh(): Promise<void> {
-		const infos = await this.listInfos();
-		const seen = new Set<string>();
-		let inBatch = 0;
-		for (const info of infos) {
-			seen.add(info.path);
-			const rec = this.records.get(info.path);
+		const files = await this.listFiles();
+		const seen = new Set<string>(files);
+		for (const path of files) {
 			let mtimeMs = 0;
 			let size = 0;
 			try {
-				({ mtimeMs, size } = statSync(info.path));
+				({ mtimeMs, size } = await stat(path));
 			} catch {
 				continue;
 			}
+			const rec = this.records.get(path);
 			// Skip only when BOTH mtime and size are unchanged — an append can land in the same coarse
 			// mtime tick as the last read, but it always changes the size.
 			if (rec && rec.mtimeMs === mtimeMs && rec.size === size) continue;
-			this.loadRecord(info);
-			if (++inBatch % BATCH === 0) await new Promise((r) => setImmediate(r));
+			await this.loadRecord(path, mtimeMs, size);
 		}
 		for (const path of this.records.keys()) if (!seen.has(path)) this.records.delete(path);
 		this.built = true;
@@ -131,9 +169,9 @@ export class HistoryIndex {
 	/**
 	 * Search the index. Blocks on a cold (first-ever) build up to `COLD_BUILD_BUDGET_MS`, then returns
 	 * partial results with `indexing: true` if the build is still running. A warm revalidation (mtime
-	 * throttled to `REVALIDATE_MS`) runs in the background and is **not** awaited — it re-parses the whole
-	 * corpus via `listAll()`, so blocking on it would tax every search; results are instead at most one
-	 * revalidation cycle stale.
+	 * throttled to `REVALIDATE_MS`) runs in the background and is **not** awaited — its worst case (a bulk
+	 * change re-parsing many files) is exactly when blocking would hurt most; results are instead at most
+	 * one revalidation cycle stale.
 	 */
 	async search(input: {
 		query: string;

--- a/packages/server/src/history/index.ts
+++ b/packages/server/src/history/index.ts
@@ -1,3 +1,11 @@
+// Production public surface of the history module. Test-only session-file builders live in
+// `testFixtures.ts` and are exposed via the server package's `./history-test-fixtures` subpath export
+// (see package.json), NOT here — they write to disk and must never enter the runtime module graph.
 export { extractEntries, type HistoryEntry, MAX_SEARCHABLE } from "./extract";
-export { getHistoryIndex, HistoryIndex, makeSnippet, matchesTerms } from "./historyIndex";
-export { defaultSessionDirFor, writeFixtureSession } from "./testFixtures";
+export {
+	clampLimit,
+	getHistoryIndex,
+	HistoryIndex,
+	makeSnippet,
+	matchesTerms,
+} from "./historyIndex";

--- a/packages/server/src/history/index.ts
+++ b/packages/server/src/history/index.ts
@@ -1,0 +1,3 @@
+export { extractEntries, type HistoryEntry, MAX_SEARCHABLE } from "./extract";
+export { getHistoryIndex, HistoryIndex, makeSnippet, matchesTerms } from "./historyIndex";
+export { defaultSessionDirFor, writeFixtureSession } from "./testFixtures";

--- a/packages/server/src/history/index.ts
+++ b/packages/server/src/history/index.ts
@@ -1,7 +1,7 @@
 // Production public surface of the history module. Test-only session-file builders live in
 // `testFixtures.ts` and are exposed via the server package's `./history-test-fixtures` subpath export
 // (see package.json), NOT here — they write to disk and must never enter the runtime module graph.
-export { extractEntries, type HistoryEntry, MAX_SEARCHABLE } from "./extract";
+export { type ExtractedSession, extractSession, type HistoryEntry } from "./extract";
 export {
 	clampLimit,
 	getHistoryIndex,

--- a/packages/server/src/history/testFixtures.test.ts
+++ b/packages/server/src/history/testFixtures.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { defaultSessionDirFor, writeFixtureSession } from "./testFixtures";
+
+/**
+ * `writeFixtureSession` (and its sibling `defaultSessionDirFor`) exist to fake pi's on-disk session
+ * format well enough to fool pi's *real* `SessionManager` — never a hand-rolled parser. These tests are
+ * the tripwire: if pi's format or discovery layout ever shifts on a version bump, one of these fails
+ * here, loudly, instead of the e2e suite (or `HistoryIndex`) mysteriously finding zero sessions.
+ *
+ * Two discovery layouts exist (see SPEC.md's "pi file format" section):
+ *  - explicit `sessionDir` (`HistoryIndex`'s constructor, and this module's other tests) → flat,
+ *    non-recursive `readdir` of that exact dir.
+ *  - no-arg (`getHistoryIndex()`'s production default, and the e2e host's `PI_CODING_AGENT_DIR`) → walks
+ *    `${agentDir}/sessions/<encoded-cwd>/` one level deep. This is the layout the e2e suite actually
+ *    relies on, so it gets its own pinning case below.
+ */
+describe("writeFixtureSession — pinned against pi's real SessionManager", () => {
+	test("explicit sessionDir layout: SessionManager.list(cwd, dir) round-trips id/cwd/name/messageCount", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "trpi-fixture-explicit-"));
+		try {
+			const cwd = "/tmp/thinkrail-a5-pin-explicit";
+			writeFixtureSession(dir, {
+				id: "pin-explicit-1",
+				cwd,
+				name: "Pin test session",
+				messages: [
+					{ role: "user", text: "hello", timestamp: 1_700_000_000_000 },
+					{ role: "assistant", text: "hi there", timestamp: 1_700_000_001_000 },
+				],
+			});
+
+			const sessions = await SessionManager.list(cwd, dir);
+
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0]).toMatchObject({
+				id: "pin-explicit-1",
+				cwd,
+				name: "Pin test session",
+				messageCount: 2,
+			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("default layout: no-arg discovery finds a fixture written under defaultSessionDirFor's encoded dir", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "trpi-fixture-agentdir-"));
+		const previousEnv = process.env.PI_CODING_AGENT_DIR;
+		try {
+			const cwd = "/tmp/thinkrail-a5-pin-default";
+			const sessionDir = defaultSessionDirFor(agentDir, cwd);
+			const written = writeFixtureSession(sessionDir, {
+				id: "pin-default-1",
+				cwd,
+				name: "Default layout pin",
+				messages: [{ role: "user", text: "seed prompt", timestamp: 1_700_000_000_000 }],
+			}).path;
+
+			// `getAgentDir()` (and therefore the no-arg default sessions root) reads `PI_CODING_AGENT_DIR`
+			// fresh on every call — verified by reading pi's `config.js`, not cached at module load — so
+			// setting it immediately before the call and restoring it in `finally` is sufficient; no
+			// subprocess needed to observe a "live" env read.
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+			const sessions = await SessionManager.list(cwd);
+
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0]?.path).toBe(written);
+			expect(sessions[0]).toMatchObject({
+				id: "pin-default-1",
+				cwd,
+				name: "Default layout pin",
+				messageCount: 1,
+			});
+		} finally {
+			if (previousEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousEnv;
+			rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("default layout: no-arg listAll() also finds it (the exact call HistoryIndex's production default makes)", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "trpi-fixture-listall-"));
+		const previousEnv = process.env.PI_CODING_AGENT_DIR;
+		try {
+			const cwd = "/tmp/thinkrail-a5-pin-listall";
+			const sessionDir = defaultSessionDirFor(agentDir, cwd);
+			writeFixtureSession(sessionDir, {
+				id: "pin-listall-1",
+				cwd,
+				messages: [{ role: "user", text: "seed prompt", timestamp: 1_700_000_000_000 }],
+			});
+
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+			const sessions = await SessionManager.listAll();
+
+			expect(sessions.map((s) => s.id)).toContain("pin-listall-1");
+		} finally {
+			if (previousEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousEnv;
+			rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/server/src/history/testFixtures.test.ts
+++ b/packages/server/src/history/testFixtures.test.ts
@@ -82,7 +82,9 @@ describe("writeFixtureSession — pinned against pi's real SessionManager", () =
 		}
 	});
 
-	test("default layout: no-arg listAll() also finds it (the exact call HistoryIndex's production default makes)", async () => {
+	// `HistoryIndex` no longer calls `listAll()` (it walks the layout itself — see SPEC.md), so this now
+	// pins the *layout facts* both walkers share: what pi's real discovery sees is what ours must see.
+	test("default layout: pi's real no-arg listAll() finds what HistoryIndex's own default walk must also find", async () => {
 		const agentDir = mkdtempSync(join(tmpdir(), "trpi-fixture-listall-"));
 		const previousEnv = process.env.PI_CODING_AGENT_DIR;
 		try {

--- a/packages/server/src/history/testFixtures.ts
+++ b/packages/server/src/history/testFixtures.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/**
+ * Writes a minimal but real pi session JSONL file, parseable by pi's actual
+ * `SessionManager.list`/`listAll` (see SPEC.md's "pi file format" note for the pinned facts this
+ * relies on: header shape, `.jsonl`-suffix discovery, `cwd` recovery from the header).
+ *
+ * Writes **flat**, directly under `dir` — a custom `sessionDir` is read non-recursively by pi, so
+ * multi-session fixtures must NOT nest files in per-cwd subdirectories the way pi's real default
+ * sessions root does; distinct `cwd`s are expressed via each file's own header instead.
+ *
+ * `opts.id` is optional — omit it to get a fresh `sess-<uuid>` every call (the right default for a
+ * fixture that's seeded once and never referenced by id again); pass an explicit `id` when a caller
+ * needs it to be deterministic (idempotent re-seeding across calls, or a test that asserts against the
+ * literal id) — see e.g. `testFixtures.test.ts`'s pinning cases, which always pass one on purpose.
+ *
+ * Exported (not test-only in the barrel sense) so A5's e2e fixture seeder can reuse it against a real
+ * on-disk sessions directory.
+ *
+ * @returns the resolved `id` (generated or the one passed in) and the written file's `path` — callers
+ * can `appendFileSync` more lines onto `path` directly (e.g. to exercise `HistoryIndex`'s mtime
+ * revalidation).
+ */
+export function writeFixtureSession(
+	dir: string,
+	opts: {
+		id?: string;
+		cwd: string;
+		name?: string;
+		messages: Array<{ role: "user" | "assistant"; text: string; timestamp: number }>;
+	},
+): { id: string; path: string } {
+	mkdirSync(dir, { recursive: true });
+
+	const sessionId = opts.id ?? `sess-${randomUUID()}`;
+	const entryId = (suffix: string) => `${sessionId}-${suffix}`;
+	let parentId: string | null = null;
+	const lines: string[] = [
+		JSON.stringify({
+			type: "session",
+			version: 3,
+			id: sessionId,
+			timestamp: new Date(opts.messages[0]?.timestamp ?? Date.now()).toISOString(),
+			cwd: opts.cwd,
+		}),
+	];
+
+	if (opts.name !== undefined) {
+		const id = entryId("info");
+		lines.push(
+			JSON.stringify({
+				type: "session_info",
+				id,
+				parentId,
+				timestamp: new Date().toISOString(),
+				name: opts.name,
+			}),
+		);
+		parentId = id;
+	}
+
+	opts.messages.forEach((m, i) => {
+		const id = entryId(`m${i}`);
+		// `UserMessage.content` is typed as `string | (TextContent | ImageContent)[]` (a bare string is
+		// valid), but `AssistantMessage.content` is array-only — pi never emits a bare string there, since
+		// an assistant turn can interleave text with thinking/tool-call blocks. Web-client code (e.g.
+		// `chat/rows.ts`'s `deriveRows`, `chat/ChatView.tsx`'s jump-anchor matching) relies on that
+		// distinction, so a fixture with a bare-string assistant `content` silently renders as an empty
+		// turn instead of tripping a loud parse error — match each role's real shape.
+		const content = m.role === "assistant" ? [{ type: "text", text: m.text }] : m.text;
+		lines.push(
+			JSON.stringify({
+				type: "message",
+				id,
+				parentId,
+				timestamp: new Date(m.timestamp).toISOString(),
+				message: { role: m.role, content, timestamp: m.timestamp },
+			}),
+		);
+		parentId = id;
+	});
+
+	const path = join(dir, `${opts.messages[0]?.timestamp ?? Date.now()}_${sessionId}.jsonl`);
+	writeFileSync(path, `${lines.join("\n")}\n`);
+	return { id: sessionId, path };
+}
+
+/**
+ * Replica of pi's `getDefaultSessionDirPath` (`core/session-manager.js`) — the encoding
+ * `SessionManager.list(cwd)` / no-arg `listAll()` use to compute where a cwd's sessions live when no
+ * explicit `sessionDir` is passed: `${agentDir}/sessions/--<cwd, / and \ and : → '-'>--`. Not importable:
+ * that helper isn't exported from `session-manager.js`, and even the mkdir-ing wrapper that IS exported
+ * from it (`getDefaultSessionDir`) isn't re-exported from the package root `@earendil-works/pi-coding-agent`
+ * index (checked `dist/index.js`) — so this is a from-scratch replica, not a thin wrapper.
+ *
+ * Pinned by testFixtures.test.ts's "default layout" case against a real `SessionManager.list(cwd)` call;
+ * re-verify against `dist/core/session-manager.js` on a pi version bump.
+ *
+ * Exported (not test-only in the barrel sense) so A5's e2e fixture seeder can compute the same directory
+ * for an arbitrary cwd (`seedWorkspaceSession`) without duplicating the regex.
+ */
+export function defaultSessionDirFor(agentDir: string, cwd: string): string {
+	const resolvedCwd = resolve(cwd);
+	const resolvedAgentDir = resolve(agentDir);
+	const safePath = `--${resolvedCwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+	return join(resolvedAgentDir, "sessions", safePath);
+}

--- a/packages/server/src/history/testFixtures.ts
+++ b/packages/server/src/history/testFixtures.ts
@@ -16,8 +16,9 @@ import { join, resolve } from "node:path";
  * needs it to be deterministic (idempotent re-seeding across calls, or a test that asserts against the
  * literal id) — see e.g. `testFixtures.test.ts`'s pinning cases, which always pass one on purpose.
  *
- * Exported (not test-only in the barrel sense) so A5's e2e fixture seeder can reuse it against a real
- * on-disk sessions directory.
+ * Test-only. Not on the production `history` barrel (it writes to disk); the e2e fixture seeder reaches
+ * it through the server package's `@thinkrail/server/history-test-fixtures` subpath export, in-package
+ * tests import this module relatively.
  *
  * @returns the resolved `id` (generated or the one passed in) and the written file's `path` — callers
  * can `appendFileSync` more lines onto `path` directly (e.g. to exercise `HistoryIndex`'s mtime
@@ -98,8 +99,9 @@ export function writeFixtureSession(
  * Pinned by testFixtures.test.ts's "default layout" case against a real `SessionManager.list(cwd)` call;
  * re-verify against `dist/core/session-manager.js` on a pi version bump.
  *
- * Exported (not test-only in the barrel sense) so A5's e2e fixture seeder can compute the same directory
- * for an arbitrary cwd (`seedWorkspaceSession`) without duplicating the regex.
+ * Test-only, reached via the `@thinkrail/server/history-test-fixtures` subpath (see `writeFixtureSession`
+ * above) so A5's e2e fixture seeder can compute the same directory for an arbitrary cwd
+ * (`seedWorkspaceSession`) without duplicating the regex.
  */
 export function defaultSessionDirFor(agentDir: string, cwd: string): string {
 	const resolvedCwd = resolve(cwd);

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -2,6 +2,7 @@ import type {
 	AppConfig,
 	AskUserQuestionResult,
 	ExtUiResponse,
+	HistoryScope,
 	ImageContent,
 	LoginReply,
 	ThinkingLevel,
@@ -48,6 +49,7 @@ import { selectDirectory } from "../dialog";
 import { readDir, readFile } from "../fs";
 import { gitDiffFile, gitStatus, listBranches, prefetchBranch } from "../git";
 import { githubAuthStatus, githubRefresh } from "../github";
+import { getHistoryIndex } from "../history";
 import {
 	acknowledgeProjectSkills,
 	closeProject,
@@ -74,12 +76,14 @@ import {
 	createWorkspace,
 	forgetWorkspace,
 	getWorkspace,
+	listWorkspaceRecords,
 	listWorkspaces,
 	reclaimWorktree,
 	setWorkspaceSkillOverride,
 	workspaceDiffStats,
 } from "../workspaces";
 import { ackSend } from "./ackSend";
+import { buildHistoryScope } from "./historyScope";
 
 type Handler = (params: unknown) => unknown | Promise<unknown>;
 
@@ -397,6 +401,21 @@ const handlers: Record<string, Handler> = {
 	// Merge + persist a partial into the server-synced app config (theme, …); the broadcast is fired by
 	// `updateConfig`'s injected publisher (wired in `createServer`), so every client converges.
 	"settings.update": (params) => updateConfig((params as { config: Partial<AppConfig> }).config),
+	// Prompt recall + conversation search over pi's session files. Scope mapping is resolved here (host
+	// owns the registries); the index itself stays registry-free (see history/SPEC.md).
+	// Uses listWorkspaceRecords (diffStats-free registry read) to avoid blocking on git per keystroke.
+	"history.search": (params) => {
+		const p = params as { query: string; scope: HistoryScope; limit?: number };
+		const { filter, labels } = buildHistoryScope(p.scope, listProjects(), (projectId) =>
+			listWorkspaceRecords(projectId),
+		);
+		return getHistoryIndex().search({
+			query: p.query,
+			filter,
+			labels,
+			...(p.limit ? { limit: p.limit } : {}),
+		});
+	},
 };
 
 /** Route a WS request to its handler. Throws on unknown method (→ a `{ ok:false }` WS response). */

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -49,7 +49,7 @@ import { selectDirectory } from "../dialog";
 import { readDir, readFile } from "../fs";
 import { gitDiffFile, gitStatus, listBranches, prefetchBranch } from "../git";
 import { githubAuthStatus, githubRefresh } from "../github";
-import { getHistoryIndex } from "../history";
+import { clampLimit, getHistoryIndex } from "../history";
 import {
 	acknowledgeProjectSkills,
 	closeProject,
@@ -409,11 +409,12 @@ const handlers: Record<string, Handler> = {
 		const { filter, labels } = buildHistoryScope(p.scope, listProjects(), (projectId) =>
 			listWorkspaceRecords(projectId),
 		);
+		// Clamp the client-controlled limit at the boundary (defense in depth; `search()` clamps too).
 		return getHistoryIndex().search({
 			query: p.query,
 			filter,
 			labels,
-			...(p.limit ? { limit: p.limit } : {}),
+			limit: clampLimit(p.limit),
 		});
 	},
 };

--- a/packages/server/src/host/historyScope.test.ts
+++ b/packages/server/src/host/historyScope.test.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "bun:test";
+import type { Project, Workspace } from "@thinkrail/contracts";
+import { buildHistoryScope } from "./historyScope";
+
+test("all scope: filter matches any cwd + sessionId", () => {
+	const { filter } = buildHistoryScope({ kind: "all" }, [], () => []);
+
+	expect(filter("/some/cwd", "session1")).toBe(true);
+	expect(filter("/another/cwd", "session2")).toBe(true);
+	expect(filter("", "")).toBe(true);
+});
+
+test("chat scope: filter matches only the exact sessionId", () => {
+	const { filter } = buildHistoryScope({ kind: "chat", sessionId: "target-session" }, [], () => []);
+
+	expect(filter("/some/cwd", "target-session")).toBe(true);
+	expect(filter("/some/cwd", "other-session")).toBe(false);
+	expect(filter("/another/cwd", "target-session")).toBe(true);
+});
+
+test("workspace scope: filter matches the worktreePath of a known workspace", () => {
+	const p1: Project = {
+		id: "p1",
+		name: "project",
+		path: "/proj",
+		slug: "project",
+		lastOpened: 0,
+	};
+	const ws1: Workspace = {
+		id: "ws1",
+		projectId: "p1",
+		name: "ws1",
+		branch: "ws1",
+		worktreePath: "/proj/worktrees/ws1",
+		baseBranch: "main",
+	};
+	const ws2: Workspace = {
+		id: "ws2",
+		projectId: "p1",
+		name: "ws2",
+		branch: "ws2",
+		worktreePath: "/proj/worktrees/ws2",
+		baseBranch: "main",
+	};
+
+	const { filter } = buildHistoryScope(
+		{ kind: "workspace", workspaceId: "ws1" },
+		[p1],
+		(projectId) => (projectId === "p1" ? [ws1, ws2] : []),
+	);
+
+	expect(filter("/proj/worktrees/ws1", "any-session")).toBe(true);
+	expect(filter("/proj/worktrees/ws2", "any-session")).toBe(false);
+	expect(filter("/other/path", "any-session")).toBe(false);
+});
+
+test("workspace scope with unknown workspaceId: filter always returns false, even with other workspaces in registry", () => {
+	const p1: Project = {
+		id: "p1",
+		name: "project",
+		path: "/proj",
+		slug: "project",
+		lastOpened: 0,
+	};
+	const ws1: Workspace = {
+		id: "ws1",
+		projectId: "p1",
+		name: "ws1",
+		branch: "ws1",
+		worktreePath: "/proj/worktrees/ws1",
+		baseBranch: "main",
+	};
+	const ws2: Workspace = {
+		id: "ws2",
+		projectId: "p1",
+		name: "ws2",
+		branch: "ws2",
+		worktreePath: "/proj/worktrees/ws2",
+		baseBranch: "main",
+	};
+
+	const { filter } = buildHistoryScope(
+		{ kind: "workspace", workspaceId: "unknown-ws" },
+		[p1],
+		(projectId) => (projectId === "p1" ? [ws1, ws2] : []),
+	);
+
+	// Unknown workspace filters everything out, even though other workspaces exist
+	expect(filter("/proj/worktrees/ws1", "any-session")).toBe(false);
+	expect(filter("/proj/worktrees/ws2", "any-session")).toBe(false);
+	expect(filter("/", "session1")).toBe(false);
+	expect(filter("", "")).toBe(false);
+});
+
+test("project scope: filter matches cwds of any workspace in the project", () => {
+	const ws1: Workspace = {
+		id: "ws1",
+		projectId: "p1",
+		name: "ws1",
+		branch: "ws1",
+		worktreePath: "/proj/worktrees/ws1",
+		baseBranch: "main",
+	};
+	const ws2: Workspace = {
+		id: "ws2",
+		projectId: "p1",
+		name: "ws2",
+		branch: "ws2",
+		worktreePath: "/proj/worktrees/ws2",
+		baseBranch: "main",
+	};
+
+	const { filter } = buildHistoryScope(
+		{ kind: "project", projectId: "p1" },
+		[{ id: "p1", name: "project", path: "/proj", slug: "project", lastOpened: 0 }],
+		(projectId) => (projectId === "p1" ? [ws1, ws2] : []),
+	);
+
+	expect(filter("/proj/worktrees/ws1", "any-session")).toBe(true);
+	expect(filter("/proj/worktrees/ws2", "any-session")).toBe(true);
+	expect(filter("/other/project/worktrees/ws1", "any-session")).toBe(false);
+});
+
+test("labels: build a worktreePath → {workspaceId, projectId} map from all projects' workspaces", () => {
+	const p1: Project = {
+		id: "p1",
+		name: "project-1",
+		path: "/proj1",
+		slug: "project-1",
+		lastOpened: 0,
+	};
+	const p2: Project = {
+		id: "p2",
+		name: "project-2",
+		path: "/proj2",
+		slug: "project-2",
+		lastOpened: 0,
+	};
+
+	const p1ws1: Workspace = {
+		id: "p1ws1",
+		projectId: "p1",
+		name: "ws1",
+		branch: "ws1",
+		worktreePath: "/proj1/worktrees/ws1",
+		baseBranch: "main",
+	};
+	const p1ws2: Workspace = {
+		id: "p1ws2",
+		projectId: "p1",
+		name: "ws2",
+		branch: "ws2",
+		worktreePath: "/proj1/worktrees/ws2",
+		baseBranch: "main",
+	};
+	const p2ws1: Workspace = {
+		id: "p2ws1",
+		projectId: "p2",
+		name: "ws1",
+		branch: "ws1",
+		worktreePath: "/proj2/worktrees/ws1",
+		baseBranch: "main",
+	};
+
+	const { labels } = buildHistoryScope({ kind: "all" }, [p1, p2], (projectId) => {
+		if (projectId === "p1") return [p1ws1, p1ws2];
+		if (projectId === "p2") return [p2ws1];
+		return [];
+	});
+
+	expect(labels("/proj1/worktrees/ws1")).toEqual({
+		workspaceId: "p1ws1",
+		projectId: "p1",
+	});
+	expect(labels("/proj1/worktrees/ws2")).toEqual({
+		workspaceId: "p1ws2",
+		projectId: "p1",
+	});
+	expect(labels("/proj2/worktrees/ws1")).toEqual({
+		workspaceId: "p2ws1",
+		projectId: "p2",
+	});
+	expect(labels("/unknown/path")).toEqual({});
+});
+
+test("unknown scope kind: filter always returns false, never throws", () => {
+	// Simulate a malformed scope from a version-skewed client by casting
+	const { filter } = buildHistoryScope({ kind: "bogus" } as never, [], () => []);
+
+	// Unknown kind filters to false, never throws
+	expect(filter("/some/cwd", "session1")).toBe(false);
+	expect(filter("/another/cwd", "session2")).toBe(false);
+});

--- a/packages/server/src/host/historyScope.ts
+++ b/packages/server/src/host/historyScope.ts
@@ -1,0 +1,75 @@
+import type { HistoryScope, Project, Workspace } from "@thinkrail/contracts";
+
+/**
+ * Build the cwd/session filter + cwd→ids labeler for a scope, from registry snapshots. Pure.
+ * Single-pass registry traversal (workspacesByProject called once per project).
+ * Only uses id/projectId/worktreePath from workspaces — allows both diffStats-free and full records.
+ * For scope.kind === "workspace" with an unknown workspaceId, returns a filter that always
+ * returns false (never throws). Unknown scope kinds also filter to false at runtime.
+ */
+export function buildHistoryScope(
+	scope: HistoryScope,
+	projects: Project[],
+	workspacesByProject: (
+		projectId: string,
+	) => Array<Pick<Workspace, "id" | "projectId" | "worktreePath">>,
+): {
+	filter: (cwd: string, sessionId: string) => boolean;
+	labels: (cwd: string) => { workspaceId?: string; projectId?: string };
+} {
+	// Single pass: build all lookup tables from registry (workspacesByProject called once per project)
+	const pathMap = new Map<string, { workspaceId: string; projectId: string }>();
+	const workspaceIdMap = new Map<string, string>(); // workspaceId → worktreePath
+	const projectIdMap = new Map<string, Set<string>>(); // projectId → Set<worktreePath>
+
+	for (const project of projects) {
+		const workspaces = workspacesByProject(project.id);
+		const pathSet = new Set<string>();
+		for (const ws of workspaces) {
+			pathMap.set(ws.worktreePath, {
+				workspaceId: ws.id,
+				projectId: ws.projectId,
+			});
+			workspaceIdMap.set(ws.id, ws.worktreePath);
+			pathSet.add(ws.worktreePath);
+		}
+		projectIdMap.set(project.id, pathSet);
+	}
+
+	// Build the filter function based on scope kind
+	let filter: (cwd: string, sessionId: string) => boolean;
+
+	if (scope.kind === "all") {
+		filter = () => true;
+	} else if (scope.kind === "chat") {
+		filter = (_cwd: string, sessionId: string) => sessionId === scope.sessionId;
+	} else if (scope.kind === "workspace") {
+		const targetPath = workspaceIdMap.get(scope.workspaceId);
+		// If workspace not found, return a filter that always returns false
+		if (targetPath === undefined) {
+			filter = () => false;
+		} else {
+			filter = (cwd: string) => cwd === targetPath;
+		}
+	} else if (scope.kind === "project") {
+		const pathSet = projectIdMap.get(scope.projectId);
+		if (pathSet === undefined) {
+			// Unknown project: no workspaces to match
+			filter = () => false;
+		} else {
+			filter = (cwd: string) => pathSet.has(cwd);
+		}
+	} else {
+		// Runtime safety: unknown scope kinds filter to false, never throw
+		const _exhaustive: never = scope;
+		filter = () => false;
+	}
+
+	// Labels function: map cwd to {workspaceId, projectId}
+	const labels = (cwd: string) => {
+		const entry = pathMap.get(cwd);
+		return entry ? { workspaceId: entry.workspaceId, projectId: entry.projectId } : {};
+	};
+
+	return { filter, labels };
+}

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -47,8 +47,10 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   marking the name deliberate so the auto-namer never touches it again — what a user rename and the
   agentic auto-rename want; the host's **provisional naive rename** passes `lock: false` to rename name +
   branch while leaving `renamed` unset, so the settled-turn agentic pass still refines it),
-  `listWorkspaces` (with diff stats), `workspaceDiffStats`, `getWorkspace` (by-id lookup, throws on
-  unknown — anchors a chat session's cwd), and the **archive** primitives, split so the fast record-drop
+  `listWorkspaces` (with diff stats), `listWorkspaceRecords` (registry records without per-workspace git
+  diffStats — for read-only paths like history scope mapping that must not block on git spawns),
+  `workspaceDiffStats`, `getWorkspace` (by-id lookup, throws on unknown — anchors a chat session's cwd),
+  and the **archive** primitives, split so the fast record-drop
   and the slow git reclaim are separable (the host archives off the request's critical path):
   `forgetWorkspace(id)` (drop the persistence record, return the removed record or `null` — gone from
   `listWorkspaces` immediately), `reclaimWorktree(ws)` (the slow half — `git worktree remove --force`,
@@ -62,9 +64,9 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   `removed` carries `{ projectId, id }`) and the host maps `kind` → `workspace.*` channel. This makes the
   module the **single source of workspace lifecycle pushes** (the auto-rename tee no longer pushes — rename
   self-publishes), so registry membership stays shared domain state across every client (architecture #9).
-- **Public surface (barrel):** `createWorkspace`, `listWorkspaces`, `forgetWorkspace`, `reclaimWorktree`,
-  `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`, `setWorkspacePublisher`,
-  `WorkspaceLifecycleEvent`.
+- **Public surface (barrel):** `createWorkspace`, `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`,
+  `reclaimWorktree`, `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`,
+  `setWorkspacePublisher`, `WorkspaceLifecycleEvent`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -252,6 +252,14 @@ export function listWorkspaces(projectId: string): Workspace[] {
 }
 
 /**
+ * Registry records without per-workspace git diffStats — for read paths (like history scope mapping)
+ * that only need ids/paths and must not block the event loop on git spawns. Pure registry load.
+ */
+export function listWorkspaceRecords(projectId: string): Workspace[] {
+	return loadWorkspaces().filter((w) => w.projectId === projectId);
+}
+
+/**
  * Drop a workspace's persistence record (fast) and return the removed record (or `null` if unknown). The
  * worktree/branch are reclaimed separately via `reclaimWorktree` — splitting the record-drop from the slow
  * git subprocess lets the host archive a workspace off the request's critical path (drop the record now so


### PR DESCRIPTION
Ctrl+R prompt-history search + recall over pi's session files (like Claude Code's Ctrl+R).

- Lazy in-memory index → `history.search` (protocol **v9**), scoped chat → workspace → project → everywhere; prompt recall + full-text conversation matches, recency-ordered.
- Overlay (Ctrl+R, or the composer's history button): zoomed two-pane preview, scope picker, assistant-only message hits, jumpable prompt rows (⇧⏎ → scroll + flash the anchored turn, cross-workspace).
- Plain ↑/↓ recalls this chat's own prompts.

First of two stacked PRs (splitting the old #103 into search + templates). Rebased on main (pi 0.81). e2e: 63 no-agent specs green.