### PR TITLE
feat(install): Windows-native installer for cmd + PowerShell (install.ps1)

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -93,8 +93,11 @@ channel, download the platform asset + `SHA256SUMS`, verify the checksum, and dr
   `%USERPROFILE%\.local\bin` (same default prefix as `install.sh`, so a Git Bash install and a native
   install coincide), writes the same `~/.config/thinkrail/install.json`, appends the bin dir to the
   **user** PATH via `HKCU\Environment` (idempotent, `REG_EXPAND_SZ`-preserving, `WM_SETTINGCHANGE`
-  broadcast; `-NoModifyPath` opts out), and survives a locked running exe by renaming it aside
-  (`thinkrail.exe.*.old`, cleaned up by the next install) before replacing.
+  broadcast; `-NoModifyPath` opts out). **Idempotence is judged against the *persistent* PATH only** —
+  the HKCU + machine registry values, never `$env:Path`: a session-only `$env:Path +=` must not be
+  mistaken for an install, or the registry write is skipped and `thinkrail` is gone from the next
+  terminal. It survives a locked running exe by renaming it aside (`thinkrail.exe.*.old`, cleaned up
+  by the next install) before replacing.
 
 Both depend on the **artifact-name contract** this module produces (`thinkrail-<os>-<arch>` with `os` ∈
 {`linux`,`darwin`,`windows`}, `arch` ∈ {`x64`,`arm64`}, `.exe` on Windows) and the `SHA256SUMS` file —

--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -96,8 +96,12 @@ channel, download the platform asset + `SHA256SUMS`, verify the checksum, and dr
   broadcast; `-NoModifyPath` opts out). **Idempotence is judged against the *persistent* PATH only** —
   the HKCU + machine registry values, never `$env:Path`: a session-only `$env:Path +=` must not be
   mistaken for an install, or the registry write is skipped and `thinkrail` is gone from the next
-  terminal. It survives a locked running exe by renaming it aside (`thinkrail.exe.*.old`, cleaned up
-  by the next install) before replacing.
+  terminal. **Replacing the binary never risks the installed one**: the verified download is staged
+  *inside* the bin dir first (so a cross-volume or out-of-space failure strikes before anything
+  installed is touched), then swapped in by same-volume rename; a locked running exe is renamed aside
+  (`thinkrail.exe.*.old`, cleaned up by the next install alongside stale `.new` stages) and restored if
+  the swap then fails. A first-move failure with **no** `thinkrail.exe` present is rethrown as-is, not
+  mistaken for a lock.
 
 Both depend on the **artifact-name contract** this module produces (`thinkrail-<os>-<arch>` with `os` ∈
 {`linux`,`darwin`,`windows`}, `arch` ∈ {`x64`,`arm64`}, `.exe` on Windows) and the `SHA256SUMS` file —

--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -80,15 +80,29 @@ and, threaded `apps/cli` → `bootHost` → `createServer`, in the `server.welco
 - `actions/codesign` — JetBrains CodeSign client wrapper; **wired but disabled** (`_release.yml`'s `sign`
   job is `if: false`). Binaries ship unsigned until secrets + a signing runner are provided.
 
-## Install side (`/install.sh`)
+## Install side (`/install.sh` + `/install.ps1`)
 
-The repo-root `install.sh` is the **consumer** of the release: it resolves the latest tag for a channel,
-downloads the platform asset + `SHA256SUMS`, verifies, and drops `thinkrail` on PATH. It therefore
-depends on the **artifact-name contract** this module produces (`thinkrail-<os>-<arch>` with `os` ∈
+Two repo-root installers are the **consumers** of the release — both resolve the latest tag for a
+channel, download the platform asset + `SHA256SUMS`, verify the checksum, and drop `thinkrail` on PATH:
+
+- **`install.sh`** — bash: macOS/Linux, plus Windows under Git Bash/MSYS (`curl -fsSL … | bash`).
+- **`install.ps1`** — Windows-native, one script for **both cmd and PowerShell** (Windows PowerShell
+  5.1-compatible): `powershell -c "irm …/install.ps1 | iex"`. Options travel as env vars
+  (`THINKRAIL_CHANNEL` / `THINKRAIL_VERSION` / `THINKRAIL_PREFIX` / `THINKRAIL_NO_MODIFY_PATH`) — the
+  only syntax both shells share — with mirroring params for a saved copy. It installs to
+  `%USERPROFILE%\.local\bin` (same default prefix as `install.sh`, so a Git Bash install and a native
+  install coincide), writes the same `~/.config/thinkrail/install.json`, appends the bin dir to the
+  **user** PATH via `HKCU\Environment` (idempotent, `REG_EXPAND_SZ`-preserving, `WM_SETTINGCHANGE`
+  broadcast; `-NoModifyPath` opts out), and survives a locked running exe by renaming it aside
+  (`thinkrail.exe.*.old`, cleaned up by the next install) before replacing.
+
+Both depend on the **artifact-name contract** this module produces (`thinkrail-<os>-<arch>` with `os` ∈
 {`linux`,`darwin`,`windows`}, `arch` ∈ {`x64`,`arm64`}, `.exe` on Windows) and the `SHA256SUMS` file —
-change the asset names in `_build.yml`/`build-binary` and `install.sh` must change in lockstep. The
-README documents the user-facing install. `thinkrail update` (the CLI's self-update, see `module-cli`)
-re-invokes this same script, so `install.sh` is the one place the download/verify/PATH logic lives.
+change the asset names in `_build.yml`/`build-binary` and **both installers** must change in lockstep.
+The README documents the user-facing install. `thinkrail update` (the CLI's self-update, see
+`module-cli`) re-invokes `install.sh` on macOS/Linux — the installers stay the one place the
+download/verify/PATH logic lives; on Windows it prints the `install.ps1` one-liner instead of updating
+in place.
 
 ## Boundary
 

--- a/README.md
+++ b/README.md
@@ -17,22 +17,37 @@ spec-graph viewer, and multiple concurrent `pi` chat sessions — all scoped to 
 ## Install
 
 ThinkRail ships as a single self-contained executable per platform. The installer downloads the right
-build from the GitHub releases, verifies its SHA-256 checksum, and puts `thinkrail` on your PATH:
+build from the GitHub releases, verifies its SHA-256 checksum, and puts `thinkrail` on your PATH.
+
+**macOS / Linux** (also Windows under Git Bash):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash
 ```
 
+**Windows** — the same command works from cmd and PowerShell:
+
+```powershell
+powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"
+```
+
 Nightly builds and pinned versions:
 
 ```bash
+# macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash -s -- --channel nightly
 curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash -s -- --version 0.2.0
 ```
 
