### PR TITLE
feat(analytics): anonymous usage analytics — backend-side PostHog (EU cloud)

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -63,15 +63,15 @@ the compiled binary reports the real `{version, channel, commit}`. It surfaces v
 and, threaded `apps/cli` → `bootHost` → `createServer`, in the `server.welcome` push
 (`ServerWelcome.appVersion`, an optional field — non-breaking, no `PROTOCOL_VERSION` bump). See
 `module-cli`. **`apps/cli/src/analytics-keys.ts` rides the same seam**: stamped from the
-`THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` repo secrets (passed by `_build.yml`,
-skipped when absent — forks/PR builds keep the committed empty keys, so their binaries never send;
-see `submodule-server-analytics`).
+`THINKRAIL_POSTHOG_API_KEY` repo secret (passed by `_build.yml`, skipped when absent — forks/PR
+builds keep the committed empty key, so their binaries never send; see
+`submodule-server-analytics`).
 
 ## Parts
 
 - `scripts/next-version.sh` — channel-aware semver from tags; carries a `--tags=` override for testing.
 - `actions/build-binary` — the release build step: `build:web` → stamp `version.ts` (+
-  `analytics-keys.ts` when the GA4 secrets are provided) → `build-binary.ts
+  `analytics-keys.ts` when the PostHog secret is provided) → `build-binary.ts
   --target` → resolve artifact path → native `smoke:binary`. (The Bun replacement for the old repo's
   PyInstaller action.)
 - `actions/make-checksums` — writes `SHA256SUMS` over the release artifacts.

--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -62,12 +62,16 @@ module whose from-source default is `0.0.0-dev`) in the throwaway CI checkout be
 the compiled binary reports the real `{version, channel, commit}`. It surfaces via `thinkrail --version`
 and, threaded `apps/cli` → `bootHost` → `createServer`, in the `server.welcome` push
 (`ServerWelcome.appVersion`, an optional field — non-breaking, no `PROTOCOL_VERSION` bump). See
-`module-cli`.
+`module-cli`. **`apps/cli/src/analytics-keys.ts` rides the same seam**: stamped from the
+`THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` repo secrets (passed by `_build.yml`,
+skipped when absent — forks/PR builds keep the committed empty keys, so their binaries never send;
+see `submodule-server-analytics`).
 
 ## Parts
 
 - `scripts/next-version.sh` — channel-aware semver from tags; carries a `--tags=` override for testing.
-- `actions/build-binary` — the release build step: `build:web` → stamp `version.ts` → `build-binary.ts
+- `actions/build-binary` — the release build step: `build:web` → stamp `version.ts` (+
+  `analytics-keys.ts` when the GA4 secrets are provided) → `build-binary.ts
   --target` → resolve artifact path → native `smoke:binary`. (The Bun replacement for the old repo's
   PyInstaller action.)
 - `actions/make-checksums` — writes `SHA256SUMS` over the release artifacts.

--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -14,12 +14,8 @@ inputs:
   target:
     description: "Bun compile target for this runner (e.g. bun-darwin-arm64 / bun-windows-x64)"
     required: true
-  ga4-measurement-id:
-    description: "GA4 measurement id for anonymous usage analytics (empty: keys stay unbaked — noop sink)"
-    required: false
-    default: ""
-  ga4-api-secret:
-    description: "GA4 Measurement Protocol api_secret (empty: keys stay unbaked — noop sink)"
+  posthog-api-key:
+    description: "PostHog project API key for anonymous usage analytics (empty: key stays unbaked — noop sink)"
     required: false
     default: ""
 
@@ -55,23 +51,21 @@ runs:
         echo "Stamped apps/cli/src/version.ts:"
         cat apps/cli/src/version.ts
 
-    # Same seam as version.ts: bake the GA4 keys into the throwaway checkout before compiling. Skipped
-    # when the secrets are absent (forks, PR CI) — the committed empty defaults stay, the binary's host
-    # lands on the noop sink and never sends (see packages/server/src/analytics/SPEC.md).
-    - name: Stamp analytics keys into the CLI
-      if: inputs.ga4-measurement-id != '' && inputs.ga4-api-secret != ''
+    # Same seam as version.ts: bake the PostHog key into the throwaway checkout before compiling.
+    # Skipped when the secret is absent (forks, PR CI) — the committed empty default stays, the
+    # binary's host lands on the noop sink and never sends (see packages/server/src/analytics/SPEC.md).
+    - name: Stamp analytics key into the CLI
+      if: inputs.posthog-api-key != ''
       shell: bash
       env:
-        GA4_MEASUREMENT_ID: ${{ inputs.ga4-measurement-id }}
-        GA4_API_SECRET: ${{ inputs.ga4-api-secret }}
+        POSTHOG_API_KEY: ${{ inputs.posthog-api-key }}
       run: |
         set -eu
         cat > apps/cli/src/analytics-keys.ts <<EOF
         // Stamped at release time by .github/actions/build-binary. Do not commit this edit.
-        export const ga4MeasurementId = "${GA4_MEASUREMENT_ID}";
-        export const ga4ApiSecret = "${GA4_API_SECRET}";
+        export const posthogApiKey = "${POSTHOG_API_KEY}";
         EOF
-        echo "Stamped apps/cli/src/analytics-keys.ts (values withheld)"
+        echo "Stamped apps/cli/src/analytics-keys.ts (value withheld)"
 
     - name: Compile single-file binary
       shell: bash

--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -14,6 +14,14 @@ inputs:
   target:
     description: "Bun compile target for this runner (e.g. bun-darwin-arm64 / bun-windows-x64)"
     required: true
+  ga4-measurement-id:
+    description: "GA4 measurement id for anonymous usage analytics (empty: keys stay unbaked — noop sink)"
+    required: false
+    default: ""
+  ga4-api-secret:
+    description: "GA4 Measurement Protocol api_secret (empty: keys stay unbaked — noop sink)"
+    required: false
+    default: ""
 
 outputs:
   artifact-name:
@@ -46,6 +54,24 @@ runs:
         EOF
         echo "Stamped apps/cli/src/version.ts:"
         cat apps/cli/src/version.ts
+
+    # Same seam as version.ts: bake the GA4 keys into the throwaway checkout before compiling. Skipped
+    # when the secrets are absent (forks, PR CI) — the committed empty defaults stay, the binary's host
+    # lands on the noop sink and never sends (see packages/server/src/analytics/SPEC.md).
+    - name: Stamp analytics keys into the CLI
+      if: inputs.ga4-measurement-id != '' && inputs.ga4-api-secret != ''
+      shell: bash
+      env:
+        GA4_MEASUREMENT_ID: ${{ inputs.ga4-measurement-id }}
+        GA4_API_SECRET: ${{ inputs.ga4-api-secret }}
+      run: |
+        set -eu
+        cat > apps/cli/src/analytics-keys.ts <<EOF
+        // Stamped at release time by .github/actions/build-binary. Do not commit this edit.
+        export const ga4MeasurementId = "${GA4_MEASUREMENT_ID}";
+        export const ga4ApiSecret = "${GA4_API_SECRET}";
+        EOF
+        echo "Stamped apps/cli/src/analytics-keys.ts (values withheld)"
 
     - name: Compile single-file binary
       shell: bash

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -53,9 +53,8 @@ jobs:
           version: ${{ inputs.version }}
           channel: ${{ inputs.channel }}
           target: ${{ matrix.target }}
-          # Absent on forks/PRs → the action skips the stamp and the committed empty keys stay (noop sink).
-          ga4-measurement-id: ${{ secrets.THINKRAIL_GA4_MEASUREMENT_ID }}
-          ga4-api-secret: ${{ secrets.THINKRAIL_GA4_API_SECRET }}
+          # Absent on forks/PRs → the action skips the stamp and the committed empty key stays (noop sink).
+          posthog-api-key: ${{ secrets.THINKRAIL_POSTHOG_API_KEY }}
 
       - uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -53,6 +53,9 @@ jobs:
           version: ${{ inputs.version }}
           channel: ${{ inputs.channel }}
           target: ${{ matrix.target }}
+          # Absent on forks/PRs → the action skips the stamp and the committed empty keys stay (noop sink).
+          ga4-measurement-id: ${{ secrets.THINKRAIL_GA4_MEASUREMENT_ID }}
+          ga4-api-secret: ${{ secrets.THINKRAIL_GA4_API_SECRET }}
 
       - uses: actions/upload-artifact@v5
         with:

--- a/README.md
+++ b/README.md
@@ -127,21 +127,22 @@ spec in the same change. See [`AGENTS.md`](AGENTS.md) for the spec workflow.
 
 ## Analytics & Privacy
 
-Released ThinkRail builds send **anonymous usage analytics** (on by default; a notice is printed the
-first time anything is sent). The data answers product questions — how many installs are active, on
-which versions/platforms, which models and providers get used, and which features matter — and
-nothing more.
+Released ThinkRail builds send **anonymous usage analytics** to [PostHog](https://posthog.com) (EU
+cloud; on by default; a notice is printed the first time anything is sent). The data answers product
+questions — how many installs are active, on which versions/platforms, which models and providers
+get used, and which features matter — and nothing more.
 
 **The only stable identifier** is a random per-install id (a `uuid4`) minted on your machine and
 stored in `~/.thinkrail/installation.json`; it never leaves the host except as the anonymous
-`client_id` on events. Events additionally carry only low-cardinality, non-personal metadata: app
+`distinct_id` on events. Events additionally carry only low-cardinality, non-personal metadata: app
 version, release channel (`stable`/`nightly`), OS (`macos`/`linux`/`windows`), architecture
 (`x64`/`arm64`), and — on chat/login events — the model/provider name **only if it is a pi built-in**
-(anything user-configured is reported as `custom`).
+(anything user-configured is reported as `custom`). Events are sent **personless** (no person
+profiles are ever built) and with **GeoIP lookup disabled**.
 
 **Never collected:** file paths or names, prompts, code, chat transcripts, API keys, token counts,
 hostnames, usernames, or IP-derived fields. Development builds (`bun run dev`, from-source runs, e2e)
