### PR TITLE
feat(analytics): anonymous usage analytics — backend-side PostHog via posthog-node

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -66,14 +66,18 @@ module whose from-source default is `0.0.0-dev`) in the throwaway CI checkout be
 the compiled binary reports the real `{version, channel, commit}`. It surfaces via `thinkrail --version`
 and, threaded `apps/cli` → `bootHost` → `createServer`, in the `server.welcome` push
 (`ServerWelcome.appVersion`, an optional field — non-breaking, no `PROTOCOL_VERSION` bump). See
-`module-cli`.
+`module-cli`. **`apps/cli/src/analytics-keys.ts` rides the same seam**: stamped from the
+`THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` repo secrets (passed by `_build.yml`,
+skipped when absent — forks/PR builds keep the committed empty keys, so their binaries never send;
+see `submodule-server-analytics`).
 
 ## Parts
 
 - `CODEOWNERS` — every path is owned by @rsolmano, @danyaberezun, @OLavrik; the `main` ruleset's
   pull-request rule (`require_code_owner_review`) makes an approval from one of them required to merge.
 - `scripts/next-version.sh` — channel-aware semver from tags; carries a `--tags=` override for testing.
-- `actions/build-binary` — the release build step: `build:web` → stamp `version.ts` → `build-binary.ts
+- `actions/build-binary` — the release build step: `build:web` → stamp `version.ts` (+
+  `analytics-keys.ts` when the GA4 secrets are provided) → `build-binary.ts
   --target` → resolve artifact path → native `smoke:binary`. (The Bun replacement for the old repo's
   PyInstaller action.)
 - `actions/make-checksums` — writes `SHA256SUMS` over the release artifacts.

--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -67,9 +67,9 @@ the compiled binary reports the real `{version, channel, commit}`. It surfaces v
 and, threaded `apps/cli` → `bootHost` → `createServer`, in the `server.welcome` push
 (`ServerWelcome.appVersion`, an optional field — non-breaking, no `PROTOCOL_VERSION` bump). See
 `module-cli`. **`apps/cli/src/analytics-keys.ts` rides the same seam**: stamped from the
-`THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` repo secrets (passed by `_build.yml`,
-skipped when absent — forks/PR builds keep the committed empty keys, so their binaries never send;
-see `submodule-server-analytics`).
+`THINKRAIL_POSTHOG_API_KEY` repo secret (passed by `_build.yml`, skipped when absent — forks/PR
+builds keep the committed empty key, so their binaries never send; see
+`submodule-server-analytics`).
 
 ## Parts
 
@@ -77,7 +77,7 @@ see `submodule-server-analytics`).
   pull-request rule (`require_code_owner_review`) makes an approval from one of them required to merge.
 - `scripts/next-version.sh` — channel-aware semver from tags; carries a `--tags=` override for testing.
 - `actions/build-binary` — the release build step: `build:web` → stamp `version.ts` (+
-  `analytics-keys.ts` when the GA4 secrets are provided) → `build-binary.ts
+  `analytics-keys.ts` when the PostHog secret is provided) → `build-binary.ts
   --target` → resolve artifact path → native `smoke:binary`. (The Bun replacement for the old repo's
   PyInstaller action.)
 - `actions/make-checksums` — writes `SHA256SUMS` over the release artifacts.

--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -14,12 +14,8 @@ inputs:
   target:
     description: "Bun compile target for this runner (e.g. bun-darwin-arm64 / bun-windows-x64)"
     required: true
-  ga4-measurement-id:
-    description: "GA4 measurement id for anonymous usage analytics (empty: keys stay unbaked — noop sink)"
-    required: false
-    default: ""
-  ga4-api-secret:
-    description: "GA4 Measurement Protocol api_secret (empty: keys stay unbaked — noop sink)"
+  posthog-api-key:
+    description: "PostHog project API key for anonymous usage analytics (empty: key stays unbaked — noop sink)"
     required: false
     default: ""
 
@@ -55,23 +51,21 @@ runs:
         echo "Stamped apps/cli/src/version.ts:"
         cat apps/cli/src/version.ts
 
-    # Same seam as version.ts: bake the GA4 keys into the throwaway checkout before compiling. Skipped
-    # when the secrets are absent (forks, PR CI) — the committed empty defaults stay, the binary's host
-    # lands on the noop sink and never sends (see packages/server/src/analytics/SPEC.md).
-    - name: Stamp analytics keys into the CLI
-      if: inputs.ga4-measurement-id != '' && inputs.ga4-api-secret != ''
+    # Same seam as version.ts: bake the PostHog key into the throwaway checkout before compiling.
+    # Skipped when the secret is absent (forks, PR CI) — the committed empty default stays, the
+    # binary's host lands on the noop sink and never sends (see packages/server/src/analytics/SPEC.md).
+    - name: Stamp analytics key into the CLI
+      if: inputs.posthog-api-key != ''
       shell: bash
       env:
-        GA4_MEASUREMENT_ID: ${{ inputs.ga4-measurement-id }}
-        GA4_API_SECRET: ${{ inputs.ga4-api-secret }}
+        POSTHOG_API_KEY: ${{ inputs.posthog-api-key }}
       run: |
         set -eu
         cat > apps/cli/src/analytics-keys.ts <<EOF
         // Stamped at release time by .github/actions/build-binary. Do not commit this edit.
-        export const ga4MeasurementId = "${GA4_MEASUREMENT_ID}";
-        export const ga4ApiSecret = "${GA4_API_SECRET}";
+        export const posthogApiKey = "${POSTHOG_API_KEY}";
         EOF
-        echo "Stamped apps/cli/src/analytics-keys.ts (values withheld)"
+        echo "Stamped apps/cli/src/analytics-keys.ts (value withheld)"
 
     - name: Compile single-file binary
       shell: bash

--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -14,6 +14,14 @@ inputs:
   target:
     description: "Bun compile target for this runner (e.g. bun-darwin-arm64 / bun-windows-x64)"
     required: true
+  ga4-measurement-id:
+    description: "GA4 measurement id for anonymous usage analytics (empty: keys stay unbaked — noop sink)"
+    required: false
+    default: ""
+  ga4-api-secret:
+    description: "GA4 Measurement Protocol api_secret (empty: keys stay unbaked — noop sink)"
+    required: false
+    default: ""
 
 outputs:
   artifact-name:
@@ -46,6 +54,24 @@ runs:
         EOF
         echo "Stamped apps/cli/src/version.ts:"
         cat apps/cli/src/version.ts
+
+    # Same seam as version.ts: bake the GA4 keys into the throwaway checkout before compiling. Skipped
+    # when the secrets are absent (forks, PR CI) — the committed empty defaults stay, the binary's host
+    # lands on the noop sink and never sends (see packages/server/src/analytics/SPEC.md).
+    - name: Stamp analytics keys into the CLI
+      if: inputs.ga4-measurement-id != '' && inputs.ga4-api-secret != ''
+      shell: bash
+      env:
+        GA4_MEASUREMENT_ID: ${{ inputs.ga4-measurement-id }}
+        GA4_API_SECRET: ${{ inputs.ga4-api-secret }}
+      run: |
+        set -eu
+        cat > apps/cli/src/analytics-keys.ts <<EOF
+        // Stamped at release time by .github/actions/build-binary. Do not commit this edit.
+        export const ga4MeasurementId = "${GA4_MEASUREMENT_ID}";
+        export const ga4ApiSecret = "${GA4_API_SECRET}";
+        EOF
+        echo "Stamped apps/cli/src/analytics-keys.ts (values withheld)"
 
     - name: Compile single-file binary
       shell: bash

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -53,9 +53,8 @@ jobs:
           version: ${{ inputs.version }}
           channel: ${{ inputs.channel }}
           target: ${{ matrix.target }}
-          # Absent on forks/PRs → the action skips the stamp and the committed empty keys stay (noop sink).
-          ga4-measurement-id: ${{ secrets.THINKRAIL_GA4_MEASUREMENT_ID }}
-          ga4-api-secret: ${{ secrets.THINKRAIL_GA4_API_SECRET }}
+          # Absent on forks/PRs → the action skips the stamp and the committed empty key stays (noop sink).
+          posthog-api-key: ${{ secrets.THINKRAIL_POSTHOG_API_KEY }}
 
       - uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -53,6 +53,9 @@ jobs:
           version: ${{ inputs.version }}
           channel: ${{ inputs.channel }}
           target: ${{ matrix.target }}