+```powershell
+# Windows — options are env vars (THINKRAIL_CHANNEL, THINKRAIL_VERSION, THINKRAIL_PREFIX, THINKRAIL_NO_MODIFY_PATH)
+$env:THINKRAIL_CHANNEL='nightly'; irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex   # PowerShell
+set "THINKRAIL_VERSION=0.2.0" && powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"   # cmd
+```
+
 Then run `thinkrail` (add a git repo path to open it as a project: `thinkrail ~/code/my-repo`). To update
 later, run `thinkrail update` (re-installs the latest build for your channel; macOS/Linux only — on
-Windows, re-download from releases). `thinkrail --help` lists the flags; `thinkrail --version` prints the
+Windows, re-run the installer). `thinkrail --help` lists the flags; `thinkrail --version` prints the
 build.
 
 **Prebuilt platforms:** macOS (Apple Silicon), Linux arm64 + x64, Windows x64 (`.exe`). Intel macOS isn't

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -44,11 +44,16 @@ git repo to open as a project on boot, best-effort). Env defaults: `THINKRAIL_PO
 checksum → replace → PATH logic. Channel/prefix resolve as flag > `~/.config/thinkrail/install.json` >
 baked channel (from `version.ts`; `dev` → `stable`) / `~/.local`. Unix-only execution (in-place
 self-replace on Windows is deferred → prints the `install.ps1` command, with the releases page as the
-manual fallback). The Windows message resolves the **same** channel first and spells the command out
-**per shell** (`windowsUpdateMessage`): cmd's `set "X=v" &&` and PowerShell's `$env:X='v';` are not
-interchangeable — one shell's syntax shown to the other silently re-installs the wrong channel. The
-arg parse + channel/prefix resolution are pure (`parseUpdateArgs` / `resolveUpdateChannel` /
-`resolveUpdatePlan`, unit-tested); only fetch (`curl`) + run (`bash -s`) touch IO.
+manual fallback). The Windows message resolves the **same** channel + prefix the Unix plan would, then
+spells the command out **per shell** (`windowsUpdateMessage`): cmd's `set "X=v" &&` and PowerShell's
+`$env:X='v';` are not interchangeable — one shell's syntax shown to the other silently re-installs the
+wrong build, and a dropped `THINKRAIL_PREFIX` would put a second copy under `.local` while the
+PATH-resolved exe stays stale. `resolveWindowsPrefix` owns that seam: it omits the installer's own
+default, and refuses a metadata prefix that isn't a rooted Windows path or can't be safely quoted
+(Windows needs its own charset — `PREFIX_FORBIDDEN_RE` rejects the backslash every Windows path is made
+of). The arg parse + channel/prefix resolution are pure (`parseUpdateArgs` / `resolveUpdateChannel` /
+`resolveWindowsPrefix` / `resolveUpdatePlan`, unit-tested); only fetch (`curl`) + run (`bash -s`) touch
+IO.
 `THINKRAIL_INSTALL_SCRIPT_URL` overrides the installer URL (testing / forks). See `module-ci-release`
 for the installer itself.
 

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -42,8 +42,9 @@ git repo to open as a project on boot, best-effort). Env defaults: `THINKRAIL_PO
 `src/update.ts` ports the old repo's `thinkrail upgrade` (renamed): it re-invokes the published
 `install.sh` for the binary's channel, so the installer stays the single source of the download →
 checksum → replace → PATH logic. Channel/prefix resolve as flag > `~/.config/thinkrail/install.json` >