-never send anything — they carry no analytics keys and the `dev` channel refuses baked keys outright.
+never send anything — they carry no analytics key and the `dev` channel refuses a baked key outright.
 
 Turn it off any time:
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,33 @@ code — top-level specs at the root (`goal-and-requirements.md`, `architecture.
 `SPEC.md` for every module. When you change a boundary, contract, or decision, update the corresponding
 spec in the same change. See [`AGENTS.md`](AGENTS.md) for the spec workflow.
 
+## Analytics & Privacy
+
+Released ThinkRail builds send **anonymous usage analytics** (on by default; a notice is printed the
+first time anything is sent). The data answers product questions — how many installs are active, on
+which versions/platforms, which models and providers get used, and which features matter — and
+nothing more.
+
+**The only stable identifier** is a random per-install id (a `uuid4`) minted on your machine and
+stored in `~/.thinkrail/installation.json`; it never leaves the host except as the anonymous
+`client_id` on events. Events additionally carry only low-cardinality, non-personal metadata: app
+version, release channel (`stable`/`nightly`), OS (`macos`/`linux`/`windows`), architecture
+(`x64`/`arm64`), and — on chat/login events — the model/provider name **only if it is a pi built-in**
+(anything user-configured is reported as `custom`).
+
+**Never collected:** file paths or names, prompts, code, chat transcripts, API keys, token counts,
+hostnames, usernames, or IP-derived fields. Development builds (`bun run dev`, from-source runs, e2e)
+never send anything — they carry no analytics keys and the `dev` channel refuses baked keys outright.
+
+Turn it off any time:
+
+- **In-app:** Settings → **Privacy** → toggle off (saved on the host, synced to every client).
+- **Per run:** `thinkrail --no-analytics` (or `THINKRAIL_NO_ANALYTICS=1`) — mutes that run without
+  touching the saved setting.
+
+Turning analytics off stops all sending immediately; the install id is kept (never rotated) and simply
+goes unused until you turn it back on.
+
 ## Contributing
 
 Contributions are welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md). This project and community are

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -33,9 +33,11 @@ its URL. It is a thin launcher — all engine logic lives in `packages/server`.
 **subcommand** (`thinkrail update [--channel stable|nightly] [--version X.Y.Z]`) intercepted before the
 launch flags — see *Self-update* below. Otherwise the launch args: `--port` (stable default 24242,
 scans upward to the next free port on collision), `--host` (default `localhost`), `--no-open`,
+`--no-analytics` (**per-run mute** for anonymous usage analytics — this run sends nothing; the
+durable switch is the app's Settings → Privacy toggle, see `submodule-server-analytics`),
 `-v`/`--version` (print the baked version and exit), `-h`/`--help`, and one positional `project-dir` (a
 git repo to open as a project on boot, best-effort). Env defaults: `THINKRAIL_PORT` / `THINKRAIL_HOST` /
-`THINKRAIL_STATIC_DIR` (flag > env > default).
+`THINKRAIL_STATIC_DIR` / `THINKRAIL_NO_ANALYTICS` (flag > env > default).
 
 ## Self-update (`thinkrail update`)
 
@@ -53,7 +55,12 @@ resolution are pure (`parseUpdateArgs` / `resolveUpdatePlan`, unit-tested); only
 `src/version.ts` exports `{ version, channel, commit }` with a from-source default (`0.0.0-dev`). Unlike
 the transient `*.generated.ts`, it's a **permanent committed module** so `--version` + `tsc` work from
 source. The release pipeline (`module-ci-release`) overwrites it in the throwaway CI checkout before
-`build:binary`, baking the real release identity into the binary. `index.ts` reads it, prints it for
+`build:binary`, baking the real release identity into the binary. **`src/analytics-keys.ts` is the
+same seam for the GA4 credentials**: committed with empty-string defaults (so source/dev/e2e builds
+have no keys — the noop sink, see `submodule-server-analytics`), overwritten by the release pipeline
+from CI secrets; `THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` env vars override at
+runtime for deliberate pipeline testing. `index.ts` threads `{ channel, keys, mute }` into `bootHost`
+as the `analytics` option. `index.ts` reads it, prints it for
 `--version`, and passes `appVersion` into `bootHost` — so the host echoes it in `server.welcome`
 (`ServerWelcome.appVersion`), letting a client report host version alongside the protocol-drift check.
 

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -56,11 +56,11 @@ resolution are pure (`parseUpdateArgs` / `resolveUpdatePlan`, unit-tested); only
 the transient `*.generated.ts`, it's a **permanent committed module** so `--version` + `tsc` work from
 source. The release pipeline (`module-ci-release`) overwrites it in the throwaway CI checkout before
 `build:binary`, baking the real release identity into the binary. **`src/analytics-keys.ts` is the
-same seam for the GA4 credentials**: committed with empty-string defaults (so source/dev/e2e builds
-have no keys — the noop sink, see `submodule-server-analytics`), overwritten by the release pipeline
-from CI secrets; `THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` env vars override at
-runtime for deliberate pipeline testing. `index.ts` threads `{ channel, keys, mute }` into `bootHost`
-as the `analytics` option. `index.ts` reads it, prints it for
+same seam for the PostHog project API key**: committed with an empty-string default (so
+source/dev/e2e builds have no key — the noop sink, see `submodule-server-analytics`), overwritten by
+the release pipeline from the CI secret; `THINKRAIL_POSTHOG_API_KEY` (+ `THINKRAIL_POSTHOG_HOST`)
+env vars override at runtime for deliberate pipeline testing. `index.ts` threads
+`{ channel, key, mute }` into `bootHost` as the `analytics` option. `index.ts` reads it, prints it for
 `--version`, and passes `appVersion` into `bootHost` — so the host echoes it in `server.welcome`
 (`ServerWelcome.appVersion`), letting a client report host version alongside the protocol-drift check.
 

--- a/apps/cli/src/analytics-keys.ts
+++ b/apps/cli/src/analytics-keys.ts
@@ -1,0 +1,8 @@
+// GA4 (Firebase Analytics) credentials for anonymous usage analytics — the same release seam as
+// `version.ts`: committed with EMPTY defaults so source/dev/e2e builds have no keys (the host lands on
+// the noop sink and never sends — see packages/server/src/analytics/SPEC.md), overwritten in the
+// throwaway CI checkout by .github/actions/build-binary from repo secrets before `build:binary`.
+// Not secret in the classic sense — a shipped binary necessarily carries them (accepted, same exposure
+// class as any app's Firebase config); dev-channel builds refuse baked keys regardless.
+export const ga4MeasurementId = "";
+export const ga4ApiSecret = "";

--- a/apps/cli/src/analytics-keys.ts
+++ b/apps/cli/src/analytics-keys.ts
@@ -1,8 +1,7 @@
-// GA4 (Firebase Analytics) credentials for anonymous usage analytics — the same release seam as
-// `version.ts`: committed with EMPTY defaults so source/dev/e2e builds have no keys (the host lands on
-// the noop sink and never sends — see packages/server/src/analytics/SPEC.md), overwritten in the
-// throwaway CI checkout by .github/actions/build-binary from repo secrets before `build:binary`.
-// Not secret in the classic sense — a shipped binary necessarily carries them (accepted, same exposure
-// class as any app's Firebase config); dev-channel builds refuse baked keys regardless.
-export const ga4MeasurementId = "";
-export const ga4ApiSecret = "";
+// PostHog project API key for anonymous usage analytics — the same release seam as `version.ts`:
+// committed with an EMPTY default so source/dev/e2e builds have no key (the host lands on the noop
+// sink and never sends — see packages/server/src/analytics/SPEC.md), overwritten in the throwaway CI
+// checkout by .github/actions/build-binary from the repo secret before `build:binary`.
+// Not secret in the classic sense — a shipped binary necessarily carries it (public-by-design, like
+// any client-side analytics key); dev-channel builds refuse a baked key regardless.
+export const posthogApiKey = "";

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -7,11 +7,18 @@ describe("parseArgs", () => {
 			port: DEFAULT_PORT,
 			host: DEFAULT_HOST,
 			open: true,
+			noAnalytics: false,
 			staticDir: undefined,
 			projectDir: undefined,
 			help: false,
 			version: false,
 		});
+	});
+
+	test("--no-analytics mutes for the run; THINKRAIL_NO_ANALYTICS is the env spelling", () => {
+		expect(parseArgs(["--no-analytics"], {}).noAnalytics).toBe(true);
+		expect(parseArgs([], { THINKRAIL_NO_ANALYTICS: "1" }).noAnalytics).toBe(true);
+		expect(parseArgs([], {}).noAnalytics).toBe(false);
 	});
 
 	test("flags win over env over defaults", () => {

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -10,6 +10,8 @@ export interface CliOptions {
 	host: string;
 	/** Open the browser at the resolved URL on boot. */
 	open: boolean;
+	/** `--no-analytics` / `THINKRAIL_NO_ANALYTICS`: mute anonymous usage analytics for this run. */
+	noAnalytics: boolean;
 	/** Static SPA dir override (`THINKRAIL_STATIC_DIR`); when unset the bin derives a default. */
 	staticDir: string | undefined;
 	/** A git repo to open as a project on boot (the positional arg), or undefined. */
@@ -32,6 +34,8 @@ Options:
   --port <n>     Listen port (default ${DEFAULT_PORT}; falls back to a free port if taken).
   --host <h>     Bind host (default ${DEFAULT_HOST}).
   --no-open      Don't open the browser (e.g. headless / remote host).
+  --no-analytics Don't send anonymous usage analytics this run (the durable switch
+                 lives in the app: Settings → Privacy).
   -v, --version  Print the version and exit.
   -h, --help     Show this help.
 
@@ -40,7 +44,8 @@ Arguments:
 
 Env:
   THINKRAIL_PORT / THINKRAIL_HOST   Defaults for --port / --host.
-  THINKRAIL_STATIC_DIR                 Override the built web app served by the host.`;
+  THINKRAIL_STATIC_DIR                 Override the built web app served by the host.
+  THINKRAIL_NO_ANALYTICS               Same as --no-analytics (any non-empty value).`;
 
 /** Read a flag's value from either `--flag value` or `--flag=value`; returns the value + how many argv slots it consumed. */
 function readFlagValue(arg: string, next: string | undefined): { value: string; consumed: number } {
@@ -59,6 +64,7 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 	let port: number | undefined;
 	let host: string | undefined;
 	let open = true;
+	let noAnalytics = false;
 	let help = false;
 	let version = false;
 	let projectDir: string | undefined;
@@ -67,6 +73,8 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 		const arg = argv[i] as string;
 		if (arg === "--no-open") {
 			open = false;
+		} else if (arg === "--no-analytics") {
+			noAnalytics = true;
 		} else if (arg === "-h" || arg === "--help") {
 			help = true;
 		} else if (arg === "-v" || arg === "--version") {
@@ -100,6 +108,7 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 		port: resolvedPort,
 		host: host ?? env.THINKRAIL_HOST ?? DEFAULT_HOST,
 		open,
+		noAnalytics: noAnalytics || Boolean(env.THINKRAIL_NO_ANALYTICS),
 		staticDir: env.THINKRAIL_STATIC_DIR,
 		projectDir,
 		help,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,7 +5,7 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { bootHost } from "@thinkrail/server";
-import { ga4ApiSecret, ga4MeasurementId } from "./analytics-keys";
+import { posthogApiKey } from "./analytics-keys";
 import { type CliOptions, parseArgs, USAGE } from "./args";
 import { runUpdate } from "./update";
 import { channel, version } from "./version";
@@ -67,13 +67,12 @@ async function bootstrap(): Promise<void> {
 		portMode: "free",
 		staticDir,
 		appVersion: version,
-		// Anonymous usage analytics: channel + the release-baked GA4 keys (empty from source → the host
-		// lands on the noop sink) + the per-run `--no-analytics` mute. The durable on/off switch is the
-		// app's Settings → Privacy toggle (`AppConfig.analyticsEnabled`), host-side.
+		// Anonymous usage analytics: channel + the release-baked PostHog key (empty from source → the
+		// host lands on the noop sink) + the per-run `--no-analytics` mute. The durable on/off switch is
+		// the app's Settings → Privacy toggle (`AppConfig.analyticsEnabled`), host-side.
 		analytics: {
 			channel,
-			measurementId: ga4MeasurementId,
-			apiSecret: ga4ApiSecret,
+			posthogApiKey,
 			mute: options.noAnalytics,
 		},
 		...(options.projectDir ? { projectPath: resolve(process.cwd(), options.projectDir) } : {}),

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,9 +5,10 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { bootHost } from "@thinkrail/server";
+import { ga4ApiSecret, ga4MeasurementId } from "./analytics-keys";
 import { type CliOptions, parseArgs, USAGE } from "./args";
 import { runUpdate } from "./update";
-import { version } from "./version";
+import { channel, version } from "./version";
 
 /** The built web app shipped with the bin, relative to this file (src in dev, dist when bundled). */
 const DEFAULT_STATIC_DIR = resolve(import.meta.dir, "../../web/dist");
@@ -66,6 +67,15 @@ async function bootstrap(): Promise<void> {
 		portMode: "free",
 		staticDir,
 		appVersion: version,
+		// Anonymous usage analytics: channel + the release-baked GA4 keys (empty from source → the host
+		// lands on the noop sink) + the per-run `--no-analytics` mute. The durable on/off switch is the
+		// app's Settings → Privacy toggle (`AppConfig.analyticsEnabled`), host-side.
+		analytics: {
+			channel,
+			measurementId: ga4MeasurementId,
+			apiSecret: ga4ApiSecret,
+			mute: options.noAnalytics,
+		},
 		...(options.projectDir ? { projectPath: resolve(process.cwd(), options.projectDir) } : {}),
 	});
 	if (port !== requested) {

--- a/apps/web/src/panels/PrivacySettings.tsx
+++ b/apps/web/src/panels/PrivacySettings.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@/lib";
+import { toast, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+
+/**
+ * The "Privacy" settings section: the anonymous-usage-analytics toggle. Server-synced — flipping the
+ * switch fires `settings.update { analyticsEnabled }` and the UI converges on the host's
+ * `settings.changed` broadcast (no optimistic apply), the same pattern as the theme picker. Only this
+ * boolean ever crosses the wire: events are emitted host-side and the anonymous install id never
+ * leaves the host (see the server analytics module's spec).
+ */
+export function PrivacySettings() {
+	const enabled = useAppStore((s) => s.analyticsEnabled);
+
+	const toggle = () => {
+		getTransport()
+			.request("settings.update", { config: { analyticsEnabled: !enabled } })
+			.catch(() => toast.error("Couldn't change the analytics setting"));
+	};
+
+	return (
+		<section data-testid="settings-privacy" className="flex flex-col gap-lg">
+			<div className="flex flex-col gap-xs">
+				<h3 className="font-medium text-md text-text">Usage analytics</h3>
+				<p className="text-hint text-xs">
+					Anonymous usage analytics help us understand which features matter. Your choice is saved
+					on the host and follows you across devices.
+				</p>
+			</div>
+
+			<div className="flex items-center justify-between gap-md rounded-[var(--radius-md)] border border-border2 px-md py-sm">
+				<div className="flex flex-col gap-0.5">
+					<span className="font-medium text-sm text-text">Share anonymous usage analytics</span>
+					<span className="text-hint text-xs">
+						{enabled ? "On — thank you for helping improve ThinkRail." : "Off — nothing is sent."}
+					</span>
+				</div>
+				<button
+					type="button"
+					role="switch"
+					aria-checked={enabled}
+					aria-label="Share anonymous usage analytics"
+					data-testid="analytics-toggle"
+					data-active={enabled}
+					onClick={toggle}
+					className={cn(
+						"relative h-5 w-9 shrink-0 rounded-full outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+						enabled ? "bg-primary" : "bg-border2",
+					)}
+				>
+					<span
+						className={cn(
+							"absolute top-0.5 left-0.5 size-4 rounded-full bg-bg transition-transform",
+							enabled && "translate-x-4",
+						)}
+					/>
+				</button>
+			</div>
+
+			<div className="flex flex-col gap-xs text-xs">
+				<p className="text-muted">
+					<span className="font-medium text-text">What is collected:</span> a random anonymous
+					install id, app version and release channel, OS and architecture, when a chat starts (and
+					the model/provider it uses), and which providers you sign in to. Custom providers and
+					models are reported only as “custom”.
+				</p>
+				<p className="text-muted">
+					<span className="font-medium text-text">Never collected:</span> file paths or names,
+					prompts, code, chat transcripts, API keys, hostnames, usernames, or anything typed into
+					the app.
+				</p>
+				<p className="text-hint">
+					You can also launch with <code className="font-[var(--font-mono)]">--no-analytics</code>{" "}
+					to mute a single run. See the README’s “Analytics &amp; Privacy” section for the full
+					policy.
+				</p>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -108,11 +108,16 @@ a project picker, the prompt hero, and the reused
   Connected (Disconnect) / ready (Connect) / not signed in (in-app `central login` + Retry) / not installed
   (the host's per-OS copyable install command — from `jbcentralInstall`, for the *host's* OS, never the
   browser's — + Recheck); each mutation re-reads `provider.status`) **`GithubSettings`** (the "Local GitHub" block — `github.authStatus()`
-  Connected + login / Not connected + Refresh); and **`AppearanceSettings`** (the **theme picker** — a
+  Connected + login / Not connected + Refresh); **`AppearanceSettings`** (the **theme picker** — a
   labelled list of `utils/theme`'s `THEMES`, the active one from `store.theme` marked; clicking one fires
   `settings.update` and the UI **converges on the `settings.changed` broadcast** (no optimistic apply), a
-  rejected update raising a toast). A single dimmed "General" nav item ("Soon") still signals the shell is
-  built to grow. `ProvidersSettings`/`AppearanceSettings` are the **integration pieces** (store + transport);
+  rejected update raising a toast); and **`PrivacySettings`** (the **anonymous-usage-analytics toggle** —
+  a switch over `store.analyticsEnabled`, fired via `settings.update { analyticsEnabled }` with the same
+  converge-on-broadcast pattern as the theme, plus the what-is/isn't-collected copy — only the boolean
+  ever crosses the wire, see `submodule-server-analytics`). A single dimmed "General" nav item ("Soon")
+  still signals the shell is
+  built to grow. `ProvidersSettings`/`AppearanceSettings`/`PrivacySettings` are the **integration pieces**
+  (store + transport);
   the `LoginDialog` stays presentational (`auth` module).
   Panels compose their own sub-panels
   (e.g. `RightPanel`→`FileTree`/`ChangesPanel`, `CenterTabs`→`FilePane`→`MonacoEditor`) — an internal hierarchy.

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -1,9 +1,17 @@
-import { GitBranch, KeyRound, type LucideIcon, Palette, SlidersHorizontal } from "lucide-react";
+import {
+	GitBranch,
+	KeyRound,
+	type LucideIcon,
+	Palette,
+	ShieldCheck,
+	SlidersHorizontal,
+} from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib";
 import { SettingsSection, useAppStore } from "@/store";
 import { AppearanceSettings } from "./AppearanceSettings";
 import { GithubSettings } from "./GithubSettings";
+import { PrivacySettings } from "./PrivacySettings";
 import { ProvidersSettings } from "./ProvidersSettings";
 
 /** The live settings sections, in nav order. */
@@ -11,6 +19,7 @@ const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
 	{ id: SettingsSection.Providers, label: "Providers", icon: KeyRound },
 	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
 	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
+	{ id: SettingsSection.Privacy, label: "Privacy", icon: ShieldCheck },
 ];
 /** Placeholder sections — shown dimmed so the shell reads as built-to-grow (not yet wired). */
 const SOON: { label: string; icon: LucideIcon }[] = [{ label: "General", icon: SlidersHorizontal }];
@@ -84,6 +93,8 @@ export function SettingsDialog() {
 							<ProvidersSettings />
 						) : section === SettingsSection.Github ? (
 							<GithubSettings />
+						) : section === SettingsSection.Privacy ? (
+							<PrivacySettings />
 						) : (
 							<AppearanceSettings />
 						)}

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -71,14 +71,15 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `provider.login` frame (creating `activeLogin` if the frame arrived first; ignoring frames for a different
   live login), **`clearLoginInput()`** drops the live input the instant a reply is sent (no double-submit),
   and **`clearLogin()`** dismisses it. The **settings surface** state — **`settingsOpen`** +
-  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`) with
+  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Privacy`) with
   **`openSettings(section?)`** (deep-links to a section, defaults to Providers) / **`closeSettings()`** /
   **`setSettingsSection()`** — lives here so the top-bar gear AND the Welcome provider warning open Settings
   to a section without prop-drilling through the shell. The **theme** state — **`theme: ThemeId`** (the
   host-owned active theme) with **`applyConfig(config)`** (folds the server-synced `AppConfig` in from
   `server.welcome` / the `settings.changed` broadcast) — lives here too; it's a **pure value only** (the
   `applyTheme` DOM side-effect is the shell's, keyed off `theme`), and defaults to `Theme.Dark` until the
-  welcome arrives. The
+  welcome arrives. **`analyticsEnabled: boolean`** rides the same `applyConfig` fold (host-owned, defaults
+  `true` until the welcome arrives) — the Privacy toggle's read side. The
   **toast queue** — **`toasts: Toast[]`** (oldest-first) with **`pushToast(toast) → id`** / **`dismissToast(id)`**
   and the ergonomic **`toast.error/success/info(message, title?)`** helper (wraps `pushToast` so a non-React
   call site — a `.catch` in a fire-and-forget wire call — can fire one) — lives here so any surface can raise

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -47,12 +47,13 @@ export type EditorTab = FileTab | ChatTab;
 
 /**
  * A section of the settings dialog (a const-object "enum", the codebase convention). Extensible — the live
- * sections are providers, github, and appearance (the theme picker).
+ * sections are providers, github, appearance (the theme picker), and privacy (the analytics toggle).
  */
 export const SettingsSection = {
 	Providers: "providers",
 	Github: "github",
 	Appearance: "appearance",
+	Privacy: "privacy",
 } as const;
 export type SettingsSection = (typeof SettingsSection)[keyof typeof SettingsSection];
 
@@ -383,6 +384,9 @@ interface AppState {
 	/** The active UI theme (host-owned; `applyConfig` sets it from `server.welcome` / `settings.changed`).
 	 * The DOM side-effect (`applyTheme`) is the shell's job — this holds the value the UI reads. */
 	theme: ThemeId;
+	/** Anonymous-usage-analytics switch (host-owned, same `applyConfig` fold as `theme`). Only this boolean
+	 * ever reaches a client — events are emitted host-side and the install id never crosses the wire. */
+	analyticsEnabled: boolean;
 	/** Transient notifications, oldest-first (the Toaster renders + times them out). At-most a handful live
 	 * at once; a failed wire call that has no better home (no chat tab to host an error turn) lands here. */
 	toasts: Toast[];
@@ -585,6 +589,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	settingsOpen: false,
 	settingsSection: SettingsSection.Providers,
 	theme: Theme.Dark,
+	analyticsEnabled: true,
 	toasts: [],
 	setStatus: (status) => set({ status }),
 	setWelcome: (protocolVersion) => set({ protocolVersion }),
@@ -999,7 +1004,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 		set({ settingsOpen: true, settingsSection: section }),
 	closeSettings: () => set({ settingsOpen: false }),
 	setSettingsSection: (section) => set({ settingsSection: section }),
-	applyConfig: (config) => set({ theme: config.theme }),
+	applyConfig: (config) => set({ theme: config.theme, analyticsEnabled: config.analyticsEnabled }),
 	requestChangesView: (workspaceId, path) => set({ changesRequest: { workspaceId, path } }),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 // The Privacy settings section: the anonymous-usage-analytics toggle. The flag is SERVER-SYNCED
 // (AppConfig.analyticsEnabled in config.json, converged via the settings.changed broadcast — no
 // optimistic apply), so a flip survives a reload. The e2e host never actually sends anything
-// regardless of the flag: it runs from source (no baked GA4 keys ⇒ noop sink) on the dev channel.
+// regardless of the flag: it runs from source (no baked PostHog key ⇒ noop sink) on the dev channel.
 // This test leaves the flag back ON so the shared e2e data dir stays in its default state.
 test("privacy section toggles analytics off and the choice persists across a reload", async ({
 	page,

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+// The Privacy settings section: the anonymous-usage-analytics toggle. The flag is SERVER-SYNCED
+// (AppConfig.analyticsEnabled in config.json, converged via the settings.changed broadcast — no
+// optimistic apply), so a flip survives a reload. The e2e host never actually sends anything
+// regardless of the flag: it runs from source (no baked GA4 keys ⇒ noop sink) on the dev channel.
+// This test leaves the flag back ON so the shared e2e data dir stays in its default state.
+test("privacy section toggles analytics off and the choice persists across a reload", async ({
+	page,
+}) => {
+	await page.goto("/");
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+
+	await page.getByTestId("open-settings").click();
+	const dialog = page.getByTestId("settings-dialog");
+	await expect(dialog).toBeVisible();
+	await page.getByTestId("settings-nav-privacy").click();
+	await expect(dialog).toContainText("Usage analytics");
+
+	// Fresh data dir → DEFAULT_CONFIG → analytics enabled (the opt-out posture).
+	const toggle = page.getByTestId("analytics-toggle");
+	await expect(toggle).toHaveAttribute("data-active", "true");
+
+	// Flip off → converges on the settings.changed broadcast (the same round-trip as the theme picker).
+	await toggle.click();
+	await expect(toggle).toHaveAttribute("data-active", "false");
+	await expect(dialog).toContainText("nothing is sent");
+
+	// Server-synced: a reload comes back OFF (from server.welcome's config, not a fresh default).
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-privacy").click();
+	await expect(toggle).toHaveAttribute("data-active", "false");
+
+	// Restore the default so other specs see the data dir's default posture.
+	await toggle.click();
+	await expect(toggle).toHaveAttribute("data-active", "true");
+
+	await page.keyboard.press("Escape");
+	await expect(dialog).toBeHidden();
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -103,7 +103,10 @@ what lets the UI ship independently of the host.
   `Dark`/`Light`/`Darcula`/`Gruvbox`/`HighContrast`;
   adding a value is wire-compatible — an older client falls back to Dark's `:root` tokens), its derived
   **`ThemeId`** type + runtime-iterable **`THEME_IDS`** (the picker source), and the server-synced
-  **`AppConfig`** (`{ theme }` — an extensible bag) with its **`DEFAULT_CONFIG`** fallback (persisted host-side
+  **`AppConfig`** (`{ theme, analyticsEnabled }` — an extensible bag; `analyticsEnabled` is the
+  anonymous-usage-analytics switch, default `true` — it is the **only** analytics fact on the wire:
+  the installation id stays server-side by design, see `submodule-server-analytics`) with its
+  **`DEFAULT_CONFIG`** fallback (persisted host-side
   as `config.json`, delivered in `server.welcome`, mutated via `settings.update`);
   **`SpecGraphNode`/`SpecGraphSnapshot`** — the
   Specs-viewer read DTOs, **mirrored** (like `PiEvent`), never imported from `pi-spec-graph` — the wire

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -259,7 +259,14 @@ export const THEME_IDS: readonly ThemeId[] = Object.values(Theme);
  */
 export interface AppConfig {
 	theme: ThemeId;
+	/**
+	 * Anonymous usage analytics on/off (default on — the opt-out posture; a first-run notice + this
+	 * switch are the transparency half). This boolean is the ONLY analytics fact on the wire: events
+	 * are emitted host-side and the per-install id never leaves the host (it lives in the server-only
+	 * `installation.json`, deliberately not in this broadcast bag).
+	 */
+	analyticsEnabled: boolean;
 }
 
 /** The config a fresh host (no `config.json` yet) falls back to. */
-export const DEFAULT_CONFIG: AppConfig = { theme: Theme.Dark };
+export const DEFAULT_CONFIG: AppConfig = { theme: Theme.Dark, analyticsEnabled: true };

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -56,7 +56,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `agent` | in-process pi `AgentSession`s + the shared pi runtime + one-shot completions | [agent/SPEC.md](src/agent/SPEC.md) |
 | `auth` | provider status (`provider.status`) + in-app login (OAuth / API key / logout) | [auth/SPEC.md](src/auth/SPEC.md) |
 | `assist` | ad-hoc one-shot tasks (workspace naming, …) on a cheap model, best-effort | [assist/SPEC.md](src/assist/SPEC.md) |
-| `analytics` | anonymous usage analytics: closed event set → GA4 sink (privacy contract in its spec) | [analytics/SPEC.md](src/analytics/SPEC.md) |
+| `analytics` | anonymous usage analytics: closed event set → PostHog sink (privacy contract in its spec) | [analytics/SPEC.md](src/analytics/SPEC.md) |
 | `dialog` | the host's native folder picker | [dialog/SPEC.md](src/dialog/SPEC.md) |
 
 `src/index.ts` re-exports `host` + the `agent` barrel's `setBundledExtensions` seam; `src/dev.ts` boots

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -56,6 +56,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `agent` | in-process pi `AgentSession`s + the shared pi runtime + one-shot completions | [agent/SPEC.md](src/agent/SPEC.md) |
 | `auth` | provider status (`provider.status`) + in-app login (OAuth / API key / logout) | [auth/SPEC.md](src/auth/SPEC.md) |
 | `assist` | ad-hoc one-shot tasks (workspace naming, …) on a cheap model, best-effort | [assist/SPEC.md](src/assist/SPEC.md) |
+| `analytics` | anonymous usage analytics: closed event set → GA4 sink (privacy contract in its spec) | [analytics/SPEC.md](src/analytics/SPEC.md) |
 | `dialog` | the host's native folder picker | [dialog/SPEC.md](src/dialog/SPEC.md) |
 
 `src/index.ts` re-exports `host` + the `agent` barrel's `setBundledExtensions` seam; `src/dev.ts` boots
@@ -65,10 +66,10 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`
+- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`, `analytics`
 - `workspaces` → `projects`, `git`, `persistence`
 - `projects` → `git` (shared runner), `persistence`
-- `git`, `fs`, `spec`, `watch`, `terminal`, `settings` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
+- `git`, `fs`, `spec`, `watch`, `terminal`, `settings`, `analytics` → `persistence` (`spec` also → `pi-spec-graph/core`, external; `analytics` also → `@earendil-works/pi-ai/compat`, external — the built-in model catalog its identity bucketing checks against)
 - `assist` → `agent` (the one-shot completion primitive)
 - `auth` → `agent` (`getPiRuntime` — the shared `AuthStorage` + `ModelRegistry`; one-way, `agent` never imports `auth`)
 - `agent` → (no internal deps — only the pi runtime)
@@ -80,6 +81,9 @@ own never import `host` either: they expose a **publisher-injection seam** (`set
 `setSessionPublisher`, `setLoginPublisher`, `workspaces`' `setWorkspacePublisher` for the
 `workspace.created`/`updated`/`removed` lifecycle trio, and `settings`' `setSettingsPublisher` for
 `settings.changed`) that `host` installs at `createServer` — so the channel wiring lives only in `host`.
