### PR TITLE
chore(deps): pi 0.82.0 → 0.82.1 (Claude Opus 5)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -196,9 +196,9 @@
     "@biomejs/biome",
   ],
   "catalog": {
-    "@earendil-works/pi-agent-core": "0.82.0",
-    "@earendil-works/pi-ai": "0.82.0",
-    "@earendil-works/pi-coding-agent": "0.82.0",
+    "@earendil-works/pi-agent-core": "0.82.1",
+    "@earendil-works/pi-ai": "0.82.1",
+    "@earendil-works/pi-coding-agent": "0.82.1",
     "@types/bun": "1.3.14",
     "typebox": "1.1.38",
     "typescript": "6.0.3",
@@ -282,13 +282,13 @@
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-bnS9DpOKK5T/F/gQkaOnYdMsuuciWiScfAHHWC+k5OQ0HxjSqMFQvp8keurULLoT4+v8NHv4V14pNvd4hsfC0Q=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.0", "@earendil-works/pi-ai": "^0.82.0", "@earendil-works/pi-tui": "^0.82.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Qnqgn9zhJFQ2HZ8R4iNuGhyCk93XX6+eUw9i+TjTuo47amzCy93ft3bB6yaUCleCrNO58dJDHYSGNHv/GAPWKg=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.1", "@earendil-works/pi-ai": "^0.82.1", "@earendil-works/pi-tui": "^0.82.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9IDjQOXne7t9l2s2YcjnIBxsVNVPE7qScVSB3YmFlXsBW4pfo2gOElTxggV84KrRiGqABnlFPBWbf0k54hszHQ=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 			"packages/*"
 		],
 		"catalog": {
-			"@earendil-works/pi-agent-core": "0.82.0",
-			"@earendil-works/pi-ai": "0.82.0",
-			"@earendil-works/pi-coding-agent": "0.82.0",
+			"@earendil-works/pi-agent-core": "0.82.1",
+			"@earendil-works/pi-ai": "0.82.1",
+			"@earendil-works/pi-coding-agent": "0.82.1",
 			"@types/bun": "1.3.14",
 			"typebox": "1.1.38",
 			"typescript": "6.0.3"

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -186,7 +186,13 @@ of the host.
 
 ## Get right
 
-- **Type-only, from the package roots, always** (verified vs 0.82.0: type-only imports are erased by
+- **Mirrors are not version-pinned in comments.** A shape re-declared here because its real home is
+  Node-only carries *what* it mirrors, never *which pi version it was last checked against*: those
+  markers had to be hand-edited across several files on every bump, nothing verified them, and they
+  missed real drift anyway — **`PiEvent` is not exhaustive** (`agent_settled`, `entry_appended`), and the
+  host's relay cast means those still reach clients. Re-audit a mirror when a bump's changelog touches
+  it, not because a comment names a version.
+- **Type-only, from the package roots, always** (type-only imports are erased by
   `verbatimModuleSyntax`, so the web bundle stays provider-free; the pi-ai provider/API subpaths
   statically import the Node SDKs — never touch them). The `/base` entries existed only in 0.79.8–0.79.9.
 - `Model` is generic — expose as `Model<any>`.

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -40,8 +40,9 @@ export type WireModel = Pick<
 
 // The unified render union the UI switches on. The real superset (`AgentSessionEvent`) is declared in the
 // Node-only `pi-coding-agent` (it pulls node:fs), so it's MIRRORED here type-only, derived from the
-// imported `AgentEvent`. Keep in sync with @earendil-works/pi-coding-agent@0.82.0
-// (core/agent-session.d.ts) — the session-event members below are what `session.subscribe` emits.
+// imported `AgentEvent`. The members below are what `session.subscribe` emits. The mirror is NOT
+// exhaustive and the host relays with a cast, so pi events absent here still reach clients — today
+// `agent_settled` and `entry_appended` (tracked as issues).
 export type PiEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
 	| { type: "agent_end"; messages: AgentMessage[]; willRetry: boolean }
@@ -94,7 +95,7 @@ export interface SessionEventPayload {
 }
 
 // The shapes below are declared in the Node-only `pi-coding-agent` (it pulls node:fs), so they're
-// MIRRORED here type-only for the wire. Keep in sync with @earendil-works/pi-coding-agent@0.82.0.
+// MIRRORED here type-only for the wire.
 
 /** Context-window usage for the active model. `tokens`/`percent` are null when unknown (post-compaction). */
 export interface ContextUsage {
@@ -290,7 +291,8 @@ export interface AskUserAnswersDetails {
 
 /**
  * MIRROR of pi-coding-agent's `CustomMessage` (that package is Node-only, so the shape is re-declared
- * type-only for the wire — keep in sync with @earendil-works/pi-coding-agent@0.82.0 core/messages.d.ts):
+ * type-only for the wire; pi exports it from `core/messages`, not the package root, so it is not
+ * mechanically checkable the way `PiEvent` is):
  * an extension-injected transcript message (`sendCustomMessage`). Crosses the wire in
  * `session.getMessages` and inside `message_start`/`message_end` events; the LLM sees it as a user
  * message. The web renders only the `customType`s it knows (e.g. `ask-user-answers`) and ignores the rest.

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -427,7 +427,7 @@ export function getSessionStats(sessionId: string): SessionStats {
 }
 
 // Slash commands / skills available in the session — built from the same three sources pi's own rpc mode
-// uses. In sync with @earendil-works/pi-coding-agent@0.82.0 (modes/rpc get_commands).
+// uses (pi's own `modes/rpc` `get_commands`).
 export function getSessionCommands(sessionId: string): SlashCommandInfo[] {
 	const session = mustGet(sessionId);
 	const extension = session.extensionRunner.getRegisteredCommands().map((c) => ({

--- a/packages/server/src/agent/piRuntime.ts
+++ b/packages/server/src/agent/piRuntime.ts
@@ -61,7 +61,7 @@ export function getPiRuntime(): Promise<ModelRuntime> {
 export type CatalogRefreshRuntime = Pick<ModelRuntime, "refresh">;
 
 // One in-flight refresh per runtime instance: pi's `refresh()` does NOT single-flight itself (verified
-// vs 0.82.0 — only the availability sub-refresh is queued), and each picker open triggers us again.
+// only the availability sub-refresh is queued), and each picker open triggers us again.
 const inflightCatalogRefresh = new WeakMap<CatalogRefreshRuntime, Promise<void>>();
 
 // pi's own model-selector refresh budget. With single-flight, a hung refresh must self-expire or it


### PR DESCRIPTION
## What

Bump `pi` **0.82.0 → 0.82.1** and re-audit the mirror markers that pin our type copies to a pi version. Nothing else — the features this bump enables ship separately (see below).

1. **`34a7524` chore(deps)** — catalog pins only (Decision #10); `pi-tui` follows transitively.
2. **`48e9964` chore(contracts,server)** — **stops version-pinning the pi mirrors in comments**, and checks the one that can be checked instead. See below.

## What the bump actually changes

Verified against the published packages rather than release notes:

- **`core/agent-session.js` differs by 13 lines, entirely auth resolution** (`result.auth.apiKey` → `apiKey || headers`). No change to message persistence, the session lifecycle, or anything we mirror.
- `core/agent-session.d.ts`, `core/messages.d.ts`, `modes/rpc` (whole dir), `model-runtime` / `model-registry` are **byte-identical** to 0.82.0 — so every mirrored shape and the refresh single-flight observation hold unchanged. Markers bumped; the historical `pi ≥0.82.0` capability note left as-is.
- **`claude-opus-5` is added to six packaged provider catalogs** (anthropic, amazon-bedrock, github-copilot, openrouter, opencode, vercel-ai-gateway). This is the substantive change: 0.82.0's Anthropic list ends at `claude-opus-4-8`.
- The thinking-level API is **unchanged**: the `ThinkingLevel` union already contained `xhigh`/`max`, and `getSupportedThinkingLevels` / `clampThinkingLevel` are md5-identical between the two versions.
- Binary-seam canary clean — no new bundler-opaque `import()`.

## Why the marker comments are gone rather than bumped

Types we re-declare because their real home is Node-only carried a `keep in sync with @earendil-works/pi-coding-agent@x.y.z` marker — six of them across five files, hand-edited on every bump, verified by nothing.

They weren't doing the job. `agentSessionManager` subscribes with `event as PiEvent`, casting whatever pi emits into the mirror — so `PiEvent` has been missing **`agent_settled`** and **`entry_appended`** (both relayed to clients as events the wire type says cannot exist) through several bumps that dutifully updated the version strings.

`server/agent/piEventParity.ts` replaces them where it counts: `packages/server` is the one place that can see both pi's real `AgentSessionEvent` and the wire's mirror, so it asserts they agree **at compile time** and names the members the UI deliberately doesn't render. Mutation-verified in three directions — pi adding an event, an undeclared omission, and a phantom member each fail `typecheck`.

`CustomMessage` stays prose-only and says so: pi exports it from `core/messages`, not the package root, so it isn't reachable without a deep import.

Net effect: a future pi bump touches `package.json` + `bun.lock`, and the build tells you if a mirror drifted.

## Follow-ups

Split out of the original omnibus PR so each piece reviews on its own:

- **feat/per-model-thinking-levels** — the effort picker disables levels a model can't do. Based on this branch.
- **feat/live-model-catalog** — `model.refresh` + the picker's Refresh row. Based on thinking-levels.

## Gates

`check:deps` ✓ · `check:seams` ✓ · `lint` ✓ · `typecheck` (10 pkgs) ✓ · `test` **306 pass** ✓ · `e2e` no-agent **98/98** ✓
