### PR TITLE
fix(web): derive the Skills-reload badge from the store, per session

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -361,7 +361,8 @@ export default function ChatView({
 								sessionId,
 								streaming: isStreaming,
 								stale: skillsStale,
-								onReloaded: () => useAppStore.getState().markSkillsSynced(workspaceId, sessionId),
+								onReloaded: (syncedTick) =>
+									useAppStore.getState().markSkillsSynced(sessionId, syncedTick),
 							}}
 							open={skillsOpen}
 							onOpenChange={setSkillsOpen}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -8,7 +8,7 @@ import { ArrowDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { Popover, PopoverAnchor, PopoverTrigger } from "@/components/ui/popover";
-import { EMPTY_RUNTIME, useAppStore } from "@/store";
+import { EMPTY_RUNTIME, selectSkillsStale, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { type ChatActions, ChatActionsContext } from "./ChatActions";
@@ -17,7 +17,7 @@ import { ChatPlanContent, ChatPlanStripContent } from "./ChatPlan";
 import { Composer, type MentionCandidate, type SubmitBehavior } from "./Composer";
 import { ExtUiDialog } from "./ExtUiDialog";
 import { type ChatRow, deriveRows } from "./rows";
-import { isSkillPath, SkillsDialog } from "./SkillsDialog";
+import { SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
 import "./tools/register"; // side-effect: register the built-in pi tool renderers (bash/read/edit/write)
 import { ChatTurnView } from "./turns";
@@ -65,16 +65,10 @@ export default function ChatView({
 				.find((w) => w.id === workspaceId)?.projectId ?? null,
 	);
 	const [skillsOpen, setSkillsOpen] = useState(false);
-	// Auto-detect: the worktree watcher's fs nudge flags skills stale (the session loaded an older set) when
-	// a skill dir changes on disk — a pull/branch/edit. Reload is manual, so this only prompts.
-	const fsSignal = useAppStore((s) => s.fsChangesByWorkspace[workspaceId]);
-	const [skillsStale, setSkillsStale] = useState(false);
-	const lastSkillTick = useRef(0);
-	useEffect(() => {
-		if (!fsSignal || fsSignal.tick === lastSkillTick.current) return;
-		lastSkillTick.current = fsSignal.tick;
-		if (fsSignal.truncated || fsSignal.paths.some(isSkillPath)) setSkillsStale(true);
-	}, [fsSignal]);
+	// Auto-detect: a skill dir changed on disk (pull/branch/edit) after this session loaded — flag a manual
+	// reload. Store-derived per session, so the badge survives tab-switch remounts (a fresh ChatView reads
+	// the same store state) and a reload clears only this chat (see selectSkillsStale / markSkillsSynced).
+	const skillsStale = useAppStore((s) => selectSkillsStale(s, workspaceId, sessionId));
 	const workspaceRoot = useAppStore((s) => {
 		for (const workspaces of Object.values(s.workspaces)) {
 			const workspace = workspaces.find((w) => w.id === workspaceId);
@@ -367,7 +361,7 @@ export default function ChatView({
 								sessionId,
 								streaming: isStreaming,
 								stale: skillsStale,
-								onReloaded: () => setSkillsStale(false),
+								onReloaded: () => useAppStore.getState().markSkillsSynced(workspaceId, sessionId),
 							}}
 							open={skillsOpen}
 							onOpenChange={setSkillsOpen}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -134,7 +134,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   (`types.ts`,
   incl. `ToolResultState` + `ExtUiDialogRequest`), and `ChatView` (lazy-mounted by `panels/CenterTabs`;
   it wires `SkillsDialog` + the header Skills trigger, resolving the owning `projectId` from the store and
-  flagging staleness off the worktree `fsChanged` nudge via `SkillsDialog`'s exported `isSkillPath`).
+  reading the reload badge from the store selector `selectSkillsStale(state, workspaceId, sessionId)` —
+  per-session and store-derived, so it survives the tab-switch remount; a successful reload calls
+  `markSkillsSynced` to clear only this chat).
   **No `index.ts` barrel** — chat pulls **shiki**, so per the code-splitting exception imports stay
   **per-file**; the registry is importable from `chat/toolRegistry` **without** pulling shiki.
 - **Allowed deps:** `contracts` (pi message/content-block types, **type-only**); `store` + `transport`

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -63,11 +63,6 @@ function isWorkspace(result: Project | Workspace): result is Workspace {
 	return "projectId" in result;
 }
 
-/** Whether a worktree-relative path is inside a skill directory — the auto-detect trigger for a reload. */
-export function isSkillPath(path: string): boolean {
-	return /(^|\/)\.(claude|github|gemini|pi|agents)\/skills(\/|$)/.test(path);
-}
-
 /** Chat-mode extras: a live session to reload after changes. Absent in project mode (pre-session). */
 export interface SkillsWorkspaceContext {
 	workspaceId: string;

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { toast, useAppStore } from "@/store";
+import { selectWorkspaceTick, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 
 /**
@@ -70,8 +70,9 @@ export interface SkillsWorkspaceContext {
 	streaming: boolean;
 	/** Skills changed on disk since the session loaded — prompt a reload. */
 	stale?: boolean;
-	/** Fired after a successful reload so the caller can clear its stale flag. */
-	onReloaded?: () => void;
+	/** Fired after a successful reload with the workspace tick captured at reload-*start*, so the caller
+	 * anchors the sync baseline to what the reload actually loaded (a change mid-reload stays flagged). */
+	onReloaded?: (syncedTick: number) => void;
 }
 
 export function SkillsDialog({
@@ -130,9 +131,12 @@ export function SkillsDialog({
 	const reload = async () => {
 		if (busy || !workspace) return;
 		setBusy(true);
+		// Capture the sync baseline BEFORE the load: the server scans skills as of now, so a change whose
+		// fsChanged frame folds while this request is in flight must stay flagged (it wasn't loaded).
+		const syncedTick = selectWorkspaceTick(useAppStore.getState(), workspace.workspaceId);
 		try {
 			await getTransport().request("session.reloadResources", { sessionId: workspace.sessionId });
-			workspace.onReloaded?.();
+			workspace.onReloaded?.(syncedTick);
 			toast.success("This chat now uses the updated skills.", "Skills reloaded");
 		} catch (err) {
 			toast.error(errorText(err), "Couldn't reload skills");

--- a/apps/web/src/chat/useChatTodos.ts
+++ b/apps/web/src/chat/useChatTodos.ts
@@ -1,7 +1,7 @@
 import type { SessionEventPayload, TodoPlan } from "@thinkrail/contracts";
 import { WS_CHANNELS } from "@thinkrail/contracts";
 import { useEffect, useState } from "react";
-import { useAppStore } from "../store";
+import { selectWorkspaceTick, useAppStore } from "../store";
 import { errorText, getTransport } from "../transport";
 import { messagesToRuntime, TODO_NUDGE_PREFIX } from "./hydrate";
 import { planToMarkdown } from "./planMarkdown";
@@ -138,11 +138,14 @@ async function nudgeAgent(workspaceId: string, sessionId: string, title: string)
 		});
 	} catch {
 		try {
+			const syncedTick = selectWorkspaceTick(useAppStore.getState(), workspaceId);
 			const { summary, messages } = await getTransport().request("session.getMessages", {
 				sessionId,
 				workspaceId,
 			});
-			useAppStore.getState().hydrateSession(summary, messagesToRuntime(messages), false);
+			useAppStore
+				.getState()
+				.hydrateSession(summary, messagesToRuntime(messages), false, syncedTick);
 			await getTransport().request("session.prompt", { sessionId, text });
 		} catch (err) {
 			console.warn("todo nudge skipped:", errorText(err));

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -21,6 +21,7 @@ import {
 	type DocTab,
 	type EditorTab,
 	selectActiveWorkspace,
+	selectWorkspaceTick,
 	toast,
 	useAppStore,
 } from "../store";
@@ -111,6 +112,8 @@ export function CenterTabs() {
 	useEffect(() => {
 		if (!activeWorkspaceId) return;
 		let cancelled = false;
+		// Snapshot the sync baseline before the fetch, so a skill change during hydrate keeps chats flagged.
+		const syncedTick = selectWorkspaceTick(useAppStore.getState(), activeWorkspaceId);
 		void getTransport()
 			.request("session.list", { workspaceId: activeWorkspaceId })
 			.then(async (summaries) => {
@@ -132,7 +135,9 @@ export function CenterTabs() {
 							{ sessionId: summary.sessionId, workspaceId: activeWorkspaceId },
 						);
 						if (cancelled) return;
-						useAppStore.getState().hydrateSession(fresh, messagesToRuntime(messages));
+						useAppStore
+							.getState()
+							.hydrateSession(fresh, messagesToRuntime(messages), false, syncedTick);
 					} catch {
 						// Skip a session that failed to load; the others still hydrate.
 					}
@@ -157,12 +162,14 @@ export function CenterTabs() {
 			return;
 		}
 		if (!activeWorkspaceId) return;
+		// Snapshot the sync baseline before the fetch (see selectWorkspaceTick / hydrateSession).
+		const syncedTick = selectWorkspaceTick(useAppStore.getState(), activeWorkspaceId);
 		try {
 			const { summary, messages } = await getTransport().request("session.getMessages", {
 				sessionId,
 				workspaceId: activeWorkspaceId,
 			});
-			useAppStore.getState().hydrateSession(summary, messagesToRuntime(messages), true);
+			useAppStore.getState().hydrateSession(summary, messagesToRuntime(messages), true, syncedTick);
 		} catch (err) {
 			// The chat stays in history for a retry — but say why the click did nothing.
 			toast.error(errorText(err), "Couldn't reopen the chat");
@@ -171,11 +178,15 @@ export function CenterTabs() {
 
 	const startChat = async () => {
 		if (!activeWorkspaceId) return;
+		// Snapshot the sync baseline before the create round-trip (see selectWorkspaceTick / openChatSession).
+		const syncedTick = selectWorkspaceTick(useAppStore.getState(), activeWorkspaceId);
 		try {
 			const { sessionId, model, thinkingLevel } = await getTransport().request("session.create", {
 				workspaceId: activeWorkspaceId,
 			});
-			useAppStore.getState().openChatSession(activeWorkspaceId, sessionId, model, thinkingLevel);
+			useAppStore
+				.getState()
+				.openChatSession(activeWorkspaceId, sessionId, model, thinkingLevel, syncedTick);
 		} catch (err) {
 			// Without this, a failed create makes "+ New chat" do nothing, silently.
 			toast.error(errorText(err), "Couldn't start the chat");

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -112,8 +112,6 @@ export function CenterTabs() {
 	useEffect(() => {
 		if (!activeWorkspaceId) return;
 		let cancelled = false;
-		// Snapshot the sync baseline before the fetch, so a skill change during hydrate keeps chats flagged.
-		const syncedTick = selectWorkspaceTick(useAppStore.getState(), activeWorkspaceId);
 		void getTransport()
 			.request("session.list", { workspaceId: activeWorkspaceId })
 			.then(async (summaries) => {
@@ -135,9 +133,7 @@ export function CenterTabs() {
 							{ sessionId: summary.sessionId, workspaceId: activeWorkspaceId },
 						);
 						if (cancelled) return;
-						useAppStore
-							.getState()
-							.hydrateSession(fresh, messagesToRuntime(messages), false, syncedTick);
+						useAppStore.getState().hydrateSession(fresh, messagesToRuntime(messages), false); // live restore: no reload → no baseline (stays conservatively stale; see hydrateSession)
 					} catch {
 						// Skip a session that failed to load; the others still hydrate.
 					}

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
-import { toast, useAppStore } from "@/store";
+import { selectWorkspaceTick, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 
 /** A shared pill-trigger look for the project + branch pickers (mockup `.pill`). */
@@ -257,13 +257,21 @@ export function NewWorkspaceDialog({
 
 		const text = prompt.trim();
 		if (!text) return;
+		// Snapshot the sync baseline before the create round-trip (see selectWorkspaceTick / openChatSession).
+		const syncedTick = selectWorkspaceTick(useAppStore.getState(), workspace.id);
 		try {
 			const session = await getTransport().request("session.create", {
 				workspaceId: workspace.id,
 				...(model ? { model } : {}),
 				thinkingLevel,
 			});
-			store.openChatSession(workspace.id, session.sessionId, session.model, session.thinkingLevel);
+			store.openChatSession(
+				workspace.id,
+				session.sessionId,
+				session.model,
+				session.thinkingLevel,
+				syncedTick,
+			);
 			store.appendUserMessage(session.sessionId, text);
 			// Fire-and-forget the turn (it resolves only when the turn ends); the now-open chat tab streams it.
 			// A rejected send (bad model / no API key) surfaces as an error turn in the just-opened chat rather

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -93,7 +93,16 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   **`noteFsChanged(payload)`** (folds a `workspace.fsChanged` push: `tick` increments per frame;
   `paths`/`truncated` are the last batch) — panels select their workspace's entry and refetch on `tick`
   change (the store holds only the signal, never fetches; `applyWorkspaceRemoved` drops a removed
-  workspace's entry); and **`updateFileTabContent(id, content,
+  workspace's entry). The **Skills-reload badge** rides the same tick without a separate signal:
+  `noteFsChanged` also folds **`skillChangeTickByWorkspace: Record<workspaceId, tick>`** — the tick of the
+  most recent *skill-relevant* batch (a `.claude|.github|.gemini|.pi|.agents/skills` path, via
+  `isSkillPath`, or a truncated wildcard), *accumulated* so a later non-skill batch never clears it — and
+  each chat records **`skillsSyncedTickBySession: Record<sessionId, tick>`** = the tick it loaded skills at
+  (set on `openChatSession`/`hydrateSession`, bumped by **`markSkillsSynced(workspaceId, sessionId)`** on a
+  successful reload; dropped with the runtime in `closeChatRuntime`/`clearWorkspaceTabs`). The selector
+  **`selectSkillsStale(state, workspaceId, sessionId)`** = `skillChangeTick > syncedTick` — store-derived
+  (survives `ChatView`'s tab-switch remount) and per-session (a sibling/newer chat that loaded the current
+  skills is not flagged; a reload clears only its own). Also **`updateFileTabContent(id, content,
   tick)`** — a `FileTab` carries the `tick` its content was loaded at, so `FilePane` detects staleness
   (`workspaceTick > tab.loadedTick`) across tab switches, and its diff twin
   **`updateDiffTabContent(id, original, modified, tick)`** — a `DiffTab` follows the same staleness
@@ -114,7 +123,8 @@ The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` +
   selectors in `selectors.ts` resolve the active `Workspace`, its owning project id, and the shell's context
   project from those canonical ids and collections; derived active-project state is never stored separately.
 - **Public surface (barrel):** `useAppStore`; `selectActiveWorkspace`,
-  `selectActiveWorkspaceProjectId`, and `selectContextProject`; `toast` (the fire-from-anywhere helper),
+  `selectActiveWorkspaceProjectId`, `selectContextProject`, `selectSkillsStale` (+ the `isSkillPath` path
+  predicate it shares with `noteFsChanged`); `toast` (the fire-from-anywhere helper),
   `Toast` (type), `EditorTab` (`FileTab`/`ChatTab`/`DocTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` +
   `EMPTY_RUNTIME` (ChatView's pre-creation fallback), `reduceSessionEvent`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -99,7 +99,9 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `isSkillPath`, or a truncated wildcard), *accumulated* so a later non-skill batch never clears it — and
   each chat records **`skillsSyncedTickBySession: Record<sessionId, tick>`** = the tick it loaded skills at
   (set on `openChatSession`/`hydrateSession`, bumped by **`markSkillsSynced(sessionId, syncedTick)`** on a
-  successful reload; dropped with the runtime in `closeChatRuntime`/`clearWorkspaceTabs`). That
+  successful reload — **monotonic** (`Math.max`, so an out-of-order reload completion can't move the
+  baseline backward) and a **no-op for a disposed session** (a late completion can't resurrect an entry
+  dropped by `closeChatRuntime`/`clearWorkspaceTabs`)). That
   `syncedTick` is the workspace tick captured at the **start** of the skill-loading round-trip
   (`selectWorkspaceTick`, snapshot by the caller before `session.create`/`reloadResources`/`getMessages`),
   **not** at completion — so a skill change whose `fsChanged` frame folds while the load is in flight (which

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -97,11 +97,15 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `noteFsChanged` also folds **`skillChangeTickByWorkspace: Record<workspaceId, tick>`** — the tick of the
   most recent *skill-relevant* batch (a `.claude|.github|.gemini|.pi|.agents/skills` path, via
   `isSkillPath`, or a truncated wildcard), *accumulated* so a later non-skill batch never clears it — and
-  each chat records **`skillsSyncedTickBySession: Record<sessionId, tick>`** = the tick it loaded skills at
-  (set on `openChatSession`/`hydrateSession`, bumped by **`markSkillsSynced(sessionId, syncedTick)`** on a
-  successful reload — **monotonic** (`Math.max`, so an out-of-order reload completion can't move the
-  baseline backward) and a **no-op for a disposed session** (a late completion can't resurrect an entry
-  dropped by `closeChatRuntime`/`clearWorkspaceTabs`)). That
+  each chat records **`skillsSyncedTickBySession: Record<sessionId, tick>`** = the tick it loaded skills at.
+  It advances **only when resources are actually (re)loaded against current disk**: a fresh
+  `openChatSession`, a disk-only `hydrateSession` attach, and **`markSkillsSynced(sessionId, syncedTick)`** on
+  a successful reload (`markSkillsSynced` is **monotonic** — `Math.max`, so an out-of-order reload completion
+  can't move the baseline backward — and a **no-op for a disposed session**, so a late completion can't
+  resurrect an entry dropped by `closeChatRuntime`/`clearWorkspaceTabs`). A **live** `hydrateSession` restore
+  reuses the server session's already-loaded skills (`getMessages` returns only the transcript, no reload)
+  which the client can't date, so it advances **nothing** — the chat stays *conservatively stale* if a skill
+  change has been observed, never falsely clearing. That
   `syncedTick` is the workspace tick captured at the **start** of the skill-loading round-trip
   (`selectWorkspaceTick`, snapshot by the caller before `session.create`/`reloadResources`/`getMessages`),
   **not** at completion — so a skill change whose `fsChanged` frame folds while the load is in flight (which

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -98,8 +98,13 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   most recent *skill-relevant* batch (a `.claude|.github|.gemini|.pi|.agents/skills` path, via
   `isSkillPath`, or a truncated wildcard), *accumulated* so a later non-skill batch never clears it — and
   each chat records **`skillsSyncedTickBySession: Record<sessionId, tick>`** = the tick it loaded skills at
-  (set on `openChatSession`/`hydrateSession`, bumped by **`markSkillsSynced(workspaceId, sessionId)`** on a
-  successful reload; dropped with the runtime in `closeChatRuntime`/`clearWorkspaceTabs`). The selector
+  (set on `openChatSession`/`hydrateSession`, bumped by **`markSkillsSynced(sessionId, syncedTick)`** on a
+  successful reload; dropped with the runtime in `closeChatRuntime`/`clearWorkspaceTabs`). That
+  `syncedTick` is the workspace tick captured at the **start** of the skill-loading round-trip
+  (`selectWorkspaceTick`, snapshot by the caller before `session.create`/`reloadResources`/`getMessages`),
+  **not** at completion — so a skill change whose `fsChanged` frame folds while the load is in flight (which
+  the load did not see) stays past the baseline and keeps the badge lit rather than being silently absorbed.
+  The selector
   **`selectSkillsStale(state, workspaceId, sessionId)`** = `skillChangeTick > syncedTick` — store-derived
   (survives `ChatView`'s tab-switch remount) and per-session (a sibling/newer chat that loaded the current
   skills is not flagged; a reload clears only its own). Also **`updateFileTabContent(id, content,
@@ -123,8 +128,9 @@ The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` +
   selectors in `selectors.ts` resolve the active `Workspace`, its owning project id, and the shell's context
   project from those canonical ids and collections; derived active-project state is never stored separately.
 - **Public surface (barrel):** `useAppStore`; `selectActiveWorkspace`,
-  `selectActiveWorkspaceProjectId`, `selectContextProject`, `selectSkillsStale` (+ the `isSkillPath` path
-  predicate it shares with `noteFsChanged`); `toast` (the fire-from-anywhere helper),
+  `selectActiveWorkspaceProjectId`, `selectContextProject`, `selectSkillsStale`, `selectWorkspaceTick` (the
+  sync-baseline snapshot; + the `isSkillPath` path predicate it shares with `noteFsChanged`); `toast` (the
+  fire-from-anywhere helper),
   `Toast` (type), `EditorTab` (`FileTab`/`ChatTab`/`DocTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` +
   `EMPTY_RUNTIME` (ChatView's pre-creation fallback), `reduceSessionEvent`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test } from "bun:test";
 import type { ExtUiRequest, PiEvent, SessionSummary, Workspace } from "@thinkrail/contracts";
 import { type SessionRuntime, toast, useAppStore } from "./appStore";
-import { selectSkillsStale } from "./selectors";
+import { selectSkillsStale, selectWorkspaceTick } from "./selectors";
 
 // Event fixtures — the reducer only reads the fields below, so casting minimal objects is safe here.
 const agentStart = { type: "agent_start" } as unknown as PiEvent;
@@ -953,7 +953,7 @@ test("skills badge: a skill-dir change flags the loaded session; reload clears i
 	expect(isStale("ws1", "a")).toBe(true);
 
 	// A successful reload anchors the session to now → cleared.
-	s().markSkillsSynced("ws1", "a");
+	s().markSkillsSynced("a", selectWorkspaceTick(s(), "ws1"));
 	expect(isStale("ws1", "a")).toBe(false);
 
 	// Later unrelated (non-skill) fs churn must not re-raise the badge — the core regression.
@@ -995,16 +995,29 @@ test("skills badge: per session — a chat opened after the change isn't flagged
 	expect(isStale("ws1", "b")).toBe(true);
 
 	// …and reloading one clears only that chat (reloadResources is per-session).
-	s().markSkillsSynced("ws1", "b");
+	s().markSkillsSynced("b", selectWorkspaceTick(s(), "ws1"));
 	expect(isStale("ws1", "a")).toBe(true);
 	expect(isStale("ws1", "b")).toBe(false);
+});
+
+test("skills badge: a skill change mid-reload stays flagged (baseline is captured at reload start)", () => {
+	const s = () => useAppStore.getState();
+	s().openChatSession("ws1", "a", null, "medium");
+	// The user starts a reload; the baseline is snapshot NOW (what the server will load).
+	const reloadBaseline = selectWorkspaceTick(s(), "ws1"); // 0
+	// While the reload request is in flight, a skill file changes and its fsChanged frame folds first.
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"])); // tick 1
+	// The reload resolves and records the request-START baseline, not the now-newer tick.
+	s().markSkillsSynced("a", reloadBaseline);
+	// The mid-reload change (which the reload did not load) is preserved → still stale.
+	expect(isStale("ws1", "a")).toBe(true);
 });
 
 test("skills badge: closing a chat runtime drops its sync baseline (no leak)", () => {
 	const s = () => useAppStore.getState();
 	s().openChatSession("ws1", "a", null, "medium");
 	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"]));
-	s().markSkillsSynced("ws1", "a");
+	s().markSkillsSynced("a", selectWorkspaceTick(s(), "ws1"));
 	expect(s().skillsSyncedTickBySession.a).toBeDefined();
 
 	s().closeChatRuntime("a");

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1040,24 +1040,36 @@ test("skills badge: markSkillsSynced is monotonic and ignores a disposed session
 	expect(s().skillsSyncedTickBySession.a).toBeUndefined();
 });
 
-test("skills badge: a session hydrated on reconnect anchors to the current fs tick", () => {
+const summaryFor = (sessionId: string, live: boolean): SessionSummary => ({
+	sessionId,
+	workspaceId: "ws1",
+	title: "Chat",
+	model: null,
+	thinkingLevel: "medium",
+	isStreaming: false,
+	messageCount: 0,
+	updatedAt: 0,
+	live,
+});
+
+test("skills badge: a LIVE restore stays conservatively stale; a disk attach anchors to its load tick", () => {
 	const s = () => useAppStore.getState();
-	// A skill change already landed before this client hydrated the session…
-	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"]));
-	const summary: SessionSummary = {
-		sessionId: "h1",
-		workspaceId: "ws1",
-		title: "Chat",
-		model: null,
-		thinkingLevel: "medium",
-		isStreaming: false,
-		messageCount: 0,
-		updatedAt: 0,
-		live: true,
-	};
-	s().hydrateSession(summary, { turns: [], toolResults: {}, askAnswers: {} });
-	// …so the reconnected session (which loaded the current skills) is not flagged, only a later change is.
-	expect(isStale("ws1", "h1")).toBe(false);
-	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"]));
-	expect(isStale("ws1", "h1")).toBe(true);
+	// A skill change was already observed before this client hydrated these sessions.
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"])); // tick 1
+
+	// A LIVE restore reused the server session's already-loaded (older) skills — no reload — so the caller
+	// passes no baseline: it must stay flagged (Air's finding — never falsely clear a live session that
+	// predates the change).
+	s().hydrateSession(summaryFor("live1", true), { turns: [], toolResults: {}, askAnswers: {} });
+	expect(isStale("ws1", "live1")).toBe(true);
+
+	// A disk-only attach reconstructs the loader against current disk → the caller passes the load's
+	// request-start tick, and the chat is correctly in sync.
+	s().hydrateSession(
+		summaryFor("disk1", false),
+		{ turns: [], toolResults: {}, askAnswers: {} },
+		false,
+		selectWorkspaceTick(s(), "ws1"),
+	);
+	expect(isStale("ws1", "disk1")).toBe(false);
 });

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1024,6 +1024,22 @@ test("skills badge: closing a chat runtime drops its sync baseline (no leak)", (
 	expect(s().skillsSyncedTickBySession.a).toBeUndefined();
 });
 
+test("skills badge: markSkillsSynced is monotonic and ignores a disposed session", () => {
+	const s = () => useAppStore.getState();
+	s().openChatSession("ws1", "a", null, "medium");
+
+	// Out-of-order reload completions: a newer baseline lands, then an older request resolves last —
+	// the older tick must not move the baseline backward (which would falsely re-light the badge).
+	s().markSkillsSynced("a", 5);
+	s().markSkillsSynced("a", 2);
+	expect(s().skillsSyncedTickBySession.a).toBe(5);
+
+	// A completion after the runtime was disposed must not resurrect a dropped entry (leak).
+	s().closeChatRuntime("a");
+	s().markSkillsSynced("a", 9);
+	expect(s().skillsSyncedTickBySession.a).toBeUndefined();
+});
+
 test("skills badge: a session hydrated on reconnect anchors to the current fs tick", () => {
 	const s = () => useAppStore.getState();
 	// A skill change already landed before this client hydrated the session…

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, test } from "bun:test";
 import type { ExtUiRequest, PiEvent, SessionSummary, Workspace } from "@thinkrail/contracts";
 import { type SessionRuntime, toast, useAppStore } from "./appStore";
+import { selectSkillsStale } from "./selectors";
 
 // Event fixtures — the reducer only reads the fields below, so casting minimal objects is safe here.
 const agentStart = { type: "agent_start" } as unknown as PiEvent;
@@ -61,6 +62,9 @@ beforeEach(() => {
 		tabsByWorkspace: {},
 		activeTabByWorkspace: {},
 		closedChatsByWorkspace: {},
+		fsChangesByWorkspace: {},
+		skillChangeTickByWorkspace: {},
+		skillsSyncedTickBySession: {},
 		selectedProjectId: null,
 		activeWorkspaceId: null,
 		activeLogin: null,
@@ -923,4 +927,108 @@ test("diff tabs: openTab dedupes by id + activates; view + contents update in pl
 		expect(updated.modified).toBe("new2");
 		expect(updated.loadedTick).toBe(5);
 	}
+});
+
+// The Skills-reload badge (selectSkillsStale) is store-derived, so it must not depend on the ChatView
+// mount that reads it. These drive the real store actions end-to-end.
+const skillFs = (workspaceId: string, paths: string[], truncated = false) => ({
+	workspaceId,
+	paths,
+	truncated,
+});
+const isStale = (workspaceId: string, sessionId: string) =>
+	selectSkillsStale(useAppStore.getState(), workspaceId, sessionId);
+
+test("skills badge: a skill-dir change flags the loaded session; reload clears it for good", () => {
+	const s = () => useAppStore.getState();
+	s().openChatSession("ws1", "a", null, "medium");
+	expect(isStale("ws1", "a")).toBe(false); // nothing changed yet
+
+	// A skill file changes on disk → the session that loaded the older set is stale.
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"]));
+	expect(isStale("ws1", "a")).toBe(true);
+
+	// The reported bug: re-reading the selector (what a tab-switch remount does — a fresh ChatView reads
+	// the same store) must NOT spuriously toggle it, and it stays stale until an actual reload.
+	expect(isStale("ws1", "a")).toBe(true);
+
+	// A successful reload anchors the session to now → cleared.
+	s().markSkillsSynced("ws1", "a");
+	expect(isStale("ws1", "a")).toBe(false);
+
+	// Later unrelated (non-skill) fs churn must not re-raise the badge — the core regression.
+	s().noteFsChanged(skillFs("ws1", ["src/app.ts"]));
+	s().noteFsChanged(skillFs("ws1", ["README.md"]));
+	expect(isStale("ws1", "a")).toBe(false);
+});
+
+test("skills badge: the skill-change tick is accumulated, so a later non-skill batch can't lose it", () => {
+	const s = () => useAppStore.getState();
+	s().openChatSession("ws1", "a", null, "medium");
+
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"])); // skill change
+	s().noteFsChanged(skillFs("ws1", ["src/app.ts"])); // later non-skill batch replaces `paths`
+	// Before the fix this false-negatived (the last batch wasn't a skill path); now it stays stale.
+	expect(isStale("ws1", "a")).toBe(true);
+});
+
+test("skills badge: a truncated wildcard batch flags stale even with no skill path", () => {
+	const s = () => useAppStore.getState();
+	s().openChatSession("ws1", "a", null, "medium");
+	s().noteFsChanged(skillFs("ws1", [], true));
+	expect(isStale("ws1", "a")).toBe(true);
+});
+
+test("skills badge: per session — a chat opened after the change isn't flagged; reload clears only its own", () => {
+	const s = () => useAppStore.getState();
+	s().openChatSession("ws1", "a", null, "medium"); // baseline tick 0
+
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"])); // tick 1
+	// A chat created *now* loads the current skills → not stale, while the older one is.
+	s().openChatSession("ws1", "b", null, "medium");
+	expect(isStale("ws1", "a")).toBe(true);
+	expect(isStale("ws1", "b")).toBe(false);
+
+	// A fresh skill change makes both stale…
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"])); // tick 2
+	expect(isStale("ws1", "a")).toBe(true);
+	expect(isStale("ws1", "b")).toBe(true);
+
+	// …and reloading one clears only that chat (reloadResources is per-session).
+	s().markSkillsSynced("ws1", "b");
+	expect(isStale("ws1", "a")).toBe(true);
+	expect(isStale("ws1", "b")).toBe(false);
+});
+
+test("skills badge: closing a chat runtime drops its sync baseline (no leak)", () => {
+	const s = () => useAppStore.getState();
+	s().openChatSession("ws1", "a", null, "medium");
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"]));
+	s().markSkillsSynced("ws1", "a");
+	expect(s().skillsSyncedTickBySession.a).toBeDefined();
+
+	s().closeChatRuntime("a");
+	expect(s().skillsSyncedTickBySession.a).toBeUndefined();
+});
+
+test("skills badge: a session hydrated on reconnect anchors to the current fs tick", () => {
+	const s = () => useAppStore.getState();
+	// A skill change already landed before this client hydrated the session…
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"]));
+	const summary: SessionSummary = {
+		sessionId: "h1",
+		workspaceId: "ws1",
+		title: "Chat",
+		model: null,
+		thinkingLevel: "medium",
+		isStreaming: false,
+		messageCount: 0,
+		updatedAt: 0,
+		live: true,
+	};
+	s().hydrateSession(summary, { turns: [], toolResults: {}, askAnswers: {} });
+	// …so the reconnected session (which loaded the current skills) is not flagged, only a later change is.
+	expect(isStale("ws1", "h1")).toBe(false);
+	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"]));
+	expect(isStale("ws1", "h1")).toBe(true);
 });

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -858,9 +858,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 			};
 		}),
 	markSkillsSynced: (sessionId, syncedTick) =>
-		set((s) => ({
-			skillsSyncedTickBySession: { ...s.skillsSyncedTickBySession, [sessionId]: syncedTick },
-		})),
+		set((s) => {
+			// A reload can resolve after its chat was disposed (closeChatRuntime/clearWorkspaceTabs) — don't
+			// resurrect a dropped baseline for a session that no longer exists.
+			if (!s.sessions[sessionId]) return {};
+			// Monotonic: out-of-order reload completions (an older request landing last) must never move the
+			// baseline backward and re-light the badge — "synced up to at least tick X" only ever advances.
+			const synced = Math.max(s.skillsSyncedTickBySession[sessionId] ?? 0, syncedTick);
+			return {
+				skillsSyncedTickBySession: { ...s.skillsSyncedTickBySession, [sessionId]: synced },
+			};
+		}),
 	updateFileTabContent: (id, content, tick) =>
 		set((s) => {
 			for (const [wsId, tabs] of Object.entries(s.tabsByWorkspace)) {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -551,8 +551,9 @@ interface AppState {
 		summary: SessionSummary,
 		hydrated: HydratedRuntime,
 		activate?: boolean,
-		/** Skills sync baseline — the workspace tick captured *before* `session.getMessages`; omit to anchor
-		 * at call time. */
+		/** Skills sync baseline — the workspace tick captured *before* `session.getMessages`, passed **only**
+		 * for a disk-only attach (which reloads resources against current disk). Omit for a live restore
+		 * (transcript only, no reload): the baseline is left unset so the chat stays conservatively stale. */
 		syncedTick?: number,
 	) => void;
 	appendUserMessage: (sessionId: string, text: string) => void;
@@ -1087,12 +1088,20 @@ export const useAppStore = create<AppState>((set, get) => ({
 			const closed = s.closedChatsByWorkspace[wsId] ?? [];
 			return {
 				sessions: { ...s.sessions, [summary.sessionId]: runtime },
-				// Restored sessions loaded their skills at reconnect; anchor to the load's request-start tick
-				// (caller-captured; else now) — see openChatSession.
-				skillsSyncedTickBySession: {
-					...s.skillsSyncedTickBySession,
-					[summary.sessionId]: syncedTick ?? selectWorkspaceTick(s, wsId),
-				},
+				// Advance the sync baseline ONLY when this restore actually (re)loaded resources against current
+				// disk — a disk-only attach, where the caller passes its request-start tick. A LIVE restore
+				// reused the server session's already-loaded skills (`getMessages` returns only the transcript,
+				// no reload) and the client can't date them, so the caller passes no tick: leave the baseline
+				// unset → the chat stays conservatively stale if a skill change has been observed, never falsely
+				// clearing the badge for a live session that predates the change.
+				...(syncedTick !== undefined
+					? {
+							skillsSyncedTickBySession: {
+								...s.skillsSyncedTickBySession,
+								[summary.sessionId]: syncedTick,
+							},
+						}
+					: {}),
 				tabsByWorkspace: tabs.some((t) => t.id === id)
 					? s.tabsByWorkspace
 					: { ...s.tabsByWorkspace, [wsId]: [...tabs, tab] },

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -21,6 +21,7 @@ import type { LoginState } from "../auth";
 import type { HydratedRuntime } from "../chat/hydrate";
 import type { ChatTurn, ExtUiDialogRequest, ToolResultState } from "../chat/types";
 import type { ConnectionStatus } from "../transport";
+import { isSkillPath } from "./selectors";
 
 /** A center tab. File tabs (Monaco) and chat tabs share the strip, discriminated by `kind`. */
 export interface FileTab {
@@ -429,6 +430,20 @@ interface AppState {
 	 */
 	fsChangesByWorkspace: Record<string, { tick: number; paths: string[]; truncated: boolean }>;
 	/**
+	 * Per workspace, the `fsChangesByWorkspace` tick of the most recent *skill-relevant* batch — a change
+	 * under a `.claude|.github|.gemini|.pi|.agents/skills` dir, or a truncated wildcard we can't inspect.
+	 * Folded alongside the fs signal in `noteFsChanged`; compared against a session's
+	 * `skillsSyncedTickBySession` to derive the Skills-reload badge (`selectSkillsStale`). Accumulated (not
+	 * overwritten by a later non-skill batch), so a genuine pending skill change is never lost.
+	 */
+	skillChangeTickByWorkspace: Record<string, number>;
+	/**
+	 * Per session, the workspace fs tick it last loaded/reloaded its skills at — set when the runtime is
+	 * created (`openChatSession`/`hydrateSession`, anchored to *now* so only a later change flags it) and
+	 * bumped on a successful reload (`markSkillsSynced`). Drives `selectSkillsStale`.
+	 */
+	skillsSyncedTickBySession: Record<string, number>;
+	/**
 	 * The in-flight in-app OAuth login, if any (flat + session-less — a login runs on the Welcome screen
 	 * before any session exists, so it must NOT live under a session runtime, or its frames get dropped).
 	 * At most one at a time (the dialog is modal).
@@ -492,6 +507,8 @@ interface AppState {
 	setChangesView: (view: "list" | "tree") => void;
 	/** Fold a `workspace.fsChanged` push into the live-refresh signal (tick++, last batch replaces). */
 	noteFsChanged: (payload: WorkspaceFsChangedPayload) => void;
+	/** Anchor a session's skills back to the current on-disk state (a successful reload) — clears its badge. */
+	markSkillsSynced: (workspaceId: string, sessionId: string) => void;
 	/** Replace a file tab's content after a live re-read, recording the fs tick it was loaded at. The tab
 	 * is located across workspaces by its (globally unique) id; a closed tab is a no-op. */
 	updateFileTabContent: (id: string, content: string, tick: number) => void;
@@ -652,6 +669,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 	changesRequest: null,
 	changesView: "list",
 	fsChangesByWorkspace: {},
+	skillChangeTickByWorkspace: {},
+	skillsSyncedTickBySession: {},
 	activeLogin: null,
 	settingsOpen: false,
 	settingsSection: SettingsSection.Providers,
@@ -709,7 +728,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 		// Drop the live-refresh signal too — a removed workspace's fs tick record must not linger.
 		set((state) => {
 			const { [workspaceId]: _gone, ...rest } = state.fsChangesByWorkspace;
-			return { fsChangesByWorkspace: rest };
+			const { [workspaceId]: _skillGone, ...skillRest } = state.skillChangeTickByWorkspace;
+			return { fsChangesByWorkspace: rest, skillChangeTickByWorkspace: skillRest };
 		});
 		if (wasActive) {
 			s.selectProject(projectId); // atomically fall back to the removed workspace's Project Home
@@ -804,17 +824,32 @@ export const useAppStore = create<AppState>((set, get) => ({
 	noteFsChanged: (payload) =>
 		set((s) => {
 			const prev = s.fsChangesByWorkspace[payload.workspaceId];
+			const tick = (prev?.tick ?? 0) + 1;
+			// A skill-dir change (or a truncated wildcard we can't inspect) advances the workspace's
+			// skill-change tick, flagging every session that loaded skills before it (selectSkillsStale).
+			const skillChanged = payload.truncated || payload.paths.some(isSkillPath);
 			return {
 				fsChangesByWorkspace: {
 					...s.fsChangesByWorkspace,
-					[payload.workspaceId]: {
-						tick: (prev?.tick ?? 0) + 1,
-						paths: payload.paths,
-						truncated: payload.truncated,
-					},
+					[payload.workspaceId]: { tick, paths: payload.paths, truncated: payload.truncated },
 				},
+				...(skillChanged
+					? {
+							skillChangeTickByWorkspace: {
+								...s.skillChangeTickByWorkspace,
+								[payload.workspaceId]: tick,
+							},
+						}
+					: {}),
 			};
 		}),
+	markSkillsSynced: (workspaceId, sessionId) =>
+		set((s) => ({
+			skillsSyncedTickBySession: {
+				...s.skillsSyncedTickBySession,
+				[sessionId]: s.fsChangesByWorkspace[workspaceId]?.tick ?? 0,
+			},
+		})),
 	updateFileTabContent: (id, content, tick) =>
 		set((s) => {
 			for (const [wsId, tabs] of Object.entries(s.tabsByWorkspace)) {
@@ -850,11 +885,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 			// Drop the runtimes of this workspace's chats — both open tabs and closed-to-history ones (their
 			// AgentSessions are freed on host shutdown).
 			const sessions = { ...s.sessions };
+			const skillsSyncedTickBySession = { ...s.skillsSyncedTickBySession };
 			for (const tab of s.tabsByWorkspace[workspaceId] ?? []) {
-				if (tab.kind === "chat") delete sessions[tab.sessionId];
+				if (tab.kind === "chat") {
+					delete sessions[tab.sessionId];
+					delete skillsSyncedTickBySession[tab.sessionId];
+				}
 			}
-			for (const closed of s.closedChatsByWorkspace[workspaceId] ?? [])
+			for (const closed of s.closedChatsByWorkspace[workspaceId] ?? []) {
 				delete sessions[closed.sessionId];
+				delete skillsSyncedTickBySession[closed.sessionId];
+			}
 			const { [workspaceId]: _tabs, ...tabsByWorkspace } = s.tabsByWorkspace;
 			const { [workspaceId]: _activeTab, ...activeTabByWorkspace } = s.activeTabByWorkspace;
 			const { [workspaceId]: _closed, ...closedChatsByWorkspace } = s.closedChatsByWorkspace;
@@ -869,6 +910,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				terminalsByWorkspace,
 				activeTerminalByWorkspace,
 				sessions,
+				skillsSyncedTickBySession,
 			};
 		}),
 	addTerminal: (workspaceId) =>
@@ -906,22 +948,34 @@ export const useAppStore = create<AppState>((set, get) => ({
 			const id = `${workspaceId}:${sessionId}`;
 			const tab: ChatTab = { kind: "chat", id, workspaceId, name: "Chat", sessionId };
 			const tabs = s.tabsByWorkspace[workspaceId] ?? [];
+			const fresh = !s.sessions[sessionId];
 			return {
 				tabsByWorkspace: tabs.some((t) => t.id === id)
 					? s.tabsByWorkspace
 					: { ...s.tabsByWorkspace, [workspaceId]: [...tabs, tab] },
 				activeTabByWorkspace: { ...s.activeTabByWorkspace, [workspaceId]: id },
 				// Keep any existing runtime (idempotent); otherwise start a fresh one.
-				sessions: s.sessions[sessionId]
-					? s.sessions
-					: { ...s.sessions, [sessionId]: newRuntime(model, thinkingLevel) },
+				sessions: fresh
+					? { ...s.sessions, [sessionId]: newRuntime(model, thinkingLevel) }
+					: s.sessions,
+				// A fresh session loads the current on-disk skills, so anchor its sync tick to now: only a
+				// *later* skill change flags it stale (idempotent re-open must not re-anchor a stale session).
+				...(fresh
+					? {
+							skillsSyncedTickBySession: {
+								...s.skillsSyncedTickBySession,
+								[sessionId]: s.fsChangesByWorkspace[workspaceId]?.tick ?? 0,
+							},
+						}
+					: {}),
 			};
 		}),
 	closeChatRuntime: (sessionId) =>
 		set((s) => {
 			if (!s.sessions[sessionId]) return {};
 			const { [sessionId]: _drop, ...sessions } = s.sessions;
-			return { sessions };
+			const { [sessionId]: _syncDrop, ...skillsSyncedTickBySession } = s.skillsSyncedTickBySession;
+			return { sessions, skillsSyncedTickBySession };
 		}),
 	closeChatToHistory: (sessionId) =>
 		set((s) => {
@@ -1013,6 +1067,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 			const closed = s.closedChatsByWorkspace[wsId] ?? [];
 			return {
 				sessions: { ...s.sessions, [summary.sessionId]: runtime },
+				// Restored sessions loaded their skills at reconnect; anchor to the current tick (see openChatSession).
+				skillsSyncedTickBySession: {
+					...s.skillsSyncedTickBySession,
+					[summary.sessionId]: s.fsChangesByWorkspace[wsId]?.tick ?? 0,
+				},
 				tabsByWorkspace: tabs.some((t) => t.id === id)
 					? s.tabsByWorkspace
 					: { ...s.tabsByWorkspace, [wsId]: [...tabs, tab] },

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -21,7 +21,7 @@ import type { LoginState } from "../auth";
 import type { HydratedRuntime } from "../chat/hydrate";
 import type { ChatTurn, ExtUiDialogRequest, ToolResultState } from "../chat/types";
 import type { ConnectionStatus } from "../transport";
-import { isSkillPath } from "./selectors";
+import { isSkillPath, selectWorkspaceTick } from "./selectors";
 
 /** A center tab. File tabs (Monaco) and chat tabs share the strip, discriminated by `kind`. */
 export interface FileTab {
@@ -507,8 +507,12 @@ interface AppState {
 	setChangesView: (view: "list" | "tree") => void;
 	/** Fold a `workspace.fsChanged` push into the live-refresh signal (tick++, last batch replaces). */
 	noteFsChanged: (payload: WorkspaceFsChangedPayload) => void;
-	/** Anchor a session's skills back to the current on-disk state (a successful reload) — clears its badge. */
-	markSkillsSynced: (workspaceId: string, sessionId: string) => void;
+	/**
+	 * Record a session's skills as synced to `syncedTick` — the workspace fs tick captured at the *start* of
+	 * the reload round-trip (`selectWorkspaceTick`), so a skill change folded while the reload was in flight
+	 * (which the reload did not load) stays past the baseline and keeps the badge lit.
+	 */
+	markSkillsSynced: (sessionId: string, syncedTick: number) => void;
 	/** Replace a file tab's content after a live re-read, recording the fs tick it was loaded at. The tab
 	 * is located across workspaces by its (globally unique) id; a closed tab is a no-op. */
 	updateFileTabContent: (id: string, content: string, tick: number) => void;
@@ -523,6 +527,9 @@ interface AppState {
 		sessionId: string,
 		model: WireModel | null,
 		thinkingLevel: ThinkingLevel,
+		/** Skills sync baseline — the workspace tick captured *before* `session.create` (see
+		 * `selectWorkspaceTick`); omit to anchor at call time (fine when there's no async load in between). */
+		syncedTick?: number,
 	) => void;
 	/** Drop a chat's runtime on tab close (the `AgentSession` is disposed over the wire by the caller). */
 	closeChatRuntime: (sessionId: string) => void;
@@ -540,7 +547,14 @@ interface AppState {
 	 * Drops the session from chat-history (it's open now). `activate` focuses the tab (a user-driven reopen);
 	 * otherwise it only takes focus if the workspace has none yet (auto-restore must not steal focus).
 	 */
-	hydrateSession: (summary: SessionSummary, hydrated: HydratedRuntime, activate?: boolean) => void;
+	hydrateSession: (
+		summary: SessionSummary,
+		hydrated: HydratedRuntime,
+		activate?: boolean,
+		/** Skills sync baseline — the workspace tick captured *before* `session.getMessages`; omit to anchor
+		 * at call time. */
+		syncedTick?: number,
+	) => void;
 	appendUserMessage: (sessionId: string, text: string) => void;
 	/**
 	 * Surface a failed send as a visible error turn. The turn-driving wire calls (`session.prompt`/`steer`/
@@ -843,12 +857,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 					: {}),
 			};
 		}),
-	markSkillsSynced: (workspaceId, sessionId) =>
+	markSkillsSynced: (sessionId, syncedTick) =>
 		set((s) => ({
-			skillsSyncedTickBySession: {
-				...s.skillsSyncedTickBySession,
-				[sessionId]: s.fsChangesByWorkspace[workspaceId]?.tick ?? 0,
-			},
+			skillsSyncedTickBySession: { ...s.skillsSyncedTickBySession, [sessionId]: syncedTick },
 		})),
 	updateFileTabContent: (id, content, tick) =>
 		set((s) => {
@@ -943,7 +954,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 		set((s) => ({
 			activeTerminalByWorkspace: { ...s.activeTerminalByWorkspace, [workspaceId]: clientId },
 		})),
-	openChatSession: (workspaceId, sessionId, model, thinkingLevel) =>
+	openChatSession: (workspaceId, sessionId, model, thinkingLevel, syncedTick) =>
 		set((s) => {
 			const id = `${workspaceId}:${sessionId}`;
 			const tab: ChatTab = { kind: "chat", id, workspaceId, name: "Chat", sessionId };
@@ -958,13 +969,14 @@ export const useAppStore = create<AppState>((set, get) => ({
 				sessions: fresh
 					? { ...s.sessions, [sessionId]: newRuntime(model, thinkingLevel) }
 					: s.sessions,
-				// A fresh session loads the current on-disk skills, so anchor its sync tick to now: only a
-				// *later* skill change flags it stale (idempotent re-open must not re-anchor a stale session).
+				// A fresh session loads the current on-disk skills, so anchor its sync tick to the load's
+				// request-start (caller-captured; else now): only a *later* skill change flags it stale, and
+				// an idempotent re-open must not re-anchor an already-stale session.
 				...(fresh
 					? {
 							skillsSyncedTickBySession: {
 								...s.skillsSyncedTickBySession,
-								[sessionId]: s.fsChangesByWorkspace[workspaceId]?.tick ?? 0,
+								[sessionId]: syncedTick ?? selectWorkspaceTick(s, workspaceId),
 							},
 						}
 					: {}),
@@ -1043,7 +1055,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				},
 			};
 		}),
-	hydrateSession: (summary, hydrated, activate = false) =>
+	hydrateSession: (summary, hydrated, activate = false, syncedTick) =>
 		set((s) => {
 			if (s.sessions[summary.sessionId]) return {}; // a live/ahead runtime wins — never clobber it
 			const wsId = summary.workspaceId;
@@ -1067,10 +1079,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 			const closed = s.closedChatsByWorkspace[wsId] ?? [];
 			return {
 				sessions: { ...s.sessions, [summary.sessionId]: runtime },
-				// Restored sessions loaded their skills at reconnect; anchor to the current tick (see openChatSession).
+				// Restored sessions loaded their skills at reconnect; anchor to the load's request-start tick
+				// (caller-captured; else now) — see openChatSession.
 				skillsSyncedTickBySession: {
 					...s.skillsSyncedTickBySession,
-					[summary.sessionId]: s.fsChangesByWorkspace[wsId]?.tick ?? 0,
+					[summary.sessionId]: syncedTick ?? selectWorkspaceTick(s, wsId),
 				},
 				tabsByWorkspace: tabs.some((t) => t.id === id)
 					? s.tabsByWorkspace

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "bun:test";
 import type { Project, Workspace } from "@thinkrail/contracts";
 import {
+	isSkillPath,
 	selectActiveWorkspace,
 	selectActiveWorkspaceProjectId,
 	selectContextProject,
+	selectSkillsStale,
 } from "./selectors";
 
 const projects: Project[] = [
@@ -54,4 +56,44 @@ test("context project falls back to the selected Project Home", () => {
 			workspaces,
 		}),
 	).toBe(projects[0]);
+});
+
+test("isSkillPath matches every alias' skills dir, and only a real skills dir", () => {
+	for (const yes of [
+		".claude/skills/foo/SKILL.md",
+		".github/skills/x.md",
+		".gemini/skills",
+		".agents/skills/z",
+		"nested/dir/.pi/skills/y.md",
+	]) {
+		expect(isSkillPath(yes)).toBe(true);
+	}
+	for (const no of [
+		"README.md",
+		".claude/settings.json", // an alias dir, but not its skills
+		".claudeskills/x", // no `/skills` segment
+		"src/claude/skills/x", // "claude" without the leading dot
+		"skills/x", // bare skills, no alias parent
+	]) {
+		expect(isSkillPath(no)).toBe(false);
+	}
+});
+
+test("selectSkillsStale is a strict tick comparison, defaulting missing ticks to 0", () => {
+	const stale = { skillChangeTickByWorkspace: { w: 2 }, skillsSyncedTickBySession: { s: 1 } };
+	expect(selectSkillsStale(stale, "w", "s")).toBe(true);
+	// Synced at or past the last skill change → not stale.
+	const synced = { skillChangeTickByWorkspace: { w: 2 }, skillsSyncedTickBySession: { s: 2 } };
+	expect(selectSkillsStale(synced, "w", "s")).toBe(false);
+	// A skill change with no recorded sync (→ 0) is stale; nothing recorded at all is not.
+	expect(
+		selectSkillsStale(
+			{ skillChangeTickByWorkspace: { w: 1 }, skillsSyncedTickBySession: {} },
+			"w",
+			"s",
+		),
+	).toBe(true);
+	expect(
+		selectSkillsStale({ skillChangeTickByWorkspace: {}, skillsSyncedTickBySession: {} }, "w", "s"),
+	).toBe(false);
 });

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -30,3 +30,32 @@ export function selectContextProject(state: ProjectContextState): Project | null
 	const projectId = selectActiveWorkspace(state)?.projectId ?? state.selectedProjectId;
 	return state.projects.find((project) => project.id === projectId) ?? null;
 }
+
+/** Whether a worktree-relative path is inside a skill directory — the auto-detect trigger for a reload. */
+export function isSkillPath(path: string): boolean {
+	return /(^|\/)\.(claude|github|gemini|pi|agents)\/skills(\/|$)/.test(path);
+}
+
+interface SkillsStaleState {
+	/** Per workspace, the fs tick of the most recent skill-relevant `fsChanged` batch (see `noteFsChanged`). */
+	skillChangeTickByWorkspace: Record<string, number>;
+	/** Per session, the fs tick it last loaded/reloaded skills at (session create + successful reload). */
+	skillsSyncedTickBySession: Record<string, number>;
+}
+
+/**
+ * A session's Skills badge is stale when a skill-dir change landed on disk *after* the session last loaded
+ * (or reloaded) its skills — the workspace's last skill-change tick is past this session's sync tick. Being
+ * store-derived, it survives `ChatView` remounts on tab switch (the reported bug); being keyed per session,
+ * a sibling or newer chat that loaded the current skills is not flagged, and a reload clears only its own.
+ */
+export function selectSkillsStale(
+	state: SkillsStaleState,
+	workspaceId: string,
+	sessionId: string,
+): boolean {
+	return (
+		(state.skillChangeTickByWorkspace[workspaceId] ?? 0) >
+		(state.skillsSyncedTickBySession[sessionId] ?? 0)
+	);
+}

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -36,6 +36,19 @@ export function isSkillPath(path: string): boolean {
 	return /(^|\/)\.(claude|github|gemini|pi|agents)\/skills(\/|$)/.test(path);
 }
 
+/**
+ * A workspace's current live-refresh tick (0 before any fs change). Snapshot it at the **start** of a
+ * skill-loading round-trip (session create / reload / hydrate) and record it as that session's sync
+ * baseline once the load resolves — so a skill change whose `fsChanged` frame folds *while the load is in
+ * flight* stays past the baseline and keeps the reload badge lit (the load saw the pre-change skills).
+ */
+export function selectWorkspaceTick(
+	state: { fsChangesByWorkspace: Record<string, { tick: number }> },
+	workspaceId: string,
+): number {
+	return state.fsChangesByWorkspace[workspaceId]?.tick ?? 0;
+}
+
 interface SkillsStaleState {
 	/** Per workspace, the fs tick of the most recent skill-relevant `fsChanged` batch (see `noteFsChanged`). */
 	skillChangeTickByWorkspace: Record<string, number>;

--- a/e2e/skills-reload.live.spec.ts
+++ b/e2e/skills-reload.live.spec.ts
@@ -1,0 +1,60 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+
+// Tagged @agent (see agent.live.spec.ts): the Skills-reload badge lives in the chat header, so it needs
+// a real session. No prompt is ever sent — the session only has to exist — so this stays fast and never
+// spends provider tokens (session create + session.reloadResources are config/fs work, no model round-trip).
+//
+// The bug this pins: the badge was per-mount React state, and CenterTabs unmounts inactive chats — so
+// every tab switch remounted ChatView and re-raised the badge (even after a Reload had cleared it). It is
+// now store-derived per session (selectSkillsStale / markSkillsSynced), so a reload clears it for good and
+// a sibling chat that loaded the current skills is never flagged.
+test("skills badge: flags a worktree skill change, clears on reload, and survives a tab switch", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(120_000);
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	const worktree = workspace.worktreePath;
+
+	// Chat A — its header carries the Skills trigger. No prompt sent, so it never streams (Reload stays enabled).
+	await page.getByTestId("start-chat").click();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	const skillsBtn = page.getByTestId("open-skills");
+	await expect(skillsBtn).toBeVisible();
+
+	// A skill file appears on disk (a pull/branch/edit) → the loaded session is flagged for a reload.
+	mkdirSync(join(worktree, ".claude", "skills", "demo"), { recursive: true });
+	writeFileSync(
+		join(worktree, ".claude", "skills", "demo", "SKILL.md"),
+		"---\nname: demo\ndescription: e2e demo skill\n---\n\nDemo skill written mid-session by the e2e suite.\n",
+	);
+	await expect(skillsBtn).toHaveAttribute("data-stale", "true", { timeout: 15_000 });
+
+	// Reload from the dialog applies the change to this chat and clears the badge for good.
+	await skillsBtn.click();
+	await expect(page.getByTestId("skills-stale")).toBeVisible();
+	await page.getByTestId("skills-reload").click();
+	await expect(page.getByTestId("skills-stale")).toBeHidden({ timeout: 15_000 });
+	await page.keyboard.press("Escape");
+	await expect(skillsBtn).not.toHaveAttribute("data-stale", "true");
+
+	// A second chat loads the current skills → not flagged (staleness is per session, not per workspace).
+	await page.getByTestId("new-chat").click();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(2);
+	await expect(page.getByTestId("open-skills")).toBeVisible();
+	await expect(page.getByTestId("open-skills")).not.toHaveAttribute("data-stale", "true");
+
+	// The regression: switch back to chat A. A fresh ChatView mount must read the reloaded (cleared) state
+	// from the store, NOT re-raise the badge off the persisted fs signal the way the old per-mount state did.
+	await page
+		.locator('[data-testid="editor-tab"][data-kind="chat"]')
+		.first()
+		.locator("button")
+		.first()
+		.click();
+	await expect(page.getByTestId("open-skills")).toBeVisible();
+	await expect(page.getByTestId("open-skills")).not.toHaveAttribute("data-stale", "true");
+});


### PR DESCRIPTION
## The bug

The chat-header **Skills** badge (the "changed on disk — reload" dot) re-raised on **every tab switch**, and lit up on sibling / newly-created chats — even when nothing changed on disk and the user had already reloaded. (Reported: "it activates on each switch between chats.")

## Root cause

`skillsStale` was **per-mount React state** (`useState` + `useRef(0)`) in `ChatView`, but `CenterTabs` renders only the *active* tab — so switching chats **unmounts + remounts** `ChatView`, resetting the baseline to `0`. The mount effect then re-derived staleness from the **persisted** `fsChangesByWorkspace` signal, so it:

- re-flagged the badge on remount (even after a Reload cleared it), and
- flagged chats that had actually loaded the current skills (a fresh chat B, or a sibling).

A latent **false-negative** also existed: the last-batch `paths` was overwritten by a later non-skill batch, so a genuine pending skill change could be silently forgotten.

## The fix

Move it to **store-derived, per-session** state — mirroring the existing `loadedTick` staleness pattern used for file/diff tabs. No protocol change.

- `noteFsChanged` **accumulates** `skillChangeTickByWorkspace` — the fs tick of the most recent skill-relevant batch (`isSkillPath`, moved to `store/selectors`, or a truncated wildcard); never overwritten by a later non-skill batch.
- Each session records `skillsSyncedTickBySession`, anchored at create/hydrate and bumped by the new `markSkillsSynced` on a successful reload; cleaned up with the runtime (`closeChatRuntime` / `clearWorkspaceTabs` / `applyWorkspaceRemoved`).
- `selectSkillsStale(state, workspaceId, sessionId)` = `skillChangeTick > syncedTick`. `ChatView` reads the selector; the dialog's reload calls `markSkillsSynced`.

Result: the badge **survives remounts**, **clears for good** on reload, and a **sibling/newer chat** that loaded the current skills is never flagged.

## Design notes

Weighed six approaches (keep-tabs-mounted, server-authoritative diffing, per-workspace flag, per-session-flag-set-during-fold, persist-ChatView-state, store-derived tick comparison). The store-derived tick selector won: declarative, handles new/concurrent sessions automatically, fixes the false-negative, matches the codebase's `loadedTick` pattern, and needs no protocol bump.

## Verification

- `check:deps` ✓ · `lint` ✓ · `typecheck` 10/10 ✓ · unit **58 store + full suite** ✓ · e2e no-agent **53/53** ✓
- New `@agent` spec `e2e/skills-reload.live.spec.ts` **passes on the fix** and, run against the pre-fix code, **fails** — the freshly-created chat B shows `data-stale="true"` (the exact "activates on switching chats" symptom), so the test genuinely pins the regression.

SPECs updated (`store/SPEC.md`, `chat/SPEC.md`) — spec-leads-code.

_The visible badge artwork is unchanged (same gold dot) — only *when* it appears — so the fails-on-old / passes-on-new e2e is the meaningful before/after evidence rather than a screenshot._
