### PR TITLE
pi 0.81 follow-ups: compaction retry countdowns in chat + spec-graph link repair

### DIFF
--- a/apps/web/src/chat/ChatPlan.tsx
+++ b/apps/web/src/chat/ChatPlan.tsx
@@ -3,7 +3,7 @@ import { PopoverContent } from "@/components/ui/popover";
 import { planSummary, TodoAddRow, TodoRows } from "./TodoList";
 import type { ChatTodos } from "./useChatTodos";
 
-// The chat's TODO plan surfaced inline (design-todos): a strip in the chat header (progress + what's
+// The chat's TODO plan surfaced inline (SPEC §Chat TODO plan): a strip in the chat header (progress + what's
 // happening now) opens a popup over the chat with the plan — which lives only in the chat (there is no
 // right-panel Todo tab). The `Popover` is composed in `ChatView`, anchored to the **chat header** (not
 // the strip), so the popup's

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -97,7 +97,7 @@ export default function ChatView({
 
 	const [mentionQuery, setMentionQuery] = useState<string | null>(null);
 	const [mentionCandidates, setMentionCandidates] = useState<MentionCandidate[]>([]);
-	// The chat's TODO plan, surfaced inline via a header strip that opens a popup over the chat (design-todos).
+	// The chat's TODO plan, surfaced inline via a header strip that opens a popup over the chat (SPEC §Chat TODO plan).
 	const plan = useChatTodos(workspaceId, sessionId);
 	const [planOpen, setPlanOpen] = useState(false);
 

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -27,7 +27,11 @@ spans assistant-message boundaries (pi emits one assistant message per tool roun
 model can't group. The pure **`deriveRows(turns, toolResults, isStreaming)`** (`rows.ts`) walks blocks in
 order into rows; `ChatTurnView` dispatches on row kind:
 
-- `user` / `system` / `retry` — 1:1 renderers. **`ErrorTurn`** is a persistent tinted failure notice
+- `user` / `system` / `retry` — 1:1 renderers. The retry countdown carries a `source` (`turn` =
+  pi `auto_retry_*`; `summarization` = compaction/branch-summary `summarization_retry_*`, pi ≥0.81.1) —
+  the flows can overlap mid-run, each keeps exactly one indicator (re-scheduling replaces, each source's
+  end event clears only its own), and `RetryIndicator` labels them apart ("Retrying" vs "Retrying
+  summarization"). **`ErrorTurn`** is a persistent tinted failure notice
   (provider/model error, or a rejected send) — **never folded**, so a failed turn can't look like
   nothing happened.
 - `markdown` — a non-empty assistant text block (react-markdown + remark-gfm + shiki).
@@ -97,7 +101,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   optional `container` prop portals their popovers into a host Dialog), `SessionStatsBar`, `ChatHeader`
   (its `left` slot carries the plan strip), `ExtUiDialog`. All props-driven; behavior detail lives in the
   components' jsdoc.
-- **Chat TODO plan** ([[design-todos]]) — the chat's `pi-todos` list surfaced **only in the chat**:
+- **Chat TODO plan** — the chat's `pi-todos` list surfaced **only in the chat** (engine:
+  [[module-pi-todos]]; host read/write: [[submodule-server-todos]]):
   `useChatTodos` (the `todo.*` data hook — fetch + live `pi.event` refetch + edits + the add-nudge + the
   `openMarkdown` snapshot action), `TodoList` (loose items + named groups, add-row + an "open as markdown"
   button), `planMarkdown` (a pure `plan → markdown` compiler), and `ChatPlan` (`ChatPlanStripContent` +

--- a/apps/web/src/chat/TodoList.tsx
+++ b/apps/web/src/chat/TodoList.tsx
@@ -13,7 +13,7 @@ import {
 import { useState } from "react";
 import { cn } from "../lib";
 
-// Presentational TODO rendering for the in-chat plan popup (design-todos). Props-driven (no transport) —
+// Presentational TODO rendering for the in-chat plan popup (SPEC §Chat TODO plan). Props-driven (no transport) —
 // the caller supplies the plan + edit callbacks (see `useChatTodos`). The plan renders as three status
 // sections (In progress / To do / Done); every item (loose or grouped) falls into the section for its
 // status. The one exception is Done: a group whose every item is done folds into one expandable row

--- a/apps/web/src/chat/planMarkdown.ts
+++ b/apps/web/src/chat/planMarkdown.ts
@@ -1,6 +1,6 @@
 import type { TodoItem, TodoPlan } from "@thinkrail/contracts";
 
-// Compile a chat's TODO plan to a temporary, human-readable markdown snapshot (design-todos) — the
+// Compile a chat's TODO plan to a temporary, human-readable markdown snapshot (SPEC §Chat TODO plan) — the
 // "Open as markdown" action in the plan popup. Pure + presentational-adjacent (no store/transport): it
 // just maps the plan to GFM. Structure mirrors the plan's own shape — named groups as `##` sections, the
 // loose items last — with a progress header and GFM task-list checkboxes.

--- a/apps/web/src/chat/rows.test.ts
+++ b/apps/web/src/chat/rows.test.ts
@@ -121,11 +121,20 @@ describe("deriveRows grouping", () => {
 			user("u1"),
 			assistant("a1", [tc("t1")]),
 			{ kind: "error", id: "e1", text: "boom" },
-			{ kind: "retry", id: "r1", attempt: 1, maxAttempts: 3, delayMs: 500 },
+			{
+				kind: "retry",
+				id: "r1",
+				source: "summarization",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 500,
+			},
 			assistant("a2", [tc("t2")]),
 		];
 		const rows = deriveRows(turns, {}, true);
 		expect(kinds(rows)).toEqual(["user", "activity", "error", "retry", "activity"]);
+		// The retry row carries its source through — the renderer labels the two flows differently.
+		expect(rows[3]?.kind === "retry" && rows[3].source).toBe("summarization");
 		expect(rows[1]?.kind === "activity" && rows[1].steps.length).toBe(1);
 		expect(rows[4]?.kind === "activity" && rows[4].steps.length).toBe(1);
 	});

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -39,7 +39,14 @@ export type ChatRow =
 	| { kind: "user"; id: string; message: UserMessage }
 	| { kind: "system"; id: string; text: string }
 	| { kind: "error"; id: string; text: string }
-	| { kind: "retry"; id: string; attempt: number; maxAttempts: number; delayMs: number }
+	| {
+			kind: "retry";
+			id: string;
+			source: "turn" | "summarization";
+			attempt: number;
+			maxAttempts: number;
+			delayMs: number;
+	  }
 	| { kind: "markdown"; id: string; text: string }
 	| ({ kind: "tool"; id: string } & ToolCallData)
 	| {
@@ -131,6 +138,7 @@ export function deriveRows(
 					rows.push({
 						kind: "retry",
 						id: turn.id,
+						source: turn.source,
 						attempt: turn.attempt,
 						maxAttempts: turn.maxAttempts,
 						delayMs: turn.delayMs,

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -32,7 +32,12 @@ export function ChatTurnView({
 			return <ErrorTurn text={row.text} />;
 		case "retry":
 			return (
-				<RetryIndicator attempt={row.attempt} maxAttempts={row.maxAttempts} delayMs={row.delayMs} />
+				<RetryIndicator
+					source={row.source}
+					attempt={row.attempt}
+					maxAttempts={row.maxAttempts}
+					delayMs={row.delayMs}
+				/>
 			);
 		case "markdown":
 			return (
@@ -150,10 +155,12 @@ function ErrorTurn({ text }: { text: string }) {
  * duration is an inline style — color/width are token utilities.
  */
 function RetryIndicator({
+	source,
 	attempt,
 	maxAttempts,
 	delayMs,
 }: {
+	source: "turn" | "summarization";
 	attempt: number;
 	maxAttempts: number;
 	delayMs: number;
@@ -167,11 +174,13 @@ function RetryIndicator({
 	return (
 		<div
 			data-testid="retry-indicator"
+			data-source={source}
 			className="flex flex-col gap-xs rounded-[var(--radius-sm)] border border-border2 bg-elevated px-sm py-xs text-muted text-xs"
 		>
 			<span className="flex items-center gap-xs">
 				<RotateCw className="size-3 shrink-0" />
-				Retrying ({attempt}/{maxAttempts})…
+				{source === "summarization" ? "Retrying summarization" : "Retrying"} ({attempt}/
+				{maxAttempts})…
 			</span>
 			<div className="h-1 w-full overflow-hidden rounded-full bg-border2">
 				<div

--- a/apps/web/src/chat/types.ts
+++ b/apps/web/src/chat/types.ts
@@ -20,8 +20,20 @@ export type ChatTurn =
 	| { kind: "system"; id: string; text: string; endedAt?: number }
 	/** A failure notice: the run ended in an error, or the host rejected a send. `text` is the reason. */
 	| { kind: "error"; id: string; text: string }
-	/** A live auto-retry countdown (shown during the back-off, cleared when the retry resolves). */
-	| { kind: "retry"; id: string; attempt: number; maxAttempts: number; delayMs: number };
+	/**
+	 * A live retry countdown (shown during the back-off, cleared when the retry resolves). `source`
+	 * separates the two flows that can overlap — a `turn` retry (pi `auto_retry_*`) and a `summarization`
+	 * retry (compaction / branch-summary, pi `summarization_retry_*`) — so one flow's end event never
+	 * clears the other's countdown.
+	 */
+	| {
+			kind: "retry";
+			id: string;
+			source: "turn" | "summarization";
+			attempt: number;
+			maxAttempts: number;
+			delayMs: number;
+	  };
 
 export type ToolStatus = "running" | "done" | "error";
 

--- a/apps/web/src/chat/useChatTodos.ts
+++ b/apps/web/src/chat/useChatTodos.ts
@@ -21,7 +21,7 @@ export interface ChatTodos {
 }
 
 /**
- * The chat's TODO list as shared state (design-todos): the single data source for the in-chat plan
+ * The chat's TODO list as shared state (SPEC §Chat TODO plan): the single data source for the in-chat plan
  * popup. Reads `todo.list` for `sessionId`, refetches live off that session's `pi.event`s (any tool end /
  * settled turn, debounced) so the agent's writes surface without a manual refresh, and exposes the user's
  * edit ops. Adding an item nudges the agent (see {@link nudgeAgent}).

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -20,6 +20,18 @@ const retryStart = (attempt: number, maxAttempts: number, delayMs: number) =>
 		errorMessage: "rate limit",
 	}) as unknown as PiEvent;
 const retryEnd = { type: "auto_retry_end", success: true, attempt: 1 } as unknown as PiEvent;
+const summarizationScheduled = (
+	attempt: number,
+	maxAttempts: number,
+	delayMs: number,
+): PiEvent => ({
+	type: "summarization_retry_scheduled",
+	attempt,
+	maxAttempts,
+	delayMs,
+	errorMessage: "stream dropped",
+});
+const summarizationFinished: PiEvent = { type: "summarization_retry_finished" };
 // A turn that ends in a provider/model error: retries exhausted (or non-retryable), so `willRetry` is
 // false and the run's last assistant message carries `stopReason: "error"` + the provider's `errorMessage`
 // (this is what a bad model like a nonexistent "gpt-5.5" produces — a 404/model-not-found from the API).
@@ -244,12 +256,52 @@ test("auto-retry adds a countdown turn, and resolving it clears the indicator", 
 
 	store.handlePiEvent(retryStart(2, 3, 5_000), "a");
 	const retry = rt("a").turns.find((t) => t.kind === "retry");
+	expect(retry?.kind === "retry" && retry.source).toBe("turn");
 	expect(retry?.kind === "retry" && retry.attempt).toBe(2);
 	expect(retry?.kind === "retry" && retry.maxAttempts).toBe(3);
 	expect(retry?.kind === "retry" && retry.delayMs).toBe(5_000);
 
 	// auto_retry_end removes it — the retried attempt's streaming/answer takes over.
 	store.handlePiEvent(retryEnd, "a");
+	expect(rt("a").turns.some((t) => t.kind === "retry")).toBe(false);
+});
+
+test("summarization retries show their own countdown; re-scheduling replaces, finished clears", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+
+	store.handlePiEvent(summarizationScheduled(1, 3, 2_000), "a");
+	const first = rt("a").turns.find((t) => t.kind === "retry");
+	expect(first?.kind === "retry" && first.source).toBe("summarization");
+	expect(first?.kind === "retry" && first.attempt).toBe(1);
+
+	// The next attempt's back-off REPLACES the indicator — never stacks a second one.
+	store.handlePiEvent(summarizationScheduled(2, 3, 4_000), "a");
+	const retries = rt("a").turns.filter((t) => t.kind === "retry");
+	expect(retries.length).toBe(1);
+	expect(retries[0]?.kind === "retry" && retries[0].attempt).toBe(2);
+
+	store.handlePiEvent(summarizationFinished, "a");
+	expect(rt("a").turns.some((t) => t.kind === "retry")).toBe(false);
+});
+
+test("overlapping turn + summarization retries never clear each other", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+
+	// A threshold compaction can back off while the turn itself is also retrying.
+	store.handlePiEvent(retryStart(1, 3, 1_000), "a");
+	store.handlePiEvent(summarizationScheduled(1, 3, 2_000), "a");
+	expect(rt("a").turns.filter((t) => t.kind === "retry").length).toBe(2);
+
+	// The turn retry resolving leaves the summarization countdown alone…
+	store.handlePiEvent(retryEnd, "a");
+	const left = rt("a").turns.filter((t) => t.kind === "retry");
+	expect(left.length).toBe(1);
+	expect(left[0]?.kind === "retry" && left[0].source).toBe("summarization");
+
+	// …and vice versa: finishing summarization doesn't require a turn retry to exist.
+	store.handlePiEvent(summarizationFinished, "a");
 	expect(rt("a").turns.some((t) => t.kind === "retry")).toBe(false);
 });
 

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -183,6 +183,37 @@ function clearTurnStreaming(turns: ChatTurn[]): ChatTurn[] {
 	return turns.map((t) => (t.kind === "assistant" && t.streaming ? { ...t, streaming: false } : t));
 }
 
+type RetrySource = Extract<ChatTurn, { kind: "retry" }>["source"];
+
+/** Replace-or-append the one live retry countdown of a source (turn vs summarization flows overlap). */
+function appendRetryTurn(
+	rt: SessionRuntime,
+	source: RetrySource,
+	event: { attempt: number; maxAttempts: number; delayMs: number },
+): SessionRuntime {
+	return {
+		...rt,
+		turns: [
+			...rt.turns.filter((t) => !(t.kind === "retry" && t.source === source)),
+			{
+				kind: "retry",
+				id: crypto.randomUUID(),
+				source,
+				attempt: event.attempt,
+				maxAttempts: event.maxAttempts,
+				delayMs: event.delayMs,
+			},
+		],
+	};
+}
+
+/** Drop a source's retry countdown (its flow resolved); other sources' countdowns stay. */
+function clearRetryTurns(rt: SessionRuntime, source: RetrySource): SessionRuntime {
+	return rt.turns.some((t) => t.kind === "retry" && t.source === source)
+		? { ...rt, turns: rt.turns.filter((t) => !(t.kind === "retry" && t.source === source)) }
+		: rt;
+}
+
 /** Fold one pi event into a session's runtime. Pure — returns the same ref when nothing changes. */
 export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionRuntime {
 	switch (event.type) {
@@ -299,24 +330,17 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 		}
 		case "auto_retry_start":
 			// Show a live countdown over the back-off; cleared on auto_retry_end (or the final agent_end).
-			return {
-				...rt,
-				turns: [
-					...rt.turns,
-					{
-						kind: "retry",
-						id: crypto.randomUUID(),
-						attempt: event.attempt,
-						maxAttempts: event.maxAttempts,
-						delayMs: event.delayMs,
-					},
-				],
-			};
+			// Replace-or-append per source: the event fires once per attempt, and the two retry flows
+			// (turn vs summarization) may overlap — each keeps exactly one indicator.
+			return appendRetryTurn(rt, "turn", event);
 		case "auto_retry_end":
 			// The retry resolved → normal streaming/answer rendering replaces the indicator.
-			return rt.turns.some((t) => t.kind === "retry")
-				? { ...rt, turns: rt.turns.filter((t) => t.kind !== "retry") }
-				: rt;
+			return clearRetryTurns(rt, "turn");
+		case "summarization_retry_scheduled":
+			// A compaction / branch-summary LLM call is backing off (pi ≥0.81.1) — same countdown treatment.
+			return appendRetryTurn(rt, "summarization", event);
+		case "summarization_retry_finished":
+			return clearRetryTurns(rt, "summarization");
 		case "thinking_level_changed":
 			return { ...rt, thinkingLevel: event.level };
 		default:

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -65,7 +65,24 @@ export type PiEvent =
 			delayMs: number;
 			errorMessage: string;
 	  }
-	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+	// Compaction / branch-summary retry lifecycle (pi ≥0.81.1). The UI renders the countdown
+	// (`scheduled`) and the all-clear (`finished`); `attempt_start` is delivered but deliberately ignored
+	// (by the time an attempt starts, the countdown has drained — nothing new to show).
+	| {
+			type: "summarization_retry_scheduled";
+			attempt: number;
+			maxAttempts: number;
+			delayMs: number;
+			errorMessage: string;
+	  }
+	| { type: "summarization_retry_attempt_start"; source: "branchSummary" }
+	| {
+			type: "summarization_retry_attempt_start";
+			source: "compaction";
+			reason: "manual" | "threshold" | "overflow";
+	  }
+	| { type: "summarization_retry_finished" };
 
 /** The `pi.event` push frame: a session's event tagged with its id. */
 export interface SessionEventPayload {

--- a/packages/pi-todos/SPEC.md
+++ b/packages/pi-todos/SPEC.md
@@ -5,15 +5,15 @@ status: draft
 title: pi-todos extension — the chat TODO list
 parent: architecture
 depends-on: []
-references: [design-todos, module-spec-graph]
+references: [module-spec-graph, submodule-web-chat]
 tags: [pi-extension, todos, v2]
 ---
 
 ## Responsibility
 
 `pi-todos` is a portable pi-package that gives the `pi` agent a **chat-scoped TODO list** — its working
-plan for the conversation, which the user can also add to. It is the *engine* behind [[design-todos]],
-modeled on [[module-spec-graph]]: a skill, five `todo_*` custom tools, and one `before_agent_start` rule.
+plan for the conversation, which the user can also add to. It is the *engine* behind the chat's TODO
+plan UX ([[submodule-web-chat]]'s "Chat TODO plan"), modeled on [[module-spec-graph]]: a skill, five `todo_*` custom tools, and one `before_agent_start` rule.
 
 - **`index.ts`** — an `ExtensionFactory` registering the five tools and one always-on `before_agent_start`
   rule. The rule is deliberately **short and byte-stable** — awareness that a shared list + `todo_*` tools

--- a/packages/server/src/todos/SPEC.md
+++ b/packages/server/src/todos/SPEC.md
@@ -5,7 +5,7 @@ status: active
 title: todos — a chat's per-session TODO plan (read/write)
 parent: module-server
 depends-on: [module-contracts, submodule-server-git]
-references: [module-pi-todos, design-todos]
+references: [module-pi-todos, submodule-web-chat]
 tags: [v2, todos]
 ---
 
@@ -24,7 +24,7 @@ UI path calls it — status stays agent-owned (see [[module-pi-todos]]).
 
 This module does **not** push: a user edit isn't broadcast to other clients. The acting client updates
 optimistically; a second viewer reconciles on the next `pi.event`-driven refetch. Fine for single-owner
-V1 (see [[design-todos]]).
+V1 (the chat-plan UX this feeds: [[submodule-web-chat]]'s "Chat TODO plan").
 
 **Change artifacts (`artifacts.ts`).** Status stays agent-owned, but the host *observes* the transitions
 to attach an item's code changes. `host/server.ts` tees `isTodoToolEnd` off the session event stream and


### PR DESCRIPTION
Two small follow-ups from the pi 0.81 review, one commit each.

## 1. `feat(chat)`: compaction retry countdowns (`summarization_retry_*`)

pi 0.81.1 retries transient compaction/branch-summary failures and emits retry lifecycle session events — previously invisible here, so a compaction stuck in back-off looked like a stall.

- **Contracts**: `PiEvent` mirrors the three members (shape-faithful, stamped `@0.81.1`). The wire already delivered them (server passes session events through) — types + UI only, no server change.
- **Store**: the retry `ChatTurn` gains `source: "turn" | "summarization"`. The two flows can overlap (a threshold compaction backs off mid-run while the turn itself retries), so each keeps exactly one countdown: re-scheduling **replaces** (the event fires per attempt — no stacked indicators), each source's end event clears **only its own**, `agent_end` still sweeps all. `auto_retry_*` behavior unchanged, now tagged. `attempt_start` is deliberately ignored (countdown has drained by then; recorded in the contracts comment).
- **UI**: `RetryIndicator` labels the flows apart ("Retrying" vs "Retrying summarization") and exposes `data-source` for tests.
- **Tests**: replace semantics, source-scoped clearing, overlap isolation (turn retry resolving leaves the summarization countdown alone), row pass-through. Chat SPEC updated.

## 2. `docs(specs)`: repair dangling `design-todos` references

`spec_validate` flagged two dangling frontmatter edges: the chat-TODO feature referenced a `design-todos` node that never landed in-repo (a task-spec in a gitignored workspace context dir). The durable design lives in the module SPECs, so references now point at the real nodes (`submodule-web-chat` §Chat TODO plan; `module-pi-todos`; `submodule-server-todos`), and the five chat code comments cite "SPEC §Chat TODO plan" instead of the phantom id. `spec_validate` is clean.

## Verification

`check:deps` ✓ · lint ✓ · typecheck 9/9 ✓ · unit 8/8 packages (web 188/188) ✓ · `bun run e2e` **50/50** ✓ · suppression audit clean · `spec_validate` clean