-baked channel (from `version.ts`; `dev` → `stable`) / `~/.local`. Unix-only (replacing a running `.exe`
-in place isn't possible on Windows → points to the releases page). The arg parse + channel/prefix
+baked channel (from `version.ts`; `dev` → `stable`) / `~/.local`. Unix-only execution (in-place
+self-replace on Windows is deferred → prints the `install.ps1` one-liner — works from cmd and
+PowerShell — with the releases page as the manual fallback). The arg parse + channel/prefix
 resolution are pure (`parseUpdateArgs` / `resolveUpdatePlan`, unit-tested); only fetch (`curl`) + run
 (`bash -s`) touch IO. `THINKRAIL_INSTALL_SCRIPT_URL` overrides the installer URL (testing / forks). See
 `module-ci-release` for the installer itself.

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -43,11 +43,14 @@ git repo to open as a project on boot, best-effort). Env defaults: `THINKRAIL_PO
 `install.sh` for the binary's channel, so the installer stays the single source of the download →
 checksum → replace → PATH logic. Channel/prefix resolve as flag > `~/.config/thinkrail/install.json` >
 baked channel (from `version.ts`; `dev` → `stable`) / `~/.local`. Unix-only execution (in-place
-self-replace on Windows is deferred → prints the `install.ps1` one-liner — works from cmd and
-PowerShell — with the releases page as the manual fallback). The arg parse + channel/prefix
-resolution are pure (`parseUpdateArgs` / `resolveUpdatePlan`, unit-tested); only fetch (`curl`) + run
-(`bash -s`) touch IO. `THINKRAIL_INSTALL_SCRIPT_URL` overrides the installer URL (testing / forks). See
-`module-ci-release` for the installer itself.
+self-replace on Windows is deferred → prints the `install.ps1` command, with the releases page as the
+manual fallback). The Windows message resolves the **same** channel first and spells the command out
+**per shell** (`windowsUpdateMessage`): cmd's `set "X=v" &&` and PowerShell's `$env:X='v';` are not
+interchangeable — one shell's syntax shown to the other silently re-installs the wrong channel. The
+arg parse + channel/prefix resolution are pure (`parseUpdateArgs` / `resolveUpdateChannel` /
+`resolveUpdatePlan`, unit-tested); only fetch (`curl`) + run (`bash -s`) touch IO.
+`THINKRAIL_INSTALL_SCRIPT_URL` overrides the installer URL (testing / forks). See `module-ci-release`
+for the installer itself.
 
 ## Version stamping (release seam)
 

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseUpdateArgs, resolveUpdatePlan } from "./update";
+import { parseUpdateArgs, resolveUpdatePlan, windowsUpdateMessage } from "./update";
 
 describe("parseUpdateArgs", () => {
 	test("defaults to latest, no channel override", () => {
@@ -105,5 +105,48 @@ describe("resolveUpdatePlan", () => {
 				home,
 			}),
 		).toThrow("suspicious install prefix");
+	});
+});
+
+describe("windowsUpdateMessage", () => {
+	const psLine = (msg: string) => msg.split("\n").find((l) => l.includes("PowerShell:")) ?? "";
+	const cmdLine = (msg: string) => msg.split("\n").find((l) => l.includes("cmd:")) ?? "";
+
+	test("stable/latest is one bare command per shell", () => {
+		const msg = windowsUpdateMessage("stable", "latest");
+		expect(psLine(msg)).toContain(
+			"irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex",
+		);
+		expect(cmdLine(msg)).toContain('powershell -c "irm ');
+		expect(msg).not.toContain("THINKRAIL_CHANNEL");
+		expect(msg).not.toContain("THINKRAIL_VERSION");
+	});
+
+	test("carries the channel in each shell's own env syntax", () => {
+		const msg = windowsUpdateMessage("nightly", "latest");
+		// The bug this pins: a single cmd-syntax `set "X=v"` shown to PowerShell users, where `set` is
+		// Set-Variable and never reaches the child process -> a silent downgrade to stable.
+		expect(psLine(msg)).toContain("$env:THINKRAIL_CHANNEL='nightly';");
+		expect(psLine(msg)).not.toContain('set "');
+		expect(cmdLine(msg)).toContain('set "THINKRAIL_CHANNEL=nightly" &&');
+		expect(cmdLine(msg)).not.toContain("$env:");
+	});
+
+	test("carries a pinned version too", () => {
+		const msg = windowsUpdateMessage("nightly", "0.2.0");
+		expect(psLine(msg)).toContain(
+			"$env:THINKRAIL_CHANNEL='nightly'; $env:THINKRAIL_VERSION='0.2.0';",
+		);
+		expect(cmdLine(msg)).toContain(
+			'set "THINKRAIL_CHANNEL=nightly" && set "THINKRAIL_VERSION=0.2.0" &&',
+		);
+	});
+
+	test("stays ASCII (legacy conhost code pages garble anything else)", () => {
+		for (const channel of ["stable", "nightly"] as const) {
+			const msg = windowsUpdateMessage(channel, "1.2.3");
+			// One UTF-8 byte per char <=> every char is ASCII.
+			expect(Buffer.byteLength(msg, "utf8")).toBe(msg.length);
+		}
 	});
 });

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { parseUpdateArgs, resolveUpdatePlan, windowsUpdateMessage } from "./update";
+import {
+	parseUpdateArgs,
+	resolveUpdatePlan,
+	resolveWindowsPrefix,
+	windowsUpdateMessage,
+} from "./update";
 
 describe("parseUpdateArgs", () => {
 	test("defaults to latest, no channel override", () => {
@@ -142,11 +147,59 @@ describe("windowsUpdateMessage", () => {
 		);
 	});
 
+	test("carries a custom prefix, so the re-install lands where this one did", () => {
+		// Without it the user re-installs under the default `.local` while the PATH-resolved
+		// D:\tools\bin\thinkrail.exe stays on the old build.
+		const msg = windowsUpdateMessage("stable", "latest", "D:\\tools");
+		expect(psLine(msg)).toContain("$env:THINKRAIL_PREFIX='D:\\tools';");
+		expect(cmdLine(msg)).toContain('set "THINKRAIL_PREFIX=D:\\tools" &&');
+	});
+
+	test("escapes a quote-bearing prefix for PowerShell", () => {
+		const msg = windowsUpdateMessage("stable", "latest", "D:\\o'brien\\tools");
+		expect(psLine(msg)).toContain("$env:THINKRAIL_PREFIX='D:\\o''brien\\tools';");
+		expect(cmdLine(msg)).toContain('set "THINKRAIL_PREFIX=D:\\o\'brien\\tools" &&');
+	});
+
 	test("stays ASCII (legacy conhost code pages garble anything else)", () => {
 		for (const channel of ["stable", "nightly"] as const) {
-			const msg = windowsUpdateMessage(channel, "1.2.3");
+			const msg = windowsUpdateMessage(channel, "1.2.3", "D:\\tools");
 			// One UTF-8 byte per char <=> every char is ASCII.
 			expect(Buffer.byteLength(msg, "utf8")).toBe(msg.length);
+		}
+	});
+});
+
+describe("resolveWindowsPrefix", () => {
+	const home = "C:\\Users\\u";
+
+	test("omits the installer's own default (any casing / separator / trailing slash)", () => {
+		expect(resolveWindowsPrefix("C:\\Users\\u\\.local", home)).toBeUndefined();
+		expect(resolveWindowsPrefix("c:\\users\\U\\.LOCAL\\", home)).toBeUndefined();
+		expect(resolveWindowsPrefix("C:/Users/u/.local", home)).toBeUndefined();
+		expect(resolveWindowsPrefix(undefined, home)).toBeUndefined();
+		expect(resolveWindowsPrefix("", home)).toBeUndefined();
+	});
+
+	test("keeps a custom prefix, including a UNC path", () => {
+		expect(resolveWindowsPrefix("D:\\tools", home)).toBe("D:\\tools");
+		expect(resolveWindowsPrefix("\\\\nas\\share\\thinkrail", home)).toBe(
+			"\\\\nas\\share\\thinkrail",
+		);
+		// `&` is literal inside both `set "X=…"` and '…', so a legitimate path keeps working.
+		expect(resolveWindowsPrefix("C:\\R&D\\tools", home)).toBe("C:\\R&D\\tools");
+	});
+
+	test("refuses a prefix that isn't rooted or can't be safely quoted", () => {
+		for (const bad of [
+			"tools\\thinkrail", // relative
+			"/home/u/.local", // not a Windows root
+			'D:\\a" && del /f /q C:\\Windows\\System32 && set "X=', // breaks out of cmd's quoting
+			"D:\\%APPDATA%\\x", // cmd expands it before the installer sees it
+			"D:\\a;C:\\b", // breaks the ;-delimited PATH value install.ps1 writes
+			"D:\\a\nrm -rf /",
+		]) {
+			expect(() => resolveWindowsPrefix(bad, home)).toThrow("suspicious install prefix");
 		}
 	});
 });

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -2,7 +2,8 @@
 // (the Bun-native port of the old repo's `thinkrail upgrade`, renamed). The installer owns the
 // download → checksum → replace → PATH logic; update just fetches it and feeds it the resolved
 // channel/prefix (from `~/.config/thinkrail/install.json`, else the baked channel + `~/.local`). Unix
-// only — replacing a running .exe in place isn't possible on Windows, so we point there to the releases.
+// only — in-place self-replace on Windows is deferred, so we point there at the install.ps1 one-liner
+// (which handles a locked running exe) with the releases page as the manual fallback.
 
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -120,7 +121,13 @@ export async function runUpdate(
 	}
 	if (process.platform === "win32") {
 		console.error(
-			"Automatic update on Windows is not yet supported.\nDownload the latest binary from:\nhttps://github.com/JetBrains/thinkrail/releases",
+			[
+				"Automatic in-place update isn't supported on Windows yet.",
+				"Re-run the installer to get the latest build (works from cmd and PowerShell):",
+				'  powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"',
+				'(on the nightly channel, run  set "THINKRAIL_CHANNEL=nightly"  first)',
+				"Or download manually: https://github.com/JetBrains/thinkrail/releases",
+			].join("\n"),
 		);
 		return 1;
 	}

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -2,8 +2,8 @@
 // (the Bun-native port of the old repo's `thinkrail upgrade`, renamed). The installer owns the
 // download → checksum → replace → PATH logic; update just fetches it and feeds it the resolved
 // channel/prefix (from `~/.config/thinkrail/install.json`, else the baked channel + `~/.local`). Unix
-// only — in-place self-replace on Windows is deferred, so we point there at the install.ps1 one-liner
-// (which handles a locked running exe) with the releases page as the manual fallback.
+// only — in-place self-replace on Windows is deferred, so we point there at the install.ps1 command
+// (which handles a locked running exe), spelled out per shell, with the releases page as the fallback.
 
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -79,16 +79,28 @@ export interface UpdatePlan {
 }
 
 /**
- * Resolve which channel + prefix the re-install should target: an explicit flag wins, else the install
- * metadata, else the baked channel (falling back to `stable` for a from-source `dev` build); the prefix
- * comes from the metadata, else `~/.local`. Throws on an unsafe prefix.
+ * Which channel a re-install targets: an explicit flag wins, else the install metadata, else the baked
+ * channel (falling back to `stable` for a from-source `dev` build). Shared by the Unix plan and the
+ * Windows advice, so both name the same channel.
+ */
+export function resolveUpdateChannel(
+	args: UpdateArgs,
+	metaChannel: unknown,
+	baked: string,
+): "stable" | "nightly" {
+	return (
+		args.channel ??
+		(metaChannel === "stable" || metaChannel === "nightly" ? metaChannel : undefined) ??
+		(baked === "stable" || baked === "nightly" ? baked : "stable")
+	);
+}
+
+/**
+ * Resolve which channel + prefix the re-install should target: channel per `resolveUpdateChannel`; the
+ * prefix comes from the metadata, else `~/.local`. Throws on an unsafe prefix.
  */
 export function resolveUpdatePlan(input: ResolveUpdateInput): UpdatePlan {
-	const metaChannel = input.installMeta.channel;
-	const channel: "stable" | "nightly" =
-		input.args.channel ??
-		(metaChannel === "stable" || metaChannel === "nightly" ? metaChannel : undefined) ??
-		(input.baked === "stable" || input.baked === "nightly" ? input.baked : "stable");
+	const channel = resolveUpdateChannel(input.args, input.installMeta.channel, input.baked);
 
 	const metaPrefix = input.installMeta.prefix;
 	const prefix =
@@ -100,6 +112,33 @@ export function resolveUpdatePlan(input: ResolveUpdateInput): UpdatePlan {
 	const bashArgs = ["-s", "--", "--channel", channel, "--prefix", prefix];
 	if (input.args.version !== "latest") bashArgs.push("--version", input.args.version);
 	return { channel, prefix, bashArgs };
+}
+
+const INSTALL_PS1_URL = "https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1";
+
+/**
+ * What to print instead of self-updating on Windows: the `install.ps1` one-liner, spelled out **per
+ * shell** — cmd's `set "X=v" &&` and PowerShell's `$env:X='v';` are not interchangeable, and a
+ * PowerShell user pasting the cmd form would silently re-install the wrong channel/version (`set` there
+ * is `Set-Variable`, which never reaches the child process). Env vars appear only when they'd change
+ * the outcome, so the common stable/latest case stays a single copyable command.
+ */
+export function windowsUpdateMessage(channel: "stable" | "nightly", version: string): string {
+	const vars: Array<[string, string]> = [];
+	if (channel !== "stable") vars.push(["THINKRAIL_CHANNEL", channel]);
+	if (version !== "latest") vars.push(["THINKRAIL_VERSION", version]);
+	const psPrefix = vars.map(([k, v]) => `$env:${k}='${v}'; `).join("");
+	const cmdPrefix = vars.map(([k, v]) => `set "${k}=${v}" && `).join("");
+	const what =
+		version === "latest" ? `the latest ${channel} build` : `ThinkRail ${version} (${channel})`;
+	// ASCII only: a legacy conhost code page would garble a dash/ellipsis in the copyable block.
+	return [
+		"Automatic in-place update isn't supported on Windows yet.",
+		`Re-run the installer to get ${what}. Pick the line for your shell:`,
+		`  PowerShell:  ${psPrefix}irm ${INSTALL_PS1_URL} | iex`,
+		`  cmd:         ${cmdPrefix}powershell -c "irm ${INSTALL_PS1_URL} | iex"`,
+		"Or download manually: https://github.com/JetBrains/thinkrail/releases",
+	].join("\n");
 }
 
 function readInstallMeta(home: string): { channel?: unknown; prefix?: unknown } {
@@ -119,29 +158,19 @@ export async function runUpdate(
 		console.log(UPDATE_USAGE);
 		return 0;
 	}
-	if (process.platform === "win32") {
-		console.error(
-			[
-				"Automatic in-place update isn't supported on Windows yet.",
-				"Re-run the installer to get the latest build (works from cmd and PowerShell):",
-				'  powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"',
-				'(on the nightly channel, run  set "THINKRAIL_CHANNEL=nightly"  first)',
-				"Or download manually: https://github.com/JetBrains/thinkrail/releases",
-			].join("\n"),
-		);
-		return 1;
-	}
-
 	let plan: UpdatePlan;
 	try {
 		const args = parseUpdateArgs(argv);
 		const home = homedir();
-		plan = resolveUpdatePlan({
-			args,
-			installMeta: readInstallMeta(home),
-			baked: bakedChannel,
-			home,
-		});
+		const installMeta = readInstallMeta(home);
+		if (process.platform === "win32") {
+			// Resolve the channel the same way the Unix path does, so the printed command re-installs what
+			// the user already has (or asked for) instead of silently dropping them onto stable.
+			const channel = resolveUpdateChannel(args, installMeta.channel, bakedChannel);
+			console.error(windowsUpdateMessage(channel, args.version));
+			return 1;
+		}
+		plan = resolveUpdatePlan({ args, installMeta, baked: bakedChannel, home });
 	} catch (err) {
 		console.error(err instanceof Error ? err.message : String(err));
 		console.error(`\n${UPDATE_USAGE}`);

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -115,19 +115,53 @@ export function resolveUpdatePlan(input: ResolveUpdateInput): UpdatePlan {
 }
 
 const INSTALL_PS1_URL = "https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1";
+/** Rooted Windows path — `X:\…` or a UNC `\\server\share\…`; mirrors install.ps1's `IsPathRooted` gate. */
+const WINDOWS_ROOTED_RE = /^(?:[A-Za-z]:[\\/]|\\\\[^\\/]+[\\/])/;
+/**
+ * Chars that make a prefix unsafe to print inside cmd's `set "X=…"` or PowerShell's `'…'`: a double
+ * quote closes cmd's quoting, `%` is expanded by cmd before the installer ever sees it, and `;`/newlines
+ * would break the `;`-delimited PATH value install.ps1 writes (it rejects those too). `&`/`|`/`<`/`>`/`^`
+ * are literal inside both quotings, so a legitimate `C:\R&D\tools` still works. Windows needs its own
+ * list: `PREFIX_FORBIDDEN_RE` rejects the backslash every Windows path is made of.
+ */
+const WINDOWS_PREFIX_FORBIDDEN_RE = /["%;\n\r]/;
+
+/**
+ * The `THINKRAIL_PREFIX` the printed command needs, or `undefined` when the recorded prefix is already
+ * the installer's own default (`<home>\.local`) and the var would be noise. Without this, a user who
+ * installed under `D:\tools` would follow the command and get a *second* copy under `.local` while the
+ * `thinkrail.exe` their PATH resolves stays on the old build. Throws on a prefix that isn't a rooted
+ * Windows path or can't be safely quoted — a tampered `install.json` must not shape a command we hand
+ * the user to paste (the Unix path refuses the same way).
+ */
+export function resolveWindowsPrefix(metaPrefix: unknown, home: string): string | undefined {
+	if (typeof metaPrefix !== "string" || !metaPrefix) return undefined;
+	if (!WINDOWS_ROOTED_RE.test(metaPrefix) || WINDOWS_PREFIX_FORBIDDEN_RE.test(metaPrefix)) {
+		throw new Error(`Refusing suspicious install prefix from metadata: ${metaPrefix}`);
+	}
+	const norm = (p: string) => p.replace(/\//g, "\\").replace(/\\+$/, "").toLowerCase();
+	return norm(metaPrefix) === norm(`${home}\\.local`) ? undefined : metaPrefix;
+}
 
 /**
  * What to print instead of self-updating on Windows: the `install.ps1` one-liner, spelled out **per
  * shell** — cmd's `set "X=v" &&` and PowerShell's `$env:X='v';` are not interchangeable, and a
  * PowerShell user pasting the cmd form would silently re-install the wrong channel/version (`set` there
- * is `Set-Variable`, which never reaches the child process). Env vars appear only when they'd change
- * the outcome, so the common stable/latest case stays a single copyable command.
+ * is `Set-Variable`, which never reaches the child process). Carries every option that would otherwise
+ * be lost, so re-running the installer reproduces *this* install rather than a default one. Env vars
+ * appear only when they'd change the outcome, so the common case stays a single copyable command.
  */
-export function windowsUpdateMessage(channel: "stable" | "nightly", version: string): string {
+export function windowsUpdateMessage(
+	channel: "stable" | "nightly",
+	version: string,
+	prefix?: string,
+): string {
 	const vars: Array<[string, string]> = [];
 	if (channel !== "stable") vars.push(["THINKRAIL_CHANNEL", channel]);
 	if (version !== "latest") vars.push(["THINKRAIL_VERSION", version]);
-	const psPrefix = vars.map(([k, v]) => `$env:${k}='${v}'; `).join("");
+	if (prefix) vars.push(["THINKRAIL_PREFIX", prefix]);
+	// PowerShell's single quotes are literal except for `'` itself, which doubles to escape.
+	const psPrefix = vars.map(([k, v]) => `$env:${k}='${v.replace(/'/g, "''")}'; `).join("");
 	const cmdPrefix = vars.map(([k, v]) => `set "${k}=${v}" && `).join("");
 	const what =
 		version === "latest" ? `the latest ${channel} build` : `ThinkRail ${version} (${channel})`;
