### PR TITLE
feat(chat): prompt templates

### DIFF
--- a/.pi/prompts/commit.md
+++ b/.pi/prompts/commit.md
@@ -1,0 +1,8 @@
+---
+description: "Write a Conventional Commit message from the staged diff"
+argument-hint: "[scope]"
+---
+Read the staged changes (`git diff --cached`) and write a Conventional Commits message.
+Use the type that fits (feat/fix/refactor/docs/test/chore) with scope `${1:-infer it from the files}`,
+an imperative subject under 72 chars, and a short body explaining the why when it isn't obvious.
+Reply with only the commit message.

--- a/.pi/prompts/explain.md
+++ b/.pi/prompts/explain.md
@@ -1,0 +1,6 @@
+---
+description: "Explain how something works in this codebase"
+argument-hint: "[path-or-topic]"
+---
+Explain how $1 works in this codebase: its purpose, the key control and data flow, and what depends on it.
+Keep it concise and point to the load-bearing files and `file:line` locations.

--- a/.pi/prompts/rename.md
+++ b/.pi/prompts/rename.md
@@ -1,0 +1,6 @@
+---
+description: "Rename a symbol everywhere (demoes repeated-slot mirroring)"
+argument-hint: "[old] [new]"
+---
+Rename `$1` to `$2` across the codebase: update every definition, reference, and import of `$1`,
+plus any docs or comments that mention `$1`. Keep `$2` consistent everywhere and run the type-checker after.

--- a/.pi/prompts/review.md
+++ b/.pi/prompts/review.md
@@ -1,0 +1,6 @@
+---
+description: "Code review of a file or directory"
+argument-hint: "[path] [focus]"
+---
+Review $1 for correctness, clarity, and maintainability, focusing on ${2:-the riskiest parts}.
+List concrete findings with `file:line` references, ordered by severity, and propose a fix for each.

--- a/.pi/prompts/tests.md
+++ b/.pi/prompts/tests.md
@@ -1,0 +1,6 @@
+---
+description: "Write tests for a target"
+argument-hint: "[path]"
+---
+Write tests for $1. Cover the main behavior, the important edge cases, and one failure path.
+Match the project's existing test conventions and runner, then run them and report the result.

--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -51,9 +51,9 @@ screen, not a blank root).
 ### Dependency graph
 
 - `shell` → `panels`, `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`, `themes` (the single owner of the atomic `applyTheme` DOM effect, driven by `store.theme`)
-- `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` — `CenterTabs`'s per-tab boundary), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector` — these are shiki-free, so the eager import stays split-safe), `auth` (`ProvidersSettings` mounts `auth/LoginDialog`), `themes` (`AppearanceSettings` consumes the live catalog; code surfaces consume generic theme variables/syntax mapping)
+- `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` — `CenterTabs`'s per-tab boundary), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector` — these are shiki-free, so the eager import stays split-safe; `TemplatesSettings` reuses `chat/TemplateEditorDialog` for its New/Edit flows — see `panels/SPEC.md`'s `TemplatesSettings` paragraph), `auth` (`ProvidersSettings` mounts `auth/LoginDialog`), `themes` (`AppearanceSettings` consumes the live catalog; code surfaces consume generic theme variables/syntax mapping)
 - `chat` → `contracts` (pi message types, **type-only**), `components/ui`, `lib`; `store` + `transport`
-  (**`ChatView` + `useHistorySearch.ts` only** — the renderers stay store-free)
+  (**`ChatView` + `useHistorySearch.ts` + `TemplateEditorDialog.tsx` only** — the renderers stay store-free)
 - `auth` → `components/ui` (the dialog is store/transport-free — the panel integrates it; the state types need no imports)
 - `store` → `transport` (**type-only** — `ConnectionStatus`), `chat` (**type-only** — `ChatTurn`/`ToolResultState`), `auth` (**type-only** — `LoginState`; the `foldLoginFrame` reducer lives in `store`, like `reduceExtUi`), `contracts`
 - `transport` → `contracts`, `store` (welcome routing; the `store → transport` back-edge is type-only, so

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -30,6 +30,7 @@ import { SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
 import { parseTemplateSlots } from "./slotSession";
 import { TemplateEditorDialog } from "./TemplateEditorDialog";
+import { shouldApplyTemplatePick } from "./templatePick";
 import { stripFrontmatter } from "./templateText";
 import "./tools/register"; // side-effect: register the built-in pi tool renderers (bash/read/edit/write)
 import { ChatTurnView } from "./turns";
@@ -129,7 +130,6 @@ export default function ChatView({
 	// reload. Store-derived per session, so the badge survives tab-switch remounts (a fresh ChatView reads
 	// the same store state) and a reload clears only this chat (see selectSkillsStale / markSkillsSynced).
 	const skillsStale = useAppStore((s) => selectSkillsStale(s, workspaceId, sessionId));
-	const templatesVersion = useAppStore((s) => s.templatesVersion);
 	const workspaceRoot = useAppStore((s) => {
 		for (const workspaces of Object.values(s.workspaces)) {
 			const workspace = workspaces.find((w) => w.id === workspaceId);
@@ -249,32 +249,30 @@ export default function ChatView({
 			.catch(() => {});
 	}, [sessionId]);
 
-	// Fresh prompt templates for the `/` menu merge (`mergedCommands` below) — fetched when the slash menu
-	// opens (`slashActive`, via `onSlashActive`), cached per `(workspaceId, templatesVersion)` pair so
-	// reopening the menu doesn't re-fetch until a `template.save`/`delete` bumps the store's
-	// `templatesVersion` counter (Task B6's Templates settings panel). This is what keeps this path fresh
-	// where the typed-through `/name args` expansion (pi's own session-create-time `commands` snapshot)
-	// is deliberately stale — see `chat/SPEC.md`'s Template slots section.
-	const templatesCacheKey = useRef<string | null>(null);
+	// Fresh prompt templates for the `/` menu merge (`mergedCommands` below) — fetched on EVERY menu-open
+	// transition (`slashActive` flipping true via `onSlashActive`; it stays true while the user keeps
+	// typing the query, so this never refires per keystroke). Deliberately uncached: prompt files change
+	// outside the app too (pi CLI, an editor, a git pull), which no in-app invalidation signal can see —
+	// an earlier `(workspaceId, templatesVersion)` cache here served those externally-changed files stale
+	// for the rest of the chat. The server intentionally re-reads its dirs per call for exactly this
+	// freshness (its SPEC calls the readdirs cheap), so the client simply asks each time the menu opens.
+	// This is what keeps this path fresh where the typed-through `/name args` expansion (pi's own
+	// session-create-time `commands` snapshot) is deliberately stale — see `chat/SPEC.md`'s Template
+	// slots section. The previous (possibly stale) list stays rendered until the fresh one lands — a
+	// same-open-transition flicker would be worse than a few-ms-stale row.
 	useEffect(() => {
 		if (!slashActive) return;
-		const key = `${workspaceId}:${templatesVersion}`;
-		if (templatesCacheKey.current === key) return;
 		let cancelled = false;
 		getTransport()
 			.request("template.list", { workspaceId })
 			.then((res) => {
-				if (cancelled) return;
-				// Only latch the cache key on SUCCESS — a failed/racing fetch must never latch an empty
-				// cache until the next `templatesVersion` bump. Reopening the menu after a failure retries.
-				templatesCacheKey.current = key;
-				setTemplates(res.templates);
+				if (!cancelled) setTemplates(res.templates);
 			})
 			.catch(() => {});
 		return () => {
 			cancelled = true;
 		};
-	}, [slashActive, workspaceId, templatesVersion]);
+	}, [slashActive, workspaceId]);
 
 	// The composer's `/` menu merge: pi's `commands` snapshot minus its now-stale `source === "prompt"`
 	// entries, plus the fresh template list mapped to the same `SlashCommandInfo` shape — one list,
@@ -393,18 +391,32 @@ export default function ChatView({
 	// the frontmatter (`templateText.ts`'s shared `stripFrontmatter` — pi's own parser is server-only, but
 	// the boundary rule is pinned to match it exactly), parse the body into slots, and hand the result to
 	// `Composer`'s `insertTemplate` — which starts (or skips, if there are no slots) a slot session,
-	// replacing the whole draft the way `pickSlash` does.
+	// replacing the whole draft the way a plain slash pick does. Applied only while the pick is still
+	// CURRENT: the fetch is async, so a slow response must never clobber what the user did in the
+	// meantime — typed a fresh draft, or picked another template whose response already landed. The
+	// staleness rules (newest pick wins + the draft is untouched since pick time) live in
+	// `templatePick.ts`'s `shouldApplyTemplatePick`, pure and unit-tested.
+	const pickGeneration = useRef(0);
 	const onPickTemplate = useCallback(
 		(name: string) => {
+			const generation = ++pickGeneration.current;
+			const draftAtPick = useAppStore.getState().sessions[sessionId]?.draft ?? "";
 			getTransport()
 				.request("template.get", { workspaceId, name })
 				.then((t) => {
+					const apply = shouldApplyTemplatePick({
+						generation,
+						latestGeneration: pickGeneration.current,
+						draftAtPick,
+						currentDraft: useAppStore.getState().sessions[sessionId]?.draft ?? "",
+					});
+					if (!apply) return;
 					const parsed = parseTemplateSlots(stripFrontmatter(t.content), t.argumentHint);
 					composerRef.current?.insertTemplate(parsed);
 				})
 				.catch(() => {});
 		},
-		[workspaceId],
+		[workspaceId, sessionId],
 	);
 
 	// Consume a `chatLocationRequest` targeting this session: resolve its `messageIndex` to a turn (via

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -2,6 +2,8 @@ import type {
 	AskUserQuestionResult,
 	ImageContent,
 	PromptHit,
+	SlashCommandInfo,
+	TemplateInfo,
 	ThinkingLevel,
 	WireModel,
 } from "@thinkrail/contracts";
@@ -26,6 +28,9 @@ import { HistoryOverlay } from "./HistoryOverlay";
 import { type ChatRow, deriveRows, rowIndexForTurn } from "./rows";
 import { SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
+import { parseTemplateSlots } from "./slotSession";
+import { TemplateEditorDialog } from "./TemplateEditorDialog";
+import { stripFrontmatter } from "./templateText";
 import "./tools/register"; // side-effect: register the built-in pi tool renderers (bash/read/edit/write)
 import { ChatTurnView } from "./turns";
 import type { ChatTurn } from "./types";
@@ -57,6 +62,25 @@ function turnAnchorText(turn: ChatTurn): string {
 			.join("\n");
 	}
 	return "";
+}
+
+/** A fresh `template.list` row, mapped to the shape the composer's `/` menu already renders
+ * (`Composer.tsx:246-261`, unchanged) — `sourceInfo` synthesized to match pi's own prompt-template
+ * convention exactly (`createSyntheticSourceInfo` in `@earendil-works/pi-coding-agent`'s
+ * `core/source-info.js`): `source: "local"`, `origin: "top-level"`, `scope` mapped from our
+ * "global"/"project" to pi's "user"/"project". */
+function templateToCommand(t: TemplateInfo): SlashCommandInfo {
+	return {
+		name: t.name,
+		...(t.description ? { description: t.description } : {}),
+		source: "prompt",
+		sourceInfo: {
+			path: t.filePath,
+			source: "local",
+			scope: t.scope === "global" ? "user" : "project",
+			origin: "top-level",
+		},
+	};
 }
 
 /** Context threaded to the Virtuoso footer so the streaming loader lives at the end of the conversation. */
@@ -105,6 +129,7 @@ export default function ChatView({
 	// reload. Store-derived per session, so the badge survives tab-switch remounts (a fresh ChatView reads
 	// the same store state) and a reload clears only this chat (see selectSkillsStale / markSkillsSynced).
 	const skillsStale = useAppStore((s) => selectSkillsStale(s, workspaceId, sessionId));
+	const templatesVersion = useAppStore((s) => s.templatesVersion);
 	const workspaceRoot = useAppStore((s) => {
 		for (const workspaces of Object.values(s.workspaces)) {
 			const workspace = workspaces.find((w) => w.id === workspaceId);
@@ -174,6 +199,12 @@ export default function ChatView({
 	// The chat's TODO plan, surfaced inline via a header strip that opens a popup over the chat (SPEC §Chat TODO plan).
 	const plan = useChatTodos(workspaceId, sessionId);
 	const [planOpen, setPlanOpen] = useState(false);
+	const [slashActive, setSlashActive] = useState(false);
+	const [templates, setTemplates] = useState<TemplateInfo[]>([]);
+	// The history overlay's save-as-template dialog: non-null while open, carrying the prompt hit its body
+	// is prefilled from — `TemplateEditorDialog` itself is always mounted (controlled by `open` below), the
+	// same idiom `panels/TemplatesSettings.tsx` uses for its own New/Edit instance.
+	const [saveAsTemplateHit, setSaveAsTemplateHit] = useState<PromptHit | null>(null);
 
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
 	const { followOutput, handleAtBottom, showScrollButton, scrollToBottom, containerProps } =
@@ -217,6 +248,41 @@ export default function ChatView({
 			.then((c) => useAppStore.getState().setCommands(sessionId, c))
 			.catch(() => {});
 	}, [sessionId]);
+
+	// Fresh prompt templates for the `/` menu merge (`mergedCommands` below) — fetched when the slash menu
+	// opens (`slashActive`, via `onSlashActive`), cached per `(workspaceId, templatesVersion)` pair so
+	// reopening the menu doesn't re-fetch until a `template.save`/`delete` bumps the store's
+	// `templatesVersion` counter (Task B6's Templates settings panel). This is what keeps this path fresh
+	// where the typed-through `/name args` expansion (pi's own session-create-time `commands` snapshot)
+	// is deliberately stale — see `chat/SPEC.md`'s Template slots section.
+	const templatesCacheKey = useRef<string | null>(null);
+	useEffect(() => {
+		if (!slashActive) return;
+		const key = `${workspaceId}:${templatesVersion}`;
+		if (templatesCacheKey.current === key) return;
+		let cancelled = false;
+		getTransport()
+			.request("template.list", { workspaceId })
+			.then((res) => {
+				if (cancelled) return;
+				// Only latch the cache key on SUCCESS — a failed/racing fetch must never latch an empty
+				// cache until the next `templatesVersion` bump. Reopening the menu after a failure retries.
+				templatesCacheKey.current = key;
+				setTemplates(res.templates);
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, [slashActive, workspaceId, templatesVersion]);
+
+	// The composer's `/` menu merge: pi's `commands` snapshot minus its now-stale `source === "prompt"`
+	// entries, plus the fresh template list mapped to the same `SlashCommandInfo` shape — one list,
+	// `Composer`'s rendering is unchanged (`Composer.tsx:246-261`).
+	const mergedCommands = useMemo(
+		() => [...commands.filter((c) => c.source !== "prompt"), ...templates.map(templateToCommand)],
+		[commands, templates],
+	);
 
 	// Refresh token/cost stats when a turn starts and ends (display only — `pi` owns the numbers).
 	// biome-ignore lint/correctness/useExhaustiveDependencies: `isStreaming` is the refetch trigger, not read
@@ -315,6 +381,31 @@ export default function ChatView({
 		composerRef.current?.insertAndSubmit(hit.text, isStreaming ? "followUp" : "send");
 		closeHistory();
 	};
+
+	// A prompt hit's save-as-template action (row button or Cmd/Ctrl+S): close the overlay and open the
+	// shared editor dialog, body-prefilled with the hit's text — the dialog owns naming/scope/save from here.
+	const onSaveAsTemplateHit = (hit: PromptHit) => {
+		closeHistory();
+		setSaveAsTemplateHit(hit);
+	};
+
+	// Picking a `source: "prompt"` row: fetch the real file (never `commands`' frozen snapshot), split off
+	// the frontmatter (`templateText.ts`'s shared `stripFrontmatter` — pi's own parser is server-only, but
+	// the boundary rule is pinned to match it exactly), parse the body into slots, and hand the result to
+	// `Composer`'s `insertTemplate` — which starts (or skips, if there are no slots) a slot session,
+	// replacing the whole draft the way `pickSlash` does.
+	const onPickTemplate = useCallback(
+		(name: string) => {
+			getTransport()
+				.request("template.get", { workspaceId, name })
+				.then((t) => {
+					const parsed = parseTemplateSlots(stripFrontmatter(t.content), t.argumentHint);
+					composerRef.current?.insertTemplate(parsed);
+				})
+				.catch(() => {});
+		},
+		[workspaceId],
+	);
 
 	// Consume a `chatLocationRequest` targeting this session: resolve its `messageIndex` to a turn (via
 	// `turnIdByMessageIndex`, falling back to scanning by `anchorText` when the map entry is absent —
@@ -497,26 +588,37 @@ export default function ChatView({
 							onInsert={onInsertHit}
 							onInsertAndSend={onInsertAndSendHit}
 							onOpenMessage={openMessage}
+							onSaveAsTemplate={onSaveAsTemplateHit}
 						/>
 						<Composer
 							ref={composerRef}
 							value={draft}
 							onChange={(v) => useAppStore.getState().setChatDraft(sessionId, v)}
 							isStreaming={isStreaming}
-							commands={commands}
+							commands={mergedCommands}
 							mentionCandidates={mentionCandidates}
 							recentPrompts={recentPrompts}
 							models={models}
 							currentModel={currentModel}
 							thinkingLevel={thinkingLevel}
 							onMentionQuery={onMentionQuery}
+							onSlashActive={setSlashActive}
 							onSelectModel={onSelectModel}
 							onSelectThinking={onSelectThinking}
 							onSubmit={onSubmit}
 							onAbort={onAbort}
 							onHistoryOpen={onHistoryOpen}
+							onPickTemplate={onPickTemplate}
 						/>
 					</div>
+					<TemplateEditorDialog
+						open={saveAsTemplateHit != null}
+						onOpenChange={(open) => {
+							if (!open) setSaveAsTemplateHit(null);
+						}}
+						workspaceId={workspaceId}
+						initialBody={saveAsTemplateHit?.text ?? ""}
+					/>
 					{pendingExtUi ? (
 						<ExtUiDialog key={pendingExtUi.id} request={pendingExtUi} onReply={onExtUiReply} />
 					) : null}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -672,6 +672,12 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 									// slot's `end` as landing just *after* it (the right default in general — text typed
 									// after a filled value shouldn't retroactively join it), which would otherwise
 									// truncate a multi-character fill to whatever was typed in the very first keystroke.
+									// Growing IS filling: the extension is user-typed content, so `filled` is set here
+									// too — the `touches` check below can't do it (a zero-width insert at `end` doesn't
+									// overlap the range), and without it the FIRST keystroke into an untouched slot at
+									// its end boundary (ArrowRight collapses the marker selection exactly there, then
+									// the user types) would leave `filled: false` — `stripUntouchedSlots` would then
+									// delete the marker together with everything typed into it on send.
 									const growing =
 										removedLen === 0 &&
 										insertedLen > 0 &&
@@ -680,7 +686,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 									const shifted = shiftSlots(slots, editStart, removedLen, insertedLen).map(
 										(slot, i) => {
 											const grown =
-												growing && i === slotIdx ? { ...slot, end: slot.end + insertedLen } : slot;
+												growing && i === slotIdx
+													? { ...slot, end: slot.end + insertedLen, filled: true }
+													: slot;
 											const original = slots[i];
 											return original && touches(original, editStart, editEnd)
 												? { ...grown, filled: true }

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -21,8 +21,17 @@ import { ModelSelector } from "./ModelSelector";
 import {
 	SlashCommandMenu,
 	selectedSlashCommandValue,
+	slashCommandQuery,
 	useSlashCommandCompletion,
 } from "./SlashCommandCompletion";
+import type { ParsedTemplate, SlotHighlightState, SlotSegment, TemplateSlot } from "./slotSession";
+import {
+	highlightSegments,
+	mirrorAllGroups,
+	mirrorSlotGroup,
+	shiftSlots,
+	stripUntouchedSlots,
+} from "./slotSession";
 import { ThinkingSelector } from "./ThinkingSelector";
 
 /** How a submit is delivered: a fresh turn, an interrupt, or a queued message after the current turn. */
@@ -64,6 +73,73 @@ function activeToken(value: string, caret: number): { token: string; start: numb
 	return { token: match[0], start: caret - match[0].length };
 }
 
+/**
+ * Diff two textarea values around the post-edit caret (`newCaret` — always right after whatever was just
+ * typed/pasted/deleted): grows the common prefix greedily but capped at `newCaret`, then grows the common
+ * suffix over what's left. Capping the prefix at the caret is what keeps a coincidentally-matching run
+ * elsewhere in the string (e.g. a repeated word) from being mistaken for the untouched region. Returns the
+ * edit as a `[editStart, editStart + removedLen)` span of `oldVal` replaced by `insertedLen` chars of
+ * `newVal` — the same shape `shiftSlots` takes.
+ */
+function diffValues(
+	oldVal: string,
+	newVal: string,
+	newCaret: number,
+): { editStart: number; removedLen: number; insertedLen: number } {
+	const maxPrefix = Math.min(newCaret, oldVal.length, newVal.length);
+	let prefix = 0;
+	while (prefix < maxPrefix && oldVal[prefix] === newVal[prefix]) prefix++;
+
+	const maxSuffix = Math.min(oldVal.length - prefix, newVal.length - prefix);
+	let suffix = 0;
+	while (
+		suffix < maxSuffix &&
+		oldVal[oldVal.length - 1 - suffix] === newVal[newVal.length - 1 - suffix]
+	) {
+		suffix++;
+	}
+
+	return {
+		editStart: prefix,
+		removedLen: oldVal.length - prefix - suffix,
+		insertedLen: newVal.length - prefix - suffix,
+	};
+}
+
+/** Does the edit at `[editStart, editEnd)` overlap `slot`'s range — the rule for which slot(s) get
+ * flagged `filled: true` after a normal (non-session-ending) edit. */
+function touches(slot: TemplateSlot, editStart: number, editEnd: number): boolean {
+	return editStart < slot.end && editEnd > slot.start;
+}
+
+/** `highlightSegments`' output, one render pass, tagged with each segment's start offset — a stable,
+ * content-derived React key (its position in `value`, not the array index `.map` would otherwise hand
+ * out) for the backdrop's tint spans below. */
+function withOffsets(segments: SlotSegment[]): (SlotSegment & { start: number })[] {
+	let offset = 0;
+	return segments.map((seg) => {
+		const start = offset;
+		offset += seg.text.length;
+		return { ...seg, start };
+	});
+}
+
+/** The backdrop tint utility for one `highlightSegments` state — token-only per `chat/SPEC.md`'s styling
+ * rule; `"plain"` gets no tint at all (the class list is just `text-transparent`, applied unconditionally
+ * by the caller). */
+function highlightTint(state: SlotHighlightState): string {
+	switch (state) {
+		case "unfilled":
+			return "rounded-[2px] bg-[var(--primary-20)]";
+		case "active":
+			return "rounded-[2px] bg-[var(--primary-40)]";
+		case "filled":
+			return "rounded-[2px] bg-[var(--primary-10)]";
+		case "plain":
+			return "";
+	}
+}
+
 interface ComposerProps {
 	value: string;
 	onChange: (value: string) => void;
@@ -77,6 +153,9 @@ interface ComposerProps {
 	currentModel: WireModel | null;
 	thinkingLevel: ThinkingLevel;
 	onMentionQuery: (query: string | null) => void;
+	/** Fires as the `/` menu opens/closes — mirrors `onMentionQuery`'s query signal, but as a plain
+	 * boolean: `ChatView`'s fresh-template-list fetch cares only about activity, not the query text. */
+	onSlashActive: (active: boolean) => void;
 	onSelectModel: (model: WireModel) => void;
 	onSelectThinking: (level: ThinkingLevel) => void;
 	onSubmit: (text: string, images: ImageContent[], behavior: SubmitBehavior) => void;
@@ -84,9 +163,14 @@ interface ComposerProps {
 	/** `Ctrl+R` — opens the history-recall overlay (`ChatView` seeds it with the current draft). Optional
 	 * so a standalone/storybook-style render of `Composer` doesn't need to wire it. */
 	onHistoryOpen?: () => void;
+	/** Picking a `source: "prompt"` row: `ChatView` fetches + parses the template and replies via
+	 * `insertTemplate`, instead of the slash completion's plain `/name ` insert. Optional so a standalone
+	 * render of `Composer` still works — those rows just fall back to the plain insert. */
+	onPickTemplate?: (name: string) => void;
 }
 
-/** Imperative handle so `ChatView` can insert a recalled prompt without reaching into the DOM itself. */
+/** Imperative handle so `ChatView` can insert a recalled prompt (or a parsed template) without reaching
+ * into the DOM itself. */
 export interface ComposerHandle {
 	/** Replace the draft, focus the textarea, and place the caret at the end. */
 	insertText: (text: string) => void;
@@ -95,16 +179,20 @@ export interface ComposerHandle {
 	 * history overlay's ⌘/Ctrl+Enter path; a caller-side `onSubmit` would strand the composer-private
 	 * `images` state (sent without them, stale thumbnails left attached to the next message). */
 	insertAndSubmit: (text: string, behavior: SubmitBehavior) => void;
+	/** Replace the draft with a parsed template's expansion; if it produced any slots, start a slot
+	 * session selecting slot 0 (else behaves like `insertText`: caret at the end, no session). */
+	insertTemplate: (parsed: ParsedTemplate) => void;
 }
 
 /**
  * The chat composer (props-driven, no store/transport). Enter sends (or **steers** mid-stream);
  * Cmd/Ctrl+Enter queues a **follow-up**; a Stop button **aborts**. The model + effort controls sit in
  * the row under the tall prompt field, mirroring the New-Workspace dialog's layout. `@` opens worktree
- * file completion, a leading `/` opens the skill/command menu, `Ctrl+R` opens history recall (also
- * reachable via the always-rendered `history-open` button), plain `↑`/`↓` recall step through
- * `recentPrompts` when the field is empty or a recall session is already active, and images can be pasted
- * or dropped in.
+ * file completion, a leading `/` opens the skill/command menu (picking a `source: "prompt"` row starts a
+ * **slot session** — see `insertTemplate`/`stepSlot` — instead of the plain `/name ` insert every other
+ * row gets), `Ctrl+R` opens history recall (also reachable via the always-rendered `history-open` button),
+ * plain `↑`/`↓` recall step through `recentPrompts` when the field is empty or a recall session is already
+ * active, and images can be pasted or dropped in.
  */
 export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer(
 	{
@@ -118,11 +206,13 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		currentModel,
 		thinkingLevel,
 		onMentionQuery,
+		onSlashActive,
 		onSelectModel,
 		onSelectThinking,
 		onSubmit,
 		onAbort,
 		onHistoryOpen,
+		onPickTemplate,
 	},
 	handleRef,
 ) {
@@ -135,11 +225,26 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// newest). Reset on a diverging edit (the textarea's `onChange` below) or a submit — see `onKeyDown`'s
 	// recall block (after the mention/slash menu) for the stepping rules.
 	const [recallIdx, setRecallIdx] = useState<number | null>(null);
+	// The template slot session: `null` when inactive. Starts on `insertTemplate`, steps via `stepSlot`
+	// (Tab/Shift+Tab and the hint chip), re-tracked across edits in the textarea's `onChange`, and ends on
+	// `Escape`, submit, or any programmatic mutation that doesn't participate in slot tracking (recall,
+	// mention/plain-slash pick, `insertText`) — see `chat/SPEC.md`'s Template slots section.
+	const [slots, setSlots] = useState<TemplateSlot[] | null>(null);
+	const [slotIdx, setSlotIdx] = useState(0);
+	// The textarea's live scroll offset, mirrored onto the highlight backdrop's inner layer (see the
+	// `onScroll` handler below) so its tint spans stay pixel-aligned with the real text while scrolling.
+	// Tracked unconditionally (not gated on `slots !== null`) so the backdrop already has the right offset
+	// the instant a session starts, rather than flashing at `{0, 0}` for one frame.
+	const [scroll, setScroll] = useState({ left: 0, top: 0 });
 
 	const { token, start } = activeToken(value, caret);
 	const mentionQuery = token.startsWith("@") ? token.slice(1) : null;
+	// The same leading-`/` rule the completion hook applies (`slashCommandQuery` is its exported query
+	// parser) — recomputed here only to drive the `onSlashActive` activity signal below.
+	const slashQuery = slashCommandQuery(value);
 
 	useEffect(() => onMentionQuery(mentionQuery), [mentionQuery, onMentionQuery]);
+	useEffect(() => onSlashActive(slashQuery !== null), [slashQuery, onSlashActive]);
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset selection when the query changes
 	useEffect(() => {
 		setMentionActiveIndex(0);
@@ -148,49 +253,57 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
 	const mentionOpen = !mentionDismissed && mentionQuery !== null && mentionCandidates.length > 0;
 
-	// A one-shot imperative caret move requested by `focusCaret`, applied in `useLayoutEffect` below rather
-	// than a `requestAnimationFrame`: RAF only guarantees "before the next paint", leaving a gap *after the
-	// current task ends* where another actor touching the same textarea's selection (a fast follow-up
-	// keystroke, Playwright's `fill()`, a paste) can run first — a stale RAF then collapses *that* selection
-	// instead of the one it was scheduled for. Concretely: `fill()` does select-all then insert-text as
-	// separate steps; if a stale RAF's `setSelectionRange(pos, pos)` fires in the gap between them, it
-	// collapses the select-all to a bare caret, so the subsequent insert appends at `pos` instead of
-	// replacing — producing a doubled `oldValue + newValue` (this is the exact mechanism behind the flake
-	// once seen on the recall test below). `useLayoutEffect` runs synchronously in React's commit phase, in
-	// the same task as the keystroke that triggered it, so there is no gap for anything else to interleave.
-	const [pendingCaret, setPendingCaret] = useState<number | null>(null);
+	// A one-shot imperative caret/selection move requested by `focusSelection`, applied in
+	// `useLayoutEffect` below rather than a `requestAnimationFrame`: RAF only guarantees "before the next
+	// paint", leaving a gap *after the current task ends* where another actor touching the same
+	// textarea's selection (a fast follow-up keystroke, Playwright's `fill()`, a paste) can run first — a
+	// stale RAF then collapses *that* selection instead of the one it was scheduled for. Concretely:
+	// `fill()` does select-all then insert-text as separate steps; if a stale RAF's
+	// `setSelectionRange(pos, pos)` fires in the gap between them, it collapses the select-all to a bare
+	// caret, so the subsequent insert appends at `pos` instead of replacing — producing a doubled
+	// `oldValue + newValue` (this is the exact mechanism behind the flake once seen on the recall test
+	// below). `useLayoutEffect` runs synchronously in React's commit phase, in the same task as the
+	// keystroke that triggered it, so there is no gap for anything else to interleave.
+	const [pendingSelection, setPendingSelection] = useState<{ start: number; end: number } | null>(
+		null,
+	);
 
 	useLayoutEffect(() => {
-		if (pendingCaret === null) return;
+		if (pendingSelection === null) return;
 		const el = ref.current;
 		if (el) {
 			el.focus();
-			el.setSelectionRange(pendingCaret, pendingCaret);
+			el.setSelectionRange(pendingSelection.start, pendingSelection.end);
 		}
-		setCaret(pendingCaret);
-		setPendingCaret(null);
-	}, [pendingCaret]);
+		setCaret(pendingSelection.start);
+		setPendingSelection(null);
+	}, [pendingSelection]);
 
-	/** Place a collapsed caret at `pos` (after the current commit — see `pendingCaret` above). */
-	const focusCaret = useCallback((pos: number) => setPendingCaret(pos), []);
+	/** Move the caret (`end` defaults to `start` — a collapsed caret) or place a real selection — a
+	 * template slot's marker range needs the latter so typing over it replaces the whole thing. */
+	const focusSelection = useCallback((start: number, end: number = start) => {
+		setPendingSelection({ start, end });
+	}, []);
 
 	// The single seam for replacing the draft programmatically (history recall, mention, slash). Sets the
-	// value, places the caret, and — crucially — exits any active `↑`-recall session: these paths set the
-	// controlled `value` directly (not via the textarea's `onChange`), so the diverging-edit reset there
-	// never fires, and a leftover `recallIdx` would let a subsequent `↓` overwrite what was just inserted.
+	// value, places the caret, and — crucially — exits any active `↑`-recall session (these paths set the
+	// controlled `value` directly, not via the textarea's `onChange`, so the diverging-edit reset there
+	// never fires, and a leftover `recallIdx` would let a subsequent `↓` overwrite what was just inserted)
+	// AND any active template slot session (the inserted text has nothing to do with the tracked ranges).
 	const replaceDraft = useCallback(
 		(text: string, caret: number = text.length) => {
 			setRecallIdx(null);
+			setSlots(null);
 			onChange(text);
-			focusCaret(caret);
+			focusSelection(caret);
 		},
-		[onChange, focusCaret],
+		[onChange, focusSelection],
 	);
 
 	// The one submit seam — the composer's own send gestures (`submit` below) and the imperative
 	// `insertAndSubmit` both land here, so whatever initiated the send, pending images always travel
-	// with the text and are cleared with the draft in the same step. No-op when both the (trimmed)
-	// text and the image list are empty.
+	// with the text and are cleared with the draft in the same step (and any recall or template slot
+	// session ends with the send). No-op when both the (trimmed) text and the image list are empty.
 	const submitText = (raw: string, behavior: SubmitBehavior) => {
 		const text = raw.trim();
 		if (!text && images.length === 0) return;
@@ -202,6 +315,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		onChange("");
 		setImages([]);
 		setRecallIdx(null);
+		setSlots(null);
 	};
 
 	// No dependency array: `submitText` closes over the live draft/images on purpose, so the handle is
@@ -209,6 +323,22 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	useImperativeHandle(handleRef, () => ({
 		insertText: (text: string) => replaceDraft(text),
 		insertAndSubmit: (text: string, behavior: SubmitBehavior) => submitText(text, behavior),
+		insertTemplate: (parsed: ParsedTemplate) => {
+			const first = parsed.slots[0];
+			if (!first) {
+				// No slots — behaves exactly like `insertText` (and picks up its recall/slot resets).
+				replaceDraft(parsed.text);
+				return;
+			}
+			// A slotted insert is the one programmatic mutation that STARTS a slot session instead of
+			// ending one — but it must still exit any `↑`-recall session the way `replaceDraft` does
+			// (this path sets `value` directly, so the textarea's diverging-edit reset never fires).
+			setRecallIdx(null);
+			onChange(parsed.text);
+			setSlots(parsed.slots);
+			setSlotIdx(0);
+			focusSelection(first.start, first.end);
+		},
 	}));
 
 	const pickMention = (c: MentionCandidate) => {
@@ -225,8 +355,18 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const slashCompletion = useSlashCommandCompletion({
 		value,
 		commands,
-		onSelect: (command) => replaceDraft(selectedSlashCommandValue(command)),
+		// A fresh `template.list` row (`source: "prompt"`) routes to the template flow (fetch + parse +
+		// slot session, owned by `ChatView`, which replies via the `insertTemplate` handle) instead of
+		// the plain `/name ` insert every other row gets.
+		onSelect: (command) =>
+			command.source === "prompt" && onPickTemplate
+				? onPickTemplate(command.name)
+				: replaceDraft(selectedSlashCommandValue(command)),
 	});
+
+	// Either floating completion panel — the slot-session keys and the hint chip both stand down while
+	// one is open (all the composer's floating panels share the same anchor rect).
+	const menuOpen = mentionOpen || slashCompletion.open;
 
 	// The single entry point to the history overlay — both the `Ctrl+R` chord and the always-rendered
 	// history button go through here, so both dismiss any open mention/slash menu first (the two floating
@@ -247,7 +387,45 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		]);
 	};
 
-	const submit = (behavior: SubmitBehavior) => submitText(value, behavior);
+	const submit = (behavior: SubmitBehavior) => {
+		// An active session's text is sent stripped of any untouched marker slots — sent *or* queued
+		// (steer/followUp), same rule; either way, the session always ends here (`submitText` resets it).
+		// Mirroring runs first: Tab (`stepSlot` below) mirrors a filled slot's text into its same-group
+		// siblings on exit, but a direct Send can fire before ever tabbing out of the slot that was actually
+		// filled — e.g. filling slot 1 of a repeated-group template and clicking Send without Tab. Without
+		// this, `stripUntouchedSlots` would strip the sibling as "untouched" and the group's mirrored value
+		// would silently never reach it.
+		let text = value;
+		if (slots) {
+			const mirrored = mirrorAllGroups(value, slots);
+			text = stripUntouchedSlots(mirrored.value, mirrored.slots);
+		}
+		submitText(text, behavior);
+	};
+
+	/** Tab/Shift+Tab (and the hint chip's tap): move to the next/previous slot (wrap), and — when the slot
+	 * being left is `filled` (real content, not an untouched marker) — mirror its current text into every
+	 * OTHER slot sharing its `group` whose text differs (repeated placeholder occurrences propagate on
+	 * exit, not per keystroke). `mirrorSlotGroup` (shared with `submit`'s own mirror-on-send path above)
+	 * re-tracks each splice via `shiftSlots` before the next one, so later offsets in the same step stay
+	 * correct even when more than one sibling needs the mirror. */
+	const stepSlot = (dir: 1 | -1) => {
+		if (!slots || slots.length === 0) return;
+		const cur = slots[slotIdx];
+		if (!cur) return;
+
+		const { value: nextValue, slots: nextSlots } = cur.filled
+			? mirrorSlotGroup(value, slots, slotIdx)
+			: { value, slots };
+
+		if (nextValue !== value) onChange(nextValue);
+		setSlots(nextSlots);
+		const len = nextSlots.length;
+		const next = (((slotIdx + dir) % len) + len) % len;
+		setSlotIdx(next);
+		const target = nextSlots[next];
+		if (target) focusSelection(target.start, target.end);
+	};
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
 		// Ctrl+R opens history recall — guarded at the very top, before the mention/slash menu, and before
@@ -259,6 +437,23 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			e.preventDefault();
 			openHistory();
 			return;
+		}
+		// A slot session's own keys — checked right after the Ctrl+R guard and before the mention/slash
+		// menu's key handling, and skipped outright while a menu IS open, so a real Tab-to-pick-a-menu-item
+		// (or an Escape that should dismiss the menu) is unaffected; the hint chip and the menus are mutually
+		// exclusive anyway (see the hint's render gate below), so the floating UIs never fight over the
+		// same key.
+		if (slots && !menuOpen) {
+			if (e.key === "Tab") {
+				e.preventDefault();
+				stepSlot(e.shiftKey ? -1 : 1);
+				return;
+			}
+			if (e.key === "Escape") {
+				e.preventDefault();
+				setSlots(null);
+				return;
+			}
 		}
 		if (mentionOpen) {
 			const menuLen = mentionCandidates.length;
@@ -293,25 +488,27 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		// completion's own focus-after-change pattern.
 		if (e.key === "ArrowUp" && (value === "" || recallIdx !== null) && recentPrompts.length > 0) {
 			e.preventDefault();
+			setSlots(null);
 			const next = recallIdx === null ? 0 : Math.min(recallIdx + 1, recentPrompts.length - 1);
 			const text = recentPrompts[next] ?? "";
 			setRecallIdx(next);
 			onChange(text);
-			focusCaret(text.length);
+			focusSelection(text.length);
 			return;
 		}
 		if (e.key === "ArrowDown" && recallIdx !== null) {
 			e.preventDefault();
+			setSlots(null);
 			if (recallIdx === 0) {
 				setRecallIdx(null);
 				onChange("");
-				focusCaret(0);
+				focusSelection(0);
 			} else {
 				const next = recallIdx - 1;
 				const text = recentPrompts[next] ?? "";
 				setRecallIdx(next);
 				onChange(text);
-				focusCaret(text.length);
+				focusSelection(text.length);
 			}
 			return;
 		}
@@ -374,6 +571,17 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				/>
 			) : null}
 
+			{slots && !menuOpen ? (
+				<button
+					type="button"
+					data-testid="slot-hint"
+					onClick={() => stepSlot(1)}
+					className="absolute bottom-full left-sm mb-xs rounded-[var(--radius-sm)] border border-border2 bg-elevated px-sm py-xs text-hint text-xs shadow-[var(--shadow-md)] hover:bg-hover hover:text-text"
+				>
+					slot {slotIdx + 1}/{slots.length} · ⇥ next · esc done
+				</button>
+			) : null}
+
 			{images.length > 0 ? (
 				<div className="flex flex-wrap gap-xs px-sm pt-sm" data-testid="composer-images">
 					{images.map((img) => (
@@ -396,32 +604,112 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			) : null}
 
 			<div className="flex flex-col gap-sm p-sm">
-				<textarea
-					ref={ref}
-					data-testid="chat-input"
-					value={value}
-					onChange={(e) => {
-						const next = e.target.value;
-						// A genuine user edit (typing/pasting/deleting — never fired by the recall/insert paths
-						// themselves, since those set the controlled `value` prop directly rather than mutating the
-						// DOM node) that diverges from the recalled entry exits the recall session.
-						if (recallIdx !== null && next !== recentPrompts[recallIdx]) setRecallIdx(null);
-						onChange(next);
-						setCaret(e.target.selectionStart);
-					}}
-					onKeyUp={(e) => setCaret(e.currentTarget.selectionStart)}
-					onClick={(e) => setCaret(e.currentTarget.selectionStart)}
-					onKeyDown={onKeyDown}
-					onPaste={onPaste}
-					onDrop={onDrop}
-					rows={4}
-					placeholder={
-						isStreaming
-							? "Enter to steer · Cmd/Ctrl+Enter to queue · @ files · / commands"
-							: "Message the agent…  (@ files · / commands · Enter to send)"
-					}
-					className="min-h-[108px] w-full resize-none rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-md py-sm text-sm text-text outline-none transition-colors placeholder:text-hint focus:border-primary focus-visible:ring-2 focus-visible:ring-[var(--primary-20)]"
-				/>
+				{/* Input background now lives here (not on the textarea below — it's `bg-transparent`), so the
+				 * backdrop's tint spans, painted behind the textarea's transparent background, show through.
+				 * `rounded-[var(--radius-md)]` matches the textarea's own corner radius so this container's own
+				 * background is clipped to the same rounded shape — with no session active this wrapper is
+				 * otherwise invisible (no border, no padding of its own), so the composer looks identical to
+				 * before this layer existed. */}
+				<div className="relative rounded-[var(--radius-md)] bg-[var(--input-bg)]">
+					{slots ? (
+						<div
+							data-testid="slot-backdrop"
+							aria-hidden
+							className="pointer-events-none absolute inset-0 overflow-hidden rounded-[var(--radius-md)]"
+						>
+							{/* Mirrors the textarea's box model EXACTLY (same px-md py-sm padding, text-sm
+							 * font size/line-height, a transparent border of the same width so the content box
+							 * lines up) plus `whitespace-pre-wrap break-words` — a native textarea soft-wraps
+							 * this way by default (its own UA stylesheet), but a plain <div> does not, so this
+							 * has to be spelled out explicitly for the two to wrap identical text identically. */}
+							<div
+								className="w-full whitespace-pre-wrap break-words border border-transparent px-md py-sm text-sm"
+								// The one allowed inline style (chat/SPEC.md's styling rule): a computed pixel
+								// transform mirroring the textarea's own live scroll offset (updated by its
+								// `onScroll` handler below) — there is no token/utility for "translate by this
+								// frame's scroll position", it's inherently a runtime pixel value.
+								style={{ transform: `translate(${-scroll.left}px, ${-scroll.top}px)` }}
+							>
+								{withOffsets(highlightSegments(value, slots, slotIdx)).map((seg) => (
+									<span
+										key={seg.start}
+										data-testid={seg.state === "plain" ? undefined : "slot-highlight"}
+										data-slot-state={seg.state === "plain" ? undefined : seg.state}
+										className={`text-transparent ${highlightTint(seg.state)}`}
+									>
+										{seg.text}
+									</span>
+								))}
+							</div>
+						</div>
+					) : null}
+					<textarea
+						ref={ref}
+						data-testid="chat-input"
+						value={value}
+						onScroll={(e) =>
+							setScroll({ left: e.currentTarget.scrollLeft, top: e.currentTarget.scrollTop })
+						}
+						onChange={(e) => {
+							const next = e.target.value;
+							const nextCaret = e.target.selectionStart;
+							// A genuine user edit (typing/pasting/deleting — never fired by the recall/insert paths
+							// themselves, since those set the controlled `value` prop directly rather than mutating the
+							// DOM node) that diverges from the recalled entry exits the recall session.
+							if (recallIdx !== null && next !== recentPrompts[recallIdx]) setRecallIdx(null);
+							if (slots) {
+								const { editStart, removedLen, insertedLen } = diffValues(value, next, nextCaret);
+								if (editStart === 0 && removedLen === value.length) {
+									// The edit consumed the entire prior value (a select-all-and-type/delete, or
+									// Playwright's `fill()`) — re-tracking a now-meaningless collapsed range set would
+									// serve no purpose, so the session just ends instead.
+									setSlots(null);
+								} else {
+									const editEnd = editStart + removedLen;
+									const active = slots[slotIdx];
+									// Still typing at the exact end of the actively-selected slot should keep extending
+									// it. `shiftSlots`' boundary rule otherwise treats a zero-width insert exactly at a
+									// slot's `end` as landing just *after* it (the right default in general — text typed
+									// after a filled value shouldn't retroactively join it), which would otherwise
+									// truncate a multi-character fill to whatever was typed in the very first keystroke.
+									const growing =
+										removedLen === 0 &&
+										insertedLen > 0 &&
+										active !== undefined &&
+										active.end === editStart;
+									const shifted = shiftSlots(slots, editStart, removedLen, insertedLen).map(
+										(slot, i) => {
+											const grown =
+												growing && i === slotIdx ? { ...slot, end: slot.end + insertedLen } : slot;
+											const original = slots[i];
+											return original && touches(original, editStart, editEnd)
+												? { ...grown, filled: true }
+												: grown;
+										},
+									);
+									setSlots(shifted);
+								}
+							}
+							onChange(next);
+							setCaret(nextCaret);
+						}}
+						onKeyUp={(e) => setCaret(e.currentTarget.selectionStart)}
+						onClick={(e) => setCaret(e.currentTarget.selectionStart)}
+						onKeyDown={onKeyDown}
+						onPaste={onPaste}
+						onDrop={onDrop}
+						rows={4}
+						placeholder={
+							isStreaming
+								? "Enter to steer · Cmd/Ctrl+Enter to queue · @ files · / commands"
+								: "Message the agent…  (@ files · / commands · Enter to send)"
+						}
+						// `relative` keeps the textarea a positioned participant so it paints ABOVE the absolute
+						// slot-highlight backdrop (its earlier DOM sibling) — otherwise a static textarea paints
+						// under the backdrop and the native caret/selection get dimmed by the active-slot tint.
+						className="relative min-h-[108px] w-full resize-none rounded-[var(--radius-md)] border border-border2 bg-transparent px-md py-sm text-sm text-text outline-none transition-colors placeholder:text-hint focus:border-primary focus-visible:ring-2 focus-visible:ring-[var(--primary-20)]"
+					/>
+				</div>
 				<div className="flex flex-wrap items-center gap-sm">
 					<div className="flex min-w-0 flex-1 flex-wrap items-center gap-sm">
 						<ModelSelector models={models} current={currentModel} onSelect={onSelectModel} />

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -231,11 +231,20 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// mention/plain-slash pick, `insertText`) — see `chat/SPEC.md`'s Template slots section.
 	const [slots, setSlots] = useState<TemplateSlot[] | null>(null);
 	const [slotIdx, setSlotIdx] = useState(0);
-	// The textarea's live scroll offset, mirrored onto the highlight backdrop's inner layer (see the
-	// `onScroll` handler below) so its tint spans stay pixel-aligned with the real text while scrolling.
-	// Tracked unconditionally (not gated on `slots !== null`) so the backdrop already has the right offset
-	// the instant a session starts, rather than flashing at `{0, 0}` for one frame.
-	const [scroll, setScroll] = useState({ left: 0, top: 0 });
+	// The highlight backdrop scroll-syncs to the textarea IMPERATIVELY — the textarea's `onScroll` copies
+	// its offsets onto the backdrop element (a programmatic scroll offset needs no styling, so the repo's
+	// token-utilities-only rule holds with zero exceptions — no state, no inline `style`, and no composer
+	// re-render per scrolled frame). The ref callback seeds the offsets at mount, so a session starting
+	// in an already-scrolled composer never paints even one frame misaligned.
+	const backdropRef = useRef<HTMLDivElement | null>(null);
+	const attachBackdrop = (el: HTMLDivElement | null) => {
+		backdropRef.current = el;
+		const textarea = ref.current;
+		if (el && textarea) {
+			el.scrollLeft = textarea.scrollLeft;
+			el.scrollTop = textarea.scrollTop;
+		}
+	};
 
 	const { token, start } = activeToken(value, caret);
 	const mentionQuery = token.startsWith("@") ? token.slice(1) : null;
@@ -613,6 +622,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				<div className="relative rounded-[var(--radius-md)] bg-[var(--input-bg)]">
 					{slots ? (
 						<div
+							ref={attachBackdrop}
 							data-testid="slot-backdrop"
 							aria-hidden
 							className="pointer-events-none absolute inset-0 overflow-hidden rounded-[var(--radius-md)]"
@@ -621,15 +631,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							 * font size/line-height, a transparent border of the same width so the content box
 							 * lines up) plus `whitespace-pre-wrap break-words` — a native textarea soft-wraps
 							 * this way by default (its own UA stylesheet), but a plain <div> does not, so this
-							 * has to be spelled out explicitly for the two to wrap identical text identically. */}
-							<div
-								className="w-full whitespace-pre-wrap break-words border border-transparent px-md py-sm text-sm"
-								// The one allowed inline style (chat/SPEC.md's styling rule): a computed pixel
-								// transform mirroring the textarea's own live scroll offset (updated by its
-								// `onScroll` handler below) — there is no token/utility for "translate by this
-								// frame's scroll position", it's inherently a runtime pixel value.
-								style={{ transform: `translate(${-scroll.left}px, ${-scroll.top}px)` }}
-							>
+							 * has to be spelled out explicitly for the two to wrap identical text identically.
+							 * The mirrored content overflows the `overflow-hidden` parent, whose scroll offsets
+							 * the textarea's `onScroll` sets imperatively (see `attachBackdrop`). */}
+							<div className="w-full whitespace-pre-wrap break-words border border-transparent px-md py-sm text-sm">
 								{withOffsets(highlightSegments(value, slots, slotIdx)).map((seg) => (
 									<span
 										key={seg.start}
@@ -647,9 +652,13 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 						ref={ref}
 						data-testid="chat-input"
 						value={value}
-						onScroll={(e) =>
-							setScroll({ left: e.currentTarget.scrollLeft, top: e.currentTarget.scrollTop })
-						}
+						onScroll={(e) => {
+							const backdrop = backdropRef.current;
+							if (backdrop) {
+								backdrop.scrollLeft = e.currentTarget.scrollLeft;
+								backdrop.scrollTop = e.currentTarget.scrollTop;
+							}
+						}}
 						onChange={(e) => {
 							const next = e.target.value;
 							const nextCaret = e.target.selectionStart;

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -399,11 +399,12 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const submit = (behavior: SubmitBehavior) => {
 		// An active session's text is sent stripped of any untouched marker slots — sent *or* queued
 		// (steer/followUp), same rule; either way, the session always ends here (`submitText` resets it).
-		// Mirroring runs first: Tab (`stepSlot` below) mirrors a filled slot's text into its same-group
+		// Mirroring runs first: Tab (`stepSlot` below) mirrors a user-edited slot's text into its same-group
 		// siblings on exit, but a direct Send can fire before ever tabbing out of the slot that was actually
-		// filled — e.g. filling slot 1 of a repeated-group template and clicking Send without Tab. Without
+		// edited — e.g. filling slot 1 of a repeated-group template and clicking Send without Tab. Without
 		// this, `stripUntouchedSlots` would strip the sibling as "untouched" and the group's mirrored value
-		// would silently never reach it.
+		// would silently never reach it. Only user-`edited` slots mirror, so an untouched `${N:-default}`
+		// never overwrites a differently-defaulted group-mate (`mirrorAllGroups`, see `slotSession.ts`).
 		let text = value;
 		if (slots) {
 			const mirrored = mirrorAllGroups(value, slots);
@@ -413,17 +414,19 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	/** Tab/Shift+Tab (and the hint chip's tap): move to the next/previous slot (wrap), and — when the slot
-	 * being left is `filled` (real content, not an untouched marker) — mirror its current text into every
-	 * OTHER slot sharing its `group` whose text differs (repeated placeholder occurrences propagate on
-	 * exit, not per keystroke). `mirrorSlotGroup` (shared with `submit`'s own mirror-on-send path above)
-	 * re-tracks each splice via `shiftSlots` before the next one, so later offsets in the same step stay
-	 * correct even when more than one sibling needs the mirror. */
+	 * being left has been `edited` by the user (not an untouched marker, and crucially not an untouched
+	 * `${N:-default}` either — an untouched default must stay independent from a differently-defaulted
+	 * group-mate, see `slotSession.ts`'s `edited` doc) — mirror its current text into every OTHER slot
+	 * sharing its `group` whose text differs (repeated placeholder occurrences propagate on exit, not per
+	 * keystroke). `mirrorSlotGroup` (shared with `submit`'s own mirror-on-send path above) re-tracks each
+	 * splice via `shiftSlots` before the next one, so later offsets in the same step stay correct even when
+	 * more than one sibling needs the mirror. */
 	const stepSlot = (dir: 1 | -1) => {
 		if (!slots || slots.length === 0) return;
 		const cur = slots[slotIdx];
 		if (!cur) return;
 
-		const { value: nextValue, slots: nextSlots } = cur.filled
+		const { value: nextValue, slots: nextSlots } = cur.edited
 			? mirrorSlotGroup(value, slots, slotIdx)
 			: { value, slots };
 
@@ -681,12 +684,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 									// slot's `end` as landing just *after* it (the right default in general — text typed
 									// after a filled value shouldn't retroactively join it), which would otherwise
 									// truncate a multi-character fill to whatever was typed in the very first keystroke.
-									// Growing IS filling: the extension is user-typed content, so `filled` is set here
-									// too — the `touches` check below can't do it (a zero-width insert at `end` doesn't
-									// overlap the range), and without it the FIRST keystroke into an untouched slot at
-									// its end boundary (ArrowRight collapses the marker selection exactly there, then
-									// the user types) would leave `filled: false` — `stripUntouchedSlots` would then
-									// delete the marker together with everything typed into it on send.
+									// Growing IS filling (and editing): the extension is user-typed content, so `filled`
+									// AND `edited` are set here too — the `touches` check below can't do it (a
+									// zero-width insert at `end` doesn't overlap the range), and without it the FIRST
+									// keystroke into an untouched slot at its end boundary (ArrowRight collapses the
+									// marker selection exactly there, then the user types) would leave the slot
+									// untouched — `stripUntouchedSlots` would then delete the marker together with
+									// everything typed into it on send. `edited: true` (never set by the parser) is
+									// what makes this slot a mirror source, so a user fill propagates to its group-mates
+									// while an untouched `${N:-default}` stays independent (see `slotSession.ts`).
 									const growing =
 										removedLen === 0 &&
 										insertedLen > 0 &&
@@ -696,11 +702,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 										(slot, i) => {
 											const grown =
 												growing && i === slotIdx
-													? { ...slot, end: slot.end + insertedLen, filled: true }
+													? { ...slot, end: slot.end + insertedLen, filled: true, edited: true }
 													: slot;
 											const original = slots[i];
 											return original && touches(original, editStart, editEnd)
-												? { ...grown, filled: true }
+												? { ...grown, filled: true, edited: true }
 												: grown;
 										},
 									);

--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -1,5 +1,5 @@
 import type { HistoryScope, MessageHit, PromptHit } from "@thinkrail/contracts";
-import { Check, CornerUpRight } from "lucide-react";
+import { Check, CornerUpRight, Save } from "lucide-react";
 import { type KeyboardEvent, useEffect, useMemo, useRef } from "react";
 import {
 	DropdownMenu,
@@ -31,6 +31,15 @@ const SCOPE_MENU_LABELS: Record<HistoryScope["kind"], string> = {
 	project: "Project",
 	all: "Everywhere",
 };
+
+/** Cmd on Mac/iOS, Ctrl elsewhere — matches the modifier `onKeyDown` below actually checks
+ * (`e.metaKey || e.ctrlKey`), so the save-as-template button's tooltip never shows a glyph the user's
+ * platform doesn't have. Guarded for a non-browser environment (e.g. this module under a non-DOM test
+ * runner) — falls back to the cross-platform spelling. */
+const SAVE_SHORTCUT_LABEL =
+	typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? "")
+		? "⌘S"
+		: "Ctrl+S";
 
 /** Tiny relative-time formatter — `panels/CenterTabs.tsx` has a private twin; `chat/` can't import from
  * `panels/` (wrong dependency direction), and this is too small to promote to a shared lib. */
@@ -91,6 +100,7 @@ function PromptRow({
 	workspaceName,
 	isSelected,
 	onPick,
+	onSaveAsTemplate,
 	onOpenMessage,
 }: {
 	hit: PromptHit;
@@ -99,6 +109,7 @@ function PromptRow({
 	workspaceName: string | undefined;
 	isSelected: boolean;
 	onPick: () => void;
+	onSaveAsTemplate: () => void;
 	onOpenMessage: (target: ChatLocationRequest) => void;
 }) {
 	const firstLine = hit.text.split("\n")[0] ?? hit.text;
@@ -130,6 +141,31 @@ function PromptRow({
 					</span>
 				) : null}
 				<span className="shrink-0 text-hint text-xs">{relativeTime(hit.timestamp)}</span>
+			</button>
+			{isSelected ? (
+				// Persistent keyboard-shortcut glyph — the same precedent as the scope badge's `⌃R`
+				// (always visible next to its label, not hover-only). The icon beside it is still
+				// hover-revealed via `group-hover`/`isSelected` opacity; this glyph is the part a
+				// keyboard-only user (Shift+Enter's own audience) needs, so it can't be mouse-hover-gated
+				// the way the icon itself is.
+				<span data-testid="history-save-shortcut" className="shrink-0 text-[10px] text-hint">
+					{SAVE_SHORTCUT_LABEL}
+				</span>
+			) : null}
+			<button
+				type="button"
+				data-testid="history-save-template"
+				aria-label="Save as template"
+				title={`Save as template (${SAVE_SHORTCUT_LABEL})`}
+				onClick={(e) => {
+					e.stopPropagation();
+					onSaveAsTemplate();
+				}}
+				className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-xs text-muted opacity-0 transition hover:bg-elevated hover:text-text group-hover:opacity-100 ${
+					isSelected ? "opacity-100" : ""
+				}`}
+			>
+				<Save className="size-3.5" />
 			</button>
 			{target ? (
 				<>
@@ -286,6 +322,10 @@ export interface HistoryOverlayProps {
 	 * hit (or a prompt hit missing its anchor) never reaches here — belt-and-suspenders, not a
 	 * redundant guard inside `useHistorySearch`'s `openMessage`. */
 	onOpenMessage: (target: ChatLocationRequest) => void;
+	/** A prompt row's save-as-template action — its own button (hover-revealed, every row) and
+	 * Cmd/Ctrl+S while that row is the keyboard selection. Opens `TemplateEditorDialog` body-prefilled;
+	 * `ChatView` owns the dialog, this overlay only reports the hit. */
+	onSaveAsTemplate: (hit: PromptHit) => void;
 	/** R2's mouse path: a direct scope pick from the badge's dropdown menu. `onCycleScope` stays the
 	 * `Ctrl+R` keyboard path, unaffected — both just set the same underlying scope state
 	 * (`useHistorySearch.ts`'s `setScope`/`cycleScope` reset the results selection identically). */
@@ -308,6 +348,7 @@ export function HistoryOverlay({
 	onInsert,
 	onInsertAndSend,
 	onOpenMessage,
+	onSaveAsTemplate,
 	onSetScope,
 }: HistoryOverlayProps) {
 	const { open, stage, query, scope, result, selected, error } = state;
@@ -354,6 +395,15 @@ export function HistoryOverlay({
 		if (e.key === "r" && e.ctrlKey && !e.metaKey && !e.altKey) {
 			e.preventDefault();
 			onCycleScope();
+			return;
+		}
+		if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+			// Always swallow — Cmd/Ctrl+S is the browser's own "save page" shortcut. Only a prompt row
+			// selection actually opens the save-as-template dialog; on a message hit (or none) this is a
+			// no-op, same as Enter's message-hit gating above.
+			e.preventDefault();
+			const item = resolveHistorySelection(stage, result, selected);
+			if (item?.kind === "prompt") onSaveAsTemplate(item.hit);
 			return;
 		}
 		if (e.key === "ArrowDown") {
@@ -446,6 +496,7 @@ export function HistoryOverlay({
 									workspaceName={hit.workspaceId ? workspaceNames[hit.workspaceId] : undefined}
 									isSelected={i === selected}
 									onPick={() => onInsert(hit)}
+									onSaveAsTemplate={() => onSaveAsTemplate(hit)}
 									onOpenMessage={onOpenMessage}
 								/>
 							))}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -281,7 +281,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   is therefore promoted to a **third** sanctioned store/transport-touching integration piece (see Boundary
   below), even though it isn't `ChatView` itself.
   - **`templateText.ts`** is the single shared frontmatter splitter/assembler — `stripFrontmatter`
-    (`ChatView.tsx`'s composer-pick path), `splitTemplate`/`assembleTemplate` (this dialog). Its boundary
+    (`ChatView.tsx`'s composer-pick path + this dialog's body field), `assembleTemplate` (this dialog's
+    save). It does **no YAML value parsing**: the dialog's description/argument-hint fields are populated
+    from the server-parsed `TemplateInfo` (pi's real YAML parser — full scalar-style fidelity, pinned in
+    `packages/server/src/templates/templates.test.ts`), never from a browser-side reimplementation (an
+    earlier `splitTemplate` here handled only bare/double-quoted scalars, so a pi-native
+    `description: 'single-quoted'` loaded into the form with literal quotes and saved back corrupted).
+    Its boundary
     rule is ported byte-for-byte from pi's own `extractFrontmatter` (`@earendil-works/pi-coding-agent`'s
     `dist/utils/frontmatter.js`, pinned against pi v0.80.6 — the same pin `packages/server/src/templates/
     SPEC.md` uses server-side; re-verify both on a pi version bump): the frontmatter block ends at the

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -209,22 +209,28 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `source === "prompt"` entries, plus a fresh `template.list { workspaceId }` fetch mapped to
   `SlashCommandInfo` rows (`source: "prompt"`, `sourceInfo` synthesized to match pi's own prompt-template
   convention exactly: `{ path: filePath, source: "local", scope: scope === "global" ? "user" : "project",
-  origin: "top-level" }`) — one merged list, `Composer`'s rendering is unchanged. The fetch runs when the
-  slash menu opens (**`onSlashActive`**, a boolean prop mirroring `onMentionQuery`'s query signal), cached
-  per workspace (one `ChatView` instance never changes workspace) and invalidated by the store's
-  **`templatesVersion`** counter (see `store/SPEC.md`; bumped by `panels/TemplatesSettings.tsx` and
-  `TemplateEditorDialog.tsx` after a `template.save`/`delete` — see the Save-as-template bullet below) —
+  origin: "top-level" }`) — one merged list, `Composer`'s rendering is unchanged. The fetch runs on
+  **every** slash-menu-open transition (**`onSlashActive`**, a boolean prop mirroring `onMentionQuery`'s
+  query signal — it stays `true` while the user types the query, so no per-keystroke refires) and is
+  deliberately **uncached**: prompt files change outside the app too (pi CLI, an editor, a git pull),
+  which no in-app invalidation counter can see — an earlier `(workspaceId, templatesVersion)` cache here
+  served exactly those externally-changed files stale for the rest of the chat, and the server re-reads
+  its dirs per call precisely for this freshness (its SPEC calls the readdirs cheap) —
   this is what makes `packages/server/src/agent/SPEC.md`'s "the
   composer's `/` menu path is always fresh via `template.list`" claim true, unlike the typed-through
   `/name args` path's frozen create-time snapshot. **Picking a template** (`ChatView`'s `onPickTemplate`, a
-  `Composer` prop): instead of `pickSlash`'s plain `/name ` insert, fetches `template.get`, splits
+  `Composer` prop): instead of the plain `/name ` insert, fetches `template.get`, splits
   frontmatter client-side (`templateText.ts`'s shared `stripFrontmatter` — pi's own frontmatter parser is
   server-only, never reaches the browser bundle, but the boundary rule is pinned to match it exactly; see
   the Save-as-template bullet below), runs `parseTemplateSlots(body, argumentHint)`, and hands
   the result to `Composer` via a new **`ComposerHandle.insertTemplate`** method (alongside the existing
   `insertText`) — replaces the whole draft (like `pickSlash`, not `pickMention`: a slash command occupies
   the entire input) and, if the parse produced any slots, starts a **slot session** selecting slot 0; no
-  slots → a plain insert, caret at the end, no session. **The session** (`Composer`, local `useState`:
+  slots → a plain insert, caret at the end, no session. The async response is applied only while the pick
+  is still **current** — newest pick wins AND the draft is byte-identical to pick time — so a slow
+  response can never clobber a draft the user typed (or a second template they picked) in the meantime;
+  the rules are `templatePick.ts`'s `shouldApplyTemplatePick` (pure, unit-tested for delayed and
+  out-of-order responses). **The session** (`Composer`, local `useState`:
   `slots: TemplateSlot[] | null` + `slotIdx`, no store/transport): `Tab`/`Shift+Tab` step to the
   next/previous slot (wrap; `preventDefault`; a no-op while the mention/slash menu is open — checked at
   the top of `onKeyDown`, right after the `Ctrl+R` guard and before the menu's own key handling, so a real

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -327,7 +327,17 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   - **Editing an existing template locks its name + scope** (both fields disabled): `template.save` is
     create-or-overwrite keyed by `(scope, name)` with no rename/move primitive, so changing either while
     editing would silently orphan the old file on disk instead of renaming it. Creating new (including
-    save-as-template) leaves both fully editable.
+    save-as-template) leaves both fully editable. **An edit saves under `template.name` verbatim — never
+    trimmed or normalized**: whitespace-bearing names are server-legal *by design* (pi derives a
+    template's name from its filename verbatim, so a hand-created `report .md` lists as `report `;
+    `packages/server/src/templates/templates.ts`'s gate deliberately accepts every pi-listable name), and
+    trimming on save wrote a NEW `report.md` while leaving the file being edited untouched
+    (reviewer-flagged; `templates-manage.spec.ts` pins the round-trip). The Save button's emptiness gate
+    is new-mode-only for the same reason — a whitespace-only hand-created name is a legal edit identity.
+    Only a **new** template's typed name is trimmed before validation/save: deliberate form
+    normalization, so an accidental trailing space can't mint a file that renders identically to its
+    trimmed twin in every listing (the composer's `/` menu can *use* such hand-created names via click,
+    but a typed `/name` token can't carry a space — the UI shouldn't manufacture second-class names).
   - **Edit-open fetches the full template** via `template.get`, pinned to the row's exact `(scope,
     name)` — `template.list` is metadata-only by design (bounded head scans + a size cap, see
     `packages/server/src/templates/SPEC.md`), so the listing row can't provide the body, and — the part

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -291,7 +291,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   - **`templateText.ts`** is the single shared frontmatter splitter/assembler — `stripFrontmatter`
     (`ChatView.tsx`'s composer-pick path + this dialog's body field), `assembleTemplate` (this dialog's
     save). It does **no YAML value parsing**: the dialog's description/argument-hint fields are populated
-    from the server-parsed `TemplateInfo` (pi's real YAML parser — full scalar-style fidelity, pinned in
+    from the server-parsed `template.get` response (`Template` — pi's real YAML parser over the **full
+    file**, full scalar-style fidelity, pinned in
     `packages/server/src/templates/templates.test.ts`), never from a browser-side reimplementation (an
     earlier `splitTemplate` here handled only bare/double-quoted scalars, so a pi-native
     `description: 'single-quoted'` loaded into the form with literal quotes and saved back corrupted).
@@ -327,6 +328,19 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
     create-or-overwrite keyed by `(scope, name)` with no rename/move primitive, so changing either while
     editing would silently orphan the old file on disk instead of renaming it. Creating new (including
     save-as-template) leaves both fully editable.
+  - **Edit-open fetches the full template** via `template.get`, pinned to the row's exact `(scope,
+    name)` — `template.list` is metadata-only by design (bounded head scans + a size cap, see
+    `packages/server/src/templates/SPEC.md`), so the listing row can't provide the body, and — the part
+    that bit — can't be trusted for metadata either: a file whose frontmatter closing fence sits past the
+    listing's scan window *legitimately* lists with **no** description/argument-hint. The `get` response
+    is therefore **authoritative for every field**: body via `stripFrontmatter(content)`, and
+    description/argument-hint from its full-file parse, replacing the listing-row values that only *seed*
+    the form for instant paint. (Reviewer-flagged data loss otherwise: seeding from the degraded row and
+    writing those fields back on Save meant a body-only edit silently deleted the file's real
+    description — `templates-manage.spec.ts` pins the round-trip.) Until the fetch resolves, the
+    description/argument-hint/body inputs are disabled and Save is gated (`loading`) — an early save
+    would overwrite the file with the degraded seed; a failed fetch keeps Save gated for the same reason
+    (error shown inline, retry by reopening).
   - **Save** calls `template.save` then the store's `bumpTemplatesVersion()`; a rejected save renders its
     message inline via `data-testid="template-error"` (never a toast — the dialog stays open so the error
     is fixable in place). **Delete has no dialog involvement at all** — `panels/TemplatesSettings.tsx`'s

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -235,20 +235,27 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   next/previous slot (wrap; `preventDefault`; a no-op while the mention/slash menu is open — checked at
   the top of `onKeyDown`, right after the `Ctrl+R` guard and before the menu's own key handling, so a real
   Tab-to-pick-a-menu-item is unaffected, and symmetrically an `Escape` while the menu is also open lets the
-  menu's own dismiss win first). Stepping **out** of a *filled* slot (real content, not an untouched
-  marker) splices its current text into every other slot sharing its `group` whose text differs (group
+  menu's own dismiss win first). Stepping **out** of a *user-edited* slot (one whose text the
+  user actually changed — not an untouched marker, and crucially not an untouched `${N:-default}` either)
+  splices its current text into every other slot sharing its `group` whose text differs (group
   mirroring — repeated `$N`/`${...}` occurrences propagate on slot exit, not per keystroke), each splice
-  re-tracked via `shiftSlots` (`mirrorSlotGroup` in `slotSession.ts`). `Escape` ends the session
+  re-tracked via `shiftSlots` (`mirrorSlotGroup` in `slotSession.ts`). A slot carries two independent
+  bits: **`filled`** (a parse-time property — has real content: a `${N:-default}`'s default, or a marker
+  typed into — drives strip-on-send + the tint) and **`edited`** (session runtime state — the user
+  changed it — the sole mirror-*source* gate). They are deliberately distinct: `${1:-foo} … ${1:-bar}` is
+  born `filled` but not `edited`, so its two differing per-occurrence defaults stay independent until the
+  user provides the argument by editing one — matching pi's own expansion, which never rewrites
+  "foo … bar" to "foo … foo". `Escape` ends the session
   (`setSlots(null)`), leaving the text as-is. A genuine text edit (the textarea's own `onChange` — never a
   programmatic `onChange(text)` call; those end the session outright instead, since none of
   `pickMention`/`pickSlash`/arrow-recall/`insertText` participate in slot tracking) diffs the old/new value
   around the post-edit `selectionStart` (a common-prefix/suffix scan) into `(editStart, removedLen,
   insertedLen)`, re-tracks every slot via `shiftSlots`, and flags the slot the edit landed in
-  `filled: true`; an edit that consumes the **entire** prior value (a select-all-and-type/delete) ends the
-  session instead of re-tracking a now-meaningless collapsed range set. On send, `submit()` runs the same
-  group-mirroring pass over **every already-filled slot**, not just the one most recently Tab-exited
-  (`mirrorAllGroups` — a direct Send never has to go through Tab first for its mirroring to take effect),
-  propagating each into its unfilled same-group siblings; only **then** does it strip whatever markers are
+  `filled: true` **and** `edited: true`; an edit that consumes the **entire** prior value (a
+  select-all-and-type/delete) ends the session instead of re-tracking a now-meaningless collapsed range
+  set. On send, `submit()` runs the same group-mirroring pass over **every user-edited slot**, not just
+  the one most recently Tab-exited (`mirrorAllGroups` — a direct Send never has to go through Tab first for
+  its mirroring to take effect), propagating each into its same-group siblings; only **then** does it strip whatever markers are
   still untouched (`stripUntouchedSlots`), and always clears the session — sent **or** queued
   (steer/followUp), same rule. Switching tabs needs no
   explicit cleanup: `panels/CenterTabs.tsx` mounts only the active tab's component, so leaving a chat tab

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -115,11 +115,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   eye to it. Either resolving a row or giving up (toasted as "couldn't locate the message") always clears
   the request — `ChatView` is its only consumer, so an unresolved request must never linger.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
-  commands, image paste/drop, `Ctrl+R` → `onHistoryOpen`) plus its props-driven **slash-completion
+  commands + template **slot sessions** (Tab-through placeholders — see the Template slots bullet
+  below), image paste/drop, `Ctrl+R` → `onHistoryOpen`) plus its props-driven **slash-completion
   primitive** (filter/menu/caret + Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so
   the two inputs cannot drift; `HistoryOverlay` (the history-recall/search overlay `Composer` opens —
-  presentational, driven entirely by `useHistorySearch.ts`'s state + callbacks, plus a **zoomed-stage
-  preview pane** + **scope picker** — see the next bullet),
+  presentational, driven entirely by `useHistorySearch.ts`'s state + callbacks, plus a **Save as
+  template** action on the selected prompt row — see the Save-as-template bullet below, and a
+  **zoomed-stage preview pane** + **scope picker** — see the next bullet),
   `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip; its **Skills** button is the presentational **`SkillsButton`**
@@ -136,9 +138,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 - **History overlay: zoomed preview pane + scope picker** (`HistoryOverlay.tsx`) — `Tab` grows the
   compact single-column overlay into a **two-pane** `zoomed` layout: the existing Prompts/Messages
   sections list stays on the left (~55% width, `data-testid="history-results"` — keyboard nav,
-  `scrollIntoView`, and counts are all unchanged), and a preview of the
+  `scrollIntoView`, counts, and the save-as-template action are all unchanged), and a preview of the
   flat-list **keyboard-selected** item renders on the right (~45%, `data-testid="history-preview"`,
-  resolved via the same `resolveHistorySelection` that `Enter` already uses — the preview and
+  resolved via the same `resolveHistorySelection` that `Enter`/Cmd/Ctrl+S already use — the preview and
   the keyboard actions can never disagree on "the selected item"). The `compact` stage is untouched: no
   preview pane exists in the DOM at all until `Tab` (not merely hidden), so `history-preview`'s bare
   presence doubles as the zoomed/compact signal. **Preview body:** the hit's full `text` — never the
@@ -167,22 +169,172 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   descendant of the input — so a keydown while the menu holds focus cannot reach the input's handler by
   construction, not by a case-by-case guard.
 - **History overlay: assistant-only messages + jumpable prompts** (`HistoryOverlay.tsx`,
-  `useHistorySearch.ts`) — `MESSAGES` only ever contains assistant-role hits (the server
+  `useHistorySearch.ts` — R3) — `MESSAGES` now only ever contains assistant-role hits (the server
   filters; see `packages/server/src/history/SPEC.md`): a user-role hit is always a textual duplicate of
   its own `PromptHit` entry, so the location it used to add moved onto the prompt row instead. Every
-  prompt row renders a go-to-chat icon (`data-testid="history-jump"`, `aria-label="Go to chat"`,
-  `title="⇧⏎ go to chat"`) **when jumpable** — `workspaceId` present and `messageIndex != null` (absent
-  for an unmapped-cwd hit, or a host that never populated the prompt's anchor fields). Clicking it, or
-  **`Shift+Enter`** while a prompt row is the keyboard selection, routes through the exact same
-  `onOpenMessage` path a message hit's `Enter`/click already used — both go through the shared
-  **`jumpTarget(hit)`** helper (`useHistorySearch.ts`, exported pure), which resolves either hit shape to
-  a `ChatLocationRequest` or `null`, so the icon's render gate, the `Shift+Enter` handler, and the
-  message-hit gate can never disagree on "is this jumpable." An unmapped/legacy prompt row shows no icon
-  and `Shift+Enter` is a no-op (overlay stays open) — the same belt-and-suspenders gating the message-hit
-  path already had. The icon itself stays hover-revealed (`group-hover`/`isSelected` opacity), but its
-  shortcut glyph (`data-testid="history-jump-shortcut"`, literal `⇧⏎`) is a **selected-only**, not
-  hover-only, persistent `<span>` — the same precedent as the scope badge's `⌃R` (always next to its
-  label) — since a keyboard-only user, `Shift+Enter`'s own audience, never triggers `:hover`.
+  prompt row now renders a go-to-chat icon (`data-testid="history-jump"`, `aria-label="Go to chat"`,
+  `title="⇧⏎ go to chat"`, next to the existing save-as-template icon) **when jumpable** —
+  `workspaceId` present and `messageIndex != null` (absent for an unmapped-cwd hit, or a host that
+  doesn't populate the prompt's anchor fields). Clicking it, or **`Shift+Enter`** while a prompt row
+  is the keyboard selection, routes through the exact same `onOpenMessage` path a message hit's
+  `Enter`/click already used — both now go through the shared **`jumpTarget(hit)`** helper
+  (`useHistorySearch.ts`, exported pure), which resolves either hit shape to a `ChatLocationRequest` or
+  `null`, so the icon's render gate, the `Shift+Enter` handler, and the message-hit gate can never
+  disagree on "is this jumpable." An unmapped/legacy prompt row shows no icon and `Shift+Enter` is a
+  no-op (overlay stays open) — the same belt-and-suspenders gating the message-hit path already had.
+  The icon itself stays hover-revealed (`group-hover`/`isSelected` opacity, like the save-as-template
+  icon beside it), but its shortcut glyph (`data-testid="history-jump-shortcut"`, literal `⇧⏎`) is a
+  **selected-only**, not hover-only, persistent `<span>` — the same precedent as the scope badge's `⌃R`
+  (always next to its label) — since a keyboard-only user, `Shift+Enter`'s own audience, never triggers
+  `:hover`. The save-as-template icon's own shortcut (`SAVE_SHORTCUT_LABEL`, `⌘S`/`Ctrl+S`) gets the
+  identical selected-only glyph (`data-testid="history-save-shortcut"`) for the same reason, symmetric
+  with the jump icon.
+- **Template slots** (`slotSession.ts`'s parser + `Composer`'s session state + `ChatView`'s menu/pick
+  wiring — the composer's Tab-through placeholder flow, end to end). **Parsing** (`slotSession.ts`, pure,
+  zero deps): `parseTemplateSlots(body, argumentHint)` expands pi's own placeholder grammar (`$1..$n`,
+  `$@`/`$ARGUMENTS`, `${N:-default}`, `${@:N}`, `${@:N:L}` — pi's grammar, single owner; see
+  `packages/server/src/templates/`) into visible text plus `TemplateSlot` ranges;
+  `stripUntouchedSlots`/`shiftSlots` round out the session (strip-on-send, re-track-on-edit) — **parse
+  only**, this module never evaluates the grammar (a typed-through `/name args` prompt already expands via
+  pi's own `PromptOptions.expandPromptTemplates`, with or without this parser). **Observed** (the design's
+  "to verify" #3, resolved by `e2e/templates.live.spec.ts`'s typed-through test): pi's own transcript
+  records the ALREADY-EXPANDED body for a typed-through send, never the raw `/name args` —
+  `AgentSession.prompt()` substitutes args into `expandedText` before persisting the `role: "user"`
+  message, so a `session.getMessages` re-fetch (a reload, or reopening from history) shows the expanded
+  text. The one nuance: the web client's own immediate bubble is an **optimistic echo**
+  (`ChatView.onSubmit` → `appendUserMessage`, store-only, appended *before* the transport call resolves) —
+  it shows exactly what was typed (the raw command) until a re-fetch replaces it with pi's real persisted
+  record. **The `/` menu merge**
+  (`ChatView`): pi's `commands` snapshot (`session.getCommands`, frozen at session-create time) minus its
+  `source === "prompt"` entries, plus a fresh `template.list { workspaceId }` fetch mapped to
+  `SlashCommandInfo` rows (`source: "prompt"`, `sourceInfo` synthesized to match pi's own prompt-template
+  convention exactly: `{ path: filePath, source: "local", scope: scope === "global" ? "user" : "project",
+  origin: "top-level" }`) — one merged list, `Composer`'s rendering is unchanged. The fetch runs when the
+  slash menu opens (**`onSlashActive`**, a boolean prop mirroring `onMentionQuery`'s query signal), cached
+  per workspace (one `ChatView` instance never changes workspace) and invalidated by the store's
+  **`templatesVersion`** counter (see `store/SPEC.md`; bumped by `panels/TemplatesSettings.tsx` and
+  `TemplateEditorDialog.tsx` after a `template.save`/`delete` — see the Save-as-template bullet below) —
+  this is what makes `packages/server/src/agent/SPEC.md`'s "the
+  composer's `/` menu path is always fresh via `template.list`" claim true, unlike the typed-through
+  `/name args` path's frozen create-time snapshot. **Picking a template** (`ChatView`'s `onPickTemplate`, a
+  `Composer` prop): instead of `pickSlash`'s plain `/name ` insert, fetches `template.get`, splits
+  frontmatter client-side (`templateText.ts`'s shared `stripFrontmatter` — pi's own frontmatter parser is
+  server-only, never reaches the browser bundle, but the boundary rule is pinned to match it exactly; see
+  the Save-as-template bullet below), runs `parseTemplateSlots(body, argumentHint)`, and hands
+  the result to `Composer` via a new **`ComposerHandle.insertTemplate`** method (alongside the existing
+  `insertText`) — replaces the whole draft (like `pickSlash`, not `pickMention`: a slash command occupies
+  the entire input) and, if the parse produced any slots, starts a **slot session** selecting slot 0; no
+  slots → a plain insert, caret at the end, no session. **The session** (`Composer`, local `useState`:
+  `slots: TemplateSlot[] | null` + `slotIdx`, no store/transport): `Tab`/`Shift+Tab` step to the
+  next/previous slot (wrap; `preventDefault`; a no-op while the mention/slash menu is open — checked at
+  the top of `onKeyDown`, right after the `Ctrl+R` guard and before the menu's own key handling, so a real
+  Tab-to-pick-a-menu-item is unaffected, and symmetrically an `Escape` while the menu is also open lets the
+  menu's own dismiss win first). Stepping **out** of a *filled* slot (real content, not an untouched
+  marker) splices its current text into every other slot sharing its `group` whose text differs (group
+  mirroring — repeated `$N`/`${...}` occurrences propagate on slot exit, not per keystroke), each splice
+  re-tracked via `shiftSlots` (`mirrorSlotGroup` in `slotSession.ts`). `Escape` ends the session
+  (`setSlots(null)`), leaving the text as-is. A genuine text edit (the textarea's own `onChange` — never a
+  programmatic `onChange(text)` call; those end the session outright instead, since none of
+  `pickMention`/`pickSlash`/arrow-recall/`insertText` participate in slot tracking) diffs the old/new value
+  around the post-edit `selectionStart` (a common-prefix/suffix scan) into `(editStart, removedLen,
+  insertedLen)`, re-tracks every slot via `shiftSlots`, and flags the slot the edit landed in
+  `filled: true`; an edit that consumes the **entire** prior value (a select-all-and-type/delete) ends the
+  session instead of re-tracking a now-meaningless collapsed range set. On send, `submit()` runs the same
+  group-mirroring pass over **every already-filled slot**, not just the one most recently Tab-exited
+  (`mirrorAllGroups` — a direct Send never has to go through Tab first for its mirroring to take effect),
+  propagating each into its unfilled same-group siblings; only **then** does it strip whatever markers are
+  still untouched (`stripUntouchedSlots`), and always clears the session — sent **or** queued
+  (steer/followUp), same rule. Switching tabs needs no
+  explicit cleanup: `panels/CenterTabs.tsx` mounts only the active tab's component, so leaving a chat tab
+  unmounts `Composer` (and its session) while the store's `draft` text itself persists. **Hint chip**:
+  while a session is active (and the menu is not, so the two absolutely-positioned overlays never share
+  the same anchor rect), a small pill above the textarea — `slot {slotIdx+1}/{n} · ⇥ next · esc done`
+  (`data-testid="slot-hint"`) — clickable, tap steps to the next slot (same mirroring rule as `Tab`), the
+  mobile path with no keyboard needed. **Highlight backdrop**: while a session is active, the composer's
+  gaps are visually tinted in the message field itself — a native `<textarea>` can't style text ranges
+  inside it, so `Composer` renders a **highlight-backdrop** (a styled mirror layer positioned behind a
+  now-`bg-transparent` textarea; the input background moves up to the wrapping container instead, clipped
+  to the same `rounded-[var(--radius-md)]` so nothing changes visually outside a session). The pure
+  `highlightSegments(value, slots, activeIdx)` (`slotSession.ts`) breaks `value` into ordered
+  plain/unfilled/filled/active runs — a slot range is `"active"` when its `slots` index is `activeIdx`
+  (`Composer`'s own `slotIdx`), else `"unfilled"`/`"filled"` per its own `filled` flag; everything else is
+  `"plain"` — pure offsets/slices, no empty segment for zero-gap-adjacent slots, and the tests pin
+  `segments.map(s => s.text).join("") === value` in every case. The backdrop's inner mirror div matches the
+  textarea's box model **exactly** (`px-md py-sm`, `text-sm`, a `border border-transparent` of the same
+  width so the content box lines up, `whitespace-pre-wrap break-words` — spelled out explicitly since a
+  `<div>`, unlike a `<textarea>`, doesn't soft-wrap this way by default) so each `SlotSegment`'s tint span
+  (`data-testid="slot-highlight"` + `data-slot-state`, `rounded-[2px]` `bg-[var(--primary-20/40/10)]` for
+  unfilled/active/filled, no tint for plain, every span `text-transparent` so only the real textarea text
+  above shows through) lands exactly under its own characters. **Scroll sync**: the textarea's `onScroll`
+  tracks `{ scrollLeft, scrollTop }` in state, applied to the backdrop's inner div as
+  `translate(-scrollLeft, -scrollTop)` — the **one** inline `style` in the whole module (chat/SPEC.md's
+  Get-right styling rule is otherwise token-utilities-only), since a computed live pixel offset has no
+  token; the backdrop's outer layer is `overflow-hidden` so the translated content never spills past it.
+- **Save-as-template + template management** (`TemplateEditorDialog.tsx`; `HistoryOverlay`'s save action;
+  `panels/TemplatesSettings.tsx`) — one shared create/edit surface for prompt-template files, reused by two
+  entry points that never talk to each other: the Settings → Templates panel (list + New/Edit/Delete, see
+  `panels/SPEC.md`) and the history overlay's save-as-template action below. **Why this lives in `chat/`,
+  not `panels/`** (a deliberate boundary exception, alongside `ChatView.tsx`/`useHistorySearch.ts` above):
+  `panels/` is allowed to import from `chat/` (already does, for `ModelSelector`/`ThinkingSelector`/
+  `Markdown`) but never the reverse, and `HistoryOverlay` — which needs this same dialog — lives in
+  `chat/`, so the one shared implementation has to live where both sides can reach it. `TemplateEditorDialog`
+  is therefore promoted to a **third** sanctioned store/transport-touching integration piece (see Boundary
+  below), even though it isn't `ChatView` itself.
+  - **`templateText.ts`** is the single shared frontmatter splitter/assembler — `stripFrontmatter`
+    (`ChatView.tsx`'s composer-pick path), `splitTemplate`/`assembleTemplate` (this dialog). Its boundary
+    rule is ported byte-for-byte from pi's own `extractFrontmatter` (`@earendil-works/pi-coding-agent`'s
+    `dist/utils/frontmatter.js`, pinned against pi v0.80.6 — the same pin `packages/server/src/templates/
+    SPEC.md` uses server-side; re-verify both on a pi version bump): the frontmatter block ends at the
+    FIRST later `\n---` line, and the body is everything after that fence run through `.trim()` — not a
+    single optional `\n`. A prior version had two independently hand-rolled regex splitters (one per
+    file), each consuming only one *optional* `\n` after the closing fence instead of trimming — a
+    leading blank line leaked into the body on every pick and every edit-reopen, and **compounded** by one
+    more `\n` per edit-save cycle (the leaked line got saved back into the body field and re-wrapped the
+    next save). `templateText.test.ts` pins the round-trip/stability properties this fix depends on.
+  - **Fields**: name (validated client-side against the exact same rule as the server's
+    `isValidTemplateName`, `packages/server/src/templates/templates.ts` — duplicated rather than shared,
+    since it's a 4-line pure predicate and the server module is server-only), a scope radio (Global / This
+    project; "This project" is disabled with no active workspace), description, argument-hint, and a body
+    `Textarea` with a static one-line syntax hint (`$1, $ARGUMENTS, ${1:-default} — pi prompt-template
+    syntax`; the real grammar is parsed by `slotSession.ts` / expanded by pi — this line is documentation
+    text only, not itself parsed).
+  - **Assembly**: `---\ndescription: …\nargument-hint: …\n---\n\n<body>`, omitting either key when its
+    field is empty, and **no frontmatter block at all** when both are empty **and the body doesn't start
+    with `---`** — a body that does gets an explicit (possibly empty, `---\n---\n\n`) block forced anyway:
+    saved bare, pi's own loader (and our splitter) would go hunting for a *later* `\n---` line inside that
+    body to treat as a closing fence, silently swallowing real content as YAML the moment the body
+    contains one; forcing the wrapper makes our own fence the earliest possible match unconditionally, so
+    the body's own `---`-looking lines are never reinterpreted (see `templateText.test.ts`'s
+    ambiguous-body case). Each value is emitted `JSON.stringify`-quoted rather than bare — YAML's
+    double-quoted scalar escape set is a superset of JSON's, so this is always valid YAML without pulling
+    in a `yaml` package just to serialize two short strings (see the seed fixture's own `argument-hint:
+    "[file] [scope]"`, quoted for the same reason: an unquoted value isn't always valid YAML).
+  - **Editing an existing template locks its name + scope** (both fields disabled): `template.save` is
+    create-or-overwrite keyed by `(scope, name)` with no rename/move primitive, so changing either while
+    editing would silently orphan the old file on disk instead of renaming it. Creating new (including
+    save-as-template) leaves both fully editable.
+  - **Save** calls `template.save` then the store's `bumpTemplatesVersion()`; a rejected save renders its
+    message inline via `data-testid="template-error"` (never a toast — the dialog stays open so the error
+    is fixable in place). **Delete has no dialog involvement at all** — `panels/TemplatesSettings.tsx`'s
+    row calls `template.delete` + `bumpTemplatesVersion()` directly, behind a `ConfirmPopover` (the same
+    confirm-before-destructive-action pattern `ProjectTree.tsx`'s workspace-remove row uses). A **rejected
+    delete** is the one deliberate asymmetry with Save: it surfaces as an error toast, not inline (there's
+    no dialog to render inline into), leaving the row in place — the same pattern `panels/SPEC.md`
+    documents for `ProjectTree`'s own workspace-remove row.
+  - **Save-as-template** (`HistoryOverlay`'s selected-prompt-row action, `data-testid="history-save-template"`,
+    keyboard **Cmd/Ctrl+S** while a prompt row is selected — the overlay's `onKeyDown` always
+    `preventDefault`s the combo, so the browser's own Save dialog never opens regardless of what's
+    selected, but only fires the action when the resolved selection is a prompt hit) opens the dialog with
+    the body prefilled from that prompt's text — a "new template" case (no existing name/scope identity),
+    same as clicking New. **The composer-overflow entry point was dropped as YAGNI** (the plan's own word)
+    — the history path already covers "reuse what I already wrote"; a second entry point for the same
+    "type it, then decide to save it" gesture would be redundant surface, not a distinct use case.
+  - **Edit-as-file** — project-scoped rows only get an `Open as file` action (`panels/TemplatesSettings.tsx`),
+    reusing `openFile.ts`'s exact `openFileInTab(workspaceId, ".pi/prompts/<name>.md")` (the same action
+    file-tree clicks use), then `store.closeSettings()`. **Global rows are dialog-only** — a deliberate
+    asymmetry, not an oversight: file tabs are worktree-scoped (`tabsByWorkspace` is keyed by workspace
+    id), but a global template lives under the host's agent dir, outside any worktree, so there's no
+    worktree-relative path to open it at.
 - **Plain `↑` recall + history button** — `Composer`'s `recentPrompts` prop (`ChatView`: this chat's own
   user-turn texts via `turnAnchorText`, newest first, deduped **keeping the newest occurrence** — the same
   recency-first ranking rule as the server history index, the atuin/fzf convention) backs a lightweight
@@ -220,16 +372,17 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   **No `index.ts` barrel** — chat pulls **shiki**, so per the code-splitting exception imports stay
   **per-file**; the registry is importable from `chat/toolRegistry` **without** pulling shiki.
 - **Allowed deps:** `contracts` (pi message/content-block types, **type-only**); `store` + `transport`
-  (**`ChatView` + its integration hook `useHistorySearch.ts` only** — the
+  (**`ChatView` + its integration hooks (`useHistorySearch.ts`) + `TemplateEditorDialog.tsx` only** — the
   app-integration edge); `react-markdown` / `remark-gfm` / `shiki` (via `lib/highlighter`); `mermaid`
   (**lazy, `tools/visualize` only**); `react-virtuoso`; `lucide-react`; `components/ui`; `lib`.
 - **Forbidden:** value-importing any `pi` package; a **presentational** renderer importing
-  `store`/`transport` (only `ChatView` and its integration hook `useHistorySearch.ts` may — keep the
+  `store`/`transport` (only `ChatView`, its integration hooks, and `TemplateEditorDialog` may — keep the
   renderers reusable).
 - **`ChatView`** is the primary app-integration file: wires this session's runtime
   (`store.sessions[sessionId]`), the transport calls, the `ChatActions` + `AskStates` contexts, and the
   divider's "files changed" → `requestChangesView` deep link — together with **`useHistorySearch.ts`**
-  (the Ctrl+R history-recall overlay's store/transport edge), the other integration point. A
+  (the Ctrl+R history-recall overlay's store/transport edge) and **`TemplateEditorDialog.tsx`** (the
+  shared template save form), the other two integration points. A
   **rejected** send (`prompt`/`steer`/`followUp`) lands in the chat via the store's `appendErrorTurn` —
   never swallowed; *streaming* faults arrive as pi events instead.
 

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -272,10 +272,12 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   (`data-testid="slot-highlight"` + `data-slot-state`, `rounded-[2px]` `bg-[var(--primary-20/40/10)]` for
   unfilled/active/filled, no tint for plain, every span `text-transparent` so only the real textarea text
   above shows through) lands exactly under its own characters. **Scroll sync**: the textarea's `onScroll`
-  tracks `{ scrollLeft, scrollTop }` in state, applied to the backdrop's inner div as
-  `translate(-scrollLeft, -scrollTop)` — the **one** inline `style` in the whole module (chat/SPEC.md's
-  Get-right styling rule is otherwise token-utilities-only), since a computed live pixel offset has no
-  token; the backdrop's outer layer is `overflow-hidden` so the translated content never spills past it.
+  copies its `scrollLeft`/`scrollTop` onto the backdrop's outer `overflow-hidden` layer **imperatively**
+  (a ref — no state, no inline `style`: a programmatic scroll offset needs no styling at all, so the
+  repo's token-utilities-only invariant holds with zero exceptions; an earlier version tracked the
+  offsets in state and applied a `translate(...)` inline style, which both violated the invariant and
+  re-rendered the composer on every scrolled frame). The backdrop's **ref callback** seeds the offsets at
+  mount, so a session starting in an already-scrolled composer never paints even one frame misaligned.
 - **Save-as-template + template management** (`TemplateEditorDialog.tsx`; `HistoryOverlay`'s save action;
   `panels/TemplatesSettings.tsx`) — one shared create/edit surface for prompt-template files, reused by two
   entry points that never talk to each other: the Settings → Templates panel (list + New/Edit/Delete, see

--- a/apps/web/src/chat/TemplateEditorDialog.tsx
+++ b/apps/web/src/chat/TemplateEditorDialog.tsx
@@ -1,0 +1,285 @@
+import type { TemplateInfo, TemplateScope } from "@thinkrail/contracts";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib";
+import { useAppStore } from "@/store";
+import { errorText, getTransport } from "@/transport";
+import { assembleTemplate, splitTemplate } from "./templateText";
+
+/** Documentation only (not itself parsed) — the real grammar is `slotSession.ts`'s parser / pi's own
+ * expansion. Kept as a constant (not inline JSX text) since `${1:-default}` would otherwise be misread
+ * as an embedded JS expression by JSX. */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi syntax being documented, not a template placeholder
+const SYNTAX_HINT = "$1, $ARGUMENTS, ${1:-default} — pi prompt-template syntax";
+
+const INPUT_CLASS =
+	"w-full rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-md py-sm text-sm text-text outline-none transition-colors placeholder:text-hint focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-[var(--primary-20)] disabled:opacity-50";
+
+/**
+ * Mirrors the server's `isValidTemplateName` (`packages/server/src/templates/templates.ts`) exactly — a
+ * path-traversal safety gate, not a naming-style rule. Duplicated rather than imported: that module is
+ * server-only and never reaches the browser bundle (the same reasoning `HistoryOverlay.tsx`'s duplicated
+ * `relativeTime` comment documents for a different helper).
+ */
+function isValidTemplateName(name: string): boolean {
+	if (name.length === 0) return false;
+	if (name.startsWith(".")) return false;
+	return !name.includes("/") && !name.includes("\\") && !name.includes("\0");
+}
+
+/**
+ * The shared create/edit surface for prompt-template files — reused by `panels/TemplatesSettings.tsx`
+ * (New/Edit) and `HistoryOverlay`'s save-as-template action. Lives in `chat/` (a sanctioned boundary
+ * exception, alongside `ChatView.tsx`/`useHistorySearch.ts`): `panels/` may import `chat/`, never the
+ * reverse, and `HistoryOverlay` — which needs this same dialog — lives in `chat/`. See the module SPEC's
+ * Save-as-template bullet for the full design writeup.
+ *
+ * Editing an existing template (`template` set) locks name + scope: `template.save` is create-or-overwrite
+ * keyed by `(scope, name)` with no rename/move primitive, so changing either while editing would silently
+ * orphan the old file instead of renaming it. Creating new (including save-as-template, via `initialBody`)
+ * leaves both fully editable.
+ */
+export function TemplateEditorDialog({
+	open,
+	onOpenChange,
+	workspaceId,
+	template,
+	initialScope = "global",
+	initialBody = "",
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** The active workspace, if any — gates whether "This project" is selectable at all. */
+	workspaceId: string | undefined;
+	/** Editing an existing template locks its name + scope. Omit (or `null`) for a brand-new template. */
+	template?: TemplateInfo | null;
+	/** New-template only: which scope starts selected (still fully editable). */
+	initialScope?: TemplateScope;
+	/** New-template only: prefills the body — the save-as-template case. */
+	initialBody?: string;
+}) {
+	const [name, setName] = useState("");
+	const [scope, setScope] = useState<TemplateScope>("global");
+	const [description, setDescription] = useState("");
+	const [argumentHint, setArgumentHint] = useState("");
+	const [body, setBody] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const [saving, setSaving] = useState(false);
+
+	const editing = template != null;
+
+	// Reset the form on every open — seeded from the template being edited, or the New/save-as-template
+	// prefill. Depending on `template`/`initialScope`/`initialBody` (not just `open`) means a *second* New
+	// or Edit while the dialog stays mounted also reseeds correctly, not just the open transition.
+	useEffect(() => {
+		if (!open) return;
+		setError(null);
+		setSaving(false);
+		if (template) {
+			const parsed = splitTemplate(template.content);
+			setName(template.name);
+			setScope(template.scope);
+			setDescription(parsed.description);
+			setArgumentHint(parsed.argumentHint);
+			setBody(parsed.body);
+		} else {
+			setName("");
+			setScope(initialScope);
+			setDescription("");
+			setArgumentHint("");
+			setBody(initialBody);
+		}
+	}, [open, template, initialScope, initialBody]);
+
+	const save = async () => {
+		if (saving) return;
+		const trimmedName = name.trim();
+		if (!isValidTemplateName(trimmedName)) {
+			setError('Name can\'t be empty, start with ".", or contain "/", "\\", or a null byte.');
+			return;
+		}
+		if (scope === "project" && !workspaceId) {
+			setError("Open a workspace first — a project-scoped template needs one.");
+			return;
+		}
+		setSaving(true);
+		setError(null);
+		try {
+			await getTransport().request("template.save", {
+				...(workspaceId ? { workspaceId } : {}),
+				scope,
+				name: trimmedName,
+				content: assembleTemplate(description, argumentHint, body),
+			});
+			useAppStore.getState().bumpTemplatesVersion();
+			onOpenChange(false);
+		} catch (err) {
+			setError(errorText(err));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-testid="template-editor-dialog" className="max-w-[36rem] gap-md">
+				<DialogHeader>
+					<DialogTitle>{editing ? `Edit ${template.name}` : "New template"}</DialogTitle>
+				</DialogHeader>
+
+				<div className="flex max-h-[60vh] flex-col gap-md overflow-y-auto">
+					<Field label="Name">
+						<input
+							data-testid="template-name-input"
+							value={name}
+							disabled={editing}
+							onChange={(e) => setName(e.target.value)}
+							placeholder="standup"
+							spellCheck={false}
+							className={INPUT_CLASS}
+						/>
+					</Field>
+
+					<div className="flex flex-col gap-xs">
+						<span className="font-medium text-sm text-text">Scope</span>
+						<div className="flex gap-sm">
+							<ScopeOption
+								id="global"
+								label="Global"
+								active={scope === "global"}
+								disabled={editing}
+								onSelect={() => setScope("global")}
+							/>
+							<ScopeOption
+								id="project"
+								label="This project"
+								active={scope === "project"}
+								disabled={editing || !workspaceId}
+								onSelect={() => setScope("project")}
+							/>
+						</div>
+						{!workspaceId && !editing ? (
+							<p className="text-hint text-xs">
+								Open a workspace to save a project-scoped template.
+							</p>
+						) : null}
+					</div>
+
+					<Field label="Description">
+						<input
+							data-testid="template-description-input"
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							placeholder="What this template is for"
+							spellCheck={false}
+							className={INPUT_CLASS}
+						/>
+					</Field>
+
+					<Field label="Argument hint">
+						<input
+							data-testid="template-argument-hint-input"
+							value={argumentHint}
+							onChange={(e) => setArgumentHint(e.target.value)}
+							placeholder="[file] [scope]"
+							spellCheck={false}
+							className={INPUT_CLASS}
+						/>
+					</Field>
+
+					<Field label="Body">
+						<Textarea
+							data-testid="template-body-input"
+							value={body}
+							onChange={(e) => setBody(e.target.value)}
+							placeholder="Prompt body…"
+							spellCheck={false}
+							rows={8}
+						/>
+						<p className="text-hint text-xs">{SYNTAX_HINT}</p>
+					</Field>
+
+					{error ? (
+						<p data-testid="template-error" className="text-red text-xs">
+							{error}
+						</p>
+					) : null}
+				</div>
+
+				<DialogFooter>
+					<Button
+						data-testid="template-cancel"
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<Button
+						data-testid="template-save"
+						disabled={saving || !name.trim()}
+						onClick={() => void save()}
+					>
+						Save
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+/** A labelled form field — a plain `<label>` wrapping its control needs no `htmlFor`/`id` pairing (the
+ * control always renders as `children`; biome's static check can't see through that indirection). */
+function Field({ label, children }: { label: string; children: ReactNode }) {
+	return (
+		// biome-ignore lint/a11y/noLabelWithoutControl: the control is `children`, always an input/textarea
+		<label className="flex flex-col gap-xs text-sm">
+			<span className="font-medium text-text">{label}</span>
+			{children}
+		</label>
+	);
+}
+
+/** One option in the scope toggle — `aria-pressed`, matching `AppearanceSettings`'s theme-option button
+ * pattern exactly (not a native `<input type="radio">` — no such primitive exists in `components/ui`, and
+ * this keeps the same token-styled toggle look as every other exclusive-choice control in the app). */
+function ScopeOption({
+	id,
+	label,
+	active,
+	disabled,
+	onSelect,
+}: {
+	id: TemplateScope;
+	label: string;
+	active: boolean;
+	disabled: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={active}
+			data-testid={`template-scope-${id}`}
+			data-active={active}
+			disabled={disabled}
+			onClick={onSelect}
+			className={cn(
+				"flex-1 rounded-[var(--radius-md)] border px-md py-sm text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50",
+				active
+					? "border-[var(--primary-40)] bg-[var(--primary-10)] text-text"
+					: "border-border2 text-muted hover:bg-hover hover:text-text",
+			)}
+		>
+			{label}
+		</button>
+	);
+}

--- a/apps/web/src/chat/TemplateEditorDialog.tsx
+++ b/apps/web/src/chat/TemplateEditorDialog.tsx
@@ -13,13 +13,12 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib";
 import { useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
-import { assembleTemplate, splitTemplate } from "./templateText";
+import { assembleTemplate, stripFrontmatter } from "./templateText";
 
 /** Documentation only (not itself parsed) — the real grammar is `slotSession.ts`'s parser / pi's own
  * expansion. Kept as a constant (not inline JSX text) since `${1:-default}` would otherwise be misread
- * as an embedded JS expression by JSX. */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi syntax being documented, not a template placeholder
-const SYNTAX_HINT = "$1, $ARGUMENTS, ${1:-default} — pi prompt-template syntax";
+ * as an embedded JS expression by JSX; the `\${` escape makes the dollar-brace literal. */
+const SYNTAX_HINT = `$1, $ARGUMENTS, \${1:-default} — pi prompt-template syntax`;
 
 const INPUT_CLASS =
 	"w-full rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-md py-sm text-sm text-text outline-none transition-colors placeholder:text-hint focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-[var(--primary-20)] disabled:opacity-50";
@@ -85,12 +84,15 @@ export function TemplateEditorDialog({
 		setError(null);
 		setSaving(false);
 		if (template) {
-			const parsed = splitTemplate(template.content);
 			setName(template.name);
 			setScope(template.scope);
-			setDescription(parsed.description);
-			setArgumentHint(parsed.argumentHint);
-			setBody(parsed.body);
+			// Field values come from the server-parsed `TemplateInfo` — pi's real YAML parser read them, so
+			// every scalar style (single-quoted, folded/block, …) arrives as its VALUE. The client-side
+			// helper is used only to locate the body (a boundary rule, not YAML) — hand-parsing values here
+			// once corrupted a pi-native `description: 'quoted'` into a form value with literal quotes.
+			setDescription(template.description ?? "");
+			setArgumentHint(template.argumentHint ?? "");
+			setBody(stripFrontmatter(template.content));
 		} else {
 			setName("");
 			setScope(initialScope);
@@ -137,8 +139,9 @@ export function TemplateEditorDialog({
 				</DialogHeader>
 
 				<div className="flex max-h-[60vh] flex-col gap-md overflow-y-auto">
-					<Field label="Name">
+					<Field id="template-name" label="Name">
 						<input
+							id="template-name"
 							data-testid="template-name-input"
 							value={name}
 							disabled={editing}
@@ -174,8 +177,9 @@ export function TemplateEditorDialog({
 						) : null}
 					</div>
 
-					<Field label="Description">
+					<Field id="template-description" label="Description">
 						<input
+							id="template-description"
 							data-testid="template-description-input"
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
@@ -185,8 +189,9 @@ export function TemplateEditorDialog({
 						/>
 					</Field>
 
-					<Field label="Argument hint">
+					<Field id="template-argument-hint" label="Argument hint">
 						<input
+							id="template-argument-hint"
 							data-testid="template-argument-hint-input"
 							value={argumentHint}
 							onChange={(e) => setArgumentHint(e.target.value)}
@@ -196,8 +201,9 @@ export function TemplateEditorDialog({
 						/>
 					</Field>
 
-					<Field label="Body">
+					<Field id="template-body" label="Body">
 						<Textarea
+							id="template-body"
 							data-testid="template-body-input"
 							value={body}
 							onChange={(e) => setBody(e.target.value)}
@@ -236,15 +242,17 @@ export function TemplateEditorDialog({
 	);
 }
 
-/** A labelled form field — a plain `<label>` wrapping its control needs no `htmlFor`/`id` pairing (the
- * control always renders as `children`; biome's static check can't see through that indirection). */
-function Field({ label, children }: { label: string; children: ReactNode }) {
+/** A labelled form field — an explicit `htmlFor`/`id` pairing (each caller passes the same `id` to its
+ * control) rather than a label wrapping opaque children: the association stays statically checkable,
+ * and non-control children (the Body field's syntax hint) aren't nested inside a `<label>`. */
+function Field({ id, label, children }: { id: string; label: string; children: ReactNode }) {
 	return (
-		// biome-ignore lint/a11y/noLabelWithoutControl: the control is `children`, always an input/textarea
-		<label className="flex flex-col gap-xs text-sm">
-			<span className="font-medium text-text">{label}</span>
+		<div className="flex flex-col gap-xs text-sm">
+			<label htmlFor={id} className="font-medium text-text">
+				{label}
+			</label>
 			{children}
-		</label>
+		</div>
 	);
 }
 

--- a/apps/web/src/chat/TemplateEditorDialog.tsx
+++ b/apps/web/src/chat/TemplateEditorDialog.tsx
@@ -79,15 +79,21 @@ export function TemplateEditorDialog({
 	// Reset the form on every open — seeded from the template being edited, or the New/save-as-template
 	// prefill. Depending on `template`/`initialScope`/`initialBody` (not just `open`) means a *second* New
 	// or Edit while the dialog stays mounted also reseeds correctly, not just the open transition.
-	// Editing fetches the BODY via `template.get` (`template.list` is metadata-only by design — the wire
-	// never ships every file's full text just to render a listing), pinned to the row's exact `scope` so
-	// editing a global template shadowed by a same-named project one fetches the right file. Until the
-	// body lands, `bodyLoading` gates Save — saving early would silently overwrite the file with an empty
-	// body; a failed fetch keeps Save gated for the same reason (the error is shown, retry by reopening).
-	// The metadata fields still come from the server-parsed listing row — pi's real YAML parser read
-	// them, so every scalar style (single-quoted, folded/block, …) arrives as its VALUE; the client-side
-	// `stripFrontmatter` locates the body only (a boundary rule, not YAML).
-	const [bodyLoading, setBodyLoading] = useState(false);
+	// Editing fetches the FULL template via `template.get`, pinned to the row's exact `scope` so editing
+	// a global template shadowed by a same-named project one fetches the right file. The response is
+	// authoritative for EVERY field, not just the body: `template.list` is metadata-only with a bounded
+	// frontmatter head-scan (`packages/server/src/templates/templates.ts`), so a file whose closing fence
+	// sits past that window legitimately lists with NO description/argument-hint — seeding those fields
+	// from the row and writing them back on Save silently deleted the file's real metadata on a body-only
+	// edit (reviewer-flagged; `templates-manage.spec.ts` pins the round-trip). The listing row still
+	// seeds the form (instant paint, identical in the common case), but the resolve replaces it with the
+	// full-file parse — pi's real YAML parser, so every scalar style (single-quoted, folded/block, …)
+	// arrives as its VALUE; the client-side `stripFrontmatter` locates the body only (a boundary rule,
+	// not YAML). Until the fetch lands, `loading` disables the three content fields and gates Save — an
+	// early save would overwrite the file with the degraded seed and an empty body, and the resolve
+	// must never clobber text the user has started typing; a failed fetch keeps Save gated for the same
+	// reason (the error is shown, retry by reopening).
+	const [loading, setLoading] = useState(false);
 	useEffect(() => {
 		if (!open) return;
 		setError(null);
@@ -98,7 +104,7 @@ export function TemplateEditorDialog({
 			setDescription(template.description ?? "");
 			setArgumentHint(template.argumentHint ?? "");
 			setBody("");
-			setBodyLoading(true);
+			setLoading(true);
 			let cancelled = false;
 			getTransport()
 				.request("template.get", {
@@ -108,8 +114,10 @@ export function TemplateEditorDialog({
 				})
 				.then((t) => {
 					if (cancelled) return;
+					setDescription(t.description ?? "");
+					setArgumentHint(t.argumentHint ?? "");
 					setBody(stripFrontmatter(t.content));
-					setBodyLoading(false);
+					setLoading(false);
 				})
 				.catch((err) => {
 					if (cancelled) return;
@@ -124,7 +132,7 @@ export function TemplateEditorDialog({
 		setDescription("");
 		setArgumentHint("");
 		setBody(initialBody);
-		setBodyLoading(false);
+		setLoading(false);
 	}, [open, template, initialScope, initialBody, workspaceId]);
 
 	const save = async () => {
@@ -206,6 +214,7 @@ export function TemplateEditorDialog({
 						<input
 							id="template-description"
 							data-testid="template-description-input"
+							disabled={loading}
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
 							placeholder="What this template is for"
@@ -218,6 +227,7 @@ export function TemplateEditorDialog({
 						<input
 							id="template-argument-hint"
 							data-testid="template-argument-hint-input"
+							disabled={loading}
 							value={argumentHint}
 							onChange={(e) => setArgumentHint(e.target.value)}
 							placeholder="[file] [scope]"
@@ -230,7 +240,7 @@ export function TemplateEditorDialog({
 						<Textarea
 							id="template-body"
 							data-testid="template-body-input"
-							disabled={bodyLoading}
+							disabled={loading}
 							value={body}
 							onChange={(e) => setBody(e.target.value)}
 							placeholder="Prompt body…"
@@ -257,7 +267,7 @@ export function TemplateEditorDialog({
 					</Button>
 					<Button
 						data-testid="template-save"
-						disabled={saving || bodyLoading || !name.trim()}
+						disabled={saving || loading || !name.trim()}
 						onClick={() => void save()}
 					>
 						Save

--- a/apps/web/src/chat/TemplateEditorDialog.tsx
+++ b/apps/web/src/chat/TemplateEditorDialog.tsx
@@ -137,8 +137,16 @@ export function TemplateEditorDialog({
 
 	const save = async () => {
 		if (saving) return;
-		const trimmedName = name.trim();
-		if (!isValidTemplateName(trimmedName)) {
+		// Identity rule: an EDIT saves under `template.name` VERBATIM — never trimmed or normalized.
+		// Whitespace-bearing names are server-legal by design (pi derives a template's name from its
+		// filename verbatim, so a hand-created `report .md` lists as `report `), and trimming here wrote
+		// a NEW `report.md` while leaving the file being edited untouched (reviewer-flagged;
+		// `templates-manage.spec.ts` pins the round-trip). Only a NEW template's typed name is trimmed —
+		// deliberate form normalization, so an accidental "standup " can't mint a file that renders
+		// identically to "standup" in every listing. The Save button's emptiness gate below is
+		// new-mode-only for the same reason: a whitespace-only hand-created name is a legal edit identity.
+		const finalName = template ? template.name : name.trim();
+		if (!isValidTemplateName(finalName)) {
 			setError('Name can\'t be empty, start with ".", or contain "/", "\\", or a null byte.');
 			return;
 		}
@@ -152,7 +160,7 @@ export function TemplateEditorDialog({
 			await getTransport().request("template.save", {
 				...(workspaceId ? { workspaceId } : {}),
 				scope,
-				name: trimmedName,
+				name: finalName,
 				content: assembleTemplate(description, argumentHint, body),
 			});
 			useAppStore.getState().bumpTemplatesVersion();
@@ -267,7 +275,7 @@ export function TemplateEditorDialog({
 					</Button>
 					<Button
 						data-testid="template-save"
-						disabled={saving || loading || !name.trim()}
+						disabled={saving || loading || (!editing && !name.trim())}
 						onClick={() => void save()}
 					>
 						Save

--- a/apps/web/src/chat/TemplateEditorDialog.tsx
+++ b/apps/web/src/chat/TemplateEditorDialog.tsx
@@ -79,6 +79,15 @@ export function TemplateEditorDialog({
 	// Reset the form on every open — seeded from the template being edited, or the New/save-as-template
 	// prefill. Depending on `template`/`initialScope`/`initialBody` (not just `open`) means a *second* New
 	// or Edit while the dialog stays mounted also reseeds correctly, not just the open transition.
+	// Editing fetches the BODY via `template.get` (`template.list` is metadata-only by design — the wire
+	// never ships every file's full text just to render a listing), pinned to the row's exact `scope` so
+	// editing a global template shadowed by a same-named project one fetches the right file. Until the
+	// body lands, `bodyLoading` gates Save — saving early would silently overwrite the file with an empty
+	// body; a failed fetch keeps Save gated for the same reason (the error is shown, retry by reopening).
+	// The metadata fields still come from the server-parsed listing row — pi's real YAML parser read
+	// them, so every scalar style (single-quoted, folded/block, …) arrives as its VALUE; the client-side
+	// `stripFrontmatter` locates the body only (a boundary rule, not YAML).
+	const [bodyLoading, setBodyLoading] = useState(false);
 	useEffect(() => {
 		if (!open) return;
 		setError(null);
@@ -86,21 +95,37 @@ export function TemplateEditorDialog({
 		if (template) {
 			setName(template.name);
 			setScope(template.scope);
-			// Field values come from the server-parsed `TemplateInfo` — pi's real YAML parser read them, so
-			// every scalar style (single-quoted, folded/block, …) arrives as its VALUE. The client-side
-			// helper is used only to locate the body (a boundary rule, not YAML) — hand-parsing values here
-			// once corrupted a pi-native `description: 'quoted'` into a form value with literal quotes.
 			setDescription(template.description ?? "");
 			setArgumentHint(template.argumentHint ?? "");
-			setBody(stripFrontmatter(template.content));
-		} else {
-			setName("");
-			setScope(initialScope);
-			setDescription("");
-			setArgumentHint("");
-			setBody(initialBody);
+			setBody("");
+			setBodyLoading(true);
+			let cancelled = false;
+			getTransport()
+				.request("template.get", {
+					...(workspaceId ? { workspaceId } : {}),
+					name: template.name,
+					scope: template.scope,
+				})
+				.then((t) => {
+					if (cancelled) return;
+					setBody(stripFrontmatter(t.content));
+					setBodyLoading(false);
+				})
+				.catch((err) => {
+					if (cancelled) return;
+					setError(errorText(err));
+				});
+			return () => {
+				cancelled = true;
+			};
 		}
-	}, [open, template, initialScope, initialBody]);
+		setName("");
+		setScope(initialScope);
+		setDescription("");
+		setArgumentHint("");
+		setBody(initialBody);
+		setBodyLoading(false);
+	}, [open, template, initialScope, initialBody, workspaceId]);
 
 	const save = async () => {
 		if (saving) return;
@@ -205,6 +230,7 @@ export function TemplateEditorDialog({
 						<Textarea
 							id="template-body"
 							data-testid="template-body-input"
+							disabled={bodyLoading}
 							value={body}
 							onChange={(e) => setBody(e.target.value)}
 							placeholder="Prompt body…"
@@ -231,7 +257,7 @@ export function TemplateEditorDialog({
 					</Button>
 					<Button
 						data-testid="template-save"
-						disabled={saving || !name.trim()}
+						disabled={saving || bodyLoading || !name.trim()}
 						onClick={() => void save()}
 					>
 						Save

--- a/apps/web/src/chat/slotSession.test.ts
+++ b/apps/web/src/chat/slotSession.test.ts
@@ -24,18 +24,14 @@ test("$1 repeated shares one group; no argumentHint falls back to argN", () => {
 	expect(slots[0]?.group).toBe(slots[1]?.group);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("${2:-src/} pre-fills the default text and is marked filled", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { text, slots } = parseTemplateSlots("copy to ${2:-src/}");
+test(`\${2:-src/} pre-fills the default text and is marked filled`, () => {
+	const { text, slots } = parseTemplateSlots(`copy to \${2:-src/}`);
 	expect(text).toBe("copy to src/");
 	expect(slots).toEqual([{ start: 8, end: 12, group: 0, filled: true }]);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("${N:-default} with an empty default is a zero-length filled slot", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { text, slots } = parseTemplateSlots("note: ${1:-}");
+test(`\${N:-default} with an empty default is a zero-length filled slot`, () => {
+	const { text, slots } = parseTemplateSlots(`note: \${1:-}`);
 	expect(text).toBe("note: ");
 	expect(slots).toEqual([{ start: 6, end: 6, group: 0, filled: true }]);
 });
@@ -52,10 +48,8 @@ test("$@ becomes one ⟨arguments⟩ marker slot, sharing $ARGUMENTS's group (th
 	expect(slots).toEqual([{ start: 5, end: 16, group: 0, filled: false }]);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("${@:2} becomes one ⟨arguments⟩ marker slot, grouped apart from $1 and from plain arguments", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { text, slots } = parseTemplateSlots("send $1 and ${@:2}");
+test(`\${@:2} becomes one ⟨arguments⟩ marker slot, grouped apart from $1 and from plain arguments`, () => {
+	const { text, slots } = parseTemplateSlots(`send $1 and \${@:2}`);
 	expect(text).toBe("send ⟨arg1⟩ and ⟨arguments⟩");
 	expect(slots).toHaveLength(2);
 	expect(slots[0]).toEqual({ start: 5, end: 11, group: 0, filled: false });
@@ -63,10 +57,8 @@ test("${@:2} becomes one ⟨arguments⟩ marker slot, grouped apart from $1 and 
 	expect(slots[0]?.group).not.toBe(slots[1]?.group);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("${@:2:3} still parses to one marker slot — a length limit changes its value-class, not the slot count", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { text, slots } = parseTemplateSlots("send ${@:2:3}");
+test(`\${@:2:3} still parses to one marker slot — a length limit changes its value-class, not the slot count`, () => {
+	const { text, slots } = parseTemplateSlots(`send \${@:2:3}`);
 	expect(text).toBe("send ⟨arguments⟩");
 	expect(slots).toEqual([{ start: 5, end: 16, group: 0, filled: false }]);
 });
@@ -96,34 +88,26 @@ test("$0 and $ARGUMENTS get DISTINCT groups — $0 is its own positional slot, n
 	expect(slots[0]?.group).not.toBe(slots[1]?.group);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("$@, $ARGUMENTS, and ${@:1} share one group — pi clamps N <= 1 to the same 'from the start' value", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { slots } = parseTemplateSlots("a=$@ b=$ARGUMENTS c=${@:1}");
+test(`$@, $ARGUMENTS, and \${@:1} share one group — pi clamps N <= 1 to the same 'from the start' value`, () => {
+	const { slots } = parseTemplateSlots(`a=$@ b=$ARGUMENTS c=\${@:1}`);
 	expect(slots).toHaveLength(3);
 	expect(new Set(slots.map((s) => s.group)).size).toBe(1);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("${@:2} repeated shares one group, same as any repeated placeholder", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { slots } = parseTemplateSlots("x=${@:2} y=${@:2}");
+test(`\${@:2} repeated shares one group, same as any repeated placeholder`, () => {
+	const { slots } = parseTemplateSlots(`x=\${@:2} y=\${@:2}`);
 	expect(slots).toHaveLength(2);
 	expect(slots[0]?.group).toBe(slots[1]?.group);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("${@:2} and ${@:3} get DISTINCT groups — a different start position is a different value", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { slots } = parseTemplateSlots("x=${@:2} y=${@:3}");
+test(`\${@:2} and \${@:3} get DISTINCT groups — a different start position is a different value`, () => {
+	const { slots } = parseTemplateSlots(`x=\${@:2} y=\${@:3}`);
 	expect(slots).toHaveLength(2);
 	expect(slots[0]?.group).not.toBe(slots[1]?.group);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("${@:2} and ${@:2:3} get DISTINCT groups too — a length limit always makes its own class", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { slots } = parseTemplateSlots("x=${@:2} y=${@:2:3}");
+test(`\${@:2} and \${@:2:3} get DISTINCT groups too — a length limit always makes its own class`, () => {
+	const { slots } = parseTemplateSlots(`x=\${@:2} y=\${@:2:3}`);
 	expect(slots).toHaveLength(2);
 	expect(slots[0]?.group).not.toBe(slots[1]?.group);
 });
@@ -140,11 +124,9 @@ test("docs example: 'Create a React component named $1 with features: $@'", () =
 	]);
 });
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-test("docs example: 'Summarize the current state in ${1:-7} bullet points.'", () => {
+test(`docs example: 'Summarize the current state in \${1:-7} bullet points.'`, () => {
 	const { text, slots } = parseTemplateSlots(
-		// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-		"Summarize the current state in ${1:-7} bullet points.",
+		`Summarize the current state in \${1:-7} bullet points.`,
 	);
 	expect(text).toBe("Summarize the current state in 7 bullet points.");
 	expect(slots).toEqual([{ start: 31, end: 32, group: 0, filled: true }]);
@@ -180,14 +162,12 @@ test("stripUntouchedSlots removes an unfilled marker and collapses the doubled w
 });
 
 test("stripUntouchedSlots leaves a filled default slot untouched", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { text, slots } = parseTemplateSlots("a ${1:-x} b");
+	const { text, slots } = parseTemplateSlots(`a \${1:-x} b`);
 	expect(stripUntouchedSlots(text, slots)).toBe("a x b");
 });
 
 test("stripUntouchedSlots strips only the unfilled slot among a mix of filled + unfilled", () => {
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
-	const { text, slots } = parseTemplateSlots("${1:-keep} then $2");
+	const { text, slots } = parseTemplateSlots(`\${1:-keep} then $2`);
 	// The lone marker sits at the very end behind a single (non-doubled) space, so that one space isn't
 	// collapsed — collapsing only ever fires on a *run* of 2+ spaces/tabs, never a single one.
 	expect(stripUntouchedSlots(text, slots)).toBe("keep then ");

--- a/apps/web/src/chat/slotSession.test.ts
+++ b/apps/web/src/chat/slotSession.test.ts
@@ -1,0 +1,481 @@
+import { expect, test } from "bun:test";
+import type { TemplateSlot } from "./slotSession";
+import {
+	highlightSegments,
+	mirrorAllGroups,
+	mirrorSlotGroup,
+	parseTemplateSlots,
+	shiftSlots,
+	stripUntouchedSlots,
+} from "./slotSession";
+
+// slotSession parses pi's placeholder grammar into visible text + editable ranges — it never evaluates
+// it (no args exist client-side; Task B5's composer slot session drives the user through the ranges
+// returned here). See slotSession.ts for the grammar this pins against.
+
+// ---- parseTemplateSlots ----
+
+test("$1 repeated shares one group; no argumentHint falls back to argN", () => {
+	const { text, slots } = parseTemplateSlots("fix $1 then fix $1 again");
+	expect(text).toBe("fix ⟨arg1⟩ then fix ⟨arg1⟩ again");
+	expect(slots).toHaveLength(2);
+	expect(slots[0]).toEqual({ start: 4, end: 10, group: 0, filled: false });
+	expect(slots[1]).toEqual({ start: 20, end: 26, group: 0, filled: false });
+	expect(slots[0]?.group).toBe(slots[1]?.group);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("${2:-src/} pre-fills the default text and is marked filled", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { text, slots } = parseTemplateSlots("copy to ${2:-src/}");
+	expect(text).toBe("copy to src/");
+	expect(slots).toEqual([{ start: 8, end: 12, group: 0, filled: true }]);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("${N:-default} with an empty default is a zero-length filled slot", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { text, slots } = parseTemplateSlots("note: ${1:-}");
+	expect(text).toBe("note: ");
+	expect(slots).toEqual([{ start: 6, end: 6, group: 0, filled: true }]);
+});
+
+test("$ARGUMENTS becomes one ⟨arguments⟩ marker slot", () => {
+	const { text, slots } = parseTemplateSlots("run: $ARGUMENTS");
+	expect(text).toBe("run: ⟨arguments⟩");
+	expect(slots).toEqual([{ start: 5, end: 16, group: 0, filled: false }]);
+});
+
+test("$@ becomes one ⟨arguments⟩ marker slot, sharing $ARGUMENTS's group (they're aliases)", () => {
+	const { text, slots } = parseTemplateSlots("run: $@");
+	expect(text).toBe("run: ⟨arguments⟩");
+	expect(slots).toEqual([{ start: 5, end: 16, group: 0, filled: false }]);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("${@:2} becomes one ⟨arguments⟩ marker slot, grouped apart from $1 and from plain arguments", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { text, slots } = parseTemplateSlots("send $1 and ${@:2}");
+	expect(text).toBe("send ⟨arg1⟩ and ⟨arguments⟩");
+	expect(slots).toHaveLength(2);
+	expect(slots[0]).toEqual({ start: 5, end: 11, group: 0, filled: false });
+	expect(slots[1]).toEqual({ start: 16, end: 27, group: 1, filled: false });
+	expect(slots[0]?.group).not.toBe(slots[1]?.group);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("${@:2:3} still parses to one marker slot — a length limit changes its value-class, not the slot count", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { text, slots } = parseTemplateSlots("send ${@:2:3}");
+	expect(text).toBe("send ⟨arguments⟩");
+	expect(slots).toEqual([{ start: 5, end: 16, group: 0, filled: false }]);
+});
+
+// ---- pi's real $ behavior (no escape syntax exists) ----
+// An earlier version of this parser had a $$-escape branch; that was a bug — pi's own substituteArgs
+// regex (see slotSession.ts's header comment) has no $-escape alternative at all.
+
+test("a $ that never starts a recognized placeholder is a literal character, unconditionally", () => {
+	const { text, slots } = parseTemplateSlots("just $$ dollars");
+	expect(text).toBe("just $$ dollars");
+	expect(slots).toEqual([]);
+});
+
+test("$$1 is a literal $ immediately followed by a live $1 slot — pi has no escape form for $", () => {
+	const { text, slots } = parseTemplateSlots("cost is $$1 dollars");
+	expect(text).toBe("cost is $⟨arg1⟩ dollars");
+	expect(slots).toEqual([{ start: 9, end: 15, group: 0, filled: false }]);
+	expect(text.slice(slots[0]?.start, slots[0]?.end)).toBe("⟨arg1⟩");
+});
+
+// ---- group scheme: two slots share a group iff they're the same value-class (see TemplateSlot's doc) ----
+
+test("$0 and $ARGUMENTS get DISTINCT groups — $0 is its own positional slot, never an all-args alias", () => {
+	const { slots } = parseTemplateSlots("arg0=$0 all=$ARGUMENTS");
+	expect(slots).toHaveLength(2);
+	expect(slots[0]?.group).not.toBe(slots[1]?.group);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("$@, $ARGUMENTS, and ${@:1} share one group — pi clamps N <= 1 to the same 'from the start' value", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { slots } = parseTemplateSlots("a=$@ b=$ARGUMENTS c=${@:1}");
+	expect(slots).toHaveLength(3);
+	expect(new Set(slots.map((s) => s.group)).size).toBe(1);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("${@:2} repeated shares one group, same as any repeated placeholder", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { slots } = parseTemplateSlots("x=${@:2} y=${@:2}");
+	expect(slots).toHaveLength(2);
+	expect(slots[0]?.group).toBe(slots[1]?.group);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("${@:2} and ${@:3} get DISTINCT groups — a different start position is a different value", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { slots } = parseTemplateSlots("x=${@:2} y=${@:3}");
+	expect(slots).toHaveLength(2);
+	expect(slots[0]?.group).not.toBe(slots[1]?.group);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("${@:2} and ${@:2:3} get DISTINCT groups too — a length limit always makes its own class", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { slots } = parseTemplateSlots("x=${@:2} y=${@:2:3}");
+	expect(slots).toHaveLength(2);
+	expect(slots[0]?.group).not.toBe(slots[1]?.group);
+});
+
+// ---- fidelity: examples verbatim from pi's own bundled docs/prompt-templates.md ----
+// Catches future grammar drift against the upstream authority, not just this module's own regex.
+
+test("docs example: 'Create a React component named $1 with features: $@'", () => {
+	const { text, slots } = parseTemplateSlots("Create a React component named $1 with features: $@");
+	expect(text).toBe("Create a React component named ⟨arg1⟩ with features: ⟨arguments⟩");
+	expect(slots).toEqual([
+		{ start: 31, end: 37, group: 0, filled: false },
+		{ start: 53, end: 64, group: 1, filled: false },
+	]);
+});
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+test("docs example: 'Summarize the current state in ${1:-7} bullet points.'", () => {
+	const { text, slots } = parseTemplateSlots(
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+		"Summarize the current state in ${1:-7} bullet points.",
+	);
+	expect(text).toBe("Summarize the current state in 7 bullet points.");
+	expect(slots).toEqual([{ start: 31, end: 32, group: 0, filled: true }]);
+});
+
+test("marker text uses the Nth argumentHint word, stripped of []-brackets", () => {
+	const { text, slots } = parseTemplateSlots("$1 at $2 severity", "[file] [severity]");
+	expect(text).toBe("⟨file⟩ at ⟨severity⟩ severity");
+	expect(slots).toHaveLength(2);
+});
+
+test("a $N beyond the hint's word count falls back to argN", () => {
+	const { text } = parseTemplateSlots("$1 $2", "[file]");
+	expect(text).toBe("⟨file⟩ ⟨arg2⟩");
+});
+
+test("a blank/whitespace-only argumentHint behaves like no hint at all", () => {
+	const { text } = parseTemplateSlots("$1", "   ");
+	expect(text).toBe("⟨arg1⟩");
+});
+
+test("a hint word that strips down to nothing (a bare bracket pair) falls back to argN too", () => {
+	const { text } = parseTemplateSlots("$1", "[]");
+	expect(text).toBe("⟨arg1⟩");
+});
+
+// ---- stripUntouchedSlots ----
+
+test("stripUntouchedSlots removes an unfilled marker and collapses the doubled whitespace it leaves", () => {
+	const { text, slots } = parseTemplateSlots("a $1 b");
+	expect(text).toBe("a ⟨arg1⟩ b"); // sanity: sits between two single spaces before stripping
+	expect(stripUntouchedSlots(text, slots)).toBe("a b");
+});
+
+test("stripUntouchedSlots leaves a filled default slot untouched", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { text, slots } = parseTemplateSlots("a ${1:-x} b");
+	expect(stripUntouchedSlots(text, slots)).toBe("a x b");
+});
+
+test("stripUntouchedSlots strips only the unfilled slot among a mix of filled + unfilled", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: pi grammar syntax, not a template literal
+	const { text, slots } = parseTemplateSlots("${1:-keep} then $2");
+	// The lone marker sits at the very end behind a single (non-doubled) space, so that one space isn't
+	// collapsed — collapsing only ever fires on a *run* of 2+ spaces/tabs, never a single one.
+	expect(stripUntouchedSlots(text, slots)).toBe("keep then ");
+});
+
+test("stripUntouchedSlots preserves a blank line left by a slot alone on its own line", () => {
+	// The newline-preservation case: collapsing must target spaces/tabs only, never eat the newlines
+	// flanking a stripped slot — a naive `\s{2,}` collapse would merge the two lines into one.
+	const { text, slots } = parseTemplateSlots("line one\n$1\nline two");
+	expect(text).toBe("line one\n⟨arg1⟩\nline two");
+	expect(stripUntouchedSlots(text, slots)).toBe("line one\n\nline two");
+});
+
+test("stripUntouchedSlots collapses only runs of spaces/tabs, not a lone space next to a newline", () => {
+	const { text, slots } = parseTemplateSlots("a $1\nb");
+	expect(text).toBe("a ⟨arg1⟩\nb");
+	expect(stripUntouchedSlots(text, slots)).toBe("a \nb");
+});
+
+// ---- shiftSlots ----
+
+const slot = (start: number, end: number): TemplateSlot => ({
+	start,
+	end,
+	group: 1,
+	filled: false,
+});
+
+test("shiftSlots: an edit before a slot shifts it, leaving its length unchanged", () => {
+	const [shifted] = shiftSlots([slot(5, 8)], 0, 0, 3);
+	expect(shifted).toEqual({ start: 8, end: 11, group: 1, filled: false });
+});
+
+test("shiftSlots: an edit inside a slot grows it by the inserted length", () => {
+	const [shifted] = shiftSlots([slot(5, 8)], 6, 0, 4);
+	expect(shifted).toEqual({ start: 5, end: 12, group: 1, filled: false });
+});
+
+test("shiftSlots: an edit after a slot leaves it untouched", () => {
+	const [shifted] = shiftSlots([slot(5, 8)], 10, 0, 5);
+	expect(shifted).toEqual({ start: 5, end: 8, group: 1, filled: false });
+});
+
+test("shiftSlots: typing over a fully-selected marker resizes the slot to the typed text", () => {
+	// "⟨arg1⟩" is 6 chars, selected whole (per the design, a slot is selected on entry) and replaced by
+	// typing "index.tsx" (9 chars) — the slot grows to exactly cover the new text.
+	const [shifted] = shiftSlots([slot(5, 11)], 5, 6, 9);
+	expect(shifted).toEqual({ start: 5, end: 14, group: 1, filled: false });
+});
+
+test("shiftSlots: a deletion before a slot shifts it left", () => {
+	const [shifted] = shiftSlots([slot(5, 8)], 0, 2, 0);
+	expect(shifted).toEqual({ start: 3, end: 6, group: 1, filled: false });
+});
+
+test("shiftSlots does not mutate its input", () => {
+	const original = slot(5, 8);
+	const slots = [original];
+	shiftSlots(slots, 0, 0, 1);
+	expect(slots[0]).toEqual(original);
+});
+
+test("shiftSlots re-tracks every slot in the array independently", () => {
+	const shifted = shiftSlots([slot(5, 8), slot(20, 24)], 0, 0, 2);
+	expect(shifted[0]).toEqual({ start: 7, end: 10, group: 1, filled: false });
+	expect(shifted[1]).toEqual({ start: 22, end: 26, group: 1, filled: false });
+});
+
+test("shiftSlots keeps filled/group as-is — it is purely geometric, not a fill-tracking decision", () => {
+	const filledSlot: TemplateSlot = { start: 5, end: 8, group: 3, filled: true };
+	const [shifted] = shiftSlots([filledSlot], 6, 0, 2);
+	expect(shifted).toEqual({ start: 5, end: 10, group: 3, filled: true });
+});
+
+// ---- shiftSlots: zero-gap adjacent slots (regression — B5 review) ----
+// A "$1$2"-shaped template (no literal text between the placeholders) produces two slots with zero gap:
+// `first.end === second.start`. A zero-width insert (pure keystroke, no selection) landing exactly there
+// is ambiguous — it could belong to `first` (growing its end) or `second` (pushing its start along). Left
+// undifferentiated, the shipped bug always resolved it as "unaffected", which is right for `first.end`
+// but silently let `second.start` absorb the inserted text instead of moving out of its way — corrupting
+// the sibling's boundary one keystroke at a time. See `slotSession.ts`'s `mapOffset` doc for the fix.
+
+test("shiftSlots: a zero-width insert at a zero-gap boundary pushes the following slot's start forward, never letting it absorb the inserted text", () => {
+	const first = slot(0, 6);
+	const second = slot(6, 12);
+	const [shiftedFirst, shiftedSecond] = shiftSlots([first, second], 6, 0, 3);
+	// shiftSlots alone never grows a slot by default — that is the composer's decision (see below) — so
+	// `first` is unaffected by this call...
+	expect(shiftedFirst).toEqual({ start: 0, end: 6, group: 1, filled: false });
+	// ...while `second` is pushed forward by the inserted length, not stolen from.
+	expect(shiftedSecond).toEqual({ start: 9, end: 15, group: 1, filled: false });
+	// The invariant that actually matters: the two never overlap.
+	expect(shiftedSecond?.start).toBeGreaterThanOrEqual(shiftedFirst?.end ?? 0);
+});
+
+test("shiftSlots composes with the composer's own active-slot growth to stay non-overlapping across several keystrokes", () => {
+	// Simulates `Composer.tsx`'s own post-process for the actively-selected slot: after `shiftSlots`,
+	// manually extend the active slot's `end` by the inserted length. `shiftSlots` itself only guarantees
+	// the *other* slot's coincident start gets out of the way; growing the active one is layered on top,
+	// exactly as production code does it — this pins that the composition never overlaps, keystroke after
+	// keystroke, not just on the first one.
+	const grow = (slots: TemplateSlot[], editStart: number, insertedLen: number): TemplateSlot[] =>
+		shiftSlots(slots, editStart, 0, insertedLen).map((s, i) =>
+			i === 0 ? { ...s, end: s.end + insertedLen } : s,
+		);
+
+	let slots: TemplateSlot[] = [slot(0, 6), slot(6, 12)];
+	slots = grow(slots, 6, 1); // 1st keystroke, landing right at the shared boundary
+	expect(slots).toEqual([
+		{ start: 0, end: 7, group: 1, filled: false },
+		{ start: 7, end: 13, group: 1, filled: false },
+	]);
+	expect(slots[1]?.start).toBeGreaterThanOrEqual(slots[0]?.end ?? 0);
+
+	slots = grow(slots, 7, 1); // 2nd keystroke, boundary having moved along with the growth
+	slots = grow(slots, 8, 1); // 3rd keystroke
+	expect(slots).toEqual([
+		{ start: 0, end: 9, group: 1, filled: false },
+		{ start: 9, end: 15, group: 1, filled: false },
+	]);
+	expect(slots[1]?.start).toBeGreaterThanOrEqual(slots[0]?.end ?? 0);
+});
+
+// ---- mirrorSlotGroup / mirrorAllGroups ----
+// A repeated placeholder (same `group`) is one conceptual argument occurring more than once — pi would
+// expand every occurrence from the same value, so the composer mirrors a filled slot's text into its
+// unfilled (or differently-filled) group-mates. `stepSlot` (Tab-out) and `submit()` (direct Send) both
+// need this; these functions are the pure, shared core both call into (see Composer.tsx).
+
+const gslot = (start: number, end: number, group: number, filled: boolean): TemplateSlot => ({
+	start,
+	end,
+	group,
+	filled,
+});
+
+test("mirrorSlotGroup propagates the source's text into a differing same-group sibling, marking it filled", () => {
+	const value = "a=X b=Y";
+	const slots = [gslot(2, 3, 0, true), gslot(6, 7, 0, false)];
+	const { value: next, slots: nextSlots } = mirrorSlotGroup(value, slots, 0);
+	expect(next).toBe("a=X b=X");
+	expect(nextSlots[0]).toEqual({ start: 2, end: 3, group: 0, filled: true });
+	expect(nextSlots[1]).toEqual({ start: 6, end: 7, group: 0, filled: true });
+});
+
+test("mirrorSlotGroup never touches a sibling in a different group", () => {
+	const value = "a=X b=Y";
+	const slots = [gslot(2, 3, 0, true), gslot(6, 7, 1, false)];
+	const { value: next, slots: nextSlots } = mirrorSlotGroup(value, slots, 0);
+	expect(next).toBe(value);
+	expect(nextSlots[1]).toEqual(slots[1]);
+});
+
+test("mirrorSlotGroup is a no-op once every member of a group already agrees — returns the same references", () => {
+	const value = "a=X b=X";
+	const slots = [gslot(2, 3, 0, true), gslot(6, 7, 0, true)];
+	const { value: next, slots: nextSlots } = mirrorSlotGroup(value, slots, 0);
+	expect(next).toBe(value);
+	expect(nextSlots).toBe(slots);
+});
+
+test("mirrorSlotGroup propagates a MULTI-WORD value into every same-group sibling, re-tracking offsets", () => {
+	// three occurrences of one placeholder (one group) — the /rename shape at scale
+	const { text, slots } = parseTemplateSlots("update $1, then test $1, then ship $1");
+	expect(slots).toHaveLength(3);
+	expect(new Set(slots.map((s) => s.group)).size).toBe(1); // all one group
+	// simulate the user typing a multi-word value into the first occurrence
+	const filled = "the auth module";
+	const s0 = slots[0];
+	if (!s0) throw new Error("expected a first slot");
+	const value = text.slice(0, s0.start) + filled + text.slice(s0.end);
+	const filledSlots = shiftSlots(slots, s0.start, s0.end - s0.start, filled.length).map((s, i) =>
+		i === 0 ? { ...s, filled: true } : s,
+	);
+	const { value: next, slots: out } = mirrorSlotGroup(value, filledSlots, 0);
+	expect(next).toBe("update the auth module, then test the auth module, then ship the auth module");
+	// every occurrence carries the full multi-word text, and each slot's range still bounds it exactly
+	for (const s of out) expect(next.slice(s.start, s.end)).toBe(filled);
+});
+
+test("mirrorAllGroups propagates every already-filled slot's text into its own group's unfilled siblings, and never touches a different group", () => {
+	const value = "W.m.M";
+	const slots = [gslot(0, 1, 0, true), gslot(2, 3, 1, false), gslot(4, 5, 0, false)];
+	const { value: next, slots: nextSlots } = mirrorAllGroups(value, slots);
+	expect(next).toBe("W.m.W");
+	expect(nextSlots[0]).toEqual({ start: 0, end: 1, group: 0, filled: true });
+	expect(nextSlots[1]).toEqual({ start: 2, end: 3, group: 1, filled: false });
+	expect(nextSlots[2]).toEqual({ start: 4, end: 5, group: 0, filled: true });
+});
+
+test("mirrorAllGroups: when two siblings are independently filled with different text, the earliest in array order wins", () => {
+	const value = "a=X b=Y";
+	const slots = [gslot(2, 3, 0, true), gslot(6, 7, 0, true)];
+	const { value: next, slots: nextSlots } = mirrorAllGroups(value, slots);
+	expect(next).toBe("a=X b=X");
+	expect(nextSlots.every((s) => s.filled)).toBe(true);
+});
+
+// ---- highlightSegments ----
+// The composer's backdrop layer breaks the live value into ordered plain/unfilled/filled/active runs for
+// the highlight tint spans. Every case below also asserts the concatenation invariant: the segments must
+// reconstruct `value` exactly, or the backdrop text would silently drift from the textarea's real text.
+
+const segText = (segs: { text: string }[]) => segs.map((s) => s.text).join("");
+
+test("highlightSegments: no slots produces one plain segment spanning the whole value", () => {
+	const value = "hello world";
+	const segs = highlightSegments(value, [], 0);
+	expect(segs).toEqual([{ text: "hello world", state: "plain" }]);
+	expect(segText(segs)).toBe(value);
+});
+
+test("highlightSegments: no slots on an empty value still round-trips (one empty plain segment)", () => {
+	const segs = highlightSegments("", [], 0);
+	expect(segs).toEqual([{ text: "", state: "plain" }]);
+	expect(segText(segs)).toBe("");
+});
+
+test("highlightSegments: a single unfilled slot renders plain/unfilled/plain around it", () => {
+	const before = "fix ";
+	const marker = "⟨arg1⟩";
+	const after = " now";
+	const value = before + marker + after;
+	const slots = [gslot(before.length, before.length + marker.length, 0, false)];
+	// activeIdx points at no real slot — nothing should be marked "active".
+	const segs = highlightSegments(value, slots, -1);
+	expect(segs).toEqual([
+		{ text: before, state: "plain" },
+		{ text: marker, state: "unfilled" },
+		{ text: after, state: "plain" },
+	]);
+	expect(segText(segs)).toBe(value);
+});
+
+test("highlightSegments: a filled slot renders as 'filled'", () => {
+	const before = "copy to ";
+	const filled = "src/";
+	const value = before + filled;
+	const slots = [gslot(before.length, before.length + filled.length, 0, true)];
+	const segs = highlightSegments(value, slots, -1);
+	expect(segs).toEqual([
+		{ text: before, state: "plain" },
+		{ text: filled, state: "filled" },
+	]);
+	expect(segText(segs)).toBe(value);
+});
+
+test("highlightSegments: activeIdx marks exactly the slot at that array index 'active', regardless of filled", () => {
+	const value = "ab";
+	const slots = [gslot(0, 1, 0, false), gslot(1, 2, 1, true)];
+	const segs = highlightSegments(value, slots, 1);
+	expect(segs).toEqual([
+		{ text: "a", state: "unfilled" },
+		{ text: "b", state: "active" },
+	]);
+	expect(segs.filter((s) => s.state === "active")).toHaveLength(1);
+	expect(segText(segs)).toBe(value);
+});
+
+test("highlightSegments: zero-gap adjacent slots (the $1$2 shape) produce no empty plain segment between them", () => {
+	const first = "⟨arg1⟩";
+	const second = "⟨arg2⟩";
+	const value = first + second;
+	const slots = [
+		gslot(0, first.length, 0, false),
+		gslot(first.length, first.length + second.length, 1, false),
+	];
+	const segs = highlightSegments(value, slots, 0);
+	expect(segs).toEqual([
+		{ text: first, state: "active" },
+		{ text: second, state: "unfilled" },
+	]);
+	expect(segs.some((s) => s.state === "plain")).toBe(false);
+	expect(segText(segs)).toBe(value);
+});
+
+test("highlightSegments: a multi-word slot's text stays in one segment", () => {
+	const before = "Rename ";
+	const mid = "the auth module";
+	const after = " now";
+	const value = before + mid + after;
+	const slots = [gslot(before.length, before.length + mid.length, 0, true)];
+	const segs = highlightSegments(value, slots, -1);
+	expect(segs).toEqual([
+		{ text: before, state: "plain" },
+		{ text: mid, state: "filled" },
+		{ text: after, state: "plain" },
+	]);
+	expect(segs).toHaveLength(3);
+	expect(segText(segs)).toBe(value);
+});

--- a/apps/web/src/chat/slotSession.test.ts
+++ b/apps/web/src/chat/slotSession.test.ts
@@ -297,12 +297,13 @@ test("shiftSlots composes with the composer's own active-slot growth to stay non
 // unfilled (or differently-filled) group-mates. `stepSlot` (Tab-out) and `submit()` (direct Send) both
 // need this; these functions are the pure, shared core both call into (see Composer.tsx).
 
-const gslot = (start: number, end: number, group: number, filled: boolean): TemplateSlot => ({
-	start,
-	end,
-	group,
-	filled,
-});
+const gslot = (
+	start: number,
+	end: number,
+	group: number,
+	filled: boolean,
+	edited = false,
+): TemplateSlot => ({ start, end, group, filled, ...(edited ? { edited: true } : {}) });
 
 test("mirrorSlotGroup propagates the source's text into a differing same-group sibling, marking it filled", () => {
 	const value = "a=X b=Y";
@@ -348,22 +349,62 @@ test("mirrorSlotGroup propagates a MULTI-WORD value into every same-group siblin
 	for (const s of out) expect(next.slice(s.start, s.end)).toBe(filled);
 });
 
-test("mirrorAllGroups propagates every already-filled slot's text into its own group's unfilled siblings, and never touches a different group", () => {
+test("mirrorAllGroups propagates every user-edited slot's text into its own group's siblings, and never touches a different group", () => {
 	const value = "W.m.M";
-	const slots = [gslot(0, 1, 0, true), gslot(2, 3, 1, false), gslot(4, 5, 0, false)];
+	// slot 0 is edited (a mirror source); slot 2 shares its group but is only mirrored INTO — it becomes
+	// filled, never `edited` (a mirrored value isn't a user edit). slot 1 is a different group, untouched.
+	const slots = [gslot(0, 1, 0, true, true), gslot(2, 3, 1, false), gslot(4, 5, 0, false)];
 	const { value: next, slots: nextSlots } = mirrorAllGroups(value, slots);
 	expect(next).toBe("W.m.W");
-	expect(nextSlots[0]).toEqual({ start: 0, end: 1, group: 0, filled: true });
+	expect(nextSlots[0]).toEqual({ start: 0, end: 1, group: 0, filled: true, edited: true });
 	expect(nextSlots[1]).toEqual({ start: 2, end: 3, group: 1, filled: false });
 	expect(nextSlots[2]).toEqual({ start: 4, end: 5, group: 0, filled: true });
 });
 
-test("mirrorAllGroups: when two siblings are independently filled with different text, the earliest in array order wins", () => {
+test("mirrorAllGroups: when two siblings are independently EDITED with different text, the earliest in array order wins", () => {
 	const value = "a=X b=Y";
-	const slots = [gslot(2, 3, 0, true), gslot(6, 7, 0, true)];
+	const slots = [gslot(2, 3, 0, true, true), gslot(6, 7, 0, true, true)];
 	const { value: next, slots: nextSlots } = mirrorAllGroups(value, slots);
 	expect(next).toBe("a=X b=X");
 	expect(nextSlots.every((s) => s.filled)).toBe(true);
+});
+
+// ---- regression (Air review): filled ≠ edited — differing `${N:-default}` occurrences ----
+// `${1:-foo} … ${1:-bar}` share one group and are both born `filled` (real defaults) but NOT `edited`.
+// Mirroring keyed on `filled` used to collapse "foo … bar" to "foo … foo" on a plain Send, unlike pi's own
+// expansion (unprovided `${1:-foo}`/`${1:-bar}` yield "foo"/"bar"). Keyed on `edited`, an untouched default
+// is never a mirror source; editing one occurrence (providing the argument) is what starts the mirror.
+
+test(`parseTemplateSlots marks a \${N:-default} filled but NOT edited`, () => {
+	const { slots } = parseTemplateSlots(`copy to \${2:-src/}`);
+	expect(slots).toHaveLength(1);
+	expect(slots[0]?.filled).toBe(true);
+	expect(slots[0]?.edited).toBeUndefined();
+});
+
+test("mirrorAllGroups leaves two differing UNTOUCHED defaults independent — no edit means no mirror", () => {
+	const { text, slots } = parseTemplateSlots(`\${1:-foo} versus \${1:-bar}`);
+	expect(text).toBe("foo versus bar");
+	expect(slots).toHaveLength(2);
+	expect(slots[0]?.group).toBe(slots[1]?.group); // one argument, one group
+	expect(slots.every((s) => s.filled && !s.edited)).toBe(true); // real defaults, none edited
+	const { value: next, slots: nextSlots } = mirrorAllGroups(text, slots);
+	expect(next).toBe("foo versus bar"); // the bug produced "foo versus foo"
+	expect(nextSlots).toBe(slots); // nothing edited ⇒ nothing to mirror ⇒ same references (cheap no-op)
+});
+
+test("mirrorAllGroups mirrors from an EDITED default into its group-mate (the user provided the argument)", () => {
+	const { slots } = parseTemplateSlots(`\${1:-foo} versus \${1:-bar}`);
+	// Simulate the user replacing the first default "foo" with "cats" — the composer marks it filled+edited.
+	const s0 = slots[0];
+	if (!s0) throw new Error("expected a first slot");
+	const typed = "cats";
+	const value = `${typed} versus bar`;
+	const editedSlots = shiftSlots(slots, s0.start, s0.end - s0.start, typed.length).map((s, i) =>
+		i === 0 ? { ...s, filled: true, edited: true } : s,
+	);
+	const { value: next } = mirrorAllGroups(value, editedSlots);
+	expect(next).toBe("cats versus cats");
 });
 
 // ---- highlightSegments ----

--- a/apps/web/src/chat/slotSession.ts
+++ b/apps/web/src/chat/slotSession.ts
@@ -1,0 +1,346 @@
+// Parses pi's prompt-template placeholder grammar (`$1..$n`, `$@`/`$ARGUMENTS`, `${N:-default}`,
+// `${@:N}`, `${@:N:L}` — pi's grammar, single owner; verified against the installed
+// `@earendil-works/pi-coding-agent`'s own `substituteArgs` regex (`dist/core/prompt-templates.js`) and
+// its `docs/prompt-templates.md`, and see `packages/server/src/templates/`, which walks the same
+// template dirs but never evaluates the grammar either) into visible text + editable slot ranges for the
+// composer's future Tab-through slot session (Task B5). This module only ever PARSES — no args exist
+// client-side (the user fills slots interactively), so there is nothing here to *evaluate*; that stays
+// pi's, server-side, via `PromptOptions.expandPromptTemplates` (defaults to `true`) — the same
+// in-session expansion that already runs a typed-through `/name args` prompt today, with or without this
+// module. pi has **no escape syntax**: a lone `$` that doesn't start a recognized placeholder is always
+// just a literal `$` passed through untouched (see `parseTemplateSlots`'s doc for the `$$1` case this
+// implies). Pure: no React, no store/transport, no `pi` import of any kind — plain strings and offsets
+// in, plain strings and offsets out.
+
+/**
+ * One editable range inside `ParsedTemplate.text` — a placeholder pi's grammar expanded, tracked by
+ * plain offsets (a plain textarea, no contentEditable in V1; `shiftSlots` re-tracks these across edits).
+ * `group` ties sibling ranges together so the composer can mirror an edit across them on slot exit — two
+ * slots share a `group` iff they're the same conceptual argument slot (pi would treat them as one
+ * mirrored value). Internally, each distinct placeholder form gets a fresh, opaque `group` number the
+ * first time it's seen, in appearance order (see `groupFor`) — the number itself carries no meaning
+ * beyond equality:
+ *  - positional `$N` and `${N:-default}` share one group per `N`. `N` ≥ 0 is valid syntax — pi evaluates
+ *    `$0` as always-blank (there's no argument 0), but it's still its own distinct positional slot, never
+ *    the same group as any of the all-arguments forms below.
+ *  - the plain "all arguments" spellings — `$@`, `$ARGUMENTS`, and `${@:N}` with N ≤ 1 — are pi-verified
+ *    aliases of each other (pi clamps N ≤ 1 to "from the start", so they're the same value for any args)
+ *    and share one group.
+ *  - an unlimited `${@:N}` with N ≥ 2 gets its own group per distinct `N` (a different start position is
+ *    generally a different value, so `${@:2}` and `${@:3}` never share).
+ *  - a length-limited `${@:N:L}` gets its own group per distinct `N:L` pair, for *any* `N` — the limit
+ *    changes the value even when N ≤ 1 (a truncated slice of "all arguments" isn't "all arguments"), so
+ *    it never joins the plain all-arguments group either.
+ */
+export interface TemplateSlot {
+	start: number;
+	end: number;
+	group: number;
+	/** shown marker or prefilled default */
+	filled: boolean;
+}
+
+/**
+ * The result of expanding one template body: the visible text plus its editable slot ranges. `slots` is
+ * the **sole source of truth** for where the editable ranges are — never re-derive positions by scanning
+ * `text` for the `⟨…⟩` marker glyphs; a template body may legitimately contain those characters itself.
+ */
+export interface ParsedTemplate {
+	text: string;
+	slots: TemplateSlot[];
+}
+
+// The one scan across the grammar, lifted verbatim from pi's own `substituteArgs` regex
+// (`@earendil-works/pi-coding-agent`'s `dist/core/prompt-templates.js`) — pi has no `$$`/escape
+// alternative at all, which is why there isn't one here either. Capture groups line up with the branches
+// below: 1/2 = N/default for `${N:-default}`, 3/4 = N/L for `${@:N(:L)}`, 5 = the bare form's payload
+// ("ARGUMENTS", "@", or a digit string for `$N`).
+const SLOT_PATTERN = /\$\{(\d+):-([^}]*)\}|\$\{@:(\d+)(?::(\d+))?\}|\$(ARGUMENTS|@|\d+)/g;
+
+const ARGUMENTS_MARKER = "⟨arguments⟩";
+
+/**
+ * The Nth (1-based) word of `argumentHint`, stripped of the `[]` brackets pi's own hint convention wraps
+ * words in (e.g. `"[file] [severity]"`). Falls back to `argN` when there's no hint, the hint has fewer
+ * than N words, or the Nth word strips down to nothing (e.g. a bare `"[]"`).
+ */
+function hintMarkerWord(argumentHint: string | undefined, n: number): string {
+	const word = argumentHint?.trim().split(/\s+/).filter(Boolean)[n - 1];
+	const stripped = word?.replace(/[[\]]/g, "");
+	return stripped || `arg${n}`;
+}
+
+/**
+ * Assigns each distinct value-class `key` (see {@link TemplateSlot}'s `group` doc) a fresh, opaque
+ * `group` number the first time it's seen, in appearance order; later matches of the same key reuse it.
+ * `seen` is scoped to one `parseTemplateSlots` call — group numbers carry no meaning across calls.
+ */
+function groupFor(key: string, seen: Map<string, number>): number {
+	const existing = seen.get(key);
+	if (existing !== undefined) return existing;
+	const group = seen.size;
+	seen.set(key, group);
+	return group;
+}
+
+/** The `${@:N}` / `${@:N:L}` value-class key (see {@link TemplateSlot}'s `group` doc): the length limit,
+ * when present, always makes its own class; without one, N ≤ 1 clamps to the plain all-arguments class. */
+function rangeKey(rangeN: string, rangeL: string | undefined): string {
+	if (rangeL !== undefined) return `args:${rangeN}:${rangeL}`;
+	return Number(rangeN) <= 1 ? "args" : `args:${rangeN}`;
+}
+
+/**
+ * Expand pi's placeholders into visible text + editable ranges (see {@link TemplateSlot}). `$N` becomes
+ * a visible `⟨hint⟩` marker (or `⟨argN⟩` without a usable hint word), `filled: false` — nothing is
+ * "there" yet, it's a prompt to fill in. `${N:-default}` inserts the default text itself, `filled: true`
+ * — it's already real content, just still selected/editable. `$@`/`$ARGUMENTS`/`${@:N}`/`${@:N:L}` each
+ * become one `⟨arguments⟩` marker slot. Parse only — evaluation semantics (what a slot's content
+ * actually substitutes to) stay pi's; in particular, pi has no escape syntax, so a lone `$` that doesn't
+ * start a recognized placeholder is always just a literal `$` passed through untouched — e.g. `$$1` is a
+ * literal `$` immediately followed by a live `$1` slot, never an escaped `$`.
+ */
+export function parseTemplateSlots(body: string, argumentHint?: string): ParsedTemplate {
+	let text = "";
+	let cursor = 0;
+	const slots: TemplateSlot[] = [];
+	const groups = new Map<string, number>();
+
+	for (const match of body.matchAll(SLOT_PATTERN)) {
+		const [full = "", defN, defValue = "", rangeN, rangeL, simple] = match;
+		text += body.slice(cursor, match.index);
+		cursor = match.index + full.length;
+
+		if (defN !== undefined) {
+			const start = text.length;
+			text += defValue;
+			const group = groupFor(`pos:${defN}`, groups);
+			slots.push({ start, end: start + defValue.length, group, filled: true });
+		} else if (rangeN !== undefined) {
+			const start = text.length;
+			text += ARGUMENTS_MARKER;
+			const group = groupFor(rangeKey(rangeN, rangeL), groups);
+			slots.push({ start, end: start + ARGUMENTS_MARKER.length, group, filled: false });
+		} else if (simple === "ARGUMENTS" || simple === "@") {
+			const start = text.length;
+			text += ARGUMENTS_MARKER;
+			const group = groupFor("args", groups);
+			slots.push({ start, end: start + ARGUMENTS_MARKER.length, group, filled: false });
+		} else if (simple !== undefined) {
+			const marker = `⟨${hintMarkerWord(argumentHint, Number(simple))}⟩`;
+			const start = text.length;
+			text += marker;
+			const group = groupFor(`pos:${simple}`, groups);
+			slots.push({ start, end: start + marker.length, group, filled: false });
+		}
+	}
+	text += body.slice(cursor);
+	return { text, slots };
+}
+
+/**
+ * On send: strip untouched marker slots (filled=false ranges), collapsing doubled whitespace. Only
+ * contiguous runs of spaces/tabs are collapsed (to one space) — a stripped slot's flanking newlines are
+ * never touched, so an intentional blank line around a slot-only line survives (it becomes two adjacent
+ * `\n`s, not one, and not a space).
+ */
+export function stripUntouchedSlots(text: string, slots: TemplateSlot[]): string {
+	const cuts = slots
+		.filter((slot) => !slot.filled)
+		.slice()
+		.sort((a, b) => a.start - b.start);
+
+	let out = "";
+	let cursor = 0;
+	for (const cut of cuts) {
+		if (cut.start < cursor) continue; // defensive: ignore an out-of-order/overlapping range
+		out += text.slice(cursor, cut.start);
+		cursor = Math.max(cursor, cut.end);
+	}
+	out += text.slice(cursor);
+
+	return out.replace(/[ \t]{2,}/g, " ");
+}
+
+/**
+ * Map one offset across a `[editStart, editEnd)` → `insertedLen`-chars text edit, preserving the
+ * invariant `shiftSlots` exists to hold: **slots never overlap after a shift**. A point at or before
+ * `editStart` is unaffected; at or after `editEnd` it shifts by the net length delta; a point strictly
+ * inside the replaced span collapses to just after the inserted text (this is what makes `shiftSlots`
+ * grow/shrink a slot whose interior an edit lands in, rather than leaving it pointing at stale content).
+ *
+ * `isSlotStart` breaks the one remaining tie, for **zero-width insertions** (`editStart === editEnd`)
+ * landing exactly on a point where one slot's `end` meets the next one's `start` with zero gap between
+ * them (e.g. a `"$1$2"`-shaped template, no literal text separating the two placeholders). Both
+ * `pos <= editStart` (an `end`, unaffected) and `pos >= editEnd` (a `start`, shifted) are simultaneously
+ * true at that exact point when `editStart === editEnd` — without a tie-break, the *first* branch always
+ * wins, which is correct for the `end` it belongs to but wrong for the coincident `start` right after it:
+ * left in place, that `start` would silently absorb whatever was just inserted (the following slot's
+ * left edge grows by the insert instead of the slot being pushed out of its way — a real, previously
+ * shipped bug: two zero-gap-adjacent slots, filling the first via more than one keystroke, corrupted the
+ * second's boundary one character at a time). The fix: a `start` exactly at a zero-width insert's point
+ * is always treated as `>= editEnd` (pushed forward, out of the way) rather than `<= editStart`
+ * (unaffected) — an `end` at that same point is untouched by this tie-break and still defaults to
+ * unaffected, i.e. it does **not** grow on its own. Growing the slot an edit is conceptually "inside"
+ * (e.g. the composer's actively-selected slot, as the user keeps typing past its end) is a UI/intent
+ * decision this pure module can't make — that stays the composer's job (see `Composer.tsx`'s own
+ * `growing` check) and composes correctly on top of this: the composer grows the one slot it knows is
+ * active, this function independently guarantees any *other* slot's coincident start gets out of the way,
+ * and the two together never overlap.
+ */
+function mapOffset(
+	pos: number,
+	editStart: number,
+	editEnd: number,
+	insertedLen: number,
+	isSlotStart: boolean,
+): number {
+	if (isSlotStart && pos === editStart && editStart === editEnd && insertedLen > 0) {
+		return pos + insertedLen;
+	}
+	if (pos <= editStart) return pos;
+	if (pos >= editEnd) return pos + insertedLen - (editEnd - editStart);
+	return editStart + insertedLen;
+}
+
+/**
+ * Re-track ranges across a text edit at `[editStart, editStart + removedLen)` replaced by `insertedLen`
+ * chars: an edit before a slot shifts it (same length); an edit after a slot leaves it untouched; an
+ * edit inside a slot grows/shrinks it to match. Purely geometric — it never touches `filled` or `group`.
+ * Whether an edit inside a slot should also flip `filled` to `true` is a decision about user intent
+ * (did they actually type something, vs. e.g. an external re-render touching the range?) that belongs to
+ * the composer's slot session (Task B5), not this parser; this function only ever moves boundaries.
+ *
+ * **Invariant: slots never overlap after a shift** — including the degenerate case of two zero-gap-
+ * adjacent slots (see `mapOffset`'s `isSlotStart` tie-break). Returns a new array — `slots` is never
+ * mutated.
+ */
+export function shiftSlots(
+	slots: TemplateSlot[],
+	editStart: number,
+	removedLen: number,
+	insertedLen: number,
+): TemplateSlot[] {
+	const editEnd = editStart + removedLen;
+	return slots.map((slot) => ({
+		...slot,
+		start: mapOffset(slot.start, editStart, editEnd, insertedLen, true),
+		end: mapOffset(slot.end, editStart, editEnd, insertedLen, false),
+	}));
+}
+
+/**
+ * Propagate slot `sourceIdx`'s current text into every OTHER slot sharing its `group`, marking each one
+ * `filled: true` as it's overwritten — the same mirroring rule {@link TemplateSlot}'s `group` doc
+ * documents (siblings are one conceptual argument; pi would expand them from the same value). A sibling
+ * whose text already matches is left untouched — including its `filled` flag, so a sibling a user
+ * independently typed the same text into isn't retroactively relabeled "just mirrored." Skips `sourceIdx`
+ * itself. Purely geometric composition of `shiftSlots`, one sibling at a time, left to right — safe
+ * because mirroring never changes which offsets are `group`-equal, only their text/`filled`.
+ *
+ * Returns `{ value, slots }` unchanged (same references) when there's nothing to mirror — no group-mate,
+ * or every group-mate already agrees — so a caller can cheaply skip the `onChange`/`setSlots` it would
+ * otherwise trigger.
+ */
+export function mirrorSlotGroup(
+	value: string,
+	slots: TemplateSlot[],
+	sourceIdx: number,
+): { value: string; slots: TemplateSlot[] } {
+	const source = slots[sourceIdx];
+	if (!source) return { value, slots };
+	const text = value.slice(source.start, source.end);
+	let nextValue = value;
+	let nextSlots = slots;
+	for (let i = 0; i < nextSlots.length; i++) {
+		if (i === sourceIdx) continue;
+		const sib = nextSlots[i];
+		if (!sib || sib.group !== source.group) continue;
+		if (nextValue.slice(sib.start, sib.end) === text) continue;
+		nextValue = nextValue.slice(0, sib.start) + text + nextValue.slice(sib.end);
+		nextSlots = shiftSlots(nextSlots, sib.start, sib.end - sib.start, text.length).map((s, si) =>
+			si === i ? { ...s, filled: true } : s,
+		);
+	}
+	return { value: nextValue, slots: nextSlots };
+}
+
+/** One of the composer backdrop's four tint states for a highlight segment: `"plain"` is ordinary text
+ * (outside any slot, no tint); `"unfilled"`/`"filled"` mirror a slot's own `filled` flag; `"active"`
+ * overrides both for whichever slot the session is currently sitting on (`Composer`'s `slotIdx`). */
+export type SlotHighlightState = "plain" | "unfilled" | "filled" | "active";
+
+/** One run of `value` for the composer's highlight backdrop, tagged with the tint its span should render
+ * (see {@link SlotHighlightState}). Ordered left to right; concatenating every `text` reconstructs
+ * `value` exactly. */
+export interface SlotSegment {
+	text: string;
+	state: SlotHighlightState;
+}
+
+/**
+ * Break `value` into ordered segments for the highlight backdrop (see `Composer.tsx`'s backdrop layer):
+ * text inside a slot range is `"active"` when its index into `slots` equals `activeIdx`, else
+ * `"filled"`/`"unfilled"` per that slot's own `filled` flag; text between/outside slots is `"plain"`.
+ * `slots` is assumed non-overlapping and sorted by `start` (it is, post-`shiftSlots` — this function
+ * still sorts defensively by `start` before walking, so a caller passing them in `slots` array order
+ * rather than left-to-right text order can't produce out-of-order segments). Zero-gap-adjacent slots
+ * (the `$1$2` shape — one slot's `end` equals the next one's `start`) never get an empty `"plain"`
+ * segment spliced between them: a plain run is only emitted for a strictly positive gap. Pure — no
+ * React, just offsets and slices, so the tests can assert the concatenation invariant directly. `activeIdx`
+ * is an index into `slots` (matching `Composer`'s own `slotIdx` state), not a text offset; an out-of-range
+ * value (e.g. `-1`) simply means no segment is ever marked `"active"`.
+ */
+export function highlightSegments(
+	value: string,
+	slots: TemplateSlot[],
+	activeIdx: number,
+): SlotSegment[] {
+	const ordered = slots
+		.map((slot, index) => ({ slot, index }))
+		.sort((a, b) => a.slot.start - b.slot.start);
+
+	const segments: SlotSegment[] = [];
+	let cursor = 0;
+	for (const { slot, index } of ordered) {
+		if (slot.start > cursor) {
+			segments.push({ text: value.slice(cursor, slot.start), state: "plain" });
+		}
+		const state: SlotHighlightState =
+			index === activeIdx ? "active" : slot.filled ? "filled" : "unfilled";
+		segments.push({ text: value.slice(slot.start, slot.end), state });
+		cursor = Math.max(cursor, slot.end);
+	}
+	if (cursor < value.length || segments.length === 0) {
+		segments.push({ text: value.slice(cursor), state: "plain" });
+	}
+	return segments;
+}
+
+/**
+ * `mirrorSlotGroup` for every already-`filled` slot, in array order — the composer's send path has no
+ * single "slot the user just left" the way Tab-stepping does (`Composer.tsx`'s `stepSlot`, the sole other
+ * caller of `mirrorSlotGroup`): a direct Send can happen with any subset of slots filled, in any order, so
+ * every filled slot needs to propagate to its unfilled group-mates, not just the most recently edited one.
+ *
+ * When two group-mates are BOTH already filled and disagree (each independently typed into, never
+ * mirrored against each other — Tab-stepping's own mirroring would normally prevent this, but a direct
+ * Send can still reach it, e.g. pasting into a later slot without ever tabbing back through an earlier
+ * one), the earliest one in array order wins: later iterations see the earlier slot's mirrored text
+ * already sitting at that group's shared offsets and treat it as agreement, same as any other
+ * already-matching sibling. Which literal value "wins" here is inherently arbitrary — the two disagreeing
+ * values can't both survive — earliest-wins is just a deterministic, easy-to-explain tie-break.
+ */
+export function mirrorAllGroups(
+	value: string,
+	slots: TemplateSlot[],
+): { value: string; slots: TemplateSlot[] } {
+	let nextValue = value;
+	let nextSlots = slots;
+	for (let i = 0; i < nextSlots.length; i++) {
+		if (nextSlots[i]?.filled) {
+			({ value: nextValue, slots: nextSlots } = mirrorSlotGroup(nextValue, nextSlots, i));
+		}
+	}
+	return { value: nextValue, slots: nextSlots };
+}

--- a/apps/web/src/chat/slotSession.ts
+++ b/apps/web/src/chat/slotSession.ts
@@ -36,8 +36,23 @@ export interface TemplateSlot {
 	start: number;
 	end: number;
 	group: number;
-	/** shown marker or prefilled default */
+	/** Has real content now — a `${N:-default}`'s prefilled default text, or a marker the user typed into.
+	 * A **parse-time property of the placeholder form**: `${N:-default}` is born `filled` (its default is
+	 * real content), every marker (`$N`, `$@`, `${@:N}`, …) is born unfilled. Drives strip-on-send
+	 * (`stripUntouchedSlots` keeps filled ranges, drops untouched markers) and the highlight tint
+	 * (`highlightSegments`). Distinct from `edited` — see below. */
 	filled: boolean;
+	/** The user actually changed this slot's text. **Session runtime state** the composer sets on a real
+	 * edit (`Composer`'s `onChange`); `parseTemplateSlots` never emits it (a freshly parsed template has
+	 * been edited nowhere), so absent ⇒ never edited. Gates mirror-*source* eligibility: only an edited
+	 * slot propagates its text to its group-mates (`mirrorAllGroups`, and `Composer`'s Tab-out `stepSlot`).
+	 * Deliberately **separate from `filled`**: a `${1:-foo} … ${1:-bar}` pair is born `filled` (two real
+	 * defaults) but NOT `edited`, so its two per-occurrence defaults stay independent until the user
+	 * provides argument 1 by editing one of them — matching pi's own expansion (unprovided `${1:-foo}` and
+	 * `${1:-bar}` yield "foo" and "bar", not "foo" twice). Conflating the two would silently rewrite
+	 * "foo … bar" to "foo … foo" on Tab or Send. A slot mirrored *into* becomes `filled` but stays
+	 * un-`edited` — it holds a mirrored value, not a user edit, so it never re-sources. */
+	edited?: boolean;
 }
 
 /**
@@ -230,13 +245,16 @@ export function shiftSlots(
 }
 
 /**
- * Propagate slot `sourceIdx`'s current text into every OTHER slot sharing its `group`, marking each one
- * `filled: true` as it's overwritten — the same mirroring rule {@link TemplateSlot}'s `group` doc
- * documents (siblings are one conceptual argument; pi would expand them from the same value). A sibling
- * whose text already matches is left untouched — including its `filled` flag, so a sibling a user
- * independently typed the same text into isn't retroactively relabeled "just mirrored." Skips `sourceIdx`
- * itself. Purely geometric composition of `shiftSlots`, one sibling at a time, left to right — safe
- * because mirroring never changes which offsets are `group`-equal, only their text/`filled`.
+ * Propagate slot `sourceIdx`'s current text into every OTHER slot sharing its `group`, marking each
+ * overwritten one `filled: true` (but never `edited` — a mirrored value isn't a user edit, so it never
+ * becomes a mirror source itself) — the same mirroring rule {@link TemplateSlot}'s `group` doc documents
+ * (siblings are one conceptual argument; pi would expand them from the same value). The caller picks the
+ * source, always a user-`edited` slot (`mirrorAllGroups` / `Composer`'s `stepSlot`) — that `edited` gate,
+ * not `filled`, is what keeps a `${1:-foo} … ${1:-bar}` pair's untouched defaults from mirroring over each
+ * other. A sibling whose text already matches is left untouched — including its `filled` flag, so a
+ * sibling a user independently typed the same text into isn't retroactively relabeled "just mirrored."
+ * Skips `sourceIdx` itself. Purely geometric composition of `shiftSlots`, one sibling at a time, left to
+ * right — safe because mirroring never changes which offsets are `group`-equal, only their text/`filled`.
  *
  * Returns `{ value, slots }` unchanged (same references) when there's nothing to mirror — no group-mate,
  * or every group-mate already agrees — so a caller can cheaply skip the `onChange`/`setSlots` it would
@@ -318,18 +336,23 @@ export function highlightSegments(
 }
 
 /**
- * `mirrorSlotGroup` for every already-`filled` slot, in array order — the composer's send path has no
+ * `mirrorSlotGroup` for every user-`edited` slot, in array order — the composer's send path has no
  * single "slot the user just left" the way Tab-stepping does (`Composer.tsx`'s `stepSlot`, the sole other
- * caller of `mirrorSlotGroup`): a direct Send can happen with any subset of slots filled, in any order, so
- * every filled slot needs to propagate to its unfilled group-mates, not just the most recently edited one.
+ * caller of `mirrorSlotGroup`): a direct Send can happen with any subset of slots edited, in any order, so
+ * every edited slot needs to propagate to its group-mates, not just the most recently edited one.
  *
- * When two group-mates are BOTH already filled and disagree (each independently typed into, never
- * mirrored against each other — Tab-stepping's own mirroring would normally prevent this, but a direct
- * Send can still reach it, e.g. pasting into a later slot without ever tabbing back through an earlier
- * one), the earliest one in array order wins: later iterations see the earlier slot's mirrored text
- * already sitting at that group's shared offsets and treat it as agreement, same as any other
- * already-matching sibling. Which literal value "wins" here is inherently arbitrary — the two disagreeing
- * values can't both survive — earliest-wins is just a deterministic, easy-to-explain tie-break.
+ * The source gate is `edited`, **not** `filled`: an untouched `${N:-default}` is born `filled` (real
+ * default content) but not `edited`, so it must never mirror — `${1:-foo} … ${1:-bar}` has to stay
+ * "foo … bar", not collapse to "foo … foo" (see {@link TemplateSlot}'s `edited` doc). A default only
+ * starts mirroring once the user edits one of its occurrences, i.e. actually provides that argument.
+ *
+ * When two group-mates are BOTH edited and disagree (each independently typed into, never mirrored
+ * against each other — Tab-stepping's own mirroring would normally prevent this, but a direct Send can
+ * still reach it, e.g. pasting into a later slot without ever tabbing back through an earlier one), the
+ * earliest one in array order wins: later iterations see the earlier slot's mirrored text already sitting
+ * at that group's shared offsets and treat it as agreement, same as any other already-matching sibling.
+ * Which literal value "wins" here is inherently arbitrary — the two disagreeing values can't both
+ * survive — earliest-wins is just a deterministic, easy-to-explain tie-break.
  */
 export function mirrorAllGroups(
 	value: string,
@@ -338,7 +361,7 @@ export function mirrorAllGroups(
 	let nextValue = value;
 	let nextSlots = slots;
 	for (let i = 0; i < nextSlots.length; i++) {
-		if (nextSlots[i]?.filled) {
+		if (nextSlots[i]?.edited) {
 			({ value: nextValue, slots: nextSlots } = mirrorSlotGroup(nextValue, nextSlots, i));
 		}
 	}

--- a/apps/web/src/chat/templatePick.test.ts
+++ b/apps/web/src/chat/templatePick.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { shouldApplyTemplatePick } from "./templatePick";
+
+test("a current pick with an untouched draft applies", () => {
+	expect(
+		shouldApplyTemplatePick({
+			generation: 1,
+			latestGeneration: 1,
+			draftAtPick: "/rev",
+			currentDraft: "/rev",
+		}),
+	).toBe(true);
+});
+
+test("a delayed response is dropped once the user has typed a new draft", () => {
+	// The user picked, then typed something else before `template.get` resolved — applying now would
+	// destroy that newer input.
+	expect(
+		shouldApplyTemplatePick({
+			generation: 1,
+			latestGeneration: 1,
+			draftAtPick: "/rev",
+			currentDraft: "an entirely new draft the user typed meanwhile",
+		}),
+	).toBe(false);
+});
+
+test("out-of-order responses: only the newest pick applies, whatever order the responses land in", () => {
+	// Pick A (gen 1) then pick B (gen 2); B's response lands first and applies…
+	expect(
+		shouldApplyTemplatePick({
+			generation: 2,
+			latestGeneration: 2,
+			draftAtPick: "/rev",
+			currentDraft: "/rev",
+		}),
+	).toBe(true);
+	// …then A's slower response arrives — superseded, dropped, regardless of the draft state.
+	expect(
+		shouldApplyTemplatePick({
+			generation: 1,
+			latestGeneration: 2,
+			draftAtPick: "/rev",
+			currentDraft: "/rev",
+		}),
+	).toBe(false);
+});

--- a/apps/web/src/chat/templatePick.ts
+++ b/apps/web/src/chat/templatePick.ts
@@ -1,0 +1,27 @@
+/**
+ * Should a `template.get` response — an async pick from the composer's `/` menu — still be applied to
+ * the composer? Two independent staleness rules, both required:
+ *
+ * - **Newest pick wins:** `generation` must still be the latest one issued. Two quick picks can resolve
+ *   out of order (nothing on the wire guarantees ordering across requests), and only the most recent
+ *   choice may insert — a slower first response arriving second must be dropped.
+ * - **The draft is untouched:** the current draft must be byte-identical to what it was at pick time.
+ *   If the user typed anything while the fetch was in flight, a late `insertTemplate` would silently
+ *   destroy that newer input — the same "programmatic replace must respect what the user did since"
+ *   class of bug `Composer`'s `replaceDraft` doc describes for recall.
+ *
+ * Pure and exported so the race rules are unit-testable (`templatePick.test.ts`) without a transport;
+ * `ChatView.tsx`'s `onPickTemplate` is the only production caller.
+ */
+export function shouldApplyTemplatePick(pick: {
+	/** The generation stamped when this pick was issued. */
+	generation: number;
+	/** The newest generation issued so far (read when the response arrives). */
+	latestGeneration: number;
+	/** The composer draft exactly as it was when this pick was issued. */
+	draftAtPick: string;
+	/** The composer draft as it is when the response arrives. */
+	currentDraft: string;
+}): boolean {
+	return pick.generation === pick.latestGeneration && pick.draftAtPick === pick.currentDraft;
+}

--- a/apps/web/src/chat/templateText.test.ts
+++ b/apps/web/src/chat/templateText.test.ts
@@ -1,64 +1,49 @@
 import { expect, test } from "bun:test";
-import { assembleTemplate, splitTemplate, stripFrontmatter } from "./templateText";
+import { assembleTemplate, stripFrontmatter } from "./templateText";
 
-// ---- splitTemplate / stripFrontmatter: boundary-finding, pinned to pi's extractFrontmatter ----
+// This module never reads frontmatter VALUES (those come from the server-parsed `TemplateInfo`, i.e.
+// pi's real YAML parser — value fidelity for single-quoted/block scalars is pinned server-side in
+// `packages/server/src/templates/templates.test.ts`). What's pinned here is the *boundary* rule
+// (`stripFrontmatter`, ported from pi's extractFrontmatter) and the writer (`assembleTemplate`).
+
+// ---- stripFrontmatter: boundary-finding, pinned to pi's extractFrontmatter ----
 
 test("no frontmatter at all: content that doesn't start with --- is the body untouched, no trimming", () => {
 	const content = "\n  leading whitespace and a blank line\nBody text\n  ";
-	expect(splitTemplate(content)).toEqual({ description: "", argumentHint: "", body: content });
 	expect(stripFrontmatter(content)).toBe(content);
 });
 
 test("an opener with no closing fence: the whole content is body, completely untouched (not even trimmed)", () => {
 	const content = "---\ndescription: never closes\nstill going\n\n";
-	expect(splitTemplate(content)).toEqual({ description: "", argumentHint: "", body: content });
 	expect(stripFrontmatter(content)).toBe(content);
 });
 
 test("closing fence found: the body is trimmed of ALL leading/trailing blank lines, not just one \\n", () => {
 	const content = '---\ndescription: "d"\n---\n\n\nBody text\n\n';
-	const parsed = splitTemplate(content);
-	expect(parsed.description).toBe("d");
-	expect(parsed.body).toBe("Body text");
+	expect(stripFrontmatter(content)).toBe("Body text");
 });
 
 test("an empty frontmatter block (--- / ---) still finds the fence and trims the body", () => {
 	const content = "---\n---\n\nBody text\n";
-	expect(splitTemplate(content)).toEqual({ description: "", argumentHint: "", body: "Body text" });
+	expect(stripFrontmatter(content)).toBe("Body text");
 });
 
-test("reads both a JSON.stringify-quoted value and a bare (hand-authored) scalar value", () => {
-	const quoted = '---\ndescription: "Quoted value"\nargument-hint: "[a] [b]"\n---\nBody';
-	expect(splitTemplate(quoted)).toEqual({
-		description: "Quoted value",
-		argumentHint: "[a] [b]",
-		body: "Body",
-	});
-	const bare = "---\ndescription: Bare value\n---\nBody";
-	expect(splitTemplate(bare)).toEqual({
-		description: "Bare value",
-		argumentHint: "",
-		body: "Body",
-	});
+test("the boundary rule is style-blind: single-quoted and block-scalar frontmatter never leak into the body", () => {
+	// The values themselves are pi's (server-side) job — but the body must come out clean whatever
+	// scalar style the frontmatter uses, since block-scalar content lines are indented and a valid YAML
+	// block can never contain a column-0 `---` line before the real closing fence.
+	const singleQuoted = "---\ndescription: 'Review safely'\n---\nBody";
+	expect(stripFrontmatter(singleQuoted)).toBe("Body");
+	const blockScalar = "---\ndescription: >\n  folded description\n  over two lines\n---\nBody";
+	expect(stripFrontmatter(blockScalar)).toBe("Body");
 });
 
 test("real fixture compatibility: e2e/fixtures/templates.ts's review.md (one \\n after the fence, bare description, quoted argument-hint) splits correctly", () => {
-	const content =
-		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi placeholder syntax in a fixture string, not a template placeholder
-		'---\ndescription: Review a file for issues\nargument-hint: "[file] [scope]"\n---\nReview $1 for issues, focusing on ${2:-src/}.\n';
-	const parsed = splitTemplate(content);
-	expect(parsed.description).toBe("Review a file for issues");
-	expect(parsed.argumentHint).toBe("[file] [scope]");
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi placeholder syntax being asserted on, not a template placeholder
-	expect(parsed.body).toBe("Review $1 for issues, focusing on ${2:-src/}.");
+	const content = `---\ndescription: Review a file for issues\nargument-hint: "[file] [scope]"\n---\nReview $1 for issues, focusing on \${2:-src/}.\n`;
+	expect(stripFrontmatter(content)).toBe(`Review $1 for issues, focusing on \${2:-src/}.`);
 });
 
-test("stripFrontmatter (ChatView's composer-pick path) agrees with splitTemplate's body for the same content", () => {
-	const content = '---\ndescription: "d"\n---\n\nBody\n';
-	expect(stripFrontmatter(content)).toBe(splitTemplate(content).body);
-});
-
-// ---- assembleTemplate: the inverse, and the forced-wrapper fix for ----leading bodies ----
+// ---- assembleTemplate: the writer, and the forced-wrapper fix for ----leading bodies ----
 
 test("omits the frontmatter block entirely when both fields are empty and the body doesn't start with ---", () => {
 	expect(assembleTemplate("", "", "plain body")).toBe("plain body");
@@ -71,7 +56,7 @@ test("a body starting with --- gets an explicit (empty) wrapper even with no key
 	const body = "---\nMeeting notes\n---\nAfter the second fence";
 	const assembled = assembleTemplate("", "", body);
 	expect(assembled).toBe(`---\n---\n\n${body}`);
-	expect(splitTemplate(assembled)).toEqual({ description: "", argumentHint: "", body });
+	expect(stripFrontmatter(assembled)).toBe(body);
 });
 
 test("emits only the keys with non-empty values", () => {
@@ -86,40 +71,36 @@ test("trims description/argument-hint before deciding whether they're empty", ()
 	expect(assembleTemplate("   ", "  ", "body")).toBe("body");
 });
 
-// ---- round-trip identity: assemble -> split is the identity on (desc, hint, body) ----
+// ---- round-trip identity: assemble -> stripFrontmatter is the identity on the body ----
 
-function roundTrips(description: string, argumentHint: string, body: string) {
-	const assembled = assembleTemplate(description, argumentHint, body);
-	const parsed = splitTemplate(assembled);
-	expect(parsed.description).toBe(description.trim());
-	expect(parsed.argumentHint).toBe(argumentHint.trim());
-	expect(parsed.body).toBe(body);
+function bodyRoundTrips(description: string, argumentHint: string, body: string) {
+	expect(stripFrontmatter(assembleTemplate(description, argumentHint, body))).toBe(body);
 }
 
 test("round-trip: plain body, both fields set", () => {
-	roundTrips("A description", "[file]", "Do the thing.");
+	bodyRoundTrips("A description", "[file]", "Do the thing.");
 });
 
 test("round-trip: empty description/argument-hint combos", () => {
-	roundTrips("", "", "Body only.");
-	roundTrips("Only description", "", "Body.");
-	roundTrips("", "Only hint", "Body.");
+	bodyRoundTrips("", "", "Body only.");
+	bodyRoundTrips("Only description", "", "Body.");
+	bodyRoundTrips("", "Only hint", "Body.");
 });
 
 test("round-trip: a body with no wrapper at all preserves its own leading blank line exactly", () => {
-	roundTrips("", "", "\nBody with a leading blank line, no wrapper needed");
+	bodyRoundTrips("", "", "\nBody with a leading blank line, no wrapper needed");
 });
 
 test("round-trip: --- mid-body (real frontmatter present) never confuses the boundary search", () => {
-	roundTrips("d", "", "before\n---\nlooks like a fence\n---\nafter");
+	bodyRoundTrips("d", "", "before\n---\nlooks like a fence\n---\nafter");
 });
 
 test("round-trip: body starting with --- and no keys set survives even with embedded fence-looking lines", () => {
-	roundTrips("", "", "---\nfake: frontmatter\n---\nreal body");
+	bodyRoundTrips("", "", "---\nfake: frontmatter\n---\nreal body");
 });
 
 test("round-trip: multi-line body with no leading/trailing whitespace of its own", () => {
-	roundTrips("d", "h", "line one\nline two");
+	bodyRoundTrips("d", "h", "line one\nline two");
 });
 
 // ---- pi-semantics pin: what survives vs what pi's own .trim() rule discards ----
@@ -127,46 +108,43 @@ test("round-trip: multi-line body with no leading/trailing whitespace of its own
 test("a body's own leading blank lines survive with no frontmatter at all, but are trimmed away once any frontmatter block wraps it — matching pi's real .trim()-based boundary rule exactly, not a bug", () => {
 	const body = "\n\nBody with two leading blank lines";
 	// No wrapper (empty desc/hint, body doesn't start with "---"): the whole file IS the body, untouched.
-	expect(splitTemplate(assembleTemplate("", "", body)).body).toBe(body);
+	expect(stripFrontmatter(assembleTemplate("", "", body))).toBe(body);
 	// A wrapper forces the boundary through `.trim()`, same as pi's own extractFrontmatter — the leading
 	// blank lines are indistinguishable from the block separator and don't survive. This is intentional:
 	// pi's own loader would produce the exact same trimmed body for this exact file, frontmatter and all.
-	expect(splitTemplate(assembleTemplate("d", "", body)).body).toBe(
+	expect(stripFrontmatter(assembleTemplate("d", "", body))).toBe(
 		"Body with two leading blank lines",
 	);
 });
 
-// ---- stability: split(assemble(split(x))) must not compound (the reviewer's second bug) ----
+// ---- stability: strip(assemble(strip(x))) must not compound (the reviewer's second bug) ----
 
 test("re-splitting an already-split-and-reassembled template never grows the body, even starting from a hand-authored single-\\n file", () => {
 	const original = "---\ndescription: Bare value\n---\nBody text";
-	const once = splitTemplate(original);
-	expect(once.body).toBe("Body text");
+	const once = stripFrontmatter(original);
+	expect(once).toBe("Body text");
 
-	const reassembled = assembleTemplate(once.description, once.argumentHint, once.body);
-	// Our own assembler always normalizes to the canonical two-`\n` separator...
+	// The edit flow re-saves the (server-parsed) description with the stripped body...
+	const reassembled = assembleTemplate("Bare value", "", once);
+	// ...our own assembler always normalizes to the canonical two-`\n` separator...
 	expect(reassembled).toBe('---\ndescription: "Bare value"\n---\n\nBody text');
-	const twice = splitTemplate(reassembled);
-	expect(twice.body).toBe("Body text");
+	expect(stripFrontmatter(reassembled)).toBe("Body text");
 
 	// ...and a second save from there is a byte-identical fixed point — not one more leaked `\n`.
-	const reassembledAgain = assembleTemplate(twice.description, twice.argumentHint, twice.body);
+	const reassembledAgain = assembleTemplate("Bare value", "", stripFrontmatter(reassembled));
 	expect(reassembledAgain).toBe(reassembled);
-	expect(splitTemplate(reassembledAgain).body).toBe("Body text");
+	expect(stripFrontmatter(reassembledAgain)).toBe("Body text");
 });
 
 test("editing only the description across repeated save cycles leaves the body byte-for-byte unchanged", () => {
-	// The exact reviewer-flagged regression: TemplateEditorDialog's edit flow re-saves `parsed.body`
+	// The exact reviewer-flagged regression: TemplateEditorDialog's edit flow re-saves the stripped body
 	// verbatim every time the user only touches the description field.
 	const original = assembleTemplate("first description", "", "Notes for the day");
-	let parsed = splitTemplate(original);
-	expect(parsed.body).toBe("Notes for the day");
+	expect(stripFrontmatter(original)).toBe("Notes for the day");
 
-	const firstSave = assembleTemplate("revised once", parsed.argumentHint, parsed.body);
-	parsed = splitTemplate(firstSave);
-	expect(parsed.body).toBe("Notes for the day");
+	const firstSave = assembleTemplate("revised once", "", stripFrontmatter(original));
+	expect(stripFrontmatter(firstSave)).toBe("Notes for the day");
 
-	const secondSave = assembleTemplate("revised twice", parsed.argumentHint, parsed.body);
-	parsed = splitTemplate(secondSave);
-	expect(parsed.body).toBe("Notes for the day");
+	const secondSave = assembleTemplate("revised twice", "", stripFrontmatter(firstSave));
+	expect(stripFrontmatter(secondSave)).toBe("Notes for the day");
 });

--- a/apps/web/src/chat/templateText.test.ts
+++ b/apps/web/src/chat/templateText.test.ts
@@ -1,0 +1,172 @@
+import { expect, test } from "bun:test";
+import { assembleTemplate, splitTemplate, stripFrontmatter } from "./templateText";
+
+// ---- splitTemplate / stripFrontmatter: boundary-finding, pinned to pi's extractFrontmatter ----
+
+test("no frontmatter at all: content that doesn't start with --- is the body untouched, no trimming", () => {
+	const content = "\n  leading whitespace and a blank line\nBody text\n  ";
+	expect(splitTemplate(content)).toEqual({ description: "", argumentHint: "", body: content });
+	expect(stripFrontmatter(content)).toBe(content);
+});
+
+test("an opener with no closing fence: the whole content is body, completely untouched (not even trimmed)", () => {
+	const content = "---\ndescription: never closes\nstill going\n\n";
+	expect(splitTemplate(content)).toEqual({ description: "", argumentHint: "", body: content });
+	expect(stripFrontmatter(content)).toBe(content);
+});
+
+test("closing fence found: the body is trimmed of ALL leading/trailing blank lines, not just one \\n", () => {
+	const content = '---\ndescription: "d"\n---\n\n\nBody text\n\n';
+	const parsed = splitTemplate(content);
+	expect(parsed.description).toBe("d");
+	expect(parsed.body).toBe("Body text");
+});
+
+test("an empty frontmatter block (--- / ---) still finds the fence and trims the body", () => {
+	const content = "---\n---\n\nBody text\n";
+	expect(splitTemplate(content)).toEqual({ description: "", argumentHint: "", body: "Body text" });
+});
+
+test("reads both a JSON.stringify-quoted value and a bare (hand-authored) scalar value", () => {
+	const quoted = '---\ndescription: "Quoted value"\nargument-hint: "[a] [b]"\n---\nBody';
+	expect(splitTemplate(quoted)).toEqual({
+		description: "Quoted value",
+		argumentHint: "[a] [b]",
+		body: "Body",
+	});
+	const bare = "---\ndescription: Bare value\n---\nBody";
+	expect(splitTemplate(bare)).toEqual({
+		description: "Bare value",
+		argumentHint: "",
+		body: "Body",
+	});
+});
+
+test("real fixture compatibility: e2e/fixtures/templates.ts's review.md (one \\n after the fence, bare description, quoted argument-hint) splits correctly", () => {
+	const content =
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi placeholder syntax in a fixture string, not a template placeholder
+		'---\ndescription: Review a file for issues\nargument-hint: "[file] [scope]"\n---\nReview $1 for issues, focusing on ${2:-src/}.\n';
+	const parsed = splitTemplate(content);
+	expect(parsed.description).toBe("Review a file for issues");
+	expect(parsed.argumentHint).toBe("[file] [scope]");
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi placeholder syntax being asserted on, not a template placeholder
+	expect(parsed.body).toBe("Review $1 for issues, focusing on ${2:-src/}.");
+});
+
+test("stripFrontmatter (ChatView's composer-pick path) agrees with splitTemplate's body for the same content", () => {
+	const content = '---\ndescription: "d"\n---\n\nBody\n';
+	expect(stripFrontmatter(content)).toBe(splitTemplate(content).body);
+});
+
+// ---- assembleTemplate: the inverse, and the forced-wrapper fix for ----leading bodies ----
+
+test("omits the frontmatter block entirely when both fields are empty and the body doesn't start with ---", () => {
+	expect(assembleTemplate("", "", "plain body")).toBe("plain body");
+});
+
+test("a body starting with --- gets an explicit (empty) wrapper even with no keys set, and round-trips exactly", () => {
+	// The ambiguous case: saved bare, this body's OWN embedded --- lines would later be misread as a (junk)
+	// frontmatter block by any splitter that mirrors pi's real algorithm — silent data loss. Forcing an
+	// explicit wrapper sidesteps it unconditionally, since our own fence is always the earliest "\n---".
+	const body = "---\nMeeting notes\n---\nAfter the second fence";
+	const assembled = assembleTemplate("", "", body);
+	expect(assembled).toBe(`---\n---\n\n${body}`);
+	expect(splitTemplate(assembled)).toEqual({ description: "", argumentHint: "", body });
+});
+
+test("emits only the keys with non-empty values", () => {
+	expect(assembleTemplate("d", "", "body")).toBe('---\ndescription: "d"\n---\n\nbody');
+	expect(assembleTemplate("", "h", "body")).toBe('---\nargument-hint: "h"\n---\n\nbody');
+	expect(assembleTemplate("d", "h", "body")).toBe(
+		'---\ndescription: "d"\nargument-hint: "h"\n---\n\nbody',
+	);
+});
+
+test("trims description/argument-hint before deciding whether they're empty", () => {
+	expect(assembleTemplate("   ", "  ", "body")).toBe("body");
+});
+
+// ---- round-trip identity: assemble -> split is the identity on (desc, hint, body) ----
+
+function roundTrips(description: string, argumentHint: string, body: string) {
+	const assembled = assembleTemplate(description, argumentHint, body);
+	const parsed = splitTemplate(assembled);
+	expect(parsed.description).toBe(description.trim());
+	expect(parsed.argumentHint).toBe(argumentHint.trim());
+	expect(parsed.body).toBe(body);
+}
+
+test("round-trip: plain body, both fields set", () => {
+	roundTrips("A description", "[file]", "Do the thing.");
+});
+
+test("round-trip: empty description/argument-hint combos", () => {
+	roundTrips("", "", "Body only.");
+	roundTrips("Only description", "", "Body.");
+	roundTrips("", "Only hint", "Body.");
+});
+
+test("round-trip: a body with no wrapper at all preserves its own leading blank line exactly", () => {
+	roundTrips("", "", "\nBody with a leading blank line, no wrapper needed");
+});
+
+test("round-trip: --- mid-body (real frontmatter present) never confuses the boundary search", () => {
+	roundTrips("d", "", "before\n---\nlooks like a fence\n---\nafter");
+});
+
+test("round-trip: body starting with --- and no keys set survives even with embedded fence-looking lines", () => {
+	roundTrips("", "", "---\nfake: frontmatter\n---\nreal body");
+});
+
+test("round-trip: multi-line body with no leading/trailing whitespace of its own", () => {
+	roundTrips("d", "h", "line one\nline two");
+});
+
+// ---- pi-semantics pin: what survives vs what pi's own .trim() rule discards ----
+
+test("a body's own leading blank lines survive with no frontmatter at all, but are trimmed away once any frontmatter block wraps it — matching pi's real .trim()-based boundary rule exactly, not a bug", () => {
+	const body = "\n\nBody with two leading blank lines";
+	// No wrapper (empty desc/hint, body doesn't start with "---"): the whole file IS the body, untouched.
+	expect(splitTemplate(assembleTemplate("", "", body)).body).toBe(body);
+	// A wrapper forces the boundary through `.trim()`, same as pi's own extractFrontmatter — the leading
+	// blank lines are indistinguishable from the block separator and don't survive. This is intentional:
+	// pi's own loader would produce the exact same trimmed body for this exact file, frontmatter and all.
+	expect(splitTemplate(assembleTemplate("d", "", body)).body).toBe(
+		"Body with two leading blank lines",
+	);
+});
+
+// ---- stability: split(assemble(split(x))) must not compound (the reviewer's second bug) ----
+
+test("re-splitting an already-split-and-reassembled template never grows the body, even starting from a hand-authored single-\\n file", () => {
+	const original = "---\ndescription: Bare value\n---\nBody text";
+	const once = splitTemplate(original);
+	expect(once.body).toBe("Body text");
+
+	const reassembled = assembleTemplate(once.description, once.argumentHint, once.body);
+	// Our own assembler always normalizes to the canonical two-`\n` separator...
+	expect(reassembled).toBe('---\ndescription: "Bare value"\n---\n\nBody text');
+	const twice = splitTemplate(reassembled);
+	expect(twice.body).toBe("Body text");
+
+	// ...and a second save from there is a byte-identical fixed point — not one more leaked `\n`.
+	const reassembledAgain = assembleTemplate(twice.description, twice.argumentHint, twice.body);
+	expect(reassembledAgain).toBe(reassembled);
+	expect(splitTemplate(reassembledAgain).body).toBe("Body text");
+});
+
+test("editing only the description across repeated save cycles leaves the body byte-for-byte unchanged", () => {
+	// The exact reviewer-flagged regression: TemplateEditorDialog's edit flow re-saves `parsed.body`
+	// verbatim every time the user only touches the description field.
+	const original = assembleTemplate("first description", "", "Notes for the day");
+	let parsed = splitTemplate(original);
+	expect(parsed.body).toBe("Notes for the day");
+
+	const firstSave = assembleTemplate("revised once", parsed.argumentHint, parsed.body);
+	parsed = splitTemplate(firstSave);
+	expect(parsed.body).toBe("Notes for the day");
+
+	const secondSave = assembleTemplate("revised twice", parsed.argumentHint, parsed.body);
+	parsed = splitTemplate(secondSave);
+	expect(parsed.body).toBe("Notes for the day");
+});

--- a/apps/web/src/chat/templateText.ts
+++ b/apps/web/src/chat/templateText.ts
@@ -3,9 +3,13 @@
  * `stripFrontmatter`/`parseFrontmatter` (`@earendil-works/pi-coding-agent`'s `dist/utils/frontmatter.js`,
  * pinned against pi v0.80.6 — the same pin `packages/server/src/templates/SPEC.md` uses for the server
  * side; re-verify both on a pi version bump). pi's real parser is server-only (real YAML via the `yaml`
- * package, `node:fs`) and never reaches the browser bundle, so this file is a small, hand-rolled mirror —
- * not a general YAML parser, since our own frontmatter only ever has two possible keys (`description`,
- * `argument-hint`), each written on its own single line, `JSON.stringify`-quoted by {@link assembleTemplate}.
+ * package, `node:fs`) and never reaches the browser bundle — and this module deliberately does **no YAML
+ * value parsing at all**: it only locates the frontmatter *boundary* (`stripFrontmatter`) and writes a
+ * block from form fields (`assembleTemplate`). Frontmatter VALUES always come from the server-parsed
+ * `TemplateInfo.description`/`argumentHint` — pi's real parser — never from a browser-side reimplementation
+ * (an earlier `splitTemplate` here hand-parsed values and handled only bare/JSON-double-quoted scalars, so
+ * a pi-native `description: 'single-quoted'` loaded into the edit form with its literal quotes and saved
+ * back corrupted).
  *
  * The rule that matters, ported byte-for-byte from pi's `extractFrontmatter`: content must start with the
  * literal `---`; the frontmatter block ends at the FIRST later `\n---` line (never one embedded inside a
@@ -31,73 +35,32 @@ function normalizeNewlines(value: string): string {
 }
 
 /**
- * Locates the frontmatter block's boundary exactly the way pi's own `extractFrontmatter` does.
- * `yamlString` is `null` when there's no frontmatter block at all (content doesn't start with `---`, or a
- * `---` opener never finds a closing `\n---`) — in that case `body` is the untouched (only
- * newline-normalized) content. `yamlString` is `""` (falsy, but not `null`) for a block that's present but
- * empty (`---\n---\n...`) — `body` is still correctly boundary-found and trimmed in that case, same as a
- * non-empty block.
+ * The body pi's own loader would hand to `expandPromptTemplate`, located exactly the way pi's own
+ * `extractFrontmatter` finds the boundary (see the module doc's ported rule). Used by `ChatView.tsx`'s
+ * composer-pick path and `TemplateEditorDialog.tsx`'s body field. Never reads a frontmatter *value* —
+ * those come from `TemplateInfo.description`/`argumentHint`, already parsed server-side by pi. No
+ * frontmatter block at all (content doesn't start with `---`, or a `---` opener never finds a closing
+ * `\n---`) → the untouched (only newline-normalized) content; a present-but-empty block (`---\n---\n…`)
+ * is still boundary-found and its body trimmed, same as a non-empty one.
  */
-function extractFrontmatterBlock(content: string): { yamlString: string | null; body: string } {
-	const normalized = normalizeNewlines(content);
-	if (!normalized.startsWith("---")) return { yamlString: null, body: normalized };
-	const endIndex = normalized.indexOf("\n---", 3);
-	if (endIndex === -1) return { yamlString: null, body: normalized };
-	return { yamlString: normalized.slice(4, endIndex), body: normalized.slice(endIndex + 4).trim() };
-}
-
-/**
- * Best-effort single-line scalar read for a `key: value` frontmatter line. Handles exactly the two shapes
- * {@link assembleTemplate} ever writes — a bare scalar (also what a hand-authored file like the seed
- * fixture's `description: Review a file for issues` uses), or one `JSON.stringify`-quoted by this module —
- * not general YAML.
- */
-function readFrontmatterKey(block: string, key: string): string {
-	const line = block.split("\n").find((l) => l.startsWith(`${key}:`));
-	if (!line) return "";
-	const raw = line.slice(key.length + 1).trim();
-	if (raw.startsWith('"') && raw.endsWith('"')) {
-		try {
-			return JSON.parse(raw) as string;
-		} catch {
-			return raw;
-		}
-	}
-	return raw;
-}
-
-/** The body pi's own loader would hand to `expandPromptTemplate` — used by `ChatView.tsx`'s composer-pick
- * path (never a frontmatter *value*; those come from `TemplateInfo.description`/`argumentHint`, already
- * parsed server-side). */
 export function stripFrontmatter(content: string): string {
-	return extractFrontmatterBlock(content).body;
-}
-
-/** Splits a template file's leading frontmatter block from its body. Used by `TemplateEditorDialog.tsx`,
- * which (unlike `stripFrontmatter` above) also needs the two field values to populate its form. */
-export function splitTemplate(content: string): {
-	description: string;
-	argumentHint: string;
-	body: string;
-} {
-	const { yamlString, body } = extractFrontmatterBlock(content);
-	if (!yamlString) return { description: "", argumentHint: "", body };
-	return {
-		description: readFrontmatterKey(yamlString, "description"),
-		argumentHint: readFrontmatterKey(yamlString, "argument-hint"),
-		body,
-	};
+	const normalized = normalizeNewlines(content);
+	if (!normalized.startsWith("---")) return normalized;
+	const endIndex = normalized.indexOf("\n---", 3);
+	if (endIndex === -1) return normalized;
+	return normalized.slice(endIndex + 4).trim();
 }
 
 /**
- * Assembles a template file's full text from form fields — the inverse of {@link splitTemplate}. Omits
+ * Assembles a template file's full text from form fields — the writer whose output `stripFrontmatter`
+ * (and pi's own loader) can always split back apart. Omits
  * either frontmatter key when its field is empty, and omits the frontmatter block entirely when both are
  * empty *and* `body` doesn't start with `---` (see below). Each present value is `JSON.stringify`-quoted:
  * YAML's double-quoted scalar escape set is a superset of JSON's, so this is always valid YAML without a
  * `yaml` package dependency (see the seed fixture's own quoted `argument-hint: "[file] [scope]"`).
  *
  * **The `---`-body case**: a body that itself starts with `---`, saved with no frontmatter keys, would be
- * written bare — and pi's own loader (and this module's `extractFrontmatterBlock`) would then go hunting
+ * written bare — and pi's own loader (and this module's `stripFrontmatter`) would then go hunting
  * for a *later* `\n---` line inside that body to treat as a closing fence, silently swallowing real body
  * content as if it were YAML the moment the body ever contains (now, or after some future edit) a second
  * line that looks like a fence. Emitting an explicit block — even an empty one, `---\n---\n\n` —

--- a/apps/web/src/chat/templateText.ts
+++ b/apps/web/src/chat/templateText.ts
@@ -1,0 +1,118 @@
+/**
+ * Frontmatter split/assemble for prompt-template files — the client-side mirror of pi's own
+ * `stripFrontmatter`/`parseFrontmatter` (`@earendil-works/pi-coding-agent`'s `dist/utils/frontmatter.js`,
+ * pinned against pi v0.80.6 — the same pin `packages/server/src/templates/SPEC.md` uses for the server
+ * side; re-verify both on a pi version bump). pi's real parser is server-only (real YAML via the `yaml`
+ * package, `node:fs`) and never reaches the browser bundle, so this file is a small, hand-rolled mirror —
+ * not a general YAML parser, since our own frontmatter only ever has two possible keys (`description`,
+ * `argument-hint`), each written on its own single line, `JSON.stringify`-quoted by {@link assembleTemplate}.
+ *
+ * The rule that matters, ported byte-for-byte from pi's `extractFrontmatter`: content must start with the
+ * literal `---`; the frontmatter block ends at the FIRST later `\n---` line (never one embedded inside a
+ * value — our values can't contain a raw newline, since they're single-line JSON-quoted); the body is
+ * everything after that closing fence's own `---`, run through `String.prototype.trim()` — every
+ * leading/trailing blank line and space, not just one `\n`. No closing fence anywhere → the WHOLE content
+ * is body, completely untouched (not even trimmed) — pi treats a dangling `---` opener with no closer as
+ * plain content, not a parse error.
+ *
+ * `ChatView.tsx` (composer pick) and `TemplateEditorDialog.tsx` (settings edit / save-as-template) both
+ * import this one module rather than keeping their own splitter. A prior version had two independently
+ * hand-rolled regex splitters (one per file), each consuming only a single *optional* `\n` after the
+ * closing fence instead of trimming — a leading blank line leaked into the body on every pick and every
+ * edit-reopen, and *compounded* by one more `\n` per edit-save cycle (the leaked line got saved back into
+ * the body field and re-wrapped the next save). `templateText.test.ts` pins the round-trip properties this
+ * fix depends on.
+ */
+
+/** CRLF/CR → LF, exactly like pi's own `normalizeNewlines` — a file saved on one platform round-trips the
+ * same everywhere. */
+function normalizeNewlines(value: string): string {
+	return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Locates the frontmatter block's boundary exactly the way pi's own `extractFrontmatter` does.
+ * `yamlString` is `null` when there's no frontmatter block at all (content doesn't start with `---`, or a
+ * `---` opener never finds a closing `\n---`) — in that case `body` is the untouched (only
+ * newline-normalized) content. `yamlString` is `""` (falsy, but not `null`) for a block that's present but
+ * empty (`---\n---\n...`) — `body` is still correctly boundary-found and trimmed in that case, same as a
+ * non-empty block.
+ */
+function extractFrontmatterBlock(content: string): { yamlString: string | null; body: string } {
+	const normalized = normalizeNewlines(content);
+	if (!normalized.startsWith("---")) return { yamlString: null, body: normalized };
+	const endIndex = normalized.indexOf("\n---", 3);
+	if (endIndex === -1) return { yamlString: null, body: normalized };
+	return { yamlString: normalized.slice(4, endIndex), body: normalized.slice(endIndex + 4).trim() };
+}
+
+/**
+ * Best-effort single-line scalar read for a `key: value` frontmatter line. Handles exactly the two shapes
+ * {@link assembleTemplate} ever writes — a bare scalar (also what a hand-authored file like the seed
+ * fixture's `description: Review a file for issues` uses), or one `JSON.stringify`-quoted by this module —
+ * not general YAML.
+ */
+function readFrontmatterKey(block: string, key: string): string {
+	const line = block.split("\n").find((l) => l.startsWith(`${key}:`));
+	if (!line) return "";
+	const raw = line.slice(key.length + 1).trim();
+	if (raw.startsWith('"') && raw.endsWith('"')) {
+		try {
+			return JSON.parse(raw) as string;
+		} catch {
+			return raw;
+		}
+	}
+	return raw;
+}
+
+/** The body pi's own loader would hand to `expandPromptTemplate` — used by `ChatView.tsx`'s composer-pick
+ * path (never a frontmatter *value*; those come from `TemplateInfo.description`/`argumentHint`, already
+ * parsed server-side). */
+export function stripFrontmatter(content: string): string {
+	return extractFrontmatterBlock(content).body;
+}
+
+/** Splits a template file's leading frontmatter block from its body. Used by `TemplateEditorDialog.tsx`,
+ * which (unlike `stripFrontmatter` above) also needs the two field values to populate its form. */
+export function splitTemplate(content: string): {
+	description: string;
+	argumentHint: string;
+	body: string;
+} {
+	const { yamlString, body } = extractFrontmatterBlock(content);
+	if (!yamlString) return { description: "", argumentHint: "", body };
+	return {
+		description: readFrontmatterKey(yamlString, "description"),
+		argumentHint: readFrontmatterKey(yamlString, "argument-hint"),
+		body,
+	};
+}
+
+/**
+ * Assembles a template file's full text from form fields — the inverse of {@link splitTemplate}. Omits
+ * either frontmatter key when its field is empty, and omits the frontmatter block entirely when both are
+ * empty *and* `body` doesn't start with `---` (see below). Each present value is `JSON.stringify`-quoted:
+ * YAML's double-quoted scalar escape set is a superset of JSON's, so this is always valid YAML without a
+ * `yaml` package dependency (see the seed fixture's own quoted `argument-hint: "[file] [scope]"`).
+ *
+ * **The `---`-body case**: a body that itself starts with `---`, saved with no frontmatter keys, would be
+ * written bare — and pi's own loader (and this module's `extractFrontmatterBlock`) would then go hunting
+ * for a *later* `\n---` line inside that body to treat as a closing fence, silently swallowing real body
+ * content as if it were YAML the moment the body ever contains (now, or after some future edit) a second
+ * line that looks like a fence. Emitting an explicit block — even an empty one, `---\n---\n\n` —
+ * sidesteps this unconditionally: the boundary search always finds *this* fence first, since it's the
+ * earliest possible `\n---` in the file (our own values can't contain a raw newline), so the body's own
+ * `---`-looking lines are never reinterpreted, no matter what they say or how many of them there are.
+ */
+export function assembleTemplate(description: string, argumentHint: string, body: string): string {
+	const lines: string[] = [];
+	const d = description.trim();
+	const a = argumentHint.trim();
+	if (d) lines.push(`description: ${JSON.stringify(d)}`);
+	if (a) lines.push(`argument-hint: ${JSON.stringify(a)}`);
+	if (lines.length === 0) {
+		return body.startsWith("---") ? `---\n---\n\n${body}` : body;
+	}
+	return `---\n${lines.join("\n")}\n---\n\n${body}`;
+}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -142,14 +142,39 @@ a project picker, the prompt hero, and the reused
   Connected (Disconnect) / ready (Connect) / not signed in (in-app `central login` + Retry) / not installed
   (the host's per-OS copyable install command — from `jbcentralInstall`, for the *host's* OS, never the
   browser's — + Recheck); each mutation re-reads `provider.status`) **`GithubSettings`** (the "Local GitHub" block — `github.authStatus()`
-  Connected + login / Not connected + Refresh); and **`AppearanceSettings`** (the **theme picker** — the
-  bundled catalog from `themes`, with the resolved active selection from `store.theme` marked;
-  clicking one fires `settings.update` and the UI **converges on the `settings.changed` broadcast** (no
-  optimistic apply), a rejected update raising a toast). The picker never owns a theme list — it renders
-  the catalog the glob discovered at build time. A single dimmed "General" nav item
-  ("Soon") still signals the shell is
-  built to grow. `ProvidersSettings`/`AppearanceSettings` are the **integration pieces** (store + transport);
-  the `LoginDialog` stays presentational (`auth` module).
+  Connected + login / Not connected + Refresh); **`AppearanceSettings`** (the **theme picker** — the
+  bundled catalog from `themes`, with the resolved active selection from `store.theme` marked; clicking
+  one fires `settings.update` and the UI **converges on the `settings.changed` broadcast** (no optimistic
+  apply), a rejected update raising a toast; the picker never owns a theme list — it renders the catalog
+  the glob discovered at build time); and **`TemplatesSettings`** — two groups, **Global** and **This
+  project** (the project group renders only with an active workspace), each a header with a **New**
+  button plus its rows, fetched via **two independent `template.list` calls** (both refetched whenever the
+  store's `templatesVersion` bumps, each with its own failure flag so one's success can never clobber the
+  other's still-real failure): unscoped (`{}`) for **Global**, and `{ workspaceId }` filtered to
+  `scope === "project"` for **This project**. The unscoped call matters specifically because the server's
+  `template.list { workspaceId }` response is **shadow-merged** (`templates.ts`'s `listTemplates`: a
+  project template wins over a same-named global one) — right for the composer's `/` menu, but if Settings
+  used that same workspace-scoped call for its Global group too, a shadowed global template would vanish
+  from view entirely with no way to find, edit, or delete it
+  (`data-testid="template-row"`: name + description, and — project rows only — an
+  **Open as file** action that opens `.pi/prompts/<name>.md` through the exact same `openFile.ts`
+  `openFileInTab` the file tree uses, then closes Settings, and an **Edit** action; a global template has
+  no worktree to open a file tab against, so global rows stay dialog-only). **New**/**Edit** open the shared
+  `chat/TemplateEditorDialog` (see `chat/SPEC.md`'s Save-as-template bullet — it lives in `chat/` because
+  `HistoryOverlay`'s save-as-template action needs the identical form, and `chat/` can't import
+  `panels/`). **Delete** is a `ConfirmPopover` on the row (the same anchored-confirm pattern
+  `ProjectTree.tsx`'s workspace-remove uses) calling `template.delete` directly — the dialog itself is
+  never involved in deletion. **R4 — starter-templates offer:** when the **Global** group's fetch has
+  resolved with zero rows and no error, its empty state swaps the bare "No templates yet." for that same
+  hint plus a button (`data-testid="template-starters"`) — clicking it `template.save`s four verbatim
+  starter templates (review/explain/tests/standup; scope `"global"`, body assembled client-side via
+  `chat/templateText.ts`'s `assembleTemplate`, the same helper `TemplateEditorDialog` uses) sequentially,
+  then bumps `templatesVersion` once, the same invalidation the row list already refetches on — the
+  offer disappears on its own next render once the list is non-empty, no dismiss state to track. **This
+  project**'s empty state is unchanged (still the bare text) — the offer is Global-only, since it only
+  ever seeds global files. No server change. A single dimmed "General" nav item ("Soon") still signals the shell is
+  built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings` are the **integration pieces**
+  (store + transport); the `LoginDialog` stays presentational (`auth` module).
   Panels compose their own sub-panels
   (e.g. `RightPanel`→`FileTree`/`ChangesPanel`, `CenterTabs`→`FilePane`→`MonacoEditor`) — an internal hierarchy.
   When the active workspace has no open center tab, `CenterTabs` uses the empty surface as a persistent
@@ -182,7 +207,7 @@ a project picker, the prompt hero, and the reused
   one set or the other on the active-workspace branch.)
 - **Allowed deps:** `store`, `transport`, `components/ui` (incl. `popover`/`command`/`textarea` for the
   dialog), `chat` (`ModelSelector`/`ThinkingSelector`, reused by `NewWorkspaceDialog`; `Markdown`,
-  reused by `MarkdownPreview`), `lib`, `themes` (catalog + generic application contract),
+  reused by `MarkdownPreview`; `TemplateEditorDialog`, reused by `TemplatesSettings`), `lib`, `themes` (catalog + generic application contract),
   `contracts`; `lucide-react`; and the heavy libs each lazy panel owns (`monaco-editor`, `shiki`,
   `@xterm/*`) loaded via `import()`.
 - **Forbidden:** `server`/`shared`/`pi`; importing `shell`; reaching across unrelated panels.

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -1,16 +1,25 @@
-import { GitBranch, KeyRound, type LucideIcon, Palette, SlidersHorizontal } from "lucide-react";
+import {
+	GitBranch,
+	KeyRound,
+	LayoutTemplate,
+	type LucideIcon,
+	Palette,
+	SlidersHorizontal,
+} from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib";
 import { SettingsSection, useAppStore } from "@/store";
 import { AppearanceSettings } from "./AppearanceSettings";
 import { GithubSettings } from "./GithubSettings";
 import { ProvidersSettings } from "./ProvidersSettings";
+import { TemplatesSettings } from "./TemplatesSettings";
 
 /** The live settings sections, in nav order. */
 const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
 	{ id: SettingsSection.Providers, label: "Providers", icon: KeyRound },
 	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
 	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
+	{ id: SettingsSection.Templates, label: "Templates", icon: LayoutTemplate },
 ];
 /** Placeholder sections — shown dimmed so the shell reads as built-to-grow (not yet wired). */
 const SOON: { label: string; icon: LucideIcon }[] = [{ label: "General", icon: SlidersHorizontal }];
@@ -84,6 +93,8 @@ export function SettingsDialog() {
 							<ProvidersSettings />
 						) : section === SettingsSection.Github ? (
 							<GithubSettings />
+						) : section === SettingsSection.Templates ? (
+							<TemplatesSettings />
 						) : (
 							<AppearanceSettings />
 						)}

--- a/apps/web/src/panels/TemplatesSettings.tsx
+++ b/apps/web/src/panels/TemplatesSettings.tsx
@@ -1,0 +1,397 @@
+import type { TemplateInfo, TemplateScope } from "@thinkrail/contracts";
+import { FileText, Pencil, Plus, Sparkles, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { TemplateEditorDialog } from "@/chat/TemplateEditorDialog";
+import { assembleTemplate } from "@/chat/templateText";
+import { Button } from "@/components/ui/button";
+import { PopoverTrigger } from "@/components/ui/popover";
+import { toast, useAppStore } from "@/store";
+import { errorText, getTransport } from "@/transport";
+import { ConfirmPopover } from "./ConfirmPopover";
+import { openFileInTab } from "./openFile";
+
+/**
+ * R4: verbatim starter-template content offered by `StarterTemplatesOffer` below (design doc "Amendments
+ * (2026-07-22)" item 4). Bodies use pi's own `$1`/`${N:-default}` placeholder grammar — not a JS template
+ * literal — so `${2:-the riskiest parts}` / `${1:-mine}` need a lint escape (see the two biome-ignores
+ * below); `explain`/`tests` only ever use bare `$1`, which doesn't trip the rule.
+ */
+const STARTER_TEMPLATES: ReadonlyArray<{
+	name: string;
+	description: string;
+	argumentHint: string;
+	body: string;
+}> = [
+	{
+		name: "review",
+		description: "Code review of a file or directory",
+		argumentHint: "[path] [focus]",
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi prompt-template syntax, not a JS placeholder
+		body: "Review $1 for correctness, clarity, and maintainability, focusing on ${2:-the riskiest parts}.\nList concrete findings with file:line references, ordered by severity, then suggest fixes.",
+	},
+	{
+		name: "explain",
+		description: "Explain how something works",
+		argumentHint: "[path-or-topic]",
+		body: "Explain how $1 works in this codebase: its purpose, the key control/data flow, and what depends on\nit. Keep it concise and point to the load-bearing files and lines.",
+	},
+	{
+		name: "tests",
+		description: "Write tests for a target",
+		argumentHint: "[path]",
+		body: "Write tests for $1. Cover the main behavior, the edge cases, and one failure path. Match the\nproject's existing test conventions and runner, and run the tests after writing them.",
+	},
+	{
+		name: "standup",
+		description: "One-line standup update",
+		argumentHint: "[team]",
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi prompt-template syntax, not a JS placeholder
+		body: "Write a one-line standup update for team ${1:-mine} based on this workspace's recent changes.\nReply with just that line.",
+	},
+];
+
+/**
+ * R4: the Global group's empty-state nudge — one click seeds the four `STARTER_TEMPLATES` above via the
+ * same `template.save` wire call `TemplateEditorDialog` uses (scope `"global"`, body assembled by the same
+ * `assembleTemplate` helper), sequentially, then bumps `templatesVersion` once so both this panel and the
+ * composer's `/` menu cache pick them up. No dismiss state to track: once the list is non-empty,
+ * `TemplateGroup` renders the normal row list instead and this component never mounts again.
+ */
+function StarterTemplatesOffer() {
+	const [adding, setAdding] = useState(false);
+
+	const addStarters = async () => {
+		if (adding) return;
+		setAdding(true);
+		try {
+			for (const t of STARTER_TEMPLATES) {
+				await getTransport().request("template.save", {
+					scope: "global",
+					name: t.name,
+					content: assembleTemplate(t.description, t.argumentHint, t.body),
+				});
+			}
+		} catch (err) {
+			toast.error(errorText(err), "Couldn't add starter templates");
+		} finally {
+			// Bump even on a partial failure (e.g. the 3rd of 4 saves throws): `template.save` is an
+			// idempotent overwrite, so whichever starters landed before the throw are real rows the
+			// list refetch should pick up — without the bump they'd exist on disk but never appear, and
+			// the offer would linger since the (still-empty, per its stale fetch) list never re-renders.
+			useAppStore.getState().bumpTemplatesVersion();
+			setAdding(false);
+		}
+	};
+
+	return (
+		<div className="flex flex-col items-start gap-sm">
+			<p className="text-hint text-xs">No templates yet. Add a few common ones to get started.</p>
+			<Button
+				data-testid="template-starters"
+				variant="outline"
+				size="sm"
+				disabled={adding}
+				onClick={() => void addStarters()}
+			>
+				<Sparkles className="size-3.5" />
+				Add starter templates
+			</Button>
+		</div>
+	);
+}
+
+/**
+ * The Settings → Templates panel: two groups — **Global** (always) and **This project** (only with an
+ * active workspace) — each listing its prompt-template files with New/Edit/Delete, and (project rows
+ * only) an Open-as-file shortcut. Fetches `template.list` **twice**, both refetched whenever the store's
+ * `templatesVersion` bumps (a save or delete from anywhere — this panel or `HistoryOverlay`'s
+ * save-as-template — invalidates it):
+ *  - unscoped (`{}`) for the **Global** group — the server's shadow-merge (`templates.ts`'s
+ *    `listTemplates`: a project template wins over a same-named global one, by design — see that
+ *    module's own doc) means a *workspace-scoped* list would silently drop a shadowed global template
+ *    from view entirely. That's the right behavior for the composer's `/` menu (one name expands to one
+ *    thing), but wrong here: Settings must still let the user find, edit, or delete it.
+ *  - `{ workspaceId }`, filtered to `scope === "project"`, for the **This project** group — exactly the
+ *    templates that exist in this worktree's `.pi/prompts/`, whether or not a same-named global template
+ *    also exists.
+ * New/Edit open the shared `chat/TemplateEditorDialog` (see `chat/SPEC.md`'s Save-as-template bullet for
+ * why it lives in `chat/`, not here). Delete never touches the dialog — it's a `ConfirmPopover` directly
+ * on the row.
+ */
+export function TemplatesSettings() {
+	const workspaceId = useAppStore((s) => s.activeWorkspaceId);
+	const templatesVersion = useAppStore((s) => s.templatesVersion);
+	const [globalTemplates, setGlobalTemplates] = useState<TemplateInfo[] | null>(null);
+	const [projectTemplates, setProjectTemplates] = useState<TemplateInfo[] | null>(null);
+	const [globalFailed, setGlobalFailed] = useState(false);
+	const [projectFailed, setProjectFailed] = useState(false);
+	const [editorOpen, setEditorOpen] = useState(false);
+	const [editing, setEditing] = useState<TemplateInfo | null>(null);
+	const [newScope, setNewScope] = useState<TemplateScope>("global");
+
+	// Global group: always unscoped — never the shadow-merged `{ workspaceId }` response (see doc above).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: templatesVersion is the invalidation trigger, not a body input
+	useEffect(() => {
+		let cancelled = false;
+		getTransport()
+			.request("template.list", {})
+			.then((res) => {
+				if (!cancelled) {
+					setGlobalTemplates(res.templates.filter((t) => t.scope === "global"));
+					setGlobalFailed(false);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) setGlobalFailed(true);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [templatesVersion]);
+
+	// Project group: the workspace-scoped (shadow-merged) list, filtered down to the project-scoped
+	// entries. A separate failure flag from the global fetch above — two independent in-flight requests
+	// must never let one's success silently clear the other's already-reported failure.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: templatesVersion is the invalidation trigger, not a body input
+	useEffect(() => {
+		if (!workspaceId) {
+			setProjectTemplates(null);
+			setProjectFailed(false);
+			return;
+		}
+		let cancelled = false;
+		getTransport()
+			.request("template.list", { workspaceId })
+			.then((res) => {
+				if (!cancelled) {
+					setProjectTemplates(res.templates.filter((t) => t.scope === "project"));
+					setProjectFailed(false);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) setProjectFailed(true);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [workspaceId, templatesVersion]);
+
+	const openNew = (scope: TemplateScope) => {
+		setEditing(null);
+		setNewScope(scope);
+		setEditorOpen(true);
+	};
+	const openEdit = (template: TemplateInfo) => {
+		setEditing(template);
+		setEditorOpen(true);
+	};
+
+	const failed = globalFailed || projectFailed;
+	const loading =
+		!failed && (globalTemplates == null || (workspaceId != null && projectTemplates == null));
+
+	return (
+		<section data-testid="settings-templates" className="flex flex-col gap-lg">
+			<div className="flex flex-col gap-xs">
+				<h3 className="font-medium text-md text-text">Prompt templates</h3>
+				<p className="text-hint text-xs">
+					Reusable prompts, expanded from the composer's <code>/</code> menu. Global templates are
+					available in every workspace; project templates live in this worktree's{" "}
+					<code>.pi/prompts/</code>.
+				</p>
+			</div>
+
+			{loading ? (
+				<p className="text-hint text-sm">Loading templates…</p>
+			) : failed ? (
+				<p data-testid="templates-error" className="text-hint text-sm">
+					Couldn't read templates from the host — reopen Settings to retry.
+				</p>
+			) : (
+				<>
+					<TemplateGroup
+						title="Global"
+						scope="global"
+						templates={globalTemplates ?? []}
+						workspaceId={workspaceId ?? undefined}
+						showOpenAsFile={false}
+						onNew={() => openNew("global")}
+						onEdit={openEdit}
+					/>
+					{workspaceId ? (
+						<TemplateGroup
+							title="This project"
+							scope="project"
+							templates={projectTemplates ?? []}
+							workspaceId={workspaceId}
+							showOpenAsFile
+							onNew={() => openNew("project")}
+							onEdit={openEdit}
+						/>
+					) : null}
+				</>
+			)}
+
+			<TemplateEditorDialog
+				open={editorOpen}
+				onOpenChange={setEditorOpen}
+				workspaceId={workspaceId ?? undefined}
+				template={editing}
+				initialScope={newScope}
+			/>
+		</section>
+	);
+}
+
+function TemplateGroup({
+	title,
+	scope,
+	templates,
+	workspaceId,
+	showOpenAsFile,
+	onNew,
+	onEdit,
+}: {
+	title: string;
+	scope: TemplateScope;
+	templates: TemplateInfo[];
+	workspaceId: string | undefined;
+	showOpenAsFile: boolean;
+	onNew: () => void;
+	onEdit: (template: TemplateInfo) => void;
+}) {
+	return (
+		<section className="flex flex-col gap-sm">
+			<div className="flex items-center justify-between">
+				<h4 className="font-medium text-muted text-xs uppercase tracking-wider">{title}</h4>
+				<button
+					type="button"
+					data-testid={`template-new-${scope}`}
+					onClick={onNew}
+					className="flex items-center gap-xs rounded-[var(--radius-sm)] px-sm py-xs text-muted text-xs transition-colors hover:bg-hover hover:text-text"
+				>
+					<Plus className="size-3.5" />
+					New
+				</button>
+			</div>
+			{templates.length === 0 ? (
+				scope === "global" ? (
+					<StarterTemplatesOffer />
+				) : (
+					<p className="text-hint text-xs">No templates yet.</p>
+				)
+			) : (
+				<div className="flex flex-col gap-xs">
+					{templates.map((t) => (
+						<TemplateRow
+							key={t.name}
+							template={t}
+							workspaceId={workspaceId}
+							showOpenAsFile={showOpenAsFile}
+							onEdit={() => onEdit(t)}
+						/>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}
+
+function TemplateRow({
+	template,
+	workspaceId,
+	showOpenAsFile,
+	onEdit,
+}: {
+	template: TemplateInfo;
+	workspaceId: string | undefined;
+	showOpenAsFile: boolean;
+	onEdit: () => void;
+}) {
+	const [confirmOpen, setConfirmOpen] = useState(false);
+
+	const del = async () => {
+		try {
+			await getTransport().request("template.delete", {
+				...(workspaceId ? { workspaceId } : {}),
+				scope: template.scope,
+				name: template.name,
+			});
+			// The list re-fetches itself off this bump (see TemplatesSettings's effect) — no local state to update.
+			useAppStore.getState().bumpTemplatesVersion();
+		} catch (err) {
+			toast.error(errorText(err), "Couldn't delete the template");
+		}
+	};
+
+	const openAsFile = () => {
+		if (!workspaceId) return;
+		void openFileInTab(workspaceId, `.pi/prompts/${template.name}.md`);
+		useAppStore.getState().closeSettings();
+	};
+
+	return (
+		<ConfirmPopover
+			open={confirmOpen}
+			onOpenChange={setConfirmOpen}
+			title={`Delete ${template.name}?`}
+			description="Removes the template file. This can't be undone."
+			confirmLabel="Delete"
+			destructive
+			confirmTestId="template-confirm-delete"
+			onConfirm={() => void del()}
+			align="end"
+		>
+			{/* Anchored to the Delete button (the PopoverTrigger below), mirroring ProjectTree.tsx's
+			    workspace-remove row. */}
+			<div
+				data-testid="template-row"
+				data-name={template.name}
+				data-scope={template.scope}
+				className="group flex items-center gap-sm rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-md py-sm"
+			>
+				<div className="flex min-w-0 flex-1 flex-col">
+					<span className="truncate font-medium text-sm text-text">{template.name}</span>
+					{template.description ? (
+						<span className="truncate text-hint text-xs">{template.description}</span>
+					) : null}
+				</div>
+				<div className="flex shrink-0 items-center gap-xs">
+					{showOpenAsFile ? (
+						<button
+							type="button"
+							data-testid="template-open-file"
+							aria-label="Open as file"
+							title="Open as file"
+							onClick={openAsFile}
+							className="flex size-6 items-center justify-center rounded-[var(--radius-sm)] text-muted transition hover:bg-elevated hover:text-text"
+						>
+							<FileText className="size-3.5" />
+						</button>
+					) : null}
+					<button
+						type="button"
+						data-testid="template-edit"
+						aria-label="Edit"
+						title="Edit"
+						onClick={onEdit}
+						className="flex size-6 items-center justify-center rounded-[var(--radius-sm)] text-muted transition hover:bg-elevated hover:text-text"
+					>
+						<Pencil className="size-3.5" />
+					</button>
+					<PopoverTrigger asChild>
+						<button
+							type="button"
+							data-testid="template-delete"
+							aria-label="Delete"
+							title="Delete"
+							className="flex size-6 items-center justify-center rounded-[var(--radius-sm)] text-muted transition hover:bg-elevated hover:text-red"
+						>
+							<Trash2 className="size-3.5" />
+						</button>
+					</PopoverTrigger>
+				</div>
+			</div>
+		</ConfirmPopover>
+	);
+}

--- a/apps/web/src/panels/TemplatesSettings.tsx
+++ b/apps/web/src/panels/TemplatesSettings.tsx
@@ -12,9 +12,10 @@ import { openFileInTab } from "./openFile";
 
 /**
  * R4: verbatim starter-template content offered by `StarterTemplatesOffer` below (design doc "Amendments
- * (2026-07-22)" item 4). Bodies use pi's own `$1`/`${N:-default}` placeholder grammar — not a JS template
- * literal — so `${2:-the riskiest parts}` / `${1:-mine}` need a lint escape (see the two biome-ignores
- * below); `explain`/`tests` only ever use bare `$1`, which doesn't trip the rule.
+ * (2026-07-22)" item 4). Bodies use pi's own `$1`/`${N:-default}` placeholder grammar — not JS
+ * interpolation — so the two bodies containing `${…}` are written as template literals with the `\${`
+ * escape (a literal dollar-brace, never an embedded expression); `explain`/`tests` only ever use bare
+ * `$1`, which needs no escape.
  */
 const STARTER_TEMPLATES: ReadonlyArray<{
 	name: string;
@@ -26,8 +27,7 @@ const STARTER_TEMPLATES: ReadonlyArray<{
 		name: "review",
 		description: "Code review of a file or directory",
 		argumentHint: "[path] [focus]",
-		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi prompt-template syntax, not a JS placeholder
-		body: "Review $1 for correctness, clarity, and maintainability, focusing on ${2:-the riskiest parts}.\nList concrete findings with file:line references, ordered by severity, then suggest fixes.",
+		body: `Review $1 for correctness, clarity, and maintainability, focusing on \${2:-the riskiest parts}.\nList concrete findings with file:line references, ordered by severity, then suggest fixes.`,
 	},
 	{
 		name: "explain",
@@ -45,8 +45,7 @@ const STARTER_TEMPLATES: ReadonlyArray<{
 		name: "standup",
 		description: "One-line standup update",
 		argumentHint: "[team]",
-		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal pi prompt-template syntax, not a JS placeholder
-		body: "Write a one-line standup update for team ${1:-mine} based on this workspace's recent changes.\nReply with just that line.",
+		body: `Write a one-line standup update for team \${1:-mine} based on this workspace's recent changes.\nReply with just that line.`,
 	},
 ];
 
@@ -101,6 +100,58 @@ function StarterTemplatesOffer() {
 }
 
 /**
+ * One `template.list` fetch per `(enabled, workspaceId, templatesVersion)` generation, filtered to
+ * `scope`. The store's `templatesVersion` is recorded WITH the response, and only a current-generation
+ * list is returned — so a bump (a save/delete/seed from anywhere: this panel, the editor dialog,
+ * `HistoryOverlay`'s save-as-template) instantly invalidates the display while the refetch is in
+ * flight, and a response from a superseded generation can never be shown as fresh. Recording the
+ * generation is also what keeps the effect's dependency list honest: the version is a real input of
+ * the body, not a trigger-only extra dependency. `enabled: false` (no workspace for the project group)
+ * pins the result to `null` without issuing a request.
+ */
+function useTemplateList(
+	workspaceId: string | undefined,
+	scope: TemplateScope,
+	enabled: boolean,
+): { templates: TemplateInfo[] | null; failed: boolean } {
+	const templatesVersion = useAppStore((s) => s.templatesVersion);
+	const [fetched, setFetched] = useState<{ version: number; templates: TemplateInfo[] } | null>(
+		null,
+	);
+	const [failed, setFailed] = useState(false);
+
+	useEffect(() => {
+		if (!enabled) {
+			setFetched(null);
+			setFailed(false);
+			return;
+		}
+		let cancelled = false;
+		getTransport()
+			.request("template.list", workspaceId ? { workspaceId } : {})
+			.then((res) => {
+				if (cancelled) return;
+				setFetched({
+					version: templatesVersion,
+					templates: res.templates.filter((t) => t.scope === scope),
+				});
+				setFailed(false);
+			})
+			.catch(() => {
+				if (!cancelled) setFailed(true);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [enabled, workspaceId, scope, templatesVersion]);
+
+	return {
+		templates: fetched?.version === templatesVersion ? fetched.templates : null,
+		failed,
+	};
+}
+
+/**
  * The Settings → Templates panel: two groups — **Global** (always) and **This project** (only with an
  * active workspace) — each listing its prompt-template files with New/Edit/Delete, and (project rows
  * only) an Open-as-file shortcut. Fetches `template.list` **twice**, both refetched whenever the store's
@@ -120,61 +171,24 @@ function StarterTemplatesOffer() {
  */
 export function TemplatesSettings() {
 	const workspaceId = useAppStore((s) => s.activeWorkspaceId);
-	const templatesVersion = useAppStore((s) => s.templatesVersion);
-	const [globalTemplates, setGlobalTemplates] = useState<TemplateInfo[] | null>(null);
-	const [projectTemplates, setProjectTemplates] = useState<TemplateInfo[] | null>(null);
-	const [globalFailed, setGlobalFailed] = useState(false);
-	const [projectFailed, setProjectFailed] = useState(false);
 	const [editorOpen, setEditorOpen] = useState(false);
 	const [editing, setEditing] = useState<TemplateInfo | null>(null);
 	const [newScope, setNewScope] = useState<TemplateScope>("global");
 
 	// Global group: always unscoped — never the shadow-merged `{ workspaceId }` response (see doc above).
-	// biome-ignore lint/correctness/useExhaustiveDependencies: templatesVersion is the invalidation trigger, not a body input
-	useEffect(() => {
-		let cancelled = false;
-		getTransport()
-			.request("template.list", {})
-			.then((res) => {
-				if (!cancelled) {
-					setGlobalTemplates(res.templates.filter((t) => t.scope === "global"));
-					setGlobalFailed(false);
-				}
-			})
-			.catch(() => {
-				if (!cancelled) setGlobalFailed(true);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [templatesVersion]);
-
+	const { templates: globalTemplates, failed: globalFailed } = useTemplateList(
+		undefined,
+		"global",
+		true,
+	);
 	// Project group: the workspace-scoped (shadow-merged) list, filtered down to the project-scoped
-	// entries. A separate failure flag from the global fetch above — two independent in-flight requests
-	// must never let one's success silently clear the other's already-reported failure.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: templatesVersion is the invalidation trigger, not a body input
-	useEffect(() => {
-		if (!workspaceId) {
-			setProjectTemplates(null);
-			setProjectFailed(false);
-			return;
-		}
-		let cancelled = false;
-		getTransport()
-			.request("template.list", { workspaceId })
-			.then((res) => {
-				if (!cancelled) {
-					setProjectTemplates(res.templates.filter((t) => t.scope === "project"));
-					setProjectFailed(false);
-				}
-			})
-			.catch(() => {
-				if (!cancelled) setProjectFailed(true);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [workspaceId, templatesVersion]);
+	// entries. A separate hook instance means a separate failure flag — two independent in-flight
+	// requests must never let one's success silently clear the other's already-reported failure.
+	const { templates: projectTemplates, failed: projectFailed } = useTemplateList(
+		workspaceId ?? undefined,
+		"project",
+		workspaceId != null,
+	);
 
 	const openNew = (scope: TemplateScope) => {
 		setEditing(null);

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -91,9 +91,11 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   complementing `appendErrorTurn` (which handles the in-chat case).
   The host-wide **`templatesVersion: number`** counter + **`bumpTemplatesVersion()`** (increment) is a bare
   invalidation signal, the same shape as `fsChangesByWorkspace`'s `tick` below — **`panels/TemplatesSettings.tsx`**
-  and **`chat/TemplateEditorDialog.tsx`** call it after a `template.save`/`delete`, and `chat/ChatView.tsx`'s
-  composer-`/`-menu template fetch keys off it to know its per-workspace cache is stale (see `chat/SPEC.md`'s
-  Save-as-template bullet); the store holds only the counter, never fetches. The **live-refresh signal** —
+  and **`chat/TemplateEditorDialog.tsx`** call it after a `template.save`/`delete`, and the Templates
+  settings panel's own lists refetch off it (its `useTemplateList` fetch generation). It is deliberately
+  NOT a freshness source for the composer's `/` menu — that fetch runs uncached on every menu open,
+  since files also change outside the app where no in-app counter can see (see `chat/SPEC.md`'s Template
+  slots section); the store holds only the counter, never fetches. The **live-refresh signal** —
   **`fsChangesByWorkspace: Record<workspaceId, { tick, paths, truncated }>`** with
   **`noteFsChanged(payload)`** (folds a `workspace.fsChanged` push: `tick` increments per frame;
   `paths`/`truncated` are the last batch) — panels select their workspace's entry and refetch on `tick`

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -71,7 +71,7 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `provider.login` frame (creating `activeLogin` if the frame arrived first; ignoring frames for a different
   live login), **`clearLoginInput()`** drops the live input the instant a reply is sent (no double-submit),
   and **`clearLogin()`** dismisses it. The **settings surface** state — **`settingsOpen`** +
-  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`) with
+  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Templates`) with
   **`openSettings(section?)`** (deep-links to a section, defaults to Providers) / **`closeSettings()`** /
   **`setSettingsSection()`** — lives here so the top-bar gear AND the Welcome provider warning open Settings
   to a section without prop-drilling through the shell. The **theme** state — **`theme: ThemeId`** (the
@@ -88,7 +88,12 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   the existing id instead of stacking a twin) and **caps the queue at 5** (oldest drop — the viewport doesn't
   scroll, so the newest must stay visible).
   It's the home for a **rejected wire call with no better place to land** (no chat tab to host an error turn),
-  complementing `appendErrorTurn` (which handles the in-chat case). The **live-refresh signal** —
+  complementing `appendErrorTurn` (which handles the in-chat case).
+  The host-wide **`templatesVersion: number`** counter + **`bumpTemplatesVersion()`** (increment) is a bare
+  invalidation signal, the same shape as `fsChangesByWorkspace`'s `tick` below — **`panels/TemplatesSettings.tsx`**
+  and **`chat/TemplateEditorDialog.tsx`** call it after a `template.save`/`delete`, and `chat/ChatView.tsx`'s
+  composer-`/`-menu template fetch keys off it to know its per-workspace cache is stale (see `chat/SPEC.md`'s
+  Save-as-template bullet); the store holds only the counter, never fetches. The **live-refresh signal** —
   **`fsChangesByWorkspace: Record<workspaceId, { tick, paths, truncated }>`** with
   **`noteFsChanged(payload)`** (folds a `workspace.fsChanged` push: `tick` increments per frame;
   `paths`/`truncated` are the last batch) — panels select their workspace's entry and refetch on `tick`

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -81,12 +81,13 @@ export type EditorTab = FileTab | ChatTab | DocTab | DiffTab;
 
 /**
  * A section of the settings dialog (a const-object "enum", the codebase convention). Extensible — the live
- * sections are providers, github, and appearance (the theme picker).
+ * sections are providers, github, appearance (the theme picker), and templates (prompt-template manager).
  */
 export const SettingsSection = {
 	Providers: "providers",
 	Github: "github",
 	Appearance: "appearance",
+	Templates: "templates",
 } as const;
 export type SettingsSection = (typeof SettingsSection)[keyof typeof SettingsSection];
 
@@ -438,6 +439,10 @@ interface AppState {
 	sessions: Record<string, SessionRuntime>;
 	/** Models with configured auth (cheap win #1) — fetched once, shared by every chat's picker. */
 	models: WireModel[];
+	/** Bare invalidation counter for the composer's `/`-menu template cache (`chat/ChatView.tsx`) — the
+	 * Templates settings panel (Task B6) bumps it after a `template.save`/`delete`; the store holds only
+	 * the counter, never fetches (see `chat/SPEC.md`'s Template slots bullet). */
+	templatesVersion: number;
 	/**
 	 * A request to surface a file in the right-panel Changes view (e.g. a chat turn-divider's "files
 	 * changed" chip). The panels watch it and, when it targets the active workspace, switch to the Changes
@@ -595,6 +600,7 @@ interface AppState {
 	appendErrorTurn: (sessionId: string, text: string) => void;
 	handlePiEvent: (event: PiEvent, sessionId: string) => void;
 	setModels: (models: WireModel[]) => void;
+	bumpTemplatesVersion: () => void;
 	setCurrentModel: (sessionId: string, model: WireModel) => void;
 	setThinkingLevel: (sessionId: string, level: ThinkingLevel) => void;
 	setStats: (sessionId: string, stats: SessionStats) => void;
@@ -718,6 +724,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	activeTerminalByWorkspace: {},
 	sessions: {},
 	models: [],
+	templatesVersion: 0,
 	changesRequest: null,
 	changesView: "list",
 	chatLocationRequest: null,
@@ -1189,6 +1196,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	handlePiEvent: (event, sessionId) =>
 		set((s) => withRuntime(s, sessionId, (rt) => reduceSessionEvent(rt, event))),
 	setModels: (models) => set({ models }),
+	bumpTemplatesVersion: () => set((s) => ({ templatesVersion: s.templatesVersion + 1 })),
 	setCurrentModel: (sessionId, model) =>
 		set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, model }))),
 	setThinkingLevel: (sessionId, level) =>

--- a/e2e/fixtures/templates.ts
+++ b/e2e/fixtures/templates.ts
@@ -1,0 +1,83 @@
+// Seeds a real prompt-template file directly into the e2e host's isolated agent dir (bypassing the wire),
+// so `template.list`/`template.get` — and the composer's `/` menu (Task B5) — have something real to
+// discover. Mirrors `sessions.ts`'s fixture pattern: a pure, re-callable seeding function, called once
+// from `globalSetup`. Safe there: per-test `resetState` (`fixtures/app.ts`) wipes `pi-agent/sessions/`, not
+// `pi-agent/prompts/`, so this never needs re-seeding mid-suite the way session fixtures sometimes do.
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { E2E_PI_AGENT_DIR } from "./paths";
+
+/**
+ * A global-scope template (`${agentDir}/prompts/review.md`) with one unfilled positional slot (`$1`, no
+ * default — a marker the user must type over) and one prefilled-default slot (`${2:-src/}` — already
+ * "src/", tab-through with no typing required), exercising both slot flavors `slotSession.ts` produces.
+ * `argument-hint` is quoted: pi's frontmatter is real YAML (the `yaml` package), and an unquoted
+ * `[file] [scope]` isn't valid flow-sequence syntax.
+ *
+ * A second template (`rename.md`) repeats `$1` twice — same positional slot, same `group` — so the
+ * composer's Tab-out **group mirroring** (splice the just-filled slot's text into every sibling sharing
+ * its group) has something real to exercise: filling the first `⟨name⟩` occurrence and tabbing out must
+ * propagate the typed text into the second occurrence without the user typing it twice.
+ *
+ * A third template (`adjacent.md`) is `$1$2` with no literal text between them and deliberately **no**
+ * `argument-hint` at all, so both markers fall back to pi's `arg${n}` naming — `⟨arg1⟩`/`⟨arg2⟩`, 6 chars
+ * each — producing two slots with **zero gap**: `slots[0]` is exactly `[0, 6)`, `slots[1]` exactly
+ * `[6, 12)`. This is the shape the B5 review's zero-gap boundary bug needed (`slotSession.ts`'s
+ * `mapOffset` doc): filling slot 1 with more than one keystroke used to corrupt slot 2's `start`, one
+ * character at a time, because a zero-width insert landing exactly on `slots[0].end === slots[1].start`
+ * was silently absorbed into the following slot instead of pushing it along.
+ */
+export function seedTemplateFixtures(agentDir: string = E2E_PI_AGENT_DIR): void {
+	const dir = join(agentDir, "prompts");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(
+		join(dir, "review.md"),
+		`---
+description: Review a file for issues
+argument-hint: "[file] [scope]"
+---
+Review $1 for issues, focusing on \${2:-src/}.
+`,
+	);
+	writeFileSync(
+		join(dir, "rename.md"),
+		`---
+description: Rename a symbol everywhere
+argument-hint: "[name]"
+---
+Rename $1 and update every $1 reference.
+`,
+	);
+	writeFileSync(
+		join(dir, "adjacent.md"),
+		`---
+description: Two zero-gap adjacent slots (regression fixture)
+---
+$1$2
+`,
+	);
+}
+
+/**
+ * Removes named global template files, by template name (not filename) — a targeted delete, never a
+ * blanket directory wipe, so this can't clobber something an unrelated test/file has independently
+ * written into the same shared prompts dir. The primitive both helpers below are built from.
+ */
+export function removeGlobalTemplates(names: string[], agentDir: string = E2E_PI_AGENT_DIR): void {
+	const dir = join(agentDir, "prompts");
+	for (const name of names) {
+		rmSync(join(dir, `${name}.md`), { force: true });
+	}
+}
+
+/**
+ * Removes just the three `seedTemplateFixtures` files. `globalSetup` seeds them once for the whole run
+ * and `resetState` never wipes `prompts/` (see this file's header), so the Global templates group is
+ * otherwise never empty during the suite — a test of the empty-state starter-templates offer (R3+R4
+ * brief, `templates-manage.spec.ts`) has to manufacture that condition itself. Paired with a re-call of
+ * `seedTemplateFixtures()` to restore them once that test is done, so every other test/file keeps seeing
+ * the same three fixtures regardless of run order.
+ */
+export function clearTemplateFixtures(agentDir: string = E2E_PI_AGENT_DIR): void {
+	removeGlobalTemplates(["review", "rename", "adjacent"], agentDir);
+}

--- a/e2e/fixtures/templates.ts
+++ b/e2e/fixtures/templates.ts
@@ -26,6 +26,12 @@ import { E2E_PI_AGENT_DIR } from "./paths";
  * `mapOffset` doc): filling slot 1 with more than one keystroke used to corrupt slot 2's `start`, one
  * character at a time, because a zero-width insert landing exactly on `slots[0].end === slots[1].start`
  * was silently absorbed into the following slot instead of pushing it along.
+ *
+ * A fourth template (`defaults.md`) repeats argument 1 with **different** per-occurrence defaults —
+ * `${1:-foo} versus ${1:-bar}` — the shape the Air review's `filled`/`edited` bug needed: both slots share
+ * one group and are born `filled` (real defaults) but not `edited`, so Tab/Send must keep "foo versus bar"
+ * independent (mirroring keyed on `filled` used to collapse it to "foo versus foo"); editing one occurrence
+ * provides the argument and then mirrors. See `slotSession.ts`'s `edited` doc.
  */
 export function seedTemplateFixtures(agentDir: string = E2E_PI_AGENT_DIR): void {
 	const dir = join(agentDir, "prompts");
@@ -56,6 +62,14 @@ description: Two zero-gap adjacent slots (regression fixture)
 $1$2
 `,
 	);
+	writeFileSync(
+		join(dir, "defaults.md"),
+		`---
+description: One argument, two different per-occurrence defaults (regression fixture)
+---
+\${1:-foo} versus \${1:-bar}
+`,
+	);
 }
 
 /**
@@ -71,7 +85,7 @@ export function removeGlobalTemplates(names: string[], agentDir: string = E2E_PI
 }
 
 /**
- * Removes just the three `seedTemplateFixtures` files. `globalSetup` seeds them once for the whole run
+ * Removes just the four `seedTemplateFixtures` files. `globalSetup` seeds them once for the whole run
  * and `resetState` never wipes `prompts/` (see this file's header), so the Global templates group is
  * otherwise never empty during the suite — a test of the empty-state starter-templates offer (R3+R4
  * brief, `templates-manage.spec.ts`) has to manufacture that condition itself. Paired with a re-call of
@@ -79,5 +93,5 @@ export function removeGlobalTemplates(names: string[], agentDir: string = E2E_PI
  * the same three fixtures regardless of run order.
  */
 export function clearTemplateFixtures(agentDir: string = E2E_PI_AGENT_DIR): void {
-	removeGlobalTemplates(["review", "rename", "adjacent"], agentDir);
+	removeGlobalTemplates(["review", "rename", "adjacent", "defaults"], agentDir);
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -11,6 +11,7 @@ import {
 } from "./fixtures/paths";
 import { seedFixtureRepo } from "./fixtures/repo";
 import { seedExternalCwdSessions } from "./fixtures/sessions";
+import { seedTemplateFixtures } from "./fixtures/templates";
 
 /** Fresh, isolated state dir + a throwaway git repo to open as a project. (Runs under node, not bun.) */
 export default function globalSetup(): void {
@@ -49,6 +50,11 @@ export default function globalSetup(): void {
 	// layout production `HistoryIndex` discovers (see fixtures/sessions.ts + history/SPEC.md's "pi file
 	// format" section) — so `history.search` has real, searchable history the moment the host boots.
 	seedExternalCwdSessions();
+
+	// Seed a global-scope prompt template (`prompts/review.md`) so `template.list`/`template.get` — and the
+	// composer's `/` menu (Task B5) — have something real to discover. `resetState` never wipes
+	// `pi-agent/prompts/`, so one seed here covers the whole suite (see fixtures/templates.ts).
+	seedTemplateFixtures();
 
 	// Seed the shared fixture repo (git init + seed files + commit). Shared with per-test `resetState`, which
 	// re-seeds it if a flaky @agent spec damages the repo (see fixtures/repo.ts).

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -1,0 +1,295 @@
+import { expect, type Locator, test } from "@playwright/test";
+import { openWorkspaceChat } from "./fixtures/app";
+
+/** The textarea's own native selection — `readSelection` reads it straight off the DOM (not React state),
+ * since a slot session places a real `setSelectionRange`, not just a caret. */
+async function readSelection(
+	input: Locator,
+): Promise<{ start: number; end: number; value: string }> {
+	return input.evaluate((el) => {
+		const t = el as HTMLTextAreaElement;
+		return { start: t.selectionStart ?? 0, end: t.selectionEnd ?? 0, value: t.value };
+	});
+}
+
+// No-agent: the composer's `/` menu template merge + slot session, against a real prompt-template file.
+// `e2e/fixtures/templates.ts` seeds `${E2E_PI_AGENT_DIR}/prompts/review.md` once, in `globalSetup` — a
+// global-scope template, untouched by per-test `resetState` (which only wipes `pi-agent/sessions/`), so no
+// per-test re-seed is needed here (unlike the external-cwd session fixture `history-search.spec.ts` re-seeds
+// per test). The fixture's body is:
+//   Review $1 for issues, focusing on ${2:-src/}.
+// with `argument-hint: "[file] [scope]"` — one unfilled marker slot (`⟨file⟩`, no default) and one
+// prefilled-default slot ("src/"), exercising both `slotSession.ts` slot flavors end to end. Sending in this
+// suite works the same way `history-search.spec.ts` relies on: `ChatView.onSubmit` appends the user message
+// to the store *before* the (here, rejected — no auth in this suite) transport call resolves, so the sent
+// text lands in the transcript regardless of what the (absent) agent does next.
+test.describe("prompt templates in the composer", () => {
+	test("full lifecycle: filter, pick, fill, tab to the default, and send strips no markers", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		// `/rev` matches only the fixture template (no builtin/extension/skill command name contains "rev").
+		await input.fill("/rev");
+		const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
+		await expect(rows).toHaveCount(1);
+		await expect(rows.first()).toContainText("/review");
+
+		// Picking replaces the draft with the expanded body — the unfilled `$1` became a visible `⟨file⟩`
+		// marker, `${2:-src/}` became its own default text "src/" — and starts a slot session on slot 1/2.
+		await rows.first().click();
+		await expect(input).toHaveValue(/^Review ⟨file⟩ for issues, focusing on src\/\.\s*$/);
+
+		const hint = page.getByTestId("slot-hint");
+		await expect(hint).toBeVisible();
+		await expect(hint).toContainText("slot 1/2");
+
+		// The selection sits exactly on the `⟨file⟩` marker (computed from the live value, not a hardcoded
+		// offset), so typing over it — a real DOM selection, not just a collapsed caret — replaces it.
+		const sel1 = await readSelection(input);
+		expect(sel1.value.slice(sel1.start, sel1.end)).toBe("⟨file⟩");
+
+		await page.keyboard.type("watcher.ts");
+		await expect(input).toHaveValue(/^Review watcher\.ts for issues, focusing on src\/\.\s*$/);
+
+		// Tab jumps to slot 2/2 — the prefilled default — selecting "src/" whole.
+		await input.press("Tab");
+		await expect(hint).toContainText("slot 2/2");
+		const sel2 = await readSelection(input);
+		expect(sel2.value.slice(sel2.start, sel2.end)).toBe("src/");
+
+		// Both slots are filled (one typed, one prefilled) — send produces a user bubble with the expanded
+		// text and no leftover `⟨…⟩` marker glyphs, and the hint chip goes away with the session.
+		await page.getByTestId("chat-send").click();
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]');
+		await expect(bubble).toContainText("Review watcher.ts for issues, focusing on src/.");
+		await expect(bubble).not.toContainText("⟨");
+		await expect(hint).not.toBeVisible();
+	});
+
+	// `rename.md` repeats `$1` twice (same positional slot, same `group` — see `slotSession.ts`'s `group`
+	// doc) — group mirroring: filling the first occurrence and tabbing out splices that text into the
+	// second occurrence too, without the user typing it twice.
+	test("tabbing out of a filled slot mirrors its text into a sibling sharing its group", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rena");
+		const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
+		await expect(rows).toHaveCount(1);
+		await expect(rows.first()).toContainText("/rename");
+
+		await rows.first().click();
+		await expect(input).toHaveValue(/^Rename ⟨name⟩ and update every ⟨name⟩ reference\.\s*$/);
+
+		const hint = page.getByTestId("slot-hint");
+		await expect(hint).toContainText("slot 1/2");
+		const sel1 = await readSelection(input);
+		expect(sel1.value.slice(sel1.start, sel1.end)).toBe("⟨name⟩");
+
+		await page.keyboard.type("Widget");
+		await expect(input).toHaveValue(/^Rename Widget and update every ⟨name⟩ reference\.\s*$/);
+
+		// Tab out of the now-filled first slot mirrors "Widget" into the second `⟨name⟩` occurrence — one
+		// typing action fills both — and selects the just-mirrored text.
+		await input.press("Tab");
+		await expect(hint).toContainText("slot 2/2");
+		await expect(input).toHaveValue(/^Rename Widget and update every Widget reference\.\s*$/);
+		const sel2 = await readSelection(input);
+		expect(sel2.value.slice(sel2.start, sel2.end)).toBe("Widget");
+
+		await page.getByTestId("chat-send").click();
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]');
+		await expect(bubble).toContainText("Rename Widget and update every Widget reference.");
+		await expect(bubble).not.toContainText("⟨");
+	});
+
+	// The highlight backdrop (Task R5): `rename.md`'s two `⟨name⟩` occurrences give one gap per slot, so
+	// the tint span count must match the slot count exactly, the currently-selected slot must be the one
+	// marked "active", and stepping via Tab must move both the mirrored fill state and the active marker.
+	test("the highlight backdrop tints each gap and tracks the active slot as Tab steps through", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rena");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		await expect(input).toHaveValue(/^Rename ⟨name⟩ and update every ⟨name⟩ reference\.\s*$/);
+
+		const backdrop = page.getByTestId("slot-backdrop");
+		await expect(backdrop).toBeVisible();
+		const highlights = page.getByTestId("slot-highlight");
+		// One tint span per gap — both `⟨name⟩` occurrences, none more, none folded together.
+		await expect(highlights).toHaveCount(2);
+		await expect(highlights.nth(0)).toHaveAttribute("data-slot-state", "active");
+		await expect(highlights.nth(1)).toHaveAttribute("data-slot-state", "unfilled");
+
+		await page.keyboard.type("Widget");
+		// Tab out of the now-filled first slot mirrors "Widget" into the sibling and moves the active
+		// marker to slot 2 — the backdrop must reflect both: the first gap is now filled (mirrored, not
+		// untouched), and the active tint is on the second.
+		await input.press("Tab");
+		await expect(highlights.nth(0)).toHaveAttribute("data-slot-state", "filled");
+		await expect(highlights.nth(1)).toHaveAttribute("data-slot-state", "active");
+
+		// Sending ends the session — the backdrop unmounts along with it.
+		await page.getByTestId("chat-send").click();
+		await expect(backdrop).not.toBeVisible();
+	});
+
+	// Reviewer-flagged regression: mirroring used to run only inside `stepSlot` (Tab-out) — `submit()`
+	// stripped untouched slots immediately, so filling slot 1 of a repeated-group template and clicking
+	// Send *without* ever tabbing out sent a prompt with the sibling silently stripped instead of mirrored.
+	// `submit()` now mirrors every already-filled slot into its unfilled group-mates before stripping (see
+	// `slotSession.ts`'s `mirrorAllGroups`, shared with `stepSlot`'s own `mirrorSlotGroup` call).
+	test("sending directly (no Tab) still mirrors a filled slot's text into its same-group sibling", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rena");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		await expect(input).toHaveValue(/^Rename ⟨name⟩ and update every ⟨name⟩ reference\.\s*$/);
+
+		await page.keyboard.type("Widget");
+		await expect(input).toHaveValue(/^Rename Widget and update every ⟨name⟩ reference\.\s*$/);
+
+		// No Tab — send directly while the second `⟨name⟩` occurrence is still a live, untouched marker.
+		await page.getByTestId("chat-send").click();
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]').first();
+		await expect(bubble).toContainText("Rename Widget and update every Widget reference.");
+		await expect(bubble).not.toContainText("⟨");
+	});
+
+	test("Escape ends the session and leaves the text as-is", async ({ page }) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+		await input.fill("/rev");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+
+		const hint = page.getByTestId("slot-hint");
+		await expect(hint).toBeVisible();
+		const before = await input.inputValue();
+
+		await input.press("Escape");
+		await expect(hint).not.toBeVisible();
+		expect(await input.inputValue()).toBe(before);
+	});
+
+	test("a wholesale replacement of the draft ends the session instead of tracking a meaningless range", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+		await input.fill("/rev");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		await expect(page.getByTestId("slot-hint")).toBeVisible();
+
+		// A single-event full-value replace (no shared prefix/suffix with the templated text) — the edit
+		// "consumes the entire prior value", so the session ends instead of re-tracking a now-meaningless
+		// collapsed slot range at the tail of the new text.
+		await input.fill("something completely different");
+		await expect(page.getByTestId("slot-hint")).not.toBeVisible();
+		await expect(input).toHaveValue("something completely different");
+	});
+
+	test("picking a template replaces whatever draft was already there", async ({ page }) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+		await input.fill("leftover draft text");
+		await input.fill("/rev");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+
+		// The pick fetches `template.get` over the wire before replacing the draft, so wait on the value
+		// itself (auto-retrying) rather than a one-shot `inputValue()` read racing that round trip.
+		await expect(input).toHaveValue(/^Review/);
+		expect(await input.inputValue()).not.toContain("leftover draft text");
+	});
+
+	test("the merged menu still shows non-template commands", async ({ page }) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+		// `pi-spec-graph`'s bundled skill is wired unconditionally into every session (see
+		// `packages/server/src/agent/extensions.ts`), so `skill:spec-graph` is a stable, always-present
+		// non-template command — proving the merge (commands minus stale `source==="prompt"` entries, plus
+		// the fresh template list) never drops the other two sources.
+		await input.fill("/skill:spec-graph");
+		const row = page.locator('[data-testid="slash-command"][data-source="skill"]');
+		await expect(row).toHaveCount(1);
+		await expect(row).toContainText("skill:spec-graph");
+	});
+
+	// `adjacent.md`'s `$1$2` (no `argument-hint`, no literal text between the two placeholders) is the
+	// exact zero-gap shape the B5 review found broken: filling slot 1 across more than one keystroke used
+	// to corrupt slot 2's `start`, silently absorbing typed characters into it one at a time (see
+	// `slotSession.ts`'s `mapOffset` doc for the fix).
+	test("filling an unfilled slot across several keystrokes never steals characters from a zero-gap sibling", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/adj");
+		const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
+		await expect(rows).toHaveCount(1);
+		await expect(rows.first()).toContainText("/adjacent");
+
+		await rows.first().click();
+		await expect(input).toHaveValue(/^⟨arg1⟩⟨arg2⟩\s*$/);
+
+		const hint = page.getByTestId("slot-hint");
+		await expect(hint).toContainText("slot 1/2");
+		const sel1 = await readSelection(input);
+		expect(sel1.value.slice(sel1.start, sel1.end)).toBe("⟨arg1⟩");
+
+		// The first keystroke replaces the whole selected marker (a real edit, not zero-width); the
+		// remaining four are pure zero-width inserts landing exactly on the — now shrunk — shared boundary
+		// with slot 2, one after another. A single keystroke can only ever steal one character, so it's the
+		// repeated boundary hit across several keystrokes that actually exercises the bug.
+		await page.keyboard.type("hello");
+		await expect(input).toHaveValue(/^hello⟨arg2⟩\s*$/);
+
+		// Tab to slot 2 — its selection must be exactly its own marker, never short the characters "hello"
+		// stole into its left edge.
+		await input.press("Tab");
+		await expect(hint).toContainText("slot 2/2");
+		const sel2 = await readSelection(input);
+		expect(sel2.value.slice(sel2.start, sel2.end)).toBe("⟨arg2⟩");
+
+		// Send with slot 2 still unfilled — it gets stripped, and the full "hello" (all 5 characters) must
+		// survive untouched, with no marker glyph left behind.
+		await page.getByTestId("chat-send").click();
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]');
+		await expect(bubble).toContainText("hello");
+		await expect(bubble).not.toContainText("⟨");
+	});
+
+	// Minor 2 (B5 review): every send test above ends with all slots filled — none exercises the
+	// strip-at-send path against a *live*, never-touched marker. `review.md`'s `$1` (`⟨file⟩`, no default)
+	// is that marker: sending without ever typing into it strips it and must collapse the doubled space it
+	// would otherwise leave behind down to exactly one — not zero, not two. `toContainText`/`toHaveText`
+	// always normalize whitespace before comparing, even given a plain string — a `not.toContainText("  ")`
+	// assertion here would vacuously pass regardless of the actual bug — so this reads `textContent()`
+	// straight off the DOM and compares it exactly.
+	test("sending with a live unfilled marker strips it and collapses the doubled space to exactly one", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rev");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		await expect(input).toHaveValue(/^Review ⟨file⟩ for issues, focusing on src\/\.\s*$/);
+
+		// Slot 1 (`⟨file⟩`) is never typed into — it stays live/unfilled all the way to send.
+		await page.getByTestId("chat-send").click();
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]').first();
+		await expect(bubble).toBeVisible();
+		expect(await bubble.textContent()).toBe("Review for issues, focusing on src/.");
+	});
+});

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -68,6 +68,38 @@ test.describe("prompt templates in the composer", () => {
 		await expect(hint).not.toBeVisible();
 	});
 
+	// Reviewer-flagged regression (data loss): collapsing the marker's selection to its END (ArrowRight —
+	// the most natural "deselect" gesture) and then typing hits the composer's grow-at-end path, which
+	// used to grow the slot WITHOUT marking it filled — `stripUntouchedSlots` then deleted the marker
+	// together with everything the user had typed into it on send. Growing now fills: the typed text must
+	// survive in the sent message. (The still-visible `⟨file⟩` glyphs are the composer's WYSIWYG contract —
+	// the user sees them next to their text and can delete them; only *untouched* markers are stripped.)
+	test("typing after ArrowRight-collapsing the marker selection is never deleted by the send", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rev");
+		const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
+		await rows.first().click();
+		await expect(input).toHaveValue(/^Review ⟨file⟩ for issues, focusing on src\/\.\s*$/);
+		await expect(page.getByTestId("slot-hint")).toContainText("slot 1/2");
+
+		// ArrowRight collapses the marker's selection to its end — a bare caret at the slot boundary.
+		await input.press("ArrowRight");
+		const sel = await readSelection(input);
+		expect(sel.start).toBe(sel.end);
+		expect(sel.value.slice(0, sel.start).endsWith("⟨file⟩")).toBe(true);
+
+		await page.keyboard.type("server.ts");
+		await page.getByTestId("chat-send").click();
+
+		// The regression: this text used to vanish from the sent message entirely.
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]');
+		await expect(bubble).toContainText("server.ts for issues, focusing on src/.");
+	});
+
 	// `rename.md` repeats `$1` twice (same positional slot, same `group` — see `slotSession.ts`'s `group`
 	// doc) — group mirroring: filling the first occurrence and tabbing out splices that text into the
 	// second occurrence too, without the user typing it twice.

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -1,5 +1,8 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect, type Locator, test } from "@playwright/test";
 import { openWorkspaceChat } from "./fixtures/app";
+import { E2E_PI_AGENT_DIR } from "./fixtures/paths";
 
 /** The textarea's own native selection — `readSelection` reads it straight off the DOM (not React state),
  * since a slot session places a real `setSelectionRange`, not just a caret. */
@@ -66,6 +69,37 @@ test.describe("prompt templates in the composer", () => {
 		await expect(bubble).toContainText("Review watcher.ts for issues, focusing on src/.");
 		await expect(bubble).not.toContainText("⟨");
 		await expect(hint).not.toBeVisible();
+	});
+
+	// Reviewer-flagged regression (freshness): the `/` menu's template list is fetched on every menu-open
+	// transition, never cached across opens — prompt files change outside the app too (pi CLI, an editor,
+	// a git pull), which no in-app invalidation signal can see. An earlier per-chat cache served such
+	// externally-changed files stale for the rest of the chat; this writes a file straight to the global
+	// prompts dir (bypassing the wire, exactly like an external tool) between two menu opens.
+	test("a template file added outside the app appears on the next menu open", async ({ page }) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+		const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
+		const freshFile = join(E2E_PI_AGENT_DIR, "prompts", "freshly-added.md");
+
+		try {
+			// First open: the externally-added template doesn't exist yet.
+			await input.fill("/rev");
+			await expect(rows.filter({ hasText: "/review" })).toBeVisible();
+			await input.fill("/freshly");
+			await expect(rows).toHaveCount(0);
+
+			// An "external tool" (here: the test itself, straight to disk) adds a template file.
+			writeFileSync(freshFile, "---\ndescription: Added outside the app\n---\nFresh body $1\n");
+
+			// Close the menu (empty draft) and reopen — the new file must be offered without any in-app
+			// save/delete having bumped an invalidation counter.
+			await input.fill("");
+			await input.fill("/freshly");
+			await expect(rows.filter({ hasText: "/freshly-added" })).toBeVisible();
+		} finally {
+			rmSync(freshFile, { force: true }); // never leak into other tests' template listings
+		}
 	});
 
 	// Reviewer-flagged regression (data loss): collapsing the marker's selection to its END (ArrowRight —

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -232,6 +232,65 @@ test.describe("prompt templates in the composer", () => {
 		await expect(bubble).not.toContainText("⟨");
 	});
 
+	// Air-review regression (data corruption): `defaults.md` is `${1:-foo} versus ${1:-bar}` — one argument
+	// with two DIFFERENT per-occurrence defaults (same `group`, both born `filled` but not `edited`). Group
+	// mirroring keyed on `filled` collapsed this to "foo versus foo" on Tab or a direct Send; keyed on
+	// `edited`, an untouched default is never a mirror source, so the two stay independent unless the user
+	// edits one — matching pi's own expansion (unprovided `${1:-foo}`/`${1:-bar}` yield "foo"/"bar"). See
+	// `slotSession.ts`'s `edited` doc.
+	test("differing per-occurrence defaults stay independent through Tab and a direct Send (no edit)", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/def");
+		const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
+		await expect(rows).toHaveCount(1);
+		await expect(rows.first()).toContainText("/defaults");
+
+		await rows.first().click();
+		await expect(input).toHaveValue(/^foo versus bar\s*$/);
+		const hint = page.getByTestId("slot-hint");
+		await expect(hint).toContainText("slot 1/2");
+
+		// Tab across both defaults WITHOUT typing — an untouched default must never mirror over its sibling.
+		await input.press("Tab");
+		await expect(hint).toContainText("slot 2/2");
+		await expect(input).toHaveValue(/^foo versus bar\s*$/);
+
+		// Direct Send: still "foo versus bar", never the "foo versus foo" the filled-keyed bug produced.
+		await page.getByTestId("chat-send").click();
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]').first();
+		await expect(bubble).toContainText("foo versus bar");
+		await expect(bubble).not.toContainText("foo versus foo");
+	});
+
+	test("editing one default occurrence provides the argument and mirrors it into the group-mate on Tab", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/def");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		await expect(input).toHaveValue(/^foo versus bar\s*$/);
+
+		// The first default "foo" is selected whole on session start — type over it to "provide argument 1".
+		const sel = await readSelection(input);
+		expect(sel.value.slice(sel.start, sel.end)).toBe("foo");
+		await page.keyboard.type("cats");
+		await expect(input).toHaveValue(/^cats versus bar\s*$/);
+
+		// Tab out of the now-edited slot mirrors "cats" into the second occurrence, replacing its "bar".
+		await input.press("Tab");
+		await expect(input).toHaveValue(/^cats versus cats\s*$/);
+
+		await page.getByTestId("chat-send").click();
+		const bubble = page.locator('[data-testid="chat-message"][data-role="user"]').first();
+		await expect(bubble).toContainText("cats versus cats");
+	});
+
 	test("Escape ends the session and leaves the text as-is", async ({ page }) => {
 		await openWorkspaceChat(page);
 		const input = page.getByTestId("chat-input");

--- a/e2e/templates-manage.spec.ts
+++ b/e2e/templates-manage.spec.ts
@@ -1,0 +1,385 @@
+import { expect, test } from "@playwright/test";
+import { openWorkspaceChat } from "./fixtures/app";
+import { seedExternalCwdSessions } from "./fixtures/sessions";
+import {
+	clearTemplateFixtures,
+	removeGlobalTemplates,
+	seedTemplateFixtures,
+} from "./fixtures/templates";
+
+// No-agent: Settings → Templates (create/edit/delete, both scopes) + the history overlay's
+// save-as-template action. `templates-compose.spec.ts` already covers the composer `/` menu + slot
+// session against pre-seeded global fixtures (`e2e/fixtures/templates.ts`, untouched here); this suite
+// instead drives the *management* surface end to end — a template created here must show up in (and a
+// deleted one must vanish from) that same `/` menu, proving the store's `templatesVersion` bump actually
+// invalidates `ChatView`'s cached fetch rather than just exercising the settings panel in isolation.
+test.describe("templates management", () => {
+	// R4 (design doc "Amendments (2026-07-22)" item 4): when the Global group's list is empty, the panel
+	// offers to seed four starter templates instead of the bare "No templates yet." — one click creates
+	// all four, sequentially, via the same `template.save` wire call the editor dialog uses.
+	//
+	// Deliberately the FIRST test in this file: Playwright preserves declaration order within a file
+	// (`fullyParallel: false`, `workers: 1`, see playwright.config.ts), and this file is the only place
+	// anything ever adds to the Global group (`templates-compose.spec.ts` only reads the fixtures below;
+	// no other spec touches templates at all) — so running first guarantees neither "standup" (created and
+	// deleted by the test below) nor "foo" (created, and left, by the shadowing test below) exists yet.
+	// `globalSetup` seeds three Global fixtures once for the whole run and `resetState` never wipes
+	// `prompts/` (see `fixtures/templates.ts`), so the Global group is otherwise never empty during the
+	// suite — manufacturing that condition means removing those three ourselves first. Restores them (and
+	// removes the four starters this test adds) at the end, so every test/file that runs after — including
+	// this file's own later tests, and `templates-compose.spec.ts`, which depends on `review`/`rename`/
+	// `adjacent`'s exact original content — sees the world exactly as it was before this test ran.
+	test("Global empty state offers starter templates; adding them fills the composer's / menu", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		clearTemplateFixtures();
+
+		// Everything from here on must restore the three original fixtures no matter how the test body
+		// exits: this is a serial suite (one shared host, `workers: 1`), there's no `afterEach`, and
+		// `templates-compose.spec.ts` depends on `review`/`rename`/`adjacent`'s exact original content — a
+		// thrown assertion between the clear above and the restore below would otherwise leave the shared
+		// `prompts/` dir permanently short those three fixtures for every test that runs after this one.
+		try {
+			await page.getByTestId("open-settings").click();
+			await page.getByTestId("settings-nav-templates").click();
+			const settingsDialog = page.getByTestId("settings-dialog");
+			await expect(settingsDialog).toContainText("Prompt templates");
+
+			const globalRows = page.locator('[data-testid="template-row"][data-scope="global"]');
+			await expect(globalRows).toHaveCount(0);
+			const offer = page.getByTestId("template-starters");
+			await expect(offer).toBeVisible();
+
+			await offer.click();
+			await expect(globalRows).toHaveCount(4);
+			for (const name of ["review", "explain", "tests", "standup"]) {
+				await expect(
+					page.locator(`[data-testid="template-row"][data-name="${name}"][data-scope="global"]`),
+				).toBeVisible();
+			}
+			// The offer disappears the instant the list is non-empty.
+			await expect(offer).toHaveCount(0);
+
+			await page.keyboard.press("Escape");
+			await expect(settingsDialog).toBeHidden();
+
+			// The freshly-added "review" starter (not the fixture of the same name — that one was removed
+			// above) shows up in the composer's `/` menu, same as any other template would.
+			const input = page.getByTestId("chat-input");
+			await input.fill("/rev");
+			await expect(
+				page
+					.locator('[data-testid="slash-command"][data-source="prompt"]')
+					.filter({ hasText: "review" }),
+			).toHaveCount(1);
+			await input.fill("");
+		} finally {
+			// Restore: remove the four starters this test added, then put the original three fixtures
+			// back — always, even if an assertion above threw.
+			removeGlobalTemplates(["review", "explain", "tests", "standup"]);
+			seedTemplateFixtures();
+		}
+	});
+
+	test("global template: create shows up in the composer's / menu, edit updates it, delete removes it from both", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+		const menuHit = page
+			.locator('[data-testid="slash-command"][data-source="prompt"]')
+			.filter({ hasText: "standup" });
+
+		// Not there yet.
+		await input.fill("/stand");
+		await expect(menuHit).toHaveCount(0);
+		await input.fill("");
+
+		await page.getByTestId("open-settings").click();
+		await page.getByTestId("settings-nav-templates").click();
+		const settingsDialog = page.getByTestId("settings-dialog");
+		await expect(settingsDialog).toContainText("Prompt templates");
+
+		await page.getByTestId("template-new-global").click();
+		const editor = page.getByTestId("template-editor-dialog");
+		await expect(editor).toBeVisible();
+		await expect(page.getByTestId("template-scope-global")).toHaveAttribute("data-active", "true");
+
+		await page.getByTestId("template-name-input").fill("standup");
+		await page.getByTestId("template-description-input").fill("Daily standup notes");
+		await page.getByTestId("template-body-input").fill("What did you do yesterday?");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+
+		const row = page.locator('[data-testid="template-row"][data-name="standup"]');
+		await expect(row).toBeVisible();
+		await expect(row).toContainText("standup");
+		await expect(row).toContainText("Daily standup notes");
+
+		await page.keyboard.press("Escape");
+		await expect(settingsDialog).toBeHidden();
+
+		// Now it shows up — the save bumped `templatesVersion`, invalidating the composer's cached fetch.
+		await input.fill("/stand");
+		await expect(menuHit).toHaveCount(1);
+		await input.fill("");
+
+		// Edit: name + scope lock, description changes and the row (and re-fetch) reflect it.
+		await page.getByTestId("open-settings").click();
+		await page.getByTestId("settings-nav-templates").click();
+		await row.getByTestId("template-edit").click();
+		await expect(editor).toBeVisible();
+		await expect(page.getByTestId("template-name-input")).toBeDisabled();
+		await expect(page.getByTestId("template-scope-project")).toBeDisabled();
+		await page.getByTestId("template-description-input").fill("Standup notes, revised");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+		await expect(row).toContainText("Standup notes, revised");
+
+		// Delete (confirm popover, mirroring the workspace-remove pattern) — gone from the panel... Scoped
+		// to this row: the Global group also lists the suite-wide seeded fixture templates, so an unscoped
+		// `template-delete` would be ambiguous.
+		await row.getByTestId("template-delete").click();
+		await expect(page.getByRole("alertdialog", { name: /Delete standup/ })).toBeVisible();
+		await page.getByTestId("template-confirm-delete").click();
+		await expect(row).toHaveCount(0);
+
+		// ...and gone from the / menu too.
+		await page.keyboard.press("Escape");
+		await expect(settingsDialog).toBeHidden();
+		await input.fill("/stand");
+		await expect(menuHit).toHaveCount(0);
+	});
+
+	// Reviewer-flagged regression: the assembler always wraps a real description in frontmatter, so picking
+	// the saved template back up must hand back the body exactly as typed — no leaked leading blank line —
+	// and an edit-save cycle that only touches the description must never grow the body (unit-level pin:
+	// `chat/templateText.test.ts`; this is the end-to-end proof over the real dialog + wire).
+	test("frontmatter round-trip: picking a saved template gets the body verbatim, and an edit-save cycle never grows it", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+		const settingsDialog = page.getByTestId("settings-dialog");
+		const editor = page.getByTestId("template-editor-dialog");
+
+		await page.getByTestId("open-settings").click();
+		await page.getByTestId("settings-nav-templates").click();
+		await page.getByTestId("template-new-global").click();
+		await expect(editor).toBeVisible();
+
+		await page.getByTestId("template-name-input").fill("roundtrip");
+		await page.getByTestId("template-description-input").fill("Round-trip check");
+		await page.getByTestId("template-body-input").fill("Notes for the day");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+
+		await page.keyboard.press("Escape");
+		await expect(settingsDialog).toBeHidden();
+
+		// Pick via /roundtrip: the draft must equal the body exactly — no leading blank line leaked in by
+		// the client-side splitter.
+		await input.fill("/roundtrip");
+		await page
+			.locator('[data-testid="slash-command"][data-source="prompt"]')
+			.filter({ hasText: "roundtrip" })
+			.first()
+			.click();
+		await expect(input).toHaveValue("Notes for the day");
+		await input.fill("");
+
+		// Edit only the description, save, reopen: the body must be byte-for-byte unchanged — not
+		// compounded with an extra leading blank line from the previous split/assemble cycle.
+		await page.getByTestId("open-settings").click();
+		await page.getByTestId("settings-nav-templates").click();
+		const row = page.locator('[data-testid="template-row"][data-name="roundtrip"]');
+		await row.getByTestId("template-edit").click();
+		await expect(editor).toBeVisible();
+		await expect(page.getByTestId("template-body-input")).toHaveValue("Notes for the day");
+		await page.getByTestId("template-description-input").fill("Round-trip check, revised");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+
+		await row.getByTestId("template-edit").click();
+		await expect(editor).toBeVisible();
+		await expect(page.getByTestId("template-body-input")).toHaveValue("Notes for the day");
+		await page.getByTestId("template-cancel").click();
+	});
+
+	test("an invalid template name shows an inline error instead of saving", async ({ page }) => {
+		await openWorkspaceChat(page);
+		await page.getByTestId("open-settings").click();
+		await page.getByTestId("settings-nav-templates").click();
+		await page.getByTestId("template-new-global").click();
+		const editor = page.getByTestId("template-editor-dialog");
+		await expect(editor).toBeVisible();
+
+		// Leading "." is the server's own `isValidTemplateName` path-traversal gate, mirrored client-side.
+		await page.getByTestId("template-name-input").fill(".hidden");
+		await page.getByTestId("template-body-input").fill("anything");
+		await page.getByTestId("template-save").click();
+
+		await expect(page.getByTestId("template-error")).toBeVisible();
+		await expect(editor).toBeVisible();
+		await expect(page.locator('[data-testid="template-row"][data-name=".hidden"]')).toHaveCount(0);
+	});
+
+	test("a project-scoped template is written into the worktree and shows up in the Files tree", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+
+		await page.getByTestId("open-settings").click();
+		await page.getByTestId("settings-nav-templates").click();
+		await page.getByTestId("template-new-project").click();
+		const editor = page.getByTestId("template-editor-dialog");
+		await expect(editor).toBeVisible();
+		await expect(page.getByTestId("template-scope-project")).toHaveAttribute("data-active", "true");
+
+		await page.getByTestId("template-name-input").fill("scoped-note");
+		await page.getByTestId("template-body-input").fill("Project-scoped body");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+
+		const row = page.locator(
+			'[data-testid="template-row"][data-name="scoped-note"][data-scope="project"]',
+		);
+		await expect(row).toBeVisible();
+
+		// Open-as-file is project-only — global rows never get this action. Clicking it both opens the real
+		// file as a center editor tab (the exact `openFileInTab` action the file tree itself uses) and closes
+		// Settings — no separate Escape needed.
+		const settingsDialog = page.getByTestId("settings-dialog");
+		await row.getByTestId("template-open-file").click();
+		await expect(settingsDialog).toBeHidden();
+		await expect(
+			page.locator('[data-testid="editor-tab"]').filter({ hasText: "scoped-note.md" }),
+		).toBeVisible();
+
+		// The file really landed in the worktree: `.pi/prompts/scoped-note.md`, browsable like any other file
+		// — `fs.readDir` doesn't special-case dotdirs beyond `.git`, so no app-side special-casing is needed.
+		await page.getByTestId("tab-files").click();
+		const piDir = page
+			.locator('[data-testid="file-node"][data-kind="dir"]')
+			.filter({ hasText: /^\.pi$/ });
+		await expect(piDir).toBeVisible();
+		await piDir.click();
+		const promptsDir = page
+			.locator('[data-testid="file-node"][data-kind="dir"]')
+			.filter({ hasText: /^prompts$/ });
+		await expect(promptsDir).toBeVisible();
+		await promptsDir.click();
+		await expect(
+			page
+				.locator('[data-testid="file-node"][data-kind="file"]')
+				.filter({ hasText: /^scoped-note\.md$/ }),
+		).toBeVisible();
+	});
+
+	// Save-as-template's other entry point: the Ctrl+R history overlay's selected prompt row. Reuses
+	// `seedExternalCwdSessions`'s deterministic fixture ("fix the flaky watcher test") the same way
+	// `history-search.spec.ts` does — cycle scope to "all" so the deliberately-unmapped external-cwd
+	// session is in view, then act on its (default-selected) prompt row.
+	test("history overlay: save-as-template opens the shared editor prefilled with the selected prompt", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		seedExternalCwdSessions();
+
+		const input = page.getByTestId("chat-input");
+		const overlay = page.getByTestId("history-overlay");
+		const query = page.getByTestId("history-query");
+		const scopeBadge = page.getByTestId("history-scope");
+		const promptRow = page
+			.locator('[data-testid="history-item"][data-kind="prompt"]')
+			.filter({ hasText: "fix the flaky watcher test" });
+
+		await input.press("Control+r");
+		await expect(overlay).toBeVisible();
+		await query.fill("flaky");
+		await query.press("Control+r");
+		await query.press("Control+r");
+		await expect(scopeBadge).toHaveAttribute("data-scope", "all");
+		await expect(promptRow).toBeVisible();
+
+		// Click affordance: hovering the row reveals its save-as-template button.
+		await promptRow.hover();
+		await expect(promptRow.getByTestId("history-save-template")).toBeVisible();
+
+		// Keyboard affordance: Cmd/Ctrl+S while this (sole, hence default-selected) prompt row is the
+		// keyboard selection — the overlay closes and the shared editor opens, body-prefilled.
+		await query.press("Control+s");
+		await expect(overlay).toBeHidden();
+		const editor = page.getByTestId("template-editor-dialog");
+		await expect(editor).toBeVisible();
+		await expect(page.getByTestId("template-body-input")).toHaveValue("fix the flaky watcher test");
+		await expect(page.getByTestId("template-name-input")).toHaveValue("");
+
+		await page.getByTestId("template-cancel").click();
+		await expect(editor).toBeHidden();
+	});
+
+	// Reviewer-flagged regression: `TemplatesSettings` used to fetch `template.list { workspaceId }` once
+	// and derive both groups from that one response. The server shadow-merges by design (`templates.ts`'s
+	// `listTemplates`: a project template wins over a same-named global one) — right for the composer's
+	// `/` menu (one name, one expansion), but it meant a global template shadowed by a same-named project
+	// one vanished from the Global group entirely, with no way left to find, edit, or delete it. The panel
+	// now fetches twice — unscoped for Global, `{ workspaceId }` filtered to project-scope for This
+	// project — so a shadowed global template stays visible and independently editable.
+	test("a project template shadowing a same-named global one leaves both visible and independently editable", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		await page.getByTestId("open-settings").click();
+		await page.getByTestId("settings-nav-templates").click();
+		const editor = page.getByTestId("template-editor-dialog");
+
+		// Global "foo" first.
+		await page.getByTestId("template-new-global").click();
+		await expect(editor).toBeVisible();
+		await page.getByTestId("template-name-input").fill("foo");
+		await page.getByTestId("template-description-input").fill("Global foo");
+		await page.getByTestId("template-body-input").fill("Global foo body");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+
+		const globalRow = page.locator(
+			'[data-testid="template-row"][data-name="foo"][data-scope="global"]',
+		);
+		await expect(globalRow).toBeVisible();
+		await expect(globalRow).toContainText("Global foo");
+
+		// Project "foo" — same name, shadowing the global one for the composer's `/` menu, but Settings
+		// must still show both rows.
+		await page.getByTestId("template-new-project").click();
+		await expect(editor).toBeVisible();
+		await page.getByTestId("template-name-input").fill("foo");
+		await page.getByTestId("template-description-input").fill("Project foo");
+		await page.getByTestId("template-body-input").fill("Project foo body");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+
+		const projectRow = page.locator(
+			'[data-testid="template-row"][data-name="foo"][data-scope="project"]',
+		);
+		await expect(projectRow).toBeVisible();
+		await expect(projectRow).toContainText("Project foo");
+		// The regression: the global row used to vanish the moment a same-named project template existed.
+		await expect(globalRow).toBeVisible();
+		await expect(globalRow).toContainText("Global foo");
+
+		// Editing the GLOBAL row must update the global template, not the project one — proving the editor
+		// is handed the correct scope regardless of which group's affordance opened it.
+		await globalRow.getByTestId("template-edit").click();
+		await expect(editor).toBeVisible();
+		await expect(page.getByTestId("template-scope-global")).toHaveAttribute("data-active", "true");
+		await page.getByTestId("template-description-input").fill("Global foo, revised");
+		await page.getByTestId("template-save").click();
+		await expect(editor).toBeHidden();
+
+		await expect(globalRow).toContainText("Global foo, revised");
+		await expect(projectRow).toContainText("Project foo");
+		await expect(projectRow).not.toContainText("revised");
+	});
+});

--- a/e2e/templates-manage.spec.ts
+++ b/e2e/templates-manage.spec.ts
@@ -1,5 +1,8 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { openWorkspaceChat } from "./fixtures/app";
+import { E2E_PI_AGENT_DIR } from "./fixtures/paths";
 import { seedExternalCwdSessions } from "./fixtures/sessions";
 import {
 	clearTemplateFixtures,
@@ -381,5 +384,64 @@ test.describe("templates management", () => {
 		await expect(globalRow).toContainText("Global foo, revised");
 		await expect(projectRow).toContainText("Project foo");
 		await expect(projectRow).not.toContainText("revised");
+	});
+
+	// Reviewer-flagged data-loss regression: `template.list` is metadata-only with a BOUNDED frontmatter
+	// head-scan (`packages/server/src/templates/templates.ts` — the whole point is that a listing never
+	// does full-file reads), so a file whose closing fence sits past that window legitimately lists with
+	// NO description/argument-hint. The edit dialog used to seed its metadata fields from that degraded
+	// listing row and write them back on Save — a body-only edit silently deleted the file's real
+	// frontmatter. Now the `template.get` response (a full-file parse) is authoritative for every field:
+	// its metadata replaces the listing seed when it resolves, and the fields + Save stay disabled until
+	// then, so what gets written back is what the file actually said.
+	test("editing a template whose frontmatter fence is past the listing scan window keeps its metadata", async ({
+		page,
+	}) => {
+		// 16 KiB of hint pushes the closing fence well past the 8 KiB scan window — the same construction
+		// the server suite pins the list/get asymmetry with (`templates.test.ts`). The description itself
+		// is short, but a truncated block with no closing fence in view parses as "no frontmatter at all",
+		// so the listing drops EVERY field, not just the ones past the window.
+		const hugeHint = "p".repeat(16 * 1024);
+		const filePath = join(E2E_PI_AGENT_DIR, "prompts", "deep-meta.md");
+		writeFileSync(
+			filePath,
+			`---\ndescription: "buried description"\nargument-hint: "${hugeHint}"\n---\nOriginal body\n`,
+		);
+		try {
+			await openWorkspaceChat(page);
+			await page.getByTestId("open-settings").click();
+			await page.getByTestId("settings-nav-templates").click();
+
+			// The listing row really is degraded — the name lists, the description doesn't.
+			const row = page.locator(
+				'[data-testid="template-row"][data-name="deep-meta"][data-scope="global"]',
+			);
+			await expect(row).toBeVisible();
+			await expect(row).not.toContainText("buried description");
+
+			// Edit-open: once `template.get` resolves, the full-file parse's metadata has replaced the
+			// degraded listing seed in the form.
+			await row.getByTestId("template-edit").click();
+			const editor = page.getByTestId("template-editor-dialog");
+			await expect(editor).toBeVisible();
+			await expect(page.getByTestId("template-description-input")).toHaveValue(
+				"buried description",
+			);
+			await expect(page.getByTestId("template-body-input")).toHaveValue("Original body");
+
+			// A body-only edit + save…
+			await page.getByTestId("template-body-input").fill("Edited body");
+			await page.getByTestId("template-save").click();
+			await expect(editor).toBeHidden();
+
+			// …must not have touched the metadata on disk.
+			const onDisk = readFileSync(filePath, "utf-8");
+			expect(onDisk).toContain('description: "buried description"');
+			expect(onDisk).toContain(`argument-hint: "${hugeHint}"`);
+			expect(onDisk).toContain("Edited body");
+			expect(onDisk).not.toContain("Original body");
+		} finally {
+			removeGlobalTemplates(["deep-meta"]);
+		}
 	});
 });

--- a/e2e/templates-manage.spec.ts
+++ b/e2e/templates-manage.spec.ts
@@ -26,23 +26,24 @@ test.describe("templates management", () => {
 	// anything ever adds to the Global group (`templates-compose.spec.ts` only reads the fixtures below;
 	// no other spec touches templates at all) — so running first guarantees neither "standup" (created and
 	// deleted by the test below) nor "foo" (created, and left, by the shadowing test below) exists yet.
-	// `globalSetup` seeds three Global fixtures once for the whole run and `resetState` never wipes
+	// `globalSetup` seeds four Global fixtures once for the whole run and `resetState` never wipes
 	// `prompts/` (see `fixtures/templates.ts`), so the Global group is otherwise never empty during the
-	// suite — manufacturing that condition means removing those three ourselves first. Restores them (and
+	// suite — manufacturing that condition means removing those four ourselves first. Restores them (and
 	// removes the four starters this test adds) at the end, so every test/file that runs after — including
-	// this file's own later tests, and `templates-compose.spec.ts`, which depends on `review`/`rename`/
-	// `adjacent`'s exact original content — sees the world exactly as it was before this test ran.
+	// this file's own later tests, and `templates-compose.spec.ts`, which depends on
+	// `review`/`rename`/`adjacent`/`defaults`'s exact original content — sees the world exactly as it was
+	// before this test ran.
 	test("Global empty state offers starter templates; adding them fills the composer's / menu", async ({
 		page,
 	}) => {
 		await openWorkspaceChat(page);
 		clearTemplateFixtures();
 
-		// Everything from here on must restore the three original fixtures no matter how the test body
+		// Everything from here on must restore the four original fixtures no matter how the test body
 		// exits: this is a serial suite (one shared host, `workers: 1`), there's no `afterEach`, and
-		// `templates-compose.spec.ts` depends on `review`/`rename`/`adjacent`'s exact original content — a
-		// thrown assertion between the clear above and the restore below would otherwise leave the shared
-		// `prompts/` dir permanently short those three fixtures for every test that runs after this one.
+		// `templates-compose.spec.ts` depends on `review`/`rename`/`adjacent`/`defaults`'s exact original
+		// content — a thrown assertion between the clear above and the restore below would otherwise leave
+		// the shared `prompts/` dir permanently short those fixtures for every test that runs after this one.
 		try {
 			await page.getByTestId("open-settings").click();
 			await page.getByTestId("settings-nav-templates").click();
@@ -78,7 +79,7 @@ test.describe("templates management", () => {
 			).toHaveCount(1);
 			await input.fill("");
 		} finally {
-			// Restore: remove the four starters this test added, then put the original three fixtures
+			// Restore: remove the four starters this test added, then put the original four fixtures
 			// back — always, even if an assertion above threw.
 			removeGlobalTemplates(["review", "explain", "tests", "standup"]);
 			seedTemplateFixtures();

--- a/e2e/templates-manage.spec.ts
+++ b/e2e/templates-manage.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { openWorkspaceChat } from "./fixtures/app";
@@ -442,6 +442,51 @@ test.describe("templates management", () => {
 			expect(onDisk).not.toContain("Original body");
 		} finally {
 			removeGlobalTemplates(["deep-meta"]);
+		}
+	});
+
+	// Reviewer-flagged identity regression: whitespace-bearing template names are server-legal BY DESIGN
+	// (pi derives a template's name from its filename verbatim, so a hand-created `report .md` lists as
+	// `report ` — the gate in `packages/server/src/templates/templates.ts` deliberately accepts every
+	// pi-listable name). The dialog used to trim the name on every save, so editing `report ` wrote a NEW
+	// `report.md` and left the file being edited untouched — the edit looked successful while the selected
+	// template never changed. An edit now saves under `template.name` verbatim; only new-template names
+	// are trimmed (deliberate form normalization).
+	test("editing a hand-created template with a whitespace-bearing name round-trips to the same file", async ({
+		page,
+	}) => {
+		const promptsDir = join(E2E_PI_AGENT_DIR, "prompts");
+		const filePath = join(promptsDir, "report .md");
+		writeFileSync(filePath, `---\ndescription: "Trailing-space name"\n---\nHand-created body\n`);
+		try {
+			await openWorkspaceChat(page);
+			await page.getByTestId("open-settings").click();
+			await page.getByTestId("settings-nav-templates").click();
+
+			const row = page.locator(
+				'[data-testid="template-row"][data-name="report "][data-scope="global"]',
+			);
+			await expect(row).toBeVisible();
+			await row.getByTestId("template-edit").click();
+			const editor = page.getByTestId("template-editor-dialog");
+			await expect(editor).toBeVisible();
+			await expect(page.getByTestId("template-name-input")).toHaveValue("report ");
+			await expect(page.getByTestId("template-body-input")).toHaveValue("Hand-created body");
+
+			// A body-only edit + save…
+			await page.getByTestId("template-body-input").fill("Edited body");
+			await page.getByTestId("template-save").click();
+			await expect(editor).toBeHidden();
+
+			// …must land in the file being edited…
+			const onDisk = readFileSync(filePath, "utf-8");
+			expect(onDisk).toContain("Edited body");
+			expect(onDisk).toContain('description: "Trailing-space name"');
+			// …and mint no trimmed twin (the regression: save used to write `report.md` instead).
+			expect(existsSync(join(promptsDir, "report.md"))).toBe(false);
+		} finally {
+			// "report" too: if the regression ever recurs, the minted twin must not leak into later tests.
+			removeGlobalTemplates(["report ", "report"]);
 		}
 	});
 });

--- a/e2e/templates.live.spec.ts
+++ b/e2e/templates.live.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+import { openWorkspaceChat, waitForDone } from "./fixtures/app";
+
+// Tagged @agent (see agent.live.spec.ts): drives a REAL pi agent against the seeded prompt-template
+// fixtures (`e2e/fixtures/templates.ts`). The no-agent `templates-compose.spec.ts` already covers the
+// composer's slot-session mechanics end to end (against a rejected send — no auth in that suite); these
+// two specs are what actually reach a live agent: the menu path (client-expanded plain text — proving a
+// real turn still completes) and the typed-through path (a literal `/name args` prompt, which never
+// touches the slot parser at all — it rides pi's OWN server-side expansion, `PromptOptions.
+// expandPromptTemplates`, default `true`; see `packages/server/src/agent/SPEC.md`). The typed-through test
+// is also what resolves the design's "to verify" #3 — how pi records an expanded prompt in the transcript
+// — empirically; the observed result is documented in `apps/web/src/chat/SPEC.md`'s Template slots bullet.
+
+test("picking the seeded template from the / menu sends the expanded text and gets a reply", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(90_000);
+	await openWorkspaceChat(page);
+	const input = page.getByTestId("chat-input");
+
+	// `/rev` matches only the fixture template (`review.md`: `Review $1 for issues, focusing on
+	// ${2:-src/}.`) — same pick as `templates-compose.spec.ts`, but sent to a real agent instead of just
+	// asserting the client-side draft.
+	await input.fill("/rev");
+	const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
+	await expect(rows).toHaveCount(1);
+	await rows.first().click();
+	await expect(input).toHaveValue(/^Review ⟨file⟩ for issues, focusing on src\/\.\s*$/);
+
+	// Fill slot 1/2; Tab to slot 2/2 and leave its prefilled default ("src/") untouched.
+	await page.keyboard.type("README.md");
+	await expect(input).toHaveValue(/^Review README\.md for issues, focusing on src\/\.\s*$/);
+	await input.press("Tab");
+	await expect(page.getByTestId("slot-hint")).toContainText("slot 2/2");
+
+	await page.getByTestId("chat-send").click();
+
+	// The menu path always sends pre-expanded plain text (Composer's own slot substitution never
+	// produces a `/name` string), so the bubble is the fully-expanded body: both slot fills are present,
+	// no leftover marker glyph, and no literal command name.
+	const bubble = page.locator('[data-testid="chat-message"][data-role="user"]').first();
+	await expect(bubble).toContainText("README.md");
+	await expect(bubble).toContainText("src/");
+	await expect(bubble).not.toContainText("⟨");
+	await expect(bubble).not.toContainText("/review");
+
+	// An assistant reply arrives — any non-error completion (`agent_end` without a `stopReason: "error"`
+	// last message renders "✓ Done"; an error renders a distinct `ErrorTurn` instead — see
+	// `store/appStore.ts`'s `agent_end` case). The pinned e2e default model; content isn't asserted.
+	await waitForDone(page);
+});
+
+test("a typed-through /name command is expanded by pi itself, not the composer's slot parser", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(120_000);
+	await openWorkspaceChat(page);
+	const input = page.getByTestId("chat-input");
+
+	// Type the command literally — never picking it from the menu. Real per-character key events
+	// (`keyboard.type`, not `.fill`) are what exercise the menu's live-closing transition: `slashQuery`
+	// (Composer.tsx) goes null the instant ANY space lands in the value, so the menu already closes
+	// right after "/review " — long before the trailing space this prompt happens to end with.
+	await input.click();
+	await page.keyboard.type("/review alpha beta ");
+	await expect(page.getByTestId("slash-menu")).toHaveCount(0);
+	await page.keyboard.press("Enter");
+
+	// The trailing space is trimmed at submit, so "/review alpha beta" (no client-side expansion — this
+	// never touched `insertTemplate`/the slot parser) is what's actually sent. This first bubble is the
+	// web client's own OPTIMISTIC echo (`ChatView.onSubmit` → `appendUserMessage`: store-only, appended
+	// before the transport call resolves) — it always shows exactly what was typed, regardless of what
+	// the agent does with the text next.
+	const bubble = page.locator('[data-testid="chat-message"][data-role="user"]').first();
+	await expect(bubble).toHaveText("/review alpha beta");
+
+	await waitForDone(page);
+
+	// Reload to inspect what pi actually PERSISTED, not the client's optimistic echo: a fresh page has
+	// no in-memory runtime for this session, so `CenterTabs`'s hydrate-on-connect effect refetches
+	// `session.getMessages` and rebuilds the transcript from pi's own message list
+	// (`messagesToRuntime`) — the same "come back later" path `history-jump.spec.ts`/
+	// `history-search.spec.ts` use to inspect a session's durable record. A reload doesn't auto-restore
+	// the active project/workspace, so re-pick both.
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("project-item").first().click();
+	await page.getByTestId("workspace-item").first().click();
+	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+
+	// The session is still live in the host's memory (never closed), so it auto-restores as the active
+	// tab — no history entry to reopen from.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	const restoredBubble = page.locator('[data-testid="chat-message"][data-role="user"]').first();
+	await expect(restoredBubble).toBeVisible();
+
+	// OBSERVED (see `apps/web/src/chat/SPEC.md`'s Template slots bullet): pi's `AgentSession.prompt()`
+	// substitutes args into `expandedText` *before* persisting the `role: "user"` message, so its own
+	// transcript carries the fully-expanded body — never the raw typed command — once re-fetched.
+	await expect(restoredBubble).toContainText("Review alpha for issues, focusing on beta.");
+	await expect(restoredBubble).not.toContainText("/review");
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -125,7 +125,10 @@ of the host.
   conversation match; assistant-only — a user-role hit only ever duplicates its own `PromptHit`'s text,
   so the jump affordance lives there instead; `messageIndex` anchors jump-to-message into
   `session.getMessages` order, `anchorText` makes the anchor drift-tolerant), and
-  **`HistorySearchResult`** (the prompts + full-text messages sections, with totals and indexing status).
+  **`HistorySearchResult`** (the prompts + full-text messages sections, with totals and indexing status);
+  **prompt-template DTOs** — **`TemplateScope`** (`"global"` | `"project"` — where a template lives),
+  and **`TemplateInfo`** (name, optional `description`/`argumentHint`, full `content` — frontmatter +
+  body — `scope`, and `filePath` for breadcrumbing).
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.inspect`** (classify a path) +
   **`project.init`** (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "has any
   registered spec?" for the Welcome screen — a full-tree walk, so requested only for the shown project,
@@ -158,7 +161,10 @@ of the host.
   read side) / **`settings.update`** (merge + persist a partial `AppConfig`, returns the merged
   config) / **`history.search`** (the prompt-recall + conversation-search read; results capped,
   recency-ordered; the messages section is assistant-only — a user-role hit surfaces as a jumpable
-  `PromptHit` instead, never a separate `MessageHit`)),
+  `PromptHit` instead, never a separate `MessageHit`) / **`template.*`** — prompt-template CRUD
+  (**`template.list`**, **`template.get`**
+  — `scope` optional, project wins over global, **`template.save`**, **`template.delete`**) — all
+  read/write pi's prompt dirs (global + project), so templates stay CLI-portable,
   `WS_CHANNELS` (`server.welcome` — which carries the initial `config: AppConfig` alongside `projects` /
   `pi.event` / `pi.extensionUi` / **`settings.changed`** (the full `AppConfig`, broadcast so every client
   converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -127,8 +127,10 @@ of the host.
   `session.getMessages` order, `anchorText` makes the anchor drift-tolerant), and
   **`HistorySearchResult`** (the prompts + full-text messages sections, with totals and indexing status);
   **prompt-template DTOs** — **`TemplateScope`** (`"global"` | `"project"` — where a template lives),
-  and **`TemplateInfo`** (name, optional `description`/`argumentHint`, full `content` — frontmatter +
-  body — `scope`, and `filePath` for breadcrumbing).
+  **`TemplateInfo`** (metadata only: name, optional `description`/`argumentHint`, `scope`, `filePath` —
+  what `template.list` returns; deliberately body-free so a listing never ships every file's full text),
+  and **`Template`** (`TemplateInfo` + full `content` — frontmatter + body — the by-name
+  `template.get`/`template.save` shape).
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.inspect`** (classify a path) +
   **`project.init`** (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "has any
   registered spec?" for the Welcome screen — a full-tree walk, so requested only for the shown project,

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -401,3 +401,22 @@ export interface HistorySearchResult {
 	messageTotal: number;
 	indexing: boolean;
 }
+
+/** Scope of a prompt template — global (pi's global dir) or project-scoped. */
+export type TemplateScope = "global" | "project";
+
+/** A prompt template: a re-usable text snippet with optional metadata. */
+export interface TemplateInfo {
+	/** The template's unique name (within its scope). */
+	name: string;
+	/** Optional description of the template's purpose. */
+	description?: string;
+	/** Optional hint for argument placeholders or usage. */
+	argumentHint?: string;
+	/** The full file text: frontmatter + body. */
+	content: string;
+	/** Where the template lives — global or project-scoped. */
+	scope: TemplateScope;
+	/** Absolute path to the template file on disk. */
+	filePath: string;
+}

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -405,7 +405,11 @@ export interface HistorySearchResult {
 /** Scope of a prompt template — global (pi's global dir) or project-scoped. */
 export type TemplateScope = "global" | "project";
 
-/** A prompt template: a re-usable text snippet with optional metadata. */
+/** A prompt template's metadata — what `template.list` returns. Deliberately body-free: both list
+ * consumers (the composer's `/` menu, the Templates settings rows) render metadata only, and shipping
+ * every file's full text would make a listing cost the whole corpus (the host reads only each file's
+ * bounded frontmatter head to build these). The full text travels solely on the by-name `template.get`/
+ * `template.save` path, as {@link Template}. */
 export interface TemplateInfo {
 	/** The template's unique name (within its scope). */
 	name: string;
@@ -413,10 +417,14 @@ export interface TemplateInfo {
 	description?: string;
 	/** Optional hint for argument placeholders or usage. */
 	argumentHint?: string;
-	/** The full file text: frontmatter + body. */
-	content: string;
 	/** Where the template lives — global or project-scoped. */
 	scope: TemplateScope;
 	/** Absolute path to the template file on disk. */
 	filePath: string;
+}
+
+/** A full prompt template: metadata + the complete file text (frontmatter + body). */
+export interface Template extends TemplateInfo {
+	/** The full file text: frontmatter + body. */
+	content: string;
 }

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -15,6 +15,8 @@ import type {
 	ProjectPathStatus,
 	ProviderStatusReport,
 	SpecGraphSnapshot,
+	TemplateInfo,
+	TemplateScope,
 	TodoItem,
 	TodoPlan,
 	TodoStatus,
@@ -68,7 +70,9 @@ import type {
 // messages section is assistant-only (a user-role hit only ever duplicates its own prompt's text);
 // `PromptHit` carries optional `messageIndex`/`anchorText` so the prompt row itself is jumpable — the
 // location a dropped user-role message hit used to carry.
-export const PROTOCOL_VERSION = 15;
+// v16: prompt-template CRUD — template.* reads/writes pi's prompt dirs (global + project), so
+// templates stay pi-CLI-portable.
+export const PROTOCOL_VERSION = 16;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -197,6 +201,11 @@ export const WS_METHODS = {
 	// `config.json`, and broadcasts `settings.changed` — the caller converges on that push, not optimism.
 	settingsUpdate: "settings.update",
 	historySearch: "history.search",
+	// Prompt-template CRUD: list/read/write/delete pi's global + project-scoped templates.
+	templateList: "template.list",
+	templateGet: "template.get",
+	templateSave: "template.save",
+	templateDelete: "template.delete",
 } as const;
 
 /** Server→client push channels. */
@@ -441,6 +450,33 @@ export interface WsMethodMap {
 	"history.search": {
 		params: { query: string; scope: HistoryScope; limit?: number };
 		result: HistorySearchResult;
+	};
+	// List all templates (global + project-scoped). `workspaceId` needed to resolve the project dir;
+	// omitted → global templates only.
+	"template.list": {
+		params: { workspaceId?: string };
+		result: { templates: TemplateInfo[] };
+	};
+	// Fetch a single template by name. `scope` is optional (project wins over global when omitted).
+	// `workspaceId` is required only if the template may be project-scoped.
+	"template.get": {
+		params: { workspaceId?: string; name: string; scope?: TemplateScope };
+		result: TemplateInfo;
+	};
+	// Save a template (creates or overwrites). Returns the persisted `TemplateInfo`.
+	"template.save": {
+		params: {
+			workspaceId?: string;
+			scope: TemplateScope;
+			name: string;
+			content: string;
+		};
+		result: TemplateInfo;
+	};
+	// Delete a template. Returns `Ack` on success.
+	"template.delete": {
+		params: { workspaceId?: string; scope: TemplateScope; name: string };
+		result: Ack;
 	};
 }
 

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -15,6 +15,7 @@ import type {
 	ProjectPathStatus,
 	ProviderStatusReport,
 	SpecGraphSnapshot,
+	Template,
 	TemplateInfo,
 	TemplateScope,
 	TodoItem,
@@ -71,7 +72,9 @@ import type {
 // `PromptHit` carries optional `messageIndex`/`anchorText` so the prompt row itself is jumpable — the
 // location a dropped user-role message hit used to carry.
 // v16: prompt-template CRUD — template.* reads/writes pi's prompt dirs (global + project), so
-// templates stay pi-CLI-portable.
+// templates stay pi-CLI-portable. `template.list` is metadata-only (`TemplateInfo`, no `content` — the
+// host reads just each file's bounded frontmatter head); the full text travels solely on the by-name
+// `template.get`/`template.save` path (`Template`), both size-capped host-side.
 export const PROTOCOL_VERSION = 16;
 
 /**
@@ -457,13 +460,14 @@ export interface WsMethodMap {
 		params: { workspaceId?: string };
 		result: { templates: TemplateInfo[] };
 	};
-	// Fetch a single template by name. `scope` is optional (project wins over global when omitted).
-	// `workspaceId` is required only if the template may be project-scoped.
+	// Fetch a single template by name — the only read that carries the full `content` (list is
+	// metadata-only). `scope` is optional (project wins over global when omitted). `workspaceId` is
+	// required only if the template may be project-scoped.
 	"template.get": {
 		params: { workspaceId?: string; name: string; scope?: TemplateScope };
-		result: TemplateInfo;
+		result: Template;
 	};
-	// Save a template (creates or overwrites). Returns the persisted `TemplateInfo`.
+	// Save a template (creates or overwrites). Returns the persisted `Template`.
 	"template.save": {
 		params: {
 			workspaceId?: string;
@@ -471,7 +475,7 @@ export interface WsMethodMap {
 			name: string;
 			content: string;
 		};
-		result: TemplateInfo;
+		result: Template;
 	};
 	// Delete a template. Returns `Ack` on success.
 	"template.delete": {

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -61,6 +61,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `assist` | ad-hoc one-shot tasks (workspace naming, …) on a cheap model, best-effort | [assist/SPEC.md](src/assist/SPEC.md) |
 | `dialog` | the host's native folder picker | [dialog/SPEC.md](src/dialog/SPEC.md) |
 | `history` | prompt recall + conversation search over pi's session files | [history/SPEC.md](src/history/SPEC.md) |
+| `templates` | file CRUD over pi's prompt-template dirs (global + project scoped) | [templates/SPEC.md](src/templates/SPEC.md) |
 
 `src/index.ts` re-exports `host` + the `agent` barrel's `registerBundledRuntime` seam; `src/dev.ts` boots
 the host from env via `bootHost` for dev/e2e.
@@ -69,7 +70,7 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`, `history`
+- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`
 - `workspaces` → `projects`, `git`, `persistence`
 - `projects` → `git` (shared runner), `persistence`
 - `git`, `fs`, `spec`, `watch`, `terminal`, `settings` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
@@ -77,7 +78,7 @@ the host from env via `bootHost` for dev/e2e.
 - `assist` → `agent` (the one-shot completion primitive)
 - `auth` → `agent` (`getPiRuntime` — the shared `AuthStorage` + `ModelRegistry`; one-way, `agent` never imports `auth`)
 - `agent` → (no internal deps — only the pi runtime)
-- `persistence`, `dialog`, `github`, `history` → (leaves)
+- `persistence`, `dialog`, `github`, `history`, `templates` → (leaves)
 
 Rules: features never import `host`, and never each other except the edges above. The graph is acyclic.
 `agent`'s WS surface (`session.*` + `pi.event` forwarding) attaches to `host`. Features that push on their
@@ -86,7 +87,9 @@ own never import `host` either: they expose a **publisher-injection seam** (`set
 `workspace.created`/`updated`/`removed` lifecycle trio, and `settings`' `setSettingsPublisher` for
 `settings.changed`) that `host` installs at `createServer` — so the channel wiring lives only in `host`.
 `history` stays registry-free (never imports `projects`/`workspaces`); `host` injects the scope filter
-+ labels from the registries at the handler layer (`history.search` handler).
++ labels from the registries at the handler layer (`history.search` handler). `templates` stays
+registry-free too — it takes a plain `cwd`, never a `workspaceId`; the `template.*` handler resolves
+`workspaceId` → `cwd` via `workspaces` before calling into `templates`.
 
 ## Get right
 

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -253,3 +253,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   except for the accepted base-branch/current-checkout timing difference.
 - Dialog promises honor abort/timeout and are settled (+ dismissed in the UI) on session disposal — a
   bridged `uiContext` call must never hang.
+- **Prompt-template `/name` expansion** — typed-through references like `/name args` in a prompt ride
+  the agent's default `expandPromptTemplates: true` (no agent code change). It expands from the
+  session's **create-time template snapshot** — a template saved mid-session is **NOT** seen by an
+  already-open session's typed-through path (pi passes unknown `/name` text through verbatim). The
+  composer's `/` menu path is always fresh via `template.list` (see `templates/SPEC.md` freshness rule).

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -5,6 +5,7 @@ import type {
 	HistoryScope,
 	ImageContent,
 	LoginReply,
+	TemplateScope,
 	ThinkingLevel,
 	TodoStatus,
 	WireModel,
@@ -63,6 +64,13 @@ import {
 } from "../projects";
 import { updateConfig } from "../settings";
 import { evictSpecIndex, projectHasSpecs, specGraph } from "../spec";
+import {
+	deleteTemplate,
+	getTemplate,
+	listTemplates,
+	saveTemplate,
+	templateDirs,
+} from "../templates";
 import {
 	closeTerminal,
 	closeWorkspaceTerminals,
@@ -416,6 +424,35 @@ const handlers: Record<string, Handler> = {
 			labels,
 			limit: clampLimit(p.limit),
 		});
+	},
+	// Prompt-template CRUD: list/read/write/delete pi's global + project-scoped templates. The
+	// template.* handlers resolve workspaceId → cwd via getWorkspace, then delegate to the templates
+	// module (which stays registry-free: it only takes a cwd, never a workspaceId).
+	"template.list": (params) => {
+		const p = params as { workspaceId?: string };
+		const dirs = templateDirs(p.workspaceId ? getWorkspace(p.workspaceId).worktreePath : undefined);
+		return { templates: listTemplates(dirs) };
+	},
+	"template.get": (params) => {
+		const p = params as { workspaceId?: string; name: string; scope?: TemplateScope };
+		const dirs = templateDirs(p.workspaceId ? getWorkspace(p.workspaceId).worktreePath : undefined);
+		return getTemplate(dirs, p.name, p.scope);
+	},
+	"template.save": (params) => {
+		const p = params as {
+			workspaceId?: string;
+			scope: TemplateScope;
+			name: string;
+			content: string;
+		};
+		const dirs = templateDirs(p.workspaceId ? getWorkspace(p.workspaceId).worktreePath : undefined);
+		return saveTemplate(dirs, p.scope, p.name, p.content);
+	},
+	"template.delete": (params) => {
+		const p = params as { workspaceId?: string; scope: TemplateScope; name: string };
+		const dirs = templateDirs(p.workspaceId ? getWorkspace(p.workspaceId).worktreePath : undefined);
+		deleteTemplate(dirs, p.scope, p.name);
+		return { ok: true } as const;
 	},
 };
 

--- a/packages/server/src/templates/SPEC.md
+++ b/packages/server/src/templates/SPEC.md
@@ -1,0 +1,180 @@
+---
+id: submodule-server-templates
+type: submodule-design
+status: active
+title: templates — file CRUD over pi's prompt-template dirs
+parent: module-server
+depends-on: [module-contracts]
+tags: [v1, templates]
+---
+
+## Responsibility
+
+File CRUD over pi's two sanctioned prompt-template directories (global + project-scoped): list / get /
+save / delete `.md` files, surfacing pi's own frontmatter (`description`, `argument-hint`) as metadata.
+Consumed by the `template.*` host handlers (Task B3); this module owns no WS surface itself — `cwd` is
+passed in by the caller (a resolved workspace), never looked up here.
+
+## pi facts (pinned against pi v0.80.6 — `@earendil-works/pi-coding-agent`)
+
+Verified by reading `dist/core/prompt-templates.js` (`loadTemplateFromFile` / `loadTemplatesFromDir` /
+`loadPromptTemplates`), `dist/core/resource-loader.js` (`dedupePrompts`, `updatePromptsFromPaths`), and
+`dist/utils/frontmatter.js` in the installed package — source of truth over assumption; re-verify on a
+pi version bump.
+
+- **Directories:** global = `join(agentDir, "prompts")`; project = `resolve(cwd, CONFIG_DIR_NAME,
+  "prompts")` (`CONFIG_DIR_NAME = ".pi"`, pi root export) — exactly `templateDirs`'s two fields.
+- **Frontmatter keys:** `description` (string) and `argument-hint` (kebab-case; pi's own loader maps it
+  to a camelCase `argumentHint` field via `...(frontmatter["argument-hint"] && { argumentHint:
+  frontmatter["argument-hint"] })`). No other frontmatter keys are read by pi's loader.
+- **Name derivation:** `basename(filePath).replace(/\.md$/, "")` — filename minus a trailing `.md`
+  suffix, once (a name with an embedded dot like `foo.bar.md` derives `foo.bar`).
+- **No name validation in pi's loader, at all.** `loadTemplatesFromDir` accepts any directory entry
+  where `entry.isFile()` (or a symlink resolving to a file) `&& entry.name.endsWith(".md")` — no regex,
+  no traversal guard, and no dot-leading filter either (pi would list a hand-placed `.hidden.md`).
+  Path-traversal safety for **our** by-name paths (`saveTemplate` / `getTemplate` / `deleteTemplate`) is
+  entirely this module's own `isValidTemplateName` gate; pi gives us nothing to lean on there.
+- **`loadTemplatesFromDir`'s error handling is two-layered, at two different granularities.** The whole
+  `readdirSync` call plus the loop around it sits inside one `try { … } catch { return templates; }` — an
+  unreadable directory returns whatever had already been collected rather than throwing out of the
+  function. Independently, each file goes through `loadTemplateFromFile`, which has its *own* inner
+  `try { … } catch { return null; }` around the read + `parseFrontmatter` + object-build. This module's
+  `listDir` mirrors both layers (see "Design" below) — the whole-scan wrapper is what protects
+  `listTemplates` from an EACCES (or similar) blanking every scope's results, not just the bad one's.
+- **`parseFrontmatter`'s real signature** (`dist/utils/frontmatter.d.ts`): `parseFrontmatter<T extends
+  Record<string, unknown> = Record<string, unknown>>(content: string): { frontmatter: T; body: string
+  }` — a plain sync function, generic over the frontmatter shape (unvalidated at runtime; the generic
+  is the caller's own assertion, exactly as pi's own loader trusts it). We use the default
+  `Record<string, unknown>` and narrow with `typeof` before trusting a value as a `string`.
+- **No-frontmatter files parse to `{ frontmatter: {}, body: <normalized content> }`.** Reading
+  `frontmatter.js` itself: newlines are normalized (`\r\n`/`\r` → `\n`) first; if the content doesn't
+  start with `"---"`, or a `"---"` opener never finds a closing `"\n---"`, the whole (normalized)
+  content becomes `body`, un-trimmed. Only a *successfully closed* frontmatter block yields a `body`
+  that's `.trim()`ed. This module never reads pi's `body` at all (see "content" below), so none of that
+  trim/normalize behavior leaks into `TemplateInfo` — it only matters for the description-extraction
+  path, and even there we don't lean on it.
+- **pi's loader synthesizes a fallback `description`** from the body's first non-empty line (truncated
+  to 60 chars + `"…"`) when frontmatter has none — used for pi's own `/` menu blurbs. We deliberately do
+  **not** replicate this: `TemplateInfo.description` is optional on the wire (`contracts/domain.ts`), so
+  a template with no `description` frontmatter key surfaces `description: undefined` (key omitted),
+  never a manufactured value pi never wrote to disk.
+- **Precedence is not decided inside `loadPromptTemplates` itself.** Its `includeDefaults` branch just
+  concatenates `[...global, ...project]` with **no dedup at all** at that layer. Real precedence is
+  resolved later, in `resource-loader.js`'s `dedupePrompts` — a `Map` keyed by name where the **first**
+  prompt registered for a name wins (subsequent same-name entries become a `collision` diagnostic, not
+  an overwrite) — over a `promptPaths` list built from project config merge order we did not trace
+  further (out of this module's bounded investigation, and irrelevant: none of `loadPromptTemplates` /
+  `dedupePrompts` is root-exported — the sealed exports map gives us only `parseFrontmatter` /
+  `stripFrontmatter` / `getAgentDir` / `CONFIG_DIR_NAME`, so we can't call pi's version even if we
+  wanted to). **"Project shadows global" here is our own product decision** (design spec §2.2, "scope
+  omitted → pi precedence: project wins over global" — matching the brief), implemented independently
+  in `listTemplates`/`getTemplate` with a `Map` keyed by name where global is inserted first and project
+  second (`Map.set` on an existing key overwrites the value) — the mirror image of pi's own first-wins
+  `dedupePrompts`, chosen deliberately because "more specific scope wins" is the behavior the product
+  spec calls for, not because pi's internals resolve it that way for us.
+- **`stripFrontmatter` (also root-exported) is not used by this module.** `TemplateInfo.content` is "the
+  full file text: frontmatter + body" (`contracts/domain.ts`), and design spec §2.4 confirms it end to
+  end: "The client assembles the markdown (frontmatter + body); the server writes it verbatim." So
+  `content` is always the raw `readFileSync` result — never pi's parsed/stripped `body` — and
+  `stripFrontmatter` has no field to feed. (A later task's slot parser, over in `apps/web`, will need
+  its own tiny non-pi frontmatter strip if it wants pi's `body` shape — it can't import pi's at all,
+  browser-bundled code included, per the root architecture invariant.)
+
+## Design
+
+- `templateDirs(cwd?, agentDir = getAgentDir())` → `{ globalDir, projectDir? }` — pure path arithmetic,
+  no filesystem access. `agentDir`'s default is a **default-parameter expression**, evaluated at call
+  time, not a module-level constant — `getAgentDir()` reads `PI_CODING_AGENT_DIR` live (history/SPEC.md
+  pins this same fact for pi's `SessionManager` path), so caching it at import time would go stale the
+  moment a test (or the e2e seeder) sets the env var after this module has already loaded.
+- `listTemplates` re-reads both directories **on every call** — no cache, anywhere in this module. This
+  is the "/ menu freshness" rule (design spec §2.2): pi's own `session.promptTemplates` getter reads
+  through `ResourceLoader.getPrompts()`, populated once at session load and only refreshed by an
+  explicit resource reload — a **create-time snapshot** that goes stale the moment a template is saved
+  mid-session (confirmed by reading `agent-session.js`'s `get promptTemplates()` /
+  `resource-loader.js`'s `updatePromptsFromPaths`). A template saved through `template.save` must show
+  up the next time any client asks (`template.list`, the web `/` menu, the Templates settings panel), so
+  this module never memoizes; the cost is a couple of small `readdir`s per call, which is cheap enough.
+- `isValidTemplateName` is the **traversal gate**: applied to every caller-supplied `name` before it's
+  `join()`-ed into a path, in `getTemplate`, `saveTemplate`, and `deleteTemplate` alike. Its job is
+  path-traversal *safety*, not naming style, so it rejects only the shapes that are unsafe as a single
+  filename segment — empty, a leading `.` (covers `.`, `..`, and `.hidden`-style dotfiles with one rule),
+  a path separator anywhere in the name (`/` or `\`), or an embedded NUL byte — and accepts everything
+  else, including interior dots (`foo.bar`), uppercase, spaces, and unicode. This matters because pi's
+  own loader performs **no sanitization at all** when deriving a name from a filename (see "pi facts"
+  above), so a narrower rule breaks **list/get parity**: a name `listTemplates` can show but
+  `getTemplate`/`saveTemplate`/`deleteTemplate` refuse is a user-visible bug, not a safety improvement.
+  (This gate originally used an `/^[a-z0-9][a-z0-9-_]*$/i` allowlist regex — safe, but over-restrictive:
+  it rejected any name with an interior dot, so a perfectly ordinary, pi-legal template named `foo.bar`
+  would list but 404 on get/save/delete. Fixed once caught — the allowlist shape was solving the wrong
+  problem, aesthetics instead of traversal.) `listTemplates` (via `listDir`) **does** filter by this
+  exact gate — not to mirror pi (pi's own scanner has no such filter and would happily list a hand-placed
+  `.hidden.md`), but so list/get parity holds *structurally*: reusing the very predicate that guards
+  get/save/delete, rather than a hand-rolled dot-check that could quietly drift from it later, means any
+  name the gate rejects is invisible to `listTemplates` too, not just un-fetchable through it. (This
+  filter was itself a fix: an earlier version listed every `.md` file unconditionally, so a hand-placed
+  `.hidden.md` would show up in `template.list` and then 404 on `template.get`.)
+- Two layers of failure containment inside `listDir` (the directory scan `listTemplates` calls twice),
+  each mirroring a different pi behavior at a different granularity: **(1)** a per-file read/parse
+  failure (unreadable file, malformed YAML frontmatter) is caught and that one file is skipped — mirrors
+  pi's own `loadTemplateFromFile`'s `try { … } catch { return null; }`. **(2)** the *directory scan
+  itself* — the `readdirSync` call plus the loop around it — is also wrapped, so an unreadable directory
+  (EACCES, or, deterministically, a path that turns out not to be a directory at all) returns whatever
+  had already been collected instead of throwing out of `listTemplates` entirely — mirrors pi's own
+  `loadTemplatesFromDir`, whose try/catch wraps the *whole* scan, not just each file. (Layer (2) was
+  itself a fix: an earlier version had only layer (1), so an unreadable directory propagated straight
+  through `listTemplates` and could blank the *other* scope's results too, not just the bad one's.)
+  `getTemplate` makes no such allowance for a *directly named* file: a parse failure there propagates,
+  since the caller asked for that one file specifically and deserves to know something's wrong with it
+  (covered by a dedicated test — the documented asymmetry against `listTemplates`'s swallow).
+- `saveTemplate` parses the incoming `content`'s frontmatter *before* writing anything. Building the
+  return value already called `parseFrontmatter` via `readTemplateFile` after the write — which meant a
+  syntactically-invalid `---`-fenced block would land the file on disk and *then* throw, orphaning a file
+  that's invisible to `listTemplates` (layer (1) above swallows it) and un-`get`-able (propagates there,
+  by design) — present on disk but unreachable through this module. Validating first turns a rejected
+  save into a no-op on the filesystem: nothing is written, `mkdirSync`/`writeFileSync` never run. The
+  read-back after a successful write can in principle still fail, but only for a filesystem race at that
+  point, not a content problem — an acceptable residual this function doesn't try to eliminate.
+- `listTemplates`'s result is sorted by `name` — `readdir` order isn't guaranteed across platforms, and
+  every consumer of a template *list* (the `/` menu, the Templates settings panel) wants a stable order
+  more than it wants filesystem-arrival order.
+
+## Boundary
+
+- **Owns:** file CRUD in exactly the two sanctioned dirs (`TemplateDirs.globalDir` / `.projectDir`);
+  name validation as the traversal gate; frontmatter → metadata extraction for `description` /
+  `argumentHint`. Never touches any other path — no `resolvePath` / symlink-following of caller input,
+  only `join(dir, \`${name}.md\`)` after `name` has passed `isValidTemplateName`.
+- **Public surface (barrel):** `templateDirs`, `TemplateDirs`, `listTemplates`, `getTemplate`,
+  `saveTemplate`, `deleteTemplate`, `isValidTemplateName`.
+- **Allowed deps:** `@earendil-works/pi-coding-agent` (`getAgentDir`, `CONFIG_DIR_NAME`,
+  `parseFrontmatter` — root exports only), `@thinkrail/contracts` (`TemplateInfo`, `TemplateScope`),
+  `node:fs`, `node:path`.
+- **Forbidden:** importing `workspaces` / `projects` — stays registry-free like `history`; the
+  `template.*` handler resolves `workspaceId` → `cwd` and passes `cwd` into `templateDirs` itself.
+  Caching the listing across calls. Writing or reading anything outside `globalDir` / `projectDir`.
+
+## Get right
+
+- **`content` is the full file text, not pi's parsed `body`.** `TemplateInfo.content` round-trips
+  byte-for-byte through `saveTemplate` → disk → `getTemplate` / `listTemplates`, independent of
+  `parseFrontmatter`'s trim/newline-normalization quirks — those only ever affect metadata extraction,
+  never the `content` field.
+- **Fresh read, every call.** No in-memory cache anywhere in this module (see "Design" above) — this is
+  deliberate, not an oversight; don't add one without re-reading the freshness rationale it exists to
+  satisfy.
+- **List/get parity, both directions — structural, not a convention.** `isValidTemplateName` excludes
+  only the shapes that are unsafe as a filename segment (empty, leading `.`, a separator, NUL), never an
+  ordinary pi-legal name like `foo.bar` — so don't tighten it without checking it still admits everything
+  pi's own loader would list (a narrower "clean slug" regex looks safe in review but silently breaks
+  this; it did, once — see "Design" above). The reverse direction holds too, by construction: `listDir`
+  filters every directory entry through this *exact same* gate function, not a partial or hand-rolled
+  re-check, so a dot-leading file like a hand-placed `.hidden.md` is ignored by the scan entirely and
+  never surfaces in `listTemplates` in the first place. The gate and the scan can't drift apart because
+  they share one predicate — don't reintroduce a second, parallel check for either direction.
+- **`deleteTemplate` throws when the target is already gone**, rather than treating a missing file as a
+  successful no-op — this is the handler contract Task B3 should build on. A delete request only reaches
+  this module because a caller's UI named one specific existing-as-far-as-it-knows template; if the file
+  is already gone, that view is stale, and the `template.*` handler should surface that as an error (e.g.
+  "already deleted, refresh") rather than reporting success for something that didn't happen. Loud beats
+  silent for a stale UI.

--- a/packages/server/src/templates/SPEC.md
+++ b/packages/server/src/templates/SPEC.md
@@ -127,9 +127,14 @@ pi version bump.
   `template.save` overwrite it, so a checked-out repo could plant a link and turn a routine template
   edit into a file write outside the worktree. Cost: a legitimately symlinked individual template that
   pi's own `/` menu would offer doesn't appear in ThinkRail's — acceptable, and already the listing's
-  behavior before this gate existed. **Project-scope writes** additionally refuse to operate through a
-  symlinked `<cwd>/.pi` or `<cwd>/.pi/prompts` *directory* (the same escape one level up — the repo
-  controls those path components); the **global** dir is exempt on purpose: `~/.pi/agent/prompts` is
+  behavior before this gate existed. The same rule applies **one level up**: a symlinked `<cwd>/.pi` or
+  `<cwd>/.pi/prompts` *directory* (the repo controls those path components) makes the project dir
+  untraversable for **every** project-scope operation — `listTemplates`/`getTemplate` treat it as having
+  no templates (list and get share one predicate, `readableProjectDir`, so they can never disagree),
+  while `saveTemplate`/`deleteTemplate` refuse loudly (a write must fail visibly, never silently no-op).
+  Without the read half, `template.list`/`template.get` would still disclose the link target's `.md`
+  files over the wire — the same escape the file-level gate closes. The **global** dir is exempt on
+  purpose: `~/.pi/agent/prompts` is
   user-owned (an attacker writing there has already won) and dotfile managers routinely symlink it. The
   `lstat`-then-write gap is a TOCTOU race only a concurrent local process could exploit — out of scope
   for an owner-scoped host (such a process could write the target directly). Pinned by the symlink

--- a/packages/server/src/templates/SPEC.md
+++ b/packages/server/src/templates/SPEC.md
@@ -114,6 +114,26 @@ pi version bump.
   name the gate rejects is invisible to `listTemplates` too, not just un-fetchable through it. (This
   filter was itself a fix: an earlier version listed every `.md` file unconditionally, so a hand-placed
   `.hidden.md` would show up in `template.list` and then 404 on `template.get`.)
+- **The no-follow gate (symlink containment):** the traversal gate above constrains the *name*; this one
+  constrains what the name may *resolve to*. Every by-name operation `lstat`s the target (never
+  following) and treats anything that isn't a regular file — a symlink first of all — as **not a
+  template**: `getTemplate` reports it absent, `saveTemplate` refuses to write through it (loud error,
+  nothing touched on disk), `deleteTemplate` reports it not-found; `listDir` already skips symlinks
+  structurally (a symlink dirent's `isFile()` is false, and no follow-up `stat` is taken). This is a
+  **deliberate divergence from pi's own scanner**, which explicitly follows a file symlink
+  (`loadTemplatesFromDir` stats it and loads a file target — "pi facts" above): pi's loader is a
+  read-only, local convenience, while this module is a *write-capable CRUD surface over the wire* —
+  following `.pi/prompts/linked.md → ~/somewhere` would let `template.get` disclose the target and
+  `template.save` overwrite it, so a checked-out repo could plant a link and turn a routine template
+  edit into a file write outside the worktree. Cost: a legitimately symlinked individual template that
+  pi's own `/` menu would offer doesn't appear in ThinkRail's — acceptable, and already the listing's
+  behavior before this gate existed. **Project-scope writes** additionally refuse to operate through a
+  symlinked `<cwd>/.pi` or `<cwd>/.pi/prompts` *directory* (the same escape one level up — the repo
+  controls those path components); the **global** dir is exempt on purpose: `~/.pi/agent/prompts` is
+  user-owned (an attacker writing there has already won) and dotfile managers routinely symlink it. The
+  `lstat`-then-write gap is a TOCTOU race only a concurrent local process could exploit — out of scope
+  for an owner-scoped host (such a process could write the target directly). Pinned by the symlink
+  cases in `templates.test.ts`.
 - Two layers of failure containment inside `listDir` (the directory scan `listTemplates` calls twice),
   each mirroring a different pi behavior at a different granularity: **(1)** a per-file read/parse
   failure (unreadable file, malformed YAML frontmatter) is caught and that one file is skipped — mirrors

--- a/packages/server/src/templates/SPEC.md
+++ b/packages/server/src/templates/SPEC.md
@@ -72,7 +72,7 @@ pi version bump.
   second (`Map.set` on an existing key overwrites the value) — the mirror image of pi's own first-wins
   `dedupePrompts`, chosen deliberately because "more specific scope wins" is the behavior the product
   spec calls for, not because pi's internals resolve it that way for us.
-- **`stripFrontmatter` (also root-exported) is not used by this module.** `TemplateInfo.content` is "the
+- **`stripFrontmatter` (also root-exported) is not used by this module.** `Template.content` is "the
   full file text: frontmatter + body" (`contracts/domain.ts`), and design spec §2.4 confirms it end to
   end: "The client assembles the markdown (frontmatter + body); the server writes it verbatim." So
   `content` is always the raw `readFileSync` result — never pi's parsed/stripped `body` — and
@@ -139,6 +139,19 @@ pi version bump.
   `lstat`-then-write gap is a TOCTOU race only a concurrent local process could exploit — out of scope
   for an owner-scoped host (such a process could write the target directly). Pinned by the symlink
   cases in `templates.test.ts`.
+- **Bounded listing + the size cap:** `listTemplates` is **metadata-only** (`TemplateInfo`, no
+  `content`) and does bounded work per file regardless of what a checkout dropped in the dir:
+  `readTemplateMeta` reuses the no-follow `lstat` as a size gate (a file over **`MAX_TEMPLATE_BYTES`**,
+  1 MiB, is silently skipped — list/get parity: neither surfaces it usefully) and reads only the first
+  `FRONTMATTER_SCAN_BYTES` (8 KiB) of the head for the frontmatter — pi's `extractFrontmatter` treats a
+  truncated block with no closing fence as plain content, so a pathological >8 KiB frontmatter degrades
+  to "no metadata," never an error or a full-file read (the by-name path still sees such metadata — a
+  documented asymmetry of the bounded listing, pinned in tests). The **full text** travels only on the
+  by-name `template.get`/`template.save` path (`Template`), where an oversized file/payload fails
+  **loudly** (read: before `readFileSync`; save: before anything touches disk) — a directly-named
+  operation deserves a loud answer, the same loud-vs-skip asymmetry as malformed frontmatter. This is
+  what keeps one huge checked-in `.pi/prompts/*.md` from blocking the shared in-process host on every
+  `/`-menu open or bloating a single WS response with every file's body.
 - Two layers of failure containment inside `listDir` (the directory scan `listTemplates` calls twice),
   each mirroring a different pi behavior at a different granularity: **(1)** a per-file read/parse
   failure (unreadable file, malformed YAML frontmatter) is caught and that one file is skipped — mirrors

--- a/packages/server/src/templates/index.ts
+++ b/packages/server/src/templates/index.ts
@@ -1,0 +1,9 @@
+export {
+	deleteTemplate,
+	getTemplate,
+	isValidTemplateName,
+	listTemplates,
+	saveTemplate,
+	type TemplateDirs,
+	templateDirs,
+} from "./templates";

--- a/packages/server/src/templates/index.ts
+++ b/packages/server/src/templates/index.ts
@@ -3,6 +3,7 @@ export {
 	getTemplate,
 	isValidTemplateName,
 	listTemplates,
+	MAX_TEMPLATE_BYTES,
 	saveTemplate,
 	type TemplateDirs,
 	templateDirs,

--- a/packages/server/src/templates/templates.test.ts
+++ b/packages/server/src/templates/templates.test.ts
@@ -337,26 +337,42 @@ describe("symlink containment", () => {
 		expect(existsSync(outsideTarget)).toBe(true);
 	});
 
-	test("project-scope writes refuse a symlinked .pi/prompts directory (the same escape one level up)", () => {
-		const evilRoot = mkdtempSync(join(tmpdir(), "trpi-templates-evil-"));
-		try {
-			const elsewhere = join(evilRoot, "elsewhere");
-			mkdirSync(elsewhere, { recursive: true });
-			const worktreePi = join(evilRoot, "worktree", ".pi");
-			mkdirSync(worktreePi, { recursive: true });
-			symlinkSync(elsewhere, join(worktreePi, "prompts"));
-			const evilDirs: TemplateDirs = { globalDir, projectDir: join(worktreePi, "prompts") };
+	// Both symlinked directory levels (`.pi/prompts` itself, and `.pi` above it), every operation:
+	// writes refuse loudly; reads treat the project dir as having no templates — without the read half,
+	// `template.list`/`template.get` would disclose the link target's `.md` files over the wire.
+	for (const level of ["prompts", ".pi"] as const) {
+		test(`a symlinked ${level === ".pi" ? ".pi" : ".pi/prompts"} directory: writes refuse, list/get treat the project dir as empty`, () => {
+			const evilRoot = mkdtempSync(join(tmpdir(), "trpi-templates-evil-"));
+			try {
+				const elsewhere = join(evilRoot, "elsewhere");
+				const elsewherePrompts = level === ".pi" ? join(elsewhere, "prompts") : elsewhere;
+				mkdirSync(elsewherePrompts, { recursive: true });
+				writeFileSync(join(elsewherePrompts, "secret.md"), "outside content");
+				const worktree = join(evilRoot, "worktree");
+				let promptsDir: string;
+				if (level === ".pi") {
+					mkdirSync(worktree, { recursive: true });
+					symlinkSync(elsewhere, join(worktree, ".pi"));
+					promptsDir = join(worktree, ".pi", "prompts");
+				} else {
+					mkdirSync(join(worktree, ".pi"), { recursive: true });
+					symlinkSync(elsewhere, join(worktree, ".pi", "prompts"));
+					promptsDir = join(worktree, ".pi", "prompts");
+				}
+				const evilDirs: TemplateDirs = { globalDir, projectDir: promptsDir };
 
-			expect(() => saveTemplate(evilDirs, "project", "x", "body")).toThrow(/symlinked directory/);
-			expect(existsSync(join(elsewhere, "x.md"))).toBe(false);
-			expect(() => deleteTemplate(evilDirs, "project", "x")).toThrow(/symlinked directory/);
-			// Reads still work through it, matching pi's own loader (which follows the directory too).
-			writeFileSync(join(elsewhere, "readable.md"), "readable body");
-			expect(getTemplate(evilDirs, "readable", "project").content).toBe("readable body");
-		} finally {
-			rmSync(evilRoot, { recursive: true, force: true });
-		}
-	});
+				expect(() => saveTemplate(evilDirs, "project", "x", "body")).toThrow(/symlinked directory/);
+				expect(existsSync(join(elsewherePrompts, "x.md"))).toBe(false);
+				expect(() => deleteTemplate(evilDirs, "project", "x")).toThrow(/symlinked directory/);
+				// The read half of the gate: the target's .md files are neither listed nor fetchable.
+				expect(listTemplates(evilDirs).map((t) => t.name)).not.toContain("secret");
+				expect(() => getTemplate(evilDirs, "secret", "project")).toThrow(/not found/);
+				expect(() => getTemplate(evilDirs, "secret")).toThrow(/not found/);
+			} finally {
+				rmSync(evilRoot, { recursive: true, force: true });
+			}
+		});
+	}
 
 	test("the global dir may itself be a symlink (dotfile setups) — writes still work there", () => {
 		const realGlobal = join(root, "real-global-prompts");

--- a/packages/server/src/templates/templates.test.ts
+++ b/packages/server/src/templates/templates.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -289,5 +297,101 @@ describe("project ops without a projectDir throw", () => {
 		saveTemplate(globalOnly, "global", "solo", "global body");
 
 		expect(getTemplate(globalOnly, "solo").content).toBe("global body");
+	});
+});
+
+// The no-follow gate (SPEC.md "symlink containment"): a checked-out repo can plant
+// `.pi/prompts/linked.md → <anywhere>`; no by-name operation may read, overwrite, or act through it —
+// a deliberate divergence from pi's read-only scanner, which follows file symlinks.
+describe("symlink containment", () => {
+	let outsideTarget: string;
+
+	beforeEach(() => {
+		outsideTarget = join(root, "outside-secret.txt");
+		writeFileSync(outsideTarget, "outside secret — must never be disclosed or clobbered");
+		mkdirSync(projectDir, { recursive: true });
+		symlinkSync(outsideTarget, join(projectDir, "linked.md"));
+	});
+
+	test("listTemplates omits a symlinked entry (dirent isFile is false — no follow)", () => {
+		expect(listTemplates(dirs).map((t) => t.name)).not.toContain("linked");
+	});
+
+	test("getTemplate treats a symlinked entry as absent — never discloses the target", () => {
+		expect(() => getTemplate(dirs, "linked", "project")).toThrow(/not found/);
+		// Scope-omitted lookup falls through the project dir the same way (and finds no global either).
+		expect(() => getTemplate(dirs, "linked")).toThrow(/not found/);
+	});
+
+	test("saveTemplate refuses to write through a symlinked entry — the target stays untouched", () => {
+		expect(() => saveTemplate(dirs, "project", "linked", "attacker-chosen content")).toThrow(
+			/non-regular file/,
+		);
+		expect(readFileSync(outsideTarget, "utf-8")).toBe(
+			"outside secret — must never be disclosed or clobbered",
+		);
+	});
+
+	test("deleteTemplate treats a symlinked entry as not-found (it was never listed or fetchable)", () => {
+		expect(() => deleteTemplate(dirs, "project", "linked")).toThrow(/not found/);
+		expect(existsSync(outsideTarget)).toBe(true);
+	});
+
+	test("project-scope writes refuse a symlinked .pi/prompts directory (the same escape one level up)", () => {
+		const evilRoot = mkdtempSync(join(tmpdir(), "trpi-templates-evil-"));
+		try {
+			const elsewhere = join(evilRoot, "elsewhere");
+			mkdirSync(elsewhere, { recursive: true });
+			const worktreePi = join(evilRoot, "worktree", ".pi");
+			mkdirSync(worktreePi, { recursive: true });
+			symlinkSync(elsewhere, join(worktreePi, "prompts"));
+			const evilDirs: TemplateDirs = { globalDir, projectDir: join(worktreePi, "prompts") };
+
+			expect(() => saveTemplate(evilDirs, "project", "x", "body")).toThrow(/symlinked directory/);
+			expect(existsSync(join(elsewhere, "x.md"))).toBe(false);
+			expect(() => deleteTemplate(evilDirs, "project", "x")).toThrow(/symlinked directory/);
+			// Reads still work through it, matching pi's own loader (which follows the directory too).
+			writeFileSync(join(elsewhere, "readable.md"), "readable body");
+			expect(getTemplate(evilDirs, "readable", "project").content).toBe("readable body");
+		} finally {
+			rmSync(evilRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("the global dir may itself be a symlink (dotfile setups) — writes still work there", () => {
+		const realGlobal = join(root, "real-global-prompts");
+		mkdirSync(realGlobal, { recursive: true });
+		const linkedGlobal = join(root, "linked-global-prompts");
+		symlinkSync(realGlobal, linkedGlobal);
+		const linkedDirs: TemplateDirs = { globalDir: linkedGlobal, projectDir };
+
+		saveTemplate(linkedDirs, "global", "dotfiled", "body via dir symlink");
+		expect(readFileSync(join(realGlobal, "dotfiled.md"), "utf-8")).toBe("body via dir symlink");
+		deleteTemplate(linkedDirs, "global", "dotfiled");
+		expect(existsSync(join(realGlobal, "dotfiled.md"))).toBe(false);
+	});
+});
+
+// The client's TemplateEditorDialog populates its form fields from THESE parsed values (never from a
+// browser-side YAML reimplementation), so full-YAML scalar fidelity here is what keeps an edit of a
+// pi-native template from corrupting its metadata — pin the styles pi accepts beyond bare/double-quoted.
+describe("frontmatter value fidelity (pi's real YAML parser)", () => {
+	test("a single-quoted scalar parses to its value — quotes are never part of the description", () => {
+		mkdirSync(globalDir, { recursive: true });
+		writeFileSync(join(globalDir, "sq.md"), "---\ndescription: 'Review safely'\n---\nBody\n");
+
+		expect(getTemplate(dirs, "sq", "global").description).toBe("Review safely");
+	});
+
+	test("a folded block scalar parses to its (joined) value, not a literal '>'", () => {
+		mkdirSync(globalDir, { recursive: true });
+		writeFileSync(
+			join(globalDir, "folded.md"),
+			"---\ndescription: >-\n  folded description\n  over two lines\n---\nBody\n",
+		);
+
+		expect(getTemplate(dirs, "folded", "global").description).toBe(
+			"folded description over two lines",
+		);
 	});
 });

--- a/packages/server/src/templates/templates.test.ts
+++ b/packages/server/src/templates/templates.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	deleteTemplate,
+	getTemplate,
+	isValidTemplateName,
+	listTemplates,
+	saveTemplate,
+	type TemplateDirs,
+	templateDirs,
+} from "./templates";
+
+/** Names that are unsafe as a filename segment — must be rejected by `isValidTemplateName` and,
+ * transitively, by save/get/delete. Shared between the direct gate tests and the by-name-operation tests
+ * below so the two lists can never drift apart. */
+const INVALID_NAMES = ["../x", "a/b", "a\\b", ".hidden", ""];
+
+let root: string;
+let globalDir: string;
+let projectDir: string;
+let dirs: TemplateDirs;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "trpi-templates-test-"));
+	globalDir = join(root, "agent-home", "prompts");
+	projectDir = join(root, "worktree", ".pi", "prompts");
+	dirs = { globalDir, projectDir };
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe("templateDirs", () => {
+	test("computes globalDir under agentDir/prompts and projectDir under cwd/.pi/prompts", () => {
+		const result = templateDirs("/some/cwd", "/some/agent-dir");
+		expect(result.globalDir).toBe(join("/some/agent-dir", "prompts"));
+		expect(result.projectDir).toBe(join("/some/cwd", ".pi", "prompts"));
+	});
+
+	test("projectDir is absent when cwd is omitted", () => {
+		const result = templateDirs(undefined, "/some/agent-dir");
+		expect(result.projectDir).toBeUndefined();
+	});
+});
+
+describe("isValidTemplateName", () => {
+	for (const name of INVALID_NAMES) {
+		test(`rejects ${JSON.stringify(name)}`, () => {
+			expect(isValidTemplateName(name)).toBe(false);
+		});
+	}
+
+	// Interior dots, uppercase, and spaces are all pi-legal (pi's loader does no sanitization) and must
+	// be accepted — this is a traversal gate, not a naming-style rule. "foo.bar" in particular is the
+	// case that a former, over-restrictive allowlist regex used to reject.
+	for (const name of ["greet", "My_Template-2", "a", "foo.bar", "my template"]) {
+		test(`accepts ${JSON.stringify(name)}`, () => {
+			expect(isValidTemplateName(name)).toBe(true);
+		});
+	}
+});
+
+describe("saveTemplate -> listTemplates -> getTemplate", () => {
+	test("round-trips frontmatter, surfacing description/argumentHint, content = full file text", () => {
+		const content = [
+			"---",
+			"description: Say hi",
+			"argument-hint: <name>",
+			"---",
+			"",
+			"Hello $1",
+		].join("\n");
+
+		const saved = saveTemplate(dirs, "global", "greet", content);
+		expect(saved).toEqual({
+			name: "greet",
+			description: "Say hi",
+			argumentHint: "<name>",
+			content,
+			scope: "global",
+			filePath: join(globalDir, "greet.md"),
+		});
+
+		const listed = listTemplates(dirs);
+		expect(listed).toEqual([saved]);
+
+		expect(getTemplate(dirs, "greet")).toEqual(saved);
+		expect(getTemplate(dirs, "greet", "global")).toEqual(saved);
+	});
+
+	test("a template with no frontmatter round-trips (content = body, no description/argumentHint)", () => {
+		const content = "Just a plain body, no frontmatter here.";
+		const saved = saveTemplate(dirs, "project", "plain", content);
+
+		expect(saved.content).toBe(content);
+		expect(saved.description).toBeUndefined();
+		expect(saved.argumentHint).toBeUndefined();
+		expect(getTemplate(dirs, "plain", "project").content).toBe(content);
+	});
+
+	test("saveTemplate creates the scope dir if missing and writes content verbatim", () => {
+		expect(existsSync(globalDir)).toBe(false);
+		const content = "line one\nline two\n";
+
+		saveTemplate(dirs, "global", "fresh", content);
+
+		expect(readFileSync(join(globalDir, "fresh.md"), "utf-8")).toBe(content);
+	});
+
+	test("saveTemplate overwrites an existing template", () => {
+		saveTemplate(dirs, "global", "dup", "first version");
+		const second = saveTemplate(dirs, "global", "dup", "second version");
+
+		expect(second.content).toBe("second version");
+		expect(getTemplate(dirs, "dup", "global").content).toBe("second version");
+	});
+
+	test("saveTemplate rejects malformed frontmatter before writing anything (no orphan file)", () => {
+		const badContent = "---\nbad: [unterminated\n---\nbody";
+
+		expect(() => saveTemplate(dirs, "global", "broken", badContent)).toThrow();
+
+		expect(existsSync(join(globalDir, "broken.md"))).toBe(false);
+	});
+
+	test(
+		"a name with an interior dot (foo.bar) round-trips through save -> list -> get -> delete " +
+			"(list/get parity: pi lists any *.md with no sanitization, so this module must accept it too)",
+		() => {
+			const content = "Body for a dotted name.";
+			const saved = saveTemplate(dirs, "global", "foo.bar", content);
+			expect(saved.name).toBe("foo.bar");
+
+			expect(listTemplates(dirs).map((t) => t.name)).toEqual(["foo.bar"]);
+			expect(getTemplate(dirs, "foo.bar").content).toBe(content);
+
+			deleteTemplate(dirs, "global", "foo.bar");
+			expect(listTemplates(dirs)).toEqual([]);
+		},
+	);
+});
+
+describe("listTemplates precedence + freshness", () => {
+	test("missing dirs -> empty list", () => {
+		expect(listTemplates(dirs)).toEqual([]);
+	});
+
+	test("project entries shadow same-named global ones", () => {
+		saveTemplate(dirs, "global", "dup", "global body");
+		saveTemplate(dirs, "project", "dup", "project body");
+
+		const listed = listTemplates(dirs);
+
+		expect(listed).toHaveLength(1);
+		expect(listed[0]?.scope).toBe("project");
+		expect(listed[0]?.content).toBe("project body");
+	});
+
+	test("non-colliding entries from both dirs are all present, sorted by name", () => {
+		saveTemplate(dirs, "global", "bbb", "b");
+		saveTemplate(dirs, "project", "aaa", "a");
+		saveTemplate(dirs, "global", "ccc", "c");
+
+		expect(listTemplates(dirs).map((t) => t.name)).toEqual(["aaa", "bbb", "ccc"]);
+	});
+
+	test("reflects a save that happens between two calls (no caching)", () => {
+		expect(listTemplates(dirs)).toEqual([]);
+		saveTemplate(dirs, "global", "late", "arrived after the first list() call");
+		expect(listTemplates(dirs).map((t) => t.name)).toEqual(["late"]);
+	});
+
+	test("skips a file it can't parse (malformed frontmatter) without throwing, keeps the rest", () => {
+		mkdirSync(globalDir, { recursive: true });
+		writeFileSync(join(globalDir, "broken.md"), "---\nbad: [unterminated\n---\nbody");
+		saveTemplate(dirs, "global", "ok", "a fine template");
+
+		expect(listTemplates(dirs).map((t) => t.name)).toEqual(["ok"]);
+	});
+
+	test("skips dot-leading filenames entirely (list/get parity: the gate would reject the name too)", () => {
+		mkdirSync(globalDir, { recursive: true });
+		writeFileSync(join(globalDir, ".hidden.md"), "sneaky");
+		saveTemplate(dirs, "global", "visible", "shown");
+
+		expect(listTemplates(dirs).map((t) => t.name)).toEqual(["visible"]);
+	});
+
+	test("a scope dir that isn't actually a directory doesn't blank the other scope's listing", () => {
+		// A deterministic stand-in for an unreadable directory (EACCES setup is flaky cross-platform):
+		// point globalDir at a path that's a plain file. `existsSync` is true, but `readdirSync` throws
+		// (ENOTDIR) just like a permissions failure would.
+		mkdirSync(join(root, "agent-home"), { recursive: true });
+		writeFileSync(globalDir, "not a directory");
+		saveTemplate(dirs, "project", "solo", "project body");
+
+		expect(listTemplates(dirs).map((t) => t.name)).toEqual(["solo"]);
+	});
+});
+
+describe("getTemplate", () => {
+	test("scope disambiguates a name collision", () => {
+		saveTemplate(dirs, "global", "dup", "global body");
+		saveTemplate(dirs, "project", "dup", "project body");
+
+		expect(getTemplate(dirs, "dup", "global").content).toBe("global body");
+		expect(getTemplate(dirs, "dup", "project").content).toBe("project body");
+	});
+
+	test("scope-omitted get follows project-over-global precedence", () => {
+		saveTemplate(dirs, "global", "dup", "global body");
+		saveTemplate(dirs, "project", "dup", "project body");
+
+		expect(getTemplate(dirs, "dup").content).toBe("project body");
+	});
+
+	test("scope-omitted get falls back to global when there's no project entry", () => {
+		saveTemplate(dirs, "global", "solo", "global body");
+
+		expect(getTemplate(dirs, "solo").content).toBe("global body");
+	});
+
+	test("throws when the template is absent", () => {
+		expect(() => getTemplate(dirs, "missing")).toThrow();
+		expect(() => getTemplate(dirs, "missing", "global")).toThrow();
+		expect(() => getTemplate(dirs, "missing", "project")).toThrow();
+	});
+
+	test("throws on a directly-named file with malformed frontmatter (asymmetric vs listTemplates's swallow)", () => {
+		mkdirSync(globalDir, { recursive: true });
+		writeFileSync(join(globalDir, "broken.md"), "---\nbad: [unterminated\n---\nbody");
+
+		expect(() => getTemplate(dirs, "broken", "global")).toThrow();
+	});
+});
+
+describe("deleteTemplate", () => {
+	test("removes exactly one file, leaving siblings untouched", () => {
+		saveTemplate(dirs, "global", "keep", "keep me");
+		saveTemplate(dirs, "global", "gone", "delete me");
+
+		deleteTemplate(dirs, "global", "gone");
+
+		expect(existsSync(join(globalDir, "gone.md"))).toBe(false);
+		expect(existsSync(join(globalDir, "keep.md"))).toBe(true);
+		expect(listTemplates(dirs).map((t) => t.name)).toEqual(["keep"]);
+	});
+
+	test("only removes the file in the given scope, not a same-named file in the other scope", () => {
+		saveTemplate(dirs, "global", "dup", "global body");
+		saveTemplate(dirs, "project", "dup", "project body");
+
+		deleteTemplate(dirs, "global", "dup");
+
+		expect(existsSync(join(globalDir, "dup.md"))).toBe(false);
+		expect(existsSync(join(projectDir, "dup.md"))).toBe(true);
+	});
+
+	test("throws when the template is absent", () => {
+		expect(() => deleteTemplate(dirs, "global", "missing")).toThrow();
+	});
+});
+
+describe("invalid names are rejected on save/get/delete", () => {
+	for (const name of INVALID_NAMES) {
+		test(`rejects ${JSON.stringify(name)}`, () => {
+			expect(() => saveTemplate(dirs, "global", name, "x")).toThrow();
+			expect(() => getTemplate(dirs, name, "global")).toThrow();
+			expect(() => getTemplate(dirs, name)).toThrow();
+			expect(() => deleteTemplate(dirs, "global", name)).toThrow();
+		});
+	}
+});
+
+describe("project ops without a projectDir throw", () => {
+	test('saveTemplate/getTemplate/deleteTemplate all throw for scope "project"', () => {
+		const globalOnly: TemplateDirs = { globalDir };
+
+		expect(() => saveTemplate(globalOnly, "project", "x", "content")).toThrow();
+		expect(() => getTemplate(globalOnly, "x", "project")).toThrow();
+		expect(() => deleteTemplate(globalOnly, "project", "x")).toThrow();
+	});
+
+	test("scope-omitted getTemplate does not throw — it simply can't find a project entry", () => {
+		const globalOnly: TemplateDirs = { globalDir };
+		saveTemplate(globalOnly, "global", "solo", "global body");
+
+		expect(getTemplate(globalOnly, "solo").content).toBe("global body");
+	});
+});

--- a/packages/server/src/templates/templates.test.ts
+++ b/packages/server/src/templates/templates.test.ts
@@ -15,6 +15,7 @@ import {
 	getTemplate,
 	isValidTemplateName,
 	listTemplates,
+	MAX_TEMPLATE_BYTES,
 	saveTemplate,
 	type TemplateDirs,
 	templateDirs,
@@ -92,8 +93,10 @@ describe("saveTemplate -> listTemplates -> getTemplate", () => {
 			filePath: join(globalDir, "greet.md"),
 		});
 
-		const listed = listTemplates(dirs);
-		expect(listed).toEqual([saved]);
+		// The listing is metadata-only — the same fields as `saved` MINUS `content` (the full text travels
+		// only on the by-name get/save path; a listing never reads whole files).
+		const { content: _content, ...metadata } = saved;
+		expect(listTemplates(dirs)).toEqual([metadata]);
 
 		expect(getTemplate(dirs, "greet")).toEqual(saved);
 		expect(getTemplate(dirs, "greet", "global")).toEqual(saved);
@@ -164,7 +167,7 @@ describe("listTemplates precedence + freshness", () => {
 
 		expect(listed).toHaveLength(1);
 		expect(listed[0]?.scope).toBe("project");
-		expect(listed[0]?.content).toBe("project body");
+		expect(listed[0]?.filePath).toBe(join(projectDir, "dup.md"));
 	});
 
 	test("non-colliding entries from both dirs are all present, sorted by name", () => {
@@ -409,5 +412,49 @@ describe("frontmatter value fidelity (pi's real YAML parser)", () => {
 		expect(getTemplate(dirs, "folded", "global").description).toBe(
 			"folded description over two lines",
 		);
+	});
+});
+
+// The size cap + bounded metadata reads (the "one huge checked-in .md must not cost the host" rule):
+// a listing does bounded work per file whatever a checkout contains; the full-text path is capped loudly.
+describe("size cap + bounded metadata reads", () => {
+	test("saveTemplate rejects content over MAX_TEMPLATE_BYTES before writing anything", () => {
+		const huge = "x".repeat(MAX_TEMPLATE_BYTES + 1);
+
+		expect(() => saveTemplate(dirs, "global", "huge", huge)).toThrow(/too large/);
+		expect(existsSync(join(globalDir, "huge.md"))).toBe(false);
+	});
+
+	test("an oversized on-disk file: get throws loudly, list skips it silently (neither surfaces it)", () => {
+		mkdirSync(globalDir, { recursive: true });
+		writeFileSync(join(globalDir, "huge.md"), "y".repeat(MAX_TEMPLATE_BYTES + 1));
+		saveTemplate(dirs, "global", "ok", "a fine template");
+
+		expect(() => getTemplate(dirs, "huge", "global")).toThrow(/too large/);
+		expect(listTemplates(dirs).map((t) => t.name)).toEqual(["ok"]);
+	});
+
+	test("a large-but-capped file lists with its metadata via the bounded head read (never a full read)", () => {
+		mkdirSync(globalDir, { recursive: true });
+		const bigBody = "z".repeat(MAX_TEMPLATE_BYTES - 1024); // just under the cap, far past the scan window
+		writeFileSync(join(globalDir, "big.md"), `---\ndescription: Big but fine\n---\n${bigBody}`);
+
+		const listed = listTemplates(dirs);
+		expect(listed.map((t) => t.name)).toEqual(["big"]);
+		expect(listed[0]?.description).toBe("Big but fine");
+	});
+
+	test("a frontmatter block whose closing fence sits past the scan window degrades to no metadata, never an error", () => {
+		mkdirSync(globalDir, { recursive: true });
+		const hugeFrontmatter = `---\ndescription: buried\npadding: "${"p".repeat(16 * 1024)}"\n---\nBody`;
+		writeFileSync(join(globalDir, "deep.md"), hugeFrontmatter);
+
+		const listed = listTemplates(dirs);
+		expect(listed.map((t) => t.name)).toEqual(["deep"]);
+		// The head read never found the closing fence, so the block reads as plain content — no metadata.
+		expect(listed[0]?.description).toBeUndefined();
+		// The by-name path reads the whole (capped) file and DOES see the metadata — the asymmetry is the
+		// bounded-listing tradeoff, not a parity bug.
+		expect(getTemplate(dirs, "deep", "global").description).toBe("buried");
 	});
 });

--- a/packages/server/src/templates/templates.ts
+++ b/packages/server/src/templates/templates.ts
@@ -1,0 +1,191 @@
+// File CRUD over pi's two sanctioned prompt-template directories (global + project-scoped). Frontmatter
+// is pi's own convention (`description` / `argument-hint`, pinned in SPEC.md against pi v0.80.6); this
+// module owns the traversal gate (`isValidTemplateName`) that pi's own loader doesn't provide. `content`
+// is always the full file text (frontmatter + body) — the wire's `TemplateInfo.content` contract — never
+// pi's parsed/stripped body. See SPEC.md for the pinned pi facts and the freshness rationale.
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG_DIR_NAME, getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
+import type { TemplateInfo, TemplateScope } from "@thinkrail/contracts";
+
+/** The two sanctioned template directories. `projectDir` is absent whenever there's no workspace. */
+export interface TemplateDirs {
+	globalDir: string;
+	projectDir?: string;
+}
+
+/**
+ * The traversal gate: every caller-supplied name is checked against this before it's used to build a
+ * path (`${name}.md` under one of the sanctioned dirs). This is a **path-traversal safety check, not a
+ * naming-style rule** — pi's own loader derives a template's name from the filename alone
+ * (`basename(filePath).replace(/\.md$/, "")`, with no sanitization at all — see SPEC.md's pinned pi
+ * facts), so this gate must accept every name pi could legally list, or `listTemplates` and the by-name
+ * operations fall out of parity: a name that shows up in a listing but can't be fetched, overwritten, or
+ * deleted by that same name is a user-visible bug, not a safety win. (An earlier version of this gate
+ * used an `/^[a-z0-9][a-z0-9-_]*$/i` allowlist regex — safe, but over-restrictive: it rejected any name
+ * with an interior dot, e.g. "foo.bar", which pi itself lists without complaint.)
+ *
+ * Rejected — exactly the shapes that are unsafe as a single filename segment:
+ * - empty string
+ * - a leading "." (covers ".", "..", and dotfiles like ".hidden" with one rule)
+ * - a path separator anywhere in the name ("/" or "\" — blocks "a/b", "../x", absolute paths, and
+ *   Windows-style separators)
+ * - an embedded NUL byte
+ *
+ * Everything else — interior dots, uppercase, spaces, unicode — is accepted.
+ */
+export function isValidTemplateName(name: string): boolean {
+	if (name.length === 0) return false;
+	if (name.startsWith(".")) return false;
+	return !name.includes("/") && !name.includes("\\") && !name.includes("\0");
+}
+
+/** The global + (if `cwd` is given) project prompt directories, pi's own layout: `<agentDir>/prompts`
+ * and `<cwd>/.pi/prompts`. Pure path arithmetic — no filesystem access. `agentDir`'s default is a
+ * call-time expression (not a cached module-level constant): `getAgentDir()` reads
+ * `PI_CODING_AGENT_DIR` live, so a test that sets the env var right before calling this must see it. */
+export function templateDirs(cwd?: string, agentDir: string = getAgentDir()): TemplateDirs {
+	return {
+		globalDir: join(agentDir, "prompts"),
+		...(cwd ? { projectDir: join(cwd, CONFIG_DIR_NAME, "prompts") } : {}),
+	};
+}
+
+/** The directory for `scope`. Throws for "project" when no workspace is available. */
+function dirForScope(dirs: TemplateDirs, scope: TemplateScope): string {
+	if (scope === "project") {
+		if (!dirs.projectDir)
+			throw new Error('template scope "project" requires a workspace (projectDir)');
+		return dirs.projectDir;
+	}
+	return dirs.globalDir;
+}
+
+/** Read + parse one template file from `dir`. `null` if it doesn't exist. Propagates a frontmatter
+ * parse failure — a directly-named lookup deserves to know the file itself is broken. */
+function readTemplateFile(dir: string, scope: TemplateScope, name: string): TemplateInfo | null {
+	const filePath = join(dir, `${name}.md`);
+	if (!existsSync(filePath)) return null;
+	const content = readFileSync(filePath, "utf-8");
+	const { frontmatter } = parseFrontmatter(content);
+	const description =
+		typeof frontmatter.description === "string" ? frontmatter.description : undefined;
+	const argumentHint =
+		typeof frontmatter["argument-hint"] === "string" ? frontmatter["argument-hint"] : undefined;
+	return {
+		name,
+		...(description ? { description } : {}),
+		...(argumentHint ? { argumentHint } : {}),
+		content,
+		scope,
+		filePath,
+	};
+}
+
+/** Every `.md` file directly inside `dir` (non-recursive) whose derived name passes
+ * `isValidTemplateName`, as `TemplateInfo`s. Reusing that exact gate (not a hand-rolled dot check) is
+ * what makes list/get parity structurally guaranteed rather than true by coincidence: whatever this
+ * lists, `getTemplate`/`saveTemplate`/`deleteTemplate` can always act on by that same name, and the two
+ * can never drift apart since they share one predicate. This is a deliberate divergence from pi's own
+ * scanner (`loadTemplatesFromDir`), which has no such filter — pi would happily list a hand-placed
+ * `.hidden.md` — done in service of *our* parity invariant, not something pi does for us.
+ *
+ * A per-file read/parse failure (malformed frontmatter, unreadable file) is caught and that one file is
+ * skipped, not fatal — one bad file must never blank the whole listing. The *directory scan itself*
+ * (`readdirSync` and the loop around it) is wrapped too: an unreadable directory (EACCES, or — the
+ * deterministic case exercised in tests — a path that isn't actually a directory) is treated the same
+ * way, mirroring pi's own `loadTemplatesFromDir`'s try/catch-the-whole-scan shape (distinct from
+ * `loadTemplateFromFile`'s narrower per-file catch, which guards a different failure — see SPEC.md).
+ * Missing/absent `dir` → empty, checked before any of this. */
+function listDir(dir: string | undefined, scope: TemplateScope): TemplateInfo[] {
+	if (!dir || !existsSync(dir)) return [];
+	const templates: TemplateInfo[] = [];
+	try {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+			const name = entry.name.replace(/\.md$/, "");
+			if (!isValidTemplateName(name)) continue;
+			try {
+				const template = readTemplateFile(dir, scope, name);
+				if (template) templates.push(template);
+			} catch {
+				// Malformed frontmatter or an unreadable file — skip it, don't fail the whole list.
+			}
+		}
+	} catch {
+		// The directory itself couldn't be scanned — same "one bad thing never blanks everything" policy,
+		// one level up: return whatever's already been collected (nothing, in practice, since a failing
+		// readdirSync throws before yielding any entry).
+	}
+	return templates;
+}
+
+/** All templates from both dirs, project entries shadowing same-named global ones (design spec §2.2 —
+ * this is a product decision, not something pi's own loader resolves for us; see SPEC.md). Always a
+ * fresh `readdir` — never cached (the "/ menu freshness" rule, SPEC.md). Sorted by name. */
+export function listTemplates(dirs: TemplateDirs): TemplateInfo[] {
+	const byName = new Map<string, TemplateInfo>();
+	for (const template of listDir(dirs.globalDir, "global")) byName.set(template.name, template);
+	for (const template of listDir(dirs.projectDir, "project")) byName.set(template.name, template);
+	return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Fetch one template by name. `scope` omitted → project wins over global (same precedence as
+ * `listTemplates`); an explicit `scope` reads exactly that dir. Throws if absent, if `name` is invalid,
+ * or if `scope` is "project" with no workspace. */
+export function getTemplate(dirs: TemplateDirs, name: string, scope?: TemplateScope): TemplateInfo {
+	if (!isValidTemplateName(name)) throw new Error(`invalid template name: ${JSON.stringify(name)}`);
+	if (scope) {
+		const template = readTemplateFile(dirForScope(dirs, scope), scope, name);
+		if (!template) throw new Error(`template not found: ${name} (scope: ${scope})`);
+		return template;
+	}
+	if (dirs.projectDir) {
+		const projectTemplate = readTemplateFile(dirs.projectDir, "project", name);
+		if (projectTemplate) return projectTemplate;
+	}
+	const globalTemplate = readTemplateFile(dirs.globalDir, "global", name);
+	if (globalTemplate) return globalTemplate;
+	throw new Error(`template not found: ${name}`);
+}
+
+/** Create or overwrite a template. Writes `content` verbatim (the caller assembles frontmatter + body;
+ * this module never rewrites it) and creates the scope's dir if missing. Throws on an invalid `name`, a
+ * "project" scope with no workspace, or — checked BEFORE anything touches disk — malformed frontmatter in
+ * `content` (an unparseable `---`-fenced block throws inside `parseFrontmatter`; validating first means a
+ * rejected save writes nothing, instead of landing an orphan file that's invisible to `listTemplates`
+ * (swallowed there) and un-`get`-able (throws there) once it exists). After a successful write, the
+ * read-back used to build the return value can in principle still fail, but only for a filesystem race,
+ * not a content problem — an acceptable residual this function doesn't try to eliminate. */
+export function saveTemplate(
+	dirs: TemplateDirs,
+	scope: TemplateScope,
+	name: string,
+	content: string,
+): TemplateInfo {
+	if (!isValidTemplateName(name)) throw new Error(`invalid template name: ${JSON.stringify(name)}`);
+	try {
+		parseFrontmatter(content);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`invalid frontmatter: ${message}`);
+	}
+	const dir = dirForScope(dirs, scope);
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, `${name}.md`), content, "utf-8");
+	const template = readTemplateFile(dir, scope, name);
+	if (!template) throw new Error(`failed to save template: ${name}`);
+	return template;
+}
+
+/** Delete a template. Throws on an invalid `name`, a "project" scope with no workspace, or if the
+ * template doesn't exist — a missing file is treated as an error, not a silent no-op, since a delete
+ * request implies the caller's view already named a specific file; loud beats silent for a UI that might
+ * be looking at a stale list (see SPEC.md's "Get right"). */
+export function deleteTemplate(dirs: TemplateDirs, scope: TemplateScope, name: string): void {
+	if (!isValidTemplateName(name)) throw new Error(`invalid template name: ${JSON.stringify(name)}`);
+	const dir = dirForScope(dirs, scope);
+	const filePath = join(dir, `${name}.md`);
+	if (!existsSync(filePath)) throw new Error(`template not found: ${name} (scope: ${scope})`);
+	rmSync(filePath);
+}

--- a/packages/server/src/templates/templates.ts
+++ b/packages/server/src/templates/templates.ts
@@ -90,17 +90,34 @@ function isRegularFile(path: string): boolean {
 	return lstatOrNull(path)?.isFile() ?? false;
 }
 
-/** The dir-level half of the no-follow gate, for **project-scope writes** only: the repo controls
- * `<cwd>/.pi` and `<cwd>/.pi/prompts`, so a symlinked component there is the same escape one level up
- * (`saveTemplate` would `mkdir`/write, `deleteTemplate` would `rm`, inside the link's target). The
- * global dir is exempt on purpose — it's user-owned, and dotfile managers routinely symlink it. */
+/** The dir-level half of the no-follow gate: the repo controls `<cwd>/.pi` and `<cwd>/.pi/prompts`, so
+ * a symlinked component there is the same escape one level up — `template.list`/`template.get` would
+ * disclose the link target's `.md` files over the wire, `saveTemplate` would `mkdir`/write and
+ * `deleteTemplate` would `rm` inside it. Every project-scope operation checks this: reads treat an
+ * untraversable project dir as having no templates (same "absent, not followed" posture as the
+ * file-level gate), writes refuse loudly via {@link assertProjectWriteSafe}. The global dir is exempt
+ * on purpose — it's user-owned, and dotfile managers routinely symlink it. */
+function projectDirTraversable(projectDir: string): boolean {
+	return ![dirname(projectDir), projectDir].some(
+		(dir) => lstatOrNull(dir)?.isSymbolicLink() ?? false,
+	);
+}
+
+/** The loud (write-path) form of {@link projectDirTraversable} — a save/delete aimed through a
+ * symlinked project dir must fail visibly, never silently no-op. */
 function assertProjectWriteSafe(dirs: TemplateDirs, scope: TemplateScope): void {
 	if (scope !== "project" || !dirs.projectDir) return;
-	for (const dir of [dirname(dirs.projectDir), dirs.projectDir]) {
-		if (lstatOrNull(dir)?.isSymbolicLink()) {
-			throw new Error(`refusing to write templates through a symlinked directory: ${dir}`);
-		}
+	if (!projectDirTraversable(dirs.projectDir)) {
+		throw new Error(
+			`refusing to write templates through a symlinked directory: ${dirs.projectDir}`,
+		);
 	}
+}
+
+/** `dirs.projectDir`, or `undefined` when it's absent OR untraversable (dir-level no-follow gate) —
+ * the single predicate every project-scope READ goes through, so list and get can never disagree. */
+function readableProjectDir(dirs: TemplateDirs): string | undefined {
+	return dirs.projectDir && projectDirTraversable(dirs.projectDir) ? dirs.projectDir : undefined;
 }
 
 /** Read + parse one template file from `dir`. `null` if it doesn't exist — or exists but isn't a
@@ -170,7 +187,8 @@ function listDir(dir: string | undefined, scope: TemplateScope): TemplateInfo[] 
 export function listTemplates(dirs: TemplateDirs): TemplateInfo[] {
 	const byName = new Map<string, TemplateInfo>();
 	for (const template of listDir(dirs.globalDir, "global")) byName.set(template.name, template);
-	for (const template of listDir(dirs.projectDir, "project")) byName.set(template.name, template);
+	for (const template of listDir(readableProjectDir(dirs), "project"))
+		byName.set(template.name, template);
 	return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
@@ -180,12 +198,17 @@ export function listTemplates(dirs: TemplateDirs): TemplateInfo[] {
 export function getTemplate(dirs: TemplateDirs, name: string, scope?: TemplateScope): TemplateInfo {
 	if (!isValidTemplateName(name)) throw new Error(`invalid template name: ${JSON.stringify(name)}`);
 	if (scope) {
-		const template = readTemplateFile(dirForScope(dirs, scope), scope, name);
+		// `dirForScope` first, for its own distinct error (project scope with no workspace at all);
+		// past that, an untraversable project dir reads as "absent" — the dir-level no-follow gate.
+		const scopeDir = dirForScope(dirs, scope);
+		const dir = scope === "project" ? readableProjectDir(dirs) : scopeDir;
+		const template = dir ? readTemplateFile(dir, scope, name) : null;
 		if (!template) throw new Error(`template not found: ${name} (scope: ${scope})`);
 		return template;
 	}
-	if (dirs.projectDir) {
-		const projectTemplate = readTemplateFile(dirs.projectDir, "project", name);
+	const projectDir = readableProjectDir(dirs);
+	if (projectDir) {
+		const projectTemplate = readTemplateFile(projectDir, "project", name);
 		if (projectTemplate) return projectTemplate;
 	}
 	const globalTemplate = readTemplateFile(dirs.globalDir, "global", name);

--- a/packages/server/src/templates/templates.ts
+++ b/packages/server/src/templates/templates.ts
@@ -3,8 +3,17 @@
 // module owns the traversal gate (`isValidTemplateName`) that pi's own loader doesn't provide. `content`
 // is always the full file text (frontmatter + body) — the wire's `TemplateInfo.content` contract — never
 // pi's parsed/stripped body. See SPEC.md for the pinned pi facts and the freshness rationale.
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	type Stats,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import type { TemplateInfo, TemplateScope } from "@thinkrail/contracts";
 
@@ -61,11 +70,46 @@ function dirForScope(dirs: TemplateDirs, scope: TemplateScope): string {
 	return dirs.globalDir;
 }
 
-/** Read + parse one template file from `dir`. `null` if it doesn't exist. Propagates a frontmatter
+/** `lstat` that never follows a symlink and never throws — `null` for a missing path. */
+function lstatOrNull(path: string): Stats | null {
+	try {
+		return lstatSync(path);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * The **no-follow gate** (see SPEC.md): a directory entry named `<name>.md` that isn't a regular file —
+ * a symlink first of all — is *not a template*, for every by-name operation alike. pi's own read-only
+ * scanner deliberately follows file symlinks; this write-capable CRUD surface deliberately does not — a
+ * checked-out repo's `.pi/prompts/linked.md → ~/somewhere` must never be disclosed by `template.get` or
+ * overwritten by `template.save`. (`lstat`, never `stat`/`existsSync`, so the check itself can't follow.)
+ */
+function isRegularFile(path: string): boolean {
+	return lstatOrNull(path)?.isFile() ?? false;
+}
+
+/** The dir-level half of the no-follow gate, for **project-scope writes** only: the repo controls
+ * `<cwd>/.pi` and `<cwd>/.pi/prompts`, so a symlinked component there is the same escape one level up
+ * (`saveTemplate` would `mkdir`/write, `deleteTemplate` would `rm`, inside the link's target). The
+ * global dir is exempt on purpose — it's user-owned, and dotfile managers routinely symlink it. */
+function assertProjectWriteSafe(dirs: TemplateDirs, scope: TemplateScope): void {
+	if (scope !== "project" || !dirs.projectDir) return;
+	for (const dir of [dirname(dirs.projectDir), dirs.projectDir]) {
+		if (lstatOrNull(dir)?.isSymbolicLink()) {
+			throw new Error(`refusing to write templates through a symlinked directory: ${dir}`);
+		}
+	}
+}
+
+/** Read + parse one template file from `dir`. `null` if it doesn't exist — or exists but isn't a
+ * regular file (the no-follow gate above; a symlinked entry is absent to every by-name operation, the
+ * same way `listDir`'s dirent `isFile()` already hides it from listings). Propagates a frontmatter
  * parse failure — a directly-named lookup deserves to know the file itself is broken. */
 function readTemplateFile(dir: string, scope: TemplateScope, name: string): TemplateInfo | null {
 	const filePath = join(dir, `${name}.md`);
-	if (!existsSync(filePath)) return null;
+	if (!isRegularFile(filePath)) return null;
 	const content = readFileSync(filePath, "utf-8");
 	const { frontmatter } = parseFrontmatter(content);
 	const description =
@@ -171,8 +215,16 @@ export function saveTemplate(
 		throw new Error(`invalid frontmatter: ${message}`);
 	}
 	const dir = dirForScope(dirs, scope);
+	assertProjectWriteSafe(dirs, scope);
+	const filePath = join(dir, `${name}.md`);
+	// The file-level no-follow gate: `writeFileSync` follows an existing symlink, which would land the
+	// write on its target — refuse loudly instead of clobbering whatever a checked-out repo pointed at.
+	const existing = lstatOrNull(filePath);
+	if (existing && !existing.isFile()) {
+		throw new Error(`refusing to write through a non-regular file: ${name}.md`);
+	}
 	mkdirSync(dir, { recursive: true });
-	writeFileSync(join(dir, `${name}.md`), content, "utf-8");
+	writeFileSync(filePath, content, "utf-8");
 	const template = readTemplateFile(dir, scope, name);
 	if (!template) throw new Error(`failed to save template: ${name}`);
 	return template;
@@ -185,7 +237,10 @@ export function saveTemplate(
 export function deleteTemplate(dirs: TemplateDirs, scope: TemplateScope, name: string): void {
 	if (!isValidTemplateName(name)) throw new Error(`invalid template name: ${JSON.stringify(name)}`);
 	const dir = dirForScope(dirs, scope);
+	assertProjectWriteSafe(dirs, scope);
 	const filePath = join(dir, `${name}.md`);
-	if (!existsSync(filePath)) throw new Error(`template not found: ${name} (scope: ${scope})`);
+	// No-follow gate: a symlinked entry is not a template (never listed, never fetched), so a delete by
+	// its name is a not-found, same as get — not an action on the link.
+	if (!isRegularFile(filePath)) throw new Error(`template not found: ${name} (scope: ${scope})`);
 	rmSync(filePath);
 }

--- a/packages/server/src/templates/templates.ts
+++ b/packages/server/src/templates/templates.ts
@@ -4,18 +4,21 @@
 // is always the full file text (frontmatter + body) — the wire's `TemplateInfo.content` contract — never
 // pi's parsed/stripped body. See SPEC.md for the pinned pi facts and the freshness rationale.
 import {
+	closeSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
+	openSync,
 	readdirSync,
 	readFileSync,
+	readSync,
 	rmSync,
 	type Stats,
 	writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
-import type { TemplateInfo, TemplateScope } from "@thinkrail/contracts";
+import type { Template, TemplateInfo, TemplateScope } from "@thinkrail/contracts";
 
 /** The two sanctioned template directories. `projectDir` is absent whenever there's no workspace. */
 export interface TemplateDirs {
@@ -120,27 +123,73 @@ function readableProjectDir(dirs: TemplateDirs): string | undefined {
 	return dirs.projectDir && projectDirTraversable(dirs.projectDir) ? dirs.projectDir : undefined;
 }
 
-/** Read + parse one template file from `dir`. `null` if it doesn't exist — or exists but isn't a
- * regular file (the no-follow gate above; a symlinked entry is absent to every by-name operation, the
- * same way `listDir`'s dirent `isFile()` already hides it from listings). Propagates a frontmatter
- * parse failure — a directly-named lookup deserves to know the file itself is broken. */
-function readTemplateFile(dir: string, scope: TemplateScope, name: string): TemplateInfo | null {
-	const filePath = join(dir, `${name}.md`);
-	if (!isRegularFile(filePath)) return null;
-	const content = readFileSync(filePath, "utf-8");
-	const { frontmatter } = parseFrontmatter(content);
+/** Hard cap on a template file / `template.save` payload — prompts are text, so 1 MiB is already
+ * generous. A directly-named read or a save of anything larger fails LOUDLY; `listTemplates` simply
+ * skips oversized files (list/get parity: neither surfaces them). This is what keeps one huge
+ * checked-in `.pi/prompts/*.md` from blocking the shared in-process host or bloating a WS response. */
+export const MAX_TEMPLATE_BYTES = 1024 * 1024;
+
+/** How much of a file's head `readTemplateMeta` reads to find the frontmatter — pi's own convention
+ * puts the block first, and real frontmatter is two short lines; a block whose closing fence sits past
+ * this window degrades to "no metadata" (never an error, never a full-file read). */
+const FRONTMATTER_SCAN_BYTES = 8 * 1024;
+
+/** The first `bytes` of `filePath`, decoded as UTF-8. Callers lstat-gate first (see the no-follow
+ * gate); the open-then-read itself is the same bounded-head pattern pi's `readSessionHeader` uses. */
+function readHead(filePath: string, bytes: number): string {
+	const fd = openSync(filePath, "r");
+	try {
+		const buffer = Buffer.alloc(bytes);
+		const bytesRead = readSync(fd, buffer, 0, bytes, 0);
+		return buffer.toString("utf-8", 0, bytesRead);
+	} finally {
+		closeSync(fd);
+	}
+}
+
+/** The two optional metadata fields out of a file's frontmatter (full content or bounded head — pi's
+ * `extractFrontmatter` inside `parseFrontmatter` treats a truncated block with no closing fence as
+ * plain content, i.e. no frontmatter, so a head read degrades safely). */
+function frontmatterMeta(text: string): Pick<TemplateInfo, "description" | "argumentHint"> {
+	const { frontmatter } = parseFrontmatter(text);
 	const description =
 		typeof frontmatter.description === "string" ? frontmatter.description : undefined;
 	const argumentHint =
 		typeof frontmatter["argument-hint"] === "string" ? frontmatter["argument-hint"] : undefined;
 	return {
-		name,
 		...(description ? { description } : {}),
 		...(argumentHint ? { argumentHint } : {}),
-		content,
-		scope,
-		filePath,
 	};
+}
+
+/** Metadata-only read for `listTemplates` — never reads the full file (a listing must cost bounded
+ * work per file, whatever a checkout put in the dir): the no-follow lstat doubles as the size gate
+ * (oversized → `null`, skipped), then only `FRONTMATTER_SCAN_BYTES` of the head are read for the
+ * frontmatter. `null` for missing / non-regular / oversized entries. */
+function readTemplateMeta(dir: string, scope: TemplateScope, name: string): TemplateInfo | null {
+	const filePath = join(dir, `${name}.md`);
+	const stats = lstatOrNull(filePath);
+	if (!stats?.isFile() || stats.size > MAX_TEMPLATE_BYTES) return null;
+	const head = readHead(filePath, FRONTMATTER_SCAN_BYTES);
+	return { name, ...frontmatterMeta(head), scope, filePath };
+}
+
+/** Full read + parse of one template file from `dir`. `null` if it doesn't exist — or exists but isn't
+ * a regular file (the no-follow gate above; a symlinked entry is absent to every by-name operation, the
+ * same way `listDir`'s dirent `isFile()` already hides it from listings). An oversized file THROWS —
+ * unlike the listing's silent skip, a directly-named lookup deserves a loud answer (the same
+ * loud-vs-skip asymmetry as malformed frontmatter, which also propagates from here). */
+function readTemplateFile(dir: string, scope: TemplateScope, name: string): Template | null {
+	const filePath = join(dir, `${name}.md`);
+	const stats = lstatOrNull(filePath);
+	if (!stats?.isFile()) return null;
+	if (stats.size > MAX_TEMPLATE_BYTES) {
+		throw new Error(
+			`template file too large: ${name}.md (${stats.size} bytes, limit ${MAX_TEMPLATE_BYTES})`,
+		);
+	}
+	const content = readFileSync(filePath, "utf-8");
+	return { name, ...frontmatterMeta(content), content, scope, filePath };
 }
 
 /** Every `.md` file directly inside `dir` (non-recursive) whose derived name passes
@@ -151,6 +200,8 @@ function readTemplateFile(dir: string, scope: TemplateScope, name: string): Temp
  * scanner (`loadTemplatesFromDir`), which has no such filter — pi would happily list a hand-placed
  * `.hidden.md` — done in service of *our* parity invariant, not something pi does for us.
  *
+ * Metadata-only (`readTemplateMeta` — bounded head reads, oversized files skipped): a listing must cost
+ * bounded work per file whatever a checkout dropped in the dir, and neither list consumer renders a body.
  * A per-file read/parse failure (malformed frontmatter, unreadable file) is caught and that one file is
  * skipped, not fatal — one bad file must never blank the whole listing. The *directory scan itself*
  * (`readdirSync` and the loop around it) is wrapped too: an unreadable directory (EACCES, or — the
@@ -167,7 +218,7 @@ function listDir(dir: string | undefined, scope: TemplateScope): TemplateInfo[] 
 			const name = entry.name.replace(/\.md$/, "");
 			if (!isValidTemplateName(name)) continue;
 			try {
-				const template = readTemplateFile(dir, scope, name);
+				const template = readTemplateMeta(dir, scope, name);
 				if (template) templates.push(template);
 			} catch {
 				// Malformed frontmatter or an unreadable file — skip it, don't fail the whole list.
@@ -195,7 +246,7 @@ export function listTemplates(dirs: TemplateDirs): TemplateInfo[] {
 /** Fetch one template by name. `scope` omitted → project wins over global (same precedence as
  * `listTemplates`); an explicit `scope` reads exactly that dir. Throws if absent, if `name` is invalid,
  * or if `scope` is "project" with no workspace. */
-export function getTemplate(dirs: TemplateDirs, name: string, scope?: TemplateScope): TemplateInfo {
+export function getTemplate(dirs: TemplateDirs, name: string, scope?: TemplateScope): Template {
 	if (!isValidTemplateName(name)) throw new Error(`invalid template name: ${JSON.stringify(name)}`);
 	if (scope) {
 		// `dirForScope` first, for its own distinct error (project scope with no workspace at all);
@@ -229,8 +280,14 @@ export function saveTemplate(
 	scope: TemplateScope,
 	name: string,
 	content: string,
-): TemplateInfo {
+): Template {
 	if (!isValidTemplateName(name)) throw new Error(`invalid template name: ${JSON.stringify(name)}`);
+	// The same cap `getTemplate` enforces on reads, applied before anything touches disk — without it a
+	// single oversized save would create a file every later read refuses and every listing skips.
+	const size = Buffer.byteLength(content, "utf-8");
+	if (size > MAX_TEMPLATE_BYTES) {
+		throw new Error(`template too large: ${size} bytes (limit ${MAX_TEMPLATE_BYTES})`);
+	}
 	try {
 		parseFrontmatter(content);
 	} catch (err) {


### PR DESCRIPTION
Reusable prompt templates over pi's own prompt dirs (global + project `.pi/prompts`), so they stay pi-CLI-portable.

- `/` menu lists templates fresh; picking one starts a Tab-through slot session (placeholder fill + group mirroring + gap highlighting).
- Templates manager (Settings → Templates): list/create/edit/delete, save-as-template from the history overlay, and a starter-templates offer. Ships 5 starter project templates.
- Wire: `template.*` CRUD (protocol **v10**).

**Stacked on #109** (base = `feat/chat-history-search`) — review/merge that first; this diff is templates-only on top of it. e2e: 80 no-agent specs green.