### PR TITLE
fix(chat): own Ctrl+R and Escape app-wide; surface starter templates

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -11,7 +11,7 @@ import { ArrowDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { Popover, PopoverAnchor, PopoverTrigger } from "@/components/ui/popover";
-import { EMPTY_RUNTIME, selectSkillsStale, toast, useAppStore } from "@/store";
+import { EMPTY_RUNTIME, SettingsSection, selectSkillsStale, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { type ChatActions, ChatActionsContext } from "./ChatActions";
@@ -361,9 +361,24 @@ export default function ChatView({
 			.catch(() => {});
 	};
 
-	// Ctrl+R in the composer seeds the overlay with the current draft (never a stale store value) —
+	// Opening history recall seeds the overlay with the current draft (never a stale store value) —
 	// `useHistorySearch` owns everything from here (debounce, scope cycling, stale-response drop).
 	const onHistoryOpen = () => openOverlay(draft);
+
+	// Open the Templates manager — what the `/` menu's empty-state nudge does. The store edge lives here,
+	// not in the presentational `Composer`.
+	const onManageTemplates = () => useAppStore.getState().openSettings(SettingsSection.Templates);
+
+	// Dismissing the overlay (Escape) hands focus BACK to the prompt field, caret where it was, so the
+	// user can keep typing the draft they interrupted. Opening the overlay moved focus into its query
+	// input; closing unmounts that input, which would otherwise strand focus on `<body>` — every
+	// subsequent keystroke lost. This is the dismiss path only: the *other* ways the overlay closes each
+	// own where focus goes next (an insert focuses the composer itself, a jump scrolls another chat into
+	// view, save-as-template hands off to a dialog), so none of them route through here.
+	const onDismissHistory = () => {
+		closeHistory();
+		composerRef.current?.refocus();
+	};
 
 	// Enter on a prompt hit: replace the draft, focus, caret at end, close — no submit.
 	const onInsertHit = (hit: PromptHit) => {
@@ -451,6 +466,20 @@ export default function ChatView({
 		setFlashRowId(rows[index]?.id ?? null);
 		useAppStore.getState().clearChatLocation();
 	}, [chatLocationRequest, sessionId, rows, runtime.turnIdByMessageIndex, turns]);
+
+	// Consume the shell's global `Ctrl+R` (`store.historyOpenRequest`), the chord's only handler app-wide —
+	// it fires with focus anywhere, so it can't be a key handler in the composer or the overlay. Already
+	// open → cycle the scope (what the chord means once the overlay has focus); otherwise open it through
+	// the composer's `openHistory` handle, so the chord and the composer's own history button take the
+	// identical path (menus dismissed, draft-seeded).
+	const historyOpenRequest = useAppStore((s) => s.historyOpenRequest);
+	const historyOverlayOpen = historyState.open;
+	useEffect(() => {
+		if (historyOpenRequest?.sessionId !== sessionId) return;
+		useAppStore.getState().clearHistoryOpen();
+		if (historyOverlayOpen) cycleScope();
+		else composerRef.current?.openHistory();
+	}, [historyOpenRequest, sessionId, historyOverlayOpen, cycleScope]);
 
 	// Auto-clear the flash, decoupled from the effect above: `clearChatLocation()` there flips
 	// `chatLocationRequest` to null, which is one of that effect's own deps — if the timeout lived there,
@@ -592,11 +621,10 @@ export default function ChatView({
 							state={historyState}
 							workspaceNames={workspaceNames}
 							onQueryChange={setQuery}
-							onCycleScope={cycleScope}
 							onSetScope={setScope}
 							onToggleStage={toggleStage}
 							onMoveSelection={moveSelection}
-							onClose={closeHistory}
+							onClose={onDismissHistory}
 							onInsert={onInsertHit}
 							onInsertAndSend={onInsertAndSendHit}
 							onOpenMessage={openMessage}
@@ -621,6 +649,7 @@ export default function ChatView({
 							onAbort={onAbort}
 							onHistoryOpen={onHistoryOpen}
 							onPickTemplate={onPickTemplate}
+							onManageTemplates={onManageTemplates}
 						/>
 					</div>
 					<TemplateEditorDialog

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -201,6 +201,9 @@ export default function ChatView({
 	const [planOpen, setPlanOpen] = useState(false);
 	const [slashActive, setSlashActive] = useState(false);
 	const [templates, setTemplates] = useState<TemplateInfo[]>([]);
+	// "A `template.list` response came back and it was empty" — never "we haven't asked yet" or "the ask
+	// failed". See the fetch effect below for why the distinction matters.
+	const [templatesEmpty, setTemplatesEmpty] = useState(false);
 	// The history overlay's save-as-template dialog: non-null while open, carrying the prompt hit its body
 	// is prefilled from — `TemplateEditorDialog` itself is always mounted (controlled by `open` below), the
 	// same idiom `panels/TemplatesSettings.tsx` uses for its own New/Edit instance.
@@ -260,13 +263,20 @@ export default function ChatView({
 	// session-create-time `commands` snapshot) is deliberately stale — see `chat/SPEC.md`'s Template
 	// slots section. The previous (possibly stale) list stays rendered until the fresh one lands — a
 	// same-open-transition flicker would be worse than a few-ms-stale row.
+	// `templatesEmpty` is what gates the menu's "no templates yet" nudge, and it is deliberately NOT
+	// `templates.length === 0`: that list starts empty and stays empty when a request fails (the catch is
+	// silent by design — a failed listing must not break the menu), so deriving emptiness from it would
+	// claim "you have no templates" during the first fetch of every chat and permanently after a failure.
+	// Only a resolved response can answer the question, so only a resolved response sets this.
 	useEffect(() => {
 		if (!slashActive) return;
 		let cancelled = false;
 		getTransport()
 			.request("template.list", { workspaceId })
 			.then((res) => {
-				if (!cancelled) setTemplates(res.templates);
+				if (cancelled) return;
+				setTemplates(res.templates);
+				setTemplatesEmpty(res.templates.length === 0);
 			})
 			.catch(() => {});
 		return () => {
@@ -650,6 +660,7 @@ export default function ChatView({
 							onHistoryOpen={onHistoryOpen}
 							onPickTemplate={onPickTemplate}
 							onManageTemplates={onManageTemplates}
+							templatesEmpty={templatesEmpty}
 						/>
 					</div>
 					<TemplateEditorDialog

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -171,6 +171,11 @@ interface ComposerProps {
 	/** Open the Templates manager (Settings → Templates). Wired by `ChatView` (the store lives there, not
 	 * here) to back the `/` menu's "no prompt templates yet" nudge; without it the nudge isn't rendered. */
 	onManageTemplates?: () => void;
+	/** Whether a `template.list` response has come back **empty** — the nudge's gate. Not derivable from
+	 * `commands`: that list is equally empty before the first fetch resolves and after one fails, so
+	 * reading emptiness off it would flash (or strand) a nudge that contradicts the templates the user
+	 * actually has. Only the owner of the request knows, so only it can say. */
+	templatesEmpty?: boolean;
 }
 
 /** Imperative handle so `ChatView` can insert a recalled prompt (or a parsed template) without reaching
@@ -228,6 +233,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		onHistoryOpen,
 		onPickTemplate,
 		onManageTemplates,
+		templatesEmpty,
 	},
 	handleRef,
 ) {
@@ -368,12 +374,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// Either floating completion panel — the slot-session keys and the hint chip both stand down while
 	// one is open (all the composer's floating panels share the same anchor rect).
 	const menuOpen = mentionOpen || slashCompletion.open;
-
-	// Whether ANY prompt template exists (not: any that matches the current query) — the `/` menu's
-	// empty-state nudge is about having none at all, so a query that simply misses must not raise it.
-	// `commands` is the merged list `ChatView` builds, so a fresh `template.list` clears this the moment
-	// the first template lands.
-	const hasTemplates = commands.some((c) => c.source === "prompt");
 
 	// The single entry point to the history overlay — the always-rendered history button and the shell's
 	// global `Ctrl+R` (via the handle below) both go through here, so both dismiss any open mention/slash
@@ -608,8 +608,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 					activeIndex={slashCompletion.activeIndex}
 					onSelect={slashCompletion.pick}
 					className="absolute bottom-full left-sm mb-xs"
+					// The nudge is about having NO templates at all — never about the current query matching
+					// none — so it keys on the owner's confirmed-empty listing, not on the visible matches.
 					footer={
-						!hasTemplates && onManageTemplates ? (
+						templatesEmpty && onManageTemplates ? (
 							<button
 								type="button"
 								data-testid="slash-templates-empty"

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -4,7 +4,7 @@ import type {
 	ThinkingLevel,
 	WireModel,
 } from "@thinkrail/contracts";
-import { ArrowUp, FileIcon, FolderIcon, History, Square, X } from "lucide-react";
+import { ArrowUp, FileIcon, FolderIcon, History, Sparkles, Square, X } from "lucide-react";
 import {
 	type ClipboardEvent,
 	type DragEvent,
@@ -160,13 +160,17 @@ interface ComposerProps {
 	onSelectThinking: (level: ThinkingLevel) => void;
 	onSubmit: (text: string, images: ImageContent[], behavior: SubmitBehavior) => void;
 	onAbort: () => void;
-	/** `Ctrl+R` — opens the history-recall overlay (`ChatView` seeds it with the current draft). Optional
-	 * so a standalone/storybook-style render of `Composer` doesn't need to wire it. */
+	/** Opens the history-recall overlay (`ChatView` seeds it with the current draft) — the history button
+	 * and the shell's global `Ctrl+R`, via the `openHistory` handle. Optional so a standalone/storybook-style
+	 * render of `Composer` doesn't need to wire it. */
 	onHistoryOpen?: () => void;
 	/** Picking a `source: "prompt"` row: `ChatView` fetches + parses the template and replies via
 	 * `insertTemplate`, instead of the slash completion's plain `/name ` insert. Optional so a standalone
 	 * render of `Composer` still works — those rows just fall back to the plain insert. */
 	onPickTemplate?: (name: string) => void;
+	/** Open the Templates manager (Settings → Templates). Wired by `ChatView` (the store lives there, not
+	 * here) to back the `/` menu's "no prompt templates yet" nudge; without it the nudge isn't rendered. */
+	onManageTemplates?: () => void;
 }
 
 /** Imperative handle so `ChatView` can insert a recalled prompt (or a parsed template) without reaching
@@ -182,6 +186,15 @@ export interface ComposerHandle {
 	/** Replace the draft with a parsed template's expansion; if it produced any slots, start a slot
 	 * session selecting slot 0 (else behaves like `insertText`: caret at the end, no session). */
 	insertTemplate: (parsed: ParsedTemplate) => void;
+	/** Open the history overlay the way the composer's own history button does — dismissing any open
+	 * mention/slash menu first. The seam the shell's global `Ctrl+R` reaches, via `ChatView`. */
+	openHistory: () => void;
+	/** Return focus to the prompt field without touching the draft, so typing resumes exactly where it
+	 * left off: the caret goes back where it was (tracked on every click/keyup/change), or, with a slot
+	 * session live, back onto the current slot's marker selection. `ChatView` calls this when the history
+	 * overlay is *dismissed* — the overlay took focus on open, and Escape would otherwise strand it on
+	 * `<body>`. */
+	refocus: () => void;
 }
 
 /**
@@ -190,7 +203,8 @@ export interface ComposerHandle {
  * the row under the tall prompt field, mirroring the New-Workspace dialog's layout. `@` opens worktree
  * file completion, a leading `/` opens the skill/command menu (picking a `source: "prompt"` row starts a
  * **slot session** — see `insertTemplate`/`stepSlot` — instead of the plain `/name ` insert every other
- * row gets), `Ctrl+R` opens history recall (also reachable via the always-rendered `history-open` button),
+ * row gets), the always-rendered `history-open` button opens history recall (as does the shell's global
+ * `Ctrl+R`, which arrives through the `openHistory` handle rather than a key handler here),
  * plain `↑`/`↓` recall step through `recentPrompts` when the field is empty or a recall session is already
  * active, and images can be pasted or dropped in.
  */
@@ -213,6 +227,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		onAbort,
 		onHistoryOpen,
 		onPickTemplate,
+		onManageTemplates,
 	},
 	handleRef,
 ) {
@@ -327,29 +342,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		setSlots(null);
 	};
 
-	// No dependency array: `submitText` closes over the live draft/images on purpose, so the handle is
-	// refreshed every render — memoizing it against stale closures is exactly the bug this avoids.
-	useImperativeHandle(handleRef, () => ({
-		insertText: (text: string) => replaceDraft(text),
-		insertAndSubmit: (text: string, behavior: SubmitBehavior) => submitText(text, behavior),
-		insertTemplate: (parsed: ParsedTemplate) => {
-			const first = parsed.slots[0];
-			if (!first) {
-				// No slots — behaves exactly like `insertText` (and picks up its recall/slot resets).
-				replaceDraft(parsed.text);
-				return;
-			}
-			// A slotted insert is the one programmatic mutation that STARTS a slot session instead of
-			// ending one — but it must still exit any `↑`-recall session the way `replaceDraft` does
-			// (this path sets `value` directly, so the textarea's diverging-edit reset never fires).
-			setRecallIdx(null);
-			onChange(parsed.text);
-			setSlots(parsed.slots);
-			setSlotIdx(0);
-			focusSelection(first.start, first.end);
-		},
-	}));
-
 	const pickMention = (c: MentionCandidate) => {
 		const before = value.slice(0, start);
 		const after = value.slice(caret);
@@ -377,14 +369,54 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// one is open (all the composer's floating panels share the same anchor rect).
 	const menuOpen = mentionOpen || slashCompletion.open;
 
-	// The single entry point to the history overlay — both the `Ctrl+R` chord and the always-rendered
-	// history button go through here, so both dismiss any open mention/slash menu first (the two floating
-	// panels share the composer's anchor rect; leaving one open would paint both at once).
+	// Whether ANY prompt template exists (not: any that matches the current query) — the `/` menu's
+	// empty-state nudge is about having none at all, so a query that simply misses must not raise it.
+	// `commands` is the merged list `ChatView` builds, so a fresh `template.list` clears this the moment
+	// the first template lands.
+	const hasTemplates = commands.some((c) => c.source === "prompt");
+
+	// The single entry point to the history overlay — the always-rendered history button and the shell's
+	// global `Ctrl+R` (via the handle below) both go through here, so both dismiss any open mention/slash
+	// menu first (the two floating panels share the composer's anchor rect; leaving one open would paint
+	// both at once).
 	const openHistory = () => {
 		setMentionDismissed(true);
 		slashCompletion.dismiss();
 		onHistoryOpen?.();
 	};
+
+	// No dependency array: `submitText` closes over the live draft/images on purpose, so the handle is
+	// refreshed every render — memoizing it against stale closures is exactly the bug this avoids. Declared
+	// after `openHistory`/`slashCompletion` so nothing here forward-references a later binding.
+	useImperativeHandle(handleRef, () => ({
+		insertText: (text: string) => replaceDraft(text),
+		insertAndSubmit: (text: string, behavior: SubmitBehavior) => submitText(text, behavior),
+		insertTemplate: (parsed: ParsedTemplate) => {
+			const first = parsed.slots[0];
+			if (!first) {
+				// No slots — behaves exactly like `insertText` (and picks up its recall/slot resets).
+				replaceDraft(parsed.text);
+				return;
+			}
+			// A slotted insert is the one programmatic mutation that STARTS a slot session instead of
+			// ending one — but it must still exit any `↑`-recall session the way `replaceDraft` does
+			// (this path sets `value` directly, so the textarea's diverging-edit reset never fires).
+			setRecallIdx(null);
+			onChange(parsed.text);
+			setSlots(parsed.slots);
+			setSlotIdx(0);
+			focusSelection(first.start, first.end);
+		},
+		openHistory,
+		refocus: () => {
+			// A live slot session gets its marker re-selected rather than a collapsed caret: the session
+			// survives the overlay (Escape closes the topmost panel only), so "where the user was" is the
+			// slot they were filling, and typing must still replace the whole marker.
+			const slot = slots?.[slotIdx];
+			if (slot) focusSelection(slot.start, slot.end);
+			else focusSelection(caret);
+		},
+	}));
 
 	const addFiles = async (files: File[]) => {
 		const picked = files.filter((f) => f.type.startsWith("image/"));
@@ -440,17 +472,13 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-		// Ctrl+R opens history recall — guarded at the very top, before the mention/slash menu, and before
-		// Enter-to-send. Ctrl+R is the browser-reload chord on Windows/Linux, so this must preventDefault
-		// unconditionally; Cmd+R (mac reload) and Alt+R are left alone. Dismiss any open mention/slash menu
-		// first — the two floating panels share the same anchor rect, so leaving the menu open would paint
-		// both at once (mutual exclusion between the composer's floating panels).
-		if (e.key === "r" && e.ctrlKey && !e.metaKey && !e.altKey) {
-			e.preventDefault();
-			openHistory();
-			return;
-		}
-		// A slot session's own keys — checked right after the Ctrl+R guard and before the mention/slash
+		// There is deliberately no Ctrl+R branch here: the chord is owned app-wide by
+		// `shell/useGlobalHotkeys`, which swallows the browser's reload wherever focus sits and routes back
+		// into this composer through `ChatView` (the `openHistory` handle above). A textarea-local handler
+		// only ever covered focus-in-composer — the reload it was written to prevent still fired everywhere
+		// else.
+		//
+		// A slot session's own keys — checked first, before the mention/slash
 		// menu's key handling, and skipped outright while a menu IS open, so a real Tab-to-pick-a-menu-item
 		// (or an Escape that should dismiss the menu) is unaffected; the hint chip and the menus are mutually
 		// exclusive anyway (see the hint's render gate below), so the floating UIs never fight over the
@@ -580,6 +608,29 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 					activeIndex={slashCompletion.activeIndex}
 					onSelect={slashCompletion.pick}
 					className="absolute bottom-full left-sm mb-xs"
+					footer={
+						!hasTemplates && onManageTemplates ? (
+							<button
+								type="button"
+								data-testid="slash-templates-empty"
+								// Clears the slash query as it navigates: this row is a way OUT of the menu, not a
+								// completion, so leaving `/…` in the draft would keep the (now-answered) nudge on
+								// screen behind the dialog. It also matters for freshness — the template list is
+								// fetched per menu-OPEN transition, so the menu has to actually close for the
+								// templates the user is about to add to show up when they come back.
+								onClick={() => {
+									replaceDraft("");
+									onManageTemplates();
+								}}
+								className="flex w-full items-center gap-sm rounded-[var(--radius-sm)] border-border2 border-t px-sm py-xs text-left text-hint text-xs hover:bg-hover hover:text-text"
+							>
+								<Sparkles className="size-3 shrink-0" />
+								<span className="truncate">
+									No prompt templates yet — add starters in Settings → Templates
+								</span>
+							</button>
+						) : null
+					}
 				/>
 			) : null}
 

--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -1,6 +1,6 @@
 import type { HistoryScope, MessageHit, PromptHit } from "@thinkrail/contracts";
 import { Check, CornerUpRight, Save } from "lucide-react";
-import { type KeyboardEvent, useEffect, useMemo, useRef } from "react";
+import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -308,9 +308,11 @@ export interface HistoryOverlayProps {
 	 * workspace chip can show a human label without this presentational component touching the store. */
 	workspaceNames: Record<string, string>;
 	onQueryChange: (query: string) => void;
-	onCycleScope: () => void;
 	onToggleStage: () => void;
 	onMoveSelection: (delta: number) => void;
+	/** **Dismissal** — Escape, the overlay's only "close and do nothing else" exit (every other close is a
+	 * side effect of insert/jump/save, which the respective callback owns). The caller both closes the
+	 * overlay and hands focus back to the composer; this component never decides where focus lands next. */
 	onClose: () => void;
 	/** Enter on a prompt hit — replace the draft, focus, caret at end, close. */
 	onInsert: (hit: PromptHit) => void;
@@ -326,9 +328,10 @@ export interface HistoryOverlayProps {
 	 * Cmd/Ctrl+S while that row is the keyboard selection. Opens `TemplateEditorDialog` body-prefilled;
 	 * `ChatView` owns the dialog, this overlay only reports the hit. */
 	onSaveAsTemplate: (hit: PromptHit) => void;
-	/** R2's mouse path: a direct scope pick from the badge's dropdown menu. `onCycleScope` stays the
-	 * `Ctrl+R` keyboard path, unaffected — both just set the same underlying scope state
-	 * (`useHistorySearch.ts`'s `setScope`/`cycleScope` reset the results selection identically). */
+	/** R2's mouse path: a direct scope pick from the badge's dropdown menu. The `Ctrl+R` keyboard path
+	 * (`cycleScope`, routed from the shell through `ChatView`) is unaffected — both just set the same
+	 * underlying scope state (`useHistorySearch.ts`'s `setScope`/`cycleScope` reset the results selection
+	 * identically). */
 	onSetScope: (kind: HistoryScope["kind"]) => void;
 }
 
@@ -341,7 +344,6 @@ export function HistoryOverlay({
 	state,
 	workspaceNames,
 	onQueryChange,
-	onCycleScope,
 	onToggleStage,
 	onMoveSelection,
 	onClose,
@@ -354,6 +356,9 @@ export function HistoryOverlay({
 	const { open, stage, query, scope, result, selected, error } = state;
 	const inputRef = useRef<HTMLInputElement>(null);
 	const resultsRef = useRef<HTMLDivElement>(null);
+	// The scope picker is a CONTROLLED Radix menu purely so the Escape handler below can stand down while
+	// it is open — Escape must dismiss the innermost layer (the menu), not the overlay under it.
+	const [scopeMenuOpen, setScopeMenuOpen] = useState(false);
 
 	// Auto-focus with the seeded text selected, the instant the overlay opens — not on every keystroke.
 	useEffect(() => {
@@ -363,6 +368,26 @@ export function HistoryOverlay({
 		el.focus();
 		el.select();
 	}, [open]);
+
+	// Escape dismisses the overlay from ANYWHERE, not just the query input. Focus routinely leaves that
+	// input while the overlay is up — a click back into the composer, a row's icon button, an errant click
+	// on the page — and an input-local handler was the only way out, so the panel got stuck open with no
+	// keyboard dismissal at all. Window + **capture** phase, so it wins over anything downstream that also
+	// treats Escape as its own (the composer's slot session, which must survive the dismissal); the
+	// `stopPropagation` is what enforces that "topmost floating panel closes first" ordering. Registered
+	// only while `open`, and stood down while the scope menu is up so Radix's own Escape (a document-level
+	// capture listener, which would otherwise fire in the same keystroke) closes just that menu.
+	useEffect(() => {
+		if (!open || scopeMenuOpen) return;
+		const onWindowKeyDown = (e: globalThis.KeyboardEvent) => {
+			if (e.key !== "Escape") return;
+			e.preventDefault();
+			e.stopPropagation();
+			onClose();
+		};
+		window.addEventListener("keydown", onWindowKeyDown, true);
+		return () => window.removeEventListener("keydown", onWindowKeyDown, true);
+	}, [open, scopeMenuOpen, onClose]);
 
 	// A stable identity for the currently-selected row, derived from stage/result/selected. It changes
 	// exactly when the selection lands on a different row — including when a stage toggle or a fresh result
@@ -391,12 +416,10 @@ export function HistoryOverlay({
 
 	if (!open) return null;
 
+	// No Ctrl+R or Escape branch here: both chords are owned outside this input, because both must work
+	// with focus anywhere — `Ctrl+R` by `shell/useGlobalHotkeys` (which routes a scope cycle back through
+	// `ChatView` while the overlay is open), Escape by the window listener above.
 	const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-		if (e.key === "r" && e.ctrlKey && !e.metaKey && !e.altKey) {
-			e.preventDefault();
-			onCycleScope();
-			return;
-		}
 		if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
 			// Always swallow — Cmd/Ctrl+S is the browser's own "save page" shortcut. Only a prompt row
 			// selection actually opens the save-as-template dialog; on a message hit (or none) this is a
@@ -419,11 +442,6 @@ export function HistoryOverlay({
 		if (e.key === "Tab") {
 			e.preventDefault();
 			onToggleStage();
-			return;
-		}
-		if (e.key === "Escape") {
-			e.preventDefault();
-			onClose();
 			return;
 		}
 		if (e.key === "Enter") {
@@ -547,7 +565,7 @@ export function HistoryOverlay({
 					placeholder="Search prompts and conversations…"
 					className="min-w-0 flex-1 bg-transparent text-sm text-text outline-none placeholder:text-hint"
 				/>
-				<DropdownMenu>
+				<DropdownMenu open={scopeMenuOpen} onOpenChange={setScopeMenuOpen}>
 					<DropdownMenuTrigger
 						data-testid="history-scope"
 						data-scope={scope.kind}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -116,7 +116,7 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   the request — `ChatView` is its only consumer, so an unresolved request must never linger.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
   commands + template **slot sessions** (Tab-through placeholders — see the Template slots bullet
-  below), image paste/drop, `Ctrl+R` → `onHistoryOpen`) plus its props-driven **slash-completion
+  below), image paste/drop, `openHistory` on its imperative handle → `onHistoryOpen`) plus its props-driven **slash-completion
   primitive** (filter/menu/caret + Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so
   the two inputs cannot drift; `HistoryOverlay` (the history-recall/search overlay `Composer` opens —
   presentational, driven entirely by `useHistorySearch.ts`'s state + callbacks, plus a **Save as
@@ -160,14 +160,41 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   (`data-testid="history-scope-option"` + `data-scope`, fuller labels than the badge itself — "This
   chat" / "Workspace" / "Project" / "Everywhere" — with the current one check-marked). Picking one
   calls `useHistorySearch.ts`'s new `setScope(kind)`, which resets the results selection exactly like
-  `cycleScope` — the unchanged `Ctrl+R` keyboard path, since both just set the same underlying scope
+  `cycleScope` — the `Ctrl+R` keyboard path (see the chord-ownership bullet below), since both just set
+  the same underlying scope
   state. Radix's default on close is to return focus to the trigger; `onCloseAutoFocus` is overridden
   (`preventDefault` + focus the query input) so a mouse pick hands focus back to the query input
-  instead — typing (and `Ctrl+R` cycling) resumes immediately, no extra click needed. The menu never
+  instead — typing resumes immediately, no extra click needed. The menu is a **controlled** Radix menu
+  (`scopeMenuOpen`) for one reason: the overlay's window-level `Escape` stands down while it is open, so
+  Escape dismisses the innermost layer. The menu never
   fights the overlay's own `ArrowUp`/`ArrowDown`/`Enter` handling: that handler is bound to the query
   `<input>` element itself, and Radix's portaled dropdown content is a **sibling** subtree — never a
   descendant of the input — so a keydown while the menu holds focus cannot reach the input's handler by
   construction, not by a case-by-case guard.
+- **Chord ownership: `Ctrl+R` and `Escape` are not element-local.** Both used to be single-element key
+  handlers — `Ctrl+R` on the composer textarea, `Escape` on the overlay's query `<input>` — and both were
+  wrong for the same reason: they only fired while that one element held focus. Outside it, `Ctrl+R`
+  reached the browser and **reloaded the app**, and an overlay whose input had lost focus (a click back
+  into the composer, a row's icon button) had *no* keyboard dismissal at all. Now:
+  - **`Ctrl+R`** is owned by `shell/useGlobalHotkeys` — a window capture-phase listener that swallows the
+    chord app-wide (`preventDefault` + `stopPropagation`, so it has exactly one handler) and routes it via
+    `store.requestHistoryOpen(sessionId)` to the one mounted `ChatView` (`selectActiveChatSessionId`).
+    `ChatView` translates it: overlay closed → `composerRef.openHistory()` (identical path to the history
+    button — menus dismissed, draft-seeded); overlay open → `cycleScope()`. Neither `Composer` nor
+    `HistoryOverlay` carries a `Ctrl+R` branch any more. Deliberate exclusions: a keydown from inside a
+    terminal (`.xterm`) passes through untouched (reverse-i-search belongs to the PTY), and
+    `Ctrl+Shift+R` / `Cmd+R` are left alone so a keyboard reload stays possible.
+  - **`Escape`** is owned by `HistoryOverlay`'s own window capture-phase listener, registered only while
+    it is open. Capture + `stopPropagation` encodes "the topmost floating panel closes first" (a composer
+    slot session survives the dismissal rather than being cleared by the same keystroke). It stands down
+    while the scope picker is open — see the controlled `scopeMenuOpen` note above — so Radix's own
+    Escape closes just that menu. There is deliberately **no** click-outside dismissal.
+  - **Dismissal returns focus to the prompt field** (`ChatView.onDismissHistory` → the composer's
+    `refocus` handle): opening moved focus into the overlay's query input, and closing unmounts it, so
+    without this every post-Escape keystroke would land on `<body>` and be lost. The caret goes back where
+    it was (`Composer` tracks it on click/keyup/change), or onto the current slot's marker when a slot
+    session is live. Dismissal is the *only* close that routes through `onClose` — insert, jump, and
+    save-as-template each own where focus goes next (the composer, another chat, a dialog).
 - **History overlay: assistant-only messages + jumpable prompts** (`HistoryOverlay.tsx`,
   `useHistorySearch.ts` — R3) — `MESSAGES` now only ever contains assistant-role hits (the server
   filters; see `packages/server/src/history/SPEC.md`): a user-role hit is always a textual duplicate of
@@ -209,7 +236,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `source === "prompt"` entries, plus a fresh `template.list { workspaceId }` fetch mapped to
   `SlashCommandInfo` rows (`source: "prompt"`, `sourceInfo` synthesized to match pi's own prompt-template
   convention exactly: `{ path: filePath, source: "local", scope: scope === "global" ? "user" : "project",
-  origin: "top-level" }`) — one merged list, `Composer`'s rendering is unchanged. The fetch runs on
+  origin: "top-level" }`) — one merged list. When that merged list holds **no** `source === "prompt"` row
+  at all, `SlashCommandMenu` renders a `footer` nudge (`data-testid="slash-templates-empty"`) that
+  deep-links to Settings → Templates via `ChatView`'s `onManageTemplates` — the discoverability half of
+  the starter-templates offer (`panels/SPEC.md`), since a fresh install has an empty global prompts dir
+  and the manager is otherwise two clicks deep in a dialog. Gated on "no templates exist", never on "the
+  current query matched none", so a query that simply misses doesn't raise it; `footer` is optional, so
+  `NewWorkspaceDialog`'s reuse of the same menu is unaffected. The fetch runs on
   **every** slash-menu-open transition (**`onSlashActive`**, a boolean prop mirroring `onMentionQuery`'s
   query signal — it stays `true` while the user types the query, so no per-keystroke refires) and is
   deliberately **uncached**: prompt files change outside the app too (pi CLI, an editor, a git pull),
@@ -233,7 +266,7 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   out-of-order responses). **The session** (`Composer`, local `useState`:
   `slots: TemplateSlot[] | null` + `slotIdx`, no store/transport): `Tab`/`Shift+Tab` step to the
   next/previous slot (wrap; `preventDefault`; a no-op while the mention/slash menu is open — checked at
-  the top of `onKeyDown`, right after the `Ctrl+R` guard and before the menu's own key handling, so a real
+  the top of `onKeyDown`, before the menu's own key handling, so a real
   Tab-to-pick-a-menu-item is unaffected, and symmetrically an `Escape` while the menu is also open lets the
   menu's own dismiss win first). Stepping **out** of a *user-edited* slot (one whose text the
   user actually changed — not an untouched marker, and crucially not an untouched `${N:-default}` either)
@@ -387,8 +420,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   **empty** or a recall is already active (older → higher index), `↓` steps newer (past the newest
   restores `""`), any diverging edit or a submit exits the session, and the recalled text lands with the
   caret at its end. A `History`-icon button (`data-testid="history-open"`, `aria-label="Search history"`,
-  always rendered next to send) calls the same `onHistoryOpen` as `Ctrl+R` — the tap path on mobile, a
-  discoverability affordance on desktop.
+  always rendered next to send) calls the same `openHistory` the global `Ctrl+R` reaches — the tap path
+  on mobile, a discoverability affordance on desktop.
 - **Chat TODO plan** — the chat's `pi-todos` list surfaced **only in the chat** (engine:
   [[module-pi-todos]]; host read/write: [[submodule-server-todos]]):
   `useChatTodos` (the `todo.*` data hook — fetch + live `pi.event` refetch + edits + the add-nudge + the

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -236,13 +236,18 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `source === "prompt"` entries, plus a fresh `template.list { workspaceId }` fetch mapped to
   `SlashCommandInfo` rows (`source: "prompt"`, `sourceInfo` synthesized to match pi's own prompt-template
   convention exactly: `{ path: filePath, source: "local", scope: scope === "global" ? "user" : "project",
-  origin: "top-level" }`) — one merged list. When that merged list holds **no** `source === "prompt"` row
-  at all, `SlashCommandMenu` renders a `footer` nudge (`data-testid="slash-templates-empty"`) that
+  origin: "top-level" }`) — one merged list. When a `template.list` response comes back **empty**,
+  `SlashCommandMenu` renders a `footer` nudge (`data-testid="slash-templates-empty"`) that
   deep-links to Settings → Templates via `ChatView`'s `onManageTemplates` — the discoverability half of
   the starter-templates offer (`panels/SPEC.md`), since a fresh install has an empty global prompts dir
   and the manager is otherwise two clicks deep in a dialog. Gated on "no templates exist", never on "the
   current query matched none", so a query that simply misses doesn't raise it; `footer` is optional, so
-  `NewWorkspaceDialog`'s reuse of the same menu is unaffected. The fetch runs on
+  `NewWorkspaceDialog`'s reuse of the same menu is unaffected. **The gate is `ChatView`'s explicit
+  `templatesEmpty` prop — a resolved, empty listing — never `commands` having no `source === "prompt"`
+  row.** The merged list is equally empty *before* the first fetch resolves and *after* one fails (that
+  `.catch` is silent by design — a failed listing must not break the menu), so reading emptiness off it
+  would flash "you have no templates" on every chat's first `/` and strand that claim permanently after a
+  failed listing — over a row whose click also clears the user's slash draft. The fetch runs on
   **every** slash-menu-open transition (**`onSlashActive`**, a boolean prop mirroring `onMentionQuery`'s
   query signal — it stays `true` while the user types the query, so no per-keystroke refires) and is
   deliberately **uncached**: prompt files change outside the app too (pi CLI, an editor, a git pull),

--- a/apps/web/src/chat/SlashCommandCompletion.tsx
+++ b/apps/web/src/chat/SlashCommandCompletion.tsx
@@ -1,5 +1,5 @@
 import type { SlashCommandInfo } from "@thinkrail/contracts";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { cn } from "@/lib/utils";
 
 const MAX_MATCHES = 8;
@@ -120,17 +120,23 @@ export function useSlashCommandCompletion({
 	return { activeIndex: visibleActiveIndex, dismiss, handleKeyDown, matches, open, pick };
 }
 
-/** Presentational command list shared by the chat composer and New Workspace prompt. */
+/**
+ * Presentational command list shared by the chat composer and New Workspace prompt. `footer` renders
+ * under the rows for owner-specific affordances the list itself knows nothing about (the composer's
+ * "no prompt templates yet" nudge); the New Workspace prompt passes none.
+ */
 export function SlashCommandMenu({
 	commands,
 	activeIndex,
 	onSelect,
 	className,
+	footer,
 }: {
 	commands: readonly SlashCommandInfo[];
 	activeIndex: number;
 	onSelect: (command: SlashCommandInfo) => void;
 	className?: string;
+	footer?: ReactNode;
 }) {
 	return (
 		<div
@@ -161,6 +167,7 @@ export function SlashCommandMenu({
 					</span>
 				</button>
 			))}
+			{footer}
 		</div>
 	);
 }

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -166,11 +166,16 @@ a project picker, the prompt hero, and the reused
   `ProjectTree.tsx`'s workspace-remove uses) calling `template.delete` directly — the dialog itself is
   never involved in deletion. **R4 — starter-templates offer:** when the **Global** group's fetch has
   resolved with zero rows and no error, its empty state swaps the bare "No templates yet." for that same
-  hint plus a button (`data-testid="template-starters"`) — clicking it `template.save`s four verbatim
-  starter templates (review/explain/tests/standup; scope `"global"`, body assembled client-side via
+  hint plus a button (`data-testid="template-starters"`) — clicking it `template.save`s five verbatim
+  starter templates (scope `"global"`, body assembled client-side via
   `chat/templateText.ts`'s `assembleTemplate`, the same helper `TemplateEditorDialog` uses) sequentially,
   then bumps `templatesVersion` once, the same invalidation the row list already refetches on — the
-  offer disappears on its own next render once the list is non-empty, no dismiss state to track. **This
+  offer disappears on its own next render once the list is non-empty, no dismiss state to track. The five
+  (review/explain/tests/commit/rename) are **the same set this repo checks into its own `.pi/prompts/`**:
+  those ship at *project* scope, so only a ThinkRail checkout ever sees them, and "the templates ThinkRail
+  ships" must mean one thing rather than two — change one, change the other. The composer's `/` menu
+  carries the discoverability half (`chat/SPEC.md`: a `slash-templates-empty` footer nudge deep-linking
+  here when no template exists anywhere), since this offer is otherwise two clicks deep in a dialog. **This
   project**'s empty state is unchanged (still the bare text) — the offer is Global-only, since it only
   ever seeds global files. No server change. A single dimmed "General" nav item ("Soon") still signals the shell is
   built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings` are the **integration pieces**

--- a/apps/web/src/panels/TemplatesSettings.tsx
+++ b/apps/web/src/panels/TemplatesSettings.tsx
@@ -14,8 +14,13 @@ import { openFileInTab } from "./openFile";
  * R4: verbatim starter-template content offered by `StarterTemplatesOffer` below (design doc "Amendments
  * (2026-07-22)" item 4). Bodies use pi's own `$1`/`${N:-default}` placeholder grammar — not JS
  * interpolation — so the two bodies containing `${…}` are written as template literals with the `\${`
- * escape (a literal dollar-brace, never an embedded expression); `explain`/`tests` only ever use bare
- * `$1`, which needs no escape.
+ * escape (a literal dollar-brace, never an embedded expression); the rest only use bare `$1`/`$2`, which
+ * need no escape.
+ *
+ * These are the **same five** this repo checks into its own `.pi/prompts/` — the set a ThinkRail checkout
+ * gets for free at project scope, which an install working on any *other* project would otherwise never
+ * see. Keeping the two in sync is deliberate: "the templates ThinkRail ships" should mean one thing, not
+ * two. Change one, change the other.
  */
 const STARTER_TEMPLATES: ReadonlyArray<{
 	name: string;
@@ -27,30 +32,36 @@ const STARTER_TEMPLATES: ReadonlyArray<{
 		name: "review",
 		description: "Code review of a file or directory",
 		argumentHint: "[path] [focus]",
-		body: `Review $1 for correctness, clarity, and maintainability, focusing on \${2:-the riskiest parts}.\nList concrete findings with file:line references, ordered by severity, then suggest fixes.`,
+		body: `Review $1 for correctness, clarity, and maintainability, focusing on \${2:-the riskiest parts}.\nList concrete findings with \`file:line\` references, ordered by severity, and propose a fix for each.`,
 	},
 	{
 		name: "explain",
-		description: "Explain how something works",
+		description: "Explain how something works in this codebase",
 		argumentHint: "[path-or-topic]",
-		body: "Explain how $1 works in this codebase: its purpose, the key control/data flow, and what depends on\nit. Keep it concise and point to the load-bearing files and lines.",
+		body: "Explain how $1 works in this codebase: its purpose, the key control and data flow, and what depends on it.\nKeep it concise and point to the load-bearing files and `file:line` locations.",
 	},
 	{
 		name: "tests",
 		description: "Write tests for a target",
 		argumentHint: "[path]",
-		body: "Write tests for $1. Cover the main behavior, the edge cases, and one failure path. Match the\nproject's existing test conventions and runner, and run the tests after writing them.",
+		body: "Write tests for $1. Cover the main behavior, the important edge cases, and one failure path.\nMatch the project's existing test conventions and runner, then run them and report the result.",
 	},
 	{
-		name: "standup",
-		description: "One-line standup update",
-		argumentHint: "[team]",
-		body: `Write a one-line standup update for team \${1:-mine} based on this workspace's recent changes.\nReply with just that line.`,
+		name: "commit",
+		description: "Write a Conventional Commit message from the staged diff",
+		argumentHint: "[scope]",
+		body: `Read the staged changes (\`git diff --cached\`) and write a Conventional Commits message.\nUse the type that fits (feat/fix/refactor/docs/test/chore) with scope \${1:-infer it from the files},\nan imperative subject under 72 chars, and a short body explaining the why when it isn't obvious.\nReply with only the commit message.`,
+	},
+	{
+		name: "rename",
+		description: "Rename a symbol everywhere (demoes repeated-slot mirroring)",
+		argumentHint: "[old] [new]",
+		body: "Rename `$1` to `$2` across the codebase: update every definition, reference, and import of `$1`,\nplus any docs or comments that mention `$1`. Keep `$2` consistent everywhere and run the type-checker after.",
 	},
 ];
 
 /**
- * R4: the Global group's empty-state nudge — one click seeds the four `STARTER_TEMPLATES` above via the
+ * R4: the Global group's empty-state nudge — one click seeds the five `STARTER_TEMPLATES` above via the
  * same `template.save` wire call `TemplateEditorDialog` uses (scope `"global"`, body assembled by the same
  * `assembleTemplate` helper), sequentially, then bumps `templatesVersion` once so both this panel and the
  * composer's `/` menu cache pick them up. No dismiss state to track: once the list is non-empty,

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -65,10 +65,16 @@ duplicate handling downstream).
 Today that's **`Ctrl+R` → chat history search**. Previously handled only on the composer textarea, so
 with focus anywhere else — the file tree, Monaco, a diff, the transcript, bare `<body>` — the browser
 reloaded the app instead. It is deliberately *not* a browser-reserved chord (unlike `Ctrl+T`/`Ctrl+W`/
-`Ctrl+N`), so swallowing it works. Routing goes through the store (`selectActiveChatSessionId` →
-`requestHistoryOpen`), never a ref: the chord fires far outside the chat subtree, and `CenterTabs` mounts
-one tab body at a time, so the selector names the only `ChatView` there is. With a file tab active there
-is nothing to open and the chord is *only* swallowed.
+`Ctrl+N`), so swallowing it works. Routing goes through the store (`selectHistoryTarget` →
+`requestHistoryOpen`), never a ref: the chord fires far outside the chat subtree entirely.
+
+Because `CenterTabs` mounts one tab body at a time, "which chat" and "is it even mounted" are the same
+question. `selectHistoryTarget` answers it: the active tab when that's a chat, else the workspace's most
+recently opened one — and `requestHistoryOpen` **activates that tab atomically with the request**, so the
+`ChatView` that mounts is the one that consumes it. Resolving to "no target" over a file/diff tab would
+have been worse than the bug: the chord is swallowed there too, so it would silently do *nothing* over
+Monaco, a diff, or the file tree — the very places this handler exists for. Only a workspace with **no**
+chat tab at all has nothing to open; there the chord is purely swallowed (still never a reload).
 
 Two carve-outs, both load-bearing:
 - **Terminals.** A keydown from inside `.xterm` passes straight through — `Ctrl+R` there is the shell's

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -34,8 +34,11 @@ later, the mobile single-view-with-switcher).
   `applyTheme(theme)` + `writeThemeHint(theme)` (the localStorage first-paint cache). The value flows
   store ← transport (welcome /
   `settings.changed`); the shell just performs the swap, so no other component touches `[data-theme]`.
+  **Owns the app-wide keyboard chords** — `useGlobalHotkeys.ts`, mounted once by `Shell`. See
+  "Global chords" below.
 - **Public surface:** `Shell`.
-- **Allowed deps:** `panels`, `store` (status + theme + project/workspace context), `transport` (`ConnectionStatus` type), `components/ui`
+- **Allowed deps:** `panels`, `store` (status + theme + project/workspace context + the active-chat
+  selector and `requestHistoryOpen`), `transport` (`ConnectionStatus` type), `components/ui`
   (resizable), `components/ErrorBoundary`, `constants` (branding), `themes` (`applyTheme`/`writeThemeHint`).
 - **Forbidden:** `server`/`shared`/`pi`; being imported by `panels`/`store`/`transport`.
 
@@ -50,3 +53,28 @@ clears a stuck error. A **last-resort boundary wraps `<Shell />` in `main.tsx`**
 per-tab boundary (`resetKeys={[active.id]}`) so one bad tab keeps the tab strip usable. The boundary
 detects failed dynamic imports (`isChunkLoadError`) and steers those to a page **reload** (re-fetches
 the chunk) rather than an in-place retry. Each region degrades independently — never the whole app.
+
+## Global chords (why a key handler lives this high up)
+
+A chord that must work "wherever the user is" cannot be an element's `onKeyDown` — that only fires while
+that element holds focus, and outside it the *browser* gets the keystroke. `useGlobalHotkeys` is the one
+place that owns such chords: a single window listener in the **capture** phase, so it sees the keystroke
+before any component does and can both `preventDefault` (deny the browser) and `stopPropagation` (deny
+duplicate handling downstream).
+
+Today that's **`Ctrl+R` → chat history search**. Previously handled only on the composer textarea, so
+with focus anywhere else — the file tree, Monaco, a diff, the transcript, bare `<body>` — the browser
+reloaded the app instead. It is deliberately *not* a browser-reserved chord (unlike `Ctrl+T`/`Ctrl+W`/
+`Ctrl+N`), so swallowing it works. Routing goes through the store (`selectActiveChatSessionId` →
+`requestHistoryOpen`), never a ref: the chord fires far outside the chat subtree, and `CenterTabs` mounts
+one tab body at a time, so the selector names the only `ChatView` there is. With a file tab active there
+is nothing to open and the chord is *only* swallowed.
+
+Two carve-outs, both load-bearing:
+- **Terminals.** A keydown from inside `.xterm` passes straight through — `Ctrl+R` there is the shell's
+  reverse-i-search and belongs to the PTY. (`.xterm` is xterm's own root class, not a hook of ours.)
+- **Reload stays reachable.** `Ctrl+Shift+R` (hard reload), `Cmd+R` (macOS), `F5` and the browser's own
+  reload button are all untouched. Swallowing a reload chord is only acceptable while another one works.
+
+The shell is the natural owner: it is the composition root, mounted exactly once for the app's lifetime,
+and it already owns the other app-scoped DOM side-effect (the theme).

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -13,6 +13,7 @@ import { WelcomePanel } from "../panels/WelcomePanel";
 import { selectActiveWorkspace, selectContextProject, useAppStore } from "../store";
 import { applyTheme, writeThemeHint } from "../themes";
 import type { ConnectionStatus } from "../transport";
+import { useGlobalHotkeys } from "./useGlobalHotkeys";
 
 const STATUS_LABEL: Record<ConnectionStatus, string> = {
 	connected: "Connected",
@@ -39,6 +40,8 @@ export function Shell() {
 		applyTheme(theme);
 		writeThemeHint(theme);
 	}, [theme]);
+	// App-wide chords the browser would otherwise take (`Ctrl+R` → history search, not a reload).
+	useGlobalHotkeys();
 	return (
 		<div data-testid="shell" className="grid h-full grid-rows-[auto_1fr]">
 			<header className="flex items-center justify-between border-b border-border2 bg-bg-dark px-lg py-sm">

--- a/apps/web/src/shell/useGlobalHotkeys.ts
+++ b/apps/web/src/shell/useGlobalHotkeys.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { selectActiveChatSessionId, useAppStore } from "../store";
+import { selectHistoryTarget, useAppStore } from "../store";
 
 /**
  * xterm's own DOM root. Everything the terminal renders (including the offscreen helper textarea that
@@ -30,9 +30,12 @@ function isInTerminal(target: EventTarget | null): boolean {
  *   by keyboard is always still possible — alongside `F5` and the browser's own reload button.
  *
  * Routing: the request goes through the store rather than a ref, because the chord fires far outside the
- * chat subtree. `CenterTabs` mounts one tab body at a time, so `selectActiveChatSessionId` names the only
- * `ChatView` that exists; with a file tab active there is nothing to open and the chord is *only*
- * swallowed (never a reload, never a stray overlay on a hidden chat).
+ * chat subtree. `selectHistoryTarget` resolves which chat it means — the active tab when that's a chat,
+ * else the workspace's most recently opened one — and `requestHistoryOpen` activates that tab atomically
+ * with the request, since `CenterTabs` mounts one tab body at a time and a request for an off-screen chat
+ * would never be consumed. So the chord works over Monaco, a diff, or the file tree, not just over a
+ * chat. Only a workspace with **no** chat tab at all has nothing to open; there the chord is purely
+ * swallowed (never a reload).
  */
 export function useGlobalHotkeys(): void {
 	useEffect(() => {
@@ -41,8 +44,8 @@ export function useGlobalHotkeys(): void {
 			if (isInTerminal(e.target)) return;
 			e.preventDefault();
 			e.stopPropagation();
-			const sessionId = selectActiveChatSessionId(useAppStore.getState());
-			if (sessionId) useAppStore.getState().requestHistoryOpen(sessionId);
+			const target = selectHistoryTarget(useAppStore.getState());
+			if (target) useAppStore.getState().requestHistoryOpen(target);
 		};
 		window.addEventListener("keydown", onKeyDown, true);
 		return () => window.removeEventListener("keydown", onKeyDown, true);

--- a/apps/web/src/shell/useGlobalHotkeys.ts
+++ b/apps/web/src/shell/useGlobalHotkeys.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { selectActiveChatSessionId, useAppStore } from "../store";
+
+/**
+ * xterm's own DOM root. Everything the terminal renders (including the offscreen helper textarea that
+ * actually receives keystrokes) lives under `.xterm`, so this is the library-native way to ask "is the
+ * user typing into a shell?" — a class xterm sets itself, not a hook of ours it could stop honouring.
+ */
+const TERMINAL_ROOT_SELECTOR = ".xterm";
+
+/** Whether a keydown originated inside a terminal, whose shell owns the raw chord. */
+function isInTerminal(target: EventTarget | null): boolean {
+	return target instanceof Element && target.closest(TERMINAL_ROOT_SELECTOR) !== null;
+}
+
+/**
+ * App-wide keyboard chords the browser would otherwise take.
+ *
+ * **`Ctrl+R` — history search, not a page reload.** The chat's own recall chord was handled only on the
+ * composer textarea, so with focus anywhere else (the file tree, Monaco, a diff, the transcript, plain
+ * `<body>`) the browser reloaded the app instead. `Ctrl+R` is not a browser-*reserved* chord the way
+ * `Ctrl+T`/`Ctrl+W`/`Ctrl+N` are, so a window listener can swallow it outright; this one does, in the
+ * **capture** phase, and additionally `stopPropagation`s so the chord has exactly one handler app-wide
+ * (the composer and the overlay no longer carry their own — see `chat/SPEC.md`).
+ *
+ * Deliberate exclusions:
+ * - **Terminals.** `Ctrl+R` in a shell is reverse-i-search; the chord belongs to the PTY, so a keydown
+ *   from inside `.xterm` passes straight through untouched.
+ * - **`Ctrl+Shift+R`** (hard reload) and **`Cmd+R`** (macOS reload) are left alone, so reloading the app
+ *   by keyboard is always still possible — alongside `F5` and the browser's own reload button.
+ *
+ * Routing: the request goes through the store rather than a ref, because the chord fires far outside the
+ * chat subtree. `CenterTabs` mounts one tab body at a time, so `selectActiveChatSessionId` names the only
+ * `ChatView` that exists; with a file tab active there is nothing to open and the chord is *only*
+ * swallowed (never a reload, never a stray overlay on a hidden chat).
+ */
+export function useGlobalHotkeys(): void {
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== "r" || !e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+			if (isInTerminal(e.target)) return;
+			e.preventDefault();
+			e.stopPropagation();
+			const sessionId = selectActiveChatSessionId(useAppStore.getState());
+			if (sessionId) useAppStore.getState().requestHistoryOpen(sessionId);
+		};
+		window.addEventListener("keydown", onKeyDown, true);
+		return () => window.removeEventListener("keydown", onKeyDown, true);
+	}, []);
+}

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -144,16 +144,19 @@ paths only; opened by `ChangesPanel`). The transient **`chatLocationRequest`** �
   `useHistorySearch.openMessage` loads the destination project's workspaces first when absent) and cleared
   by **`clearChatLocation()`**; the target's anchor resolves against the runtime's `turnIdByMessageIndex`
   (see `chat/SPEC.md`'s hydration bullet), falling back to the newest `anchorText` match when absent.
-  The sibling transient **`historyOpenRequest { sessionId }`** — set by **`requestHistoryOpen(sessionId)`**,
-  cleared by **`clearHistoryOpen()`** — carries the shell's app-wide `Ctrl+R` to the on-screen chat, which
-  opens (or, when already open, re-scopes) its history overlay; it goes through the store precisely because
-  the chord fires outside the chat subtree entirely (see `shell/SPEC.md`'s "Global chords"). The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
+  The sibling transient **`historyOpenRequest { sessionId }`** — set by **`requestHistoryOpen(target)`**,
+  cleared by **`clearHistoryOpen()`** — carries the shell's app-wide `Ctrl+R` to a chat, which opens (or,
+  when already open, re-scopes) its history overlay; it goes through the store precisely because the chord
+  fires outside the chat subtree entirely (see `shell/SPEC.md`'s "Global chords"). The target comes from
+  **`selectHistoryTarget`** (active chat tab, else the workspace's newest chat) and the action **activates
+  that tab atomically** with the request — one `set`, because `CenterTabs` mounts one tab body at a time,
+  so a request for an off-screen chat would never be consumed. The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
   `SessionRuntime` types. (Chat *render* types + renderers live in the `chat` module.) The pure context
   selectors in `selectors.ts` resolve the active `Workspace`, its owning project id, and the shell's context
   project from those canonical ids and collections; derived active-project state is never stored separately.
 - **Public surface (barrel):** `useAppStore`; `selectActiveWorkspace`,
-  `selectActiveWorkspaceProjectId`, `selectActiveChatSessionId` (the on-screen chat's session id, or null
-  when a file/diff/doc tab is active — the shell's `Ctrl+R` routing target),
+  `selectActiveWorkspaceProjectId`, `selectHistoryTarget` + `HistoryTarget` (the shell's `Ctrl+R` routing
+  target: the active chat tab, or the workspace's newest chat when a file/diff/doc tab is active),
   `selectContextProject`, `selectSkillsStale`, `selectWorkspaceTick` (the
   sync-baseline snapshot; + the `isSkillPath` path predicate it shares with `noteFsChanged`); `toast` (the
   fire-from-anywhere helper),

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -143,12 +143,18 @@ paths only; opened by `ChangesPanel`). The transient **`chatLocationRequest`** �
   can live in a different project/workspace than the one the search ran from — the caller
   `useHistorySearch.openMessage` loads the destination project's workspaces first when absent) and cleared
   by **`clearChatLocation()`**; the target's anchor resolves against the runtime's `turnIdByMessageIndex`
-  (see `chat/SPEC.md`'s hydration bullet), falling back to the newest `anchorText` match when absent. The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
+  (see `chat/SPEC.md`'s hydration bullet), falling back to the newest `anchorText` match when absent.
+  The sibling transient **`historyOpenRequest { sessionId }`** — set by **`requestHistoryOpen(sessionId)`**,
+  cleared by **`clearHistoryOpen()`** — carries the shell's app-wide `Ctrl+R` to the on-screen chat, which
+  opens (or, when already open, re-scopes) its history overlay; it goes through the store precisely because
+  the chord fires outside the chat subtree entirely (see `shell/SPEC.md`'s "Global chords"). The `EditorTab` (`FileTab` | `ChatTab` | `DocTab` | `DiffTab`) + `TerminalTab` + `ClosedChat` +
   `SessionRuntime` types. (Chat *render* types + renderers live in the `chat` module.) The pure context
   selectors in `selectors.ts` resolve the active `Workspace`, its owning project id, and the shell's context
   project from those canonical ids and collections; derived active-project state is never stored separately.
 - **Public surface (barrel):** `useAppStore`; `selectActiveWorkspace`,
-  `selectActiveWorkspaceProjectId`, `selectContextProject`, `selectSkillsStale`, `selectWorkspaceTick` (the
+  `selectActiveWorkspaceProjectId`, `selectActiveChatSessionId` (the on-screen chat's session id, or null
+  when a file/diff/doc tab is active — the shell's `Ctrl+R` routing target),
+  `selectContextProject`, `selectSkillsStale`, `selectWorkspaceTick` (the
   sync-baseline snapshot; + the `isSkillPath` path predicate it shares with `noteFsChanged`); `toast` (the
   fire-from-anywhere helper),
   `Toast` (type), `EditorTab` (`FileTab`/`ChatTab`/`DocTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` +

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -21,7 +21,7 @@ import type { LoginState } from "../auth";
 import type { HydratedRuntime } from "../chat/hydrate";
 import type { ChatTurn, ExtUiDialogRequest, ToolResultState } from "../chat/types";
 import type { ConnectionStatus } from "../transport";
-import { isSkillPath, selectWorkspaceTick } from "./selectors";
+import { type HistoryTarget, isSkillPath, selectWorkspaceTick } from "./selectors";
 
 /** A center tab. File tabs (Monaco) and chat tabs share the strip, discriminated by `kind`. */
 export interface FileTab {
@@ -641,8 +641,12 @@ interface AppState {
 	requestChatLocation: (req: ChatLocationRequest) => void;
 	/** Dismiss the jump deep link once `ChatView` has consumed it (scrolled to the anchored turn). */
 	clearChatLocation: () => void;
-	/** Ask `sessionId`'s chat to open its history-search overlay (the shell's global `Ctrl+R`). */
-	requestHistoryOpen: (sessionId: string) => void;
+	/**
+	 * Ask a chat to open its history-search overlay (the shell's global `Ctrl+R`). Activates the target
+	 * tab **atomically** with the request: the chord fires over any tab, and `CenterTabs` mounts one tab
+	 * body at a time, so a request for a chat that isn't on screen would never be consumed.
+	 */
+	requestHistoryOpen: (target: HistoryTarget) => void;
 	/** Dismiss the history-open request once `ChatView` has acted on it. */
 	clearHistoryOpen: () => void;
 	/** Enqueue a toast; returns its id so a caller can dismiss it early. An identical live toast (same
@@ -1288,7 +1292,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 			activeWorkspaceId: req.workspaceId,
 		}),
 	clearChatLocation: () => set({ chatLocationRequest: null }),
-	requestHistoryOpen: (sessionId) => set({ historyOpenRequest: { sessionId } }),
+	requestHistoryOpen: (target) =>
+		set((s) => ({
+			historyOpenRequest: { sessionId: target.sessionId },
+			activeTabByWorkspace: { ...s.activeTabByWorkspace, [target.workspaceId]: target.tabId },
+		})),
 	clearHistoryOpen: () => set({ historyOpenRequest: null }),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -458,6 +458,14 @@ interface AppState {
 	 */
 	chatLocationRequest: ChatLocationRequest | null;
 	/**
+	 * A request to open (or, when it is already open, re-trigger) the active chat's history-search
+	 * overlay, set by the shell's global `Ctrl+R` handler and consumed by that chat's `ChatView`. The
+	 * chord is swallowed app-wide (it would otherwise reload the page), so it fires with focus anywhere —
+	 * the file tree, an editor, the transcript — and this is how it reaches the one mounted `ChatView`.
+	 * A fresh object each call so a repeated chord still fires.
+	 */
+	historyOpenRequest: { sessionId: string } | null;
+	/**
 	 * The live-refresh signal, per workspace: `tick` increments on every `workspace.fsChanged` push (the
 	 * host's debounced worktree change notifier); `paths`/`truncated` are the LAST batch only. Panels
 	 * select their workspace's entry and silently refetch on `tick` change — the store holds only the
@@ -633,6 +641,10 @@ interface AppState {
 	requestChatLocation: (req: ChatLocationRequest) => void;
 	/** Dismiss the jump deep link once `ChatView` has consumed it (scrolled to the anchored turn). */
 	clearChatLocation: () => void;
+	/** Ask `sessionId`'s chat to open its history-search overlay (the shell's global `Ctrl+R`). */
+	requestHistoryOpen: (sessionId: string) => void;
+	/** Dismiss the history-open request once `ChatView` has acted on it. */
+	clearHistoryOpen: () => void;
 	/** Enqueue a toast; returns its id so a caller can dismiss it early. An identical live toast (same
 	 * variant/title/message — e.g. a retried failure) coalesces: no twin is added, the existing id returns.
 	 * The queue caps at `MAX_TOASTS` (oldest drop). Prefer the `toast` helper. */
@@ -728,6 +740,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	changesRequest: null,
 	changesView: "list",
 	chatLocationRequest: null,
+	historyOpenRequest: null,
 	fsChangesByWorkspace: {},
 	skillChangeTickByWorkspace: {},
 	skillsSyncedTickBySession: {},
@@ -1275,6 +1288,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 			activeWorkspaceId: req.workspaceId,
 		}),
 	clearChatLocation: () => set({ chatLocationRequest: null }),
+	requestHistoryOpen: (sessionId) => set({ historyOpenRequest: { sessionId } }),
+	clearHistoryOpen: () => set({ historyOpenRequest: null }),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(
 			(t) => t.variant === toast.variant && t.title === toast.title && t.message === toast.message,

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -3,10 +3,10 @@ import type { Project, Workspace } from "@thinkrail/contracts";
 import type { EditorTab } from "./appStore";
 import {
 	isSkillPath,
-	selectActiveChatSessionId,
 	selectActiveWorkspace,
 	selectActiveWorkspaceProjectId,
 	selectContextProject,
+	selectHistoryTarget,
 	selectSkillsStale,
 } from "./selectors";
 
@@ -100,61 +100,77 @@ test("selectSkillsStale is a strict tick comparison, defaulting missing ticks to
 	).toBe(false);
 });
 
-// The shell's global Ctrl+R routes its history-open request by session id, so "which chat is on screen"
-// has to be answerable from store state alone — a file/diff/doc tab (or none) must resolve to null rather
-// than to some other workspace's chat.
-test("selectActiveChatSessionId names the on-screen chat, and only a chat", () => {
-	const chat: EditorTab = {
-		kind: "chat",
-		id: "w2:s1",
-		workspaceId: "w2",
-		name: "Chat",
-		sessionId: "s1",
-	};
-	const file: EditorTab = {
-		kind: "file",
-		id: "w2:src/a.ts",
-		workspaceId: "w2",
-		name: "a.ts",
-		path: "src/a.ts",
-	};
-	const tabsByWorkspace = { w2: [chat, file] };
+// The shell swallows Ctrl+R app-wide, so "which chat did that mean" has to be answerable from store state
+// alone — and must resolve to SOMETHING whenever the workspace has a chat at all, or the chord silently
+// dies over a file/diff tab.
+const chat1: EditorTab = {
+	kind: "chat",
+	id: "w2:s1",
+	workspaceId: "w2",
+	name: "One",
+	sessionId: "s1",
+};
+const chat2: EditorTab = {
+	kind: "chat",
+	id: "w2:s2",
+	workspaceId: "w2",
+	name: "Two",
+	sessionId: "s2",
+};
+const fileTab: EditorTab = {
+	kind: "file",
+	id: "w2:src/a.ts",
+	workspaceId: "w2",
+	name: "a.ts",
+	path: "src/a.ts",
+};
 
+test("selectHistoryTarget prefers the active chat tab", () => {
 	expect(
-		selectActiveChatSessionId({
+		selectHistoryTarget({
 			activeWorkspaceId: "w2",
-			tabsByWorkspace,
+			tabsByWorkspace: { w2: [chat1, chat2, fileTab] },
 			activeTabByWorkspace: { w2: "w2:s1" },
 		}),
-	).toBe("s1");
-	// A file tab is active → no chat on screen.
+	).toEqual({ workspaceId: "w2", tabId: "w2:s1", sessionId: "s1" });
+});
+
+test("selectHistoryTarget falls back to the newest chat tab when a non-chat tab is active", () => {
+	// The regression this guards: returning null here made Ctrl+R a silent no-op over Monaco/diffs —
+	// exactly the tabs the app-wide swallow exists to cover. `chat2` is last in open order, so it wins.
+	for (const activeTabId of ["w2:src/a.ts", null]) {
+		expect(
+			selectHistoryTarget({
+				activeWorkspaceId: "w2",
+				tabsByWorkspace: { w2: [chat1, chat2, fileTab] },
+				activeTabByWorkspace: { w2: activeTabId },
+			}),
+		).toEqual({ workspaceId: "w2", tabId: "w2:s2", sessionId: "s2" });
+	}
+});
+
+test("selectHistoryTarget is null only with no chat to open", () => {
+	// No chat tab in the workspace at all.
 	expect(
-		selectActiveChatSessionId({
+		selectHistoryTarget({
 			activeWorkspaceId: "w2",
-			tabsByWorkspace,
+			tabsByWorkspace: { w2: [fileTab] },
 			activeTabByWorkspace: { w2: "w2:src/a.ts" },
 		}),
 	).toBeNull();
-	// No active tab, and no active workspace at all.
+	// No active workspace.
 	expect(
-		selectActiveChatSessionId({
-			activeWorkspaceId: "w2",
-			tabsByWorkspace,
-			activeTabByWorkspace: { w2: null },
-		}),
-	).toBeNull();
-	expect(
-		selectActiveChatSessionId({
+		selectHistoryTarget({
 			activeWorkspaceId: null,
-			tabsByWorkspace,
+			tabsByWorkspace: { w2: [chat1] },
 			activeTabByWorkspace: { w2: "w2:s1" },
 		}),
 	).toBeNull();
-	// The active tab belongs to another workspace's list — never reachable through the active one.
+	// Another workspace's chats are never reachable through the active one.
 	expect(
-		selectActiveChatSessionId({
+		selectHistoryTarget({
 			activeWorkspaceId: "w1",
-			tabsByWorkspace,
+			tabsByWorkspace: { w2: [chat1] },
 			activeTabByWorkspace: { w1: "w2:s1" },
 		}),
 	).toBeNull();

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
 import type { Project, Workspace } from "@thinkrail/contracts";
+import type { EditorTab } from "./appStore";
 import {
 	isSkillPath,
+	selectActiveChatSessionId,
 	selectActiveWorkspace,
 	selectActiveWorkspaceProjectId,
 	selectContextProject,
@@ -96,4 +98,64 @@ test("selectSkillsStale is a strict tick comparison, defaulting missing ticks to
 	expect(
 		selectSkillsStale({ skillChangeTickByWorkspace: {}, skillsSyncedTickBySession: {} }, "w", "s"),
 	).toBe(false);
+});
+
+// The shell's global Ctrl+R routes its history-open request by session id, so "which chat is on screen"
+// has to be answerable from store state alone — a file/diff/doc tab (or none) must resolve to null rather
+// than to some other workspace's chat.
+test("selectActiveChatSessionId names the on-screen chat, and only a chat", () => {
+	const chat: EditorTab = {
+		kind: "chat",
+		id: "w2:s1",
+		workspaceId: "w2",
+		name: "Chat",
+		sessionId: "s1",
+	};
+	const file: EditorTab = {
+		kind: "file",
+		id: "w2:src/a.ts",
+		workspaceId: "w2",
+		name: "a.ts",
+		path: "src/a.ts",
+	};
+	const tabsByWorkspace = { w2: [chat, file] };
+
+	expect(
+		selectActiveChatSessionId({
+			activeWorkspaceId: "w2",
+			tabsByWorkspace,
+			activeTabByWorkspace: { w2: "w2:s1" },
+		}),
+	).toBe("s1");
+	// A file tab is active → no chat on screen.
+	expect(
+		selectActiveChatSessionId({
+			activeWorkspaceId: "w2",
+			tabsByWorkspace,
+			activeTabByWorkspace: { w2: "w2:src/a.ts" },
+		}),
+	).toBeNull();
+	// No active tab, and no active workspace at all.
+	expect(
+		selectActiveChatSessionId({
+			activeWorkspaceId: "w2",
+			tabsByWorkspace,
+			activeTabByWorkspace: { w2: null },
+		}),
+	).toBeNull();
+	expect(
+		selectActiveChatSessionId({
+			activeWorkspaceId: null,
+			tabsByWorkspace,
+			activeTabByWorkspace: { w2: "w2:s1" },
+		}),
+	).toBeNull();
+	// The active tab belongs to another workspace's list — never reachable through the active one.
+	expect(
+		selectActiveChatSessionId({
+			activeWorkspaceId: "w1",
+			tabsByWorkspace,
+			activeTabByWorkspace: { w1: "w2:s1" },
+		}),
+	).toBeNull();
 });

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,4 +1,5 @@
 import type { Project, Workspace } from "@thinkrail/contracts";
+import type { EditorTab } from "./appStore";
 
 interface ActiveWorkspaceState {
 	activeWorkspaceId: string | null;
@@ -29,6 +30,24 @@ export function selectActiveWorkspaceProjectId(state: ActiveWorkspaceState): str
 export function selectContextProject(state: ProjectContextState): Project | null {
 	const projectId = selectActiveWorkspace(state)?.projectId ?? state.selectedProjectId;
 	return state.projects.find((project) => project.id === projectId) ?? null;
+}
+
+/**
+ * The session id of the chat currently rendered in the center pane, or null when the active tab is a
+ * file/diff/doc (or there is none). `CenterTabs` mounts exactly one tab body at a time, so this is also
+ * "the one `ChatView` that exists" — which is what the shell's global `Ctrl+R` routes its history-open
+ * request to.
+ */
+export function selectActiveChatSessionId(state: {
+	activeWorkspaceId: string | null;
+	tabsByWorkspace: Record<string, EditorTab[]>;
+	activeTabByWorkspace: Record<string, string | null>;
+}): string | null {
+	const workspaceId = state.activeWorkspaceId;
+	if (!workspaceId) return null;
+	const activeTabId = state.activeTabByWorkspace[workspaceId] ?? null;
+	const tab = (state.tabsByWorkspace[workspaceId] ?? []).find((t) => t.id === activeTabId);
+	return tab?.kind === "chat" ? tab.sessionId : null;
 }
 
 /** Whether a worktree-relative path is inside a skill directory — the auto-detect trigger for a reload. */

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -32,22 +32,39 @@ export function selectContextProject(state: ProjectContextState): Project | null
 	return state.projects.find((project) => project.id === projectId) ?? null;
 }
 
+/** Where the shell's global `Ctrl+R` sends its history-open request — see `selectHistoryTarget`. */
+export interface HistoryTarget {
+	workspaceId: string;
+	/** The chat tab to make active (already active in the common case). */
+	tabId: string;
+	sessionId: string;
+}
+
 /**
- * The session id of the chat currently rendered in the center pane, or null when the active tab is a
- * file/diff/doc (or there is none). `CenterTabs` mounts exactly one tab body at a time, so this is also
- * "the one `ChatView` that exists" — which is what the shell's global `Ctrl+R` routes its history-open
- * request to.
+ * The chat the active workspace's history search belongs to: the active tab when it *is* a chat,
+ * otherwise the workspace's most recently opened one. Null only when the workspace has no chat tab at
+ * all (or there's no active workspace) — the one case where `Ctrl+R` has nothing to open.
+ *
+ * The fallback is the point. `CenterTabs` mounts one tab body at a time, so with a file/diff/doc tab
+ * active there is no `ChatView` to route to — and since the chord is swallowed app-wide, resolving to
+ * "no target" there would make `Ctrl+R` silently do *nothing* over Monaco, a diff, or the file tree:
+ * precisely the places the global handler exists to cover. Returning the chat tab (which the caller
+ * activates, atomically with the request) means the chord always lands somewhere.
  */
-export function selectActiveChatSessionId(state: {
+export function selectHistoryTarget(state: {
 	activeWorkspaceId: string | null;
 	tabsByWorkspace: Record<string, EditorTab[]>;
 	activeTabByWorkspace: Record<string, string | null>;
-}): string | null {
+}): HistoryTarget | null {
 	const workspaceId = state.activeWorkspaceId;
 	if (!workspaceId) return null;
+	const tabs = state.tabsByWorkspace[workspaceId] ?? [];
 	const activeTabId = state.activeTabByWorkspace[workspaceId] ?? null;
-	const tab = (state.tabsByWorkspace[workspaceId] ?? []).find((t) => t.id === activeTabId);
-	return tab?.kind === "chat" ? tab.sessionId : null;
+	const active = tabs.find((t) => t.id === activeTabId);
+	// `findLast`, not `find`: tabs are appended in open order, so the last chat tab is the most recently
+	// opened one — the best "which chat did they mean" answer available without an MRU we don't track.
+	const chat = active?.kind === "chat" ? active : tabs.findLast((t) => t.kind === "chat");
+	return chat ? { workspaceId, tabId: chat.id, sessionId: chat.sessionId } : null;
 }
 
 /** Whether a worktree-relative path is inside a skill directory — the auto-detect trigger for a reload. */

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject, openWorkspaceChat } from "./fixtures/app";
+import {
+	createWorkspaceViaDialog,
+	openFixtureProject,
+	openTerminal,
+	openWorkspaceChat,
+	visibleTerminal,
+	visibleTerminalScreen,
+} from "./fixtures/app";
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
 
 // No-agent (see composer.live.spec.ts for the @agent-tagged composer suite): the Ctrl+R history-recall
@@ -692,4 +699,106 @@ test("the scope badge opens a picker that selects a scope directly without distu
 	// Ctrl+R still cycles after the mouse pick — from "all" it wraps forward to "chat".
 	await query.press("Control+r");
 	await expect(scopeBadge).toHaveAttribute("data-scope", "chat");
+});
+
+// The chord and the dismissal both had exactly one handler, and both were bound to a single element —
+// `Ctrl+R` to the composer textarea, `Escape` to the overlay's query input. So with focus anywhere else
+// the browser reloaded the page on Ctrl+R, and an overlay whose input had lost focus (a click back into
+// the composer, an errant click on the page) could not be dismissed by keyboard at all. Both are now
+// owned centrally: `shell/useGlobalHotkeys` swallows Ctrl+R app-wide and routes it, and the overlay
+// registers a window-level Escape while it is open.
+//
+// One caveat this suite cannot assert: that the *browser* no longer reloads. Playwright's synthetic
+// key events are delivered to the renderer and never reach Chromium's own shortcut layer, so Ctrl+R in a
+// test never reloaded in the first place. What is covered here is the functional half — the chord being
+// seen, and acted on, from outside the composer.
+test("Ctrl+R and Escape are owned app-wide: both work with focus outside the composer", async ({
+	page,
+}) => {
+	await openWorkspaceChat(page);
+	seedExternalCwdSessions();
+
+	const input = page.getByTestId("chat-input");
+	const overlay = page.getByTestId("history-overlay");
+	const query = page.getByTestId("history-query");
+	const scopeBadge = page.getByTestId("history-scope");
+	// An inert bit of the topbar — clicking it parks focus well outside the chat subtree without
+	// triggering anything.
+	const outside = page.getByTestId("scope-context");
+
+	// Ctrl+R with focus outside the chat opens the overlay and focuses its query, exactly as the chord
+	// from inside the composer does.
+	await outside.click();
+	await page.keyboard.press("Control+r");
+	await expect(overlay).toBeVisible();
+	await expect(query).toBeFocused();
+
+	// Escape with focus back in the composer — the reported bug: the overlay used to stay open forever.
+	await input.click();
+	await page.keyboard.press("Escape");
+	await expect(overlay).toBeHidden();
+
+	// Escape with focus nowhere in particular closes it too — and lands focus back in the prompt field,
+	// so typing just continues. (Without the refocus, closing unmounts the query input and focus falls to
+	// `<body>`: the overlay is gone but every keystroke after it is silently dropped.)
+	await page.keyboard.press("Control+r");
+	await expect(overlay).toBeVisible();
+	await outside.click();
+	await page.keyboard.press("Escape");
+	await expect(overlay).toBeHidden();
+	await expect(input).toBeFocused();
+	await page.keyboard.type("still typing");
+	await expect(input).toHaveValue("still typing");
+
+	// …and the caret comes back where it was, not at the end: park it mid-draft, round-trip the overlay,
+	// and the next keystrokes land at that same spot.
+	await input.click();
+	await page.keyboard.press("Home");
+	await page.keyboard.press("Control+r");
+	await expect(overlay).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(input).toBeFocused();
+	await page.keyboard.type("i am ");
+	await expect(input).toHaveValue("i am still typing");
+	await input.fill("");
+
+	// While the overlay is open, Ctrl+R still means "cycle the scope" — including from outside it, since
+	// the chord no longer depends on the query input holding focus.
+	await page.keyboard.press("Control+r");
+	await expect(scopeBadge).toHaveAttribute("data-scope", "workspace");
+	await outside.click();
+	await page.keyboard.press("Control+r");
+	await expect(scopeBadge).toHaveAttribute("data-scope", "project");
+
+	// Escape dismisses the INNERMOST layer: with the scope picker open it closes just the menu, leaving
+	// the overlay up. The window-level handler stands down while that menu is open, so Radix's own
+	// Escape is the only one that fires.
+	await scopeBadge.click();
+	await expect(page.getByTestId("history-scope-option")).toHaveCount(4);
+	await page.keyboard.press("Escape");
+	await expect(page.getByTestId("history-scope-option")).toHaveCount(0);
+	await expect(overlay).toBeVisible();
+	// The next Escape closes the overlay itself.
+	await page.keyboard.press("Escape");
+	await expect(overlay).toBeHidden();
+});
+
+// The one deliberate hole in the app-wide Ctrl+R swallow: inside a terminal the chord is the shell's
+// reverse-i-search and belongs to the PTY, so the global handler passes it straight through. The chat
+// tab is still the active center tab throughout (terminals are their own panel), so this is exactly the
+// case where the exclusion has to hold rather than a case where routing had nothing to do anyway.
+test("Ctrl+R inside a terminal belongs to the shell, not to history search", async ({ page }) => {
+	await openWorkspaceChat(page);
+	seedExternalCwdSessions();
+
+	await openTerminal(page);
+	await visibleTerminal(page).locator(".xterm-helper-textarea").focus();
+	await page.keyboard.press("Control+r");
+
+	// No overlay — and the byte really reached the PTY: depending on what the CI/dev machine's login
+	// shell binds `^R` to, the screen shows either its reverse-search prompt (`bck-i-search`/
+	// `reverse-i-search`) or the literal `^R` echo. Either way the keystroke was the shell's, not ours;
+	// asserting only "no overlay" would also pass if the chord had been swallowed and dropped.
+	await expect(page.getByTestId("history-overlay")).toBeHidden();
+	await expect(visibleTerminalScreen(page)).toContainText(/i-search|\^R/i);
 });

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -802,3 +802,35 @@ test("Ctrl+R inside a terminal belongs to the shell, not to history search", asy
 	await expect(page.getByTestId("history-overlay")).toBeHidden();
 	await expect(visibleTerminalScreen(page)).toContainText(/i-search|\^R/i);
 });
+
+// The Air review's blocking finding: routing that resolves only "the active tab, if it's a chat" makes the
+// app-wide swallow *worse* than the bug it fixes over a file/diff tab — Ctrl+R is prevented, nothing opens,
+// and the shortcut silently dies exactly where Monaco and diffs live. The target now falls back to the
+// workspace's most recently opened chat and the request activates that tab atomically with itself.
+test("Ctrl+R from an active file tab switches to the chat and opens history search", async ({
+	page,
+}) => {
+	await openWorkspaceChat(page);
+	seedExternalCwdSessions();
+
+	// Open a file tab on top of the chat, so the center pane is Monaco/preview and no ChatView is mounted.
+	await page.getByTestId("tab-files").click();
+	const readme = page.getByTestId("file-node").filter({ hasText: "README.md" });
+	await expect(readme).toBeVisible();
+	await readme.dblclick();
+	const fileTab = page.getByTestId("editor-tab").filter({ hasText: "README.md" });
+	await expect(fileTab).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("chat-input")).toHaveCount(0);
+
+	// Ctrl+R with the file tab active (focus in the editor pane, not any chat surface).
+	await page.getByTestId("editor-pane").click();
+	await page.keyboard.press("Control+r");
+
+	// The chat tab is active again and its overlay is up, focused and ready to type.
+	await expect(page.getByTestId("editor-tab").filter({ hasText: "README.md" })).toHaveAttribute(
+		"data-active",
+		"false",
+	);
+	await expect(page.getByTestId("history-overlay")).toBeVisible();
+	await expect(page.getByTestId("history-query")).toBeFocused();
+});

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -417,4 +417,49 @@ test.describe("prompt templates in the composer", () => {
 		await expect(bubble).toBeVisible();
 		expect(await bubble.textContent()).toBe("Review for issues, focusing on src/.");
 	});
+
+	// Escape means "close the topmost floating panel", not "reset everything the composer is doing". The
+	// history overlay's dismissal is a window-level capture handler that `stopPropagation`s (it has to be
+	// window-level — focus is rarely on its query input by then; see `chat/SPEC.md`'s chord-ownership
+	// bullet), so this pins the other half of that contract: the keystroke that closes the overlay must
+	// not also reach the composer's own Escape branch and tear down an active slot session.
+	test("Escape closes the history overlay without ending an active slot session", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rev");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		const hint = page.getByTestId("slot-hint");
+		await expect(hint).toContainText("slot 1/2");
+		const draft = await input.inputValue();
+
+		// Ctrl+R over the live slot session, then Escape.
+		await page.keyboard.press("Control+r");
+		const overlay = page.getByTestId("history-overlay");
+		await expect(overlay).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(overlay).toBeHidden();
+
+		// Overlay gone, slot session intact (draft untouched, still on slot 1/2) — and the dismissal handed
+		// focus back to the prompt field with the slot's MARKER re-selected, not a collapsed caret: typing
+		// still replaces the whole `⟨file⟩`, exactly as it would have before the overlay interrupted.
+		await expect(input).toHaveValue(draft);
+		await expect(hint).toContainText("slot 1/2");
+		await expect(input).toBeFocused();
+		const restored = await readSelection(input);
+		expect(restored.value.slice(restored.start, restored.end)).toBe("⟨file⟩");
+		await page.keyboard.type("watcher.ts");
+		await expect(input).toHaveValue(/^Review watcher\.ts for issues, focusing on src\/\.\s*$/);
+
+		// Tab still steps the session.
+		await input.press("Tab");
+		await expect(hint).toContainText("slot 2/2");
+
+		// A second Escape — now with no overlay above it — is the composer's own, and ends the session.
+		await input.press("Escape");
+		await expect(hint).toHaveCount(0);
+		await input.fill("");
+	});
 });

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -38,6 +38,10 @@ test.describe("prompt templates in the composer", () => {
 		const rows = page.locator('[data-testid="slash-command"][data-source="prompt"]');
 		await expect(rows).toHaveCount(1);
 		await expect(rows.first()).toContainText("/review");
+		// Air review: the "no templates yet" nudge must never appear on this — the very first `/` open of a
+		// chat that HAS templates. It keys on a resolved-empty `template.list`, not on the merged command
+		// list, which is equally empty before that first response lands (and after a failed one).
+		await expect(page.getByTestId("slash-templates-empty")).toHaveCount(0);
 
 		// Picking replaces the draft with the expanded body — the unfilled `$1` became a visible `⟨file⟩`
 		// marker, `${2:-src/}` became its own default text "src/" — and starts a slot session on slot 1/2.

--- a/e2e/templates-manage.spec.ts
+++ b/e2e/templates-manage.spec.ts
@@ -18,14 +18,17 @@ import {
 // invalidates `ChatView`'s cached fetch rather than just exercising the settings panel in isolation.
 test.describe("templates management", () => {
 	// R4 (design doc "Amendments (2026-07-22)" item 4): when the Global group's list is empty, the panel
-	// offers to seed four starter templates instead of the bare "No templates yet." — one click creates
-	// all four, sequentially, via the same `template.save` wire call the editor dialog uses.
+	// offers to seed the starter templates instead of the bare "No templates yet." — one click creates
+	// them all, sequentially, via the same `template.save` wire call the editor dialog uses. The set is
+	// the same five this repo checks into its own `.pi/prompts/` (see `STARTER_TEMPLATES`), so an install
+	// working on any other project gets what a ThinkRail checkout gets for free at project scope.
 	//
 	// Deliberately the FIRST test in this file: Playwright preserves declaration order within a file
 	// (`fullyParallel: false`, `workers: 1`, see playwright.config.ts), and this file is the only place
 	// anything ever adds to the Global group (`templates-compose.spec.ts` only reads the fixtures below;
 	// no other spec touches templates at all) — so running first guarantees neither "standup" (created and
-	// deleted by the test below) nor "foo" (created, and left, by the shadowing test below) exists yet.
+	// deleted by the test below; deliberately NOT one of the starters, so the two can't collide) nor "foo"
+	// (created, and left, by the shadowing test below) exists yet.
 	// `globalSetup` seeds four Global fixtures once for the whole run and `resetState` never wipes
 	// `prompts/` (see `fixtures/templates.ts`), so the Global group is otherwise never empty during the
 	// suite — manufacturing that condition means removing those four ourselves first. Restores them (and
@@ -45,8 +48,17 @@ test.describe("templates management", () => {
 		// content — a thrown assertion between the clear above and the restore below would otherwise leave
 		// the shared `prompts/` dir permanently short those fixtures for every test that runs after this one.
 		try {
-			await page.getByTestId("open-settings").click();
-			await page.getByTestId("settings-nav-templates").click();
+			// The `/` menu's own empty-state nudge — the discoverability half of the same problem the
+			// starter offer solves: with no templates anywhere, the manager is two clicks deep in Settings
+			// and nothing in the composer says it exists. Doubles as this test's way IN to the Templates
+			// panel (one gesture instead of the gear + nav clicks), which also pins that it deep-links to
+			// the right section.
+			const input = page.getByTestId("chat-input");
+			await input.fill("/");
+			const nudge = page.getByTestId("slash-templates-empty");
+			await expect(nudge).toBeVisible();
+			await nudge.click();
+
 			const settingsDialog = page.getByTestId("settings-dialog");
 			await expect(settingsDialog).toContainText("Prompt templates");
 
@@ -56,8 +68,8 @@ test.describe("templates management", () => {
 			await expect(offer).toBeVisible();
 
 			await offer.click();
-			await expect(globalRows).toHaveCount(4);
-			for (const name of ["review", "explain", "tests", "standup"]) {
+			await expect(globalRows).toHaveCount(5);
+			for (const name of ["review", "explain", "tests", "commit", "rename"]) {
 				await expect(
 					page.locator(`[data-testid="template-row"][data-name="${name}"][data-scope="global"]`),
 				).toBeVisible();
@@ -70,18 +82,19 @@ test.describe("templates management", () => {
 
 			// The freshly-added "review" starter (not the fixture of the same name — that one was removed
 			// above) shows up in the composer's `/` menu, same as any other template would.
-			const input = page.getByTestId("chat-input");
 			await input.fill("/rev");
 			await expect(
 				page
 					.locator('[data-testid="slash-command"][data-source="prompt"]')
 					.filter({ hasText: "review" }),
 			).toHaveCount(1);
+			// …and the nudge is gone with it — a menu that has templates to offer never shows it.
+			await expect(nudge).toHaveCount(0);
 			await input.fill("");
 		} finally {
-			// Restore: remove the four starters this test added, then put the original four fixtures
+			// Restore: remove the five starters this test added, then put the original four fixtures
 			// back — always, even if an assertion above threw.
-			removeGlobalTemplates(["review", "explain", "tests", "standup"]);
+			removeGlobalTemplates(["review", "explain", "tests", "commit", "rename"]);
 			seedTemplateFixtures();
 		}
 	});


### PR DESCRIPTION
Three post-merge fixes to chat search (#109) + templates (#110), all reported against the merged UI.

### 1. `Ctrl+R` reloaded the page
Handled only on the composer textarea, so with focus anywhere else — file tree, Monaco, a diff, the transcript, bare `<body>` — the browser got the chord. Now owned by **`shell/useGlobalHotkeys`**: a window capture-phase listener that swallows it (`preventDefault` + `stopPropagation`, exactly one handler app-wide) and routes it via `store.requestHistoryOpen` → `selectActiveChatSessionId` to the one mounted `ChatView`, which opens the overlay through the composer's new `openHistory` handle — or cycles the scope if it's already open. The composer's and the overlay's own `Ctrl+R` branches are gone.

Carve-outs: a keydown from inside `.xterm` passes through untouched (reverse-i-search belongs to the PTY), and `Ctrl+Shift+R` / `Cmd+R` / `F5` still reload.

### 2. `Esc` didn't exit search
Bound to the overlay's query `<input>` alone, so the moment focus left it (a click back into the composer, a row's icon button) there was no keyboard dismissal at all. `HistoryOverlay` now registers a window capture-phase Escape while open; capture + `stopPropagation` encodes "topmost floating panel closes first", so a live slot session survives. The scope picker became a controlled Radix menu (`scopeMenuOpen`) purely so the handler stands down while it's up and Radix closes just the menu.

Dismissal also **hands focus back to the prompt field** — caret where it was, or the current slot's marker re-selected. Closing unmounts the query input, which would otherwise strand focus on `<body>` and silently drop every keystroke after Escape.

### 3. No pre-defined templates
The five in `.pi/prompts/` are *project*-scoped, so only a ThinkRail checkout sees them; the global dir is empty on a fresh install and the starter offer is two clicks deep in Settings. Kept opt-in (no auto-writing to the user's `~/.pi/agent/prompts` — that's their pi CLI config too), fixed discoverability instead:
- Starter set now **matches the repo's five** (adds `commit` + `rename`, drops `standup`) — one meaning for "the templates ThinkRail ships".
- The composer's `/` menu grows a `slash-templates-empty` footer nudge deep-linking to Settings → Templates when no template exists anywhere. Gated on "none exist", not "this query matched none".

### Verification
`bun run e2e` — **97/97** green, including three new specs: the chords from outside the composer (plus caret-preserving refocus), the terminal carve-out, and a slot session surviving dismissal. Plus a `selectActiveChatSessionId` unit test. `lint` / `typecheck` / `test` / `check:deps` / `check:seams` clean; zero suppressions added.

Specs led the code: new "Global chords" section in `shell/SPEC.md`, chord-ownership bullet in `chat/SPEC.md`, plus `store/SPEC.md` and `panels/SPEC.md`.

**One caveat:** the suite can't prove the browser no longer reloads — Playwright's synthetic key events never reach Chromium's shortcut layer, so `Ctrl+R` never reloaded in a test to begin with. Covered here is the functional half; worth one manual check in a real browser.