### PR TITLE
fix(binary): restore OAuth sign-in in release binaries + gates to keep it fixed

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -15,8 +15,12 @@ GitHub releases. It owns no product code — only workflows, composite actions, 
 
 ## CI vs release
 
-- **CI** (`ci.yml`, on PRs to `main`): lint+typecheck, unit tests, no-agent e2e, and a **host-target**
-  binary build+smoke. Fast, no provider auth. Gates merges.
+- **CI** (`ci.yml`, on PRs to `main`): lint+typecheck (incl. `check:seams` — the pi binary-seam canary,
+  see `scripts/check-binary-seams.ts`), unit tests, no-agent e2e, and a **host-target** binary
+  build+smoke+**e2e-vs-binary** (`bun run e2e:binary`: the same no-agent suite against the compiled
+  artifact, minus the `@dev-seam` fake-login specs — the regression class that only exists inside the
+  binary; ubuntu only by decision, see `task-artifact-verification`). Fast, no provider auth. Gates
+  merges.
 - **Release** (`nightly.yml` / `stable.yml` → `_release.yml` → `_build.yml`): trusts a green `main` (no
   test gate of its own) and produces published binaries + a GitHub release.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
       - run: bun run check:deps
+      # Canary for the compiled-binary seam: fails when a pi bump introduces a new bundler-opaque
+      # dynamic import that registerBundledRuntime doesn't statically register (see the script header).
+      - run: bun run check:seams
       - run: bun run lint
       - run: bun run typecheck
 
@@ -77,7 +80,7 @@ jobs:
           retention-days: 7
 
   binary:
-    name: Binary smoke
+    name: Binary smoke & e2e
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -92,7 +95,20 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
       # Build the single-file binary for the runner's platform, then boot the artifact and assert it