@@ -164,10 +198,11 @@ export async function runUpdate(
 		const home = homedir();
 		const installMeta = readInstallMeta(home);
 		if (process.platform === "win32") {
-			// Resolve the channel the same way the Unix path does, so the printed command re-installs what
-			// the user already has (or asked for) instead of silently dropping them onto stable.
+			// Resolve channel + prefix the same way the Unix plan does, so the printed command re-installs
+			// *this* install instead of silently dropping the user onto stable under the default prefix.
 			const channel = resolveUpdateChannel(args, installMeta.channel, bakedChannel);
-			console.error(windowsUpdateMessage(channel, args.version));
+			const prefix = resolveWindowsPrefix(installMeta.prefix, home);
+			console.error(windowsUpdateMessage(channel, args.version, prefix));
 			return 1;
 		}
 		plan = resolveUpdatePlan({ args, installMeta, baked: bakedChannel, home });

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -461,6 +461,9 @@
 							<pre class="code-block install-block"><code><span class="sx-cm"># one line: downloads the right build, verifies its SHA-256, puts `thinkrail` on your PATH</span>
 <span class="line-copy" data-copy="curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash"><span class="sx-fn">curl</span> -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | <span class="sx-fn">bash</span></span>
 
+<span class="sx-cm"># windows — same thing, from cmd or powershell</span>
+<span class="line-copy" data-copy="powershell -c &quot;irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex&quot;"><span class="sx-fn">powershell</span> -c <span class="sx-str">"irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"</span></span>
+
 <span class="sx-cm"># nightly channel, or pin a version</span>
 <span class="line-copy" data-copy="curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash -s -- --channel nightly"><span class="sx-fn">curl</span> -fsSL … | <span class="sx-fn">bash</span> -s -- <span class="sx-str">--channel nightly</span></span>
 <span class="line-copy" data-copy="curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash -s -- --version 0.2.0"><span class="sx-fn">curl</span> -fsSL … | <span class="sx-fn">bash</span> -s -- <span class="sx-str">--version 0.2.0</span></span>

--- a/install.ps1
+++ b/install.ps1
@@ -52,12 +52,42 @@ function Resolve-ThinkRailTag {
     return $null
 }
 
+function Get-ThinkRailPersistentPath {
+    # Raw (unexpanded) entries of the *persistent* PATH: the per-user value in HKCU\Environment plus the
+    # machine value (readable without admin). Deliberately NOT $env:Path -- the live process PATH also
+    # carries session-only edits (`$env:Path += ...`, a parent script, an earlier -NoModifyPath run whose
+    # advice the user followed by hand), and taking those as proof of installation would skip the
+    # registry write and leave thinkrail off PATH in the next terminal. An unreadable hive contributes
+    # nothing, which at worst re-adds an entry that was already there.
+    $entries = @()
+    foreach ($scope in @('User', 'Machine')) {
+        $key = $null
+        try {
+            # Resolved inside the try on purpose: this runs *after* the binary is in place, so no
+            # registry mishap may throw out of here and abort an otherwise finished install.
+            $key = if ($scope -eq 'User') {
+                [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment')
+            } else {
+                [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\CurrentControlSet\Control\Session Manager\Environment')
+            }
+            if ($key) {
+                $entries += ([string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)) -split ';'
+            }
+        } catch {
+            # Hive not readable -- treat as "no entries" rather than failing the install.
+        } finally {
+            if ($key) { $key.Dispose() }
+        }
+    }
+    # `,` keeps an empty result an empty array instead of $null (PowerShell unrolls a bare @() on return).
+    return , $entries
+}
+
 function Test-ThinkRailOnPath {
-    # Is $Dir already reachable: on the live process PATH (covers the system PATH) or among the given
-    # raw user-PATH entries (compared unexpanded and %VAR%-expanded, case-insensitively)?
-    param([string]$Dir, [string[]]$RawUserPath)
+    # Is $Dir among these PATH entries (compared unexpanded and %VAR%-expanded, case-insensitively)?
+    param([string]$Dir, [string[]]$PathEntries)
     $norm = $Dir.TrimEnd('\')
-    foreach ($entry in (@($env:Path -split ';') + $RawUserPath)) {
+    foreach ($entry in $PathEntries) {
         if (-not $entry) { continue }
         $e = $entry.Trim().TrimEnd('\')
         if (-not $e) { continue }
@@ -82,7 +112,7 @@ function Add-ThinkRailToUserPath {
             $kind = $key.GetValueKind('Path')
             $raw = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
         }
-        if (Test-ThinkRailOnPath -Dir $Dir -RawUserPath ($raw -split ';')) { return 'already' }
+        if (Test-ThinkRailOnPath -Dir $Dir -PathEntries (Get-ThinkRailPersistentPath)) { return 'already' }
         $newRaw = if ($raw -and -not $raw.EndsWith(';')) { "$raw;$Dir" } elseif ($raw) { "$raw$Dir" } else { $Dir }
         $key.SetValue('Path', $newRaw, $kind)
         return 'added'
@@ -225,21 +255,26 @@ function Install-ThinkRail {
 
     $pathAdvice = $null
     if ($NoModifyPath) {
-        if (Test-ThinkRailOnPath -Dir $binDir -RawUserPath @()) {
+        if (Test-ThinkRailOnPath -Dir $binDir -PathEntries (Get-ThinkRailPersistentPath)) {
             Write-Host 'PATH:           already configured'
         } else {
             $pathAdvice = "$binDir (skipped: -NoModifyPath)"
         }
     } else {
-        switch (Add-ThinkRailToUserPath -Dir $binDir) {
+        $pathStatus = Add-ThinkRailToUserPath -Dir $binDir
+        switch ($pathStatus) {
             'already' { Write-Host 'PATH:           already configured' }
             'added' {
                 Send-ThinkRailSettingChange
-                $env:Path = "$env:Path;$binDir"
                 Write-Host "PATH:           added $binDir to your user PATH"
                 Write-Host '                open a new terminal to pick it up'
             }
             'failed' { $pathAdvice = "$binDir (could not update the registry)" }
+        }
+        # Persisted -- also make `thinkrail` runnable in *this* session (a saved-copy run in an
+        # interactive shell), without duplicating an entry the process PATH already carries.
+        if ($pathStatus -ne 'failed' -and -not (Test-ThinkRailOnPath -Dir $binDir -PathEntries ($env:Path -split ';'))) {
+            $env:Path = "$env:Path;$binDir"
         }
     }
     if ($pathAdvice) { Write-Host "Add to PATH:    $pathAdvice" }

--- a/install.ps1
+++ b/install.ps1
@@ -141,6 +141,39 @@ public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wP
     }
 }
 
+function Install-ThinkRailBinary {
+    # Put the verified download at $Dest so that no failure can leave the user without a working exe:
+    #   1. Stage the asset *inside* $Dest's own directory first. Crossing volumes (a custom prefix on
+    #      another drive) and running out of space happen here -- before anything installed is touched.
+    #   2. Swap it in. From here every step is a same-volume rename: it either succeeds or changes
+    #      nothing, so it cannot half-fail with the old binary already moved away.
+    #   3. Only if $Dest exists and refuses to be overwritten is it locked (thinkrail is running).
+    #      Renaming a running exe IS allowed: move it aside, drop the new one in, leave the `.old` for
+    #      the next install to clean. If $Dest does *not* exist the first failure was something else
+    #      (permissions, AV, full disk) -- rethrow it rather than masking it with a bogus rename.
+    #   4. If the swap still fails after the rename-aside, put the old binary back before rethrowing.
+    param([string]$Source, [string]$Dest)
+    $staged = "$Dest." + [System.IO.Path]::GetRandomFileName() + '.new'
+    Move-Item -LiteralPath $Source -Destination $staged -Force
+    $aside = $null
+    try {
+        try {
+            Move-Item -LiteralPath $staged -Destination $Dest -Force
+        } catch {
+            if (-not (Test-Path -LiteralPath $Dest)) { throw }
+            $aside = "$Dest." + [System.IO.Path]::GetRandomFileName() + '.old'
+            Move-Item -LiteralPath $Dest -Destination $aside -Force
+            Move-Item -LiteralPath $staged -Destination $Dest -Force
+        }
+    } catch {
+        if ($aside -and (Test-Path -LiteralPath $aside) -and -not (Test-Path -LiteralPath $Dest)) {
+            Move-Item -LiteralPath $aside -Destination $Dest -Force -ErrorAction SilentlyContinue
+        }
+        Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
+        throw
+    }
+}
+
 function Install-ThinkRail {
     param([string]$Channel, [string]$Version, [string]$Prefix, [switch]$NoModifyPath)
 
@@ -219,18 +252,12 @@ function Install-ThinkRail {
         Write-Host '  -> ok'
 
         New-Item -ItemType Directory -Path $binDir -Force | Out-Null
-        # Clean renamed-aside binaries left by earlier update-while-running installs (best-effort).
-        Get-ChildItem -Path $binDir -Filter 'thinkrail.exe*.old' -ErrorAction SilentlyContinue |
+        # Leftovers from earlier installs: `.old` (a renamed-aside running exe) and `.new` (a staged
+        # download whose swap was interrupted). Best-effort -- an `.old` may still be running.
+        Get-ChildItem -Path $binDir -Filter 'thinkrail.exe.*' -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like '*.old' -or $_.Name -like '*.new' } |
             Remove-Item -Force -ErrorAction SilentlyContinue
-        try {
-            Move-Item -Path $assetPath -Destination $dest -Force
-        } catch {
-            # The existing exe is locked (thinkrail is running). Renaming a running exe IS allowed:
-            # move it aside, drop the new one in, and let the next install clean up the .old.
-            $aside = "$dest." + [System.IO.Path]::GetRandomFileName() + '.old'
-            Move-Item -Path $dest -Destination $aside -Force
-            Move-Item -Path $assetPath -Destination $dest -Force
-        }
+        Install-ThinkRailBinary -Source $assetPath -Dest $dest
         Write-Host "Installed -> $dest"
     } finally {
         Remove-Item -Recurse -Force -Path $tmp -ErrorAction SilentlyContinue

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,250 @@
+# ThinkRail binary installer for Windows -- downloads the single-file thinkrail.exe from the GitHub
+# releases, verifies its checksum, and puts it on your PATH. The native counterpart of install.sh
+# (macOS/Linux/Git Bash); one script serves both cmd and PowerShell (Windows PowerShell 5.1+).
+#
+#   powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"
+#
+# Options are env vars (the one syntax cmd and PowerShell share) -- set before running:
+#   THINKRAIL_CHANNEL         stable|nightly   (default: stable)
+#   THINKRAIL_VERSION         X.Y.Z|latest     (default: latest)
+#   THINKRAIL_PREFIX          DIR              (default: %USERPROFILE%\.local; binary lands at <prefix>\bin\thinkrail.exe)
+#   THINKRAIL_NO_MODIFY_PATH  1                don't touch the user PATH; just print advice
+#
+#   PowerShell:  $env:THINKRAIL_CHANNEL='nightly'; irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex
+#   cmd:         set "THINKRAIL_CHANNEL=nightly" && powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"
+#
+# A saved copy also takes params: .\install.ps1 -Channel nightly -Version 0.2.0 -Prefix D:\tools -NoModifyPath
+#
+# After install, run `thinkrail`. To update later, re-run this installer (`thinkrail update` is
+# macOS/Linux-only for now).
+#
+# Kept ASCII-only on purpose: Windows PowerShell 5.1 parses a saved UTF-8 file without BOM as ANSI,
+# which would garble any non-ASCII character. Errors `throw` (never `exit`): under `irm | iex` the
+# script runs in the caller's session, where `exit` would close an interactive shell; `powershell -c`
+# maps an uncaught throw to exit code 1.
+
+param(
+    [string]$Channel = $(if ($env:THINKRAIL_CHANNEL) { $env:THINKRAIL_CHANNEL } else { 'stable' }),
+    [string]$Version = $(if ($env:THINKRAIL_VERSION) { $env:THINKRAIL_VERSION } else { 'latest' }),
+    [string]$Prefix = $(if ($env:THINKRAIL_PREFIX) { $env:THINKRAIL_PREFIX } else { '' }),
+    [switch]$NoModifyPath = ($env:THINKRAIL_NO_MODIFY_PATH -eq '1')
+)
+
+function Resolve-ThinkRailTag {
+    param([string]$Repo, [string]$Channel, [string]$Version)
+    if ($Version -ne 'latest') { return 'v' + ($Version -replace '^[vV]', '') }
+    $headers = @{ Accept = 'application/vnd.github+json' }
+    try {
+        if ($Channel -eq 'stable') {
+            $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers $headers
+            return $release.tag_name
+        }
+        # `| ForEach-Object { $_ }` flattens deliberately: Invoke-RestMethod can emit a JSON array as a
+        # single array object (so a plain @()/foreach would "iterate" once over the whole collection);
+        # script-block output enumerates it one level, normalizing every PowerShell version to N items.
+        $releases = @(Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=20" -Headers $headers | ForEach-Object { $_ })
+        foreach ($release in $releases) {
+            if ($release.tag_name -match '^v\d+\.\d+\.\d+-nightly\.\d+$') { return $release.tag_name }
+        }
+    } catch {
+        return $null
+    }
+    return $null
+}
+
+function Test-ThinkRailOnPath {
+    # Is $Dir already reachable: on the live process PATH (covers the system PATH) or among the given
+    # raw user-PATH entries (compared unexpanded and %VAR%-expanded, case-insensitively)?
+    param([string]$Dir, [string[]]$RawUserPath)
+    $norm = $Dir.TrimEnd('\')
+    foreach ($entry in (@($env:Path -split ';') + $RawUserPath)) {
+        if (-not $entry) { continue }
+        $e = $entry.Trim().TrimEnd('\')
+        if (-not $e) { continue }
+        $expanded = [System.Environment]::ExpandEnvironmentVariables($e).TrimEnd('\')
+        if (($e -ieq $norm) -or ($expanded -ieq $norm)) { return $true }
+    }
+    return $false
+}
+
+function Add-ThinkRailToUserPath {
+    # Append $Dir to the per-user PATH in HKCU\Environment. Deliberately NOT
+    # [Environment]::SetEnvironmentVariable('Path', ..., 'User'): that expands %VARS% and rewrites
+    # REG_EXPAND_SZ as REG_SZ, clobbering other tools' entries. Returns 'already', 'added', or 'failed'.
+    param([string]$Dir)
+    $key = $null
+    try {
+        $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+        if (-not $key) { return 'failed' }
+        $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+        $raw = ''
+        if (@($key.GetValueNames()) -contains 'Path') {
+            $kind = $key.GetValueKind('Path')
+            $raw = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        }
+        if (Test-ThinkRailOnPath -Dir $Dir -RawUserPath ($raw -split ';')) { return 'already' }
+        $newRaw = if ($raw -and -not $raw.EndsWith(';')) { "$raw;$Dir" } elseif ($raw) { "$raw$Dir" } else { $Dir }
+        $key.SetValue('Path', $newRaw, $kind)
+        return 'added'
+    } catch {
+        return 'failed'
+    } finally {
+        if ($key) { $key.Dispose() }
+    }
+}
+
+function Send-ThinkRailSettingChange {
+    # Broadcast WM_SETTINGCHANGE "Environment" so Explorer re-reads the registry PATH -- terminals
+    # opened after this pick it up without a sign-out. Best-effort.
+    try {
+        if (-not ('ThinkRail.NativeMethods' -as [type])) {
+            Add-Type -Namespace ThinkRail -Name NativeMethods -MemberDefinition @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+        }
+        $result = [UIntPtr]::Zero
+        # HWND_BROADCAST (0xffff), WM_SETTINGCHANGE (0x1a), SMTO_ABORTIFHUNG (0x2), 5s timeout.
+        [void][ThinkRail.NativeMethods]::SendMessageTimeout([IntPtr]0xffff, 0x1a, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$result)
+    } catch {
+        # Non-fatal: new terminals see the PATH after the next sign-in regardless.
+    }
+}
+
+function Install-ThinkRail {
+    param([string]$Channel, [string]$Version, [string]$Prefix, [switch]$NoModifyPath)
+
+    # Function-scoped preferences: `irm | iex` runs in the caller's session, so top-level assignments
+    # would leak into an interactive shell. Progress rendering also slows IWR downloads badly on 5.1.
+    $ErrorActionPreference = 'Stop'
+    $ProgressPreference = 'SilentlyContinue'
+
+    if ($env:OS -ne 'Windows_NT') {
+        throw 'This installer is for Windows. On macOS/Linux use: curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash'
+    }
+
+    # Windows PowerShell 5.1 defaults can lack TLS 1.2, which github.com requires. Additive + process-wide.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+    $repo = if ($env:THINKRAIL_REPO) { $env:THINKRAIL_REPO } else { 'JetBrains/thinkrail' }
+
+    # cmd's `set X=value && ...` embeds the space before && into the value -- trim every input.
+    $channel = $Channel.Trim()
+    if (@('stable', 'nightly') -notcontains $channel) {
+        throw "Invalid channel: $channel (expected: stable or nightly)"
+    }
+    $version = $Version.Trim()
+    if ($version -ne 'latest' -and $version -notmatch '^[vV]?\d+\.\d+\.\d+(-nightly\.\d+)?$') {
+        throw "Invalid version: $version (expected: X.Y.Z, X.Y.Z-nightly.N, or latest)"
+    }
+    $prefix = $Prefix.Trim()
+    if (-not $prefix) {
+        if (-not $env:USERPROFILE) { throw 'USERPROFILE is not set; pass -Prefix or set THINKRAIL_PREFIX' }
+        $prefix = Join-Path $env:USERPROFILE '.local'
+    }
+    # The prefix is written into the ';'-delimited PATH registry value -- reject its structural chars.
+    if ($prefix -match "[;`"`r`n]") {
+        throw "Invalid prefix: must not contain ';', double quotes, or newlines"
+    }
+    if (-not [System.IO.Path]::IsPathRooted($prefix)) {
+        throw "Invalid prefix: must be an absolute path (got: $prefix)"
+    }
+
+    # Windows-on-ARM has no native build yet; the x64 binary runs under emulation (same as install.sh).
+    $assetName = 'thinkrail-windows-x64.exe'
+
+    Write-Host "Resolving latest $channel release for windows/x64 ..."
+    $tag = Resolve-ThinkRailTag -Repo $repo -Channel $channel -Version $version
+    if (-not $tag) {
+        throw "Failed to resolve a $channel release. Has one been published yet?"
+    }
+    Write-Host "  -> $tag"
+
+    $binDir = Join-Path $prefix 'bin'
+    $dest = Join-Path $binDir 'thinkrail.exe'
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ('thinkrail-install-' + [System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+    try {
+        $assetPath = Join-Path $tmp $assetName
+        $sumsPath = Join-Path $tmp 'SHA256SUMS'
+        Write-Host "Downloading $assetName (may take a minute) ..."
+        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/$repo/releases/download/$tag/$assetName" -OutFile $assetPath
+        Write-Host 'Downloading SHA256SUMS ...'
+        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/$repo/releases/download/$tag/SHA256SUMS" -OutFile $sumsPath
+
+        Write-Host 'Verifying checksum ...'
+        $expected = $null
+        foreach ($line in (Get-Content -Path $sumsPath)) {
+            # sha256sum line format: "<64 hex chars><whitespace>[*]<name>".
+            if ($line -match '^([0-9a-fA-F]{64})\s+\*?(.+)$' -and $matches[2].Trim() -eq $assetName) {
+                $expected = $matches[1].ToLowerInvariant()
+                break
+            }
+        }
+        if (-not $expected) { throw "Checksum entry not found for $assetName in SHA256SUMS" }
+        $actual = (Get-FileHash -Algorithm SHA256 -Path $assetPath).Hash.ToLowerInvariant()
+        if ($actual -ne $expected) {
+            throw "Checksum mismatch!`n  expected: $expected`n  actual:   $actual"
+        }
+        Write-Host '  -> ok'
+
+        New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+        # Clean renamed-aside binaries left by earlier update-while-running installs (best-effort).
+        Get-ChildItem -Path $binDir -Filter 'thinkrail.exe*.old' -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+        try {
+            Move-Item -Path $assetPath -Destination $dest -Force
+        } catch {
+            # The existing exe is locked (thinkrail is running). Renaming a running exe IS allowed:
+            # move it aside, drop the new one in, and let the next install clean up the .old.
+            $aside = "$dest." + [System.IO.Path]::GetRandomFileName() + '.old'
+            Move-Item -Path $dest -Destination $aside -Force
+            Move-Item -Path $assetPath -Destination $dest -Force
+        }
+        Write-Host "Installed -> $dest"
+    } finally {
+        Remove-Item -Recurse -Force -Path $tmp -ErrorAction SilentlyContinue
+    }
+
+    # Same file + shape install.sh writes; `thinkrail update` reads it (homedir()\.config\thinkrail).
+    $configDir = Join-Path $env:USERPROFILE '.config\thinkrail'
+    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+    $meta = [ordered]@{
+        channel      = $channel
+        version      = ($tag -replace '^v', '')
+        tag          = $tag
+        prefix       = $prefix
+        installed_at = ((Get-Date).ToUniversalTime().ToString('s') + 'Z')
+    }
+    # WriteAllText writes UTF-8 without BOM (PS 5.1's Set-Content -Encoding UTF8 adds one, which
+    # breaks the JSON.parse in `thinkrail update`).
+    [System.IO.File]::WriteAllText((Join-Path $configDir 'install.json'), ($meta | ConvertTo-Json))
+
+    Write-Host ''
+    Write-Host "ThinkRail $($tag -replace '^v', '') ($channel) installed."
+
+    $pathAdvice = $null
+    if ($NoModifyPath) {
+        if (Test-ThinkRailOnPath -Dir $binDir -RawUserPath @()) {
+            Write-Host 'PATH:           already configured'
+        } else {
+            $pathAdvice = "$binDir (skipped: -NoModifyPath)"
+        }
+    } else {
+        switch (Add-ThinkRailToUserPath -Dir $binDir) {
+            'already' { Write-Host 'PATH:           already configured' }
+            'added' {
+                Send-ThinkRailSettingChange
+                $env:Path = "$env:Path;$binDir"
+                Write-Host "PATH:           added $binDir to your user PATH"
+                Write-Host '                open a new terminal to pick it up'
+            }
+            'failed' { $pathAdvice = "$binDir (could not update the registry)" }
+        }
+    }
+    if ($pathAdvice) { Write-Host "Add to PATH:    $pathAdvice" }
+    Write-Host 'Run:            thinkrail'
+    Write-Host 'Update later:   re-run this installer'
+}
+
+Install-ThinkRail -Channel $Channel -Version $Version -Prefix $Prefix -NoModifyPath:$NoModifyPath


### PR DESCRIPTION
## Summary

Windows users could only install via `install.sh` under Git Bash/MSYS, or by manually downloading from releases. This adds the native path — one `install.ps1` that works verbatim from **both cmd and PowerShell**:

```
powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"
```

Options travel as env vars — the one syntax both shells share (`THINKRAIL_CHANNEL`, `THINKRAIL_VERSION`, `THINKRAIL_PREFIX`, `THINKRAIL_NO_MODIFY_PATH`), with mirroring params for a saved copy. A `.cmd` installer was considered and rejected: batch has no native HTTPS/JSON/SHA-256 and would shell out to PowerShell anyway (same pattern as Bun/Scoop/uv).

## What it does

- Mirrors `install.sh` stage for stage: resolve tag (stable / nightly / pinned) → download `thinkrail-windows-x64.exe` + `SHA256SUMS` → verify SHA-256 → install to `%USERPROFILE%\.local\bin\thinkrail.exe` (same default prefix as `install.sh`, so a Git Bash install and a native install coincide) → write the same `~/.config/thinkrail/install.json`.
- **User PATH:** appends the bin dir to `HKCU\Environment` via the raw registry API — preserves `REG_EXPAND_SZ` and unexpanded `%VARS%` (which `[Environment]::SetEnvironmentVariable` would flatten), `WM_SETTINGCHANGE` broadcast so new terminals pick it up; `-NoModifyPath` opts out. Idempotence is judged against the **persistent** PATH only — the raw `HKCU` + machine registry values, compared unexpanded and `%VAR%`-expanded — never `$env:Path`, so a session-only `$env:Path +=` can't be mistaken for an install and silently skip the registry write. The current session's PATH is still extended, as a separate step that doesn't feed that decision.
- **Update-while-running:** the verified download is staged *inside* the bin dir first, so a cross-volume or out-of-space failure strikes before anything installed is touched; the swap is then a same-volume rename. A locked `thinkrail.exe` is renamed aside (`*.old`, cleaned by the next install alongside stale `.new` stages) before the new one drops in, and restored if the swap still fails. A first-move failure with no `thinkrail.exe` present is rethrown as-is rather than mistaken for a lock.
- Windows PowerShell 5.1-compatible; ASCII-only on purpose (5.1 parses BOM-less UTF-8 script files as ANSI); errors `throw`, never `exit` (safe under `irm | iex` in an interactive session).

Also:

- `thinkrail update` on Windows now prints this command instead of only the releases page (in-place self-update stays deferred). It resolves the installed channel first (the same `resolveUpdateChannel` the Unix plan uses) and spells the command out **per shell** — cmd's `set "X=v" &&` and PowerShell's `$env:X='v';` are not interchangeable, and one shown to the other would silently re-install the wrong channel. A pinned `--version` travels the same way.
- README + website install tab document the Windows command.
- Specs updated: `.github/SPEC.md` install side (the artifact-name lockstep contract now names **both** installers), `apps/cli/SPEC.md` self-update note.

## Verification

- pwsh 7.6.4: AST parse clean; ASCII check; `irm | iex` path fails safely via a catchable guard throw (session survives); unit-drove tag resolution, PATH matching (raw/expanded/case/trailing-slash), and input validation — including cmd's `set X=v && …` trailing-space gotcha (script trims; docs use the quoted `set "X=v"` form).
- **Full E2E against the real `v0.0.8` release** (faked `OS=Windows_NT`, sandbox prefix): 135 MB PE32+ downloaded, checksum verified, BOM-free `install.json` parsed by the exact `JSON.parse` path `update.ts` uses; registry failure degrades to printed PATH advice.
- The live probe caught a real bug pre-merge: `Invoke-RestMethod` can emit a JSON array as a *single* array object, so nightly resolution returned **all 20 tags** (member enumeration + array `-match` acting as a filter). Fixed with a `| ForEach-Object { $_ }` flatten that normalizes every PowerShell version.
- Gates green: `check:deps`, `check:seams`, `lint`, `typecheck`, unit tests.

**Caveat:** the registry PATH write/broadcast and the locked-exe rename can only be truly exercised on real Windows — worth one manual smoke (`irm | iex` from cmd and from PowerShell) before announcing.

Website change is one added line in the install block; before/after screenshots available on request (rendered locally, matches the existing `line-copy` pattern).



---

## Review round 2 (`b2af68d`)

Both blocking findings from `jetbrains-air` were real and are fixed; details in the inline replies.

1. **PATH idempotence keyed on `$env:Path`** — a session-only entry made the installer report "already configured" and skip the `HKCU` write, so `thinkrail` vanished from PATH in the next terminal. `Test-ThinkRailOnPath` is now a pure matcher; both call sites feed it `Get-ThinkRailPersistentPath` (raw `HKCU\Environment` + the machine environment key, readable without admin). Reading `HKLM` directly preserves what the process PATH was standing in for — not duplicating a system-PATH entry — without inheriting session state. The hives resolve *inside* the `try` (this runs after the binary is in place, so an unreadable hive must degrade, not abort a finished install).
2. **cmd-only nightly hint in `thinkrail update`** — in PowerShell `set` is `Set-Variable`, so the hint never reached the child process and a nightly user would be silently downgraded to stable. The message is now channel-aware and per-shell, with `windowsUpdateMessage` extracted and unit-tested (4 cases, incl. neither shell leaking the other's syntax, and ASCII-only for legacy conhost code pages).

Verification (pwsh 7.6.4): AST parse clean; ASCII-only; matcher unit-driven over exact / case / trailing-slash / surrounding-space / unexpanded `%VAR%` / empty entries; **old-vs-new contrast reproducing the reported failure** (`HEAD` answers `already = True` with only a session entry, the fix answers `False`); full install E2E re-run against the real `v0.0.8` release (135 MB PE32+, checksum verified, BOM-free `install.json`). Gates green: `check:deps`, `check:seams`, `lint`, `typecheck`, unit tests (11 in `update.test.ts`).



## Review round 3 (`7240189`)

Third blocking finding, also real — and it destroyed a *working* install rather than just failing one. Root cause: an **untyped** catch treating any first-move failure as "the exe is locked". With a prefix on a drive without room for the binary, the cross-volume move failed, the installed exe was renamed to `.old`, the retry failed identically, and nothing was left; the next install would then sweep that `.old`. On a *fresh* install the same catch masked ordinary errors (unwritable prefix, AV) behind an `ItemNotFoundException` from renaming a file that never existed.

`Install-ThinkRailBinary` stages the asset inside the bin dir first, swaps by same-volume rename, treats a failure as a lock only when the destination actually exists, restores the renamed-aside binary if the swap still fails, and sweeps stale `.new` stages. Extracting it makes the riskiest step testable without Windows: pwsh drives all five branches (fresh / replace / staging-fails / locked-exe / post-rename-failure), plus an old-vs-new contrast reproducing the reported data loss on `b2af68d` and showing the binary surviving with the fix. Full E2E re-run against the real `v0.0.8` over a pre-existing install seeded with stale `.old` + `.new`: replaced, swept, no residue.



## Review round 4 (`10a2e10`)

Fourth blocking finding, also real: the Windows handoff read `install.json` but dropped its `prefix`, so the printed command always installed under the default `%USERPROFILE%\.local` — a user installed under `D:\tools` would get a *second* copy while their PATH-resolved exe stayed stale. Same class as the dropped channel; the Unix path has always passed `--prefix`.

`resolveWindowsPrefix` omits the installer's own default (case/separator/trailing-slash-insensitive, so the common case stays a bare one-liner) and refuses a prefix that isn't a rooted Windows path or can't be safely quoted. Windows needs its own charset: `PREFIX_FORBIDDEN_RE` rejects the backslash every Windows path is made of, while `"` (closes cmd's quoting), `%` (cmd expands it first) and `;`/newlines (break the PATH value) must go — `&`/`|`/`<`/`>`/`^` stay legal since they're literal in both quotings, and `'` is doubled for PowerShell. 8 new unit tests, plus the generated PowerShell assignments round-tripped through real pwsh 7.6.4 (`D:\tools`, `D:\o'brien\tools`, `C:\R&D\tools` all byte-identical).