+          # Absent on forks/PRs → the action skips the stamp and the committed empty keys stay (noop sink).
+          ga4-measurement-id: ${{ secrets.THINKRAIL_GA4_MEASUREMENT_ID }}
+          ga4-api-secret: ${{ secrets.THINKRAIL_GA4_API_SECRET }}
 
       - uses: actions/upload-artifact@v5
         with:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,33 @@ code — top-level specs at the root (`goal-and-requirements.md`, `architecture.
 `SPEC.md` for every module. When you change a boundary, contract, or decision, update the corresponding
 spec in the same change. See [`AGENTS.md`](AGENTS.md) for the spec workflow.
 
+## Analytics & Privacy
+
+Released ThinkRail builds send **anonymous usage analytics** (on by default; a notice is printed the
+first time anything is sent). The data answers product questions — how many installs are active, on
+which versions/platforms, which models and providers get used, and which features matter — and
+nothing more.
+
+**The only stable identifier** is a random per-install id (a `uuid4`) minted on your machine and
+stored in `~/.thinkrail/installation.json`; it never leaves the host except as the anonymous
+`client_id` on events. Events additionally carry only low-cardinality, non-personal metadata: app
+version, release channel (`stable`/`nightly`), OS (`macos`/`linux`/`windows`), architecture
+(`x64`/`arm64`), and — on chat/login events — the model/provider name **only if it is a pi built-in**
+(anything user-configured is reported as `custom`).
+
+**Never collected:** file paths or names, prompts, code, chat transcripts, API keys, token counts,
+hostnames, usernames, or IP-derived fields. Development builds (`bun run dev`, from-source runs, e2e)
+never send anything — they carry no analytics keys and the `dev` channel refuses baked keys outright.
+
+Turn it off any time:
+
+- **In-app:** Settings → **Privacy** → toggle off (saved on the host, synced to every client).
+- **Per run:** `thinkrail --no-analytics` (or `THINKRAIL_NO_ANALYTICS=1`) — mutes that run without
+  touching the saved setting.
+
+Turning analytics off stops all sending immediately; the install id is kept (never rotated) and simply
+goes unused until you turn it back on.
+
 ## Contributing
 
 Contributions are welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md). This project and community are

--- a/README.md
+++ b/README.md
@@ -131,21 +131,22 @@ spec in the same change. See [`AGENTS.md`](AGENTS.md) for the spec workflow.
 
 ## Analytics & Privacy
 
-Released ThinkRail builds send **anonymous usage analytics** (on by default; a notice is printed the
-first time anything is sent). The data answers product questions — how many installs are active, on
-which versions/platforms, which models and providers get used, and which features matter — and
-nothing more.
+Released ThinkRail builds send **anonymous usage analytics** to [PostHog](https://posthog.com) (EU
+cloud; on by default; a notice is printed the first time anything is sent). The data answers product
+questions — how many installs are active, on which versions/platforms, which models and providers
+get used, and which features matter — and nothing more.
 
 **The only stable identifier** is a random per-install id (a `uuid4`) minted on your machine and
 stored in `~/.thinkrail/installation.json`; it never leaves the host except as the anonymous
-`client_id` on events. Events additionally carry only low-cardinality, non-personal metadata: app
+`distinct_id` on events. Events additionally carry only low-cardinality, non-personal metadata: app
 version, release channel (`stable`/`nightly`), OS (`macos`/`linux`/`windows`), architecture
 (`x64`/`arm64`), and — on chat/login events — the model/provider name **only if it is a pi built-in**
-(anything user-configured is reported as `custom`).
+(anything user-configured is reported as `custom`). Events are sent **personless** (no person
+profiles are ever built) and with **GeoIP lookup disabled**.
 
 **Never collected:** file paths or names, prompts, code, chat transcripts, API keys, token counts,
 hostnames, usernames, or IP-derived fields. Development builds (`bun run dev`, from-source runs, e2e)
-never send anything — they carry no analytics keys and the `dev` channel refuses baked keys outright.
+never send anything — they carry no analytics key and the `dev` channel refuses a baked key outright.
 
 Turn it off any time:
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,10 @@ version, release channel (`stable`/`nightly`), OS (`macos`/`linux`/`windows`), a
 profiles are ever built) and with **GeoIP lookup disabled**.
 
 **Never collected:** file paths or names, prompts, code, chat transcripts, API keys, token counts,
-hostnames, usernames, or IP-derived fields. Development builds (`bun run dev`, from-source runs, e2e)
-never send anything — they carry no analytics key and the `dev` channel refuses a baked key outright.
+hostnames, usernames, or IP-derived fields. **Only stable and nightly release builds ever send**:
+development builds (`bun run dev`, from-source runs, e2e) carry no analytics key, and analytics
+activates exclusively on the `stable`/`nightly` release channels — there is no way (not even an
+environment variable) to make a dev run emit events.
 
 Turn it off any time:
 

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -58,8 +58,9 @@ source. The release pipeline (`module-ci-release`) overwrites it in the throwawa
 `build:binary`, baking the real release identity into the binary. **`src/analytics-keys.ts` is the
 same seam for the PostHog project API key**: committed with an empty-string default (so
 source/dev/e2e builds have no key — the noop sink, see `submodule-server-analytics`), overwritten by
-the release pipeline from the CI secret; `THINKRAIL_POSTHOG_API_KEY` (+ `THINKRAIL_POSTHOG_HOST`)
-env vars override at runtime for deliberate pipeline testing. `index.ts` threads
+the release pipeline from the CI secret. The baked key is the **only** key source — there is no
+runtime env-var key override, so only stable/nightly release builds can ever send (see
+`submodule-server-analytics`). `index.ts` threads
 `{ channel, key, mute }` into `bootHost` as the `analytics` option. `index.ts` reads it, prints it for
 `--version`, and passes `appVersion` into `bootHost` — so the host echoes it in `server.welcome`
 (`ServerWelcome.appVersion`), letting a client report host version alongside the protocol-drift check.

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -33,9 +33,11 @@ its URL. It is a thin launcher — all engine logic lives in `packages/server`.
 **subcommand** (`thinkrail update [--channel stable|nightly] [--version X.Y.Z]`) intercepted before the
 launch flags — see *Self-update* below. Otherwise the launch args: `--port` (stable default 24242,
 scans upward to the next free port on collision), `--host` (default `localhost`), `--no-open`,
+`--no-analytics` (**per-run mute** for anonymous usage analytics — this run sends nothing; the
+durable switch is the app's Settings → Privacy toggle, see `submodule-server-analytics`),
 `-v`/`--version` (print the baked version and exit), `-h`/`--help`, and one positional `project-dir` (a
 git repo to open as a project on boot, best-effort). Env defaults: `THINKRAIL_PORT` / `THINKRAIL_HOST` /
-`THINKRAIL_STATIC_DIR` (flag > env > default).
+`THINKRAIL_STATIC_DIR` / `THINKRAIL_NO_ANALYTICS` (flag > env > default).
 
 ## Self-update (`thinkrail update`)
 
@@ -53,7 +55,12 @@ resolution are pure (`parseUpdateArgs` / `resolveUpdatePlan`, unit-tested); only
 `src/version.ts` exports `{ version, channel, commit }` with a from-source default (`0.0.0-dev`). Unlike
 the transient `*.generated.ts`, it's a **permanent committed module** so `--version` + `tsc` work from
 source. The release pipeline (`module-ci-release`) overwrites it in the throwaway CI checkout before
-`build:binary`, baking the real release identity into the binary. `index.ts` reads it, prints it for
+`build:binary`, baking the real release identity into the binary. **`src/analytics-keys.ts` is the
+same seam for the GA4 credentials**: committed with empty-string defaults (so source/dev/e2e builds
+have no keys — the noop sink, see `submodule-server-analytics`), overwritten by the release pipeline
+from CI secrets; `THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` env vars override at
+runtime for deliberate pipeline testing. `index.ts` threads `{ channel, keys, mute }` into `bootHost`
+as the `analytics` option. `index.ts` reads it, prints it for
 `--version`, and passes `appVersion` into `bootHost` — so the host echoes it in `server.welcome`
 (`ServerWelcome.appVersion`), letting a client report host version alongside the protocol-drift check.
 

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -56,11 +56,11 @@ resolution are pure (`parseUpdateArgs` / `resolveUpdatePlan`, unit-tested); only
 the transient `*.generated.ts`, it's a **permanent committed module** so `--version` + `tsc` work from
 source. The release pipeline (`module-ci-release`) overwrites it in the throwaway CI checkout before
 `build:binary`, baking the real release identity into the binary. **`src/analytics-keys.ts` is the
-same seam for the GA4 credentials**: committed with empty-string defaults (so source/dev/e2e builds
-have no keys — the noop sink, see `submodule-server-analytics`), overwritten by the release pipeline
-from CI secrets; `THINKRAIL_GA4_MEASUREMENT_ID` / `THINKRAIL_GA4_API_SECRET` env vars override at
-runtime for deliberate pipeline testing. `index.ts` threads `{ channel, keys, mute }` into `bootHost`
-as the `analytics` option. `index.ts` reads it, prints it for
+same seam for the PostHog project API key**: committed with an empty-string default (so
+source/dev/e2e builds have no key — the noop sink, see `submodule-server-analytics`), overwritten by
+the release pipeline from the CI secret; `THINKRAIL_POSTHOG_API_KEY` (+ `THINKRAIL_POSTHOG_HOST`)
+env vars override at runtime for deliberate pipeline testing. `index.ts` threads
+`{ channel, key, mute }` into `bootHost` as the `analytics` option. `index.ts` reads it, prints it for
 `--version`, and passes `appVersion` into `bootHost` — so the host echoes it in `server.welcome`
 (`ServerWelcome.appVersion`), letting a client report host version alongside the protocol-drift check.
 

--- a/apps/cli/src/analytics-keys.ts
+++ b/apps/cli/src/analytics-keys.ts
@@ -1,0 +1,8 @@
+// GA4 (Firebase Analytics) credentials for anonymous usage analytics — the same release seam as
+// `version.ts`: committed with EMPTY defaults so source/dev/e2e builds have no keys (the host lands on
+// the noop sink and never sends — see packages/server/src/analytics/SPEC.md), overwritten in the
+// throwaway CI checkout by .github/actions/build-binary from repo secrets before `build:binary`.
+// Not secret in the classic sense — a shipped binary necessarily carries them (accepted, same exposure
+// class as any app's Firebase config); dev-channel builds refuse baked keys regardless.
+export const ga4MeasurementId = "";
+export const ga4ApiSecret = "";

--- a/apps/cli/src/analytics-keys.ts
+++ b/apps/cli/src/analytics-keys.ts
@@ -1,8 +1,7 @@
-// GA4 (Firebase Analytics) credentials for anonymous usage analytics — the same release seam as
-// `version.ts`: committed with EMPTY defaults so source/dev/e2e builds have no keys (the host lands on
-// the noop sink and never sends — see packages/server/src/analytics/SPEC.md), overwritten in the
-// throwaway CI checkout by .github/actions/build-binary from repo secrets before `build:binary`.
-// Not secret in the classic sense — a shipped binary necessarily carries them (accepted, same exposure
-// class as any app's Firebase config); dev-channel builds refuse baked keys regardless.
-export const ga4MeasurementId = "";
-export const ga4ApiSecret = "";
+// PostHog project API key for anonymous usage analytics — the same release seam as `version.ts`:
+// committed with an EMPTY default so source/dev/e2e builds have no key (the host lands on the noop
+// sink and never sends — see packages/server/src/analytics/SPEC.md), overwritten in the throwaway CI
+// checkout by .github/actions/build-binary from the repo secret before `build:binary`.
+// Not secret in the classic sense — a shipped binary necessarily carries it (public-by-design, like
+// any client-side analytics key); dev-channel builds refuse a baked key regardless.
+export const posthogApiKey = "";

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -7,11 +7,18 @@ describe("parseArgs", () => {
 			port: DEFAULT_PORT,
 			host: DEFAULT_HOST,
 			open: true,
+			noAnalytics: false,
 			staticDir: undefined,
 			projectDir: undefined,
 			help: false,
 			version: false,
 		});
+	});
+
+	test("--no-analytics mutes for the run; THINKRAIL_NO_ANALYTICS is the env spelling", () => {
+		expect(parseArgs(["--no-analytics"], {}).noAnalytics).toBe(true);
+		expect(parseArgs([], { THINKRAIL_NO_ANALYTICS: "1" }).noAnalytics).toBe(true);
+		expect(parseArgs([], {}).noAnalytics).toBe(false);
 	});
 
 	test("flags win over env over defaults", () => {

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -10,6 +10,8 @@ export interface CliOptions {
 	host: string;
 	/** Open the browser at the resolved URL on boot. */
 	open: boolean;
+	/** `--no-analytics` / `THINKRAIL_NO_ANALYTICS`: mute anonymous usage analytics for this run. */
+	noAnalytics: boolean;
 	/** Static SPA dir override (`THINKRAIL_STATIC_DIR`); when unset the bin derives a default. */
 	staticDir: string | undefined;
 	/** A git repo to open as a project on boot (the positional arg), or undefined. */
@@ -32,6 +34,8 @@ Options:
   --port <n>     Listen port (default ${DEFAULT_PORT}; falls back to a free port if taken).
   --host <h>     Bind host (default ${DEFAULT_HOST}).
   --no-open      Don't open the browser (e.g. headless / remote host).
+  --no-analytics Don't send anonymous usage analytics this run (the durable switch
+                 lives in the app: Settings → Privacy).
   -v, --version  Print the version and exit.
   -h, --help     Show this help.
 
@@ -40,7 +44,8 @@ Arguments:
 
 Env:
   THINKRAIL_PORT / THINKRAIL_HOST   Defaults for --port / --host.
-  THINKRAIL_STATIC_DIR                 Override the built web app served by the host.`;
+  THINKRAIL_STATIC_DIR                 Override the built web app served by the host.
+  THINKRAIL_NO_ANALYTICS               Same as --no-analytics (any non-empty value).`;
 
 /** Read a flag's value from either `--flag value` or `--flag=value`; returns the value + how many argv slots it consumed. */
 function readFlagValue(arg: string, next: string | undefined): { value: string; consumed: number } {
@@ -59,6 +64,7 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 	let port: number | undefined;
 	let host: string | undefined;
 	let open = true;
+	let noAnalytics = false;
 	let help = false;
 	let version = false;
 	let projectDir: string | undefined;
@@ -67,6 +73,8 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 		const arg = argv[i] as string;
 		if (arg === "--no-open") {
 			open = false;
+		} else if (arg === "--no-analytics") {
+			noAnalytics = true;
 		} else if (arg === "-h" || arg === "--help") {
 			help = true;
 		} else if (arg === "-v" || arg === "--version") {
@@ -100,6 +108,7 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 		port: resolvedPort,
 		host: host ?? env.THINKRAIL_HOST ?? DEFAULT_HOST,
 		open,
+		noAnalytics: noAnalytics || Boolean(env.THINKRAIL_NO_ANALYTICS),
 		staticDir: env.THINKRAIL_STATIC_DIR,
 		projectDir,
 		help,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,7 +5,7 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { bootHost } from "@thinkrail/server";
-import { ga4ApiSecret, ga4MeasurementId } from "./analytics-keys";
+import { posthogApiKey } from "./analytics-keys";
 import { type CliOptions, parseArgs, USAGE } from "./args";
 import { runUpdate } from "./update";
 import { channel, version } from "./version";
@@ -67,13 +67,12 @@ async function bootstrap(): Promise<void> {
 		portMode: "free",
 		staticDir,
 		appVersion: version,
-		// Anonymous usage analytics: channel + the release-baked GA4 keys (empty from source → the host
-		// lands on the noop sink) + the per-run `--no-analytics` mute. The durable on/off switch is the
-		// app's Settings → Privacy toggle (`AppConfig.analyticsEnabled`), host-side.
+		// Anonymous usage analytics: channel + the release-baked PostHog key (empty from source → the
+		// host lands on the noop sink) + the per-run `--no-analytics` mute. The durable on/off switch is
+		// the app's Settings → Privacy toggle (`AppConfig.analyticsEnabled`), host-side.
 		analytics: {
 			channel,
-			measurementId: ga4MeasurementId,
-			apiSecret: ga4ApiSecret,
+			posthogApiKey,
 			mute: options.noAnalytics,
 		},
 		...(options.projectDir ? { projectPath: resolve(process.cwd(), options.projectDir) } : {}),

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,9 +5,10 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { bootHost } from "@thinkrail/server";
+import { ga4ApiSecret, ga4MeasurementId } from "./analytics-keys";
 import { type CliOptions, parseArgs, USAGE } from "./args";
 import { runUpdate } from "./update";
-import { version } from "./version";
+import { channel, version } from "./version";
 
 /** The built web app shipped with the bin, relative to this file (src in dev, dist when bundled). */
 const DEFAULT_STATIC_DIR = resolve(import.meta.dir, "../../web/dist");
@@ -66,6 +67,15 @@ async function bootstrap(): Promise<void> {
 		portMode: "free",
 		staticDir,
 		appVersion: version,
+		// Anonymous usage analytics: channel + the release-baked GA4 keys (empty from source → the host
+		// lands on the noop sink) + the per-run `--no-analytics` mute. The durable on/off switch is the
+		// app's Settings → Privacy toggle (`AppConfig.analyticsEnabled`), host-side.
+		analytics: {
+			channel,
+			measurementId: ga4MeasurementId,
+			apiSecret: ga4ApiSecret,
+			mute: options.noAnalytics,
+		},
 		...(options.projectDir ? { projectPath: resolve(process.cwd(), options.projectDir) } : {}),
 	});
 	if (port !== requested) {

--- a/apps/web/src/panels/PrivacySettings.tsx
+++ b/apps/web/src/panels/PrivacySettings.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@/lib";
+import { toast, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+
+/**
+ * The "Privacy" settings section: the anonymous-usage-analytics toggle. Server-synced — flipping the
+ * switch fires `settings.update { analyticsEnabled }` and the UI converges on the host's
+ * `settings.changed` broadcast (no optimistic apply), the same pattern as the theme picker. Only this
+ * boolean ever crosses the wire: events are emitted host-side and the anonymous install id never
+ * leaves the host (see the server analytics module's spec).
+ */
+export function PrivacySettings() {
+	const enabled = useAppStore((s) => s.analyticsEnabled);
+
+	const toggle = () => {
+		getTransport()
+			.request("settings.update", { config: { analyticsEnabled: !enabled } })
+			.catch(() => toast.error("Couldn't change the analytics setting"));
+	};
+
+	return (
+		<section data-testid="settings-privacy" className="flex flex-col gap-lg">
+			<div className="flex flex-col gap-xs">
+				<h3 className="font-medium text-md text-text">Usage analytics</h3>
+				<p className="text-hint text-xs">
+					Anonymous usage analytics help us understand which features matter. Your choice is saved
+					on the host and follows you across devices.
+				</p>
+			</div>
+
+			<div className="flex items-center justify-between gap-md rounded-[var(--radius-md)] border border-border2 px-md py-sm">
+				<div className="flex flex-col gap-0.5">
+					<span className="font-medium text-sm text-text">Share anonymous usage analytics</span>
+					<span className="text-hint text-xs">
+						{enabled ? "On — thank you for helping improve ThinkRail." : "Off — nothing is sent."}
+					</span>
+				</div>
+				<button
+					type="button"
+					role="switch"
+					aria-checked={enabled}
+					aria-label="Share anonymous usage analytics"
+					data-testid="analytics-toggle"
+					data-active={enabled}
+					onClick={toggle}
+					className={cn(
+						"relative h-5 w-9 shrink-0 rounded-full outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+						enabled ? "bg-primary" : "bg-border2",
+					)}
+				>
+					<span
+						className={cn(
+							"absolute top-0.5 left-0.5 size-4 rounded-full bg-bg transition-transform",
+							enabled && "translate-x-4",
+						)}
+					/>
+				</button>
+			</div>
+
+			<div className="flex flex-col gap-xs text-xs">
+				<p className="text-muted">
+					<span className="font-medium text-text">What is collected:</span> a random anonymous
+					install id, app version and release channel, OS and architecture, when a chat starts (and
+					the model/provider it uses), and which providers you sign in to. Custom providers and
+					models are reported only as “custom”.
+				</p>
+				<p className="text-muted">
+					<span className="font-medium text-text">Never collected:</span> file paths or names,
+					prompts, code, chat transcripts, API keys, hostnames, usernames, or anything typed into
+					the app.
+				</p>
+				<p className="text-hint">
+					You can also launch with <code className="font-[var(--font-mono)]">--no-analytics</code>{" "}
+					to mute a single run. See the README’s “Analytics &amp; Privacy” section for the full
+					policy.
+				</p>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/panels/PrivacySettings.tsx
+++ b/apps/web/src/panels/PrivacySettings.tsx
@@ -69,11 +69,6 @@ export function PrivacySettings() {
 					prompts, code, chat transcripts, API keys, hostnames, usernames, or anything typed into
 					the app.
 				</p>
-				<p className="text-hint">
-					You can also launch with <code className="font-[var(--font-mono)]">--no-analytics</code>{" "}
-					to mute a single run. See the README’s “Analytics &amp; Privacy” section for the full
-					policy.
-				</p>
 			</div>
 		</section>
 	);

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -177,9 +177,14 @@ a project picker, the prompt hero, and the reused
   carries the discoverability half (`chat/SPEC.md`: a `slash-templates-empty` footer nudge deep-linking
   here when no template exists anywhere), since this offer is otherwise two clicks deep in a dialog. **This
   project**'s empty state is unchanged (still the bare text) — the offer is Global-only, since it only
-  ever seeds global files. No server change. A single dimmed "General" nav item ("Soon") still signals the shell is
-  built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings` are the **integration pieces**
+  ever seeds global files. No server change. **`PrivacySettings`** is the **anonymous-usage-analytics
+  toggle** — a switch over `store.analyticsEnabled`, fired via `settings.update { analyticsEnabled }`
+  with the same converge-on-broadcast pattern as the theme, plus the what-is/isn't-collected copy; only
+  the boolean ever crosses the wire, see `submodule-server-analytics`. A single dimmed "General" nav item ("Soon") still signals the shell is
+  built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings`/`PrivacySettings` are the
+  **integration pieces**
   (store + transport); the `LoginDialog` stays presentational (`auth` module).
+
   Panels compose their own sub-panels
   (e.g. `RightPanel`→`FileTree`/`ChangesPanel`, `CenterTabs`→`FilePane`→`MonacoEditor`) — an internal hierarchy.
   When the active workspace has no open center tab, `CenterTabs` uses the empty surface as a persistent

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -4,6 +4,7 @@ import {
 	LayoutTemplate,
 	type LucideIcon,
 	Palette,
+	ShieldCheck,
 	SlidersHorizontal,
 } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -11,6 +12,7 @@ import { cn } from "@/lib";
 import { SettingsSection, useAppStore } from "@/store";
 import { AppearanceSettings } from "./AppearanceSettings";
 import { GithubSettings } from "./GithubSettings";
+import { PrivacySettings } from "./PrivacySettings";
 import { ProvidersSettings } from "./ProvidersSettings";
 import { TemplatesSettings } from "./TemplatesSettings";
 
@@ -20,6 +22,7 @@ const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
 	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
 	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
 	{ id: SettingsSection.Templates, label: "Templates", icon: LayoutTemplate },
+	{ id: SettingsSection.Privacy, label: "Privacy", icon: ShieldCheck },
 ];
 /** Placeholder sections — shown dimmed so the shell reads as built-to-grow (not yet wired). */
 const SOON: { label: string; icon: LucideIcon }[] = [{ label: "General", icon: SlidersHorizontal }];
@@ -95,6 +98,8 @@ export function SettingsDialog() {
 							<GithubSettings />
 						) : section === SettingsSection.Templates ? (
 							<TemplatesSettings />
+						) : section === SettingsSection.Privacy ? (
+							<PrivacySettings />
 						) : (
 							<AppearanceSettings />
 						)}

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -71,7 +71,7 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `provider.login` frame (creating `activeLogin` if the frame arrived first; ignoring frames for a different
   live login), **`clearLoginInput()`** drops the live input the instant a reply is sent (no double-submit),
   and **`clearLogin()`** dismisses it. The **settings surface** state — **`settingsOpen`** +
-  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Templates`) with
+  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Templates`/`Privacy`) with
   **`openSettings(section?)`** (deep-links to a section, defaults to Providers) / **`closeSettings()`** /
   **`setSettingsSection()`** — lives here so the top-bar gear AND the Welcome provider warning open Settings
   to a section without prop-drilling through the shell. The **theme** state — **`theme: ThemeId`** (the
@@ -79,7 +79,9 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   (folds the server-synced `AppConfig` in from
   `server.welcome` / the `settings.changed` broadcast) — lives here too; it's a **pure value only** (the
   theme-application side-effect is the shell's, keyed off `theme`), and defaults to
-  `DEFAULT_CONFIG.theme` until the welcome arrives. The
+  `DEFAULT_CONFIG.theme` until the welcome arrives. **`analyticsEnabled: boolean`** rides the same
+  `applyConfig` fold (host-owned, defaults to `DEFAULT_CONFIG.analyticsEnabled` until the welcome
+  arrives) — the Privacy toggle's read side. The
   **toast queue** — **`toasts: Toast[]`** (oldest-first) with **`pushToast(toast) → id`** / **`dismissToast(id)`**
   and the ergonomic **`toast.error/success/info(message, title?)`** helper (wraps `pushToast` so a non-React
   call site — a `.catch` in a fire-and-forget wire call — can fire one) — lives here so any surface can raise

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -81,13 +81,15 @@ export type EditorTab = FileTab | ChatTab | DocTab | DiffTab;
 
 /**
  * A section of the settings dialog (a const-object "enum", the codebase convention). Extensible — the live
- * sections are providers, github, appearance (the theme picker), and templates (prompt-template manager).
+ * sections are providers, github, appearance (the theme picker), templates (prompt-template manager),
+ * and privacy (the analytics toggle).
  */
 export const SettingsSection = {
 	Providers: "providers",
 	Github: "github",
 	Appearance: "appearance",
 	Templates: "templates",
+	Privacy: "privacy",
 } as const;
 export type SettingsSection = (typeof SettingsSection)[keyof typeof SettingsSection];
 
@@ -499,6 +501,9 @@ interface AppState {
 	/** The active UI theme (host-owned; `applyConfig` sets it from `server.welcome` / `settings.changed`).
 	 * The DOM side-effect (`applyTheme`) is the shell's job — this holds the value the UI reads. */
 	theme: ThemeId;
+	/** Anonymous-usage-analytics switch (host-owned, same `applyConfig` fold as `theme`). Only this boolean
+	 * ever reaches a client — events are emitted host-side and the install id never crosses the wire. */
+	analyticsEnabled: boolean;
 	/** Transient notifications, oldest-first (the Toaster renders + times them out). At-most a handful live
 	 * at once; a failed wire call that has no better home (no chat tab to host an error turn) lands here. */
 	toasts: Toast[];
@@ -752,6 +757,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	settingsOpen: false,
 	settingsSection: SettingsSection.Providers,
 	theme: DEFAULT_CONFIG.theme,
+	analyticsEnabled: DEFAULT_CONFIG.analyticsEnabled,
 	toasts: [],
 	setStatus: (status) => set({ status }),
 	setWelcome: (protocolVersion) => set({ protocolVersion }),
@@ -1279,7 +1285,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 		set({ settingsOpen: true, settingsSection: section }),
 	closeSettings: () => set({ settingsOpen: false }),
 	setSettingsSection: (section) => set({ settingsSection: section }),
-	applyConfig: (config) => set({ theme: config.theme }),
+	applyConfig: (config) => set({ theme: config.theme, analyticsEnabled: config.analyticsEnabled }),
 	requestChangesView: (workspaceId, path) => set({ changesRequest: { workspaceId, path } }),
 	// Activate project + workspace together (the same atomicity `activateWorkspace` upholds) so a jump into
 	// another project can never leave `selectedProjectId` on the source while `activeWorkspaceId` points

--- a/bun.lock
+++ b/bun.lock
@@ -154,6 +154,7 @@
         "pi-todos": "workspace:*",
         "pi-visualize": "workspace:*",
         "pi-web-access": "0.13.0",
+        "posthog-node": "5.46.1",
         "typebox": "catalog:",
       },
       "devDependencies": {
@@ -365,6 +366,10 @@
     "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
     "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
+
+    "@posthog/core": ["@posthog/core@1.45.1", "", { "dependencies": { "@posthog/types": "^1.398.0" } }, "sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA=="],
+
+    "@posthog/types": ["@posthog/types@1.398.0", "", {}, "sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -1155,6 +1160,8 @@
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "posthog-node": ["posthog-node@5.46.1", "", { "dependencies": { "@posthog/core": "^1.45.1" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-WjCqExq44pBdyg9MSsH6UAE0tNZ88p4aIuVFicgqhjf2Fbws6IhS4ioYUa4aBrbUPS9EDRXtBTtF5DpP1ml8Pw=="],
 
     "promise-stream-reader": ["promise-stream-reader@1.0.1", "", {}, "sha512-Tnxit5trUjBAqqZCGWwjyxhmgMN4hGrtpW3Oc/tRI4bpm/O2+ej72BB08l6JBnGQgVDGCLvHFGjGgQS6vzhwXg=="],
 

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 // The Privacy settings section: the anonymous-usage-analytics toggle. The flag is SERVER-SYNCED
 // (AppConfig.analyticsEnabled in config.json, converged via the settings.changed broadcast — no
 // optimistic apply), so a flip survives a reload. The e2e host never actually sends anything
-// regardless of the flag: it runs from source (no baked GA4 keys ⇒ noop sink) on the dev channel.
+// regardless of the flag: it runs from source (no baked PostHog key ⇒ noop sink) on the dev channel.
 // This test leaves the flag back ON so the shared e2e data dir stays in its default state.
 test("privacy section toggles analytics off and the choice persists across a reload", async ({
 	page,

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+// The Privacy settings section: the anonymous-usage-analytics toggle. The flag is SERVER-SYNCED
+// (AppConfig.analyticsEnabled in config.json, converged via the settings.changed broadcast — no
+// optimistic apply), so a flip survives a reload. The e2e host never actually sends anything
+// regardless of the flag: it runs from source (no baked GA4 keys ⇒ noop sink) on the dev channel.
+// This test leaves the flag back ON so the shared e2e data dir stays in its default state.
+test("privacy section toggles analytics off and the choice persists across a reload", async ({
+	page,
+}) => {
+	await page.goto("/");
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+
+	await page.getByTestId("open-settings").click();
+	const dialog = page.getByTestId("settings-dialog");
+	await expect(dialog).toBeVisible();
+	await page.getByTestId("settings-nav-privacy").click();
+	await expect(dialog).toContainText("Usage analytics");
+
+	// Fresh data dir → DEFAULT_CONFIG → analytics enabled (the opt-out posture).
+	const toggle = page.getByTestId("analytics-toggle");
+	await expect(toggle).toHaveAttribute("data-active", "true");
+
+	// Flip off → converges on the settings.changed broadcast (the same round-trip as the theme picker).
+	await toggle.click();
+	await expect(toggle).toHaveAttribute("data-active", "false");
+	await expect(dialog).toContainText("nothing is sent");
+
+	// Server-synced: a reload comes back OFF (from server.welcome's config, not a fresh default).
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-privacy").click();
+	await expect(toggle).toHaveAttribute("data-active", "false");
+
+	// Restore the default so other specs see the data dir's default posture.
+	await toggle.click();
+	await expect(toggle).toHaveAttribute("data-active", "true");
+
+	await page.keyboard.press("Escape");
+	await expect(dialog).toBeHidden();
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -110,7 +110,10 @@ of the host.
   hint on this result));
   the **theme/config selection** — **`ThemeId`** is an open string on the wire, because the host persists
   an opaque selection while the independently shipped web client owns the available manifest catalog;
-  **`AppConfig`** (`{ theme }` — an extensible bag) carries it with the **`DEFAULT_CONFIG`** fallback
+  **`AppConfig`** (`{ theme, analyticsEnabled }` — an extensible bag; `analyticsEnabled` is the
+  anonymous-usage-analytics switch, default `true` — it is the **only** analytics fact on the wire:
+  the installation id stays server-side by design, see `submodule-server-analytics`) carries it with the
+  **`DEFAULT_CONFIG`** fallback
   (persisted host-side as `config.json`, delivered in `server.welcome`, mutated via `settings.update`).
   Contracts deliberately exports no theme enum/list/labels: a future manifest can mint an id unknown when
   the host was built, and a client missing it resolves its own bundled default;

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -327,10 +327,17 @@ export type ThemeId = string;
  */
 export interface AppConfig {
 	theme: ThemeId;
+	/**
+	 * Anonymous usage analytics on/off (default on — the opt-out posture; a first-run notice + this
+	 * switch are the transparency half). This boolean is the ONLY analytics fact on the wire: events
+	 * are emitted host-side and the per-install id never leaves the host (it lives in the server-only
+	 * `installation.json`, deliberately not in this broadcast bag).
+	 */
+	analyticsEnabled: boolean;
 }
 
 /** The config a fresh host (no `config.json` yet) falls back to. */
-export const DEFAULT_CONFIG: AppConfig = { theme: "dark" };
+export const DEFAULT_CONFIG: AppConfig = { theme: "dark", analyticsEnabled: true };
 
 /**
  * Prefix on the internal "wake the agent" nudge the client sends when a TODO is added. It is control

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -74,7 +74,7 @@ the host from env via `bootHost` for dev/e2e.
 - `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`, `analytics`
 - `workspaces` → `projects`, `git`, `persistence`
 - `projects` → `git` (shared runner), `persistence`
-- `git`, `fs`, `spec`, `watch`, `terminal`, `settings`, `analytics` → `persistence` (`spec` also → `pi-spec-graph/core`, external; `analytics` also → the pi-ai built-in provider/model catalog, external — what its identity bucketing checks against)
+- `git`, `fs`, `spec`, `watch`, `terminal`, `settings`, `analytics` → `persistence` (`spec` also → `pi-spec-graph/core`, external; `analytics` also → the pi-ai built-in provider/model catalog + `posthog-node`, external — the identity-bucketing vocabulary and the delivery SDK)
 - `todos` → `workspaces` (worktree path lookup) + `pi-todos/core` (external, value-imported, pi-free)
 - `assist` → `agent` (the one-shot completion primitive)
 - `auth` → `agent` (`getPiRuntime` — the shared `AuthStorage` + `ModelRegistry`; one-way, `agent` never imports `auth`)

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -59,7 +59,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `agent` | in-process pi `AgentSession`s + the shared pi runtime + one-shot completions | [agent/SPEC.md](src/agent/SPEC.md) |
 | `auth` | provider status (`provider.status`) + in-app login (OAuth / API key / logout) | [auth/SPEC.md](src/auth/SPEC.md) |
 | `assist` | ad-hoc one-shot tasks (workspace naming, …) on a cheap model, best-effort | [assist/SPEC.md](src/assist/SPEC.md) |
-| `analytics` | anonymous usage analytics: closed event set → GA4 sink (privacy contract in its spec) | [analytics/SPEC.md](src/analytics/SPEC.md) |
+| `analytics` | anonymous usage analytics: closed event set → PostHog sink (privacy contract in its spec) | [analytics/SPEC.md](src/analytics/SPEC.md) |
 | `dialog` | the host's native folder picker | [dialog/SPEC.md](src/dialog/SPEC.md) |
 | `history` | prompt recall + conversation search over pi's session files | [history/SPEC.md](src/history/SPEC.md) |
 | `templates` | file CRUD over pi's prompt-template dirs (global + project scoped) | [templates/SPEC.md](src/templates/SPEC.md) |

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -59,6 +59,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `agent` | in-process pi `AgentSession`s + the shared pi runtime + one-shot completions | [agent/SPEC.md](src/agent/SPEC.md) |
 | `auth` | provider status (`provider.status`) + in-app login (OAuth / API key / logout) | [auth/SPEC.md](src/auth/SPEC.md) |
 | `assist` | ad-hoc one-shot tasks (workspace naming, …) on a cheap model, best-effort | [assist/SPEC.md](src/assist/SPEC.md) |
+| `analytics` | anonymous usage analytics: closed event set → GA4 sink (privacy contract in its spec) | [analytics/SPEC.md](src/analytics/SPEC.md) |
 | `dialog` | the host's native folder picker | [dialog/SPEC.md](src/dialog/SPEC.md) |
 | `history` | prompt recall + conversation search over pi's session files | [history/SPEC.md](src/history/SPEC.md) |
 | `templates` | file CRUD over pi's prompt-template dirs (global + project scoped) | [templates/SPEC.md](src/templates/SPEC.md) |
@@ -70,10 +71,10 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`
+- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `watch`, `terminal`, `dialog`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`, `analytics`
 - `workspaces` → `projects`, `git`, `persistence`
 - `projects` → `git` (shared runner), `persistence`
-- `git`, `fs`, `spec`, `watch`, `terminal`, `settings` → `persistence` (`spec` also → `pi-spec-graph/core`, external)
+- `git`, `fs`, `spec`, `watch`, `terminal`, `settings`, `analytics` → `persistence` (`spec` also → `pi-spec-graph/core`, external; `analytics` also → the pi-ai built-in provider/model catalog, external — what its identity bucketing checks against)
 - `todos` → `workspaces` (worktree path lookup) + `pi-todos/core` (external, value-imported, pi-free)
 - `assist` → `agent` (the one-shot completion primitive)
 - `auth` → `agent` (`getPiRuntime` — the shared `AuthStorage` + `ModelRegistry`; one-way, `agent` never imports `auth`)
@@ -90,6 +91,10 @@ own never import `host` either: they expose a **publisher-injection seam** (`set
 + labels from the registries at the handler layer (`history.search` handler). `templates` stays
 registry-free too — it takes a plain `cwd`, never a `workspaceId`; the `template.*` handler resolves
 `workspaceId` → `cwd` via `workspaces` before calling into `templates`.
