### PR TITLE
chore(deps): upgrade pi 0.81.1 → 0.82.0 (reloadConfig → refresh migration)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -188,9 +188,9 @@
     "@biomejs/biome",
   ],
   "catalog": {
-    "@earendil-works/pi-agent-core": "0.81.1",
-    "@earendil-works/pi-ai": "0.81.1",
-    "@earendil-works/pi-coding-agent": "0.81.1",
+    "@earendil-works/pi-agent-core": "0.82.0",
+    "@earendil-works/pi-ai": "0.82.0",
+    "@earendil-works/pi-coding-agent": "0.82.0",
     "@types/bun": "1.3.14",
     "typebox": "1.1.38",
     "typescript": "6.0.3",
@@ -274,13 +274,13 @@
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.81.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.81.1", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.81.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.81.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.81.1", "@earendil-works/pi-ai": "^0.81.1", "@earendil-works/pi-tui": "^0.81.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.81.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-OMEe+Zt8oQYi/rCq3upxsTlIScWL0FPhXwQus34TbQb3EmTx88S7Uzx32JxvQiEeWOw8eDCdJf2PBUBE9r6wIg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 			"packages/*"
 		],
 		"catalog": {
-			"@earendil-works/pi-agent-core": "0.81.1",
-			"@earendil-works/pi-ai": "0.81.1",
-			"@earendil-works/pi-coding-agent": "0.81.1",
+			"@earendil-works/pi-agent-core": "0.82.0",
+			"@earendil-works/pi-ai": "0.82.0",
+			"@earendil-works/pi-coding-agent": "0.82.0",
 			"@types/bun": "1.3.14",
 			"typebox": "1.1.38",
 			"typescript": "6.0.3"

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -46,7 +46,9 @@ of the host.
     `off`-inclusive one);
   - the local render union **`PiEvent`** — the real superset `AgentSessionEvent` lives in the Node-only
     `pi-coding-agent`, so it's **mirrored** here (the `agent_end.willRetry` + `queue_update` /
-    `compaction_*` / `auto_retry_*` / `session_info_changed` / `thinking_level_changed` members);
+    `compaction_*` / `auto_retry_*` / `summarization_retry_*` / `session_info_changed` /
+    `thinking_level_changed` members, plus `bash_execution_update` — mirrored for union fidelity only;
+    the host never calls `executeBash`, so the UI never receives it);
   - **`SessionEventPayload`** (`{ sessionId, event: PiEvent }`) — the `pi.event` push frame.
   - the cheap-win mirrors (declared in the Node-only `pi-coding-agent`): **`SessionStats`** + **`ContextUsage`**
     (tokens/cost/context bar — display only) and **`SlashCommandInfo`** + **`SlashCommandSourceInfo`** (the
@@ -147,7 +149,7 @@ of the host.
 
 ## Get right
 
-- **Type-only, from the package roots, always** (verified vs 0.81.1: type-only imports are erased by
+- **Type-only, from the package roots, always** (verified vs 0.82.0: type-only imports are erased by
   `verbatimModuleSyntax`, so the web bundle stays provider-free; the pi-ai provider/API subpaths
   statically import the Node SDKs — never touch them). The `/base` entries existed only in 0.79.8–0.79.9.
 - `Model` is generic — expose as `Model<any>`.

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -40,7 +40,7 @@ export type WireModel = Pick<
 
 // The unified render union the UI switches on. The real superset (`AgentSessionEvent`) is declared in the
 // Node-only `pi-coding-agent` (it pulls node:fs), so it's MIRRORED here type-only, derived from the
-// imported `AgentEvent`. Keep in sync with @earendil-works/pi-coding-agent@0.81.1
+// imported `AgentEvent`. Keep in sync with @earendil-works/pi-coding-agent@0.82.0
 // (core/agent-session.d.ts) — the session-event members below are what `session.subscribe` emits.
 export type PiEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
@@ -82,7 +82,10 @@ export type PiEvent =
 			source: "compaction";
 			reason: "manual" | "threshold" | "overflow";
 	  }
-	| { type: "summarization_retry_finished" };
+	| { type: "summarization_retry_finished" }
+	// Streamed output of `session.executeBash` (pi ≥0.82.0) — mirrored for union fidelity only: this host
+	// never calls `executeBash` (terminals are real PTYs), so the UI never receives it and ignores it.
+	| { type: "bash_execution_update"; id?: string; delta: string };
 
 /** The `pi.event` push frame: a session's event tagged with its id. */
 export interface SessionEventPayload {
@@ -91,7 +94,7 @@ export interface SessionEventPayload {
 }
 
 // The shapes below are declared in the Node-only `pi-coding-agent` (it pulls node:fs), so they're
-// MIRRORED here type-only for the wire. Keep in sync with @earendil-works/pi-coding-agent@0.81.1.
+// MIRRORED here type-only for the wire. Keep in sync with @earendil-works/pi-coding-agent@0.82.0.
 
 /** Context-window usage for the active model. `tokens`/`percent` are null when unknown (post-compaction). */
 export interface ContextUsage {
@@ -264,7 +267,7 @@ export interface AskUserAnswersDetails {
 
 /**
  * MIRROR of pi-coding-agent's `CustomMessage` (that package is Node-only, so the shape is re-declared
- * type-only for the wire — keep in sync with @earendil-works/pi-coding-agent@0.81.1 core/messages.d.ts):
+ * type-only for the wire — keep in sync with @earendil-works/pi-coding-agent@0.82.0 core/messages.d.ts):
  * an extension-injected transcript message (`sendCustomMessage`). Crosses the wire in
  * `session.getMessages` and inside `message_start`/`message_end` events; the LLM sees it as a user
  * message. The web renders only the `customType`s it knows (e.g. `ask-user-answers`) and ignores the rest.

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -27,7 +27,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     runtime's ambient-network default from that env at construction; the option now gates only the
     create-time refresh — in 0.80.x it fed both; the scoped value is restored immediately, a user-set
     one untouched — pinned by `piRuntime.test.ts`): catalog reads stay local (builtins + models.json +
-    the persisted models-store), because `reloadConfig()`/`refresh()` await remote pi.dev catalog
+    the persisted models-store), because a network-enabled `refresh()` (pi 0.82 folded the old
+    `reloadConfig()` into it) awaits remote pi.dev catalog
     checks with no timeout — on the `provider.status` and jbcentral-connect paths that stalls wherever
     egress is slow or blocked. The one deliberate opt-in to
     live catalogs is **`refreshCatalogsDetached(runtime)`** (issue #98, mirroring pi's own `/model`):

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -383,7 +383,7 @@ export function getSessionStats(sessionId: string): SessionStats {
 }
 
 // Slash commands / skills available in the session — built from the same three sources pi's own rpc mode
-// uses. In sync with @earendil-works/pi-coding-agent@0.81.1 (modes/rpc get_commands).
+// uses. In sync with @earendil-works/pi-coding-agent@0.82.0 (modes/rpc get_commands).
 export function getSessionCommands(sessionId: string): SlashCommandInfo[] {
 	const session = mustGet(sessionId);
 	const extension = session.extensionRunner.getRegisteredCommands().map((c) => ({

--- a/packages/server/src/agent/piRuntime.test.ts
+++ b/packages/server/src/agent/piRuntime.test.ts
@@ -42,25 +42,36 @@ function cleanup(agentDir: string): void {
 	rmSync(agentDir, { recursive: true, force: true });
 }
 
-test("reloadConfig() on the shared runtime never opts into the network (provider.status must not stall on pi.dev)", async () => {
+test("refresh() on the shared runtime never opts into the network (provider.status must not stall on pi.dev)", async () => {
 	const { runtime, agentDir } = await isolatedRuntime();
 	try {
 		// The scoped PI_OFFLINE used during construction must not leak into the process env…
 		expect(process.env.PI_OFFLINE).toBeUndefined();
 
-		// …and the constructed runtime resolves reloadConfig's refresh to allowNetwork:false.
-		const seen: (ModelsRefreshOptions | undefined)[] = [];
-		const originalRefresh = runtime.refresh.bind(runtime);
-		runtime.refresh = (options?: ModelsRefreshOptions): Promise<ModelsRefreshResult> => {
-			seen.push(options);
-			return Promise.resolve({ aborted: false, errors: new Map() });
-		};
+		// …and a no-options refresh() (what provider.status / jbcentral call — pi 0.82 folded the old
+		// reloadConfig() into it) resolves allowNetwork to the runtime's ambient default: OFF. That
+		// default is internal, so pin it at the boundary it protects — the network: pi's remote-catalog
+		// and availability paths ride global fetch, so a blocking spy proves no egress is attempted.
+		// Refresh only touches providers holding a credential, so seed one — that's also the production
+		// shape (a signed-in user whose provider.status reads must not stall on pi.dev).
+		await runtime.setRuntimeApiKey("anthropic", "sk-test-never-used", { allowNetwork: false });
+		const originalFetch = globalThis.fetch;
+		const fetched: string[] = [];
+		globalThis.fetch = ((input: string | URL | Request) => {
+			fetched.push(String(input instanceof Request ? input.url : input));
+			return Promise.reject(new Error("unit tests never touch the network"));
+		}) as typeof fetch;
 		try {
-			await runtime.reloadConfig();
-			expect(seen.length).toBe(1);
-			expect(seen[0]?.allowNetwork).toBe(false);
+			await runtime.refresh();
+			expect(fetched).toEqual([]);
+
+			// Positive control so the spy can't rot vacuous: an explicit network opt-in (force bypasses
+			// the freshness throttle) must attempt egress — the spy blocks it, and refresh() swallows
+			// the per-provider failures into its result.
+			await runtime.refresh({ allowNetwork: true, force: true });
+			expect(fetched.length).toBeGreaterThan(0);
 		} finally {
-			runtime.refresh = originalRefresh;
+			globalThis.fetch = originalFetch;
 		}
 	} finally {
 		cleanup(agentDir);

--- a/packages/server/src/agent/piRuntime.ts
+++ b/packages/server/src/agent/piRuntime.ts
@@ -17,16 +17,17 @@ export function configurePiRuntime(rt: ModelRuntime | null): void {
  * Create the shared runtime from on-disk auth + catalogs (`~/.pi/agent`), with ambient network OFF.
  *
  * Model-catalog reads stay **local** (builtin catalogs + models.json + the persisted models-store),
- * matching the pre-0.80.8 behavior. Without that, every `reloadConfig()`/`refresh()` — i.e. every
- * `provider.status` read and jbcentral connect — would await remote pi.dev catalog checks with **no
- * timeout** (the catalog fetch takes only the caller's signal, and `reloadConfig` passes none),
- * stalling those paths wherever that egress is slow or blocked (CI, offline). The one deliberate
- * opt-in to live catalogs is `refreshCatalogsDetached` below (issue #98).
+ * matching the pre-0.80.8 behavior. Without that, every no-options `refresh()` (pi 0.82 folded the
+ * old `reloadConfig()` into it) — i.e. every `provider.status` read and jbcentral connect — would
+ * await remote pi.dev catalog checks with **no timeout** (the catalog fetch takes only the caller's
+ * signal, and those callers pass none), stalling those paths wherever that egress is slow or blocked
+ * (CI, offline). The one deliberate opt-in to live catalogs is `refreshCatalogsDetached` below
+ * (issue #98).
  *
  * HOW it stays local changed under us in pi 0.81: `allowModelNetwork: false` now gates only the
- * create-time refresh, while the runtime's ambient-network default (`modelNetworkEnabled`, what
- * `reloadConfig()` resolves) is derived from **`PI_OFFLINE` at construction** — in 0.80.x the option
- * fed both. So the runtime is constructed under a scoped `PI_OFFLINE` (restored right after — a
+ * create-time refresh, while the runtime's ambient-network default (`modelNetworkEnabled`, what a
+ * no-options `refresh()` resolves) is derived from **`PI_OFFLINE` at construction** — in 0.80.x the
+ * option fed both. So the runtime is constructed under a scoped `PI_OFFLINE` (restored right after — a
  * user-set value is left untouched), which restores the 0.80.x semantics: ambient reads local,
  * network strictly a per-call `allowNetwork: true` opt-in. One-time, at the single creation choke
  * point; pi's other PI_OFFLINE consumers (tool downloads, version checks) never see the override
@@ -60,7 +61,7 @@ export function getPiRuntime(): Promise<ModelRuntime> {
 export type CatalogRefreshRuntime = Pick<ModelRuntime, "refresh">;
 
 // One in-flight refresh per runtime instance: pi's `refresh()` does NOT single-flight itself (verified
-// vs 0.81.1 — only the availability sub-refresh is queued), and each picker open triggers us again.
+// vs 0.82.0 — only the availability sub-refresh is queued), and each picker open triggers us again.
 const inflightCatalogRefresh = new WeakMap<CatalogRefreshRuntime, Promise<void>>();
 
 // pi's own model-selector refresh budget. With single-flight, a hung refresh must self-expire or it

--- a/packages/server/src/auth/SPEC.md
+++ b/packages/server/src/auth/SPEC.md
@@ -23,8 +23,9 @@ ourselves and never surface a credential value over the wire.
   - `providerStatus` — `getProviderStatus()` → the wire `ProviderStatusReport`: per-provider `configured`
     (pi's `hasAuth`-family truth, so env-var auth counts) + auth `kind` (oauth / api-key / env /
     **central** / other) + display name + the in-app-login capability flags **`canOAuth`/`canApiKey`**,
-    configured-first. It **revalidates on every read**: `runtime.reloadConfig()` reloads models.json and
-    recomposes providers (it does **not** touch auth.json itself), and its internal availability refresh
+    configured-first. It **revalidates on every read**: a no-options `runtime.refresh()` (pi 0.82 folded
+    the old `reloadConfig()` into it; `allowNetwork` resolves to the runtime's ambient default — OFF)
+    reloads models.json and recomposes providers (it does **not** touch auth.json itself), and its availability refresh
     re-runs the per-provider auth checks against pi's credential store — which reads auth.json fresh
     (under a lock) on every access, so no separate credentials reload exists or is needed. A `pi`
     `/login` (or a terminal `central` re-wire) — or an in-app mutation below — thus shows up on the next
@@ -71,7 +72,7 @@ ourselves and never surface a credential value over the wire.
     - `setLoginPublisher(fn)` — the server→client push seam (defaults to a no-op).
   - `jbcentral` — the in-app **JetBrains AI** (jbcentral proxy) wiring, composing `@thinkrail/shared/jbcentral`
     (which owns the protocol) and adding the one live-runtime step the standalone CLI can't:
-    `connectJbcentral()` (`wireJbcentral` → on success `runtime.reloadConfig()` → a `JbcentralConnectResult`:
+    `connectJbcentral()` (`wireJbcentral` → on success a no-options `runtime.refresh()` → a `JbcentralConnectResult`:
     connected / needs-install / needs-login / error), `disconnectJbcentral()` (`unwireJbcentral` + refresh),
     `jbcentralLogin()` (best-effort `central login` browser launch). `providerStatus` also surfaces
     `jbcentralInstalled` (via `isJbcentralInstalled`) **and `jbcentralInstall`** (the host's per-OS install
@@ -90,8 +91,8 @@ ourselves and never surface a credential value over the wire.
 
 - **`loginStart` must not `await` the flow** — return the handle, run `login()` detached.
 - **Writes refresh themselves** (pi's `login`/`logout` refresh availability internally) — but the status
-  read still `reloadConfig()`s, or external changes (a terminal `pi /login`, a `central` re-wire) stay
-  invisible until restart.
+  read still `refresh()`es (which reloads models.json), or external changes (a terminal `pi /login`, a
+  `central` re-wire) stay invisible until restart.
 - **API keys persist only through `login(id, "api_key", interaction)`** — `setRuntimeApiKey` is a
   session-lifetime overlay and would silently drop the key on host restart. The interaction is the real
   dialog bridge, never a canned auto-answer (a canned one can only serve single-prompt providers).

--- a/packages/server/src/auth/jbcentral.ts
+++ b/packages/server/src/auth/jbcentral.ts
@@ -18,14 +18,15 @@ export function jbcentralInstalled(): boolean {
 }
 
 /**
- * Wire Claude+GPT through the jbcentral proxy (writes models.json), then reload the runtime's config so
- * it takes effect at once. Returns the outcome so the card can walk the user forward (install → sign in → connect).
+ * Wire Claude+GPT through the jbcentral proxy (writes models.json), then `refresh()` the runtime (which
+ * reloads models.json — pi 0.82 folded the old `reloadConfig()` into it) so it takes effect at once.
+ * Returns the outcome so the card can walk the user forward (install → sign in → connect).
  */
 export async function connectJbcentral(): Promise<JbcentralConnectResult> {
 	const result = await wireJbcentral(process.env);
 	switch (result.outcome) {
 		case "connected":
-			await (await getPiRuntime()).reloadConfig();
+			await (await getPiRuntime()).refresh();
 			return { outcome: "connected" };
 		case "needs-install":
 			return { outcome: "needs-install" };
@@ -36,10 +37,10 @@ export async function connectJbcentral(): Promise<JbcentralConnectResult> {
 	}
 }
 
-/** Undo the jbcentral overrides (models.json) and reload the config so the built-in endpoints return. */
+/** Undo the jbcentral overrides (models.json) and refresh so the built-in endpoints return. */
 export async function disconnectJbcentral(): Promise<void> {
 	await unwireJbcentral(process.env);
-	await (await getPiRuntime()).reloadConfig();
+	await (await getPiRuntime()).refresh();
 }
 
 /** Best-effort launch of `central login` (its browser sign-in) on the host. */

--- a/packages/server/src/auth/providerStatus.ts
+++ b/packages/server/src/auth/providerStatus.ts
@@ -145,16 +145,18 @@ export function buildProviderReport(sources: ProviderStatusSources): ProviderSta
 }
 
 /**
- * The `provider.status` read. **Revalidates on every call** — `runtime.reloadConfig()` reloads
- * models.json and recomposes providers (it does NOT touch auth.json itself), and its internal
- * availability refresh re-runs the per-provider auth checks against pi's credential store, which reads
- * auth.json fresh (under a lock) on every access — so a `pi` `/login` (or a terminal `central` re-wire)
- * shows up on the next read without restarting the host. (Accepted micro-risk: refreshing the shared
- * runtime concurrent with a streaming session — the same thing pi's TUI does on `/login`.)
+ * The `provider.status` read. **Revalidates on every call** — `runtime.refresh()` (pi 0.82 folded the
+ * old `reloadConfig()` into it) reloads models.json and recomposes providers (it does NOT touch
+ * auth.json itself), and its availability refresh re-runs the per-provider auth checks against pi's
+ * credential store, which reads auth.json fresh (under a lock) on every access — so a `pi` `/login`
+ * (or a terminal `central` re-wire) shows up on the next read without restarting the host. Called with
+ * no options so `allowNetwork` resolves to the runtime's ambient default — OFF (see `piRuntime`).
+ * (Accepted micro-risk: refreshing the shared runtime concurrent with a streaming session — the same
+ * thing pi's TUI does on `/login`.)
  */
 export async function getProviderStatus(): Promise<ProviderStatusReport> {
 	const runtime = await getPiRuntime();
-	await runtime.reloadConfig();
+	await runtime.refresh();
 
 	const modelProviders = new Map<string, string[]>();
 	for (const model of runtime.getModels()) {

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -38,7 +38,7 @@ if (process.env.THINKRAIL_E2E_FAKE_OAUTH === "1") {
 		},
 	};
 	// An extension provider on the shared runtime: pi keeps extension registrations across
-	// refresh()/reloadConfig() (they're a composed overlay), so no re-register hook is needed.
+	// refresh() (they're a composed overlay), so no re-register hook is needed.
 	(await getPiRuntime()).registerProvider("e2e-oauth", { oauth: fakeOauth });
 
 	// The API-key fake must be a NATIVE provider (pi 0.81 full provider extensions): only `Provider.auth`


### PR DESCRIPTION
## Summary

Upgrades the pinned pi engine from **0.81.1 → 0.82.0** (all three catalog pins: `pi-coding-agent`, `pi-ai`, `pi-agent-core`), audited against the dist `.d.ts` diffs of everything we import.

**The one breaking change that touched us:** `ModelRuntime.reloadConfig()` was removed — 0.82's `refresh()` subsumes it (verified in pi's source: same `models.json` reload + provider recompose + same `allowNetwork ?? modelNetworkEnabled` defaulting). Migrated:

- `auth/providerStatus.ts` (the `provider.status` read) and `auth/jbcentral.ts` (connect/disconnect) now call `refresh()` with no options — `allowNetwork` resolves to the runtime's ambient default, OFF.
- `agent/piRuntime.test.ts`: the old test observed `reloadConfig()`'s internal delegation to `refresh()`, which no longer exists. Re-pinned at the boundary the test actually protects — the network: a blocking `globalThis.fetch` spy proves a no-options `refresh()` performs **zero egress**, with a credentialed provider seeded (refresh skips credential-less providers — the seed is what makes the pin real, and matches the production shape). A `force: true` positive control keeps the spy from rotting vacuous.

**Contracts:** the `PiEvent` mirror gains 0.82's `bash_execution_update` member (union fidelity only — this host never calls `executeBash`; terminals are real PTYs), 0.82 now officially types `auto_retry_end` with exactly the shape our mirror already declared, and all keep-in-sync markers moved to 0.82.0. The type-only/bundle rule was re-verified: pi-ai's exports map is unchanged and the built web bundle contains no `node:fs` / provider SDKs.

**Specs updated alongside** (spec leads code): `packages/contracts/SPEC.md`, `packages/server/src/auth/SPEC.md`, `packages/server/src/agent/SPEC.md`.

**Inherited for free (no code):** OpenRouter + Kimi Code OAuth sign-in appear automatically in the Welcome provider strip (we enumerate providers dynamically); DNS-failure auto-retry; retry waits honoring abort signals; compaction/branch-summary requests on fresh routing session IDs with prompt caching disabled; catalog-freshness mtime fix; protobufjs GHSA-j3f2-48v5-ccww bump; debug/crash logs respecting `PI_CODING_AGENT_DIR` (our isolated e2e agent dirs).

Follow-up (separate PR): adopt 0.82's `constrainedSampling` on our custom tools.

## Related issues

None — proactive engine upgrade.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test` (192/192)
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, 52/52) — **note:** the `@agent`-tagged suite (`e2e:agent`) was *not* run (spends real provider tokens); happy to run it on request before merge
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