-      # serves the staged UI + skills and shuts down cleanly — regressions in the extension/asset
-      # bundling only exist inside the compiled binary, so from-source suites can't catch them.
+      # serves the staged UI + skills, completes a real OAuth login up to its auth URL, and shuts down
+      # cleanly — regressions in the extension/asset/provider-flow bundling only exist inside the
+      # compiled binary, so from-source suites can't catch them.
       - run: bun run build:binary
       - run: bun run smoke:binary
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+      # The whole no-agent e2e suite against the artifact (grep-inverts @dev-seam too — the fake login
+      # providers only exist in the dev boot): the broad net for works-from-source/broken-in-the-binary.
+      - run: bun run e2e:binary
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report-binary
+          path: playwright-report-binary/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ apps/cli/src/*.generated.ts
 .env
 .env.local
 .env.*.local
+test-results-binary/
+playwright-report-binary/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bun run check:deps && bun run lint && bun run typecheck
+bun run check:deps && bun run check:seams && bun run lint && bun run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,15 +145,20 @@ pin a default mid-run.) Select suites by marker: `bun run e2e`
 runs the **no-agent** suite (`--grep-invert @agent`) — projects/workspaces/files/editor/changes/terminals,
 fast, no auth, run anytime; `bun run e2e:full` runs everything; `bun run e2e:agent` runs only the
 `@agent` specs (which need `pi` authenticated + more time). There is **no fake agent** — agent coverage
-runs against a real provider.
+runs against a real provider. **`bun run e2e:binary`** (after `bun run build:binary`) runs the no-agent
+suite against the **compiled single-file binary** instead of the dev host (skipping the `@dev-seam`
+fake-login specs — those fakes live only in the dev boot): the gate for the regression class that only
+exists inside the artifact (e.g. pi's dynamic imports resolving from `node_modules`), alongside the
+targeted probes in `smoke:binary`.
 
 Separate from the browser suite: `bun run test:workflows` — the headless **workflow-skill suite**
 (`e2e/workflows/`, own Playwright config, no browser/webServer; drives a real in-process pi agent
 through the workflow skills). On-demand only: needs pi auth and spends real provider tokens — never a
 commit/CI gate. Design: `e2e/workflows/SPEC.md`.
 
-Fast gates (also the husky pre-commit): `bun run check:deps` (dependency pins) + `bun run lint` (biome) +
-`bun run typecheck`. Unit tests:
+Fast gates (also the husky pre-commit): `bun run check:deps` (dependency pins) + `bun run check:seams`
+(the pi binary-seam canary — fails when a pi bump adds a bundler-opaque dynamic import that
+`registerBundledRuntime` doesn't statically register) + `bun run lint` (biome) + `bun run typecheck`. Unit tests:
 `bun run test` (bun test, per package). One-time setup for a fresh machine: `bunx playwright install chromium`.
 
 ## Handoff hygiene (before any commit, PR, or "done" summary)

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -70,11 +70,11 @@ extensions** (which the server path-loads out of `node_modules` in dev — impos
   when the `.ts` is absent:
   - `src/web-assets.generated.ts` — enumerates `apps/web/dist`: a Bun file-attribute import per asset +
     a `{ route, data }[]` manifest + a content-hash version.
-  - `src/bundled-extensions.generated.ts` — **value-imports the four bundled extension entries**
-    (`pi-web-access`, `pi-visualize`, `pi-spec-graph`, `pi-thinkrail-workflow`), resolved from the
+  - `src/bundled-extensions.generated.ts` — **value-imports the five bundled extension entries**
+    (`pi-web-access`, `pi-visualize`, `pi-spec-graph`, `pi-thinkrail-workflow`, `pi-todos`), resolved from the
     *server package's* module context (absolute paths — they aren't deps of `cli`), so Bun compiles the
     raw `.ts` and their real deps (`yaml`, `linkedom`, `unpdf`, …) into the binary; plus the
-    `pi-spec-graph`/`pi-thinkrail-workflow` `skills/` files embedded like web assets (matching what dev
+    `pi-spec-graph`/`pi-thinkrail-workflow`/`pi-todos` `skills/` files embedded like web assets (matching what dev
     wires via `additionalSkillPaths` — parity, not a superset). Its `.d.ts` types the factories via the
     server's exported `BundledExtensionFactory`, so `cli` still never imports
     `@earendil-works/pi-coding-agent`.
@@ -83,8 +83,10 @@ extensions** (which the server path-loads out of `node_modules` in dev — impos
   then a sibling `<dir>.complete` marker written **last** — readiness is gated on the marker, so a killed
   first run leaves an incomplete cache that's re-extracted next launch. **No stage-then-rename**: Bun's
   `renameSync` of a fresh non-empty dir `EPERM`s on Windows, so the marker replaces the directory-rename
-  publish), sets `THINKRAIL_STATIC_DIR`, registers the factories + staged skills dir via
-  the server's **`setBundledExtensions`** seam, then hands off to `index.ts`. (`bun-pty` self-extracts
+  publish), sets `THINKRAIL_STATIC_DIR`, then **awaits** the server's **`registerBundledRuntime`** seam — which
+  injects the factories + staged skills dir **and** performs pi's binary-only registrations (the
+  statically-bundled OAuth flows + the Bedrock provider module, replacing pi's binary-hostile dynamic
+  imports — see the server agent SPEC) — then hands off to `index.ts`. (`bun-pty` self-extracts
   automatically; **no photon wasm** — the agent's read tool is set to send images raw, server-side.
   Skills must be staged to the *real* filesystem: pi reads `SKILL.md` via plain fs and embeds the path in
   the system prompt.)
@@ -94,10 +96,18 @@ extensions** (which the server path-loads out of `node_modules` in dev — impos
   runtime — e.g. path-loading broke silently for every extension added after the binary build first landed.
   `scripts/smoke-binary.ts` (root: `bun run smoke:binary`, after `build:binary`) boots the built binary
   against throwaway data/agent/cache dirs and asserts: `/health` answers, `/` serves the staged UI, the
-  bundled skills staged to the cache dir, and SIGTERM exits 0. CI builds + smokes the binary on every PR
+  bundled skills staged to the cache dir, **an OAuth sign-in reaches its auth URL** (a WS
+  `provider.loginStart` for the Codex provider must answer the method select and push an `authUrl`
+  frame — offline and credential-free, since pi's flow only does PKCE + a local callback server before
+  notifying the URL; this pins the statically-registered OAuth flows, which can only break inside the
+  artifact — the frames are hand-rolled JSON, keeping `contracts` out of the cli), and SIGTERM exits 0. CI builds + smokes the binary on every PR
   (its host target — the generation/bundling/staging logic is platform-independent). What it can't cover
   without provider auth: the factories registering inside a live session (that's `e2e:agent` territory,
-  run-from-source).
+  run-from-source). The smoke's **broad-net sibling** is `bun run e2e:binary` (root
+  `playwright.binary.config.ts`): the whole no-agent e2e suite executed against this binary — also in CI
+  on every PR. And `bun run check:seams` (root `scripts/check-binary-seams.ts`) is the build-time canary
+  for the seam class: it fails when a pi bump introduces a new bundler-opaque dynamic import the server's
+  `registerBundledRuntime` doesn't statically register.
 
 ## Boundary
 
@@ -107,7 +117,7 @@ extensions** (which the server path-loads out of `node_modules` in dev — impos
   `src/web-assets.generated.*`, `src/bundled-extensions.generated.*`), `src/version.ts` (the release
   version stamped in at build time), `src/update.ts` (the `update` subcommand), and `src/jbcentral.ts` (the
   `jbcentral` subcommand — JetBrains Central CLI proxy wiring).
-- **Allowed deps:** `@thinkrail/server` (`createServer`, `setBundledExtensions`),
+- **Allowed deps:** `@thinkrail/server` (`createServer`, `registerBundledRuntime`),
   `@thinkrail/shared/shellEnv` (`resolveShellEnv`), Bun/Node; the generated build module may
   value-import the bundled extension packages' entries (resolved via the server package — build-time
   only, deleted after compile).

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -98,6 +98,81 @@ function rpc(socket: WebSocket, method: string, params: unknown): Promise<unknow
 	});
 }
 
+/**
+ * Drive a real OAuth sign-in far enough to prove the flow module is inside the binary: start a Codex
+ * OAuth login, answer the login-method select over the push channel, and require the `authUrl` frame.
+ * This pins the seam that statically registers pi's OAuth flows (`registerBundledRuntime`) — pi
+ * otherwise loads them through bundler-opaque dynamic imports that resolve from `node_modules`, so
+ * **only the compiled artifact** can regress here (every OAuth sign-in dies with `Cannot find module
+ * './openai-codex.js'`). Offline + credential-free: pi's flow does PKCE + a local callback server
+ * before notifying the URL, and the login is cancelled right after. Frames are hand-rolled JSON — the
+ * cli module doesn't import `contracts` (its boundary); the shapes are pinned by the host's wire tests.
+ */
+async function assertOAuthLoginReachesAuthUrl(socket: WebSocket): Promise<void> {
+	let loginId: string | undefined;
+	const authUrl = new Promise<string>((resolve, reject) => {
+		const settle = (fn: () => void) => {
+			socket.removeEventListener("message", onPush);
+			fn();
+		};
+		const onPush = (event: MessageEvent) => {
+			if (typeof event.data !== "string") return;
+			const message = JSON.parse(event.data) as {
+				channel?: string;
+				data?: {
+					loginId?: string;
+					frame?: {
+						kind: string;
+						url?: string;
+						message?: string;
+						options?: { id: string; label: string }[];
+					};
+				};
+			};
+			if (message.channel !== "provider.login" || !message.data?.frame) return;
+			const { loginId: pushLoginId, frame } = message.data;
+			switch (frame.kind) {
+				case "select": {
+					// The Codex flow first asks browser-vs-device-code; pick the browser method (no network).
+					const browser = frame.options?.find((o) => /browser/i.test(`${o.id} ${o.label}`));
+					const optionId = browser?.id ?? frame.options?.[0]?.id;
+					if (!optionId || !pushLoginId) {
+						return settle(() =>
+							reject(new Error(`unanswerable select frame: ${JSON.stringify(frame)}`)),
+						);
+					}
+					rpc(socket, "provider.loginReply", { loginId: pushLoginId, value: optionId }).catch(
+						(err) => settle(() => reject(err instanceof Error ? err : new Error(String(err)))),
+					);
+					return;
+				}
+				case "authUrl":
+					return settle(() => resolve(frame.url ?? ""));
+				case "error":
+					// Pre-registration this is exactly "ResolveMessage: Cannot find module './openai-codex.js'".
+					return settle(() => reject(new Error(`login flow failed: ${frame.message}`)));
+				default:
+					return; // progress etc. — keep waiting
+			}
+		};
+		socket.addEventListener("message", onPush);
+		rpc(socket, "provider.loginStart", { providerId: "openai-codex" }).then(
+			(result) => {
+				loginId = (result as { loginId?: string }).loginId;
+			},
+			(err) => settle(() => reject(err instanceof Error ? err : new Error(String(err)))),
+		);
+	});
+
+	try {
+		const reached = await within(authUrl, 30_000, "Codex OAuth login did not reach its auth URL");
+		if (!reached.includes("auth.openai.com")) fail(`unexpected auth URL: ${reached}`);
+	} finally {
+		// Best-effort: unblocks pi's parked manual-code prompt; host shutdown cancels any stragglers.
+		if (loginId !== undefined) rpc(socket, "provider.loginCancel", { loginId }).catch(() => {});
+	}
+}
+
 /** The URL from the CLI's `thinkrail → http://…` line (it may scan past a busy port). */
 async function readServedUrl(): Promise<string> {
 	const decoder = new TextDecoder();
@@ -177,6 +252,10 @@ try {
 		fail("compiled skill.list did not load bundled workflow skills");
 	}
 
+	// A real OAuth sign-in must reach its auth URL — pi's statically-registered flows working inside
+	// the artifact (registerBundledRuntime), reusing the live RPC socket for the push-channel frames.
+	await assertOAuthLoginReachesAuthUrl(rpcSocket);
+
 	// The bundled extensions' skills must be staged to the real filesystem (pi reads SKILL.md via fs).
 	// Full inventory — pi-spec-graph's skill + the whole pi-thinkrail-workflow family (keep in sync with
 	// the family table in packages/pi-thinkrail-workflow/skills/SPEC.md). `choosing-a-workflow` matters
@@ -210,7 +289,7 @@ try {
 	}
 
 	console.log(
-		`smoke OK: ${binary} booted at ${url}, served the UI + staged skills, exited cleanly.`,
+		`smoke OK: ${binary} booted at ${url}, served the UI + staged skills + portable alias, OAuth reached its auth URL, exited cleanly.`,
 	);
 } catch (err) {
 	proc.kill("SIGKILL");

--- a/apps/cli/src/bundled-extensions.generated.d.ts
+++ b/apps/cli/src/bundled-extensions.generated.d.ts
@@ -5,7 +5,7 @@
 
 import type { BundledExtensionFactory } from "@thinkrail/server";
 
-/** The four bundled pi extensions' default-export factories, value-imported, in load order. */
+/** The bundled pi extensions' default-export factories, value-imported, in load order. */
 export declare const bundledExtensionFactories: BundledExtensionFactory[];
 
 export interface EmbeddedSkillFile {

--- a/apps/cli/src/compiled-entry.ts
+++ b/apps/cli/src/compiled-entry.ts
@@ -4,9 +4,10 @@
 // binary are the web UI (a directory of files) and the bundled pi extensions' skills (pi reads SKILL.md
 // via plain fs). So we embed both (`web-assets.generated`, `bundled-extensions.generated`) and, on
 // startup, stage them to per-build cache dirs, point the host at them (`THINKRAIL_STATIC_DIR` + the
-// server's `setBundledExtensions` seam — which also injects the extensions themselves as value-imported
-// factories, since a binary has no `node_modules` to path-load them from), then hand off to the normal
-// bootstrap (`index.ts`).
+// server's `registerBundledRuntime` seam — which also injects the extensions themselves as value-imported
+// factories, since a binary has no `node_modules` to path-load them from, and registers pi's statically-
+// bundled provider flows: OAuth sign-in + Bedrock reach Node-only code through dynamic imports a compiled
+// binary can't resolve), then hand off to the normal bootstrap (`index.ts`).
 //
 // Run-from-source uses `index.ts` directly and never touches this file. (Image-read needs no photon wasm
 // here: the agent's read tool is configured to send images raw — see server `buildSessionSettings`.)
@@ -63,6 +64,6 @@ const staticDir = await stage("web", webAssetsVersion, embeddedWebAssets);
 const skillsDir = await stage("skills", bundledSkillsVersion, embeddedSkillFiles);
 // Respect an explicit override (e.g. pointing at a dev build); otherwise serve the staged UI.
 process.env.THINKRAIL_STATIC_DIR ??= staticDir;
-const { setBundledExtensions } = await import("@thinkrail/server");
-setBundledExtensions({ factories: bundledExtensionFactories, skillsDir });
+const { registerBundledRuntime } = await import("@thinkrail/server");
+await registerBundledRuntime({ factories: bundledExtensionFactories, skillsDir });
 await import("./index");

--- a/e2e/fixtures/paths.ts
+++ b/e2e/fixtures/paths.ts
@@ -11,6 +11,14 @@ export const E2E_HOME_DIR = join(E2E_DATA_DIR, "home");
 export const E2E_FIXTURE_REPO = join(E2E_DATA_DIR, "sample-project");
 
 /**
+ * The compiled binary's cache root (`XDG_CACHE_HOME`) for the `e2e:binary` suite, so its web/skills
+ * staging never touches the machine's real cache. Deliberately OUTSIDE `E2E_DATA_DIR`: staging happens
+ * at server boot, and this must not depend on the wipe-then-seed order between global setup and the
+ * webServer launch. Removed in global teardown instead, so every run still stages fresh.
+ */
+export const E2E_BINARY_CACHE = join(tmpdir(), "thinkrail-e2e-binary-cache");
+
+/**
  * A dev/e2e control file the stubbed directory picker (`THINKRAIL_PICK_DIR`) points at: `selectDirectory`
  * returns the path written here, re-read per call. Global setup seeds it with `E2E_FIXTURE_REPO`; a test
  * can rewrite it to hand the picker a different folder without restarting the shared host. Safe only

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,9 +1,11 @@
 import { rmSync } from "node:fs";
-import { E2E_DATA_DIR } from "./fixtures/paths";
+import { E2E_BINARY_CACHE, E2E_DATA_DIR } from "./fixtures/paths";
 
-/** Remove the isolated state/fixtures dir after the suite — leave nothing behind. */
+/** Remove the isolated state/fixtures dirs after the suite — leave nothing behind. (The binary cache
+ * only exists after an `e2e:binary` run; wiping it here is what keeps that suite's staging fresh.) */
 export default function globalTeardown(): void {
 	// Playwright tears the webServer down alongside global teardown; retry ENOTEMPTY if the host finishes a
 	// final isolated-state write while `rmSync` is walking the tree.
 	rmSync(E2E_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+	rmSync(E2E_BINARY_CACHE, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 }

--- a/e2e/live-refresh.spec.ts
+++ b/e2e/live-refresh.spec.ts
@@ -5,6 +5,13 @@ import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// For assertions at the end of the fs-PROPAGATION chain (fs.watch → ≤ 1s debounce → WS push → panel
+// re-read → render): the default 5s window was observed flaking under full-suite load on macOS — where
+// recursive fs.watch rides FSEvents, whose delivery latency spikes under load — most readily against
+// the compiled binary (`e2e:binary`). A LOST frame still fails at 10s, so real notifier bugs stay
+// visible; only late delivery is absorbed. Mount-driven reads keep the ordinary `expect`.
+const fsExpect = expect.configure({ timeout: 10_000 });
+
 // Live refresh: the host watches the active worktree (recursive fs.watch → a debounced
 // `workspace.fsChanged` push) and the panels silently re-read — so files/specs/git changes made
 // OUTSIDE the app (Finder, a terminal, the agent) appear with no manual refresh anywhere. The watcher
@@ -23,16 +30,18 @@ test("worktree changes on disk appear live in Specs, All files, Changes, and an 
 		join(worktree, "module-live", "SPEC.md"),
 		"---\nid: sample-live\ntype: module-design\ntitle: Live Module\nparent: sample-root\n---\n\n## Responsibility\n\nWritten on disk mid-session by the e2e suite.\n",
 	);
-	await expect(page.locator('[data-testid="spec-node"][data-spec-id="sample-live"]')).toBeVisible();
+	await fsExpect(
+		page.locator('[data-testid="spec-node"][data-spec-id="sample-live"]'),
+	).toBeVisible();
 
 	// --- All files: an added file appears; a deleted one drops out.
 	await page.getByTestId("tab-files").click();
 	const freshFile = page.getByTestId("file-node").filter({ hasText: "fresh-file.txt" });
 	await expect(page.getByTestId("file-node").filter({ hasText: "README.md" })).toBeVisible();
 	writeFileSync(join(worktree, "fresh-file.txt"), "hello\n");
-	await expect(freshFile).toBeVisible();
+	await fsExpect(freshFile).toBeVisible();
 	rmSync(join(worktree, "fresh-file.txt"));
-	await expect(freshFile).toHaveCount(0);
+	await fsExpect(freshFile).toHaveCount(0);
 
 	// --- Changes: a tracked-file edit surfaces while the tab is open, and the open Monaco diff tab
 	// follows further edits (DiffPane re-reads both sides on the workspace's fs tick).
@@ -43,11 +52,11 @@ test("worktree changes on disk appear live in Specs, All files, Changes, and an 
 	).toBeVisible();
 	await expect(readmeRow).toHaveCount(0);
 	writeFileSync(join(worktree, "README.md"), "# sample-project\n\nedited live by e2e\n");
-	await expect(readmeRow).toHaveAttribute("data-status", "modified");
+	await fsExpect(readmeRow).toHaveAttribute("data-status", "modified");
 	await readmeRow.click();
 	await expect(page.getByTestId("diff-pane")).toContainText("edited live by e2e");
 	writeFileSync(join(worktree, "README.md"), "# sample-project\n\nedited twice by e2e\n");
-	await expect(page.getByTestId("diff-pane")).toContainText("edited twice by e2e");
+	await fsExpect(page.getByTestId("diff-pane")).toContainText("edited twice by e2e");
 
 	// --- Open file tab: the visible tab's content follows the disk (the viewer is read-only, so a
 	// silent swap is conflict-free).
@@ -55,8 +64,8 @@ test("worktree changes on disk appear live in Specs, All files, Changes, and an 
 	await page.getByTestId("file-node").filter({ hasText: "README.md" }).dblclick();
 	await expect(page.getByTestId("editor-pane")).toContainText("edited twice by e2e");
 	writeFileSync(join(worktree, "README.md"), "# sample-project\n\nlive tab reload\n");
-	await expect(page.getByTestId("editor-pane")).toContainText("live tab reload");
-	await expect(page.getByTestId("editor-pane")).not.toContainText("edited twice by e2e");
+	await fsExpect(page.getByTestId("editor-pane")).toContainText("live tab reload");
+	await fsExpect(page.getByTestId("editor-pane")).not.toContainText("edited twice by e2e");
 });
 
 // Performance canary: live refresh must never turn a write storm into a message/refetch storm. The

--- a/e2e/provider-apikey.spec.ts
+++ b/e2e/provider-apikey.spec.ts
@@ -2,7 +2,9 @@ import { expect, test } from "@playwright/test";
 import { openAppFresh } from "./fixtures/app";
 
 // The in-app API-key setup flow (issue #97), driven against a **fake native pi provider**
-// (`e2e-apikey`, registered in dev.ts behind THINKRAIL_E2E_FAKE_OAUTH). API-key entry rides the SAME
+// (`e2e-apikey`, registered in dev.ts behind THINKRAIL_E2E_FAKE_OAUTH). Tagged @dev-seam: the fakes
+// only exist in the dev boot (dev.ts never ships), so the binary suite (`e2e:binary`) grep-inverts
+// these specs. API-key entry rides the SAME
 // session-less login bridge as OAuth — provider.loginStart {type:"api_key"} (detached) → the
 // provider-owned secret prompt as a frame on `provider.login` → the dialog's masked input → loginReply →
 // pi persists to auth.json → success → status re-read — no inline key field, no provider-specific code.
@@ -11,9 +13,9 @@ const APIKEY_BTN = '[data-testid="provider-apikey"][data-provider="e2e-apikey"]'
 const CONFIGURED =
 	'[data-testid="provider-row"][data-provider="e2e-apikey"][data-configured="true"]';
 
-test("configures a provider by API key through the login dialog (secret prompt → success)", async ({
-	page,
-}) => {
+test("configures a provider by API key through the login dialog (secret prompt → success)", {
+	tag: "@dev-seam",
+}, async ({ page }) => {
 	await openAppFresh(page);
 	await page.getByTestId("open-settings").click();
 	await expect(page.getByTestId("settings-providers")).toBeVisible();
@@ -49,9 +51,9 @@ test("configures a provider by API key through the login dialog (secret prompt �
 	await expect(page.locator(APIKEY_BTN)).toBeVisible();
 });
 
-test("the OAuth-only fake offers no API-key entry (flags derive from Provider.auth alone)", async ({
-	page,
-}) => {
+test("the OAuth-only fake offers no API-key entry (flags derive from Provider.auth alone)", {
+	tag: "@dev-seam",
+}, async ({ page }) => {
 	await openAppFresh(page);
 	await page.getByTestId("open-settings").click();
 	await expect(page.getByTestId("settings-providers")).toBeVisible();

--- a/e2e/provider-login.spec.ts
+++ b/e2e/provider-login.spec.ts
@@ -2,7 +2,10 @@ import { expect, test } from "@playwright/test";
 import { openAppFresh } from "./fixtures/app";
 
 // The in-app OAuth login flow, driven against a **fake pi OAuth provider** (`e2e-oauth`, registered in
-// dev.ts behind THINKRAIL_E2E_FAKE_OAUTH). This exercises the whole session-less login bridge end-to-end —
+// dev.ts behind THINKRAIL_E2E_FAKE_OAUTH). Tagged @dev-seam: the fake only exists in the dev boot
+// (dev.ts never ships), so the binary suite (`e2e:binary`) grep-inverts these — the artifact's login
+// path is covered by smoke-binary's real-provider probe instead.
+// This exercises the whole session-less login bridge end-to-end —
 // provider.loginStart (detached) → frames on the `provider.login` channel → the accumulating dialog → a
 // loginReply per select/prompt → success → status re-read — with no real provider or browser.
 
@@ -10,9 +13,9 @@ const SIGNIN = '[data-testid="provider-signin"][data-provider="e2e-oauth"]';
 const CONFIGURED =
 	'[data-testid="provider-row"][data-provider="e2e-oauth"][data-configured="true"]';
 
-test("signs in through the OAuth dialog (select → open-URL + paste → success), then signs out", async ({
-	page,
-}) => {
+test("signs in through the OAuth dialog (select → open-URL + paste → success), then signs out", {
+	tag: "@dev-seam",
+}, async ({ page }) => {
 	await openAppFresh(page);
 	await page.getByTestId("open-settings").click();
 	await expect(page.getByTestId("settings-providers")).toBeVisible();
@@ -48,9 +51,9 @@ test("signs in through the OAuth dialog (select → open-URL + paste → success
 	await expect(page.locator(CONFIGURED)).toHaveCount(0);
 });
 
-test("cancelling the OAuth dialog aborts the login and leaves the provider unconfigured", async ({
-	page,
-}) => {
+test("cancelling the OAuth dialog aborts the login and leaves the provider unconfigured", {
+	tag: "@dev-seam",
+}, async ({ page }) => {
 	await openAppFresh(page);
 	await page.getByTestId("open-settings").click();
 	await expect(page.getByTestId("settings-providers")).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"format": "biome check --write .",
 		"prepare": "husky",
 		"e2e": "playwright test --grep-invert @agent",
+		"e2e:binary": "playwright test -c playwright.binary.config.ts",
 		"test:workflows": "playwright test -c playwright.workflows.config.ts",
 		"e2e:full": "playwright test",
 		"e2e:full:headed": "playwright test --headed",
@@ -38,7 +39,8 @@
 		"e2e:agent:headed": "playwright test --grep @agent --headed",
 		"e2e:headed": "playwright test --headed",
 		"e2e:ui": "playwright test --ui",
-		"check:deps": "bun scripts/check-catalog.ts"
+		"check:deps": "bun scripts/check-catalog.ts",
+		"check:seams": "bun scripts/check-binary-seams.ts"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.0",

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -22,9 +22,11 @@ and runs the `pi` agent in-process via `createAgentSession`. Launched in-process
 - **Public surface:** `createServer(options) → RunningServer` (`{ port, stop }`) and `bootHost(options)
   → BootedHost` (the process-boot wrapper: resolves the login-shell PATH, picks the port per `portMode`,
   and installs SIGINT/SIGTERM graceful-shutdown handlers around `createServer`), both re-exported from
-  `host/`; plus `setBundledExtensions` (+ its types, re-exported from `agent/`) — the compiled-binary
+  `host/`; plus `registerBundledRuntime` (+ its types, re-exported from `agent/`) — the compiled-binary
   seam by which a launcher that cannot path-load the bundled pi extensions (no `node_modules` inside a
-  `bun build --compile` binary) injects them as value-imported factories + a staged skills dir. The
+  `bun build --compile` binary) injects them as value-imported factories + a staged skills dir, and
+  which registers pi's statically-bundled provider flows (the OAuth flows + the Bedrock module) that pi
+  otherwise reaches through binary-hostile variable-specifier dynamic imports (see the agent SPEC). The
   package also exposes the **`@thinkrail/server/agent` subpath export** (the `agent` barrel): the
   server-side session surface for the **headless workflow-test harness** (`e2e/workflows/`), which
   drives real in-process sessions through the production wiring without booting the HTTP host — a
@@ -59,7 +61,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `assist` | ad-hoc one-shot tasks (workspace naming, …) on a cheap model, best-effort | [assist/SPEC.md](src/assist/SPEC.md) |
 | `dialog` | the host's native folder picker | [dialog/SPEC.md](src/dialog/SPEC.md) |
 
-`src/index.ts` re-exports `host` + the `agent` barrel's `setBundledExtensions` seam; `src/dev.ts` boots
+`src/index.ts` re-exports `host` + the `agent` barrel's `registerBundledRuntime` seam; `src/dev.ts` boots
 the host from env via `bootHost` for dev/e2e.
 
 ## Internal dependency graph

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -138,10 +138,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     unit-tested against `SessionManager.inMemory`.
   - `extensions` — Pi resource wiring. `buildResourceLoader(cwd, settingsManager, getAdmission)` starts
     with a `DefaultResourceLoader` (Pi's normal settings/package + `.pi` / `.agents` discovery), adds
-    automatic **portable cross-agent skill aliases**, then loads the four bundled extensions — **`pi-web-access`**
+    automatic **portable cross-agent skill aliases**, then loads the five bundled extensions — **`pi-web-access`**
     (`web_search` + `fetch_content`), **`pi-visualize`** (`visualize`), **`pi-spec-graph`** (the `spec_*`
-    tools + its `before_agent_start` rule), and **`pi-thinkrail-workflow`** (the workflow-router rule +
-    workflow skills). Existing personal aliases are Claude
+    tools + its `before_agent_start` rule), **`pi-thinkrail-workflow`** (the workflow-router rule +
+    workflow skills), and **`pi-todos`** (the `todo_*` tools + its skill). Existing personal aliases are Claude
     (`${CLAUDE_CONFIG_DIR:-~/.claude}/skills`), Codex (`${CODEX_HOME:-~/.codex}/skills`), Copilot
     (`~/.copilot/skills`), and Gemini (`${GEMINI_CLI_HOME:-~}/.gemini/skills`), **plus each installed Claude
     plugin's `skills/` dir** (read from `~/.claude/plugins/installed_plugins.json` — the resolved `installPath`,
@@ -182,13 +182,24 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
       entries (pi's loader jiti-loads them — no value-import into our typecheck graph), resolved
       **lazily on first use** (never at module load: the resolve requires `node_modules`, which a
       compiled binary lacks). The workspace packages' `pi.skills` manifests aren't auto-discovered for
-      file-path entries — their `skills/` dirs (`pi-spec-graph`, `pi-thinkrail-workflow`) are wired via
-      **`additionalSkillPaths`**.
-    - **Compiled binary:** the launcher calls the **`setBundledExtensions({ factories, skillsDir })`
-      seam** before the first session — the same four extensions as **value-imported default-export
+      file-path entries — their `skills/` dirs (`pi-spec-graph`, `pi-thinkrail-workflow`, `pi-todos`) are
+      wired via **`additionalSkillPaths`**.
+    - **Compiled binary:** the launcher awaits the **`registerBundledRuntime({ factories, skillsDir })`
+      seam** before the first session — the same bundled extensions as **value-imported default-export
       factories** (pi gives `extensionFactories` full API parity with path loading; what's lost —
-      file-relative `baseDir`, per-reload re-evaluation — none of the four use) plus a staged on-disk
-      skills dir (pi reads `SKILL.md` via plain fs, so skills must live on the real filesystem).
+      file-relative `baseDir`, per-reload re-evaluation — none of them use) plus a staged on-disk
+      skills dir (pi reads `SKILL.md` via plain fs, so skills must live on the real filesystem). The
+      seam also performs the **binary-only pi registrations**: pi hides Node-only provider code behind
+      bundler-opaque variable-specifier dynamic imports (so browser bundles can't reach `node:http`
+      OAuth servers / the AWS SDK), which a single-file binary can't resolve at runtime — every OAuth
+      sign-in died with `Cannot find module './openai-codex.js'`. pi ships static registration seams
+      for exactly this, and we mirror pi's own binary entry (`pi-coding-agent` `dist/bun/cli.js`):
+      **`registerBunOAuthFlows()`** (`@earendil-works/pi-ai/bun-oauth`) + **`setBedrockProviderModule(
+      bedrockProviderModule)`** (`…/compat` + `…/bedrock-provider`). Both load via **dynamic literal
+      imports inside the seam** — literal specifiers are statically bundled by `bun build --compile`,
+      while dev (which never calls the seam) never loads the flow modules or the AWS SDK. Registration
+      lands in the same `pi-ai` instance pi consults at login time because the catalog pins one exact
+      `pi-ai` version repo-wide (one store entry → one bundled module instance).
     Both modes append `extensionFactories`: a **headless-search policy** (a `tool_call` hook defaulting
     `web_search`'s `workflow` to `"none"`, since pi-web-access would otherwise open a browser curator our
     `rpc` host can't render) **and** `askUserQuestionExtension` (registers the `ask_user_question` tool).
@@ -204,11 +215,12 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count);
   `reloadSessionResources(sessionId)` (active-chat reload); the **`setSkillAdmissionResolver`** seam (host
   wires `workspaceId` → the admission context);
-  the compiled-binary extension seam (`setBundledExtensions` +
+  the compiled-binary seam (`registerBundledRuntime` +
   `BundledExtensions`/`BundledExtensionFactory`).
 - **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (types + test
-  fixtures — dispatch goes through the shared `ModelRuntime`); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
-  `pi-thinkrail-workflow` (the bundled extensions — loaded by path, never value-imported here; the
+  fixtures — dispatch goes through the shared `ModelRuntime` — plus the `/bun-oauth` + `/bedrock-provider`
+  + `/compat` subpaths, value-imported **only** inside `registerBundledRuntime`'s dynamic imports); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
+  `pi-thinkrail-workflow` + `pi-todos` (the bundled extensions — loaded by path, never value-imported here; the
   compiled binary's value-imports live in `apps/cli`'s generated build module); `typebox` (the
   `ask_user_question` parameter schema);
   `contracts` (`PiEvent`/`Model`/`ThinkingLevel`/`ImageContent`/`SessionStats`/`SlashCommandInfo`/`ExtUi*`/

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -11,8 +11,9 @@
 //   `skills/` dirs, before the personal/project aliases so bundled skills outrank them (precedence in
 //   `resolveSkillInputs`).
 // - Compiled binary: the launcher injects the same five extensions as value-imported factories + a staged
-//   on-disk skills dir via `setBundledExtensions` (pi gives `extensionFactories` full API parity with
-//   path loading; pi reads skills via plain fs, so they must live on the real filesystem).
+//   on-disk skills dir via `registerBundledRuntime` (pi gives `extensionFactories` full API parity with
+//   path loading; pi reads skills via plain fs, so they must live on the real filesystem) — which also
+//   performs pi's binary-only provider registrations (OAuth flows + Bedrock, see below).
 
 import { createRequire } from "node:module";
 import { dirname, join, resolve, sep } from "node:path";
@@ -51,14 +52,30 @@ let bundled: BundledExtensions | undefined;
 /**
  * Compiled-binary seam: inject the bundled extensions as value-imported factories (+ a staged skills
  * dir) where path-loading is impossible — a `bun build --compile` binary has no `node_modules` to
- * resolve the extension entries or their deps from. Call before the first session is created.
+ * resolve the extension entries or their deps from — and perform pi's **binary-only registrations**.
+ * pi hides Node-only provider code behind bundler-opaque variable-specifier dynamic imports (so
+ * browser bundles can't reach its `node:http` OAuth servers / the AWS SDK); inside a single-file
+ * binary those imports can't resolve at runtime, so every OAuth sign-in died with `Cannot find module
+ * './openai-codex.js'` (and Bedrock streaming would die the same way). pi ships static registration
+ * seams for exactly this — mirror pi's own binary entry (`pi-coding-agent` `dist/bun/cli.js`): the
+ * bundled OAuth flows + the Bedrock provider module. The dynamic literal imports below are statically
+ * bundled by `bun build --compile`; dev never calls this seam, so it never loads the flow modules or
+ * the AWS SDK. Await before the first session or login can start.
  */
-export function setBundledExtensions(extensions: BundledExtensions): void {
+export async function registerBundledRuntime(extensions: BundledExtensions): Promise<void> {
 	bundled = extensions;
+	const [{ registerBunOAuthFlows }, { bedrockProviderModule }, { setBedrockProviderModule }] =
+		await Promise.all([
+			import("@earendil-works/pi-ai/bun-oauth"),
+			import("@earendil-works/pi-ai/bedrock-provider"),
+			import("@earendil-works/pi-ai/compat"),
+		]);
+	registerBunOAuthFlows();
+	setBedrockProviderModule(bedrockProviderModule);
 }
 
 /**
- * The run-from-source wiring: the four extension entries + the workspace packages' skills dirs, resolved
+ * The run-from-source wiring: the bundled extension entries + the workspace packages' skills dirs, resolved
  * out of `node_modules` on first use (memoized — module-load resolution would crash a compiled binary).
  */
 let devPaths: { extensionPaths: string[]; skillPaths: string[] } | undefined;

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -8,7 +8,7 @@ export {
 	listProjectAliasSkillNames,
 	listSkillCatalog,
 	listSkillCommands,
-	setBundledExtensions,
+	registerBundledRuntime,
 } from "./extensions";
 export * from "./oneshot";
 export * from "./piRuntime";

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,6 @@
 export {
 	type BundledExtensionFactory,
 	type BundledExtensions,
-	setBundledExtensions,
+	registerBundledRuntime,
 } from "./agent";
 export * from "./host";

--- a/playwright.binary.config.ts
+++ b/playwright.binary.config.ts
@@ -1,0 +1,88 @@
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+import {
+	E2E_BINARY_CACHE,
+	E2E_CENTRAL_STATE,
+	E2E_DATA_DIR,
+	E2E_HOME_DIR,
+	E2E_PI_AGENT_DIR,
+	E2E_PICK_DIR_POINTER,
+} from "./e2e/fixtures/paths";
+
+// The e2e suite run against the COMPILED single-file binary instead of the dev host (`bun run
+// e2e:binary`, after `bun run build:binary`). Same tests, same fixtures/global-setup — only the
+// webServer differs — so the whole behavioral surface (terminals/PTY, git, editor, embedded-asset
+// serving, staging, WS) executes inside the artifact users actually install. This is the broad net for
+// the regression class that run-from-source suites can never see (see `registerBundledRuntime` in the
+// server agent SPEC — e.g. pi's OAuth flows resolving only from `node_modules`); the *targeted* probes
+// for known compiled-binary seams live in `apps/cli/scripts/smoke-binary.ts`.
+//
+// Excluded here: `@agent` (needs provider auth — never in CI) and `@dev-seam` (the fake login
+// providers are registered by `packages/server/src/dev.ts`, which deliberately never ships — the
+// artifact's login path is covered by smoke-binary's real-provider probe instead).
+//
+// Not concurrent-safe with `bun run e2e` (both own E2E_DATA_DIR); run them sequentially. Unix-only for
+// now, like the main config's PATH stub wiring (`:` separator, `#!/bin/sh` central stub).
+
+const rootDir = fileURLToPath(new URL(".", import.meta.url));
+const binary =
+	process.env.THINKRAIL_E2E_BINARY ??
+	fileURLToPath(new URL("./apps/cli/dist/thinkrail", import.meta.url));
+if (!existsSync(binary)) {
+	throw new Error(`binary not found at ${binary} — run \`bun run build:binary\` first.`);
+}
+const PORT = 24272; // dev 24242 · e2e 24252 · smoke 24262 · e2e:binary 24272 — never collide
+const fakeBinDir = fileURLToPath(new URL("./e2e/fixtures/bin", import.meta.url));
+
+export default defineConfig({
+	testDir: "./e2e",
+	testIgnore: "workflows/**",
+	grepInvert: /@agent|@dev-seam/,
+	// Serial: the suite shares one stateful host (one DATA_DIR), so tests must not race on persistence.
+	fullyParallel: false,
+	workers: 1,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	timeout: 30_000,
+	reporter: process.env.CI
+		? [["github"], ["html", { open: "never", outputFolder: "playwright-report-binary" }]]
+		: "list",
+	outputDir: "test-results-binary",
+	globalSetup: "./e2e/global-setup.ts",
+	globalTeardown: "./e2e/global-teardown.ts",
+	use: {
+		baseURL: `http://localhost:${PORT}`,
+		trace: "on-first-retry",
+	},
+	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+	// The artifact under test IS the server: no THINKRAIL_STATIC_DIR (the embedded web assets are part
+	// of what's verified) and an isolated cache root so the binary's staging path runs against a dir the
+	// teardown wiped last run. Every other seam is the same as the dev-host config — all of them are
+	// honored by production code (`THINKRAIL_PICK_DIR`, `THINKRAIL_GH_OFFLINE`) or ride PATH/env
+	// (stub `central`, `PI_OFFLINE`), which is what makes the suite boot-agnostic.
+	webServer: {
+		command: `"${binary}" --no-open`,
+		cwd: rootDir,
+		url: `http://localhost:${PORT}/health`,
+		reuseExistingServer: false,
+		timeout: 120_000,
+		env: {
+			THINKRAIL_PORT: String(PORT),
+			THINKRAIL_DATA_DIR: E2E_DATA_DIR,
+			XDG_CACHE_HOME: E2E_BINARY_CACHE,
+			THINKRAIL_PICK_DIR: E2E_PICK_DIR_POINTER,
+			THINKRAIL_GH_OFFLINE: "1",
+			// Keep cross-agent personal skill aliases away from the developer's real homes/overrides.
+			HOME: E2E_HOME_DIR,
+			CLAUDE_CONFIG_DIR: `${E2E_HOME_DIR}/.claude`,
+			CODEX_HOME: `${E2E_HOME_DIR}/.codex`,
+			GEMINI_CLI_HOME: E2E_HOME_DIR,
+			PI_CODING_AGENT_DIR: E2E_PI_AGENT_DIR,
+			PI_OFFLINE: "1",
+			PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+			WIRE_PROXY_PORT: "19516",
+			CENTRAL_STUB_STATE: E2E_CENTRAL_STATE,
+		},
+	},
+});

--- a/scripts/check-binary-seams.ts
+++ b/scripts/check-binary-seams.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+// Canary for the compiled-binary seam (`registerBundledRuntime`, packages/server/src/agent/extensions.ts).
+//
+// pi deliberately hides Node-only provider code behind **bundler-opaque dynamic imports** (variable
+// specifiers) so browser bundles can't follow them — but `bun build --compile` can't follow them either,
+// and a single-file binary has no `node_modules` to resolve them from at runtime. That's how OAuth
+// sign-in shipped broken (`Cannot find module './openai-codex.js' from '/$bunfs/...'`): the seam only
+// fails inside the artifact, where no from-source suite can see it.
+//
+// This gate catches the *next* one at the cheapest possible point — the pi version bump itself: scan the
+// pinned pi packages' `dist` for non-literal `import(...)` and require the findings to match the
+// allowlist below **exactly**.
+//   - A NEW match fails: verify it (register a static seam in `registerBundledRuntime`, or confirm it
+//     only imports `node:` builtins, which a compiled binary resolves at runtime), then allowlist it
+//     with that justification.
+//   - A STALE entry also fails: pi moved/removed the file — re-verify the seam still covers the
+//     replacement, then update the entry. Both directions keep the list honest.
+//
+// Scope: `@earendil-works/pi-coding-agent` + its `@earendil-works/*` dependencies, resolved from the
+// server package's module context — exactly the instances the binary bundles.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+
+/** Known bundler-opaque dynamic imports, each verified handled-or-safe (see header for the protocol). */
+const ALLOWLIST: Record<string, string> = {
+	"pi-ai/dist/auth/oauth/load.js":
+		"handled — registerBunOAuthFlows() registered in registerBundledRuntime",
+	"pi-ai/dist/api/bedrock-converse-stream.lazy.js":
+		"handled — setBedrockProviderModule() registered in registerBundledRuntime",
+	"pi-ai/dist/auth/context.js":
+		"safe — imports node: builtins only (a compiled binary resolves those at runtime)",
+	"pi-ai/dist/env-api-keys.js":
+		"safe — imports node: builtins only (a compiled binary resolves those at runtime)",
+};
+
+/**
+ * A non-literal dynamic import: `import(` whose argument does not start with a plain quote (so variable
+ * specifiers AND template literals are flagged), excluding method calls like jiti's `.import(...)`.
+ */
+const OPAQUE_IMPORT = /(?<![.\w$])import\s*\(\s*[^"'\s)]/;
+
+/** The package root (`.../node_modules/@earendil-works/<name>`) an entry file resolved under. */
+function packageRoot(name: string, entry: string): string {
+	const marker = `${sep}@earendil-works${sep}${name}${sep}`;
+	const at = entry.lastIndexOf(marker);
+	if (at < 0) throw new Error(`cannot locate package root for ${name} from ${entry}`);
+	return entry.slice(0, at + marker.length - 1);
+}
+
+/** Every `.js` file under `dir`, recursively. */
+function listJsFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) out.push(...listJsFiles(full));
+		else if (full.endsWith(".js")) out.push(full);
+	}
+	return out;
+}
+
+/** True when a non-comment line contains a bundler-opaque dynamic import. */
+function hasOpaqueImport(file: string): boolean {
+	return readFileSync(file, "utf8")
+		.split("\n")
+		.some((line) => {
+			const trimmed = line.trimStart();
+			if (trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*"))
+				return false;
+			return OPAQUE_IMPORT.test(line);
+		});
+}
+
+// Resolve pi-coding-agent from the server package (the module context the binary bundles), then its
+// scoped deps from pi-coding-agent's own context — the very instances that end up inside the artifact.
+// `Bun.resolveSync`, not `createRequire().resolve`: pi's exports maps carry only `types`/`import`
+// conditions, so require-condition resolution is blocked.
+const repoRoot = resolve(import.meta.dir, "..");
+const codingAgentEntry = Bun.resolveSync(
+	"@earendil-works/pi-coding-agent",
+	join(repoRoot, "packages", "server"),
+);
+const codingAgentRoot = packageRoot("pi-coding-agent", codingAgentEntry);
+
+const roots = new Map<string, string>([["pi-coding-agent", codingAgentRoot]]);
+const codingAgentPkg = JSON.parse(readFileSync(join(codingAgentRoot, "package.json"), "utf8")) as {
+	dependencies?: Record<string, string>;
+};
+for (const dep of Object.keys(codingAgentPkg.dependencies ?? {})) {
+	if (!dep.startsWith("@earendil-works/")) continue;
+	const name = dep.slice("@earendil-works/".length);
+	roots.set(name, packageRoot(name, Bun.resolveSync(dep, codingAgentRoot)));
+}
+
+const found = new Set<string>();
+for (const [name, root] of roots) {
+	for (const file of listJsFiles(join(root, "dist"))) {
+		if (!hasOpaqueImport(file)) continue;
+		found.add(
+			`${name}/${file
+				.slice(root.length + 1)
+				.split(sep)
+				.join("/")}`,
+		);
+	}
+}
+
+const unexpected = [...found].filter((id) => !(id in ALLOWLIST)).sort();
+const stale = Object.keys(ALLOWLIST)
+	.filter((id) => !found.has(id))
+	.sort();
+
+if (unexpected.length > 0) {
+	console.error(
+		"check-binary-seams: NEW bundler-opaque dynamic import(s) in pi — the compiled binary cannot resolve these at runtime:",
+	);
+	for (const id of unexpected) console.error(`  - ${id}`);
+	console.error(
+		"\nVerify each one: register a static seam in registerBundledRuntime (packages/server/src/agent/extensions.ts),",
+	);
+	console.error(
+		"or confirm it only imports node: builtins — then allowlist it in scripts/check-binary-seams.ts with that justification.",
+	);
+}
+if (stale.length > 0) {
+	console.error(
+		"check-binary-seams: stale allowlist entr(y/ies) — pi moved or removed these files:",
+	);
+	for (const id of stale) console.error(`  - ${id} (${ALLOWLIST[id]})`);
+	console.error(
+		"\nRe-verify the seam still covers the replacement, then update the allowlist in scripts/check-binary-seams.ts.",
+	);
+}
+if (unexpected.length > 0 || stale.length > 0) process.exit(1);
+
+console.log(
+	`check-binary-seams: OK (${found.size} known opaque imports across ${roots.size} pi packages, all handled or safe)`,
+);

--- a/scripts/check-binary-seams.ts
+++ b/scripts/check-binary-seams.ts
@@ -7,11 +7,12 @@
 // sign-in shipped broken (`Cannot find module './openai-codex.js' from '/$bunfs/...'`): the seam only
 // fails inside the artifact, where no from-source suite can see it.
 //
-// This gate catches the *next* one at the cheapest possible point — the pi version bump itself: scan the
-// pinned pi packages' `dist` for non-literal `import(...)` and require the findings to match the
-// allowlist below **exactly, per occurrence** (file + whitespace-normalized argument expression, as a
-// multiset — not per file, so a bump that adds a second opaque import to an already-known file, or
-// reshapes a known one, fails instead of hiding behind the file's existing entry).
+// This gate catches the *next* one at the cheapest possible point — the pi version bump itself: parse
+// the pinned pi packages' `dist` (a real TypeScript AST, so comments, strings, and multiline formatting
+// can't hide or fake a match) for dynamic `import(...)` whose specifier is not a constant string, and
+// require the findings to match the allowlist below **exactly, per occurrence** (file + normalized
+// specifier expression, as a multiset — not per file, so a bump that adds a second opaque import to an
+// already-known file, or reshapes a known one, fails instead of hiding behind the file's entry).
 //   - A NEW occurrence fails: verify it (register a static seam in `registerBundledRuntime`, or confirm
 //     it only ever receives `node:` builtin specifiers, which a compiled binary resolves at runtime),
 //     then allowlist it with that justification.
@@ -21,17 +22,18 @@
 // Known limitation (why the runtime layers still exist): this sees `import(...)` call sites, not data
 // flow — a new *call site* of an existing wrapper (e.g. `dynamicImport("./x.js")` in `env-api-keys.js`)
 // adds no `import(` occurrence. Reshaping the wrapper itself trips the exact match and forces
-// re-verification; what slips past a wrapper is the job of the behavioral artifact gates
+// re-verification; what flows through an unchanged wrapper is the job of the behavioral artifact gates
 // (`smoke:binary`'s real OAuth probe + `bun run e2e:binary`).
 //
-// Scope: `@earendil-works/pi-coding-agent` + its `@earendil-works/*` dependencies, resolved from the
-// server package's module context — exactly the instances the binary bundles.
+// Scope: `@earendil-works/pi-coding-agent` + its `@earendil-works/*` dependencies (transitively) —
+// resolved from the server package's module context, i.e. exactly the instances the binary bundles.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
+import ts from "typescript";
 
 /**
- * Known bundler-opaque dynamic imports: file → the exact argument expressions (normalized) of every
+ * Known bundler-opaque dynamic imports: file → the exact specifier expressions (normalized) of every
  * opaque `import(...)` in it, plus the verified justification (see header for the update protocol).
  */
 const ALLOWLIST: Record<string, { reason: string; imports: string[] }> = {
@@ -57,12 +59,6 @@ const ALLOWLIST: Record<string, { reason: string; imports: string[] }> = {
 	},
 };
 
-/**
- * A non-literal dynamic import: `import(` whose argument does not start with a plain quote (so variable
- * specifiers AND template literals are flagged), excluding method calls like jiti's `.import(...)`.
- */
-const OPAQUE_IMPORT = /(?<![.\w$])import\s*\(\s*[^"'\s)]/g;
-
 /** The package root (`.../node_modules/@earendil-works/<name>`) an entry file resolved under. */
 function packageRoot(name: string, entry: string): string {
 	const marker = `${sep}@earendil-works${sep}${name}${sep}`;
@@ -82,56 +78,70 @@ function listJsFiles(dir: string): string[] {
 	return out;
 }
 
-/** The argument expression starting at `from` (just past `import(`), captured to its balanced `)`. */
-function captureArgument(line: string, from: number): string {
-	let depth = 1;
-	for (let i = from; i < line.length; i++) {
-		const ch = line[i];
-		if (ch === "(") depth++;
-		else if (ch === ")" && --depth === 0) return line.slice(from, i);
-	}
-	return line.slice(from); // unbalanced by line end — the truncated tail is still a stable fingerprint
-}
-
-/** Every opaque dynamic import's normalized argument expression on non-comment lines of `file`. */
-function opaqueImportsIn(file: string): string[] {
+/**
+ * Every opaque dynamic import's normalized specifier expression in `source`, from the AST: a call whose
+ * callee is the `import` keyword and whose specifier is not a constant string. A no-substitution
+ * template literal counts as constant (the bundler resolves it statically, like esbuild); a template
+ * *with* substitutions, or any other expression, is opaque.
+ */
+function opaqueImportsIn(fileName: string, source: string): string[] {
+	const sourceFile = ts.createSourceFile(
+		fileName,
+		source,
+		ts.ScriptTarget.Latest,
+		false,
+		ts.ScriptKind.JS,
+	);
 	const found: string[] = [];
-	for (const line of readFileSync(file, "utf8").split("\n")) {
-		const trimmed = line.trimStart();
-		if (trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*")) continue;
-		for (const match of line.matchAll(OPAQUE_IMPORT)) {
-			const argStart = line.indexOf("(", match.index) + 1;
-			found.push(captureArgument(line, argStart).replace(/\s+/g, " ").trim());
+	const visit = (node: ts.Node): void => {
+		if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+			const specifier = node.arguments[0];
+			const isConstant =
+				specifier !== undefined &&
+				(ts.isStringLiteral(specifier) || ts.isNoSubstitutionTemplateLiteral(specifier));
+			if (!isConstant) {
+				found.push(
+					specifier ? specifier.getText(sourceFile).replace(/\s+/g, " ").trim() : "<no argument>",
+				);
+			}
 		}
-	}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
 	return found.sort();
 }
 
-// Resolve pi-coding-agent from the server package (the module context the binary bundles), then its
-// scoped deps from pi-coding-agent's own context — the very instances that end up inside the artifact.
-// `Bun.resolveSync`, not `createRequire().resolve`: pi's exports maps carry only `types`/`import`
-// conditions, so require-condition resolution is blocked.
+// Resolve pi-coding-agent from the server package (the module context the binary bundles), then walk
+// its `@earendil-works/*` dependency closure, each dep resolved from its dependent's own context — the
+// very instances that end up inside the artifact. `Bun.resolveSync`, not `createRequire().resolve`:
+// pi's exports maps carry only `types`/`import` conditions, so require-condition resolution is blocked.
 const repoRoot = resolve(import.meta.dir, "..");
-const codingAgentEntry = Bun.resolveSync(
-	"@earendil-works/pi-coding-agent",
-	join(repoRoot, "packages", "server"),
-);
-const codingAgentRoot = packageRoot("pi-coding-agent", codingAgentEntry);
-
-const roots = new Map<string, string>([["pi-coding-agent", codingAgentRoot]]);
-const codingAgentPkg = JSON.parse(readFileSync(join(codingAgentRoot, "package.json"), "utf8")) as {
-	dependencies?: Record<string, string>;
+const roots = new Map<string, string>();
+const queue: { name: string; root: string }[] = [];
+const enqueue = (name: string, resolveFrom: string): void => {
+	if (roots.has(name)) return;
+	const root = packageRoot(name, Bun.resolveSync(`@earendil-works/${name}`, resolveFrom));
+	roots.set(name, root);
+	queue.push({ name, root });
 };
-for (const dep of Object.keys(codingAgentPkg.dependencies ?? {})) {
-	if (!dep.startsWith("@earendil-works/")) continue;
-	const name = dep.slice("@earendil-works/".length);
-	roots.set(name, packageRoot(name, Bun.resolveSync(dep, codingAgentRoot)));
+enqueue("pi-coding-agent", join(repoRoot, "packages", "server"));
+for (let next = queue.shift(); next !== undefined; next = queue.shift()) {
+	const { root } = next;
+	const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+		dependencies?: Record<string, string>;
+	};
+	for (const dep of Object.keys(pkg.dependencies ?? {})) {
+		if (dep.startsWith("@earendil-works/")) enqueue(dep.slice("@earendil-works/".length), root);
+	}
 }
 
 const found = new Map<string, string[]>();
 for (const [name, root] of roots) {
 	for (const file of listJsFiles(join(root, "dist"))) {
-		const imports = opaqueImportsIn(file);
+		const source = readFileSync(file, "utf8");
+		// Cheap pre-filter: only AST-parse files that mention a dynamic import at all.
+		if (!/\bimport\s*\(/.test(source)) continue;
+		const imports = opaqueImportsIn(file, source);
 		if (imports.length === 0) continue;
 		found.set(
 			`${name}/${file

--- a/scripts/check-binary-seams.ts
+++ b/scripts/check-binary-seams.ts
@@ -9,12 +9,20 @@
 //
 // This gate catches the *next* one at the cheapest possible point — the pi version bump itself: scan the
 // pinned pi packages' `dist` for non-literal `import(...)` and require the findings to match the
-// allowlist below **exactly**.
-//   - A NEW match fails: verify it (register a static seam in `registerBundledRuntime`, or confirm it
-//     only imports `node:` builtins, which a compiled binary resolves at runtime), then allowlist it
-//     with that justification.
-//   - A STALE entry also fails: pi moved/removed the file — re-verify the seam still covers the
-//     replacement, then update the entry. Both directions keep the list honest.
+// allowlist below **exactly, per occurrence** (file + whitespace-normalized argument expression, as a
+// multiset — not per file, so a bump that adds a second opaque import to an already-known file, or
+// reshapes a known one, fails instead of hiding behind the file's existing entry).
+//   - A NEW occurrence fails: verify it (register a static seam in `registerBundledRuntime`, or confirm
+//     it only ever receives `node:` builtin specifiers, which a compiled binary resolves at runtime),
+//     then allowlist it with that justification.
+//   - A STALE entry also fails: pi moved, removed, or reshaped the import — re-verify the seam still
+//     covers the replacement, then update the entry. Both directions keep the list honest.
+//
+// Known limitation (why the runtime layers still exist): this sees `import(...)` call sites, not data
+// flow — a new *call site* of an existing wrapper (e.g. `dynamicImport("./x.js")` in `env-api-keys.js`)
+// adds no `import(` occurrence. Reshaping the wrapper itself trips the exact match and forces
+// re-verification; what slips past a wrapper is the job of the behavioral artifact gates
+// (`smoke:binary`'s real OAuth probe + `bun run e2e:binary`).
 //
 // Scope: `@earendil-works/pi-coding-agent` + its `@earendil-works/*` dependencies, resolved from the
 // server package's module context — exactly the instances the binary bundles.
@@ -22,23 +30,38 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 
-/** Known bundler-opaque dynamic imports, each verified handled-or-safe (see header for the protocol). */
-const ALLOWLIST: Record<string, string> = {
-	"pi-ai/dist/auth/oauth/load.js":
-		"handled — registerBunOAuthFlows() registered in registerBundledRuntime",
-	"pi-ai/dist/api/bedrock-converse-stream.lazy.js":
-		"handled — setBedrockProviderModule() registered in registerBundledRuntime",
-	"pi-ai/dist/auth/context.js":
-		"safe — imports node: builtins only (a compiled binary resolves those at runtime)",
-	"pi-ai/dist/env-api-keys.js":
-		"safe — imports node: builtins only (a compiled binary resolves those at runtime)",
+/**
+ * Known bundler-opaque dynamic imports: file → the exact argument expressions (normalized) of every
+ * opaque `import(...)` in it, plus the verified justification (see header for the update protocol).
+ */
+const ALLOWLIST: Record<string, { reason: string; imports: string[] }> = {
+	"pi-ai/dist/auth/oauth/load.js": {
+		reason: "handled — registerBunOAuthFlows() registered in registerBundledRuntime",
+		imports: ["__rewriteRelativeImportExtension(runtimeSpecifier)"],
+	},
+	"pi-ai/dist/api/bedrock-converse-stream.lazy.js": {
+		reason: "handled — setBedrockProviderModule() registered in registerBundledRuntime",
+		imports: ["__rewriteRelativeImportExtension(runtimeSpecifier)"],
+	},
+	"pi-ai/dist/auth/context.js": {
+		reason:
+			"safe — the importNodeModule wrapper only ever receives node: builtin specifiers " +
+			"(a compiled binary resolves those at runtime)",
+		imports: ["__rewriteRelativeImportExtension(specifier)"],
+	},
+	"pi-ai/dist/env-api-keys.js": {
+		reason:
+			"safe — the dynamicImport wrapper only ever receives node: builtin specifiers " +
+			"(a compiled binary resolves those at runtime)",
+		imports: ["__rewriteRelativeImportExtension(specifier)"],
+	},
 };
 
 /**
  * A non-literal dynamic import: `import(` whose argument does not start with a plain quote (so variable
  * specifiers AND template literals are flagged), excluding method calls like jiti's `.import(...)`.
  */
-const OPAQUE_IMPORT = /(?<![.\w$])import\s*\(\s*[^"'\s)]/;
+const OPAQUE_IMPORT = /(?<![.\w$])import\s*\(\s*[^"'\s)]/g;
 
 /** The package root (`.../node_modules/@earendil-works/<name>`) an entry file resolved under. */
 function packageRoot(name: string, entry: string): string {
@@ -59,16 +82,29 @@ function listJsFiles(dir: string): string[] {
 	return out;
 }
 
-/** True when a non-comment line contains a bundler-opaque dynamic import. */
-function hasOpaqueImport(file: string): boolean {
-	return readFileSync(file, "utf8")
-		.split("\n")
-		.some((line) => {
-			const trimmed = line.trimStart();
-			if (trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*"))
-				return false;
-			return OPAQUE_IMPORT.test(line);
-		});
+/** The argument expression starting at `from` (just past `import(`), captured to its balanced `)`. */
+function captureArgument(line: string, from: number): string {
+	let depth = 1;
+	for (let i = from; i < line.length; i++) {
+		const ch = line[i];
+		if (ch === "(") depth++;
+		else if (ch === ")" && --depth === 0) return line.slice(from, i);
+	}
+	return line.slice(from); // unbalanced by line end — the truncated tail is still a stable fingerprint
+}
+
+/** Every opaque dynamic import's normalized argument expression on non-comment lines of `file`. */
+function opaqueImportsIn(file: string): string[] {
+	const found: string[] = [];
+	for (const line of readFileSync(file, "utf8").split("\n")) {
+		const trimmed = line.trimStart();
+		if (trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*")) continue;
+		for (const match of line.matchAll(OPAQUE_IMPORT)) {
+			const argStart = line.indexOf("(", match.index) + 1;
+			found.push(captureArgument(line, argStart).replace(/\s+/g, " ").trim());
+		}
+	}
+	return found.sort();
 }
 
 // Resolve pi-coding-agent from the server package (the module context the binary bundles), then its
@@ -92,47 +128,60 @@ for (const dep of Object.keys(codingAgentPkg.dependencies ?? {})) {
 	roots.set(name, packageRoot(name, Bun.resolveSync(dep, codingAgentRoot)));
 }
 
-const found = new Set<string>();
+const found = new Map<string, string[]>();
 for (const [name, root] of roots) {
 	for (const file of listJsFiles(join(root, "dist"))) {
-		if (!hasOpaqueImport(file)) continue;
-		found.add(
+		const imports = opaqueImportsIn(file);
+		if (imports.length === 0) continue;
+		found.set(
 			`${name}/${file
 				.slice(root.length + 1)
 				.split(sep)
 				.join("/")}`,
+			imports,
 		);
 	}
 }
 
-const unexpected = [...found].filter((id) => !(id in ALLOWLIST)).sort();
-const stale = Object.keys(ALLOWLIST)
-	.filter((id) => !found.has(id))
-	.sort();
+// Exact multiset comparison per file id, across the union of found + allowlisted ids: an occurrence in
+// only one side is a drift. `unexpected` = in the tree but not allowlisted; `stale` = the reverse.
+const unexpected: string[] = [];
+const stale: string[] = [];
+for (const id of new Set([...found.keys(), ...Object.keys(ALLOWLIST)])) {
+	const actual = [...(found.get(id) ?? [])];
+	const expected = [...(ALLOWLIST[id]?.imports ?? [])].sort();
+	for (const imp of expected) {
+		const at = actual.indexOf(imp);
+		if (at >= 0) actual.splice(at, 1);
+		else stale.push(`${id}: import(${imp})  (${ALLOWLIST[id]?.reason})`);
+	}
+	unexpected.push(...actual.map((imp) => `${id}: import(${imp})`));
+}
 
 if (unexpected.length > 0) {
 	console.error(
 		"check-binary-seams: NEW bundler-opaque dynamic import(s) in pi — the compiled binary cannot resolve these at runtime:",
 	);
-	for (const id of unexpected) console.error(`  - ${id}`);
+	for (const line of unexpected.sort()) console.error(`  - ${line}`);
 	console.error(
 		"\nVerify each one: register a static seam in registerBundledRuntime (packages/server/src/agent/extensions.ts),",
 	);
 	console.error(
-		"or confirm it only imports node: builtins — then allowlist it in scripts/check-binary-seams.ts with that justification.",
+		"or confirm it only receives node: builtins — then allowlist the occurrence in scripts/check-binary-seams.ts with that justification.",
 	);
 }
 if (stale.length > 0) {
 	console.error(
-		"check-binary-seams: stale allowlist entr(y/ies) — pi moved or removed these files:",
+		"check-binary-seams: stale allowlist occurrence(s) — pi moved, removed, or reshaped these imports:",
 	);
-	for (const id of stale) console.error(`  - ${id} (${ALLOWLIST[id]})`);
+	for (const line of stale.sort()) console.error(`  - ${line}`);
 	console.error(
 		"\nRe-verify the seam still covers the replacement, then update the allowlist in scripts/check-binary-seams.ts.",
 	);
 }
 if (unexpected.length > 0 || stale.length > 0) process.exit(1);
 
+const occurrences = [...found.values()].reduce((n, imports) => n + imports.length, 0);
 console.log(
-	`check-binary-seams: OK (${found.size} known opaque imports across ${roots.size} pi packages, all handled or safe)`,
+	`check-binary-seams: OK (${occurrences} known opaque import occurrences in ${found.size} files across ${roots.size} pi packages, all handled or safe)`,
 );


### PR DESCRIPTION
## The bug

Installing a **release binary** and signing in with OpenAI Codex failed instantly:

```
Couldn't connect
ResolveMessage: Cannot find module './openai-codex.js' from '/$bunfs/root/thinkrail-darwin-arm64'
```

**Root cause:** pi deliberately hides Node-only provider code behind bundler-opaque dynamic imports (variable specifiers) so browser bundles can't follow them — but `bun build --compile` can't follow them either, and a single-file binary has no `node_modules` to resolve them from at runtime. **Every OAuth provider was broken in release binaries** (API-key login unaffected). Dev and e2e run from source, so no existing suite could ever see it.

## The fix

pi ships the exact escape hatch for standalone binaries (its own compiled binary uses it — `pi-coding-agent` `dist/bun/cli.js`):

- The server's compiled-binary seam `setBundledExtensions` → **`registerBundledRuntime`** (async): besides injecting the bundled extensions it now registers pi's statically-bundled **OAuth flows** (`registerBunOAuthFlows()` from `@earendil-works/pi-ai/bun-oauth`) and the **Bedrock provider module** (`setBedrockProviderModule` — same latent break, one step behind) via **dynamic literal imports**: statically bundled under `--compile`, never loaded in dev. `compiled-entry` awaits it before boot.
- Binary size: 95M → 96M (~1MB for the AWS SDK).

**Proven red → green on the artifact:** the new smoke assertion fails on a pre-fix binary with the exact reported error, and passes after.

## Keeping it fixed (three layers)

| Layer | What | Catches |
| --- | --- | --- |
| `smoke:binary` | drives a **real Codex OAuth login** over WS to its auth URL (offline, credential-free; reuses the smoke's RPC helpers) | the known seams, directly |
| `bun run e2e:binary` (new, in CI's Binary job) | the whole no-agent e2e suite against the **compiled binary** (`playwright.binary.config.ts`; the fake-login specs are tagged `@dev-seam` and skipped — those fakes only exist in the dev boot) | the broad works-from-source / broken-in-artifact class |
| `bun run check:seams` (new, in CI lint job + pre-commit) | scans pi-coding-agent + its `@earendil-works/*` deps for bundler-opaque `import(...)`, exact-set-matched against a justified allowlist (4 entries) | the **next** opaque import a pi bump introduces — at bump time, before runtime |

Day-one dividend: the binary suite immediately flushed out flaky 5s expect windows in `live-refresh.spec.ts` (macOS FSEvents latency under full-suite load) — hardened with a file-local 10s `fsExpect` on fs-propagation assertions (a genuinely *lost* frame still fails).

## Docs / specs

Seam contract updated spec-first: `packages/server/src/agent/SPEC.md`, `packages/server/SPEC.md`, `apps/cli/SPEC.md`, `.github/SPEC.md`, `AGENTS.md`. Drive-by honesty fix: "four bundled extensions" lists corrected to five (`pi-todos` was missing, including in the #94 text).

## Verification

- `build:binary` → `smoke:binary` green (incl. the OAuth probe + #94's portable-skill assertions after rebase)
- `e2e:binary`: 49 passed against the artifact
- dev `e2e`: 53 passed on the merge base; branch delta to the dev suite is test-files-only (tags + timeouts)
- `check:deps` · `check:seams` (negative-tested both failure directions) · lint · typecheck · unit — all green
- User-visible before/after: sign-in dialog previously showed the ResolveMessage error; now opens the provider's auth URL

Note for reviewers: local full-suite runs on a shared dev machine surfaced that the e2e harness uses a **fixed** `/tmp/thinkrail-e2e` + fixed ports across git worktrees — two concurrent worktree sessions running e2e corrupt each other. Not addressed here (pre-existing); follow-up suggestion: key the e2e data dir + ports per worktree.