+
+Analytics is host-mediated the same way: **every `track()` call site lives in `host`** (boot,
+session-create, login-success observation), and `host` syncs `setAnalyticsSending` off the settings
+broadcast — `analytics` has no `settings` edge and no feature module knows analytics exists.
 
 ## Get right
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,10 +20,11 @@
 		"@thinkrail/shared": "workspace:*",
 		"bun-pty": "0.4.10",
 		"pi-spec-graph": "workspace:*",
-		"pi-todos": "workspace:*",
 		"pi-thinkrail-workflow": "workspace:*",
+		"pi-todos": "workspace:*",
 		"pi-visualize": "workspace:*",
 		"pi-web-access": "0.13.0",
+		"posthog-node": "5.46.1",
 		"typebox": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -10,58 +10,69 @@ tags: [v1, analytics, privacy]
 
 ## Responsibility
 
-Anonymous, no-personal-data usage analytics, emitted **host-side only** (design + privacy rationale:
-`task-analytics` while it lives; the invariants below are the durable contract). Answers product
-questions — unique users, version/platform, model preference, provider auth — via a **closed event
-set** delivered to **PostHog (EU cloud)** over its capture API (a plain `fetch` POST — no vendor
-SDK; none of the major backends need one server-side). The delivery backend hides behind the
-`AnalyticsSink` interface — swapping vendors is implementing a new sink, nothing else moves
-(exercised for real once already: the first sink was GA4's Measurement Protocol, replaced pre-ship
-by user decision — PostHog's free tier, EU residency, and self-host path won).
+Anonymous, no-personal-data usage analytics, emitted **host-side only**. Answers product questions —
+unique users, version/platform, model preference, provider auth — via a **closed event set** delivered
+to **PostHog (EU cloud)** through the official `posthog-node` SDK. The SDK is an implementation detail
+**inside** the sink: the delivery backend hides behind the `AnalyticsSink` interface — swapping vendors
+is implementing a new sink, nothing else moves (exercised for real twice: GA4's Measurement Protocol →
+a hand-rolled PostHog capture POST → `posthog-node`, each swap contained to `sink.ts` + the key seam;
+PostHog won on free tier, EU residency, and a self-host path).
 
 ## Boundary
 
 - **Owns:**
   - `events.ts` — the closed `AnalyticsEvent` union (`app_installed` / `app_started` /
-    `chat_started {provider, model}` / `provider_login {provider, method}`), the
-    **`PARAM_ALLOWLIST`** (the machine-checked privacy invariant — a param key outside it fails the
-    unit test), and `bucketProviderModel()`: identity passes raw **only** when it matches pi's
-    built-in catalog (`getProviders()` / `getModels()` from `@earendil-works/pi-ai/compat`); a
-    custom provider — or a custom model id on a known provider — becomes `"custom"`. Fails closed.
-  - `sink.ts` — `AnalyticsSink { send(events) }`; `createPostHogSink({ apiKey, host?, fetchImpl? })`
-    (fire-and-forget POST to `{host}/batch/`, EU cloud by default; errors swallowed + debug-logged,
-    no retries) and `noopSink`. Every outgoing event is **personless**
+    `chat_started {provider, model}` / `provider_login {provider, method}`) and
+    `bucketProvider()` / `bucketProviderModel()`: identity passes raw **only** when it matches pi's
+    built-in catalog (`getBuiltinProviders()` / `getBuiltinModels()`); a custom provider — or a custom
+    model id on a known provider — becomes `"custom"`. Fails closed. The machine-checked privacy pin is
+    the **unit tests**: they assert every event variant's exact outgoing properties — there is
+    deliberately no runtime allowlist filter (the union is closed and we control every call site; a
+    content-leaking field fails CI, and runtime filtering was judged over-engineering).
+  - `sink.ts` — `AnalyticsSink { send(clientId, events); shutdown?() }`; `createPostHogSink({ apiKey,
+    host?, fetchImpl? })` wraps `posthog-node` (EU cloud by default): `flushAt: 1` (a handful of events
+    per run — dispatch each capture immediately; the SDK still retries failed sends), `disableGeoip:
+    true` (explicit even though it is the SDK default — the "no IP-derived fields" invariant enforced
+    sender-side), `disableCompression: true` (tiny payloads; keeps the wire inspectable for the test
+    seam and debugging), a custom `fetch` as the injected test seam, SDK errors swallowed to the debug
+    log (`on("error")` — never a user-facing warn). Every outgoing event is **personless**
     (`$process_person_profile: false` — no person profiles server-side; unique users still count by
-    `distinct_id` = the install id) and carries **`$geoip_disable: true`** (the "no IP-derived
-    fields" invariant enforced sender-side, belt to the project-level GeoIP-off braces).
+    `distinct_id` = the install id). `shutdown()` drains the queue (bounded, 2s) for graceful stops.
+    Plus `noopSink` (disabled/dev: events vanish).
   - `service.ts` — the facade: `initializeAnalytics(opts)` (installation record via `persistence`,
     sink selection, env stamping, first-run notice + `app_installed` announce, `app_started`),
