### PR TITLE
Add CODEOWNERS (rsolmano, danyaberezun, OLavrik) to activate required code-owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners — review from one of these is required to merge into main
+# (enforced by the "main" ruleset: pull_request.require_code_owner_review).
+
+* @rsolmano @danyaberezun @OLavrik

--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -70,6 +70,8 @@ and, threaded `apps/cli` → `bootHost` → `createServer`, in the `server.welco
 
 ## Parts
 
+- `CODEOWNERS` — every path is owned by @rsolmano, @danyaberezun, @OLavrik; the `main` ruleset's
+  pull-request rule (`require_code_owner_review`) makes an approval from one of them required to merge.
 - `scripts/next-version.sh` — channel-aware semver from tags; carries a `--tags=` override for testing.
 - `actions/build-binary` — the release build step: `build:web` → stamp `version.ts` → `build-binary.ts
   --target` → resolve artifact path → native `smoke:binary`. (The Bun replacement for the old repo's


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` assigning every path (`*`) to @rsolmano, @danyaberezun, and @OLavrik.

The `main` ruleset already has `pull_request.require_code_owner_review: true`, but it was a **no-op** because the repo had no CODEOWNERS file. Once this merges, every PR into `main` will require an approval from one of the three owners (any one of them satisfies the rule; all three verified as collaborators with write+ access, which CODEOWNERS requires to bind). Note: the ruleset grants repo admins an always-bypass, so admins keep a bypass option.

Also recorded the file in `.github/SPEC.md` (module-ci-release owns everything under `.github/`).

## Related issues

None.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test` (ran via pre-commit; governance-only change, no product code touched)
- [x] E2E suite passes for app-affecting changes — N/A, not app-affecting
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)