### PR TITLE
feat(agent): strict tool sampling (pi 0.82 constrainedSampling) for ask_user_question

### DIFF
--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -98,8 +98,25 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     round-trip to the browser, fire-and-forget methods push, TUI-only members inert); `setExtUiPublisher`
     (server→client push seam), `resolveExtUi` (browser reply), `cancelExtUiForSession` (on dispose),
     `notifyExtUi`.
+  - `strictSampling` — **`strictTool(definition)`**, the opt-in to pi ≥0.82 provider-side constrained
+    sampling (`{type:"json_schema", strict:"prefer"}`): transforms the tool's schema strict-conformant
+    (every object `additionalProperties:false`, all properties required, optionals → `T | null`
+    unions — OpenAI-style strict rejects anything less; pi sends schemas as-is), strips the keywords
+    strict-mode providers reject (`default`, `minItems`/`maxItems`, `maxLength`, `pattern`, … — limits
+    a tool relies on move into prose descriptions + its runtime validator), then insulates both
+    sides — `prepareArguments` null-fills omissions from non-strict models before pi validates,
+    `execute` deep-strips nulls so handlers keep the original schema's optionals (the transcript keeps
+    the model's raw nullable args; web renderers are audited null-tolerant). Record-style nodes
+    (`Type.Record` → patternProperties) are inexpressible under strict and left untouched — a tool
+    carrying one must not opt in. **Scope: `ask_user_question` only, by provider budget** — each
+    null-union costs one of Anthropic's **≤16 union-typed parameters per request** (counted across
+    ALL tools on the request; live 400 at 39 when every custom tool was wrapped). ask costs 3, pinned
+    by `strictSampling.test.ts`; opting in another tool means re-counting that shared budget (and the
+    extension packages would each need their own copy of the helper — they carry no workspace deps).
   - `askUserQuestion` — the host-owned **`ask_user_question`** pi custom tool (`createAskUserQuestionTool`,
-    registered on every session via the `askUserQuestionExtension` factory in `extensions`), designed
+    registered on every session via the `askUserQuestionExtension` factory in `extensions` — **wrapped
+    in `strictTool`** at that seam, so the questionnaire's nested schema is strict-sampled where the
+    model supports it while unit tests keep driving the raw tool), designed
     **ack + terminate** so a questionnaire survives host restarts: `execute` renders nothing and **awaits
     nothing** — it guards on `ctx.hasUI`, runs the pure `validateQuestionnaire`, then immediately returns
     the ack (`details {kind:"ack"}`) with **`terminate: true`**, ending the turn at the tool batch with no