-    `track(event)`, `setAnalyticsSending(enabled)`, `resetAnalyticsForTests()`.
+    `track(event)`, `setAnalyticsSending(enabled)`, `shutdownAnalytics()` (best-effort flush — the
+    host's `stop()` fires it without awaiting), `resetAnalyticsForTests()`.
 - **Public surface (barrel):** `initializeAnalytics`, `track`, `setAnalyticsSending`,
-  `resetAnalyticsForTests`, the event types.
+  `shutdownAnalytics`, `resetAnalyticsForTests`, the event types + bucket helpers.
 - **Allowed deps:** `persistence` (installation record + data dir), `contracts` (types),
-  `@earendil-works/pi-ai/compat` (the built-in catalog — server-side value import), Node
-  `crypto`/`process`.
+  `@earendil-works/pi-ai` (the built-in catalog — server-side value import), `posthog-node` (the
+  delivery SDK — value-imported **only** in `sink.ts`), Node `crypto`/`process`.
 - **Forbidden:** importing `host` or any other sibling; being imported by anything but `host` (all
-  `track()` call sites live in `host` — feature modules stay analytics-free); putting the
+  `track()` call sites live in `host` — feature modules stay analytics-free; `provider_login` method
+  attribution is host's `loginAnalytics` correlation, see `submodule-server-host`); putting the
   installation id on the wire in any form.
 
 ## Get right (the privacy contract)
 
 - **The only stable identifier** is the per-install uuid4 in `persistence`'s server-only
-  `installation.json` — minted once, **never rotated** (deliberate divergence from thinkrail-v1's
-  fresh-id-on-re-enable; the user chose id continuity), never crossing the wire (deliberately not in
-  the broadcast `config.json`).
+  `installation.json` — minted once, **never rotated** (id continuity across opt-out/opt-in is the
+  chosen posture: a returning opt-in is the same install, not a fresh cohort), never crossing the wire
+  (deliberately not in the broadcast `config.json`).
 - **The flag only gates sending:** `AppConfig.analyticsEnabled` (host-mediated — `host` syncs
-  `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒
-  zero network. `app_installed` fires at most once per install (the `announced` bit), on the first
+  `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒ zero
+  network. `app_installed` fires at most once per install (the `announced` bit), on the first
   sending-enabled boot, together with the first-run notice.
 - **Dev runs never send:** a baked key is refused when `channel === "dev"`; source builds have no
   baked key anyway (double gate — e2e inherits the silence). Only the explicit
   `THINKRAIL_POSTHOG_API_KEY` env override can send from a dev run, and those events still carry
   `channel: "dev"` (`THINKRAIL_POSTHOG_HOST` retargets the endpoint — the future self-host seam).
 - **Never sent:** paths, file/spec names, prompts, code, transcripts, token counts, hostnames,
-  usernames, IP-derived fields, or any free-form user string. Params on every event:
-  `app_version`, `channel`, `os`, `arch` — nothing else outside the per-event params above
-  (transport framing like the two `$`-flags is the sink's, not the event model's).
+  usernames, IP-derived fields, or any free-form user string. Params on every event: `app_version`,
+  `channel`, `os`, `arch` — plus only the closed per-event params above; the unit tests pin each
+  variant's exact non-`$` properties (transport framing — the SDK's `$lib*` fields, `$geoip_disable`,
+  and the personless flag — is the sink's, never an event param).
 - **Fire-and-forget:** `track`/`initializeAnalytics` never throw into callers and never block boot.
+  `shutdownAnalytics` is best-effort: a graceful stop drains the queue; an abrupt exit may drop the
+  final instants' events — accepted (with `flushAt: 1` anything older than the last moment is already
+  dispatched).

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -2,7 +2,7 @@
 id: submodule-server-analytics
 type: submodule-design
 status: active
-title: analytics — anonymous usage analytics (GA4 sink)
+title: analytics — anonymous usage analytics (PostHog sink)
 parent: module-server
 depends-on: [module-contracts]
 tags: [v1, analytics, privacy]
@@ -13,9 +13,11 @@ tags: [v1, analytics, privacy]
 Anonymous, no-personal-data usage analytics, emitted **host-side only** (design + privacy rationale:
 `task-analytics` while it lives; the invariants below are the durable contract). Answers product
 questions — unique users, version/platform, model preference, provider auth — via a **closed event
-set** delivered to Firebase/GA4 over the **Measurement Protocol** (plain `fetch`; there is no
-server-side Firebase SDK). The delivery backend hides behind the `AnalyticsSink` interface —
-swapping vendors is implementing a new sink, nothing else moves.
+set** delivered to **PostHog (EU cloud)** over its capture API (a plain `fetch` POST — no vendor
+SDK; none of the major backends need one server-side). The delivery backend hides behind the
+`AnalyticsSink` interface — swapping vendors is implementing a new sink, nothing else moves
+(exercised for real once already: the first sink was GA4's Measurement Protocol, replaced pre-ship
+by user decision — PostHog's free tier, EU residency, and self-host path won).
 
 ## Boundary
 
@@ -26,9 +28,12 @@ swapping vendors is implementing a new sink, nothing else moves.
     unit test), and `bucketProviderModel()`: identity passes raw **only** when it matches pi's
     built-in catalog (`getProviders()` / `getModels()` from `@earendil-works/pi-ai/compat`); a
     custom provider — or a custom model id on a known provider — becomes `"custom"`. Fails closed.
-  - `sink.ts` — `AnalyticsSink { send(events) }`; `createGa4Sink({ measurementId, apiSecret,
-    fetchImpl? })` (fire-and-forget POST to `/mp/collect`, errors swallowed + debug-logged, no
-    retries) and `noopSink`.
+  - `sink.ts` — `AnalyticsSink { send(events) }`; `createPostHogSink({ apiKey, host?, fetchImpl? })`
+    (fire-and-forget POST to `{host}/batch/`, EU cloud by default; errors swallowed + debug-logged,
+    no retries) and `noopSink`. Every outgoing event is **personless**
+    (`$process_person_profile: false` — no person profiles server-side; unique users still count by
+    `distinct_id` = the install id) and carries **`$geoip_disable: true`** (the "no IP-derived
+    fields" invariant enforced sender-side, belt to the project-level GeoIP-off braces).
   - `service.ts` — the facade: `initializeAnalytics(opts)` (installation record via `persistence`,
     sink selection, env stamping, first-run notice + `app_installed` announce, `app_started`),
     `track(event)`, `setAnalyticsSending(enabled)`, `resetAnalyticsForTests()`.
@@ -51,11 +56,12 @@ swapping vendors is implementing a new sink, nothing else moves.
   `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒
   zero network. `app_installed` fires at most once per install (the `announced` bit), on the first
   sending-enabled boot, together with the first-run notice.
-- **Dev runs never send:** baked keys are refused when `channel === "dev"`; source builds have no
-  baked keys anyway (double gate — e2e inherits the silence). Only the explicit `THINKRAIL_GA4_*`
-  env override can send from a dev run, and those events still carry `channel: "dev"`.
+- **Dev runs never send:** a baked key is refused when `channel === "dev"`; source builds have no
+  baked key anyway (double gate — e2e inherits the silence). Only the explicit
+  `THINKRAIL_POSTHOG_API_KEY` env override can send from a dev run, and those events still carry
+  `channel: "dev"` (`THINKRAIL_POSTHOG_HOST` retargets the endpoint — the future self-host seam).
 - **Never sent:** paths, file/spec names, prompts, code, transcripts, token counts, hostnames,
   usernames, IP-derived fields, or any free-form user string. Params on every event:
-  `app_version`, `channel`, `os`, `arch` + GA4 plumbing (`session_id` per boot,
-  `engagement_time_msec: 1` — without these GA4 doesn't count active users).
+  `app_version`, `channel`, `os`, `arch` — nothing else outside the per-event params above
+  (transport framing like the two `$`-flags is the sink's, not the event model's).
 - **Fire-and-forget:** `track`/`initializeAnalytics` never throw into callers and never block boot.

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -29,16 +29,20 @@ PostHog won on free tier, EU residency, and a self-host path).
     the **unit tests**: they assert every event variant's exact outgoing properties — there is
     deliberately no runtime allowlist filter (the union is closed and we control every call site; a
     content-leaking field fails CI, and runtime filtering was judged over-engineering).
-  - `sink.ts` — `AnalyticsSink { send(clientId, events); shutdown?() }`; `createPostHogSink({ apiKey,
-    host?, fetchImpl? })` wraps `posthog-node` (EU cloud by default): `flushAt: 1` (a handful of events
-    per run — dispatch each capture immediately; the SDK still retries failed sends), `disableGeoip:
-    true` (explicit even though it is the SDK default — the "no IP-derived fields" invariant enforced
-    sender-side), `disableCompression: true` (tiny payloads; keeps the wire inspectable for the test
-    seam and debugging), a custom `fetch` as the injected test seam, SDK errors swallowed to the debug
-    log (`on("error")` — never a user-facing warn). Every outgoing event is **personless**
-    (`$process_person_profile: false` — no person profiles server-side; unique users still count by
-    `distinct_id` = the install id). `shutdown()` drains the queue (bounded, 2s) for graceful stops.
-    Plus `noopSink` (disabled/dev: events vanish).
+  - `sink.ts` — `AnalyticsSink { send(clientId, events); setSending?(enabled); shutdown?() }`;
+    `createPostHogSink({ apiKey, host?, fetchImpl? })` wraps `posthog-node` (EU cloud by default):
+    `flushAt: 1` (a handful of events per run — dispatch each capture immediately; the SDK still
+    retries failed sends), `disableGeoip: true` (explicit even though it is the SDK default — the "no
+    IP-derived fields" invariant enforced sender-side), `disableCompression: true` (tiny payloads;
+    keeps the wire inspectable for the test seam and debugging), a custom `fetch` as the injected test
+    seam, SDK errors swallowed to the debug log (`on("error")` — never a user-facing warn). Every
+    outgoing event is **personless** (`$process_person_profile: false` — no person profiles
+    server-side; unique users still count by `distinct_id` = the install id). **`setSending(false)` is
+    a transport-level gate on the very `fetch` the SDK is handed** — every subsequent SDK request
+    (queued flushes AND the retry loop of an already-failed send) dies at the gate with a synthetic
+    200, zero network; this is deliberately NOT the SDK's `disable()`, which only stops new enqueues
+    (`optedOut` is never checked in its flush/retry paths). `shutdown()` drains the queue (bounded,
+    2s) for graceful stops. Plus `noopSink` (disabled/dev: events vanish).
   - `service.ts` — the facade: `initializeAnalytics(opts)` (installation record via `persistence`,
     sink selection, env stamping, first-run notice + `app_installed` announce, `app_started`),
     `track(event)`, `setAnalyticsSending(enabled)`, `shutdownAnalytics()` (best-effort flush — the
@@ -61,7 +65,10 @@ PostHog won on free tier, EU residency, and a self-host path).
   (deliberately not in the broadcast `config.json`).
 - **The flag only gates sending:** `AppConfig.analyticsEnabled` (host-mediated — `host` syncs
   `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒ zero
-  network. `app_installed` fires at most once per install (the `announced` bit), on the first
+  network **from that instant**: the service stops emitting AND propagates the flip into the sink's
+  transport gate, so events already queued inside the SDK — and retries of an already-failed send —
+  are dropped client-side (an HTTP request already on the wire cannot be recalled; everything after it
+  can, and is). `app_installed` fires at most once per install (the `announced` bit), on the first
   sending-enabled boot, together with the first-run notice.
 - **Only stable/nightly releases send — ever:** the sink is real only when `channel` is in the
   release allowlist (`stable` / `nightly`) AND a baked key is present; anything else (dev, source,
@@ -76,6 +83,8 @@ PostHog won on free tier, EU residency, and a self-host path).
   variant's exact non-`$` properties (transport framing — the SDK's `$lib*` fields, `$geoip_disable`,
   and the personless flag — is the sink's, never an event param).
 - **Fire-and-forget:** `track`/`initializeAnalytics` never throw into callers and never block boot.
-  `shutdownAnalytics` is best-effort: a graceful stop drains the queue; an abrupt exit may drop the
-  final instants' events — accepted (with `flushAt: 1` anything older than the last moment is already
-  dispatched).
+  `shutdownAnalytics` is **idempotent** (one drain, memoized) and awaited where awaiting is possible:
+  `bootHost`'s SIGINT/SIGTERM handler drains it (bounded, concurrent with session settling) before
+  `process.exit`; the sync `server.stop()` fires the same memoized drain best-effort. An abrupt kill
+  may still drop the final instants' events — accepted (with `flushAt: 1` anything older than the
+  last moment is already dispatched).

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -63,10 +63,13 @@ PostHog won on free tier, EU residency, and a self-host path).
   `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒ zero
   network. `app_installed` fires at most once per install (the `announced` bit), on the first
   sending-enabled boot, together with the first-run notice.
-- **Dev runs never send:** a baked key is refused when `channel === "dev"`; source builds have no
-  baked key anyway (double gate — e2e inherits the silence). Only the explicit
-  `THINKRAIL_POSTHOG_API_KEY` env override can send from a dev run, and those events still carry
-  `channel: "dev"` (`THINKRAIL_POSTHOG_HOST` retargets the endpoint — the future self-host seam).
+- **Only stable/nightly releases send — ever:** the sink is real only when `channel` is in the
+  release allowlist (`stable` / `nightly`) AND a baked key is present; anything else (dev, source,
+  e2e, an unknown channel) fails closed to the noop sink. There is deliberately **no env-var key
+  override** — a dev run has no path to the network at all (pipeline verification happens by calling
+  `initializeAnalytics` directly with a release-like channel, or on a real nightly).
+  `THINKRAIL_POSTHOG_HOST` still retargets the endpoint of a *sending* (release) build — the future
+  self-host seam.
 - **Never sent:** paths, file/spec names, prompts, code, transcripts, token counts, hostnames,
   usernames, IP-derived fields, or any free-form user string. Params on every event: `app_version`,
   `channel`, `os`, `arch` — plus only the closed per-event params above; the unit tests pin each

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -1,0 +1,61 @@
+---
+id: submodule-server-analytics
+type: submodule-design
+status: active
+title: analytics — anonymous usage analytics (GA4 sink)
+parent: module-server
+depends-on: [module-contracts]
+tags: [v1, analytics, privacy]
+---
+
+## Responsibility
+
+Anonymous, no-personal-data usage analytics, emitted **host-side only** (design + privacy rationale:
+`task-analytics` while it lives; the invariants below are the durable contract). Answers product
+questions — unique users, version/platform, model preference, provider auth — via a **closed event
+set** delivered to Firebase/GA4 over the **Measurement Protocol** (plain `fetch`; there is no
+server-side Firebase SDK). The delivery backend hides behind the `AnalyticsSink` interface —
+swapping vendors is implementing a new sink, nothing else moves.
+
+## Boundary
+
+- **Owns:**
+  - `events.ts` — the closed `AnalyticsEvent` union (`app_installed` / `app_started` /
+    `chat_started {provider, model}` / `provider_login {provider, method}`), the
+    **`PARAM_ALLOWLIST`** (the machine-checked privacy invariant — a param key outside it fails the
+    unit test), and `bucketProviderModel()`: identity passes raw **only** when it matches pi's
+    built-in catalog (`getProviders()` / `getModels()` from `@earendil-works/pi-ai/compat`); a
+    custom provider — or a custom model id on a known provider — becomes `"custom"`. Fails closed.
+  - `sink.ts` — `AnalyticsSink { send(events) }`; `createGa4Sink({ measurementId, apiSecret,
+    fetchImpl? })` (fire-and-forget POST to `/mp/collect`, errors swallowed + debug-logged, no
+    retries) and `noopSink`.
+  - `service.ts` — the facade: `initializeAnalytics(opts)` (installation record via `persistence`,
+    sink selection, env stamping, first-run notice + `app_installed` announce, `app_started`),
+    `track(event)`, `setAnalyticsSending(enabled)`, `resetAnalyticsForTests()`.
+- **Public surface (barrel):** `initializeAnalytics`, `track`, `setAnalyticsSending`,
+  `resetAnalyticsForTests`, the event types.
+- **Allowed deps:** `persistence` (installation record + data dir), `contracts` (types),
+  `@earendil-works/pi-ai/compat` (the built-in catalog — server-side value import), Node
+  `crypto`/`process`.
+- **Forbidden:** importing `host` or any other sibling; being imported by anything but `host` (all
+  `track()` call sites live in `host` — feature modules stay analytics-free); putting the
+  installation id on the wire in any form.
+
+## Get right (the privacy contract)
+
+- **The only stable identifier** is the per-install uuid4 in `persistence`'s server-only
+  `installation.json` — minted once, **never rotated** (deliberate divergence from thinkrail-v1's
+  fresh-id-on-re-enable; the user chose id continuity), never crossing the wire (deliberately not in
+  the broadcast `config.json`).
+- **The flag only gates sending:** `AppConfig.analyticsEnabled` (host-mediated — `host` syncs
+  `setAnalyticsSending` on every settings change; this module has no `settings` edge). Disabled ⇒
+  zero network. `app_installed` fires at most once per install (the `announced` bit), on the first
+  sending-enabled boot, together with the first-run notice.
+- **Dev runs never send:** baked keys are refused when `channel === "dev"`; source builds have no
+  baked keys anyway (double gate — e2e inherits the silence). Only the explicit `THINKRAIL_GA4_*`
+  env override can send from a dev run, and those events still carry `channel: "dev"`.
+- **Never sent:** paths, file/spec names, prompts, code, transcripts, token counts, hostnames,
+  usernames, IP-derived fields, or any free-form user string. Params on every event:
+  `app_version`, `channel`, `os`, `arch` + GA4 plumbing (`session_id` per boot,
+  `engagement_time_msec: 1` — without these GA4 doesn't count active users).
+- **Fire-and-forget:** `track`/`initializeAnalytics` never throw into callers and never block boot.

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -228,13 +228,26 @@ test("the dev channel refuses a baked key — a dev run never sends", async () =
 	expect(sent).toHaveLength(0);
 });
 
-test("an explicit THINKRAIL_POSTHOG_API_KEY env key sends even on the dev channel (pipeline testing)", async () => {
+test("a THINKRAIL_POSTHOG_API_KEY env var is IGNORED — a dev run has no path to the network", async () => {
 	process.env.THINKRAIL_POSTHOG_API_KEY = "phc_ENV";
 	const sent: SentPayload[] = [];
 	initializeAnalytics({ channel: "dev", enabled: true, fetchImpl: makeFetch(sent) });
-	await drained(sent, 1);
-	expect(sent[0]?.body.api_key).toBe("phc_ENV");
-	expect(allEntries(sent)[0]?.properties.channel).toBe("dev"); // still excludable in insights
+	track({ name: "app_started" });
+	await settled();
+	expect(sent).toHaveLength(0);
+});
+
+test("an unknown channel fails closed — only stable/nightly ever send", async () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent, { channel: "beta" });
+	track({ name: "app_started" });
+	await settled();
+	expect(sent).toHaveLength(0);
+
+	resetAnalyticsForTests();
+	const nightly: SentPayload[] = [];
+	bootReleaseLike(nightly, { channel: "nightly" });
+	await drained(nightly, 2); // nightly is a release channel — it sends
 });
 
 test("--no-analytics (mute) silences the run even when key + config say send", async () => {

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
+import { ensureInstallation } from "../persistence";
+import {
+	type AnalyticsEvent,
+	bucketProvider,
+	bucketProviderModel,
+	CUSTOM_BUCKET,
+	PARAM_ALLOWLIST,
+} from "./events";
+import { initializeAnalytics, resetAnalyticsForTests, setAnalyticsSending, track } from "./service";
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+const savedEnvKeys = {
+	id: process.env.THINKRAIL_GA4_MEASUREMENT_ID,
+	secret: process.env.THINKRAIL_GA4_API_SECRET,
+};
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-analytics-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
+	delete process.env.THINKRAIL_GA4_API_SECRET;
+	resetAnalyticsForTests();
+});
+
+afterEach(() => {
+	resetAnalyticsForTests();
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+	if (savedEnvKeys.id === undefined) delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
+	else process.env.THINKRAIL_GA4_MEASUREMENT_ID = savedEnvKeys.id;
+	if (savedEnvKeys.secret === undefined) delete process.env.THINKRAIL_GA4_API_SECRET;
+	else process.env.THINKRAIL_GA4_API_SECRET = savedEnvKeys.secret;
+});
+
+// ── test fetch (the sink's injected seam) ──────────────────────────────
+
+interface SentPayload {
+	url: string;
+	body: { client_id: string; events: { name: string; params: Record<string, unknown> }[] };
+}
+
+function makeFetch(sent: SentPayload[]): typeof fetch {
+	return ((url: string | URL | Request, init?: RequestInit) => {
+		sent.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+		return Promise.resolve(new Response("ok"));
+	}) as typeof fetch;
+}
+
+/** Boot the service on the baked-keys path (release-like: keys + a non-dev channel). */
+function bootReleaseLike(
+	sent: SentPayload[],
+	overrides: Partial<Parameters<typeof initializeAnalytics>[0]> = {},
+): void {
+	initializeAnalytics({
+		appVersion: "1.2.3",
+		channel: "stable",
+		measurementId: "G-TEST",
+		apiSecret: "s3cret",
+		enabled: true,
+		fetchImpl: makeFetch(sent),
+		...overrides,
+	});
+}
+
+// ── the machine-checked privacy invariant ──────────────────────────────
+
+// One fully-populated sample per event variant. The `satisfies` map is EXHAUSTIVE over the union's
+// names — adding a new event variant without a sample here is a compile error, so the allowlist
+// assertions below always cover the whole event model (the v1 allowlist test, in TS).
+const EVENT_SAMPLES = {
+	app_installed: { name: "app_installed" },
+	app_started: { name: "app_started" },
+	chat_started: { name: "chat_started", params: { provider: "anthropic", model: "some-model" } },
+	provider_login: { name: "provider_login", params: { provider: "openai", method: "oauth" } },
+} as const satisfies { [K in AnalyticsEvent["name"]]: Extract<AnalyticsEvent, { name: K }> };
+
+test("every event's outgoing params are a subset of PARAM_ALLOWLIST (privacy invariant)", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	for (const event of Object.values(EVENT_SAMPLES)) track(event);
+	expect(sent.length).toBeGreaterThanOrEqual(Object.keys(EVENT_SAMPLES).length);
+	for (const payload of sent) {
+		for (const event of payload.body.events) {
+			for (const key of Object.keys(event.params)) {
+				expect(PARAM_ALLOWLIST.has(key)).toBe(true);
+			}
+		}
+	}
+});
+
+test("an off-allowlist param is dropped at runtime (fails closed even past the type system)", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	sent.length = 0; // drop the boot lifecycle events
+	// Deliberately malformed via cast: the runtime filter must catch what the compiler can't.
+	track({
+		name: "chat_started",
+		params: { provider: "anthropic", model: "m", leak: "/Users/me/secret-project" },
+	} as unknown as AnalyticsEvent);
+	expect(sent).toHaveLength(1);
+	const params = sent[0]?.body.events[0]?.params ?? {};
+	expect(params.leak).toBeUndefined();
+	expect(params.provider).toBe("anthropic");
+});
+
+test("every event is stamped with env metadata + the GA4 user-counting plumbing", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	track({ name: "app_started" });
+	const last = sent.at(-1);
+	expect(last?.body.events[0]?.params).toMatchObject({
+		app_version: "1.2.3",
+		channel: "stable",
+		engagement_time_msec: 1,
+	});
+	expect(last?.body.events[0]?.params.os).toBeString();
+	expect(last?.body.events[0]?.params.arch).toBeString();
+	expect(last?.body.events[0]?.params.session_id).toBeString();
+});
+
+// ── installation identity ──────────────────────────────────────────────
+
+test("the install id is minted once, used as client_id, and NEVER rotated by toggles", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	const id = ensureInstallation().id;
+	expect(sent[0]?.body.client_id).toBe(id);
+
+	setAnalyticsSending(false);
+	setAnalyticsSending(true);
+	track({ name: "app_started" });
+	expect(sent.at(-1)?.body.client_id).toBe(id);
+	expect(ensureInstallation().id).toBe(id); // unchanged on disk too
+});
+
+test("app_installed fires exactly once per install (announced bit survives restarts)", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed", "app_started"]);
+
+	// Simulated restart: same data dir, fresh in-memory state.
+	resetAnalyticsForTests();
+	const sentAfterRestart: SentPayload[] = [];
+	bootReleaseLike(sentAfterRestart);
+	expect(sentAfterRestart.map((p) => p.body.events[0]?.name)).toEqual(["app_started"]);
+});
+
+test("a disabled boot mints the id but sends nothing; enabling later announces once", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent, { enabled: false });
+	expect(sent).toHaveLength(0);
+	expect(readFileSync(join(dataDir, "installation.json"), "utf8")).toContain('"announced": false');
+
+	setAnalyticsSending(true);
+	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed"]);
+	setAnalyticsSending(true); // idempotent — no second announce
+	expect(sent).toHaveLength(1);
+});
+
+// ── gates ──────────────────────────────────────────────────────────────
+
+test("the dev channel refuses baked keys — a dev run never sends", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent, { channel: "dev" });
+	track({ name: "app_started" });
+	expect(sent).toHaveLength(0);
+});
+
+test("explicit THINKRAIL_GA4_* env keys send even on the dev channel (pipeline testing)", () => {
+	process.env.THINKRAIL_GA4_MEASUREMENT_ID = "G-ENV";
+	process.env.THINKRAIL_GA4_API_SECRET = "env-secret";
+	const sent: SentPayload[] = [];
+	initializeAnalytics({ channel: "dev", enabled: true, fetchImpl: makeFetch(sent) });
+	expect(sent.length).toBeGreaterThan(0);
+	expect(sent[0]?.url).toContain("measurement_id=G-ENV");
+	expect(sent[0]?.body.events[0]?.params.channel).toBe("dev"); // still excludable in reports
+});
+
+test("--no-analytics (mute) silences the run even when keys + config say send", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent, { mute: true });
+	track({ name: "app_started" });
+	setAnalyticsSending(true); // a settings toggle during a muted run must not unmute it
+	track({ name: "app_started" });
+	expect(sent).toHaveLength(0);
+});
+
+test("setAnalyticsSending(false) stops sending immediately", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	sent.length = 0;
+	setAnalyticsSending(false);
+	track({ name: "chat_started", params: { provider: "anthropic", model: "m" } });
+	expect(sent).toHaveLength(0);
+});
+
+test("track never throws into the caller, even when the transport does", () => {
+	initializeAnalytics({
+		channel: "stable",
+		measurementId: "G-TEST",
+		apiSecret: "s",
+		enabled: true,
+		fetchImpl: (() => {
+			throw new Error("boom");
+		}) as unknown as typeof fetch,
+	});
+	expect(() => track({ name: "app_started" })).not.toThrow();
+});
+
+// ── identity bucketing (closed vocabulary from pi's built-in catalog) ──
+
+test("a pi built-in provider + model pass through raw", () => {
+	const model = getBuiltinModels("anthropic")[0];
+	if (!model) throw new Error("pi catalog has no anthropic models — update the test");
+	expect(bucketProviderModel("anthropic", model.id)).toEqual({
+		provider: "anthropic",
+		model: model.id,
+	});
+	expect(bucketProvider("anthropic")).toBe("anthropic");
+});
+
+test("a custom provider — and its model — bucket to custom (fails closed)", () => {
+	expect(bucketProviderModel("acme-internal", "secret-model-v2")).toEqual({
+		provider: CUSTOM_BUCKET,
+		model: CUSTOM_BUCKET,
+	});
+	expect(bucketProvider("acme-internal")).toBe(CUSTOM_BUCKET);
+});
+
+test("a custom model id on a known provider buckets the model but keeps the provider", () => {
+	expect(bucketProviderModel("openai", "my-private-finetune")).toEqual({
+		provider: "openai",
+		model: CUSTOM_BUCKET,
+	});
+});

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -4,14 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import { ensureInstallation } from "../persistence";
+import { type AnalyticsEvent, bucketProvider, bucketProviderModel, CUSTOM_BUCKET } from "./events";
 import {
-	type AnalyticsEvent,
-	bucketProvider,
-	bucketProviderModel,
-	CUSTOM_BUCKET,
-	PARAM_ALLOWLIST,
-} from "./events";
-import { initializeAnalytics, resetAnalyticsForTests, setAnalyticsSending, track } from "./service";
+	initializeAnalytics,
+	resetAnalyticsForTests,
+	setAnalyticsSending,
+	shutdownAnalytics,
+	track,
+} from "./service";
 
 let dataDir: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
@@ -52,12 +52,29 @@ interface SentPayload {
 	body: { api_key: string; batch: BatchEntry[] };
 }
 
+// posthog-node delivers asynchronously (queue → flush), so the fake fetch fills `sent` a beat after
+// `track()` returns. `drained(n)` awaits at least n entries; negative assertions settle briefly first.
 function makeFetch(sent: SentPayload[]): typeof fetch {
 	return ((url: string | URL | Request, init?: RequestInit) => {
 		sent.push({ url: String(url), body: JSON.parse(String(init?.body)) });
-		return Promise.resolve(new Response("ok"));
+		return Promise.resolve(new Response("{}", { status: 200 }));
 	}) as typeof fetch;
 }
+
+/** Every batch entry across every captured payload. */
+function allEntries(sent: SentPayload[]): BatchEntry[] {
+	return sent.flatMap((p) => p.body.batch);
+}
+
+/** Await until at least `count` events have been delivered to the fake fetch (bounded). */
+async function drained(sent: SentPayload[], count: number): Promise<void> {
+	const deadline = Date.now() + 2_000;
+	while (allEntries(sent).length < count && Date.now() < deadline) await Bun.sleep(5);
+	expect(allEntries(sent).length).toBeGreaterThanOrEqual(count);
+}
+
+/** A short settle so "nothing was sent" assertions are honest against the async queue. */
+const settled = (): Promise<void> => Bun.sleep(25);
 
 /** Boot the service on the baked-key path (release-like: key + a non-dev channel). */
 function bootReleaseLike(
@@ -74,16 +91,12 @@ function bootReleaseLike(
 	});
 }
 
-/** Every batch entry across every captured payload. */
-function allEntries(sent: SentPayload[]): BatchEntry[] {
-	return sent.flatMap((p) => p.body.batch);
-}
-
 // ── the machine-checked privacy invariant ──────────────────────────────
 
 // One fully-populated sample per event variant. The `satisfies` map is EXHAUSTIVE over the union's
-// names — adding a new event variant without a sample here is a compile error, so the allowlist
-// assertions below always cover the whole event model (thinkrail-v1's allowlist test, in TS).
+// names — adding a new event variant without a sample here is a compile error, so the payload pinning
+// below always covers the whole event model (the closed union + these exact-set assertions ARE the
+// leak guard; there is deliberately no runtime filter).
 const EVENT_SAMPLES = {
 	app_installed: { name: "app_installed" },
 	app_started: { name: "app_started" },
@@ -91,135 +104,161 @@ const EVENT_SAMPLES = {
 	provider_login: { name: "provider_login", params: { provider: "openai", method: "oauth" } },
 } as const satisfies { [K in AnalyticsEvent["name"]]: Extract<AnalyticsEvent, { name: K }> };
 
-test("every event's outgoing properties are allowlist params + the two $ transport flags only", () => {
+const ENV_KEYS = ["app_version", "channel", "os", "arch"];
+
+/** The exact non-`$` property keys each variant may put on the wire — extend only with a spec change. */
+const EXPECTED_KEYS: Record<keyof typeof EVENT_SAMPLES, string[]> = {
+	app_installed: ENV_KEYS,
+	app_started: ENV_KEYS,
+	chat_started: [...ENV_KEYS, "provider", "model"],
+	provider_login: [...ENV_KEYS, "provider", "method"],
+};
+
+test("every event's outgoing properties are EXACTLY its declared params (+ $ transport framing)", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	for (const event of Object.values(EVENT_SAMPLES)) track(event);
-	expect(sent.length).toBeGreaterThanOrEqual(Object.keys(EVENT_SAMPLES).length);
+	// boot emits app_installed + app_started, then one per tracked sample
+	await drained(sent, 2 + Object.keys(EVENT_SAMPLES).length);
 	for (const entry of allEntries(sent)) {
-		for (const key of Object.keys(entry.properties)) {
-			if (key.startsWith("$")) continue; // transport framing, asserted below
-			expect(PARAM_ALLOWLIST.has(key)).toBe(true);
-		}
+		const plainKeys = Object.keys(entry.properties)
+			.filter((key) => !key.startsWith("$"))
+			.sort();
+		const expected = EXPECTED_KEYS[entry.event as keyof typeof EXPECTED_KEYS];
+		expect(expected).toBeDefined();
+		expect(plainKeys).toEqual([...expected].sort());
 		// PostHog framing: personless (no person profiles) + GeoIP disabled — on EVERY event.
 		expect(entry.properties.$process_person_profile).toBe(false);
 		expect(entry.properties.$geoip_disable).toBe(true);
 	}
 });
 
-test("an off-allowlist param is dropped at runtime (fails closed even past the type system)", () => {
-	const sent: SentPayload[] = [];
-	bootReleaseLike(sent);
-	sent.length = 0; // drop the boot lifecycle events
-	// Deliberately malformed via cast: the runtime filter must catch what the compiler can't.
-	track({
-		name: "chat_started",
-		params: { provider: "anthropic", model: "m", leak: "/Users/me/secret-project" },
-	} as unknown as AnalyticsEvent);
-	const entry = allEntries(sent)[0];
-	expect(entry).toBeDefined();
-	expect(entry?.properties.leak).toBeUndefined();
-	expect(entry?.properties.provider).toBe("anthropic");
-});
-
-test("every event is stamped with the env metadata", () => {
+test("every event is stamped with the env metadata", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	track({ name: "app_started" });
+	await drained(sent, 3);
 	const entry = allEntries(sent).at(-1);
 	expect(entry?.properties).toMatchObject({ app_version: "1.2.3", channel: "stable" });
 	expect(entry?.properties.os).toBeString();
 	expect(entry?.properties.arch).toBeString();
 });
 
-test("the batch goes to the EU cloud by default; THINKRAIL_POSTHOG_HOST retargets it", () => {
+test("the batch goes to the EU cloud by default; THINKRAIL_POSTHOG_HOST retargets it", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
+	await drained(sent, 1);
 	expect(sent[0]?.url).toBe("https://eu.i.posthog.com/batch/");
 
 	resetAnalyticsForTests();
-	process.env.THINKRAIL_POSTHOG_HOST = "https://ph.example.test/";
+	process.env.THINKRAIL_POSTHOG_HOST = "https://ph.example.test/"; // trailing slash normalized
 	const retargeted: SentPayload[] = [];
 	bootReleaseLike(retargeted);
+	await drained(retargeted, 1);
 	expect(retargeted[0]?.url).toBe("https://ph.example.test/batch/");
+});
+
+test("shutdownAnalytics drains the queue and never throws", async () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	track({ name: "chat_started", params: { provider: "anthropic", model: "m" } });
+	await shutdownAnalytics();
+	expect(allEntries(sent).map((e) => e.event)).toEqual([
+		"app_installed",
+		"app_started",
+		"chat_started",
+	]);
+	await shutdownAnalytics(); // idempotent, still never throws
 });
 
 // ── installation identity ──────────────────────────────────────────────
 
-test("the install id is minted once, used as distinct_id, and NEVER rotated by toggles", () => {
+test("the install id is minted once, used as distinct_id, and NEVER rotated by toggles", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
+	await drained(sent, 1);
 	const id = ensureInstallation().id;
 	expect(allEntries(sent)[0]?.distinct_id).toBe(id);
 
 	setAnalyticsSending(false);
 	setAnalyticsSending(true);
 	track({ name: "app_started" });
+	await drained(sent, 3);
 	expect(allEntries(sent).at(-1)?.distinct_id).toBe(id);
 	expect(ensureInstallation().id).toBe(id); // unchanged on disk too
 });
 
-test("app_installed fires exactly once per install (announced bit survives restarts)", () => {
+test("app_installed fires exactly once per install (announced bit survives restarts)", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
+	await drained(sent, 2);
 	expect(allEntries(sent).map((e) => e.event)).toEqual(["app_installed", "app_started"]);
 
 	// Simulated restart: same data dir, fresh in-memory state.
 	resetAnalyticsForTests();
 	const sentAfterRestart: SentPayload[] = [];
 	bootReleaseLike(sentAfterRestart);
+	await drained(sentAfterRestart, 1);
+	await settled();
 	expect(allEntries(sentAfterRestart).map((e) => e.event)).toEqual(["app_started"]);
 });
 
-test("a disabled boot mints the id but sends nothing; enabling later announces once", () => {
+test("a disabled boot mints the id but sends nothing; enabling later announces once", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent, { enabled: false });
+	await settled();
 	expect(sent).toHaveLength(0);
 	expect(readFileSync(join(dataDir, "installation.json"), "utf8")).toContain('"announced": false');
 
 	setAnalyticsSending(true);
+	await drained(sent, 1);
 	expect(allEntries(sent).map((e) => e.event)).toEqual(["app_installed"]);
 	setAnalyticsSending(true); // idempotent — no second announce
+	await settled();
 	expect(allEntries(sent)).toHaveLength(1);
 });
 
 // ── gates ──────────────────────────────────────────────────────────────
 
-test("the dev channel refuses a baked key — a dev run never sends", () => {
+test("the dev channel refuses a baked key — a dev run never sends", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent, { channel: "dev" });
 	track({ name: "app_started" });
+	await settled();
 	expect(sent).toHaveLength(0);
 });
 
-test("an explicit THINKRAIL_POSTHOG_API_KEY env key sends even on the dev channel (pipeline testing)", () => {
+test("an explicit THINKRAIL_POSTHOG_API_KEY env key sends even on the dev channel (pipeline testing)", async () => {
 	process.env.THINKRAIL_POSTHOG_API_KEY = "phc_ENV";
 	const sent: SentPayload[] = [];
 	initializeAnalytics({ channel: "dev", enabled: true, fetchImpl: makeFetch(sent) });
-	expect(sent.length).toBeGreaterThan(0);
+	await drained(sent, 1);
 	expect(sent[0]?.body.api_key).toBe("phc_ENV");
 	expect(allEntries(sent)[0]?.properties.channel).toBe("dev"); // still excludable in insights
 });
 
-test("--no-analytics (mute) silences the run even when key + config say send", () => {
+test("--no-analytics (mute) silences the run even when key + config say send", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent, { mute: true });
 	track({ name: "app_started" });
 	setAnalyticsSending(true); // a settings toggle during a muted run must not unmute it
 	track({ name: "app_started" });
+	await settled();
 	expect(sent).toHaveLength(0);
 });
 
-test("setAnalyticsSending(false) stops sending immediately", () => {
+test("setAnalyticsSending(false) stops sending immediately", async () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
-	sent.length = 0;
+	await drained(sent, 2); // let the boot lifecycle land first…
+	sent.length = 0; // …then drop it
 	setAnalyticsSending(false);
 	track({ name: "chat_started", params: { provider: "anthropic", model: "m" } });
+	await settled();
 	expect(sent).toHaveLength(0);
 });
 
-test("track never throws into the caller, even when the transport does", () => {
+test("track never throws into the caller, even when the transport does", async () => {
 	initializeAnalytics({
 		channel: "stable",
 		posthogApiKey: "phc_TEST",
@@ -229,6 +268,7 @@ test("track never throws into the caller, even when the transport does", () => {
 		}) as unknown as typeof fetch,
 	});
 	expect(() => track({ name: "app_started" })).not.toThrow();
+	await settled(); // let the SDK's internal retry/error path run inside the test's lifetime
 });
 
 // ── identity bucketing (closed vocabulary from pi's built-in catalog) ──

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -15,16 +15,16 @@ import { initializeAnalytics, resetAnalyticsForTests, setAnalyticsSending, track
 
 let dataDir: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
-const savedEnvKeys = {
-	id: process.env.THINKRAIL_GA4_MEASUREMENT_ID,
-	secret: process.env.THINKRAIL_GA4_API_SECRET,
+const savedEnv = {
+	key: process.env.THINKRAIL_POSTHOG_API_KEY,
+	host: process.env.THINKRAIL_POSTHOG_HOST,
 };
 
 beforeEach(() => {
 	dataDir = mkdtempSync(join(tmpdir(), "trpi-analytics-test-"));
 	process.env.THINKRAIL_DATA_DIR = dataDir;
-	delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
-	delete process.env.THINKRAIL_GA4_API_SECRET;
+	delete process.env.THINKRAIL_POSTHOG_API_KEY;
+	delete process.env.THINKRAIL_POSTHOG_HOST;
 	resetAnalyticsForTests();
 });
 
@@ -33,17 +33,23 @@ afterEach(() => {
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
-	if (savedEnvKeys.id === undefined) delete process.env.THINKRAIL_GA4_MEASUREMENT_ID;
-	else process.env.THINKRAIL_GA4_MEASUREMENT_ID = savedEnvKeys.id;
-	if (savedEnvKeys.secret === undefined) delete process.env.THINKRAIL_GA4_API_SECRET;
-	else process.env.THINKRAIL_GA4_API_SECRET = savedEnvKeys.secret;
+	if (savedEnv.key === undefined) delete process.env.THINKRAIL_POSTHOG_API_KEY;
+	else process.env.THINKRAIL_POSTHOG_API_KEY = savedEnv.key;
+	if (savedEnv.host === undefined) delete process.env.THINKRAIL_POSTHOG_HOST;
+	else process.env.THINKRAIL_POSTHOG_HOST = savedEnv.host;
 });
 
 // ── test fetch (the sink's injected seam) ──────────────────────────────
 
+interface BatchEntry {
+	event: string;
+	distinct_id: string;
+	properties: Record<string, unknown>;
+}
+
 interface SentPayload {
 	url: string;
-	body: { client_id: string; events: { name: string; params: Record<string, unknown> }[] };
+	body: { api_key: string; batch: BatchEntry[] };
 }
 
 function makeFetch(sent: SentPayload[]): typeof fetch {
@@ -53,7 +59,7 @@ function makeFetch(sent: SentPayload[]): typeof fetch {
 	}) as typeof fetch;
 }
 
-/** Boot the service on the baked-keys path (release-like: keys + a non-dev channel). */
+/** Boot the service on the baked-key path (release-like: key + a non-dev channel). */
 function bootReleaseLike(
 	sent: SentPayload[],
 	overrides: Partial<Parameters<typeof initializeAnalytics>[0]> = {},
@@ -61,19 +67,23 @@ function bootReleaseLike(
 	initializeAnalytics({
 		appVersion: "1.2.3",
 		channel: "stable",
-		measurementId: "G-TEST",
-		apiSecret: "s3cret",
+		posthogApiKey: "phc_TEST",
 		enabled: true,
 		fetchImpl: makeFetch(sent),
 		...overrides,
 	});
 }
 
+/** Every batch entry across every captured payload. */
+function allEntries(sent: SentPayload[]): BatchEntry[] {
+	return sent.flatMap((p) => p.body.batch);
+}
+
 // ── the machine-checked privacy invariant ──────────────────────────────
 
 // One fully-populated sample per event variant. The `satisfies` map is EXHAUSTIVE over the union's
 // names — adding a new event variant without a sample here is a compile error, so the allowlist
-// assertions below always cover the whole event model (the v1 allowlist test, in TS).
+// assertions below always cover the whole event model (thinkrail-v1's allowlist test, in TS).
 const EVENT_SAMPLES = {
 	app_installed: { name: "app_installed" },
 	app_started: { name: "app_started" },
@@ -81,17 +91,19 @@ const EVENT_SAMPLES = {
 	provider_login: { name: "provider_login", params: { provider: "openai", method: "oauth" } },
 } as const satisfies { [K in AnalyticsEvent["name"]]: Extract<AnalyticsEvent, { name: K }> };
 
-test("every event's outgoing params are a subset of PARAM_ALLOWLIST (privacy invariant)", () => {
+test("every event's outgoing properties are allowlist params + the two $ transport flags only", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	for (const event of Object.values(EVENT_SAMPLES)) track(event);
 	expect(sent.length).toBeGreaterThanOrEqual(Object.keys(EVENT_SAMPLES).length);
-	for (const payload of sent) {
-		for (const event of payload.body.events) {
-			for (const key of Object.keys(event.params)) {
-				expect(PARAM_ALLOWLIST.has(key)).toBe(true);
-			}
+	for (const entry of allEntries(sent)) {
+		for (const key of Object.keys(entry.properties)) {
+			if (key.startsWith("$")) continue; // transport framing, asserted below
+			expect(PARAM_ALLOWLIST.has(key)).toBe(true);
 		}
+		// PostHog framing: personless (no person profiles) + GeoIP disabled — on EVERY event.
+		expect(entry.properties.$process_person_profile).toBe(false);
+		expect(entry.properties.$geoip_disable).toBe(true);
 	}
 });
 
@@ -104,52 +116,59 @@ test("an off-allowlist param is dropped at runtime (fails closed even past the t
 		name: "chat_started",
 		params: { provider: "anthropic", model: "m", leak: "/Users/me/secret-project" },
 	} as unknown as AnalyticsEvent);
-	expect(sent).toHaveLength(1);
-	const params = sent[0]?.body.events[0]?.params ?? {};
-	expect(params.leak).toBeUndefined();
-	expect(params.provider).toBe("anthropic");
+	const entry = allEntries(sent)[0];
+	expect(entry).toBeDefined();
+	expect(entry?.properties.leak).toBeUndefined();
+	expect(entry?.properties.provider).toBe("anthropic");
 });
 
-test("every event is stamped with env metadata + the GA4 user-counting plumbing", () => {
+test("every event is stamped with the env metadata", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	track({ name: "app_started" });
-	const last = sent.at(-1);
-	expect(last?.body.events[0]?.params).toMatchObject({
-		app_version: "1.2.3",
-		channel: "stable",
-		engagement_time_msec: 1,
-	});
-	expect(last?.body.events[0]?.params.os).toBeString();
-	expect(last?.body.events[0]?.params.arch).toBeString();
-	expect(last?.body.events[0]?.params.session_id).toBeString();
+	const entry = allEntries(sent).at(-1);
+	expect(entry?.properties).toMatchObject({ app_version: "1.2.3", channel: "stable" });
+	expect(entry?.properties.os).toBeString();
+	expect(entry?.properties.arch).toBeString();
+});
+
+test("the batch goes to the EU cloud by default; THINKRAIL_POSTHOG_HOST retargets it", () => {
+	const sent: SentPayload[] = [];
+	bootReleaseLike(sent);
+	expect(sent[0]?.url).toBe("https://eu.i.posthog.com/batch/");
+
+	resetAnalyticsForTests();
+	process.env.THINKRAIL_POSTHOG_HOST = "https://ph.example.test/";
+	const retargeted: SentPayload[] = [];
+	bootReleaseLike(retargeted);
+	expect(retargeted[0]?.url).toBe("https://ph.example.test/batch/");
 });
 
 // ── installation identity ──────────────────────────────────────────────
 
-test("the install id is minted once, used as client_id, and NEVER rotated by toggles", () => {
+test("the install id is minted once, used as distinct_id, and NEVER rotated by toggles", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
 	const id = ensureInstallation().id;
-	expect(sent[0]?.body.client_id).toBe(id);
+	expect(allEntries(sent)[0]?.distinct_id).toBe(id);
 
 	setAnalyticsSending(false);
 	setAnalyticsSending(true);
 	track({ name: "app_started" });
-	expect(sent.at(-1)?.body.client_id).toBe(id);
+	expect(allEntries(sent).at(-1)?.distinct_id).toBe(id);
 	expect(ensureInstallation().id).toBe(id); // unchanged on disk too
 });
 
 test("app_installed fires exactly once per install (announced bit survives restarts)", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent);
-	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed", "app_started"]);
+	expect(allEntries(sent).map((e) => e.event)).toEqual(["app_installed", "app_started"]);
 
 	// Simulated restart: same data dir, fresh in-memory state.
 	resetAnalyticsForTests();
 	const sentAfterRestart: SentPayload[] = [];
 	bootReleaseLike(sentAfterRestart);
-	expect(sentAfterRestart.map((p) => p.body.events[0]?.name)).toEqual(["app_started"]);
+	expect(allEntries(sentAfterRestart).map((e) => e.event)).toEqual(["app_started"]);
 });
 
 test("a disabled boot mints the id but sends nothing; enabling later announces once", () => {
@@ -159,31 +178,30 @@ test("a disabled boot mints the id but sends nothing; enabling later announces o
 	expect(readFileSync(join(dataDir, "installation.json"), "utf8")).toContain('"announced": false');
 
 	setAnalyticsSending(true);
-	expect(sent.map((p) => p.body.events[0]?.name)).toEqual(["app_installed"]);
+	expect(allEntries(sent).map((e) => e.event)).toEqual(["app_installed"]);
 	setAnalyticsSending(true); // idempotent — no second announce
-	expect(sent).toHaveLength(1);
+	expect(allEntries(sent)).toHaveLength(1);
 });
 
 // ── gates ──────────────────────────────────────────────────────────────
 
-test("the dev channel refuses baked keys — a dev run never sends", () => {
+test("the dev channel refuses a baked key — a dev run never sends", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent, { channel: "dev" });
 	track({ name: "app_started" });
 	expect(sent).toHaveLength(0);
 });
 
-test("explicit THINKRAIL_GA4_* env keys send even on the dev channel (pipeline testing)", () => {
-	process.env.THINKRAIL_GA4_MEASUREMENT_ID = "G-ENV";
-	process.env.THINKRAIL_GA4_API_SECRET = "env-secret";
+test("an explicit THINKRAIL_POSTHOG_API_KEY env key sends even on the dev channel (pipeline testing)", () => {
+	process.env.THINKRAIL_POSTHOG_API_KEY = "phc_ENV";
 	const sent: SentPayload[] = [];
 	initializeAnalytics({ channel: "dev", enabled: true, fetchImpl: makeFetch(sent) });
 	expect(sent.length).toBeGreaterThan(0);
-	expect(sent[0]?.url).toContain("measurement_id=G-ENV");
-	expect(sent[0]?.body.events[0]?.params.channel).toBe("dev"); // still excludable in reports
+	expect(sent[0]?.body.api_key).toBe("phc_ENV");
+	expect(allEntries(sent)[0]?.properties.channel).toBe("dev"); // still excludable in insights
 });
 
-test("--no-analytics (mute) silences the run even when keys + config say send", () => {
+test("--no-analytics (mute) silences the run even when key + config say send", () => {
 	const sent: SentPayload[] = [];
 	bootReleaseLike(sent, { mute: true });
 	track({ name: "app_started" });
@@ -204,8 +222,7 @@ test("setAnalyticsSending(false) stops sending immediately", () => {
 test("track never throws into the caller, even when the transport does", () => {
 	initializeAnalytics({
 		channel: "stable",
-		measurementId: "G-TEST",
-		apiSecret: "s",
+		posthogApiKey: "phc_TEST",
 		enabled: true,
 		fetchImpl: (() => {
 			throw new Error("boom");

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -158,17 +158,51 @@ test("the batch goes to the EU cloud by default; THINKRAIL_POSTHOG_HOST retarget
 	expect(retargeted[0]?.url).toBe("https://ph.example.test/batch/");
 });
 
-test("shutdownAnalytics drains the queue and never throws", async () => {
+test("shutdownAnalytics genuinely awaits the drain (slow transport, no polling) and never throws", async () => {
 	const sent: SentPayload[] = [];
-	bootReleaseLike(sent);
+	const slowFetch: typeof fetch = (async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+		await Bun.sleep(50); // a real network-ish delay — an unawaited drain could not see this land
+		sent.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+		return new Response("{}", { status: 200 });
+	}) as typeof fetch;
+	bootReleaseLike(sent, { fetchImpl: slowFetch });
 	track({ name: "chat_started", params: { provider: "anthropic", model: "m" } });
 	await shutdownAnalytics();
+	// Asserted immediately after the await — deliverable only because shutdown really waited.
 	expect(allEntries(sent).map((e) => e.event)).toEqual([
 		"app_installed",
 		"app_started",
 		"chat_started",
 	]);
-	await shutdownAnalytics(); // idempotent, still never throws
+	await shutdownAnalytics(); // idempotent (memoized), still never throws
+});
+
+test("toggle-off silences events already queued inside the SDK — the transport gate", async () => {
+	const delivered: SentPayload[] = [];
+	let started = 0;
+	const slowFetch: typeof fetch = (async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+		started++;
+		await Bun.sleep(100); // keep this request in-flight while the next event queues behind it
+		delivered.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+		return new Response("{}", { status: 200 });
+	}) as typeof fetch;
+	bootReleaseLike(delivered, { fetchImpl: slowFetch });
+	await drained(delivered, 2); // boot lifecycle out of the way
+
+	const startedBefore = started;
+	track({ name: "chat_started", params: { provider: "anthropic", model: "m" } });
+	const deadline = Date.now() + 2_000;
+	while (started === startedBefore && Date.now() < deadline) await Bun.sleep(5);
+	expect(started).toBeGreaterThan(startedBefore); // chat_started is genuinely ON the wire…
+
+	track({ name: "provider_login", params: { provider: "openai", method: "oauth" } }); // …this one queues behind it
+	setAnalyticsSending(false); // consent off while one is in-flight and one is queued
+	await shutdownAnalytics(); // drains the queue — into the closed gate
+	await Bun.sleep(150); // let the in-flight request finish
+
+	const events = allEntries(delivered).map((e) => e.event);
+	expect(events).toContain("chat_started"); // already on the wire — cannot be recalled
+	expect(events).not.toContain("provider_login"); // queued — died at the gate, zero network
 });
 
 // ── installation identity ──────────────────────────────────────────────

--- a/packages/server/src/analytics/events.ts
+++ b/packages/server/src/analytics/events.ts
@@ -19,17 +19,16 @@ export type AnalyticsEvent =
 	| { name: "provider_login"; params: { provider: string; method: LoginMethod } };
 
 /**
- * Every param key that may ever appear on an outgoing event — env metadata + GA4 plumbing + the
- * closed per-event params. The service filters against this set at runtime; the unit test asserts
- * every event variant's payload is a subset. Extend it only alongside a spec'd event change.
+ * Every param key that may ever appear on an outgoing event — env metadata + the closed per-event
+ * params. The service filters against this set at runtime; the unit test asserts every event
+ * variant's payload is a subset. (Transport framing — the sink's `$`-prefixed PostHog flags — is the
+ * sink's own, never an event param.) Extend it only alongside a spec'd event change.
  */
 export const PARAM_ALLOWLIST: ReadonlySet<string> = new Set([
 	"app_version",
 	"channel",
 	"os",
 	"arch",
-	"session_id",
-	"engagement_time_msec",
 	"provider",
 	"model",
 	"method",

--- a/packages/server/src/analytics/events.ts
+++ b/packages/server/src/analytics/events.ts
@@ -1,7 +1,7 @@
 // The closed analytics event model — the privacy contract's data half (see SPEC.md). Every event a
-// host can emit is a member of `AnalyticsEvent`; every param key it may carry is in `PARAM_ALLOWLIST`.
-// The service drops any key outside the allowlist at runtime (fails closed) and the unit test pins the
-// exact payload of every variant, so a content-leaking field can neither ship nor land silently in CI.
+// host can emit is a member of `AnalyticsEvent`, and the unit tests pin the exact outgoing payload of
+// every variant — a content-leaking field fails CI. (No runtime allowlist filter: the union is closed
+// and we control every call site.)
 import { getBuiltinModels, getBuiltinProviders } from "@earendil-works/pi-ai/providers/all";
 
 /** How a provider credential was configured in-app. A closed vocabulary, never user input. */
@@ -17,22 +17,6 @@ export type AnalyticsEvent =
 	| { name: "app_started" }
 	| { name: "chat_started"; params: { provider: string; model: string } }
 	| { name: "provider_login"; params: { provider: string; method: LoginMethod } };
-
-/**
- * Every param key that may ever appear on an outgoing event — env metadata + the closed per-event
- * params. The service filters against this set at runtime; the unit test asserts every event
- * variant's payload is a subset. (Transport framing — the sink's `$`-prefixed PostHog flags — is the
- * sink's own, never an event param.) Extend it only alongside a spec'd event change.
- */
-export const PARAM_ALLOWLIST: ReadonlySet<string> = new Set([
-	"app_version",
-	"channel",
-	"os",
-	"arch",
-	"provider",
-	"model",
-	"method",
-]);
 
 /** The bucket a user-configured (non-built-in) provider or model id collapses to. */
 export const CUSTOM_BUCKET = "custom";

--- a/packages/server/src/analytics/events.ts
+++ b/packages/server/src/analytics/events.ts
@@ -1,0 +1,72 @@
+// The closed analytics event model — the privacy contract's data half (see SPEC.md). Every event a
+// host can emit is a member of `AnalyticsEvent`; every param key it may carry is in `PARAM_ALLOWLIST`.
+// The service drops any key outside the allowlist at runtime (fails closed) and the unit test pins the
+// exact payload of every variant, so a content-leaking field can neither ship nor land silently in CI.
+import { getBuiltinModels, getBuiltinProviders } from "@earendil-works/pi-ai/providers/all";
+
+/** How a provider credential was configured in-app. A closed vocabulary, never user input. */
+export type LoginMethod = "oauth" | "api-key" | "central";
+
+/**
+ * Every analytics event the host can emit. `app_installed`/`app_started` carry no event params (the
+ * env set below rides on every event); the identity params on the other two pass through
+ * `bucketProviderModel`/`bucketProvider` first, so a user-configured name never leaves the process.
+ */
+export type AnalyticsEvent =
+	| { name: "app_installed" }
+	| { name: "app_started" }
+	| { name: "chat_started"; params: { provider: string; model: string } }
+	| { name: "provider_login"; params: { provider: string; method: LoginMethod } };
+
+/**
+ * Every param key that may ever appear on an outgoing event — env metadata + GA4 plumbing + the
+ * closed per-event params. The service filters against this set at runtime; the unit test asserts
+ * every event variant's payload is a subset. Extend it only alongside a spec'd event change.
+ */
+export const PARAM_ALLOWLIST: ReadonlySet<string> = new Set([
+	"app_version",
+	"channel",
+	"os",
+	"arch",
+	"session_id",
+	"engagement_time_msec",
+	"provider",
+	"model",
+	"method",
+]);
+
+/** The bucket a user-configured (non-built-in) provider or model id collapses to. */
+export const CUSTOM_BUCKET = "custom";
+
+// pi's built-in catalog (provider → model ids), built lazily once — the closed vocabulary identity
+// params are checked against. Derived from the pinned pi-ai version, so it never drifts on pi bumps.
+let catalog: Map<string, ReadonlySet<string>> | null = null;
+
+function builtinCatalog(): Map<string, ReadonlySet<string>> {
+	if (!catalog) {
+		catalog = new Map();
+		for (const provider of getBuiltinProviders()) {
+			catalog.set(provider, new Set(getBuiltinModels(provider).map((model) => String(model.id))));
+		}
+	}
+	return catalog;
+}
+
+/** A provider id passes raw only when it is a pi built-in; anything user-configured is `custom`. */
+export function bucketProvider(provider: string): string {
+	return builtinCatalog().has(provider) ? provider : CUSTOM_BUCKET;
+}
+
+/**
+ * Identity for `chat_started`: the provider must be a pi built-in AND the model id must be in that
+ * provider's built-in catalog — a custom model id on a known provider (free text from models.json)
+ * buckets to `custom` too. Fails closed: unknown means `custom`, never a pass-through.
+ */
+export function bucketProviderModel(
+	provider: string,
+	modelId: string,
+): { provider: string; model: string } {
+	const models = builtinCatalog().get(provider);
+	if (!models) return { provider: CUSTOM_BUCKET, model: CUSTOM_BUCKET };
+	return { provider, model: models.has(modelId) ? modelId : CUSTOM_BUCKET };
+}

--- a/packages/server/src/analytics/index.ts
+++ b/packages/server/src/analytics/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Anonymous usage analytics (see SPEC.md — the privacy contract). Consumed by `host` ONLY: every
+ * `track()` call site lives there, feature modules never know analytics exists.
+ */
+export {
+	type AnalyticsEvent,
+	bucketProvider,
+	bucketProviderModel,
+	type LoginMethod,
+} from "./events";
+export {
+	type AnalyticsOptions,
+	initializeAnalytics,
+	resetAnalyticsForTests,
+	setAnalyticsSending,
+	track,
+} from "./service";

--- a/packages/server/src/analytics/index.ts
+++ b/packages/server/src/analytics/index.ts
@@ -13,5 +13,6 @@ export {
 	initializeAnalytics,
 	resetAnalyticsForTests,
 	setAnalyticsSending,
+	shutdownAnalytics,
 	track,
 } from "./service";

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -1,7 +1,7 @@
 // The analytics facade: initialize once at host boot, `track()` from host call sites, sync the config
 // flag via `setAnalyticsSending`. Fire-and-forget end to end — nothing here may throw into a caller or
-// block boot. The privacy contract (single anonymous id, closed events, dev-run silence) is SPEC.md's
-// "Get right" section; this file is its runtime half.
+// block boot. The privacy contract (single anonymous id, closed events, release-only sending) is
+// SPEC.md's "Get right" section; this file is its runtime half.
 import { ensureInstallation, saveInstallation } from "../persistence";
 import type { AnalyticsEvent } from "./events";
 import { type AnalyticsSink, createPostHogSink, noopSink, type OutgoingEvent } from "./sink";
@@ -9,7 +9,7 @@ import { type AnalyticsSink, createPostHogSink, noopSink, type OutgoingEvent } f
 export interface AnalyticsOptions {
 	/** The launcher's baked release version (absent from source — stamped like `appVersion`). */
 	appVersion?: string;
-	/** Release channel (`stable` / `nightly`); defaults to `dev`, which refuses a baked key. */
+	/** Release channel; only `stable` / `nightly` ever send — anything else lands on the noop sink. */
 	channel?: string;
 	/** PostHog project API key baked by the release pipeline (empty/absent from source ⇒ noop sink). */
 	posthogApiKey?: string;
@@ -37,6 +37,9 @@ interface AnalyticsState {
 
 let state: AnalyticsState | null = null;
 
+/** The ONLY channels that ever get a real sink — everything else fails closed to noop. */
+const SENDING_CHANNELS: ReadonlySet<string> = new Set(["stable", "nightly"]);
+
 function detectOs(): string {
 	if (process.platform === "darwin") return "macos";
 	if (process.platform === "win32") return "windows";
@@ -45,20 +48,19 @@ function detectOs(): string {
 
 /**
  * Boot the analytics service (called once from `createServer`). Mints/loads the installation record,
- * picks the sink — an env-override key always wins (deliberate pipeline testing); the baked key is
- * refused on the `dev` channel (dev runs never send); otherwise noop — and emits the lifecycle
- * events. On the first sending-enabled boot ever it prints the first-run notice and sends the
- * one-shot `app_installed`.
+ * picks the sink — the release-baked key on a `stable`/`nightly` channel; anything else (dev, source,
+ * e2e, unknown channels) fails closed to noop, with deliberately **no env-var key override** — and
+ * emits the lifecycle events. On the first sending-enabled boot ever it prints the first-run notice
+ * and sends the one-shot `app_installed`.
  */
 export function initializeAnalytics(options: AnalyticsOptions): void {
 	try {
 		const record = ensureInstallation();
 		const channel = options.channel ?? "dev";
-		const envApiKey = process.env.THINKRAIL_POSTHOG_API_KEY;
 		const host = process.env.THINKRAIL_POSTHOG_HOST ?? options.posthogHost;
 
 		let sink = noopSink;
-		const apiKey = envApiKey || (channel !== "dev" ? options.posthogApiKey : undefined);
+		const apiKey = SENDING_CHANNELS.has(channel) ? options.posthogApiKey : undefined;
 		if (apiKey) {
 			sink = createPostHogSink({
 				apiKey,

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -1,0 +1,167 @@
+// The analytics facade: initialize once at host boot, `track()` from host call sites, sync the config
+// flag via `setAnalyticsSending`. Fire-and-forget end to end — nothing here may throw into a caller or
+// block boot. The privacy contract (single anonymous id, closed events, dev-run silence) is SPEC.md's
+// "Get right" section; this file is its runtime half.
+import { ensureInstallation, saveInstallation } from "../persistence";
+import { type AnalyticsEvent, PARAM_ALLOWLIST } from "./events";
+import { type AnalyticsSink, createGa4Sink, noopSink, type OutgoingEvent } from "./sink";
+
+export interface AnalyticsOptions {
+	/** The launcher's baked release version (absent from source — stamped like `appVersion`). */
+	appVersion?: string;
+	/** Release channel (`stable` / `nightly`); defaults to `dev`, which refuses baked keys. */
+	channel?: string;
+	/** GA4 keys baked by the release pipeline (empty/absent from source ⇒ noop sink). */
+	measurementId?: string;
+	apiSecret?: string;
+	/** `--no-analytics`: mute this run without touching the persisted flag. */
+	mute?: boolean;
+	/** The persisted `AppConfig.analyticsEnabled` at boot. */
+	enabled: boolean;
+	/** Test seam, threaded into the GA4 sink. */
+	fetchImpl?: typeof fetch;
+}
+
+interface AnalyticsState {
+	sink: AnalyticsSink;
+	/** The anonymous per-install id (GA4 `client_id`) — never crosses the wire. */
+	clientId: string;
+	/** All gates folded: config flag AND not muted AND a real sink. */
+	sending: boolean;
+	mute: boolean;
+	realSink: boolean;
+	announced: boolean;
+	env: { app_version: string; channel: string; os: string; arch: string };
+	/** Per-boot GA4 session id — without it (+ engagement time) GA4 doesn't count active users. */
+	sessionId: string;
+}
+
+let state: AnalyticsState | null = null;
+
+function detectOs(): string {
+	if (process.platform === "darwin") return "macos";
+	if (process.platform === "win32") return "windows";
+	return process.platform;
+}
+
+/**
+ * Boot the analytics service (called once from `createServer`). Mints/loads the installation record,
+ * picks the sink — env-override keys always win (deliberate pipeline testing); baked keys are refused
+ * on the `dev` channel (dev runs never send); otherwise noop — and emits the lifecycle events. On the
+ * first sending-enabled boot ever it prints the first-run notice and sends the one-shot `app_installed`.
+ */
+export function initializeAnalytics(options: AnalyticsOptions): void {
+	try {
+		const record = ensureInstallation();
+		const channel = options.channel ?? "dev";
+		const envMeasurementId = process.env.THINKRAIL_GA4_MEASUREMENT_ID;
+		const envApiSecret = process.env.THINKRAIL_GA4_API_SECRET;
+
+		let sink = noopSink;
+		if (envMeasurementId && envApiSecret) {
+			sink = createGa4Sink({
+				measurementId: envMeasurementId,
+				apiSecret: envApiSecret,
+				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+			});
+		} else if (options.measurementId && options.apiSecret && channel !== "dev") {
+			sink = createGa4Sink({
+				measurementId: options.measurementId,
+				apiSecret: options.apiSecret,
+				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+			});
+		}
+
+		const realSink = sink !== noopSink;
+		const mute = options.mute === true;
+		state = {
+			sink,
+			clientId: record.id,
+			mute,
+			realSink,
+			sending: options.enabled && !mute && realSink,
+			announced: record.announced,
+			env: {
+				app_version: options.appVersion ?? "0.0.0-dev",
+				channel,
+				os: detectOs(),
+				arch: process.arch,
+			},
+			sessionId: String(Date.now()),
+		};
+
+		if (state.sending) {
+			if (!state.announced) announceInstall(state);
+			track({ name: "app_started" });
+		}
+	} catch (error) {
+		debugLog(error);
+	}
+}
+
+/**
+ * Emit one event, fire-and-forget. No-ops unless every gate is open; never throws into the caller.
+ * Params are stamped (env + GA4 plumbing) and filtered against `PARAM_ALLOWLIST` — an off-list key is
+ * dropped here, so a content leak cannot leave the process even if the event model grows a bug.
+ */
+export function track(event: AnalyticsEvent): void {
+	const s = state;
+	if (!s?.sending) return;
+	try {
+		s.sink.send(s.clientId, [toOutgoingEvent(event, s)]);
+	} catch (error) {
+		debugLog(error);
+	}
+}
+
+/**
+ * Sync the persisted `AppConfig.analyticsEnabled` flag into the live service — the host calls this off
+ * the settings broadcast. Flipping to enabled runs the pending install announce (notice + one-shot
+ * `app_installed`) if this install has never sent one. The id is deliberately NOT rotated on toggles.
+ */
+export function setAnalyticsSending(enabled: boolean): void {
+	const s = state;
+	if (!s) return;
+	try {
+		s.sending = enabled && !s.mute && s.realSink;
+		if (s.sending) {
+			if (!s.announced) announceInstall(s);
+		}
+	} catch (error) {
+		debugLog(error);
+	}
+}
+
+/** Drop the singleton state — unit-test isolation only. */
+export function resetAnalyticsForTests(): void {
+	state = null;
+}
+
+function announceInstall(s: AnalyticsState): void {
+	s.announced = true;
+	saveInstallation({ id: s.clientId, announced: true });
+	console.log(
+		"ThinkRail sends anonymous usage analytics (no personal data — see the README's Analytics & Privacy section). Disable in Settings → Privacy, or launch with --no-analytics.",
+	);
+	track({ name: "app_installed" });
+}
+
+function toOutgoingEvent(event: AnalyticsEvent, s: AnalyticsState): OutgoingEvent {
+	const params: Record<string, string | number> = {
+		...s.env,
+		session_id: s.sessionId,
+		engagement_time_msec: 1,
+	};
+	if ("params" in event) {
+		for (const [key, value] of Object.entries(event.params)) {
+			if (PARAM_ALLOWLIST.has(key)) params[key] = value;
+		}
+	}
+	return { name: event.name, params };
+}
+
+function debugLog(error: unknown): void {
+	if (process.env.THINKRAIL_ANALYTICS_DEBUG) {
+		console.warn(`analytics failed: ${error instanceof Error ? error.message : error}`);
+	}
+}

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -32,6 +32,8 @@ interface AnalyticsState {
 	mute: boolean;
 	realSink: boolean;
 	announced: boolean;
+	/** Memoized drain — `shutdownAnalytics` is idempotent (boot's awaited call and stop's void call share it). */
+	shutdownPromise?: Promise<void>;
 	env: { app_version: string; channel: string; os: string; arch: string };
 }
 
@@ -71,6 +73,7 @@ export function initializeAnalytics(options: AnalyticsOptions): void {
 
 		const realSink = sink !== noopSink;
 		const mute = options.mute === true;
+		sink.setSending?.(options.enabled && !mute);
 		state = {
 			sink,
 			clientId: record.id,
@@ -112,14 +115,17 @@ export function track(event: AnalyticsEvent): void {
 
 /**
  * Sync the persisted `AppConfig.analyticsEnabled` flag into the live service — the host calls this off
- * the settings broadcast. Flipping to enabled runs the pending install announce (notice + one-shot
- * `app_installed`) if this install has never sent one. The id is deliberately NOT rotated on toggles.
+ * the settings broadcast. The flip propagates into the sink's transport gate too, so turning off also
+ * silences events already queued inside the SDK and retries of a failed send — zero network from this
+ * instant. Flipping to enabled runs the pending install announce (notice + one-shot `app_installed`)
+ * if this install has never sent one. The id is deliberately NOT rotated on toggles.
  */
 export function setAnalyticsSending(enabled: boolean): void {
 	const s = state;
 	if (!s) return;
 	try {
 		s.sending = enabled && !s.mute && s.realSink;
+		s.sink.setSending?.(s.sending);
 		if (s.sending) {
 			if (!s.announced) announceInstall(s);
 		}
@@ -129,17 +135,21 @@ export function setAnalyticsSending(enabled: boolean): void {
 }
 
 /**
- * Drain the sink's queued/in-flight deliveries — the host's `stop()` fires this without awaiting
- * (best-effort by contract; bounded inside the sink). Never throws.
+ * Drain the sink's queued/in-flight deliveries — bounded inside the sink, idempotent (memoized), and
+ * it never throws. `bootHost`'s signal handler AWAITS it before `process.exit`; the sync
+ * `server.stop()` fires the same memoized drain without awaiting (best-effort by contract).
  */
-export async function shutdownAnalytics(): Promise<void> {
+export function shutdownAnalytics(): Promise<void> {
 	const s = state;
-	if (!s?.realSink) return;
-	try {
-		await s.sink.shutdown?.();
-	} catch (error) {
-		debugLog(error);
-	}
+	if (!s?.realSink) return Promise.resolve();
+	s.shutdownPromise ??= (async () => {
+		try {
+			await s.sink.shutdown?.();
+		} catch (error) {
+			debugLog(error);
+		}
+	})();
+	return s.shutdownPromise;
 }
 
 /** Drop the singleton state (draining any real sink, fire-and-forget) — unit-test isolation only. */

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -4,27 +4,28 @@
 // "Get right" section; this file is its runtime half.
 import { ensureInstallation, saveInstallation } from "../persistence";
 import { type AnalyticsEvent, PARAM_ALLOWLIST } from "./events";
-import { type AnalyticsSink, createGa4Sink, noopSink, type OutgoingEvent } from "./sink";
+import { type AnalyticsSink, createPostHogSink, noopSink, type OutgoingEvent } from "./sink";
 
 export interface AnalyticsOptions {
 	/** The launcher's baked release version (absent from source — stamped like `appVersion`). */
 	appVersion?: string;
-	/** Release channel (`stable` / `nightly`); defaults to `dev`, which refuses baked keys. */
+	/** Release channel (`stable` / `nightly`); defaults to `dev`, which refuses a baked key. */
 	channel?: string;
-	/** GA4 keys baked by the release pipeline (empty/absent from source ⇒ noop sink). */
-	measurementId?: string;
-	apiSecret?: string;
+	/** PostHog project API key baked by the release pipeline (empty/absent from source ⇒ noop sink). */
+	posthogApiKey?: string;
+	/** PostHog instance origin override (defaults to EU cloud) — the self-host seam. */
+	posthogHost?: string;
 	/** `--no-analytics`: mute this run without touching the persisted flag. */
 	mute?: boolean;
 	/** The persisted `AppConfig.analyticsEnabled` at boot. */
 	enabled: boolean;
-	/** Test seam, threaded into the GA4 sink. */
+	/** Test seam, threaded into the sink. */
 	fetchImpl?: typeof fetch;
 }
 
 interface AnalyticsState {
 	sink: AnalyticsSink;
-	/** The anonymous per-install id (GA4 `client_id`) — never crosses the wire. */
+	/** The anonymous per-install id (PostHog `distinct_id`) — never crosses the wire. */
 	clientId: string;
 	/** All gates folded: config flag AND not muted AND a real sink. */
 	sending: boolean;
@@ -32,8 +33,6 @@ interface AnalyticsState {
 	realSink: boolean;
 	announced: boolean;
 	env: { app_version: string; channel: string; os: string; arch: string };
-	/** Per-boot GA4 session id — without it (+ engagement time) GA4 doesn't count active users. */
-	sessionId: string;
 }
 
 let state: AnalyticsState | null = null;
@@ -46,28 +45,24 @@ function detectOs(): string {
 
 /**
  * Boot the analytics service (called once from `createServer`). Mints/loads the installation record,
- * picks the sink — env-override keys always win (deliberate pipeline testing); baked keys are refused
- * on the `dev` channel (dev runs never send); otherwise noop — and emits the lifecycle events. On the
- * first sending-enabled boot ever it prints the first-run notice and sends the one-shot `app_installed`.
+ * picks the sink — an env-override key always wins (deliberate pipeline testing); the baked key is
+ * refused on the `dev` channel (dev runs never send); otherwise noop — and emits the lifecycle
+ * events. On the first sending-enabled boot ever it prints the first-run notice and sends the
+ * one-shot `app_installed`.
  */
 export function initializeAnalytics(options: AnalyticsOptions): void {
 	try {
 		const record = ensureInstallation();
 		const channel = options.channel ?? "dev";
-		const envMeasurementId = process.env.THINKRAIL_GA4_MEASUREMENT_ID;
-		const envApiSecret = process.env.THINKRAIL_GA4_API_SECRET;
+		const envApiKey = process.env.THINKRAIL_POSTHOG_API_KEY;
+		const host = process.env.THINKRAIL_POSTHOG_HOST ?? options.posthogHost;
 
 		let sink = noopSink;
-		if (envMeasurementId && envApiSecret) {
-			sink = createGa4Sink({
-				measurementId: envMeasurementId,
-				apiSecret: envApiSecret,
-				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
-			});
-		} else if (options.measurementId && options.apiSecret && channel !== "dev") {
-			sink = createGa4Sink({
-				measurementId: options.measurementId,
-				apiSecret: options.apiSecret,
+		const apiKey = envApiKey || (channel !== "dev" ? options.posthogApiKey : undefined);
+		if (apiKey) {
+			sink = createPostHogSink({
+				apiKey,
+				...(host ? { host } : {}),
 				...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
 			});
 		}
@@ -87,7 +82,6 @@ export function initializeAnalytics(options: AnalyticsOptions): void {
 				os: detectOs(),
 				arch: process.arch,
 			},
-			sessionId: String(Date.now()),
 		};
 
 		if (state.sending) {
@@ -101,7 +95,7 @@ export function initializeAnalytics(options: AnalyticsOptions): void {
 
 /**
  * Emit one event, fire-and-forget. No-ops unless every gate is open; never throws into the caller.
- * Params are stamped (env + GA4 plumbing) and filtered against `PARAM_ALLOWLIST` — an off-list key is
+ * Params are stamped (env) and filtered against `PARAM_ALLOWLIST` — an off-list key is
  * dropped here, so a content leak cannot leave the process even if the event model grows a bug.
  */
 export function track(event: AnalyticsEvent): void {
@@ -147,11 +141,7 @@ function announceInstall(s: AnalyticsState): void {
 }
 
 function toOutgoingEvent(event: AnalyticsEvent, s: AnalyticsState): OutgoingEvent {
-	const params: Record<string, string | number> = {
-		...s.env,
-		session_id: s.sessionId,
-		engagement_time_msec: 1,
-	};
+	const params: Record<string, string | number> = { ...s.env };
 	if ("params" in event) {
 		for (const [key, value] of Object.entries(event.params)) {
 			if (PARAM_ALLOWLIST.has(key)) params[key] = value;

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -3,7 +3,7 @@
 // block boot. The privacy contract (single anonymous id, closed events, dev-run silence) is SPEC.md's
 // "Get right" section; this file is its runtime half.
 import { ensureInstallation, saveInstallation } from "../persistence";
-import { type AnalyticsEvent, PARAM_ALLOWLIST } from "./events";
+import type { AnalyticsEvent } from "./events";
 import { type AnalyticsSink, createPostHogSink, noopSink, type OutgoingEvent } from "./sink";
 
 export interface AnalyticsOptions {
@@ -95,8 +95,8 @@ export function initializeAnalytics(options: AnalyticsOptions): void {
 
 /**
  * Emit one event, fire-and-forget. No-ops unless every gate is open; never throws into the caller.
- * Params are stamped (env) and filtered against `PARAM_ALLOWLIST` — an off-list key is
- * dropped here, so a content leak cannot leave the process even if the event model grows a bug.
+ * Params are the env stamp + the event's own closed params — the union is closed and the unit tests
+ * pin every variant's exact payload, so a content-leaking field fails CI rather than being filtered.
  */
 export function track(event: AnalyticsEvent): void {
 	const s = state;
@@ -126,9 +126,25 @@ export function setAnalyticsSending(enabled: boolean): void {
 	}
 }
 
-/** Drop the singleton state — unit-test isolation only. */
+/**
+ * Drain the sink's queued/in-flight deliveries — the host's `stop()` fires this without awaiting
+ * (best-effort by contract; bounded inside the sink). Never throws.
+ */
+export async function shutdownAnalytics(): Promise<void> {
+	const s = state;
+	if (!s?.realSink) return;
+	try {
+		await s.sink.shutdown?.();
+	} catch (error) {
+		debugLog(error);
+	}
+}
+
+/** Drop the singleton state (draining any real sink, fire-and-forget) — unit-test isolation only. */
 export function resetAnalyticsForTests(): void {
+	const s = state;
 	state = null;
+	if (s?.realSink) void s.sink.shutdown?.();
 }
 
 function announceInstall(s: AnalyticsState): void {
@@ -141,13 +157,10 @@ function announceInstall(s: AnalyticsState): void {
 }
 
 function toOutgoingEvent(event: AnalyticsEvent, s: AnalyticsState): OutgoingEvent {
-	const params: Record<string, string | number> = { ...s.env };
-	if ("params" in event) {
-		for (const [key, value] of Object.entries(event.params)) {
-			if (PARAM_ALLOWLIST.has(key)) params[key] = value;
-		}
-	}
-	return { name: event.name, params };
+	return {
+		name: event.name,
+		params: { ...s.env, ...("params" in event ? event.params : {}) },
+	};
 }
 
 function debugLog(error: unknown): void {

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -1,10 +1,11 @@
 // The delivery backend, hidden behind `AnalyticsSink` — swapping vendors is implementing a new sink,
-// nothing else in the module (or the host) moves (proven once: the first sink was GA4's Measurement
-// Protocol, replaced by PostHog before ever shipping). The current sink is PostHog's capture API: a
-// plain fire-and-forget `fetch` POST, no dependencies, no retries, errors swallowed (debug-logged on
-// demand). Every outgoing event is personless and GeoIP-free — see `createPostHogSink`.
+// nothing else in the module (or the host) moves (proven twice: GA4's Measurement Protocol → a
+// hand-rolled PostHog capture POST → the official `posthog-node` SDK). The SDK is value-imported here
+// and nowhere else; its queue/retry machinery stays an implementation detail behind `send`/`shutdown`.
+// Errors are swallowed and debug-logged on demand — analytics failures are never user-facing.
+import { PostHog } from "posthog-node";
 
-/** One event as the service hands it to a sink: a name + the allowlist-filtered params. */
+/** One event as the service hands it to a sink: a name + the stamped event params. */
 export interface OutgoingEvent {
 	name: string;
 	params: Record<string, string | number>;
@@ -13,6 +14,8 @@ export interface OutgoingEvent {
 export interface AnalyticsSink {
 	/** Fire-and-forget delivery. Must never throw and never return a promise the caller must await. */
 	send(clientId: string, events: OutgoingEvent[]): void;
+	/** Drain queued/in-flight deliveries, bounded — a graceful-stop courtesy, never required. */
+	shutdown?(): Promise<void>;
 }
 
 /** The disabled/dev sink: events vanish. */
@@ -33,34 +36,44 @@ export interface PostHogSinkOptions {
 
 export const POSTHOG_EU_HOST = "https://eu.i.posthog.com";
 
+/** How long a graceful stop waits for the SDK to drain its queue before giving up. */
+const SHUTDOWN_TIMEOUT_MS = 2_000;
+
 /**
- * The PostHog capture sink (`POST {host}/batch/`). `distinct_id` is the anonymous per-install id.
- * Every event carries `$process_person_profile: false` (personless — PostHog builds no person
- * profiles; unique users still count by distinct_id) and `$geoip_disable: true` (no IP-derived
- * fields, enforced sender-side — the module's privacy contract, not just a project setting).
+ * The PostHog sink: `posthog-node` configured for our shape — `flushAt: 1` (a handful of events per
+ * run; dispatch each capture immediately, the SDK still retries failed sends), `disableGeoip: true`
+ * (no IP-derived fields, enforced sender-side — the module's privacy contract, not just a project
+ * setting), `disableCompression: true` (tiny payloads; keeps the wire inspectable for tests and
+ * debugging). `distinct_id` is the anonymous per-install id, and every event is sent **personless**
+ * (`$process_person_profile: false` — PostHog builds no person profiles; unique users still count by
+ * distinct_id).
  */
 export function createPostHogSink(options: PostHogSinkOptions): AnalyticsSink {
-	const fetchFn = options.fetchImpl ?? fetch;
-	const url = `${(options.host ?? POSTHOG_EU_HOST).replace(/\/+$/, "")}/batch/`;
+	const client = new PostHog(options.apiKey, {
+		host: (options.host ?? POSTHOG_EU_HOST).replace(/\/+$/, ""),
+		flushAt: 1,
+		disableGeoip: true,
+		disableCompression: true,
+		...(options.fetchImpl ? { fetch: options.fetchImpl } : {}),
+	});
+	client.on("error", (error) => debugLog(error));
 	return {
 		send(clientId, events) {
 			try {
-				fetchFn(url, {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({
-						api_key: options.apiKey,
-						batch: events.map((event) => ({
-							event: event.name,
-							distinct_id: clientId,
-							properties: {
-								...event.params,
-								$process_person_profile: false,
-								$geoip_disable: true,
-							},
-						})),
-					}),
-				}).catch((error) => debugLog(error));
+				for (const event of events) {
+					client.capture({
+						distinctId: clientId,
+						event: event.name,
+						properties: { ...event.params, $process_person_profile: false },
+					});
+				}
+			} catch (error) {
+				debugLog(error);
+			}
+		},
+		async shutdown() {
+			try {
+				await client.shutdown(SHUTDOWN_TIMEOUT_MS);
 			} catch (error) {
 				debugLog(error);
 			}

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -1,9 +1,10 @@
 // The delivery backend, hidden behind `AnalyticsSink` — swapping vendors is implementing a new sink,
-// nothing else in the module (or the host) moves. The first real sink is GA4's Measurement Protocol
-// (Firebase Analytics IS GA4; there is no server-side Firebase SDK, MP is the ingestion path): a plain
-// fire-and-forget `fetch` POST, no dependencies, no retries, errors swallowed (debug-logged on demand).
+// nothing else in the module (or the host) moves (proven once: the first sink was GA4's Measurement
+// Protocol, replaced by PostHog before ever shipping). The current sink is PostHog's capture API: a
+// plain fire-and-forget `fetch` POST, no dependencies, no retries, errors swallowed (debug-logged on
+// demand). Every outgoing event is personless and GeoIP-free — see `createPostHogSink`.
 
-/** One event as GA4's `/mp/collect` expects it inside `events[]`. */
+/** One event as the service hands it to a sink: a name + the allowlist-filtered params. */
 export interface OutgoingEvent {
 	name: string;
 	params: Record<string, string | number>;
@@ -21,31 +22,44 @@ export const noopSink: AnalyticsSink = {
 	},
 };
 
-export interface Ga4SinkOptions {
-	measurementId: string;
-	apiSecret: string;
+export interface PostHogSinkOptions {
+	/** The PostHog project API key (`phc_…`) — public by design, like any client-side analytics key. */
+	apiKey: string;
+	/** Instance origin; defaults to EU cloud. The future self-host seam. */
+	host?: string;
 	/** Test seam — capture the POST instead of hitting the network. */
 	fetchImpl?: typeof fetch;
-	/** Test/override seam for the collect endpoint. */
-	endpoint?: string;
 }
 
-const GA4_ENDPOINT = "https://www.google-analytics.com/mp/collect";
+export const POSTHOG_EU_HOST = "https://eu.i.posthog.com";
 
 /**
- * The GA4 Measurement Protocol sink. `client_id` is the anonymous per-install id; events must carry
- * `session_id` + `engagement_time_msec` params (the service adds them) or GA4 won't count active users.
+ * The PostHog capture sink (`POST {host}/batch/`). `distinct_id` is the anonymous per-install id.
+ * Every event carries `$process_person_profile: false` (personless — PostHog builds no person
+ * profiles; unique users still count by distinct_id) and `$geoip_disable: true` (no IP-derived
+ * fields, enforced sender-side — the module's privacy contract, not just a project setting).
  */
-export function createGa4Sink(options: Ga4SinkOptions): AnalyticsSink {
+export function createPostHogSink(options: PostHogSinkOptions): AnalyticsSink {
 	const fetchFn = options.fetchImpl ?? fetch;
-	const endpoint = options.endpoint ?? GA4_ENDPOINT;
-	const url = `${endpoint}?measurement_id=${encodeURIComponent(options.measurementId)}&api_secret=${encodeURIComponent(options.apiSecret)}`;
+	const url = `${(options.host ?? POSTHOG_EU_HOST).replace(/\/+$/, "")}/batch/`;
 	return {
 		send(clientId, events) {
 			try {
 				fetchFn(url, {
 					method: "POST",
-					body: JSON.stringify({ client_id: clientId, events }),
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						api_key: options.apiKey,
+						batch: events.map((event) => ({
+							event: event.name,
+							distinct_id: clientId,
+							properties: {
+								...event.params,
+								$process_person_profile: false,
+								$geoip_disable: true,
+							},
+						})),
+					}),
 				}).catch((error) => debugLog(error));
 			} catch (error) {
 				debugLog(error);

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -14,6 +14,11 @@ export interface OutgoingEvent {
 export interface AnalyticsSink {
 	/** Fire-and-forget delivery. Must never throw and never return a promise the caller must await. */
 	send(clientId: string, events: OutgoingEvent[]): void;
+	/**
+	 * Flip the transport gate. `false` ⇒ zero network from this instant — including events already
+	 * queued inside the vendor SDK and retries of an already-failed send (they die at the gate).
+	 */
+	setSending?(enabled: boolean): void;
 	/** Drain queued/in-flight deliveries, bounded — a graceful-stop courtesy, never required. */
 	shutdown?(): Promise<void>;
 }
@@ -49,12 +54,22 @@ const SHUTDOWN_TIMEOUT_MS = 2_000;
  * distinct_id).
  */
 export function createPostHogSink(options: PostHogSinkOptions): AnalyticsSink {
+	// The transport gate: the SDK only ever talks to the network through THIS fetch, so flipping
+	// `sending` silences everything downstream of it — queued flushes and the retry loop of a failed
+	// send included. (The SDK's own `disable()` can't do this: it only stops new enqueues — its
+	// flush/retry paths never re-check it.) The synthetic 200 reads as success, so retry loops end.
+	let sending = true;
+	const realFetch = options.fetchImpl ?? fetch;
+	const gatedFetch = (url: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+		if (!sending) return Promise.resolve(new Response('{"status":"dropped client-side"}'));
+		return realFetch(url, init);
+	};
 	const client = new PostHog(options.apiKey, {
 		host: (options.host ?? POSTHOG_EU_HOST).replace(/\/+$/, ""),
 		flushAt: 1,
 		disableGeoip: true,
 		disableCompression: true,
-		...(options.fetchImpl ? { fetch: options.fetchImpl } : {}),
+		fetch: gatedFetch,
 	});
 	client.on("error", (error) => debugLog(error));
 	return {
@@ -70,6 +85,9 @@ export function createPostHogSink(options: PostHogSinkOptions): AnalyticsSink {
 			} catch (error) {
 				debugLog(error);
 			}
+		},
+		setSending(enabled) {
+			sending = enabled;
 		},
 		async shutdown() {
 			try {

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -1,0 +1,62 @@
+// The delivery backend, hidden behind `AnalyticsSink` — swapping vendors is implementing a new sink,
+// nothing else in the module (or the host) moves. The first real sink is GA4's Measurement Protocol
+// (Firebase Analytics IS GA4; there is no server-side Firebase SDK, MP is the ingestion path): a plain
+// fire-and-forget `fetch` POST, no dependencies, no retries, errors swallowed (debug-logged on demand).
+
+/** One event as GA4's `/mp/collect` expects it inside `events[]`. */
+export interface OutgoingEvent {
+	name: string;
+	params: Record<string, string | number>;
+}
+
+export interface AnalyticsSink {
+	/** Fire-and-forget delivery. Must never throw and never return a promise the caller must await. */
+	send(clientId: string, events: OutgoingEvent[]): void;
+}
+
+/** The disabled/dev sink: events vanish. */
+export const noopSink: AnalyticsSink = {
+	send() {
+		// deliberately empty — analytics is off or unconfigured
+	},
+};
+
+export interface Ga4SinkOptions {
+	measurementId: string;
+	apiSecret: string;
+	/** Test seam — capture the POST instead of hitting the network. */
+	fetchImpl?: typeof fetch;
+	/** Test/override seam for the collect endpoint. */
+	endpoint?: string;
+}
+
+const GA4_ENDPOINT = "https://www.google-analytics.com/mp/collect";
+
+/**
+ * The GA4 Measurement Protocol sink. `client_id` is the anonymous per-install id; events must carry
+ * `session_id` + `engagement_time_msec` params (the service adds them) or GA4 won't count active users.
+ */
+export function createGa4Sink(options: Ga4SinkOptions): AnalyticsSink {
+	const fetchFn = options.fetchImpl ?? fetch;
+	const endpoint = options.endpoint ?? GA4_ENDPOINT;
+	const url = `${endpoint}?measurement_id=${encodeURIComponent(options.measurementId)}&api_secret=${encodeURIComponent(options.apiSecret)}`;
+	return {
+		send(clientId, events) {
+			try {
+				fetchFn(url, {
+					method: "POST",
+					body: JSON.stringify({ client_id: clientId, events }),
+				}).catch((error) => debugLog(error));
+			} catch (error) {
+				debugLog(error);
+			}
+		},
+	};
+}
+
+/** Analytics failures are silent by design (never a user-facing warn); opt into logs via env. */
+function debugLog(error: unknown): void {
+	if (process.env.THINKRAIL_ANALYTICS_DEBUG) {
+		console.warn(`analytics send failed: ${error instanceof Error ? error.message : error}`);
+	}
+}

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -26,7 +26,13 @@ channel fan-out, and the process-boot wrapper both launchers share.
   workspace-read handlers (`fs.*`, `git.status`/`git.diffFile`, `spec.graph`) — a read is the "a client is
   looking" signal; `stopWatch` in `workspace.remove`'s fast path beside `evictSpecIndex`;
   `stopAllWatches()` in `stop()`), `cancelAllLogins()` in `stop()` before the socket close,
-  an optional boot-time `openProject(projectPath)` (best-effort — a launcher convenience), and
+  an optional boot-time `openProject(projectPath)` (best-effort — a launcher convenience), the
+  **analytics wiring** (`initializeAnalytics` at boot from the launcher-threaded `analytics` option —
+  keys/channel/mute + the initial `getConfig().analyticsEnabled`; a `setAnalyticsSending` sync teed
+  off the settings publisher; and every `track()` call site: `chat_started` in `session.create`,
+  `provider_login` from the login-publisher tee's `success` frames (oauth) + `provider.setApiKey`
+  (api-key) + `provider.jbcentralConnect`→connected (central) — per `submodule-server-analytics`,
+  feature modules never track), and
   `stop()` → agent-session + terminal cleanup then socket close); `boot.ts` (`bootHost` → resolve the
   login-shell PATH, pick the port per `portMode` (`"exact"` vs `"free"`), start `createServer`, and
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -40,8 +40,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
   login-shell PATH, pick the port per `portMode` (`"exact"` vs `"free"`), start `createServer`, and
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort
   streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
-  transcripts land paired — then `stop()` + exit; an immediate exit would strand mid-tool transcripts on
-  the restart repair); `handlers.ts` (the WS method→handler registry, including the **Skills-manager set**:
+  transcripts land paired — concurrently with an awaited `shutdownAnalytics()` (bounded queue drain;
+  the same memoized drain `stop()` fires sync/best-effort) — then `stop()` + exit; an immediate exit
+  would strand mid-tool transcripts on the restart repair); `handlers.ts` (the WS method→handler registry, including the **Skills-manager set**:
   `skill.list` / `skills.state` / `project.skills` build the admission context from `projects` (+ the
   workspace's `skillOverrides` when workspace-scoped) and pass it into agent's `listSkillCommands`/
   `listSkillCatalog`; `project.setTrust` acknowledges the aliases present at grant via agent's

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -29,9 +29,12 @@ channel fan-out, and the process-boot wrapper both launchers share.
   an optional boot-time `openProject(projectPath)` (best-effort — a launcher convenience), the
   **analytics wiring** (`initializeAnalytics` at boot from the launcher-threaded `analytics` option —
   keys/channel/mute + the initial `getConfig().analyticsEnabled`; a `setAnalyticsSending` sync teed
-  off the settings publisher; and every `track()` call site: `chat_started` in `session.create`,
-  `provider_login` from the login-publisher tee's `success` frames (oauth) + `provider.setApiKey`
-  (api-key) + `provider.jbcentralConnect`→connected (central) — per `submodule-server-analytics`,
+  off the settings publisher; a fire-and-forget `shutdownAnalytics()` in `stop()` — best-effort queue
+  drain; and every `track()` call site: `chat_started` in `session.create`, `provider_login` from the
+  login-publisher tee's terminal `success` frames with the method (`oauth`/`api-key`) looked up from
+  `loginAnalytics.ts` — the loginId→method map the `provider.loginStart` handler records (and
+  `provider.loginCancel` clears; an unknown loginId tracks nothing, fails closed) — +
+  `provider.jbcentralConnect`→connected (central) — per `submodule-server-analytics`,
   feature modules never track), and
   `stop()` → agent-session + terminal cleanup then socket close); `boot.ts` (`bootHost` → resolve the
   login-shell PATH, pick the port per `portMode` (`"exact"` vs `"free"`), start `createServer`, and

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -1,6 +1,7 @@
 import { findFreePort } from "@thinkrail/shared/freePort";
 import { resolveShellEnv } from "@thinkrail/shared/shellEnv";
 import { settleSessionsForShutdown } from "../agent";
+import { shutdownAnalytics } from "../analytics";
 import { type CreateServerOptions, createServer, type RunningServer } from "./server";
 
 export interface BootHostOptions {
@@ -63,9 +64,11 @@ export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
 		// "Operation aborted" tool results — an immediate `process.exit` here would strand mid-tool
 		// transcripts (an open `ask_user_question` made that deterministic before the ack+terminate
 		// redesign) and lean on the restart repair for what a polite shutdown can persist cleanly.
+		// Concurrently, drain the analytics queue (bounded, idempotent — `stop()`'s own fire-and-forget
+		// call reuses the same drain) so a capture moments before Ctrl-C still lands.
 		void (async () => {
 			try {
-				await settleSessionsForShutdown();
+				await Promise.allSettled([settleSessionsForShutdown(), shutdownAnalytics()]);
 			} finally {
 				server.stop();
 				process.exit(0);

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -1,7 +1,7 @@
 import { findFreePort } from "@thinkrail/shared/freePort";
 import { resolveShellEnv } from "@thinkrail/shared/shellEnv";
 import { settleSessionsForShutdown } from "../agent";
-import { createServer, type RunningServer } from "./server";
+import { type CreateServerOptions, createServer, type RunningServer } from "./server";
 
 export interface BootHostOptions {
 	/** Requested listen port. */
@@ -20,6 +20,8 @@ export interface BootHostOptions {
 	projectPath?: string;
 	/** The launcher's baked release version, forwarded onto the `server.welcome` push. */
 	appVersion?: string;
+	/** Anonymous-analytics wiring (channel + baked GA4 keys + `--no-analytics` mute), forwarded verbatim. */
+	analytics?: CreateServerOptions["analytics"];
 }
 
 export interface BootedHost {
@@ -50,6 +52,7 @@ export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
 		...(options.staticDir ? { staticDir: options.staticDir } : {}),
 		...(options.projectPath ? { projectPath: options.projectPath } : {}),
 		...(options.appVersion ? { appVersion: options.appVersion } : {}),
+		...(options.analytics ? { analytics: options.analytics } : {}),
 	});
 
 	let stopping = false;

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -20,7 +20,7 @@ export interface BootHostOptions {
 	projectPath?: string;
 	/** The launcher's baked release version, forwarded onto the `server.welcome` push. */
 	appVersion?: string;
-	/** Anonymous-analytics wiring (channel + baked GA4 keys + `--no-analytics` mute), forwarded verbatim. */
+	/** Anonymous-analytics wiring (channel + the baked PostHog key + `--no-analytics` mute), forwarded verbatim. */
 	analytics?: CreateServerOptions["analytics"];
 }
 

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -36,6 +36,7 @@ import {
 	setSessionThinkingLevel,
 	steerSession,
 } from "../agent";
+import { bucketProviderModel, track } from "../analytics";
 import {
 	cancelLogin,
 	connectJbcentral,
@@ -302,12 +303,21 @@ const handlers: Record<string, Handler> = {
 			thinkingLevel?: ThinkingLevel;
 		};
 		const ws = getWorkspace(p.workspaceId);
-		return createSession({
+		const created = await createSession({
 			cwd: ws.worktreePath,
 			workspaceId: p.workspaceId,
 			...(p.model ? { model: p.model } : {}),
 			...(p.thinkingLevel ? { thinkingLevel: p.thinkingLevel } : {}),
 		});
+		// Analytics: a NEW chat only (disk re-opens via session.getMessages never land here). Identity is
+		// bucketed against pi's built-in catalog — a custom provider/model name never leaves the process.
+		if (created.model) {
+			track({
+				name: "chat_started",
+				params: bucketProviderModel(created.model.provider, created.model.id),
+			});
+		}
+		return created;
 	},
 	// Sends are acked when ACCEPTED, not when the turn ends — see `ackSend` (a turn can outlive the
 	// client's request timeout; long tool rounds are routine).
@@ -400,7 +410,15 @@ const handlers: Record<string, Handler> = {
 	},
 	// JetBrains AI (jbcentral proxy): connect/disconnect write models.json + reload the runtime config; login
 	// launches `central login` (browser) on the host.
-	"provider.jbcentralConnect": () => connectJbcentral(),
+	"provider.jbcentralConnect": async () => {
+		const result = await connectJbcentral();
+		// Analytics: only an actual connect counts (needs-install / needs-login / error don't). `jbcentral`
+		// is our own constant, not user input — no bucketing needed.
+		if (result.outcome === "connected") {
+			track({ name: "provider_login", params: { provider: "jbcentral", method: "central" } });
+		}
+		return result;
+	},
 	"provider.jbcentralDisconnect": async () => {
 		await disconnectJbcentral();
 		return { ok: true } as const;

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -93,6 +93,7 @@ import {
 } from "../workspaces";
 import { ackSend } from "./ackSend";
 import { buildHistoryScope } from "./historyScope";
+import { dropLogin, recordLoginStart } from "./loginAnalytics";
 
 type Handler = (params: unknown) => unknown | Promise<unknown>;
 
@@ -394,14 +395,21 @@ const handlers: Record<string, Handler> = {
 	// `loginReply` answers a live select/prompt frame.
 	"provider.loginStart": (params) => {
 		const p = params as { providerId: string; type?: "oauth" | "api_key" };
-		return startLogin(p.providerId, p.type ?? "oauth");
+		const type = p.type ?? "oauth";
+		const handle = startLogin(p.providerId, type);
+		// Analytics: remember the flow's method so the login channel's terminal `success` frame can carry
+		// it (the tee in `createServer` looks it up — see loginAnalytics.ts).
+		recordLoginStart(handle.loginId, type);
+		return handle;
 	},
 	"provider.loginReply": (params) => {
 		resolveLogin(params as LoginReply);
 		return { ok: true } as const;
 	},
 	"provider.loginCancel": (params) => {
-		cancelLogin((params as { loginId: string }).loginId);
+		const { loginId } = params as { loginId: string };
+		cancelLogin(loginId);
+		dropLogin(loginId);
 		return { ok: true } as const;
 	},
 	"provider.logout": async (params) => {

--- a/packages/server/src/host/loginAnalytics.test.ts
+++ b/packages/server/src/host/loginAnalytics.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initializeAnalytics, resetAnalyticsForTests } from "../analytics";
+import { dropLogin, recordLoginStart, trackLoginOutcome } from "./loginAnalytics";
+
+// The loginId→method correlation between `provider.loginStart` and the login channel's terminal
+// frame — the piece that gives `provider_login` an honest `oauth` / `api-key` method.
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+interface BatchEntry {
+	event: string;
+	properties: Record<string, unknown>;
+}
+
+let sent: BatchEntry[];
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-login-analytics-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	resetAnalyticsForTests();
+	sent = [];
+	initializeAnalytics({
+		channel: "stable",
+		posthogApiKey: "phc_TEST",
+		enabled: true,
+		fetchImpl: ((_url: string | URL | Request, init?: RequestInit) => {
+			sent.push(...JSON.parse(String(init?.body)).batch);
+			return Promise.resolve(new Response("{}", { status: 200 }));
+		}) as typeof fetch,
+	});
+});
+
+afterEach(() => {
+	resetAnalyticsForTests();
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+/** Await until `sent` holds at least `count` events (posthog-node delivers async). */
+async function drained(count: number): Promise<void> {
+	const deadline = Date.now() + 2_000;
+	while (sent.length < count && Date.now() < deadline) await Bun.sleep(5);
+	expect(sent.length).toBeGreaterThanOrEqual(count);
+}
+
+function logins(): BatchEntry[] {
+	return sent.filter((e) => e.event === "provider_login");
+}
+
+test("an oauth success tracks provider_login {method: oauth}", async () => {
+	recordLoginStart("l1", "oauth");
+	trackLoginOutcome({ loginId: "l1", providerId: "anthropic", frame: { kind: "success" } });
+	await drained(3); // app_installed + app_started + provider_login
+	expect(logins()[0]?.properties).toMatchObject({ provider: "anthropic", method: "oauth" });
+});
+
+test("an api_key success tracks provider_login {method: api-key}; the provider is bucketed", async () => {
+	recordLoginStart("l1", "api_key");
+	trackLoginOutcome({ loginId: "l1", providerId: "acme-internal", frame: { kind: "success" } });
+	await drained(3);
+	expect(logins()[0]?.properties).toMatchObject({ provider: "custom", method: "api-key" });
+});
+
+test("a success for an unknown loginId tracks nothing (fails closed, never a guessed method)", async () => {
+	trackLoginOutcome({ loginId: "ghost", providerId: "anthropic", frame: { kind: "success" } });
+	await drained(2); // just the boot lifecycle
+	await Bun.sleep(25);
+	expect(logins()).toHaveLength(0);
+});
+
+test("an error frame clears the entry — a later success for the same id tracks nothing", async () => {
+	recordLoginStart("l1", "oauth");
+	trackLoginOutcome({
+		loginId: "l1",
+		providerId: "anthropic",
+		frame: { kind: "error", message: "nope" },
+	});
+	trackLoginOutcome({ loginId: "l1", providerId: "anthropic", frame: { kind: "success" } });
+	await drained(2);
+	await Bun.sleep(25);
+	expect(logins()).toHaveLength(0);
+});
+
+test("a cancelled login (dropLogin) tracks nothing on a late success", async () => {
+	recordLoginStart("l1", "api_key");
+	dropLogin("l1");
+	trackLoginOutcome({ loginId: "l1", providerId: "openai", frame: { kind: "success" } });
+	await drained(2);
+	await Bun.sleep(25);
+	expect(logins()).toHaveLength(0);
+});
+
+test("non-terminal frames leave the entry in place for the real terminal", async () => {
+	recordLoginStart("l1", "oauth");
+	trackLoginOutcome({
+		loginId: "l1",
+		providerId: "anthropic",
+		frame: { kind: "progress", message: "…" },
+	});
+	trackLoginOutcome({ loginId: "l1", providerId: "anthropic", frame: { kind: "success" } });
+	await drained(3);
+	expect(logins()[0]?.properties).toMatchObject({ provider: "anthropic", method: "oauth" });
+});

--- a/packages/server/src/host/loginAnalytics.ts
+++ b/packages/server/src/host/loginAnalytics.ts
@@ -1,0 +1,36 @@
+// Correlates `provider.loginStart`'s auth type with the login channel's terminal frame so
+// `provider_login` can carry the method (`oauth` / `api-key`). The host is the only place both ends
+// meet: the `auth` module stays analytics-free (it may not import `analytics`), and the wire stays
+// free of analytics-serving fields — so the loginStart handler records the method here and the
+// login-publisher tee in `createServer` looks it up on the terminal frame.
+import type { AuthType } from "@earendil-works/pi-ai";
+import type { LoginPush } from "@thinkrail/contracts";
+import { bucketProvider, type LoginMethod, track } from "../analytics";
+
+const methodByLoginId = new Map<string, LoginMethod>();
+
+/** Called by the `provider.loginStart` handler: remember which flow this login runs. */
+export function recordLoginStart(loginId: string, type: AuthType): void {
+	methodByLoginId.set(loginId, type === "api_key" ? "api-key" : "oauth");
+}
+
+/** Called by the `provider.loginCancel` handler — a cancelled login never tracks. */
+export function dropLogin(loginId: string): void {
+	methodByLoginId.delete(loginId);
+}
+
+/**
+ * The login-publisher tee: a terminal `success` frame is the `provider_login` moment — provider
+ * bucketed, method from the recorded start. Terminal frames (success or error) clear the entry; a
+ * success with no recorded start tracks nothing (fails closed — never a guessed method).
+ */
+export function trackLoginOutcome(push: LoginPush): void {
+	if (push.frame.kind !== "success" && push.frame.kind !== "error") return;
+	const method = methodByLoginId.get(push.loginId);
+	methodByLoginId.delete(push.loginId);
+	if (push.frame.kind !== "success" || !method) return;
+	track({
+		name: "provider_login",
+		params: { provider: bucketProvider(push.providerId), method },
+	});
+}

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -40,10 +40,10 @@ export interface CreateServerOptions {
 	/** The launcher's baked release version, echoed in the `server.welcome` push (undefined from source). */
 	appVersion?: string;
 	/**
-	 * Anonymous-analytics wiring from the launcher: release channel + the GA4 keys baked at release +
-	 * the `--no-analytics` per-run mute. Absent (dev/e2e/source runs) ⇒ the noop sink — never sends.
+	 * Anonymous-analytics wiring from the launcher: release channel + the PostHog key baked at release
+	 * + the `--no-analytics` per-run mute. Absent (dev/e2e/source runs) ⇒ the noop sink — never sends.
 	 */
-	analytics?: Pick<AnalyticsOptions, "channel" | "measurementId" | "apiSecret" | "mute">;
+	analytics?: Pick<AnalyticsOptions, "channel" | "posthogApiKey" | "posthogHost" | "mute">;
 }
 
 export interface RunningServer {

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -10,10 +10,9 @@ import {
 } from "../agent";
 import {
 	type AnalyticsOptions,
-	bucketProvider,
 	initializeAnalytics,
 	setAnalyticsSending,
-	track,
+	shutdownAnalytics,
 } from "../analytics";
 import { cancelAllLogins, setLoginPublisher } from "../auth";
 import { resolveWorktreeFile } from "../fs";
@@ -29,6 +28,7 @@ import {
 	maybeNaiveNameWorkspace,
 } from "./autoRename";
 import { handleRequest } from "./handlers";
+import { trackLoginOutcome } from "./loginAnalytics";
 
 export interface CreateServerOptions {
 	port?: number;
@@ -211,20 +211,16 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	});
 
 	// Push in-app login flow frames (the session-less `authStorage.login` bridge) over the provider.login
-	// channel. A terminal `success` frame doubles as the `provider_login` analytics moment for OAuth flows
-	// (api-key / jbcentral successes are tracked in their handlers) — the provider id is bucketed, so a
-	// custom provider name never leaves the process.
+	// channel. A terminal `success` frame doubles as the `provider_login` analytics moment — the method
+	// (`oauth`/`api-key`) comes from `loginAnalytics`'s loginId→method map (recorded by the
+	// `provider.loginStart` handler), the provider id is bucketed, so a custom provider name never
+	// leaves the process. (jbcentral's `central` method is tracked in its own connect handler.)
 	setLoginPublisher((push) => {
 		server.publish(
 			WS_CHANNELS.providerLogin,
 			JSON.stringify({ channel: WS_CHANNELS.providerLogin, data: push }),
 		);
-		if (push.frame.kind === "success") {
-			track({
-				name: "provider_login",
-				params: { provider: bucketProvider(push.providerId), method: "oauth" },
-			});
-		}
+		trackLoginOutcome(push);
 	});
 
 	// Boot analytics before any trackable action can occur (fire-and-forget by contract — a failure in
@@ -254,7 +250,9 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		},
 		stop() {
 			// Symmetric teardown: settle in-flight logins (so no detached `login()` promise leaks), dispose
-			// in-process agent sessions + PTYs, then close the socket.
+			// in-process agent sessions + PTYs, then close the socket. Analytics drains first, fire-and-forget
+			// (best-effort by contract — stop never waits on the network).
+			void shutdownAnalytics();
 			cancelAllLogins();
 			stopAllWatches();
 			disposeAllSessions();

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -8,6 +8,13 @@ import {
 	setSessionPublisher,
 	setSkillAdmissionResolver,
 } from "../agent";
+import {
+	type AnalyticsOptions,
+	bucketProvider,
+	initializeAnalytics,
+	setAnalyticsSending,
+	track,
+} from "../analytics";
 import { cancelAllLogins, setLoginPublisher } from "../auth";
 import { resolveWorktreeFile } from "../fs";
 import { listProjects, openProject } from "../projects";
@@ -32,6 +39,11 @@ export interface CreateServerOptions {
 	projectPath?: string;
 	/** The launcher's baked release version, echoed in the `server.welcome` push (undefined from source). */
 	appVersion?: string;
+	/**
+	 * Anonymous-analytics wiring from the launcher: release channel + the GA4 keys baked at release +
+	 * the `--no-analytics` per-run mute. Absent (dev/e2e/source runs) ⇒ the noop sink — never sends.
+	 */
+	analytics?: Pick<AnalyticsOptions, "channel" | "measurementId" | "apiSecret" | "mute">;
 }
 
 export interface RunningServer {
@@ -41,7 +53,14 @@ export interface RunningServer {
 
 /** Boot the engine host: Bun.serve HTTP+WS, /health, optional static SPA, and the server.welcome push. */
 export function createServer(options: CreateServerOptions = {}): RunningServer {
-	const { port = 24242, host = "localhost", staticDir, projectPath, appVersion } = options;
+	const {
+		port = 24242,
+		host = "localhost",
+		staticDir,
+		projectPath,
+		appVersion,
+		analytics,
+	} = options;
 
 	const server = Bun.serve({
 		port,
@@ -152,12 +171,15 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	});
 
 	// Broadcast a server-synced settings change (the full `AppConfig`) to every client so they converge —
-	// the initiator applies on this push too, never optimistically (the workspace-lifecycle pattern).
+	// the initiator applies on this push too, never optimistically (the workspace-lifecycle pattern). The
+	// analytics service syncs off the same tee (host-mediated — `analytics` has no `settings` edge), so
+	// the Privacy toggle takes effect the moment the new config is persisted.
 	setSettingsPublisher((config) => {
 		server.publish(
 			WS_CHANNELS.settingsChanged,
 			JSON.stringify({ channel: WS_CHANNELS.settingsChanged, data: config }),
 		);
+		setAnalyticsSending(config.analyticsEnabled);
 	});
 
 	// Stream each in-process AgentSession's events to subscribed clients over the pi.event channel, and
@@ -188,12 +210,30 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		);
 	});
 
-	// Push in-app login flow frames (the session-less `authStorage.login` bridge) over the provider.login channel.
+	// Push in-app login flow frames (the session-less `authStorage.login` bridge) over the provider.login
+	// channel. A terminal `success` frame doubles as the `provider_login` analytics moment for OAuth flows
+	// (api-key / jbcentral successes are tracked in their handlers) — the provider id is bucketed, so a
+	// custom provider name never leaves the process.
 	setLoginPublisher((push) => {
 		server.publish(
 			WS_CHANNELS.providerLogin,
 			JSON.stringify({ channel: WS_CHANNELS.providerLogin, data: push }),
 		);
+		if (push.frame.kind === "success") {
+			track({
+				name: "provider_login",
+				params: { provider: bucketProvider(push.providerId), method: "oauth" },
+			});
+		}
+	});
+
+	// Boot analytics before any trackable action can occur (fire-and-forget by contract — a failure in
+	// here can never block or crash the host). The persisted flag gates sending; dev/source runs have no
+	// keys and land on the noop sink.
+	initializeAnalytics({
+		...(appVersion ? { appVersion } : {}),
+		...(analytics ?? {}),
+		enabled: getConfig().analyticsEnabled,
 	});
 
 	// Open a project on boot if the launcher passed one (e.g. `thinkrail /path/to/repo`). Best-effort:

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -10,16 +10,20 @@ tags: [v1]
 
 ## Responsibility
 
-Durable app state — projects, workspaces, and the server-synced app config — as JSON under the data dir.
+Durable app state — projects, workspaces, the server-synced app config, and the install identity —
+as JSON under the data dir.
 
 ## Boundary
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
-  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, and `loadConfig`/`saveConfig`
-  (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly) — all
-  tab-indented JSON.
+  `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, `loadConfig`/`saveConfig`
+  (`config.json`, merged over `DEFAULT_CONFIG` so a missing file or key degrades cleanly), and
+  `ensureInstallation`/`saveInstallation` (**`installation.json`** — `{ id, announced }`, the
+  per-install uuid4 + the `app_installed`-sent bit; **server-only by design**: it must never ride
+  the wire-broadcast `config.json` — see `submodule-server-analytics`; `ensureInstallation` mints
+  the id on first read and never rotates it) — all tab-indented JSON.
 - **Public surface (barrel):** `dataDir`, `loadProjects`, `saveProjects`, `loadWorkspaces`,