+Analytics is host-mediated the same way: **every `track()` call site lives in `host`** (boot,
+session-create, login-success observation), and `host` syncs `setAnalyticsSending` off the settings
+broadcast — `analytics` has no `settings` edge and no feature module knows analytics exists.
 
 ## Get right
 

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -2,7 +2,7 @@
 id: submodule-server-analytics
 type: submodule-design
 status: active
-title: analytics — anonymous usage analytics (GA4 sink)
+title: analytics — anonymous usage analytics (PostHog sink)
 parent: module-server
 depends-on: [module-contracts]
 tags: [v1, analytics, privacy]
@@ -13,9 +13,11 @@ tags: [v1, analytics, privacy]
 Anonymous, no-personal-data usage analytics, emitted **host-side only** (design + privacy rationale:
 `task-analytics` while it lives; the invariants below are the durable contract). Answers product
 questions — unique users, version/platform, model preference, provider auth — via a **closed event
-set** delivered to Firebase/GA4 over the **Measurement Protocol** (plain `fetch`; there is no
-server-side Firebase SDK). The delivery backend hides behind the `AnalyticsSink` interface —
-swapping vendors is implementing a new sink, nothing else moves.
+set** delivered to **PostHog (EU cloud)** over its capture API (a plain `fetch` POST — no vendor
+SDK; none of the major backends need one server-side). The delivery backend hides behind the
+`AnalyticsSink` interface — swapping vendors is implementing a new sink, nothing else moves
+(exercised for real once already: the first sink was GA4's Measurement Protocol, replaced pre-ship
+by user decision — PostHog's free tier, EU residency, and self-host path won).
 
 ## Boundary
 
@@ -26,9 +28,12 @@ swapping vendors is implementing a new sink, nothing else moves.
     unit test), and `bucketProviderModel()`: identity passes raw **only** when it matches pi's
     built-in catalog (`getProviders()` / `getModels()` from `@earendil-works/pi-ai/compat`); a
     custom provider — or a custom model id on a known provider — becomes `"custom"`. Fails closed.