--- a/packages/server/src/agent/askUserQuestion.test.ts
+++ b/packages/server/src/agent/askUserQuestion.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
 import type {
 	AgentMessage,
 	AskUserQuestionArgs,
@@ -8,6 +12,7 @@ import type {
 import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
 import {
 	ASK_ACK_TEXT,
+	askUserQuestionExtension,
 	assessAnswerability,
 	buildAnswersMessage,
 	buildQuestionnaireResponse,
@@ -126,6 +131,48 @@ test("validateQuestionnaire rejects empty, too-few-options, dupes, and reserved 
 	).toBe(false);
 });
 
+// The count/length limits moved out of the TypeBox schema (strict-mode providers reject `maxItems`/
+// `maxLength` keywords — strictTool strips them), so the pure validator owns them now.
+test("validateQuestionnaire enforces the former schema limits: option count and text lengths", () => {
+	const opt = (label: string) => ({ label, description: "d" });
+	const one = (over: Partial<AskUserQuestionArgs["questions"][number]>): AskUserQuestionArgs => ({
+		questions: [{ question: "q", header: "h", options: [opt("a"), opt("b")], ...over }],
+	});
+
+	// 5 options > MAX_OPTIONS(4)
+	expect(
+		validateQuestionnaire(one({ options: ["a", "b", "c", "d", "e"].map(opt) })).message,
+	).toContain("At most 4 options");
+	// header > 16 chars
+	expect(validateQuestionnaire(one({ header: "h".repeat(17) })).message).toContain("header");
+	// label > 60 chars
+	expect(
+		validateQuestionnaire(one({ options: [opt("x".repeat(61)), opt("b")] })).message,
+	).toContain("labels must be at most 60");
+	// recommendedReason > 160 chars
+	expect(
+		validateQuestionnaire(
+			one({
+				options: [{ label: "a", description: "d", recommendedReason: "r".repeat(161) }, opt("b")],
+			}),
+		).message,
+	).toContain("recommendedReason");
+	// …and the boundary values stay valid.
+	expect(
+		validateQuestionnaire(
+			one({
+				header: "h".repeat(16),
+				options: [
+					{ label: "x".repeat(60), description: "d", recommendedReason: "r".repeat(160) },
+					opt("b"),
+					opt("c"),
+					opt("d"),
+				],
+			}),
+		).ok,
+	).toBe(true);
+});
+
 // ---- the envelope (now the ask-user-answers message text; same wording as the blocking era) ----
 
 test("buildQuestionnaireResponse: cancelled → the canonical decline message", () => {
@@ -209,6 +256,41 @@ test("execute returns the no-UI error (non-terminating) when hasUI is false", as
 	expect(textOf(r)).toContain("UI not available");
 	expect((r.details as AskUserQuestionResult).cancelled).toBe(true);
 	expect((r as { terminate?: boolean }).terminate).toBeUndefined();
+});
+
+test("the extension registers the tool opted into strict sampling; nulls from strict models still ack", async () => {
+	const tools = new Map<string, ToolDefinition>();
+	askUserQuestionExtension({
+		registerTool(tool: ToolDefinition) {
+			tools.set(tool.name, tool);
+		},
+	} as unknown as ExtensionAPI);
+	const tool = tools.get("ask_user_question");
+	if (!tool) throw new Error("ask_user_question not registered");
+
+	expect(tool.constrainedSampling).toEqual({ type: "json_schema", strict: "prefer" });
+	// The registered (transformed) schema is all-required at the top object.
+	const params = tool.parameters as { required?: string[]; additionalProperties?: boolean };
+	expect(params.required).toEqual(["questions"]);
+	expect(params.additionalProperties).toBe(false);
+
+	// A strict model fills optionals with null — the wrapper strips them before validation logic runs.
+	const nulled = {
+		questions: [
+			{
+				question: "Which library?",
+				header: "Lib",
+				multiSelect: null,
+				options: [
+					{ label: "date-fns", description: "small", preview: null, recommendedReason: null },
+					{ label: "luxon", description: "rich", preview: null, recommendedReason: null },
+				],
+			},
+		],
+	};
+	const result = await tool.execute("tc-strict", nulled as never, undefined, undefined, ctx(true));
+	expect(textOf(result as never)).toBe(ASK_ACK_TEXT);
+	expect((result as { terminate?: boolean }).terminate).toBe(true);
 });
 
 test("execute returns a validation error (non-terminating) for a malformed questionnaire", async () => {

--- a/packages/server/src/agent/askUserQuestion.ts
+++ b/packages/server/src/agent/askUserQuestion.ts
@@ -37,6 +37,7 @@ import type {
 } from "@thinkrail/contracts";
 import { ASK_USER_ANSWERS_CUSTOM_TYPE, isAskUserAnswersMessage } from "@thinkrail/contracts";
 import { type Static, Type } from "typebox";
+import { strictTool } from "./strictSampling";
 
 // ---- limits (mirrors the rpiv contract so the model behaves the same) ----
 export const MAX_QUESTIONS = 4;
@@ -145,6 +146,9 @@ export interface ValidationResult {
 /**
  * Pure runtime validator for the questionnaire args (everything except the `no_ui` guard, which depends
  * on `ctx.hasUI` and stays at the call site). `reserved_label` short-circuits before duplicate checks.
+ * Also owns the count/length limits the TypeBox schema used to carry as `minItems`/`maxItems`/
+ * `maxLength` — strict-mode providers reject those keywords, so `strictTool` strips them from the
+ * advertised schema and this validator is where they are enforced.
  */
 export function validateQuestionnaire(args: AskUserQuestionArgs): ValidationResult {
 	const questions = args.questions ?? [];
@@ -165,6 +169,16 @@ export function validateQuestionnaire(args: AskUserQuestionArgs): ValidationResu
 				ok: false,
 				message: `Error: Each question requires at least ${MIN_OPTIONS} options`,
 			};
+		if (q.options.length > MAX_OPTIONS)
+			return {
+				ok: false,
+				message: `Error: At most ${MAX_OPTIONS} options are allowed per question`,
+			};
+		if (q.header.length > MAX_HEADER_LENGTH)
+			return {
+				ok: false,
+				message: `Error: header must be at most ${MAX_HEADER_LENGTH} characters`,
+			};
 
 		const seenLabels = new Set<string>();
 		for (const o of q.options) {
@@ -176,6 +190,16 @@ export function validateQuestionnaire(args: AskUserQuestionArgs): ValidationResu
 			if (seenLabels.has(o.label))
 				return { ok: false, message: "Error: Option labels must be unique within a question" };
 			seenLabels.add(o.label);
+			if (o.label.length > MAX_LABEL_LENGTH)
+				return {
+					ok: false,
+					message: `Error: Option labels must be at most ${MAX_LABEL_LENGTH} characters`,
+				};
+			if ((o.recommendedReason?.length ?? 0) > MAX_RECOMMENDED_REASON_LENGTH)
+				return {
+					ok: false,
+					message: `Error: recommendedReason must be at most ${MAX_RECOMMENDED_REASON_LENGTH} characters`,
+				};
 		}
 	}
 	return { ok: true, message: "" };
@@ -381,7 +405,11 @@ export function createAskUserQuestionTool(): ToolDefinition<
 	};
 }
 
-/** Extension factory (mirrors `extensions`' pattern): registers the tool on each session's `pi`. */
+/**
+ * Extension factory (mirrors `extensions`' pattern): registers the tool on each session's `pi`,
+ * opted into strict sampling (`strictTool`) — the nested questionnaire schema is exactly where
+ * malformed args hurt. `createAskUserQuestionTool` stays unwrapped so unit tests drive the raw tool.
+ */
 export function askUserQuestionExtension(pi: ExtensionAPI): void {
-	pi.registerTool(createAskUserQuestionTool());
+	pi.registerTool(strictTool(createAskUserQuestionTool()));
 }

--- a/packages/server/src/agent/strictSampling.test.ts
+++ b/packages/server/src/agent/strictSampling.test.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "bun:test";
+import { StringEnum } from "@earendil-works/pi-ai/compat";
+import type { ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import { Compile } from "typebox/compile";
+import { AskUserQuestionSchema } from "./askUserQuestion";
+import { strictSchema, strictTool } from "./strictSampling";
+
+// A schema exercising every transform case: required + optional scalars, an optional array of objects
+// with their own optionals, a `default`, and constraint keywords that must survive.
+const OptionSchema = Type.Object({
+	label: Type.String({ maxLength: 10 }),
+	preview: Type.Optional(Type.String({ description: "markdown preview" })),
+});
+const ParamsSchema = Type.Object({
+	title: Type.String(),
+	note: Type.Optional(Type.String({ description: "a note" })),
+	flag: Type.Optional(Type.Boolean({ default: false })),
+	options: Type.Optional(Type.Array(OptionSchema, { minItems: 1 })),
+});
+type Params = Static<typeof ParamsSchema>;
+
+type Node = Record<string, unknown>;
+const strict = strictSchema(ParamsSchema) as unknown as Node;
+const props = strict.properties as Record<string, Node>;
+
+test("every object node becomes additionalProperties:false with ALL properties required", () => {
+	expect(strict.additionalProperties).toBe(false);
+	expect([...(strict.required as string[])].sort()).toEqual(["flag", "note", "options", "title"]);
+
+	const optionNode = ((props.options as Node).anyOf as Node[])[0]?.items as Node;
+	expect(optionNode.additionalProperties).toBe(false);
+	expect([...(optionNode.required as string[])].sort()).toEqual(["label", "preview"]);
+});
+
+test("formerly-optional properties become null unions with the description hoisted", () => {
+	const note = props.note as Node;
+	expect(note.anyOf).toEqual([{ type: "string", description: "a note" }, { type: "null" }]);
+	expect(note.description).toBe("a note");
+	// Required properties stay untouched (constraints intact).
+	expect(props.title).toEqual({ type: "string" });
+});
+
+test("strict-unsupported keywords are stripped everywhere (default, minItems, maxLength, …)", () => {
+	// Strict-mode providers validate schemas against a narrow keyword subset and 400 the whole request
+	// otherwise (live Anthropic: `For 'array' type, property 'maxItems' is not supported`).
+	const flagInner = ((props.flag as Node).anyOf as Node[])[0] as Node;
+	expect("default" in flagInner).toBe(false);
+	expect("minItems" in (((props.options as Node).anyOf as Node[])[0] as Node)).toBe(false);
+	const optionNode = ((props.options as Node).anyOf as Node[])[0]?.items as Node;
+	expect("maxLength" in ((optionNode.properties as Record<string, Node>).label as Node)).toBe(
+		false,
+	);
+	// Enum survives — it's in the strict-safe subset and models rely on it.
+	const withEnum = strictSchema(Type.Object({ kind: StringEnum(["a", "b"]) })) as unknown as Node;
+	expect((withEnum.properties as Record<string, Node>).kind?.enum).toEqual(["a", "b"]);
+});
+
+test("record-style nodes (Type.Record → patternProperties) are preserved, never clobbered", () => {
+	const record = strictSchema(
+		Type.Object({ set: Type.Optional(Type.Record(Type.String(), Type.String())) }),
+	) as unknown as Node;
+	const setNode = ((record.properties as Record<string, Node>).set?.anyOf as Node[])[0] as Node;
+	// The record keeps validating arbitrary string keys — additionalProperties is NOT forced false…
+	expect(setNode.patternProperties).toEqual({ "^.*$": { type: "string" } });
+	expect("additionalProperties" in setNode).toBe(false);
+	// …which also means such a schema can't conform to OpenAI strict: tools carrying records stay
+	// unwrapped (spec_update) — this test pins that the helper at least never corrupts them.
+	const check = Compile(record as never);
+	expect(check.Check({ set: { title: "x" } })).toBe(true);
+	expect(check.Check({ set: null })).toBe(true);
+});
+
+test("the transform is idempotent and never mutates its input", () => {
+	const before = JSON.stringify(ParamsSchema);
+	strictSchema(ParamsSchema);
+	expect(JSON.stringify(ParamsSchema)).toBe(before);
+	expect(strictSchema(strict as never)).toEqual(strict as never);
+});
+
+// ---- validation behavior, compiled exactly like pi's validator (typebox/compile) ----
+
+test("compiled transformed schema: nulls pass, omissions fail, extra props fail (strict semantics)", () => {
+	const check = Compile(strict as never);
+	expect(
+		check.Check({ title: "t", note: null, flag: null, options: [{ label: "a", preview: null }] }),
+	).toBe(true);
+	expect(check.Check({ title: "t", note: "n", flag: true, options: null })).toBe(true);
+	// All-required now: a bare omission no longer validates (the prepareArguments fill repairs it).
+	expect(check.Check({ title: "t" })).toBe(false);
+	expect(check.Check({ title: "t", note: null, flag: null, options: null, zzz: 1 })).toBe(false);
+});
+
+// ---- the Anthropic union budget ----
+
+test("the wrapped ask schema stays far under Anthropic's 16-union-per-request budget", () => {
+	// Anthropic strict tools 400 the WHOLE request past “16 parameters with unions” counted across all
+	// tools — the reason only ask_user_question is wrapped (see header). Pin its cost so growth is loud.
+	const unionCount = (node: unknown): number => {
+		if (Array.isArray(node)) return node.reduce((sum: number, m) => sum + unionCount(m), 0);
+		if (typeof node !== "object" || node === null) return 0;
+		const n = node as Record<string, unknown>;
+		return (
+			(Array.isArray(n.anyOf) ? 1 : 0) +
+			Object.values(n).reduce((sum: number, v) => sum + unionCount(v), 0)
+		);
+	};
+	expect(unionCount(strictSchema(AskUserQuestionSchema))).toBe(3);
+});
+
+// ---- strictTool wiring ----
+
+function makeTool(
+	execute: ToolDefinition<typeof ParamsSchema, unknown>["execute"],
+): ToolDefinition<typeof ParamsSchema, unknown> {
+	return {
+		name: "probe",
+		label: "Probe",
+		description: "test probe",
+		parameters: ParamsSchema,
+		execute,
+	};
+}
+
+const ctx = {} as ExtensionContext;
+
+test("strictTool sets constrainedSampling prefer by default; an authored value (incl. false) wins", () => {
+	const wrapped = strictTool(makeTool(async () => ({ content: [], details: {} })));
+	expect(wrapped.constrainedSampling).toEqual({ type: "json_schema", strict: "prefer" });
+
+	const optedOut = strictTool({
+		...makeTool(async () => ({ content: [], details: {} })),
+		constrainedSampling: false as const,
+	});
+	expect(optedOut.constrainedSampling).toBe(false);
+});
+
+test("prepareArguments fills missing null-union keys (deep) without mutating the model's args", () => {
+	const wrapped = strictTool(makeTool(async () => ({ content: [], details: {} })));
+	const raw = { title: "t", options: [{ label: "a" }] };
+	const prepared = wrapped.prepareArguments?.(raw) as Record<string, unknown>;
+	expect(prepared).toEqual({
+		title: "t",
+		note: null,
+		flag: null,
+		options: [{ label: "a", preview: null }],
+	});
+	// The input (the transcript's toolCall.arguments) is untouched.
+	expect(raw).toEqual({ title: "t", options: [{ label: "a" }] });
+});
+
+test("prepareArguments composes: an authored shim runs first, on the raw args", () => {
+	const seen: unknown[] = [];
+	const wrapped = strictTool({
+		...makeTool(async () => ({ content: [], details: {} })),
+		prepareArguments: (args) => {
+			seen.push(args);
+			return { ...(args as Record<string, unknown>), title: "rewritten" } as Params;
+		},
+	});
+	const prepared = wrapped.prepareArguments?.({ title: "t" }) as Record<string, unknown>;
+	expect(seen).toEqual([{ title: "t" }]);
+	expect(prepared.title).toBe("rewritten");
+	expect(prepared.note).toBeNull();
+});
+
+test("execute receives null-stripped params matching the ORIGINAL schema's optionals", async () => {
+	let received: Params | undefined;
+	const wrapped = strictTool(
+		makeTool(async (_id, params) => {
+			received = params;
+			return { content: [], details: {} };
+		}),
+	);
+	await wrapped.execute(
+		"call-1",
+		{
+			title: "t",
+			note: null,
+			flag: null,
+			options: [{ label: "a", preview: null }],
+		} as never,
+		undefined,
+		undefined,
+		ctx,
+	);
+	expect(received).toEqual({ title: "t", options: [{ label: "a" }] });
+});

--- a/packages/server/src/agent/strictSampling.ts
+++ b/packages/server/src/agent/strictSampling.ts
@@ -1,0 +1,196 @@
+// Strict-sampling wrapper for pi custom tools (pi ≥0.82 `Tool.constrainedSampling`).
+//
+// SCOPE — `ask_user_question` ONLY, by provider budget, not by preference. Every formerly-optional
+// property the transform makes required-but-nullable adds one union (`anyOf`), and Anthropic's strict
+// compiler enforces a hard PER-REQUEST budget across all tools it sees (live 400: “Schemas contains
+// too many parameters with union types (39 …) … limit: 16 parameters with unions”). All our custom
+// tools ride every session, and wrapping them all costs 39 unions — every request to a
+// strict-capable Anthropic model fails outright. ask_user_question costs 3, the highest-value target
+// (its nested options schema is where malformed args actually hurt). Opting another tool in means
+// re-counting the shared budget — and its schema lives in a portable extension package, which would
+// need its own copy of this helper (they carry no workspace deps).
+//
+// WHY THIS EXISTS: `strict: "prefer"` makes capable providers sample tool args that satisfy the schema
+// by construction — but pi sends `tool.parameters` AS-IS, and OpenAI-style strict mode rejects any
+// schema whose objects aren't `additionalProperties: false` with EVERY property required (optionals
+// must be emulated as `T | null`). So opting in means transforming the schema — and then insulating
+// both sides of it:
+//   - non-strict models may still OMIT formerly-optional keys (yesterday's valid behavior): a
+//     `prepareArguments` shim fills the missing null-union keys with `null` BEFORE pi validates;
+//   - handlers keep their classic optionals: `execute` deep-strips `null` property values, so the
+//     wrapped tool sees args matching the ORIGINAL schema's Static type (and any `details` built from
+//     them stay null-free for renderers). The transcript keeps the model's raw (nullable) args —
+//     renderers reading those were audited null-tolerant.
+//
+// CONSTRAINTS on wrapped tools:
+//   - don't author `null`-typed params — property-level `null` is treated as "absent" (none of ours
+//     do; authored null-unions are left unwrapped but their nulls are still stripped before execute);
+//   - numeric/length constraint keywords (`maxItems`, `maxLength`, …) are STRIPPED from the advertised
+//     schema: strict-mode providers validate the schema against a narrow keyword subset and 400 the
+//     whole request otherwise (live Anthropic: `For 'array' type, property 'maxItems' is not
+//     supported`). A tool that relies on such a limit must state it in the property `description` and
+//     enforce it at runtime (ask_user_question's `validateQuestionnaire` does).
+
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { Static, TSchema } from "typebox";
+
+/** typebox 1.x schemas are plain JSON (no symbols), so the transform works on plain nodes. */
+type JsonNode = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonNode {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Whether a schema node already admits `null` (an authored or previously-wrapped null union). */
+function admitsNull(node: unknown): boolean {
+	if (!isPlainObject(node)) return false;
+	if (node.type === "null") return true;
+	return Array.isArray(node.anyOf) && node.anyOf.some((m) => isPlainObject(m) && m.type === "null");
+}
+
+/** Wrap a property schema as `T | null`, hoisting its description so pickers still surface it. */
+function toNullUnion(node: unknown): unknown {
+	if (admitsNull(node)) return node;
+	const wrapped: JsonNode = { anyOf: [node, { type: "null" }] };
+	if (isPlainObject(node) && typeof node.description === "string") {
+		wrapped.description = node.description;
+	}
+	return wrapped;
+}
+
+// Keywords outside the strict-safe intersection (see header): strict-capable providers reject schemas
+// carrying them, and one nonconforming tool 400s the whole request for every session it rides.
+const STRICT_UNSUPPORTED_KEYWORDS = [
+	"default",
+	"examples",
+	"minItems",
+	"maxItems",
+	"uniqueItems",
+	"minContains",
+	"maxContains",
+	"minLength",
+	"maxLength",
+	"pattern",
+	"format",
+	"minimum",
+	"maximum",
+	"exclusiveMinimum",
+	"exclusiveMaximum",
+	"multipleOf",
+	"minProperties",
+	"maxProperties",
+] as const;
+
+function visit(node: unknown): void {
+	if (!isPlainObject(node)) return;
+	for (const keyword of STRICT_UNSUPPORTED_KEYWORDS) delete node[keyword];
+
+	const props = node.properties;
+	if (isPlainObject(props)) {
+		const required = new Set(Array.isArray(node.required) ? node.required : []);
+		for (const [key, prop] of Object.entries(props)) {
+			visit(prop);
+			if (!required.has(key)) props[key] = toNullUnion(prop);
+		}
+		node.required = Object.keys(props);
+	}
+	// Forbid unmatched keys — but never clobber an authored additionalProperties schema. Record-style
+	// nodes (`Type.Record` → patternProperties) can't conform to OpenAI strict at all: keep them
+	// functional here and DON'T opt such tools in (e.g. spec_update stays unwrapped).
+	if (
+		node.type === "object" &&
+		node.additionalProperties === undefined &&
+		!isPlainObject(node.patternProperties)
+	) {
+		node.additionalProperties = false;
+	}
+	if (isPlainObject(node.additionalProperties)) visit(node.additionalProperties);
+	const patterns = node.patternProperties;
+	if (isPlainObject(patterns)) for (const value of Object.values(patterns)) visit(value);
+
+	if (Array.isArray(node.items)) for (const item of node.items) visit(item);
+	else if (node.items) visit(node.items);
+
+	for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
+		const members = node[keyword];
+		if (Array.isArray(members)) for (const member of members) visit(member);
+	}
+}
+
+/**
+ * Strict-conformant variant of a TypeBox/JSON schema: every object `additionalProperties: false` with
+ * all properties required; formerly-optional properties become `{ anyOf: [T, { type: "null" }] }`;
+ * `default` stripped. Pure — returns a transformed deep clone; idempotent.
+ */
+export function strictSchema<T extends TSchema>(schema: T): T {
+	const clone = structuredClone(schema) as unknown as JsonNode;
+	visit(clone);
+	return clone as unknown as T;
+}
+
+/**
+ * Fill missing null-union keys with `null` so a non-strict model omitting formerly-optional fields
+ * still validates against the all-required transformed schema. Non-mutating (the input object is the
+ * transcript's `toolCall.arguments` — pi replaces it only when `prepareArguments` returns a new one).
+ */
+function fillNulls(schema: unknown, value: unknown): unknown {
+	if (!isPlainObject(schema)) return value;
+	if (Array.isArray(schema.anyOf)) {
+		if (value === null) return value;
+		// Recurse into the non-null member of a null union (our wrapping produces exactly one).
+		const inner = schema.anyOf.filter((m) => !(isPlainObject(m) && m.type === "null"));
+		return inner.length === 1 ? fillNulls(inner[0], value) : value;
+	}
+	const props = schema.properties;
+	if (isPlainObject(props) && isPlainObject(value)) {
+		const out: JsonNode = { ...value };
+		for (const [key, prop] of Object.entries(props)) {
+			if (key in out) out[key] = fillNulls(prop, out[key]);
+			else if (admitsNull(prop)) out[key] = null;
+		}
+		return out;
+	}
+	if (!Array.isArray(schema.items) && schema.items && Array.isArray(value)) {
+		return value.map((item) => fillNulls(schema.items, item));
+	}
+	return value;
+}
+
+/** Deep-strip `null` property values so handlers see the original schema's optionals as absent. */
+function stripNulls(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stripNulls);
+	if (isPlainObject(value)) {
+		const out: JsonNode = {};
+		for (const [key, entry] of Object.entries(value)) {
+			if (entry !== null) out[key] = stripNulls(entry);
+		}
+		return out;
+	}
+	return value;
+}
+
+/**
+ * Opt a tool definition into provider-side strict sampling (`strict: "prefer"` — capable models sample
+ * schema-valid args; others fall back to normal tool calling). See the header for the full mechanics.
+ * An authored `constrainedSampling` (including `false`) wins over the default.
+ */
+export function strictTool<TParams extends TSchema, TDetails, TState = unknown>(
+	definition: ToolDefinition<TParams, TDetails, TState>,
+): ToolDefinition<TParams, TDetails, TState> {
+	const parameters = strictSchema(definition.parameters);
+	const prepare = definition.prepareArguments;
+	return {
+		...definition,
+		parameters,
+		constrainedSampling: definition.constrainedSampling ?? {
+			type: "json_schema",
+			strict: "prefer",
+		},
+		prepareArguments: (args: unknown) =>
+			// The fill's output conforms to the TRANSFORMED schema (nulls where the original had
+			// optionals) — Static<TParams> is the closest expressible type; execute re-narrows by strip.
+			fillNulls(parameters, prepare ? prepare(args) : args) as Static<TParams>,
+		execute: (toolCallId, params, signal, onUpdate, ctx) =>
+			definition.execute(toolCallId, stripNulls(params) as Static<TParams>, signal, onUpdate, ctx),
+	};
+}


### PR DESCRIPTION
## Summary

Adopts pi 0.82's `Tool.constrainedSampling` — **scoped to `ask_user_question`**, the tool whose nested questionnaire schema is where malformed args actually hurt. Follow-up to #114 (now merged): needs the 0.82 engine.

**The wrapper** (`packages/server/src/agent/strictSampling.ts`, `strictTool(definition)`):
- Transforms the schema strict-conformant: every object `additionalProperties: false`, **all properties required**, formerly-optional properties become `{ anyOf: [T, { type: "null" }] }` (description hoisted) — pi sends `tool.parameters` as-is and OpenAI-style strict rejects anything less.
- Strips keywords strict-mode providers reject (`default`, `minItems`/`maxItems`, `minLength`/`maxLength`, `pattern`, `format`, numeric bounds, …). Limits the tool relies on moved into `validateQuestionnaire` as runtime checks (including `MAX_OPTIONS`, which had been schema-only) with model-visible errors.
- Insulates both sides of the transform: `prepareArguments` null-fills omissions from **non-strict** models before pi validates (yesterday's valid behavior stays valid); `execute` deep-strips `null`s so the handler keeps the original schema's optionals. The transcript keeps the model's raw nullable args — web renderers were audited null-tolerant (truthiness guards / defensive parsers).
- Sets `constrainedSampling: { type: "json_schema", strict: "prefer" }` (an authored value, incl. `false`, wins). Record-style nodes (`Type.Record` → `patternProperties`) are inexpressible under strict and left untouched.

**Why only ask_user_question — live-provider evidence, not preference.** The originally intended scope was *all* custom tools (ask + `todo_*` + `spec_*` + `visualize`); the full agent suite vetoed it with two hard Anthropic 400s:
1. `For 'array' type, property 'maxItems' is not supported` → the keyword-stripping above.
2. `Schemas contains too many parameters with union types (39 …) … limit: 16 parameters with unions` — a **per-request budget across all tools**, and every custom tool rides every session. All-tools costs 39 unions → every request to a strict-capable Anthropic model fails outright (`prefer` can't help; capability is per-model, the schema is static). ask costs **3**, pinned by a unit test so growth is loud. `visualize` would cost 8 more (11/16) — possible as a deliberate follow-up, not a default.

Specs updated alongside: `packages/server/src/agent/SPEC.md` (strictSampling module + the budget rationale + the ask wrap seam).

## Related issues

Follow-up to #114. Upstream note (pi): `prefer` could count unions per request / sanitize unsupported keywords instead of letting providers 400 — may be worth filing.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test` (205, incl. 13 new)
- [x] E2E suite passes for app-affecting changes — `bun run e2e` 52/52, **`bun run e2e:agent` 38/38** (real provider, strict sampling engaged), `bun run test:workflows` 21/21 (one nondeterministic scenario failed once, passed clean on re-run; unrelated to the ask schema)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