-  `saveWorkspaces`, `loadConfig`, `saveConfig`.
+  `saveWorkspaces`, `loadConfig`, `saveConfig`, `ensureInstallation`, `saveInstallation`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`AppConfig` types + `DEFAULT_CONFIG`); Node
   `fs`/`os`/`path`.
 - **Forbidden:** importing any sibling module or `host` — this is a leaf others depend on.

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -1,5 +1,6 @@
 // App state under the data dir (THINKRAIL_DATA_DIR for dev/e2e isolation, else ~/.thinkrail).
 // This is OUR state, never the agent's — pi's own session files live under ~/.pi/agent.
+import { randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -45,4 +46,30 @@ export function loadConfig(): AppConfig {
 
 export function saveConfig(config: AppConfig): void {
 	writeJson("config.json", config);
+}
+
+/**
+ * The install identity for anonymous analytics — SERVER-ONLY by design: it must never ride the
+ * wire-broadcast `config.json` (see `submodule-server-analytics`). `id` is minted once per install
+ * and never rotated (turning analytics off only stops sending); `announced` records that the one-shot
+ * `app_installed` event was sent.
+ */
+export interface InstallationRecord {
+	id: string;
+	announced: boolean;
+}
+
+/** Load `installation.json`, minting (and persisting) a fresh record on first read or corrupt file. */
+export function ensureInstallation(): InstallationRecord {
+	const raw = readJson<Partial<InstallationRecord>>("installation.json", {});
+	if (typeof raw.id === "string" && raw.id.length > 0) {
+		return { id: raw.id, announced: raw.announced === true };
+	}
+	const record: InstallationRecord = { id: randomUUID(), announced: false };
+	saveInstallation(record);
+	return record;
+}
+
+export function saveInstallation(record: InstallationRecord): void {
+	writeJson("installation.json", record);
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,9 @@ import {
 
 const rootDir = fileURLToPath(new URL(".", import.meta.url));
 const staticDir = fileURLToPath(new URL("./apps/web/dist", import.meta.url));
-const PORT = 24252; // dedicated e2e port — never collides with dev:server (24242)
+// Dedicated e2e port — never collides with dev:server (24242). Overridable so PARALLEL WORKTREES
+// (this product's own working model) can run their suites concurrently without fighting over one port.
+const PORT = Number(process.env.THINKRAIL_E2E_PORT ?? 24252);
 // A stub `central` (JetBrains Central CLI) on the host's PATH so the JetBrains AI flow is drivable
 // deterministically — no real CLI, network, or JetBrains auth. Prepended so it wins over any real install.
 const fakeBinDir = fileURLToPath(new URL("./e2e/fixtures/bin", import.meta.url));


### PR DESCRIPTION
Adds opt-out anonymous usage analytics, emitted **host-side only** — no analytics code in the web client beyond the Settings toggle. Design was brainstormed + approved in-session; the durable contract lives in `packages/server/src/analytics/SPEC.md`.

> Supersedes #124 (same work, reworked per review + rebased; that PR's head branch was deleted on close, so it can't be reopened).

## What & why
- **Closed event set**: `app_installed` (once per install), `app_started` (per boot), `chat_started {provider, model}`, `provider_login {provider, method: oauth|api-key|central}` → answers unique users / retention / version / platform / model preference / provider auth. Feature-usage events deliberately deferred to a later design pass.
- **Sink abstraction**: `AnalyticsSink { send, shutdown? }` with the delivery backend hidden behind it — the current sink wraps the official **`posthog-node` SDK** (EU cloud; 5.46.1 exact-pinned, server-only, value-imported *only* inside `sink.ts`). Configured for our shape: `flushAt: 1` (immediate dispatch, SDK-side retries), GeoIP disabled sender-side, compression off (tiny, inspectable payloads), injected `fetch` as the test seam; `shutdown()` drains the queue on graceful host stop (fire-and-forget from `stop()`). The abstraction has been exercised for real twice — GA4 Measurement Protocol → hand-rolled PostHog POST → `posthog-node` — each swap contained to the sink + key seam.
- **Privacy contract** (machine-checked):
  - the only stable identifier is a per-install `uuid4` in server-only `installation.json` — minted once, **never rotated**, never crosses the wire (only the boolean flag does); it is PostHog's `distinct_id`
  - events are **personless** (`$process_person_profile: false` — PostHog builds no person profiles) and **GeoIP-disabled sender-side**
  - the leak guard is the **closed event union + unit tests pinning each variant's exact non-`$` outgoing properties** (a compile-time-exhaustive sample per variant; a leaking field fails CI). The earlier runtime param-allowlist filter was dropped as over-engineering — we control every call site.
  - provider/model identity passes through only when it matches **pi's built-in catalog**; anything user-configured reports as `custom`
  - `provider_login`'s method is **honest, not guessed**: `loginAnalytics.ts` correlates `provider.loginStart`'s auth type (`oauth`/`api_key`) with the login channel's terminal `success` frame (main's auth rework routes API-key setup through that same interactive channel); unknown/cancelled logins track nothing — fails closed
  - never sent: paths, prompts, code, transcripts, keys, hostnames, usernames, IP-derived fields
- **Consent surfaces**: on by default + first-run terminal notice; **Settings → Privacy** toggle (`AppConfig.analyticsEnabled`, rides the existing `settings.update`/`settings.changed` machinery — zero new WS methods); `--no-analytics` / `THINKRAIL_NO_ANALYTICS` per-run mute. Toggle-off closes a **transport gate** inside the sink: events already queued in the SDK and retries of a failed send die client-side — zero network from the flip. The graceful-stop drain is **awaited on the SIGINT/SIGTERM path** (bounded) and idempotent.
- **Only stable/nightly releases ever send — structurally**: the sink activates only when the channel is in the release allowlist (`stable`/`nightly`) AND the release-baked key is present; dev/source/e2e/unknown channels fail closed to the noop sink. There is deliberately **no env-var key override** — a dev run has no path to the network at all (`THINKRAIL_POSTHOG_HOST` remains, retargeting only a sending release build — the future self-host seam).
- **Release seam**: `apps/cli/src/analytics-keys.ts` (committed empty) is stamped by `build-binary` from the `THINKRAIL_POSTHOG_API_KEY` repo secret; skipped on forks/PRs, so their binaries stay silent.

## UI
New Settings → **Privacy** section: the toggle + what-is/never-collected copy (the `--no-analytics` footnote line was dropped as noise).

## Verification
- 23 unit tests: exact-payload pinning + PostHog framing flags, id stability across toggles, announce-once across restarts, the release-channel allowlist (dev + unknown channels silent, env key ignored, nightly sends), mute, never-throws, catalog bucketing, EU/host retargeting, the consent transport gate (in-flight delivers, queued dies), a genuinely-awaited drain (slow transport, asserted post-await), and the loginId→method correlation (oauth / api-key / unknown / cancelled / error paths)
- `e2e/privacy.spec.ts` (toggle round-trip + reload persistence); full no-agent e2e suite **99/99** on the rebased tree
- single-file binary **compiles with `posthog-node` bundled and boot-smokes** (`build:binary` + `smoke:binary`)
- `check:deps` + biome + typecheck green; suppressions audit clean
- README gains an **Analytics & Privacy** section

Also in this PR: `playwright.config.ts`'s e2e port is now overridable via `THINKRAIL_E2E_PORT` (parallel worktrees — this product's own working model — were fighting over the hard-coded port, interleaving hosts).

Ops: ✅ done — the PostHog EU project exists, its key is set as the `THINKRAIL_POSTHOG_API_KEY` repo secret, and live delivery was verified against the real capture endpoint (all four event types accepted with 200) (the earlier `THINKRAIL_GA4_*` secrets and the Firebase project `thinkrail-5b601` are unused and can be deleted).