-  - `sink.ts` — `AnalyticsSink { send(events) }`; `createGa4Sink({ measurementId, apiSecret,
-    fetchImpl? })` (fire-and-forget POST to `/mp/collect`, errors swallowed + debug-logged, no
-    retries) and `noopSink`.
+  - `sink.ts` — `AnalyticsSink { send(events) }`; `createPostHogSink({ apiKey, host?, fetchImpl? })`
+    (fire-and-forget POST to `{host}/batch/`, EU cloud by default; errors swallowed + debug-logged,
+    no retries) and `noopSink`. Every outgoing event is **personless**
+    (`$process_person_profile: false` — no person profiles server-side; unique users still count by
+    `distinct_id` = the install id) and carries **`$geoip_disable: true`** (the "no IP-derived
+    fields" invariant enforced sender-side, belt to the project-level GeoIP-off braces).
   - `service.ts` — the facade: `initializeAnalytics(opts)` (installation record via `persistence`,
     sink selection, env stamping, first-run notice + `app_installed` announce, `app_started`),
     `track(event)`, `setAnalyticsSending(enabled)`, `resetAnalyticsForTests()`.
@@ -51,11 +56,12 @@ swapping vendors is implementing a new sink, nothing else moves.
   `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒
   zero network. `app_installed` fires at most once per install (the `announced` bit), on the first
   sending-enabled boot, together with the first-run notice.
-- **Dev runs never send:** baked keys are refused when `channel === "dev"`; source builds have no
-  baked keys anyway (double gate — e2e inherits the silence). Only the explicit `THINKRAIL_GA4_*`
-  env override can send from a dev run, and those events still carry `channel: "dev"`.
+- **Dev runs never send:** a baked key is refused when `channel === "dev"`; source builds have no
+  baked key anyway (double gate — e2e inherits the silence). Only the explicit
+  `THINKRAIL_POSTHOG_API_KEY` env override can send from a dev run, and those events still carry
+  `channel: "dev"` (`THINKRAIL_POSTHOG_HOST` retargets the endpoint — the future self-host seam).
 - **Never sent:** paths, file/spec names, prompts, code, transcripts, token counts, hostnames,
   usernames, IP-derived fields, or any free-form user string. Params on every event:
-  `app_version`, `channel`, `os`, `arch` + GA4 plumbing (`session_id` per boot,
-  `engagement_time_msec: 1` — without these GA4 doesn't count active users).
+  `app_version`, `channel`, `os`, `arch` — nothing else outside the per-event params above
+  (transport framing like the two `$`-flags is the sink's, not the event model's).
 - **Fire-and-forget:** `track`/`initializeAnalytics` never throw into callers and never block boot.

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -1,0 +1,61 @@
+---
+id: submodule-server-analytics
+type: submodule-design
+status: active
+title: analytics — anonymous usage analytics (GA4 sink)
+parent: module-server
+depends-on: [module-contracts]
+tags: [v1, analytics, privacy]
+---
+
+## Responsibility
+
+Anonymous, no-personal-data usage analytics, emitted **host-side only** (design + privacy rationale:
+`task-analytics` while it lives; the invariants below are the durable contract). Answers product
+questions — unique users, version/platform, model preference, provider auth — via a **closed event
+set** delivered to Firebase/GA4 over the **Measurement Protocol** (plain `fetch`; there is no
+server-side Firebase SDK). The delivery backend hides behind the `AnalyticsSink` interface —
+swapping vendors is implementing a new sink, nothing else moves.
+
+## Boundary
+
+- **Owns:**
+  - `events.ts` — the closed `AnalyticsEvent` union (`app_installed` / `app_started` /
+    `chat_started {provider, model}` / `provider_login {provider, method}`), the
+    **`PARAM_ALLOWLIST`** (the machine-checked privacy invariant — a param key outside it fails the
+    unit test), and `bucketProviderModel()`: identity passes raw **only** when it matches pi's
+    built-in catalog (`getProviders()` / `getModels()` from `@earendil-works/pi-ai/compat`); a
+    custom provider — or a custom model id on a known provider — becomes `"custom"`. Fails closed.
+  - `sink.ts` — `AnalyticsSink { send(events) }`; `createGa4Sink({ measurementId, apiSecret,
+    fetchImpl? })` (fire-and-forget POST to `/mp/collect`, errors swallowed + debug-logged, no
+    retries) and `noopSink`.
+  - `service.ts` — the facade: `initializeAnalytics(opts)` (installation record via `persistence`,
+    sink selection, env stamping, first-run notice + `app_installed` announce, `app_started`),
+    `track(event)`, `setAnalyticsSending(enabled)`, `resetAnalyticsForTests()`.
+- **Public surface (barrel):** `initializeAnalytics`, `track`, `setAnalyticsSending`,
+  `resetAnalyticsForTests`, the event types.
+- **Allowed deps:** `persistence` (installation record + data dir), `contracts` (types),
+  `@earendil-works/pi-ai/compat` (the built-in catalog — server-side value import), Node
+  `crypto`/`process`.
+- **Forbidden:** importing `host` or any other sibling; being imported by anything but `host` (all
+  `track()` call sites live in `host` — feature modules stay analytics-free); putting the
+  installation id on the wire in any form.
+
+## Get right (the privacy contract)
+
+- **The only stable identifier** is the per-install uuid4 in `persistence`'s server-only
+  `installation.json` — minted once, **never rotated** (deliberate divergence from thinkrail-v1's
+  fresh-id-on-re-enable; the user chose id continuity), never crossing the wire (deliberately not in
+  the broadcast `config.json`).
+- **The flag only gates sending:** `AppConfig.analyticsEnabled` (host-mediated — `host` syncs
+  `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒
+  zero network. `app_installed` fires at most once per install (the `announced` bit), on the first
+  sending-enabled boot, together with the first-run notice.
+- **Dev runs never send:** baked keys are refused when `channel === "dev"`; source builds have no
+  baked keys anyway (double gate — e2e inherits the silence). Only the explicit `THINKRAIL_GA4_*`
+  env override can send from a dev run, and those events still carry `channel: "dev"`.
+- **Never sent:** paths, file/spec names, prompts, code, transcripts, token counts, hostnames,
+  usernames, IP-derived fields, or any free-form user string. Params on every event:
+  `app_version`, `channel`, `os`, `arch` + GA4 plumbing (`session_id` per boot,
+  `engagement_time_msec: 1` — without these GA4 doesn't count active users).
+- **Fire-and-forget:** `track`/`initializeAnalytics` never throw into callers and never block boot.

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
+import { ensureInstallation } from "../persistence";
+import {
+	type AnalyticsEvent,
+	bucketProvider,
+	bucketProviderModel,
+	CUSTOM_BUCKET,
+	PARAM_ALLOWLIST,
+} from "./events";
+import { initializeAnalytics, resetAnalyticsForTests, setAnalyticsSending, track } from "./service";
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+const savedEnvKeys = {
+	id: process.env.THINKRAIL_GA4_MEASUREMENT_ID,
+	secret: process.env.THINKRAIL_GA4_API_SECRET,
+};
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-analytics-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
+	delete process.env.THINKRAIL_GA4_API_SECRET;
+	resetAnalyticsForTests();
+});
+
+afterEach(() => {
+	resetAnalyticsForTests();
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+	if (savedEnvKeys.id === undefined) delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
+	else process.env.THINKRAIL_GA4_MEASUREMENT_ID = savedEnvKeys.id;
+	if (savedEnvKeys.secret === undefined) delete process.env.THINKRAIL_GA4_API_SECRET;
+	else process.env.THINKRAIL_GA4_API_SECRET = savedEnvKeys.secret;
+});
+
+// ── test fetch (the sink's injected seam) ──────────────────────────────
+
+interface SentPayload {
+	url: string;
+	body: { client_id: string; events: { name: string; params: Record<string, unknown> }[] };
+}
+
+function makeFetch(sent: SentPayload[]): typeof fetch {
+	return ((url: string | URL | Request, init?: RequestInit) => {
+		sent.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+		return Promise.resolve(new Response("ok"));
+	}) as typeof fetch;
+}
+
+/** Boot the service on the baked-keys path (release-like: keys + a non-dev channel). */
+function bootReleaseLike(
+	sent: SentPayload[],
+	overrides: Partial<Parameters<typeof initializeAnalytics>[0]> = {},
+): void {
+	initializeAnalytics({
+		appVersion: "1.2.3",
+		channel: "stable",
+		measurementId: "G-TEST",
+		apiSecret: "s3cret",
+		enabled: true,
+		fetchImpl: makeFetch(sent),
+		...overrides,
+	});
+}
+
+// ── the machine-checked privacy invariant ──────────────────────────────
+
+// One fully-populated sample per event variant. The `satisfies` map is EXHAUSTIVE over the union's
+// names — adding a new event variant without a sample here is a compile error, so the allowlist
+// assertions below always cover the whole event model (the v1 allowlist test, in TS).
+const EVENT_SAMPLES = {
+	app_installed: { name: "app_installed" },
+	app_started: { name: "app_started" },
+	chat_started: { name: "chat_started", params: { provider: "anthropic", model: "some-model" } },
+	provider_login: { name: "provider_login", params: { provider: "openai", method: "oauth" } },
+} as const satisfies { [K in AnalyticsEvent["name"]]: Extract<AnalyticsEvent, { name: K }> };
+
+test("every event's outgoing params are a subset of PARAM_ALLOWLIST (privacy invariant)", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	for (const event of Object.values(EVENT_SAMPLES)) track(event);
+	expect(sent.length).toBeGreaterThanOrEqual(Object.keys(EVENT_SAMPLES).length);
+	for (const payload of sent) {
+		for (const event of payload.body.events) {
+			for (const key of Object.keys(event.params)) {
+				expect(PARAM_ALLOWLIST.has(key)).toBe(true);
+			}
+		}
+	}
+});
+
+test("an off-allowlist param is dropped at runtime (fails closed even past the type system)", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	sent.length = 0; // drop the boot lifecycle events
+	// Deliberately malformed via cast: the runtime filter must catch what the compiler can't.
+	track({
+		name: "chat_started",
+		params: { provider: "anthropic", model: "m", leak: "/Users/me/secret-project" },
+	} as unknown as AnalyticsEvent);
+	expect(sent).toHaveLength(1);
+	const params = sent[0]?.body.events[0]?.params ?? {};
+	expect(params.leak).toBeUndefined();
+	expect(params.provider).toBe("anthropic");
+});
+
+test("every event is stamped with env metadata + the GA4 user-counting plumbing", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	track({ name: "app_started" });
+	const last = sent.at(-1);
+	expect(last?.body.events[0]?.params).toMatchObject({
+		app_version: "1.2.3",
+		channel: "stable",
+		engagement_time_msec: 1,
+	});
+	expect(last?.body.events[0]?.params.os).toBeString();
+	expect(last?.body.events[0]?.params.arch).toBeString();
+	expect(last?.body.events[0]?.params.session_id).toBeString();
+});
+
+// ── installation identity ──────────────────────────────────────────────
+
+test("the install id is minted once, used as client_id, and NEVER rotated by toggles", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	const id = ensureInstallation().id;
+	expect(sent[0]?.body.client_id).toBe(id);
+
+	setAnalyticsSending(false);
+	setAnalyticsSending(true);
+	track({ name: "app_started" });
+	expect(sent.at(-1)?.body.client_id).toBe(id);
+	expect(ensureInstallation().id).toBe(id); // unchanged on disk too
+});
+
+test("app_installed fires exactly once per install (announced bit survives restarts)", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed", "app_started"]);
+
+	// Simulated restart: same data dir, fresh in-memory state.
+	resetAnalyticsForTests();
+	const sentAfterRestart: SentPayload[] = [];
+	bootReleaseLike(sentAfterRestart);
+	expect(sentAfterRestart.map((p) => p.body.events[0]?.name)).toEqual(["app_started"]);
+});
+
+test("a disabled boot mints the id but sends nothing; enabling later announces once", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent, { enabled: false });
+	expect(sent).toHaveLength(0);
+	expect(readFileSync(join(dataDir, "installation.json"), "utf8")).toContain('"announced": false');
+
+	setAnalyticsSending(true);
+	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed"]);
+	setAnalyticsSending(true); // idempotent — no second announce
+	expect(sent).toHaveLength(1);
+});
+
+// ── gates ──────────────────────────────────────────────────────────────
+
+test("the dev channel refuses baked keys — a dev run never sends", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent, { channel: "dev" });
+	track({ name: "app_started" });
+	expect(sent).toHaveLength(0);
+});
+
+test("explicit THINKRAIL_GA4_* env keys send even on the dev channel (pipeline testing)", () => {
+	process.env.THINKRAIL_GA4_MEASUREMENT_ID = "G-ENV";
+	process.env.THINKRAIL_GA4_API_SECRET = "env-secret";
+	const sent: SentPayload[] = [];
+	initializeAnalytics({ channel: "dev", enabled: true, fetchImpl: makeFetch(sent) });
+	expect(sent.length).toBeGreaterThan(0);
+	expect(sent[0]?.url).toContain("measurement_id=G-ENV");
+	expect(sent[0]?.body.events[0]?.params.channel).toBe("dev"); // still excludable in reports
+});
+
+test("--no-analytics (mute) silences the run even when keys + config say send", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent, { mute: true });
+	track({ name: "app_started" });
+	setAnalyticsSending(true); // a settings toggle during a muted run must not unmute it
+	track({ name: "app_started" });
+	expect(sent).toHaveLength(0);
+});
+
+test("setAnalyticsSending(false) stops sending immediately", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	sent.length = 0;
+	setAnalyticsSending(false);
+	track({ name: "chat_started", params: { provider: "anthropic", model: "m" } });
+	expect(sent).toHaveLength(0);
+});
+
+test("track never throws into the caller, even when the transport does", () => {
+	initializeAnalytics({
+		channel: "stable",
+		measurementId: "G-TEST",
+		apiSecret: "s",
+		enabled: true,
+		fetchImpl: (() => {
+			throw new Error("boom");
+		}) as unknown as typeof fetch,
+	});
+	expect(() => track({ name: "app_started" })).not.toThrow();
+});
+
+// ── identity bucketing (closed vocabulary from pi's built-in catalog) ──
+
+test("a pi built-in provider + model pass through raw", () => {
+	const model = getBuiltinModels("anthropic")[0];
+	if (!model) throw new Error("pi catalog has no anthropic models — update the test");
+	expect(bucketProviderModel("anthropic", model.id)).toEqual({
+		provider: "anthropic",
+		model: model.id,
+	});
+	expect(bucketProvider("anthropic")).toBe("anthropic");
+});
+
+test("a custom provider — and its model — bucket to custom (fails closed)", () => {
+	expect(bucketProviderModel("acme-internal", "secret-model-v2")).toEqual({
+		provider: CUSTOM_BUCKET,
+		model: CUSTOM_BUCKET,
+	});
+	expect(bucketProvider("acme-internal")).toBe(CUSTOM_BUCKET);
+});
+
+test("a custom model id on a known provider buckets the model but keeps the provider", () => {
+	expect(bucketProviderModel("openai", "my-private-finetune")).toEqual({
+		provider: "openai",
+		model: CUSTOM_BUCKET,
+	});
+});

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -15,16 +15,16 @@ import { initializeAnalytics, resetAnalyticsForTests, setAnalyticsSending, track
 
 let dataDir: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
-const savedEnvKeys = {
-	id: process.env.THINKRAIL_GA4_MEASUREMENT_ID,
-	secret: process.env.THINKRAIL_GA4_API_SECRET,
+const savedEnv = {
+	key: process.env.THINKRAIL_POSTHOG_API_KEY,
+	host: process.env.THINKRAIL_POSTHOG_HOST,
 };
 
 beforeEach(() => {
 	dataDir = mkdtempSync(join(tmpdir(), "trpi-analytics-test-"));
 	process.env.THINKRAIL_DATA_DIR = dataDir;
-	delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
-	delete process.env.THINKRAIL_GA4_API_SECRET;
+	delete process.env.THINKRAIL_POSTHOG_API_KEY;
+	delete process.env.THINKRAIL_POSTHOG_HOST;
 	resetAnalyticsForTests();
 });
 
@@ -33,17 +33,23 @@ afterEach(() => {
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
-	if (savedEnvKeys.id === undefined) delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
-	else process.env.THINKRAIL_GA4_MEASUREMENT_ID = savedEnvKeys.id;
-	if (savedEnvKeys.secret === undefined) delete process.env.THINKRAIL_GA4_API_SECRET;
-	else process.env.THINKRAIL_GA4_API_SECRET = savedEnvKeys.secret;
+	if (savedEnv.key === undefined) delete process.env.THINKRAIL_POSTHOG_API_KEY;
+	else process.env.THINKRAIL_POSTHOG_API_KEY = savedEnv.key;
+	if (savedEnv.host === undefined) delete process.env.THINKRAIL_POSTHOG_HOST;
+	else process.env.THINKRAIL_POSTHOG_HOST = savedEnv.host;
 });
 
 // ── test fetch (the sink's injected seam) ──────────────────────────────
 
+interface BatchEntry {
+	event: string;
+	distinct_id: string;
+	properties: Record<string, unknown>;
+}
+
 interface SentPayload {
 	url: string;
-	body: { client_id: string; events: { name: string; params: Record<string, unknown> }[] };
+	body: { api_key: string; batch: BatchEntry[] };
 }
 
 function makeFetch(sent: SentPayload[]): typeof fetch {
@@ -53,7 +59,7 @@ function makeFetch(sent: SentPayload[]): typeof fetch {
 	}) as typeof fetch;
 }
 
-/** Boot the service on the baked-keys path (release-like: keys + a non-dev channel). */
+/** Boot the service on the baked-key path (release-like: key + a non-dev channel). */
 function bootReleaseLike(
 	sent: SentPayload[],
 	overrides: Partial<Parameters<typeof initializeAnalytics>[0]> = {},
@@ -61,19 +67,23 @@ function bootReleaseLike(
 	initializeAnalytics({
 		appVersion: "1.2.3",
 		channel: "stable",
-		measurementId: "G-TEST",
-		apiSecret: "s3cret",
+		posthogApiKey: "phc_TEST",
 		enabled: true,
 		fetchImpl: makeFetch(sent),
 		...overrides,
 	});
 }
 
+/** Every batch entry across every captured payload. */
+function allEntries(sent: SentPayload[]): BatchEntry[] {
+	return sent.flatMap((p) => p.body.batch);
+}
+
 // ── the machine-checked privacy invariant ──────────────────────────────
 
 // One fully-populated sample per event variant. The `satisfies` map is EXHAUSTIVE over the union's
 // names — adding a new event variant without a sample here is a compile error, so the allowlist
-// assertions below always cover the whole event model (the v1 allowlist test, in TS).
+// assertions below always cover the whole event model (thinkrail-v1's allowlist test, in TS).
 const EVENT_SAMPLES = {
 	app_installed: { name: "app_installed" },
 	app_started: { name: "app_started" },
@@ -81,17 +91,19 @@ const EVENT_SAMPLES = {
 	provider_login: { name: "provider_login", params: { provider: "openai", method: "oauth" } },
 } as const satisfies { [K in AnalyticsEvent["name"]]: Extract<AnalyticsEvent, { name: K }> };
 
-test("every event's outgoing params are a subset of PARAM_ALLOWLIST (privacy invariant)", () => {
+test("every event's outgoing properties are allowlist params + the two $ transport flags only", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	for (const event of Object.values(EVENT_SAMPLES)) track(event);
 	expect(sent.length).toBeGreaterThanOrEqual(Object.keys(EVENT_SAMPLES).length);
-	for (const payload of sent) {
-		for (const event of payload.body.events) {
-			for (const key of Object.keys(event.params)) {
-				expect(PARAM_ALLOWLIST.has(key)).toBe(true);
-			}
+	for (const entry of allEntries(sent)) {
+		for (const key of Object.keys(entry.properties)) {
+			if (key.startsWith("$")) continue; // transport framing, asserted below
+			expect(PARAM_ALLOWLIST.has(key)).toBe(true);
 		}
+		// PostHog framing: personless (no person profiles) + GeoIP disabled — on EVERY event.
+		expect(entry.properties.$process_person_profile).toBe(false);
+		expect(entry.properties.$geoip_disable).toBe(true);
 	}
 });
 
@@ -104,52 +116,59 @@ test("an off-allowlist param is dropped at runtime (fails closed even past the t
 		name: "chat_started",
 		params: { provider: "anthropic", model: "m", leak: "/Users/me/secret-project" },
 	} as unknown as AnalyticsEvent);
-	expect(sent).toHaveLength(1);
-	const params = sent[0]?.body.events[0]?.params ?? {};
-	expect(params.leak).toBeUndefined();
-	expect(params.provider).toBe("anthropic");
+	const entry = allEntries(sent)[0];
+	expect(entry).toBeDefined();
+	expect(entry?.properties.leak).toBeUndefined();
+	expect(entry?.properties.provider).toBe("anthropic");
 });
 
-test("every event is stamped with env metadata + the GA4 user-counting plumbing", () => {
+test("every event is stamped with the env metadata", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	track({ name: "app_started" });
-	const last = sent.at(-1);
-	expect(last?.body.events[0]?.params).toMatchObject({
-		app_version: "1.2.3",
-		channel: "stable",
-		engagement_time_msec: 1,
-	});
-	expect(last?.body.events[0]?.params.os).toBeString();
-	expect(last?.body.events[0]?.params.arch).toBeString();
-	expect(last?.body.events[0]?.params.session_id).toBeString();
+	const entry = allEntries(sent).at(-1);
+	expect(entry?.properties).toMatchObject({ app_version: "1.2.3", channel: "stable" });
+	expect(entry?.properties.os).toBeString();
+	expect(entry?.properties.arch).toBeString();
+});
+
+test("the batch goes to the EU cloud by default; THINKRAIL_POSTHOG_HOST retargets it", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	expect(sent[0]?.url).toBe("https://eu.i.posthog.com/batch/");
+
+	resetAnalyticsForTests();
+	process.env.THINKRAIL_POSTHOG_HOST = "https://ph.example.test/";
+	const retargeted: SentPayload[] = [];
+	bootReleaseLike(retargeted);
+	expect(retargeted[0]?.url).toBe("https://ph.example.test/batch/");
 });
 
 // ── installation identity ──────────────────────────────────────────────
 
-test("the install id is minted once, used as client_id, and NEVER rotated by toggles", () => {
+test("the install id is minted once, used as distinct_id, and NEVER rotated by toggles", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	const id = ensureInstallation().id;
-	expect(sent[0]?.body.client_id).toBe(id);
+	expect(allEntries(sent)[0]?.distinct_id).toBe(id);
 
 	setAnalyticsSending(false);
 	setAnalyticsSending(true);
 	track({ name: "app_started" });
-	expect(sent.at(-1)?.body.client_id).toBe(id);
+	expect(allEntries(sent).at(-1)?.distinct_id).toBe(id);
 	expect(ensureInstallation().id).toBe(id); // unchanged on disk too
 });
 
 test("app_installed fires exactly once per install (announced bit survives restarts)", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
-	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed", "app_started"]);
+	expect(allEntries(sent).map((e) => e.event)).toEqual(["app_installed", "app_started"]);
 
 	// Simulated restart: same data dir, fresh in-memory state.
 	resetAnalyticsForTests();
 	const sentAfterRestart: SentPayload[] = [];
 	bootReleaseLike(sentAfterRestart);
-	expect(sentAfterRestart.map((p) => p.body.events[0]?.name)).toEqual(["app_started"]);
+	expect(allEntries(sentAfterRestart).map((e) => e.event)).toEqual(["app_started"]);
 });
 
 test("a disabled boot mints the id but sends nothing; enabling later announces once", () => {
@@ -159,31 +178,30 @@ test("a disabled boot mints the id but sends nothing; enabling later announces o
 	expect(readFileSync(join(dataDir, "installation.json"), "utf8")).toContain('"announced": false');
 
 	setAnalyticsSending(true);
-	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed"]);
+	expect(allEntries(sent).map((e) => e.event)).toEqual(["app_installed"]);
 	setAnalyticsSending(true); // idempotent — no second announce
-	expect(sent).toHaveLength(1);
+	expect(allEntries(sent)).toHaveLength(1);
 });
 
 // ── gates ──────────────────────────────────────────────────────────────
 
-test("the dev channel refuses baked keys — a dev run never sends", () => {
+test("the dev channel refuses a baked key — a dev run never sends", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent, { channel: "dev" });
 	track({ name: "app_started" });
 	expect(sent).toHaveLength(0);
 });
 
-test("explicit THINKRAIL_GA4_* env keys send even on the dev channel (pipeline testing)", () => {
-	process.env.THINKRAIL_GA4_MEASUREMENT_ID = "G-ENV";
-	process.env.THINKRAIL_GA4_API_SECRET = "env-secret";
+test("an explicit THINKRAIL_POSTHOG_API_KEY env key sends even on the dev channel (pipeline testing)", () => {
+	process.env.THINKRAIL_POSTHOG_API_KEY = "phc_ENV";
 	const sent: SentPayload[] = [];
 	initializeAnalytics({ channel: "dev", enabled: true, fetchImpl: makeFetch(sent) });
 	expect(sent.length).toBeGreaterThan(0);
-	expect(sent[0]?.url).toContain("measurement_id=G-ENV");
-	expect(sent[0]?.body.events[0]?.params.channel).toBe("dev"); // still excludable in reports
+	expect(sent[0]?.body.api_key).toBe("phc_ENV");
+	expect(allEntries(sent)[0]?.properties.channel).toBe("dev"); // still excludable in insights
 });
 
-test("--no-analytics (mute) silences the run even when keys + config say send", () => {
+test("--no-analytics (mute) silences the run even when key + config say send", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent, { mute: true });
 	track({ name: "app_started" });
@@ -204,8 +222,7 @@ test("setAnalyticsSending(false) stops sending immediately", () => {
 test("track never throws into the caller, even when the transport does", () => {
 	initializeAnalytics({
 		channel: "stable",
-		measurementId: "G-TEST",
-		apiSecret: "s",
+		posthogApiKey: "phc_TEST",
 		enabled: true,
 		fetchImpl: (() => {
 			throw new Error("boom");

--- a/packages/server/src/analytics/events.ts
+++ b/packages/server/src/analytics/events.ts
@@ -19,17 +19,16 @@ export type AnalyticsEvent =
 	| { name: "provider_login"; params: { provider: string; method: LoginMethod } };
 
 /**
- * Every param key that may ever appear on an outgoing event — env metadata + GA4 plumbing + the
- * closed per-event params. The service filters against this set at runtime; the unit test asserts
- * every event variant's payload is a subset. Extend it only alongside a spec'd event change.
+ * Every param key that may ever appear on an outgoing event — env metadata + the closed per-event
+ * params. The service filters against this set at runtime; the unit test asserts every event
+ * variant's payload is a subset. (Transport framing — the sink's `$`-prefixed PostHog flags — is the
+ * sink's own, never an event param.) Extend it only alongside a spec'd event change.
  */
 export const PARAM_ALLOWLIST: ReadonlySet<string> = new Set([
 	"app_version",
 	"channel",
 	"os",
 	"arch",
-	"session_id",
-	"engagement_time_msec",
 	"provider",
 	"model",
 	"method",

--- a/packages/server/src/analytics/events.ts
+++ b/packages/server/src/analytics/events.ts
@@ -1,0 +1,72 @@
+// The closed analytics event model — the privacy contract's data half (see SPEC.md). Every event a
+// host can emit is a member of `AnalyticsEvent`; every param key it may carry is in `PARAM_ALLOWLIST`.
+// The service drops any key outside the allowlist at runtime (fails closed) and the unit test pins the
+// exact payload of every variant, so a content-leaking field can neither ship nor land silently in CI.
+import { getBuiltinModels, getBuiltinProviders } from "@earendil-works/pi-ai/providers/all";
+
+/** How a provider credential was configured in-app. A closed vocabulary, never user input. */
+export type LoginMethod = "oauth" | "api-key" | "central";
+
+/**
+ * Every analytics event the host can emit. `app_installed`/`app_started` carry no event params (the
+ * env set below rides on every event); the identity params on the other two pass through
+ * `bucketProviderModel`/`bucketProvider` first, so a user-configured name never leaves the process.
+ */
+export type AnalyticsEvent =
+	| { name: "app_installed" }
+	| { name: "app_started" }
+	| { name: "chat_started"; params: { provider: string; model: string } }
+	| { name: "provider_login"; params: { provider: string; method: LoginMethod } };
+
+/**
+ * Every param key that may ever appear on an outgoing event — env metadata + GA4 plumbing + the
+ * closed per-event params. The service filters against this set at runtime; the unit test asserts
+ * every event variant's payload is a subset. Extend it only alongside a spec'd event change.
+ */
+export const PARAM_ALLOWLIST: ReadonlySet<string> = new Set([
+	"app_version",
+	"channel",
+	"os",
+	"arch",
+	"session_id",
+	"engagement_time_msec",
+	"provider",
+	"model",
+	"method",
+]);
+
+/** The bucket a user-configured (non-built-in) provider or model id collapses to. */
+export const CUSTOM_BUCKET = "custom";
+
+// pi's built-in catalog (provider → model ids), built lazily once — the closed vocabulary identity
+// params are checked against. Derived from the pinned pi-ai version, so it never drifts on pi bumps.
+let catalog: Map<string, ReadonlySet<string>> | null = null;
+
+function builtinCatalog(): Map<string, ReadonlySet<string>> {
+	if (!catalog) {
+		catalog = new Map();
+		for (const provider of getBuiltinProviders()) {
+			catalog.set(provider, new Set(getBuiltinModels(provider).map((model) => String(model.id))));
+		}
+	}
+	return catalog;
+}
+
+/** A provider id passes raw only when it is a pi built-in; anything user-configured is `custom`. */
+export function bucketProvider(provider: string): string {
+	return builtinCatalog().has(provider) ? provider : CUSTOM_BUCKET;
+}
+
+/**
+ * Identity for `chat_started`: the provider must be a pi built-in AND the model id must be in that
+ * provider's built-in catalog — a custom model id on a known provider (free text from models.json)
+ * buckets to `custom` too. Fails closed: unknown means `custom`, never a pass-through.
+ */
+export function bucketProviderModel(
+	provider: string,
+	modelId: string,
+): { provider: string; model: string } {
+	const models = builtinCatalog().get(provider);
+	if (!models) return { provider: CUSTOM_BUCKET, model: CUSTOM_BUCKET };
+	return { provider, model: models.has(modelId) ? modelId : CUSTOM_BUCKET };
+}

--- a/packages/server/src/analytics/index.ts
+++ b/packages/server/src/analytics/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Anonymous usage analytics (see SPEC.md — the privacy contract). Consumed by `host` ONLY: every
+ * `track()` call site lives there, feature modules never know analytics exists.
+ */
+export {
+	type AnalyticsEvent,
+	bucketProvider,
+	bucketProviderModel,
+	type LoginMethod,
+} from "./events";
+export {
+	type AnalyticsOptions,
+	initializeAnalytics,
+	resetAnalyticsForTests,
+	setAnalyticsSending,
+	track,
+} from "./service";

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -1,0 +1,167 @@
+// The analytics facade: initialize once at host boot, `track()` from host call sites, sync the config
+// flag via `setAnalyticsSending`. Fire-and-forget end to end — nothing here may throw into a caller or
+// block boot. The privacy contract (single anonymous id, closed events, dev-run silence) is SPEC.md's
+// "Get right" section; this file is its runtime half.
+import { ensureInstallation, saveInstallation } from "../persistence";
+import { type AnalyticsEvent, PARAM_ALLOWLIST } from "./events";
+import { type AnalyticsSink, createGa4Sink, noopSink, type OutgoingEvent } from "./sink";
+
+export interface AnalyticsOptions {
+	/** The launcher's baked release version (absent from source — stamped like `appVersion`). */
+	appVersion?: string;
+	/** Release channel (`stable` / `nightly`); defaults to `dev`, which refuses baked keys. */
+	channel?: string;
+	/** GA4 keys baked by the release pipeline (empty/absent from source ⇒ noop sink). */
+	measurementId?: string;
+	apiSecret?: string;
+	/** `--no-analytics`: mute this run without touching the persisted flag. */
+	mute?: boolean;
+	/** The persisted `AppConfig.analyticsEnabled` at boot. */
+	enabled: boolean;
+	/** Test seam, threaded into the GA4 sink. */
+	fetchImpl?: typeof fetch;
+}
+
+interface AnalyticsState {
+	sink: AnalyticsSink;
+	/** The anonymous per-install id (GA4 `client_id`) — never crosses the wire. */
+	clientId: string;
+	/** All gates folded: config flag AND not muted AND a real sink. */
+	sending: boolean;
+	mute: boolean;
+	realSink: boolean;
+	announced: boolean;
+	env: { app_version: string; channel: string; os: string; arch: string };
+	/** Per-boot GA4 session id — without it (+ engagement time) GA4 doesn't count active users. */
+	sessionId: string;
+}
+
+let state: AnalyticsState | null = null;
+
+function detectOs(): string {
+	if (process.platform === "darwin") return "macos";
+	if (process.platform === "win32") return "windows";
+	return process.platform;
+}
+
+/**
+ * Boot the analytics service (called once from `createServer`). Mints/loads the installation record,
+ * picks the sink — env-override keys always win (deliberate pipeline testing); baked keys are refused
+ * on the `dev` channel (dev runs never send); otherwise noop — and emits the lifecycle events. On the
+ * first sending-enabled boot ever it prints the first-run notice and sends the one-shot `app_installed`.
+ */
+export function initializeAnalytics(options: AnalyticsOptions): void {
+	try {
+		const record = ensureInstallation();
+		const channel = options.channel ?? "dev";
+		const envMeasurementId = process.env.THINKRAIL_GA4_MEASUREMENT_ID;
+		const envApiSecret = process.env.THINKRAIL_GA4_API_SECRET;
+
+		let sink = noopSink;
+		if (envMeasurementId && envApiSecret) {
+			sink = createGa4Sink({
+				measurementId: envMeasurementId,
+				apiSecret: envApiSecret,
+				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+			});
+		} else if (options.measurementId && options.apiSecret && channel !== "dev") {
+			sink = createGa4Sink({
+				measurementId: options.measurementId,
+				apiSecret: options.apiSecret,
+				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+			});
+		}
+
+		const realSink = sink !== noopSink;
+		const mute = options.mute === true;
+		state = {
+			sink,
+			clientId: record.id,
+			mute,
+			realSink,
+			sending: options.enabled && !mute && realSink,
+			announced: record.announced,
+			env: {
+				app_version: options.appVersion ?? "0.0.0-dev",
+				channel,
+				os: detectOs(),
+				arch: process.arch,
+			},
+			sessionId: String(Date.now()),
+		};
+
+		if (state.sending) {
+			if (!state.announced) announceInstall(state);
+			track({ name: "app_started" });
+		}
+	} catch (error) {
+		debugLog(error);
+	}
+}
+
+/**
+ * Emit one event, fire-and-forget. No-ops unless every gate is open; never throws into the caller.
+ * Params are stamped (env + GA4 plumbing) and filtered against `PARAM_ALLOWLIST` — an off-list key is
+ * dropped here, so a content leak cannot leave the process even if the event model grows a bug.
+ */
+export function track(event: AnalyticsEvent): void {
+	const s = state;
+	if (!s?.sending) return;
+	try {
+		s.sink.send(s.clientId, [toOutgoingEvent(event, s)]);
+	} catch (error) {
+		debugLog(error);
+	}
+}
+
+/**
+ * Sync the persisted `AppConfig.analyticsEnabled` flag into the live service — the host calls this off
+ * the settings broadcast. Flipping to enabled runs the pending install announce (notice + one-shot
+ * `app_installed`) if this install has never sent one. The id is deliberately NOT rotated on toggles.
+ */
+export function setAnalyticsSending(enabled: boolean): void {
+	const s = state;
+	if (!s) return;
+	try {
+		s.sending = enabled && !s.mute && s.realSink;
+		if (s.sending) {
+			if (!s.announced) announceInstall(s);
+		}
+	} catch (error) {
+		debugLog(error);
+	}
+}
+
+/** Drop the singleton state — unit-test isolation only. */
+export function resetAnalyticsForTests(): void {
+	state = null;
+}
+
+function announceInstall(s: AnalyticsState): void {
+	s.announced = true;
+	saveInstallation({ id: s.clientId, announced: true });
+	console.log(
+		"ThinkRail sends anonymous usage analytics (no personal data — see the README's Analytics & Privacy section). Disable in Settings → Privacy, or launch with --no-analytics.",
+	);
+	track({ name: "app_installed" });
+}
+
+function toOutgoingEvent(event: AnalyticsEvent, s: AnalyticsState): OutgoingEvent {
+	const params: Record<string, string | number> = {
+		...s.env,
+		session_id: s.sessionId,
+		engagement_time_msec: 1,
+	};
+	if ("params" in event) {
+		for (const [key, value] of Object.entries(event.params)) {
+			if (PARAM_ALLOWLIST.has(key)) params[key] = value;
+		}
+	}
+	return { name: event.name, params };
+}
+
+function debugLog(error: unknown): void {
+	if (process.env.THINKRAIL_ANALYTICS_DEBUG) {
+		console.warn(`analytics failed: ${error instanceof Error ? error.message : error}`);
+	}
+}

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -4,27 +4,28 @@
 // "Get right" section; this file is its runtime half.
 import { ensureInstallation, saveInstallation } from "../persistence";
 import { type AnalyticsEvent, PARAM_ALLOWLIST } from "./events";
-import { type AnalyticsSink, createGa4Sink, noopSink, type OutgoingEvent } from "./sink";
+import { type AnalyticsSink, createPostHogSink, noopSink, type OutgoingEvent } from "./sink";
 
 export interface AnalyticsOptions {
 	/** The launcher's baked release version (absent from source — stamped like `appVersion`). */
 	appVersion?: string;
-	/** Release channel (`stable` / `nightly`); defaults to `dev`, which refuses baked keys. */
+	/** Release channel (`stable` / `nightly`); defaults to `dev`, which refuses a baked key. */
 	channel?: string;
-	/** GA4 keys baked by the release pipeline (empty/absent from source ⇒ noop sink). */
-	measurementId?: string;
-	apiSecret?: string;
+	/** PostHog project API key baked by the release pipeline (empty/absent from source ⇒ noop sink). */
+	posthogApiKey?: string;
+	/** PostHog instance origin override (defaults to EU cloud) — the self-host seam. */
+	posthogHost?: string;
 	/** `--no-analytics`: mute this run without touching the persisted flag. */
 	mute?: boolean;
 	/** The persisted `AppConfig.analyticsEnabled` at boot. */
 	enabled: boolean;
-	/** Test seam, threaded into the GA4 sink. */
+	/** Test seam, threaded into the sink. */
 	fetchImpl?: typeof fetch;
 }
 
 interface AnalyticsState {
 	sink: AnalyticsSink;
-	/** The anonymous per-install id (GA4 `client_id`) — never crosses the wire. */
+	/** The anonymous per-install id (PostHog `distinct_id`) — never crosses the wire. */
 	clientId: string;
 	/** All gates folded: config flag AND not muted AND a real sink. */
 	sending: boolean;
@@ -32,8 +33,6 @@ interface AnalyticsState {
 	realSink: boolean;
 	announced: boolean;
 	env: { app_version: string; channel: string; os: string; arch: string };
-	/** Per-boot GA4 session id — without it (+ engagement time) GA4 doesn't count active users. */
-	sessionId: string;
 }
 
 let state: AnalyticsState | null = null;
@@ -46,28 +45,24 @@ function detectOs(): string {
 
 /**
  * Boot the analytics service (called once from `createServer`). Mints/loads the installation record,
- * picks the sink — env-override keys always win (deliberate pipeline testing); baked keys are refused
- * on the `dev` channel (dev runs never send); otherwise noop — and emits the lifecycle events. On the
- * first sending-enabled boot ever it prints the first-run notice and sends the one-shot `app_installed`.
+ * picks the sink — an env-override key always wins (deliberate pipeline testing); the baked key is
+ * refused on the `dev` channel (dev runs never send); otherwise noop — and emits the lifecycle
+ * events. On the first sending-enabled boot ever it prints the first-run notice and sends the
+ * one-shot `app_installed`.
  */
 export function initializeAnalytics(options: AnalyticsOptions): void {
 	try {
 		const record = ensureInstallation();
 		const channel = options.channel ?? "dev";
-		const envMeasurementId = process.env.THINKRAIL_GA4_MEASUREMENT_ID;
-		const envApiSecret = process.env.THINKRAIL_GA4_API_SECRET;
+		const envApiKey = process.env.THINKRAIL_POSTHOG_API_KEY;
+		const host = process.env.THINKRAIL_POSTHOG_HOST ?? options.posthogHost;
 
 		let sink = noopSink;
-		if (envMeasurementId && envApiSecret) {
-			sink = createGa4Sink({
-				measurementId: envMeasurementId,
-				apiSecret: envApiSecret,
-				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
-			});
-		} else if (options.measurementId && options.apiSecret && channel !== "dev") {
-			sink = createGa4Sink({
-				measurementId: options.measurementId,
-				apiSecret: options.apiSecret,
+		const apiKey = envApiKey || (channel !== "dev" ? options.posthogApiKey : undefined);
+		if (apiKey) {
+			sink = createPostHogSink({
+				apiKey,
+				...(host ? { host } : {}),
 				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
 			});
 		}
@@ -87,7 +82,6 @@ export function initializeAnalytics(options: AnalyticsOptions): void {
 				os: detectOs(),
 				arch: process.arch,
 			},
-			sessionId: String(Date.now()),
 		};
 
 		if (state.sending) {
@@ -101,7 +95,7 @@ export function initializeAnalytics(options: AnalyticsOptions): void {
 
 /**
  * Emit one event, fire-and-forget. No-ops unless every gate is open; never throws into the caller.
- * Params are stamped (env + GA4 plumbing) and filtered against `PARAM_ALLOWLIST` — an off-list key is
+ * Params are stamped (env) and filtered against `PARAM_ALLOWLIST` — an off-list key is
  * dropped here, so a content leak cannot leave the process even if the event model grows a bug.
  */
 export function track(event: AnalyticsEvent): void {
@@ -147,11 +141,7 @@ function announceInstall(s: AnalyticsState): void {
 }
 
 function toOutgoingEvent(event: AnalyticsEvent, s: AnalyticsState): OutgoingEvent {
-	const params: Record<string, string | number> = {
-		...s.env,
-		session_id: s.sessionId,
-		engagement_time_msec: 1,
-	};
+	const params: Record<string, string | number> = { ...s.env };
 	if ("params" in event) {
 		for (const [key, value] of Object.entries(event.params)) {
 			if (PARAM_ALLOWLIST.has(key)) params[key] = value;

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -1,9 +1,10 @@
 // The delivery backend, hidden behind `AnalyticsSink` — swapping vendors is implementing a new sink,
-// nothing else in the module (or the host) moves. The first real sink is GA4's Measurement Protocol
-// (Firebase Analytics IS GA4; there is no server-side Firebase SDK, MP is the ingestion path): a plain
-// fire-and-forget `fetch` POST, no dependencies, no retries, errors swallowed (debug-logged on demand).
+// nothing else in the module (or the host) moves (proven once: the first sink was GA4's Measurement
+// Protocol, replaced by PostHog before ever shipping). The current sink is PostHog's capture API: a
+// plain fire-and-forget `fetch` POST, no dependencies, no retries, errors swallowed (debug-logged on
+// demand). Every outgoing event is personless and GeoIP-free — see `createPostHogSink`.
 
-/** One event as GA4's `/mp/collect` expects it inside `events[]`. */
+/** One event as the service hands it to a sink: a name + the allowlist-filtered params. */
 export interface OutgoingEvent {
 	name: string;
 	params: Record<string, string | number>;
@@ -21,31 +22,44 @@ export const noopSink: AnalyticsSink = {
 	},
 };
 
-export interface Ga4SinkOptions {
-	measurementId: string;
-	apiSecret: string;
+export interface PostHogSinkOptions {
+	/** The PostHog project API key (`phc_…`) — public by design, like any client-side analytics key. */
+	apiKey: string;
+	/** Instance origin; defaults to EU cloud. The future self-host seam. */
+	host?: string;
 	/** Test seam — capture the POST instead of hitting the network. */
 	fetchImpl?: typeof fetch;
-	/** Test/override seam for the collect endpoint. */
-	endpoint?: string;
 }
 
-const GA4_ENDPOINT = "https://www.google-analytics.com/mp/collect";
+export const POSTHOG_EU_HOST = "https://eu.i.posthog.com";
 
 /**
- * The GA4 Measurement Protocol sink. `client_id` is the anonymous per-install id; events must carry
- * `session_id` + `engagement_time_msec` params (the service adds them) or GA4 won't count active users.
+ * The PostHog capture sink (`POST {host}/batch/`). `distinct_id` is the anonymous per-install id.
+ * Every event carries `$process_person_profile: false` (personless — PostHog builds no person
+ * profiles; unique users still count by distinct_id) and `$geoip_disable: true` (no IP-derived
+ * fields, enforced sender-side — the module's privacy contract, not just a project setting).
  */
-export function createGa4Sink(options: Ga4SinkOptions): AnalyticsSink {
+export function createPostHogSink(options: PostHogSinkOptions): AnalyticsSink {
 	const fetchFn = options.fetchImpl ?? fetch;
-	const endpoint = options.endpoint ?? GA4_ENDPOINT;
-	const url = `${endpoint}?measurement_id=${encodeURIComponent(options.measurementId)}&api_secret=${encodeURIComponent(options.apiSecret)}`;
+	const url = `${(options.host ?? POSTHOG_EU_HOST).replace(/\/+$/, "")}/batch/`;
 	return {
 		send(clientId, events) {
 			try {
 				fetchFn(url, {
 					method: "POST",
-					body: JSON.stringify({ client_id: clientId, events }),
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						api_key: options.apiKey,
+						batch: events.map((event) => ({
+							event: event.name,
+							distinct_id: clientId,
+							properties: {
+								...event.params,
+								$process_person_profile: false,
+								$geoip_disable: true,
+							},
+						})),
+					}),
 				}).catch((error) => debugLog(error));
 			} catch (error) {
 				debugLog(error);

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -1,0 +1,62 @@
+// The delivery backend, hidden behind `AnalyticsSink` — swapping vendors is implementing a new sink,
+// nothing else in the module (or the host) moves. The first real sink is GA4's Measurement Protocol
+// (Firebase Analytics IS GA4; there is no server-side Firebase SDK, MP is the ingestion path): a plain
+// fire-and-forget `fetch` POST, no dependencies, no retries, errors swallowed (debug-logged on demand).
+
+/** One event as GA4's `/mp/collect` expects it inside `events[]`. */
+export interface OutgoingEvent {
+	name: string;
+	params: Record<string, string | number>;
+}
+
+export interface AnalyticsSink {
+	/** Fire-and-forget delivery. Must never throw and never return a promise the caller must await. */
+	send(clientId: string, events: OutgoingEvent[]): void;
+}
+
+/** The disabled/dev sink: events vanish. */
+export const noopSink: AnalyticsSink = {
+	send() {
+		// deliberately empty — analytics is off or unconfigured
+	},
+};
+
+export interface Ga4SinkOptions {
+	measurementId: string;
+	apiSecret: string;
+	/** Test seam — capture the POST instead of hitting the network. */
+	fetchImpl?: typeof fetch;
+	/** Test/override seam for the collect endpoint. */
+	endpoint?: string;
+}
+
+const GA4_ENDPOINT = "https://www.google-analytics.com/mp/collect";
+
+/**
+ * The GA4 Measurement Protocol sink. `client_id` is the anonymous per-install id; events must carry
+ * `session_id` + `engagement_time_msec` params (the service adds them) or GA4 won't count active users.
+ */
+export function createGa4Sink(options: Ga4SinkOptions): AnalyticsSink {
+	const fetchFn = options.fetchImpl ?? fetch;
+	const endpoint = options.endpoint ?? GA4_ENDPOINT;
+	const url = `${endpoint}?measurement_id=${encodeURIComponent(options.measurementId)}&api_secret=${encodeURIComponent(options.apiSecret)}`;
+	return {
+		send(clientId, events) {
+			try {
+				fetchFn(url, {
+					method: "POST",
+					body: JSON.stringify({ client_id: clientId, events }),
+				}).catch((error) => debugLog(error));
+			} catch (error) {
+				debugLog(error);
+			}
+		},
+	};
+}
+
+/** Analytics failures are silent by design (never a user-facing warn); opt into logs via env. */
+function debugLog(error: unknown): void {
+	if (process.env.THINKRAIL_ANALYTICS_DEBUG) {
+		console.warn(`analytics send failed: ${error instanceof Error ? error.message : error}`);
+	}
+}

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -26,7 +26,13 @@ channel fan-out, and the process-boot wrapper both launchers share.
   workspace-read handlers (`fs.*`, `git.status`/`git.diff`, `spec.graph`) — a read is the "a client is
   looking" signal; `stopWatch` in `workspace.remove`'s fast path beside `evictSpecIndex`;
   `stopAllWatches()` in `stop()`), `cancelAllLogins()` in `stop()` before the socket close,
-  an optional boot-time `openProject(projectPath)` (best-effort — a launcher convenience), and
+  an optional boot-time `openProject(projectPath)` (best-effort — a launcher convenience), the
+  **analytics wiring** (`initializeAnalytics` at boot from the launcher-threaded `analytics` option —
+  keys/channel/mute + the initial `getConfig().analyticsEnabled`; a `setAnalyticsSending` sync teed
+  off the settings publisher; and every `track()` call site: `chat_started` in `session.create`,
+  `provider_login` from the login-publisher tee's `success` frames (oauth) + `provider.setApiKey`
+  (api-key) + `provider.jbcentralConnect`→connected (central) — per `submodule-server-analytics`,
+  feature modules never track), and
   `stop()` → agent-session + terminal cleanup then socket close); `boot.ts` (`bootHost` → resolve the
   login-shell PATH, pick the port per `portMode` (`"exact"` vs `"free"`), start `createServer`, and
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -1,7 +1,7 @@
 import { findFreePort } from "@thinkrail/shared/freePort";
 import { resolveShellEnv } from "@thinkrail/shared/shellEnv";
 import { settleSessionsForShutdown } from "../agent";
-import { createServer, type RunningServer } from "./server";
+import { type CreateServerOptions, createServer, type RunningServer } from "./server";
 
 export interface BootHostOptions {
 	/** Requested listen port. */
@@ -20,6 +20,8 @@ export interface BootHostOptions {
 	projectPath?: string;
 	/** The launcher's baked release version, forwarded onto the `server.welcome` push. */
 	appVersion?: string;
+	/** Anonymous-analytics wiring (channel + baked GA4 keys + `--no-analytics` mute), forwarded verbatim. */
+	analytics?: CreateServerOptions["analytics"];
 }
 
 export interface BootedHost {
@@ -50,6 +52,7 @@ export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
 		...(options.staticDir ? { staticDir: options.staticDir } : {}),
 		...(options.projectPath ? { projectPath: options.projectPath } : {}),
 		...(options.appVersion ? { appVersion: options.appVersion } : {}),
+		...(options.analytics ? { analytics: options.analytics } : {}),
 	});
 
 	let stopping = false;

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -20,7 +20,7 @@ export interface BootHostOptions {
 	projectPath?: string;
 	/** The launcher's baked release version, forwarded onto the `server.welcome` push. */
 	appVersion?: string;
-	/** Anonymous-analytics wiring (channel + baked GA4 keys + `--no-analytics` mute), forwarded verbatim. */
+	/** Anonymous-analytics wiring (channel + the baked PostHog key + `--no-analytics` mute), forwarded verbatim. */
 	analytics?: CreateServerOptions["analytics"];
 }
 

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -29,6 +29,7 @@ import {
 	setSessionThinkingLevel,
 	steerSession,
 } from "../agent";
+import { bucketProvider, bucketProviderModel, track } from "../analytics";
 import {
 	cancelLogin,
 	connectJbcentral,
@@ -182,12 +183,21 @@ const handlers: Record<string, Handler> = {
 			thinkingLevel?: ThinkingLevel;
 		};
 		const ws = getWorkspace(p.workspaceId);
-		return createSession({
+		const created = await createSession({
 			cwd: ws.worktreePath,
 			workspaceId: p.workspaceId,
 			...(p.model ? { model: p.model } : {}),
 			...(p.thinkingLevel ? { thinkingLevel: p.thinkingLevel } : {}),
 		});
+		// Analytics: a NEW chat only (disk re-opens via session.getMessages never land here). Identity is
+		// bucketed against pi's built-in catalog — a custom provider/model name never leaves the process.
+		if (created.model) {
+			track({
+				name: "chat_started",
+				params: bucketProviderModel(created.model.provider, created.model.id),
+			});
+		}
+		return created;
 	},
 	// Sends are acked when ACCEPTED, not when the turn ends — see `ackSend` (a turn can outlive the
 	// client's request timeout; long tool rounds are routine).
@@ -273,6 +283,11 @@ const handlers: Record<string, Handler> = {
 	"provider.setApiKey": (params) => {
 		const p = params as { providerId: string; key: string };
 		setProviderApiKey(p.providerId, p.key);
+		// Analytics: an api-key auth landed (the key itself never goes anywhere near an event).
+		track({
+			name: "provider_login",
+			params: { provider: bucketProvider(p.providerId), method: "api-key" },
+		});
 		return { ok: true } as const;
 	},
 	"provider.logout": (params) => {
@@ -281,7 +296,15 @@ const handlers: Record<string, Handler> = {
 	},
 	// JetBrains AI (jbcentral proxy): connect/disconnect write models.json + refresh the registry; login
 	// launches `central login` (browser) on the host.
-	"provider.jbcentralConnect": () => connectJbcentral(),
+	"provider.jbcentralConnect": async () => {
+		const result = await connectJbcentral();
+		// Analytics: only an actual connect counts (needs-install / needs-login / error don't). `jbcentral`
+		// is our own constant, not user input — no bucketing needed.
+		if (result.outcome === "connected") {
+			track({ name: "provider_login", params: { provider: "jbcentral", method: "central" } });
+		}
+		return result;
+	},
 	"provider.jbcentralDisconnect": async () => {
 		await disconnectJbcentral();
 		return { ok: true } as const;

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -7,6 +7,13 @@ import {
 	setExtUiPublisher,
 	setSessionPublisher,
 } from "../agent";
+import {
+	type AnalyticsOptions,
+	bucketProvider,
+	initializeAnalytics,
+	setAnalyticsSending,
+	track,
+} from "../analytics";
 import { cancelAllLogins, setLoginPublisher } from "../auth";
 import { resolveWorktreeFile } from "../fs";
 import { listProjects, openProject } from "../projects";
@@ -31,6 +38,11 @@ export interface CreateServerOptions {
 	projectPath?: string;
 	/** The launcher's baked release version, echoed in the `server.welcome` push (undefined from source). */
 	appVersion?: string;
+	/**
+	 * Anonymous-analytics wiring from the launcher: release channel + the GA4 keys baked at release +
+	 * the `--no-analytics` per-run mute. Absent (dev/e2e/source runs) ⇒ the noop sink — never sends.
+	 */
+	analytics?: Pick<AnalyticsOptions, "channel" | "measurementId" | "apiSecret" | "mute">;
 }
 
 export interface RunningServer {
@@ -40,7 +52,14 @@ export interface RunningServer {
 
 /** Boot the engine host: Bun.serve HTTP+WS, /health, optional static SPA, and the server.welcome push. */
 export function createServer(options: CreateServerOptions = {}): RunningServer {
-	const { port = 24242, host = "localhost", staticDir, projectPath, appVersion } = options;
+	const {
+		port = 24242,
+		host = "localhost",
+		staticDir,
+		projectPath,
+		appVersion,
+		analytics,
+	} = options;
 
 	const server = Bun.serve({
 		port,
@@ -132,12 +151,15 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	});
 
 	// Broadcast a server-synced settings change (the full `AppConfig`) to every client so they converge —
-	// the initiator applies on this push too, never optimistically (the workspace-lifecycle pattern).
+	// the initiator applies on this push too, never optimistically (the workspace-lifecycle pattern). The
+	// analytics service syncs off the same tee (host-mediated — `analytics` has no `settings` edge), so
+	// the Privacy toggle takes effect the moment the new config is persisted.
 	setSettingsPublisher((config) => {
 		server.publish(
 			WS_CHANNELS.settingsChanged,
 			JSON.stringify({ channel: WS_CHANNELS.settingsChanged, data: config }),
 		);
+		setAnalyticsSending(config.analyticsEnabled);
 	});
 
 	// Stream each in-process AgentSession's events to subscribed clients over the pi.event channel, and
@@ -168,12 +190,30 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		);
 	});
 
-	// Push in-app login flow frames (the session-less `authStorage.login` bridge) over the provider.login channel.
+	// Push in-app login flow frames (the session-less `authStorage.login` bridge) over the provider.login
+	// channel. A terminal `success` frame doubles as the `provider_login` analytics moment for OAuth flows
+	// (api-key / jbcentral successes are tracked in their handlers) — the provider id is bucketed, so a
+	// custom provider name never leaves the process.
 	setLoginPublisher((push) => {
 		server.publish(
 			WS_CHANNELS.providerLogin,
 			JSON.stringify({ channel: WS_CHANNELS.providerLogin, data: push }),
 		);
+		if (push.frame.kind === "success") {
+			track({
+				name: "provider_login",
+				params: { provider: bucketProvider(push.providerId), method: "oauth" },
+			});
+		}
+	});
+
+	// Boot analytics before any trackable action can occur (fire-and-forget by contract — a failure in
+	// here can never block or crash the host). The persisted flag gates sending; dev/source runs have no
+	// keys and land on the noop sink.
+	initializeAnalytics({
+		...(appVersion ? { appVersion } : {}),
+		...(analytics ?? {}),
+		enabled: getConfig().analyticsEnabled,
 	});
 
 	// Open a project on boot if the launcher passed one (e.g. `thinkrail /path/to/repo`). Best-effort:

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -39,10 +39,10 @@ export interface CreateServerOptions {
 	/** The launcher's baked release version, echoed in the `server.welcome` push (undefined from source). */
 	appVersion?: string;
 	/**
-	 * Anonymous-analytics wiring from the launcher: release channel + the GA4 keys baked at release +
-	 * the `--no-analytics` per-run mute. Absent (dev/e2e/source runs) ⇒ the noop sink — never sends.
+	 * Anonymous-analytics wiring from the launcher: release channel + the PostHog key baked at release
+	 * + the `--no-analytics` per-run mute. Absent (dev/e2e/source runs) ⇒ the noop sink — never sends.
 	 */
-	analytics?: Pick<AnalyticsOptions, "channel" | "measurementId" | "apiSecret" | "mute">;
+	analytics?: Pick<AnalyticsOptions, "channel" | "posthogApiKey" | "posthogHost" | "mute">;
 }
 
 export interface RunningServer {

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -10,16 +10,20 @@ tags: [v1]
 
 ## Responsibility
 
-Durable app state — projects, workspaces, and the server-synced app config — as JSON under the data dir.
+Durable app state — projects, workspaces, the server-synced app config, and the install identity —
+as JSON under the data dir.
 
 ## Boundary
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
-  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, and `loadConfig`/`saveConfig`
-  (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly) — all
-  tab-indented JSON.
+  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, `loadConfig`/`saveConfig`
+  (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly), and
+  `ensureInstallation`/`saveInstallation` (**`installation.json`** — `{ id, announced }`, the
+  per-install uuid4 + the `app_installed`-sent bit; **server-only by design**: it must never ride
+  the wire-broadcast `config.json` — see `submodule-server-analytics`; `ensureInstallation` mints
+  the id on first read and never rotates it) — all tab-indented JSON.
 - **Public surface (barrel):** `dataDir`, `loadProjects`, `saveProjects`, `loadWorkspaces`,
-  `saveWorkspaces`, `loadConfig`, `saveConfig`.
+  `saveWorkspaces`, `loadConfig`, `saveConfig`, `ensureInstallation`, `saveInstallation`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`AppConfig` types + `DEFAULT_CONFIG`); Node
   `fs`/`os`/`path`.
 - **Forbidden:** importing any sibling module or `host` — this is a leaf others depend on.

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -1,5 +1,6 @@
 // App state under the data dir (THINKRAIL_DATA_DIR for dev/e2e isolation, else ~/.thinkrail).
 // This is OUR state, never the agent's — pi's own session files live under ~/.pi/agent.
+import { randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -45,4 +46,30 @@ export function loadConfig(): AppConfig {
 
 export function saveConfig(config: AppConfig): void {
 	writeJson("config.json", config);
+}
+
+/**
+ * The install identity for anonymous analytics — SERVER-ONLY by design: it must never ride the
+ * wire-broadcast `config.json` (see `submodule-server-analytics`). `id` is minted once per install
+ * and never rotated (turning analytics off only stops sending); `announced` records that the one-shot
+ * `app_installed` event was sent.
+ */
+export interface InstallationRecord {
+	id: string;
+	announced: boolean;
+}
+
+/** Load `installation.json`, minting (and persisting) a fresh record on first read or corrupt file. */
+export function ensureInstallation(): InstallationRecord {
+	const raw = readJson<Partial<InstallationRecord>>("installation.json", {});
+	if (typeof raw.id === "string" && raw.id.length > 0) {
+		return { id: raw.id, announced: raw.announced === true };
+	}
+	const record: InstallationRecord = { id: randomUUID(), announced: false };
+	saveInstallation(record);
+	return record;
+}
+
+export function saveInstallation(record: InstallationRecord): void {
+	writeJson("installation.json", record);
 }


### PR DESCRIPTION
Adds opt-out anonymous usage analytics, emitted **host-side only** — no analytics SDK in the web client. Design was brainstormed + approved in-session; the durable contract lives in `packages/server/src/analytics/SPEC.md`.

## What & why
- **Closed event set**: `app_installed` (once per install), `app_started` (per boot), `chat_started {provider, model}`, `provider_login {provider, method}` → answers unique users / retention / version / platform / model preference / provider auth. Feature-usage events deliberately deferred to a later design pass.
- **Sink abstraction**: `AnalyticsSink` with a **PostHog (EU cloud)** capture impl (plain `fetch` to `/batch/`, zero new deps — no vendor SDK needed server-side). The abstraction was exercised for real during review: the first sink was GA4's Measurement Protocol, replaced pre-ship by PostHog (free tier + EU residency + self-host path) — only the sink file and the key seam moved.
- **Privacy contract** (machine-checked):
  - the only stable identifier is a per-install `uuid4` in server-only `installation.json` — minted once, **never rotated**, never crosses the wire (only the boolean flag does); it is PostHog's `distinct_id`
  - events are **personless** (`$process_person_profile: false` — PostHog builds no person profiles) and **GeoIP-disabled sender-side** (`$geoip_disable: true` — no IP-derived fields)
  - runtime param **allowlist** (off-list keys dropped — fails closed) + unit tests with a compile-time-exhaustive sample per event variant
  - provider/model identity passes through only when it matches **pi's built-in catalog**; anything user-configured reports as `custom`
  - never sent: paths, prompts, code, transcripts, keys, hostnames, usernames, IP-derived fields
- **Consent surfaces**: on by default + first-run terminal notice; **Settings → Privacy** toggle (`AppConfig.analyticsEnabled`, rides the existing `settings.update`/`settings.changed` machinery — zero new WS methods); `--no-analytics` / `THINKRAIL_NO_ANALYTICS` per-run mute.
- **Dev runs never send** (double gate): source builds carry no key, and the `dev` channel refuses a baked key outright; only an explicit `THINKRAIL_POSTHOG_API_KEY` env key can send (still tagged `channel: dev`; `THINKRAIL_POSTHOG_HOST` retargets — the future self-host seam).
- **Release seam**: `apps/cli/src/analytics-keys.ts` (committed empty) is stamped by `build-binary` from the `THINKRAIL_POSTHOG_API_KEY` repo secret; skipped on forks/PRs, so their binaries stay silent.

## UI
New Settings → **Privacy** section: the toggle + what-is/never-collected copy (screenshot in the PR thread).

## Verification
- 15 unit tests: allowlist invariant + PostHog framing flags, id stability across toggles, announce-once across restarts, dev-channel gate, mute, never-throws, catalog bucketing, EU/host retargeting
- new `e2e/privacy.spec.ts` (toggle round-trip + reload persistence); full no-agent e2e suite 45/45
- `check:deps` + biome + typecheck green; suppressions audit clean
- README gains an **Analytics & Privacy** section

Ops remaining before the first analytics-enabled release: create the PostHog EU project and add its project API key as the `THINKRAIL_POSTHOG_API_KEY` repo secret (the earlier `THINKRAIL_GA4_*` secrets and the Firebase project `thinkrail-5b601` are unused and can be deleted).
