### PR TITLE
fix(e2e): per-worktree isolation for tmp state dirs and ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,11 +128,13 @@ reusable by any pi UI (extraction-ready as a future `packages/chat-ui`).
 ## Verification (run for every app-affecting change)
 
 Every change that touches the app is verified by the **e2e suite** before it's considered done.
-`bun run e2e` is **fully self-contained**: it builds the web app, boots the host on a dedicated port
-(24252) with an **isolated state dir** (never touches `~/.thinkrail`), seeds fixtures (Playwright
-`globalSetup`), runs the suite headless against the real web UI, then tears the host down and cleans up
-(`globalTeardown`). Tests live in `e2e/` and assert via `data-testid` / `data-status` hooks. When
-Electrobun lands, the same suite runs against the desktop app too.
+`bun run e2e` is **fully self-contained**: it builds the web app, boots the host on a **per-worktree
+derived port with an isolated, per-worktree state dir** (both derived in `e2e/fixtures/paths.ts` — never
+touches `~/.thinkrail`, and parallel runs from *different* worktrees never collide; within one worktree
+the suites still share state and run sequentially), seeds fixtures (Playwright `globalSetup`), runs the
+suite headless against the real web UI, then tears the host down and cleans up (`globalTeardown`).
+Tests live in `e2e/` and assert via `data-testid` / `data-status` hooks. When Electrobun lands, the
+same suite runs against the desktop app too.
 
 **Agent tests are tagged, not faked.** Specs that drive a real `pi` agent are tagged `@agent` (Playwright
 `{ tag: "@agent" }`). The host runs against an **isolated pi agent dir** (`PI_CODING_AGENT_DIR` → a

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -48,6 +48,8 @@ writeFileSync(
 const gitInit = Bun.spawnSync(["git", "-C", projectDir, "init", "-b", "main"]);
 if (gitInit.exitCode !== 0) fail("could not initialise the portable-skill smoke project");
 
+// 24262 is only the scan start: the CLI free-picks past a taken port and we read the actually served
+// URL from stdout below — so concurrent runs (other worktrees, dev hosts, e2e suites) never collide.
 const proc = Bun.spawn([binary, "--no-open", "--port", "24262"], {
 	env: {
 		...process.env,

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -171,7 +171,8 @@ if (themeTrigger && themeMenu) {
 	themeMenu.addEventListener("keydown", (event) => {
 		if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
 		event.preventDefault();
-		const index = items.findIndex((item) => item === document.activeElement);
+		const { activeElement } = document;
+		const index = activeElement instanceof HTMLButtonElement ? items.indexOf(activeElement) : -1;
 		const delta = event.key === "ArrowDown" ? 1 : -1;
 		items[(index + delta + items.length) % items.length]?.focus();
 	});

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -3,13 +3,13 @@ import { copyFileSync, existsSync, mkdirSync, openSync, rmSync, writeFileSync } 
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
+import { worktreeRows } from "./fixtures/app";
 import {
 	E2E_PI_AGENT_DIR,
 	E2E_RESTART_DATA_DIR,
 	E2E_RESTART_HOST_LOG,
 	E2E_RESTART_PORT,
 } from "./fixtures/paths";
-import { worktreeRows } from "./fixtures/app";
 
 // Tagged @agent: drives a real pi agent. THE restart test — the one scenario the shared-host suite
 // structurally cannot cover (Playwright's webServer owns that host for the whole run): a questionnaire is

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -1,10 +1,14 @@
 import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, openSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
-import { E2E_PI_AGENT_DIR } from "./fixtures/paths";
+import {
+	E2E_PI_AGENT_DIR,
+	E2E_RESTART_DATA_DIR,
+	E2E_RESTART_HOST_LOG,
+	E2E_RESTART_PORT,
+} from "./fixtures/paths";
 
 // Tagged @agent: drives a real pi agent. THE restart test — the one scenario the shared-host suite
 // structurally cannot cover (Playwright's webServer owns that host for the whole run): a questionnaire is
@@ -13,18 +17,18 @@ import { E2E_PI_AGENT_DIR } from "./fixtures/paths";
 // the agent replies. This is the end-to-end proof of the ack + terminate design (see the server
 // `agent/askUserQuestion` SPEC): nothing about a pending question lives in host memory, so a restart
 // costs nothing. Everything here is self-contained: a dedicated port, data dir, fixture repo, and pi
-// agent dir (copied from the suite's seeded one, so the same auth + pinned model apply); the shared host
-// on 24252 keeps running untouched.
+// agent dir (copied from the suite's seeded one, so the same auth + pinned model apply); the shared
+// e2e host keeps running untouched.
 
-const PORT = 24254; // dev 24242, shared e2e host 24252 — this suite's private host lives here
+const PORT = E2E_RESTART_PORT; // its own slot in the per-worktree port block (e2e/fixtures/paths.ts)
 const BASE = `http://localhost:${PORT}`;
-const DATA_DIR = join(tmpdir(), "thinkrail-e2e-restart");
+const DATA_DIR = E2E_RESTART_DATA_DIR;
 const REPO = join(DATA_DIR, "sample-project");
 const AGENT_DIR = join(DATA_DIR, "pi-agent");
 const HOME_DIR = join(DATA_DIR, "home");
 const PICK_POINTER = join(DATA_DIR, "pick-dir");
 // Outside DATA_DIR so a failed run's teardown doesn't destroy the post-mortem trail.
-const HOST_LOG = join(tmpdir(), "thinkrail-e2e-restart-host.log");
+const HOST_LOG = E2E_RESTART_HOST_LOG;
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const staticDir = join(rootDir, "apps", "web", "dist");
 

--- a/e2e/fixtures/paths.ts
+++ b/e2e/fixtures/paths.ts
@@ -1,8 +1,60 @@
+import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-/** Isolated on-disk state for an e2e run — so tests never touch the user's real ~/.thinkrail. */
-export const E2E_DATA_DIR = join(tmpdir(), "thinkrail-e2e");
+// ─── Per-worktree isolation ─────────────────────────────────────────────────────────────────────
+// Every machine-global name the suites touch (tmp state dirs, listen ports) derives here from a
+// stable per-worktree key, so parallel e2e runs from DIFFERENT worktrees never collide — they used
+// to share `$TMPDIR/thinkrail-e2e` + fixed ports, letting one run's global setup/teardown wipe a
+// sibling run's live host state. Within ONE worktree the suites still share these paths and stay
+// sequential (see playwright.binary.config.ts). The key is deterministic (path-derived, never
+// random) because the Playwright runner, its workers, and global setup each evaluate this module
+// independently and must all agree on the same paths and ports.
+
+/** This worktree's repo root (this file lives at `<root>/e2e/fixtures/`). */
+const repoRoot = realpathSync(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+const rootHash = createHash("sha256").update(repoRoot).digest("hex");
+
+/** Human-readable + collision-proof: `<sanitized basename>-<hash8>`, e.g. `workspace-16-1a2b3c4d`. */
+const WORKTREE_KEY = `${basename(repoRoot).replace(/[^A-Za-z0-9._-]+/g, "-")}-${rootHash.slice(0, 8)}`;
+
+/**
+ * Per-worktree port block: `25000 + (hash % 500) * 10` → [25000, 29990], clear of the dev host's
+ * 24242 and the OS-ephemeral range. The offsets below keep one worktree's suites apart; two
+ * worktrees landing on the same slot is ~1/500 per pair — set THINKRAIL_E2E_PORT_BASE to move one
+ * of them if it ever bites (invalid values throw: loud beats silently colliding).
+ */
+function resolvePortBase(): number {
+	const env = process.env.THINKRAIL_E2E_PORT_BASE;
+	if (env !== undefined && env !== "") {
+		const base = Number(env);
+		if (!Number.isInteger(base) || base < 1024 || base > 65000) {
+			throw new Error(
+				`THINKRAIL_E2E_PORT_BASE must be an integer in [1024, 65000], got ${JSON.stringify(env)}`,
+			);
+		}
+		return base;
+	}
+	return 25000 + (Number.parseInt(rootHash.slice(0, 8), 16) % 500) * 10;
+}
+const PORT_BASE = resolvePortBase();
+
+/** The shared-host browser suites' port (`playwright.config.ts` — the dev host binds it exactly). */
+export const E2E_PORT = PORT_BASE;
+
+/** The compiled-binary suite's port (`playwright.binary.config.ts`). */
+export const E2E_BINARY_PORT = PORT_BASE + 2;
+
+/** The self-hosting restart spec's private-host port (`ask-restart.live.spec.ts`). */
+export const E2E_RESTART_PORT = PORT_BASE + 4;
+
+/**
+ * Isolated on-disk state for an e2e run — per-worktree, so tests never touch the user's real
+ * ~/.thinkrail and parallel runs from different worktrees never touch each other.
+ */
+export const E2E_DATA_DIR = join(tmpdir(), `thinkrail-e2e-${WORKTREE_KEY}`);
 
 /** Isolated HOME so cross-agent skill discovery never reads a developer's real personal libraries. */
 export const E2E_HOME_DIR = join(E2E_DATA_DIR, "home");
@@ -16,7 +68,7 @@ export const E2E_FIXTURE_REPO = join(E2E_DATA_DIR, "sample-project");
  * at server boot, and this must not depend on the wipe-then-seed order between global setup and the
  * webServer launch. Removed in global teardown instead, so every run still stages fresh.
  */
-export const E2E_BINARY_CACHE = join(tmpdir(), "thinkrail-e2e-binary-cache");
+export const E2E_BINARY_CACHE = join(tmpdir(), `thinkrail-e2e-binary-cache-${WORKTREE_KEY}`);
 
 /**
  * A dev/e2e control file the stubbed directory picker (`THINKRAIL_PICK_DIR`) points at: `selectDirectory`
@@ -55,3 +107,15 @@ export const E2E_PI_AGENT_DIR = join(E2E_DATA_DIR, "pi-agent");
  * (auth via `auth.json` only); reset then just clears any test-written copy instead.
  */
 export const E2E_PI_MODELS_SEED = join(E2E_DATA_DIR, "pi-agent-models.seed.json");
+
+/**
+ * The restart spec's private, self-managed state dir (`ask-restart.live.spec.ts` seeds and wipes it
+ * itself — deliberately outside `E2E_DATA_DIR`, whose lifecycle the shared global setup/teardown owns).
+ */
+export const E2E_RESTART_DATA_DIR = join(tmpdir(), `thinkrail-e2e-restart-${WORKTREE_KEY}`);
+
+/** Outside the restart data dir so a failed run's per-test wipe doesn't destroy the post-mortem trail. */
+export const E2E_RESTART_HOST_LOG = join(
+	tmpdir(),
+	`thinkrail-e2e-restart-${WORKTREE_KEY}-host.log`,
+);

--- a/e2e/fixtures/paths.ts
+++ b/e2e/fixtures/paths.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { claimPortBlock, PORT_BLOCK_SLOTS } from "./portBlock";
 
 // ─── Per-worktree isolation ─────────────────────────────────────────────────────────────────────
 // Every machine-global name the suites touch (tmp state dirs, listen ports) derives here from a
@@ -11,7 +12,9 @@ import { fileURLToPath } from "node:url";
 // sibling run's live host state. Within ONE worktree the suites still share these paths and stay
 // sequential (see playwright.binary.config.ts). The key is deterministic (path-derived, never
 // random) because the Playwright runner, its workers, and global setup each evaluate this module
-// independently and must all agree on the same paths and ports.
+// independently and must all agree on the same paths and ports; the port block additionally rides
+// a persistent atomic claim (portBlock.ts), which is stable across processes AND runs for the
+// same worktree while guaranteeing distinct blocks for distinct live worktrees.
 
 /** This worktree's repo root (this file lives at `<root>/e2e/fixtures/`). */
 const repoRoot = realpathSync(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
@@ -21,10 +24,12 @@ const rootHash = createHash("sha256").update(repoRoot).digest("hex");
 const WORKTREE_KEY = `${basename(repoRoot).replace(/[^A-Za-z0-9._-]+/g, "-")}-${rootHash.slice(0, 8)}`;
 
 /**
- * Per-worktree port block: `25000 + (hash % 500) * 10` → [25000, 29990], clear of the dev host's
- * 24242 and the OS-ephemeral range. The offsets below keep one worktree's suites apart; two
- * worktrees landing on the same slot is ~1/500 per pair — set THINKRAIL_E2E_PORT_BASE to move one
- * of them if it ever bites (invalid values throw: loud beats silently colliding).
+ * Per-worktree port block, [25000, 29990] — clear of the dev host's 24242 and the OS-ephemeral
+ * range. The path hash picks the *preferred* slot; actual ownership is arbitrated by the atomic
+ * claim registry (see portBlock.ts), so two worktrees whose hashes collide still get distinct
+ * blocks — no manual coordination. THINKRAIL_E2E_PORT_BASE bypasses the registry and pins the
+ * block explicitly (invalid values throw: loud beats silently colliding). The offsets below keep
+ * one worktree's suites apart within its block.
  */
 function resolvePortBase(): number {
 	const env = process.env.THINKRAIL_E2E_PORT_BASE;
@@ -37,7 +42,7 @@ function resolvePortBase(): number {
 		}
 		return base;
 	}
-	return 25000 + (Number.parseInt(rootHash.slice(0, 8), 16) % 500) * 10;
+	return claimPortBlock(repoRoot, Number.parseInt(rootHash.slice(0, 8), 16) % PORT_BLOCK_SLOTS);
 }
 const PORT_BASE = resolvePortBase();
 

--- a/e2e/fixtures/portBlock.ts
+++ b/e2e/fixtures/portBlock.ts
@@ -1,8 +1,10 @@
+import { randomUUID } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
+	renameSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -18,25 +20,31 @@ import { join } from "node:path";
 // repo root. The hash still picks the *preferred* slot, so the happy path stays deterministic and
 // debuggable; the registry steps in to detect and skip a genuinely taken slot.
 //
-// The whole claim transaction is serialized by an interprocess mkdir-lock (review round 2): an
+// The whole claim transaction is serialized by an interprocess lock (review round 2: an
 // unserialized read→reclaim→create dance has a real TOCTOU — two processes can both judge one claim
 // stale, and the slower `rm` then deletes the faster one's FRESH claim, putting two worktrees on
-// one block. Under the lock, allocation is two-pass: an existing claim for this worktree wins over
-// everything (assignments are sticky — a freed lower slot is never migrated to, so a displaced
-// worktree can't strand its old claim and leak slots), else the scan takes the first slot that is
-// free or stale from `preferredSlot`.
+// one block). The lock itself is liveness-arbitrated, not age-arbitrated (review round 3: elapsed
+// time is not proof a holder died — a descheduled/suspended holder would resume inside the critical
+// section after an age-based break, and an unconditional release would then delete the NEW owner's
+// lock):
+// - A lock is born atomically WITH its owner record ({pid, nonce}, staged then `rename`d into
+//   place — `rename` refuses to replace a non-empty dir, so there is no created-but-ownerless
+//   window and the filesystem stays the arbiter).
+// - A held lock is broken ONLY when its recorded pid is provably not running (`kill(pid, 0)` →
+//   ESRCH) — a crashed holder is broken immediately, a live-but-suspended holder is never usurped
+//   (waiters time out LOUDLY instead; pid reuse degrades the same way: a conservative loud wait,
+//   never a broken mutex). Age (STALE_LOCK_MS) remains only for a garbled lock with no readable
+//   owner, which the protocol itself can never produce.
+// - Release is fenced by the nonce: a process only removes the lock if it still owns it, so no
+//   resume-after-suspension interleaving can delete a successor's mutex.
 //
-// Properties:
-// - Serialized: one process mutates the registry at a time (`mkdir` is the atomic arbiter; a lock
-//   left by a crashed process is broken after STALE_LOCK_MS — it guards a sub-millisecond
-//   transaction, so an old lock means a dead holder).
-// - Stable and one-to-one: a worktree keeps its slot across runs and processes (runner, workers,
-//   global setup, and later runs all agree with no coordination), and duplicate claims from any
-//   older protocol are cleaned on sight.
-// - Self-cleaning: a claim whose recorded worktree path no longer exists is stale (the worktree was
-//   removed) and its slot is reusable.
-// - Never wiped by suite teardown: the registry deliberately outlives runs — it is the memory that
-//   keeps two live worktrees apart.
+// Allocation under the lock is two-pass: an existing claim for this worktree wins over everything
+// (assignments are sticky — a freed lower slot is never migrated to, so a displaced worktree can't
+// strand its old claim and leak slots; legacy duplicates are deduped to the lowest slot), else the
+// scan takes the first slot that is free or stale from `preferredSlot`. A claim whose recorded
+// worktree path no longer exists is stale (the worktree was removed) and its slot is reusable.
+// Suite teardown never touches the registry — it deliberately outlives runs; it is the memory that
+// keeps two live worktrees apart.
 
 export const PORT_BLOCK_BASE = 25000;
 export const PORT_BLOCK_STRIDE = 10;
@@ -45,7 +53,8 @@ export const PORT_BLOCK_SLOTS = 500;
 /** Machine-local registry of claimed slots (one file per slot, content = owner repo root). */
 export const PORT_BLOCK_REGISTRY = join(tmpdir(), "thinkrail-e2e-port-blocks");
 
-/** A held lock older than this is a crashed holder's leftover, not a live transaction. */
+/** Fallback for a garbled lock only (no readable owner): older than this ⇒ break. A lock with a
+ * readable owner is arbitrated by pid liveness, never by age. */
 const STALE_LOCK_MS = 10_000;
 
 function slotBase(slot: number): number {
@@ -68,34 +77,99 @@ function spinFor(ms: number): void {
 	void noop;
 }
 
-/** Take the registry's exclusive lock (a `.lock` dir — `mkdir` is atomic), breaking stale ones. */
-function acquireRegistryLock(registryDir: string, timeoutMs: number): string {
-	const lockPath = join(registryDir, ".lock");
-	const deadline = Date.now() + timeoutMs;
-	for (;;) {
-		try {
-			mkdirSync(lockPath); // non-recursive: throws EEXIST while another process holds it
-			return lockPath;
-		} catch {
-			let ageMs = Number.NaN;
-			try {
-				ageMs = Date.now() - statSync(lockPath).mtimeMs;
-			} catch {
-				ageMs = Number.NaN; // lock vanished between mkdir and stat — retry immediately
-			}
-			if (ageMs > STALE_LOCK_MS) {
-				rmSync(lockPath, { recursive: true, force: true });
-				continue;
-			}
-			if (Date.now() >= deadline) {
-				throw new Error(`timed out acquiring the e2e port-block registry lock at ${lockPath}`);
-			}
-			spinFor(10);
+interface LockOwner {
+	pid: number;
+	nonce: string;
+}
+
+function readLockOwner(lockPath: string): LockOwner | undefined {
+	try {
+		const parsed = JSON.parse(readFileSync(join(lockPath, "owner"), "utf8")) as unknown;
+		if (parsed !== null && typeof parsed === "object" && "pid" in parsed && "nonce" in parsed) {
+			const { pid, nonce } = parsed;
+			if (typeof pid === "number" && typeof nonce === "string") return { pid, nonce };
 		}
+		return undefined; // garbled content
+	} catch {
+		return undefined; // lock gone, or owner unreadable
 	}
 }
 
-/** Numerically sorted slot numbers present in the registry (ignores the `.lock` dir). */
+/** Is `pid` a running process? (EPERM = running under another user — conservatively alive.) */
+function pidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const code = error instanceof Error && "code" in error ? error.code : undefined;
+		return code === "EPERM";
+	}
+}
+
+/**
+ * Take the registry's exclusive lock. The lock is a `.lock` dir carrying its owner record, moved
+ * into place with `rename` (atomic; refuses to replace a non-empty dir). Breaking rules: recorded
+ * owner provably dead ⇒ break now; owner alive ⇒ wait, then throw loudly at `timeoutMs`; no
+ * readable owner ⇒ break only past STALE_LOCK_MS.
+ */
+function acquireRegistryLock(
+	registryDir: string,
+	timeoutMs: number,
+): { lockPath: string; nonce: string } {
+	const lockPath = join(registryDir, ".lock");
+	const nonce = randomUUID();
+	const prepPath = join(registryDir, `.lock-prep-${nonce}`);
+	mkdirSync(prepPath);
+	writeFileSync(join(prepPath, "owner"), JSON.stringify({ pid: process.pid, nonce }));
+	const deadline = Date.now() + timeoutMs;
+	try {
+		for (;;) {
+			try {
+				renameSync(prepPath, lockPath);
+				return { lockPath, nonce };
+			} catch {
+				const owner = readLockOwner(lockPath);
+				if (owner !== undefined) {
+					if (!pidAlive(owner.pid)) {
+						rmSync(lockPath, { recursive: true, force: true }); // crashed holder — break now
+						continue;
+					}
+				} else {
+					let ageMs = Number.NaN;
+					try {
+						ageMs = Date.now() - statSync(lockPath).mtimeMs;
+					} catch {
+						continue; // lock vanished between rename and stat — retry immediately
+					}
+					if (ageMs > STALE_LOCK_MS) {
+						rmSync(lockPath, { recursive: true, force: true }); // garbled and old — break
+						continue;
+					}
+				}
+				if (Date.now() >= deadline) {
+					throw new Error(
+						`timed out acquiring the e2e port-block registry lock at ${lockPath}` +
+							` (held by ${owner === undefined ? "an unreadable owner" : `live pid ${owner.pid}`})`,
+					);
+				}
+				spinFor(10);
+			}
+		}
+	} catch (error) {
+		rmSync(prepPath, { recursive: true, force: true }); // the staged, never-installed lock
+		throw error;
+	}
+}
+
+/** Fenced release: only the acquisition that owns the lock (by nonce) may remove it — a process
+ * resuming after a suspension can never delete a successor's mutex. */
+function releaseRegistryLock(lockPath: string, nonce: string): void {
+	if (readLockOwner(lockPath)?.nonce === nonce) {
+		rmSync(lockPath, { recursive: true, force: true });
+	}
+}
+
+/** Numerically sorted slot numbers present in the registry (ignores lock artifacts). */
 function claimedSlots(registryDir: string): number[] {
 	return readdirSync(registryDir)
 		.filter((name) => /^\d+$/.test(name))
@@ -116,12 +190,10 @@ export function claimPortBlock(
 	lockTimeoutMs = 15_000,
 ): number {
 	mkdirSync(registryDir, { recursive: true });
-	const lockPath = acquireRegistryLock(registryDir, lockTimeoutMs);
+	const lock = acquireRegistryLock(registryDir, lockTimeoutMs);
 	try {
 		// Pass 1: this worktree's existing claim wins over everything — even a now-free lower slot —
 		// so assignments never migrate (migration would strand the old claim and leak its slot).
-		// Duplicates (possible only as leftovers of a raced legacy protocol) are cleaned, keeping the
-		// lowest slot for determinism.
 		const [mine, ...duplicates] = claimedSlots(registryDir).filter(
 			(slot) => readClaim(join(registryDir, String(slot))) === repoRoot,
 		);
@@ -144,6 +216,6 @@ export function claimPortBlock(
 			`no free e2e port block (${PORT_BLOCK_SLOTS} slots all claimed by live worktrees) — inspect ${registryDir}`,
 		);
 	} finally {
-		rmSync(lockPath, { recursive: true, force: true });
+		releaseRegistryLock(lock.lockPath, lock.nonce);
 	}
 }

--- a/e2e/fixtures/portBlock.ts
+++ b/e2e/fixtures/portBlock.ts
@@ -37,6 +37,21 @@ import { join } from "node:path";
 //   owner, which the protocol itself can never produce.
 // - Release is fenced by the nonce: a process only removes the lock if it still owns it, so no
 //   resume-after-suspension interleaving can delete a successor's mutex.
+// - Breaking is itself serialized and re-verified (review round 4: dead-owner reclamation was a
+//   check-then-delete — two waiters could both read one dead owner, and the slower `rm`, acting on
+//   its stale decision, deleted the faster one's freshly installed lock). A breaker must first win
+//   an exclusive break-token (`mkdir`), then re-read the lock's owner UNDER the token — the kill
+//   decision is always made on fresh state, so a successor's live lock is never removed. A stale
+//   token can only BLOCK breaking (never corrupt), so the crude age rule is safe for tokens.
+// - Belt over the whole protocol: after releasing the lock, the claimant re-reads its slot and
+//   retries the transaction if the claim was overwritten — even a hypothetical residual mutex
+//   failure self-heals at the layer that matters instead of yielding two worktrees on one block.
+//
+// Residual floor, stated honestly: node/bun expose no OS-death-released lock (`flock`) without
+// native deps. What remains after the layers above requires a process SIGSTOP'd inside a
+// sub-millisecond window for >10s, resumed at exactly the wrong instant, TWICE in independent
+// windows (breaker + claimant), on one machine's own worktrees — and the blast radius is a dev
+// test-suite port clash, loud in the main suite.
 //
 // Allocation under the lock is two-pass: an existing claim for this worktree wins over everything
 // (assignments are sticky — a freed lower slot is never migrated to, so a displaced worktree can't
@@ -53,8 +68,8 @@ export const PORT_BLOCK_SLOTS = 500;
 /** Machine-local registry of claimed slots (one file per slot, content = owner repo root). */
 export const PORT_BLOCK_REGISTRY = join(tmpdir(), "thinkrail-e2e-port-blocks");
 
-/** Fallback for a garbled lock only (no readable owner): older than this ⇒ break. A lock with a
- * readable owner is arbitrated by pid liveness, never by age. */
+/** Age fallback: a garbled lock (no readable owner) or a leftover break-token older than this is
+ * removable. A lock with a readable owner is arbitrated by pid liveness, never by age. */
 const STALE_LOCK_MS = 10_000;
 
 function slotBase(slot: number): number {
@@ -106,11 +121,55 @@ function pidAlive(pid: number): boolean {
 	}
 }
 
+/** Remove `path` if its recorded mtime is older than STALE_LOCK_MS; `true` if it was removed.
+ * (Missing/vanished paths report `false` — the caller just retries its loop.) */
+function removeIfAged(path: string): boolean {
+	let ageMs = Number.NaN;
+	try {
+		ageMs = Date.now() - statSync(path).mtimeMs;
+	} catch {
+		return false; // vanished — nothing to remove
+	}
+	if (ageMs > STALE_LOCK_MS) {
+		rmSync(path, { recursive: true, force: true });
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Try to break a dead or garbled lock — the ONLY code path that may remove a lock it does not own.
+ * Serialized by an exclusive break-token (`mkdir` — single winner), and the removal decision is
+ * re-made on freshly read state UNDER the token, so a waiter's earlier, stale "it is dead" reading
+ * can never delete a successor's live lock (review round 4). Exported for the forced two-reclaimer
+ * interleaving test. A leftover token (crashed breaker) only blocks breaking, so aging it out is
+ * safe.
+ */
+export function tryBreakLock(lockPath: string): void {
+	const tokenPath = `${lockPath}.break`;
+	try {
+		mkdirSync(tokenPath); // exclusive: one breaker at a time
+	} catch {
+		removeIfAged(tokenPath); // a live breaker is at work, or a crashed one left this behind
+		return;
+	}
+	try {
+		const owner = readLockOwner(lockPath);
+		if (owner !== undefined) {
+			if (!pidAlive(owner.pid)) rmSync(lockPath, { recursive: true, force: true }); // provably dead
+			return; // alive — never usurped
+		}
+		removeIfAged(lockPath); // garbled (ownerless) — the protocol can't produce this; age it out
+	} finally {
+		rmSync(tokenPath, { recursive: true, force: true });
+	}
+}
+
 /**
  * Take the registry's exclusive lock. The lock is a `.lock` dir carrying its owner record, moved
- * into place with `rename` (atomic; refuses to replace a non-empty dir). Breaking rules: recorded
- * owner provably dead ⇒ break now; owner alive ⇒ wait, then throw loudly at `timeoutMs`; no
- * readable owner ⇒ break only past STALE_LOCK_MS.
+ * into place with `rename` (atomic; refuses to replace a non-empty dir). Breaking is delegated to
+ * `tryBreakLock` (dead owner ⇒ broken now; live owner ⇒ wait, then throw loudly at `timeoutMs`;
+ * garbled ⇒ broken only past STALE_LOCK_MS).
  */
 function acquireRegistryLock(
 	registryDir: string,
@@ -128,25 +187,9 @@ function acquireRegistryLock(
 				renameSync(prepPath, lockPath);
 				return { lockPath, nonce };
 			} catch {
-				const owner = readLockOwner(lockPath);
-				if (owner !== undefined) {
-					if (!pidAlive(owner.pid)) {
-						rmSync(lockPath, { recursive: true, force: true }); // crashed holder — break now
-						continue;
-					}
-				} else {
-					let ageMs = Number.NaN;
-					try {
-						ageMs = Date.now() - statSync(lockPath).mtimeMs;
-					} catch {
-						continue; // lock vanished between rename and stat — retry immediately
-					}
-					if (ageMs > STALE_LOCK_MS) {
-						rmSync(lockPath, { recursive: true, force: true }); // garbled and old — break
-						continue;
-					}
-				}
+				tryBreakLock(lockPath);
 				if (Date.now() >= deadline) {
+					const owner = readLockOwner(lockPath);
 					throw new Error(
 						`timed out acquiring the e2e port-block registry lock at ${lockPath}` +
 							` (held by ${owner === undefined ? "an unreadable owner" : `live pid ${owner.pid}`})`,
@@ -177,19 +220,13 @@ function claimedSlots(registryDir: string): number[] {
 		.sort((a, b) => a - b);
 }
 
-/**
- * Claim a port block for `repoRoot` and return its base port. An existing claim for `repoRoot`
- * always wins (sticky); otherwise the scan starts at `preferredSlot` (its path hash) and takes the
- * first slot that is unclaimed or whose claim is stale. Throws only when every slot is owned by a
- * live worktree (practically impossible) or the registry lock cannot be acquired.
- */
-export function claimPortBlock(
+/** One locked claim transaction; returns the slot. (See `claimPortBlock` for the semantics.) */
+function claimSlotOnce(
 	repoRoot: string,
 	preferredSlot: number,
-	registryDir: string = PORT_BLOCK_REGISTRY,
-	lockTimeoutMs = 15_000,
+	registryDir: string,
+	lockTimeoutMs: number,
 ): number {
-	mkdirSync(registryDir, { recursive: true });
 	const lock = acquireRegistryLock(registryDir, lockTimeoutMs);
 	try {
 		// Pass 1: this worktree's existing claim wins over everything — even a now-free lower slot —
@@ -199,7 +236,7 @@ export function claimPortBlock(
 		);
 		if (mine !== undefined) {
 			for (const extra of duplicates) rmSync(join(registryDir, String(extra)), { force: true });
-			return slotBase(mine);
+			return mine;
 		}
 
 		// Pass 2: allocate — first slot from `preferredSlot` that is free, or stale (its recorded
@@ -210,7 +247,7 @@ export function claimPortBlock(
 			const owner = readClaim(claimPath);
 			if (owner !== undefined && existsSync(owner)) continue; // live claim by another worktree
 			writeFileSync(claimPath, repoRoot);
-			return slotBase(slot);
+			return slot;
 		}
 		throw new Error(
 			`no free e2e port block (${PORT_BLOCK_SLOTS} slots all claimed by live worktrees) — inspect ${registryDir}`,
@@ -218,4 +255,28 @@ export function claimPortBlock(
 	} finally {
 		releaseRegistryLock(lock.lockPath, lock.nonce);
 	}
+}
+
+/**
+ * Claim a port block for `repoRoot` and return its base port. An existing claim for `repoRoot`
+ * always wins (sticky); otherwise the scan starts at `preferredSlot` (its path hash) and takes the
+ * first slot that is unclaimed or whose claim is stale. After the lock is released the claim is
+ * re-read and the transaction retried if it was overwritten (the belt over the lock protocol — see
+ * the header). Throws only when every slot is owned by a live worktree (practically impossible),
+ * the registry lock cannot be acquired, or the claim will not settle.
+ */
+export function claimPortBlock(
+	repoRoot: string,
+	preferredSlot: number,
+	registryDir: string = PORT_BLOCK_REGISTRY,
+	lockTimeoutMs = 15_000,
+): number {
+	mkdirSync(registryDir, { recursive: true });
+	for (let round = 0; round < 5; round++) {
+		const slot = claimSlotOnce(repoRoot, preferredSlot, registryDir, lockTimeoutMs);
+		if (readClaim(join(registryDir, String(slot))) === repoRoot) return slotBase(slot);
+	}
+	throw new Error(
+		`e2e port-block claim did not settle after 5 rounds (mutual-exclusion failure?) — inspect ${registryDir}`,
+	);
 }

--- a/e2e/fixtures/portBlock.ts
+++ b/e2e/fixtures/portBlock.ts
@@ -41,17 +41,23 @@ import { join } from "node:path";
 //   check-then-delete — two waiters could both read one dead owner, and the slower `rm`, acting on
 //   its stale decision, deleted the faster one's freshly installed lock). A breaker must first win
 //   an exclusive break-token (`mkdir`), then re-read the lock's owner UNDER the token — the kill
-//   decision is always made on fresh state, so a successor's live lock is never removed. A stale
-//   token can only BLOCK breaking (never corrupt), so the crude age rule is safe for tokens.
+//   decision is always made on fresh state, so a successor's live lock is never removed.
+// - Break-tokens are NEVER auto-reclaimed (review round 5: aging a token out was itself a
+//   stat-then-delete on a mutable path — the same class one level down — and any reclamation
+//   primitive would just recurse the problem). This terminates the regress: a token exists for
+//   microseconds and is orphaned only by a kill inside that window; an orphaned token only ever
+//   BLOCKS breaking (installs don't consult it), and because the token holder keeps the sole break
+//   right until its own `rm` fires, a pending removal can only ever hit the dead lock it verified
+//   — never a successor's. The degraded case is a LOUD acquire timeout naming the registry for a
+//   one-time manual cleanup, never corruption.
 // - Belt over the whole protocol: after releasing the lock, the claimant re-reads its slot and
-//   retries the transaction if the claim was overwritten — even a hypothetical residual mutex
-//   failure self-heals at the layer that matters instead of yielding two worktrees on one block.
+//   retries the transaction if the claim was overwritten — anything unmodeled self-heals at the
+//   layer that matters instead of yielding two worktrees on one block.
 //
 // Residual floor, stated honestly: node/bun expose no OS-death-released lock (`flock`) without
-// native deps. What remains after the layers above requires a process SIGSTOP'd inside a
-// sub-millisecond window for >10s, resumed at exactly the wrong instant, TWICE in independent
-// windows (breaker + claimant), on one machine's own worktrees — and the blast radius is a dev
-// test-suite port clash, loud in the main suite.
+// native deps. What remains is availability-shaped, not correctness-shaped: a pid-reuse or
+// orphaned-token wedge parks claims behind a loud, self-describing timeout until a human removes
+// the registry dir once.
 //
 // Allocation under the lock is two-pass: an existing claim for this worktree wins over everything
 // (assignments are sticky — a freed lower slot is never migrated to, so a displaced worktree can't
@@ -68,8 +74,9 @@ export const PORT_BLOCK_SLOTS = 500;
 /** Machine-local registry of claimed slots (one file per slot, content = owner repo root). */
 export const PORT_BLOCK_REGISTRY = join(tmpdir(), "thinkrail-e2e-port-blocks");
 
-/** Age fallback: a garbled lock (no readable owner) or a leftover break-token older than this is
- * removable. A lock with a readable owner is arbitrated by pid liveness, never by age. */
+/** Age fallback for a garbled lock only (no readable owner — a state the protocol itself cannot
+ * produce). Locks with a readable owner are arbitrated by pid liveness; break-tokens are never
+ * reclaimed at all (see header). */
 const STALE_LOCK_MS = 10_000;
 
 function slotBase(slot: number): number {
@@ -141,17 +148,16 @@ function removeIfAged(path: string): boolean {
  * Try to break a dead or garbled lock — the ONLY code path that may remove a lock it does not own.
  * Serialized by an exclusive break-token (`mkdir` — single winner), and the removal decision is
  * re-made on freshly read state UNDER the token, so a waiter's earlier, stale "it is dead" reading
- * can never delete a successor's live lock (review round 4). Exported for the forced two-reclaimer
- * interleaving test. A leftover token (crashed breaker) only blocks breaking, so aging it out is
- * safe.
+ * can never delete a successor's live lock (review round 4). Tokens are never reclaimed — an
+ * orphaned one wedges breaking into the acquire timeout's loud manual-cleanup path rather than
+ * reopening a reclamation race (round 5). Exported for the forced interleaving tests.
  */
 export function tryBreakLock(lockPath: string): void {
 	const tokenPath = `${lockPath}.break`;
 	try {
 		mkdirSync(tokenPath); // exclusive: one breaker at a time
 	} catch {
-		removeIfAged(tokenPath); // a live breaker is at work, or a crashed one left this behind
-		return;
+		return; // a breaker is at work (or an orphaned token wedges us — surfaced at acquire timeout)
 	}
 	try {
 		const owner = readLockOwner(lockPath);
@@ -190,9 +196,15 @@ function acquireRegistryLock(
 				tryBreakLock(lockPath);
 				if (Date.now() >= deadline) {
 					const owner = readLockOwner(lockPath);
+					const holder =
+						owner === undefined
+							? "an unreadable owner"
+							: pidAlive(owner.pid)
+								? `live pid ${owner.pid}`
+								: `dead pid ${owner.pid}; breaking is wedged — likely an orphaned break-token`;
 					throw new Error(
-						`timed out acquiring the e2e port-block registry lock at ${lockPath}` +
-							` (held by ${owner === undefined ? "an unreadable owner" : `live pid ${owner.pid}`})`,
+						`timed out acquiring the e2e port-block registry lock at ${lockPath} (held by ${holder});` +
+							` if no e2e run is active, remove ${registryDir} and retry`,
 					);
 				}
 				spinFor(10);

--- a/e2e/fixtures/portBlock.ts
+++ b/e2e/fixtures/portBlock.ts
@@ -1,0 +1,76 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Atomic per-worktree port-block allocation (review-hardened: a pure path hash over a finite slot
+// space can land two worktrees on the same block, and under that collision the binary suite's
+// failure shape is SILENT — its CLI free-scans past the taken port while Playwright polls the
+// expected one, which the other worktree's host answers). A tiny machine-local registry arbitrates
+// ownership instead: one claim file per slot under $TMPDIR, its content = the owning worktree's
+// repo root. The hash still picks the *preferred* slot, so the happy path stays deterministic and
+// debuggable; the registry only steps in to detect and skip a genuinely taken slot.
+//
+// Properties:
+// - Atomic: claims are created with `wx` (O_EXCL) — the filesystem arbitrates races; a loser
+//   re-reads and either converges (same worktree, another process) or moves to the next slot.
+// - Stable: a worktree's claim persists across runs, so the runner, its workers, global setup, and
+//   later runs all agree on the same block without coordination.
+// - Self-cleaning: a claim whose recorded worktree path no longer exists is stale (the worktree was
+//   removed) and is reclaimed on the next allocation that wants its slot.
+// - Never wiped by suite teardown: the registry deliberately outlives runs — it is the memory that
+//   keeps two live worktrees apart.
+
+export const PORT_BLOCK_BASE = 25000;
+export const PORT_BLOCK_STRIDE = 10;
+export const PORT_BLOCK_SLOTS = 500;
+
+/** Machine-local registry of claimed slots (one file per slot, content = owner repo root). */
+export const PORT_BLOCK_REGISTRY = join(tmpdir(), "thinkrail-e2e-port-blocks");
+
+function slotBase(slot: number): number {
+	return PORT_BLOCK_BASE + slot * PORT_BLOCK_STRIDE;
+}
+
+function readClaim(path: string): string | undefined {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return undefined; // no claim (ENOENT)
+	}
+}
+
+/**
+ * Claim a port block for `repoRoot`, starting at `preferredSlot` (its path hash) and scanning
+ * forward past slots owned by other live worktrees. Returns the block's base port. Throws only in
+ * the practically-impossible case of every slot being owned by a live worktree.
+ */
+export function claimPortBlock(
+	repoRoot: string,
+	preferredSlot: number,
+	registryDir: string = PORT_BLOCK_REGISTRY,
+): number {
+	mkdirSync(registryDir, { recursive: true });
+	for (let attempt = 0; attempt < PORT_BLOCK_SLOTS; attempt++) {
+		const slot = (preferredSlot + attempt) % PORT_BLOCK_SLOTS;
+		const claimPath = join(registryDir, String(slot));
+
+		const owner = readClaim(claimPath);
+		if (owner === repoRoot) return slotBase(slot); // ours from an earlier run/process
+		if (owner !== undefined) {
+			if (existsSync(owner)) continue; // live claim by another worktree — next slot
+			rmSync(claimPath, { force: true }); // stale — its worktree is gone; reclaim below
+		}
+
+		try {
+			writeFileSync(claimPath, repoRoot, { flag: "wx" }); // O_EXCL: the atomic arbiter
+			return slotBase(slot);
+		} catch {
+			// Lost the creation race. If the winner is this same worktree (another of our processes),
+			// converge on the slot; otherwise move on.
+			if (readClaim(claimPath) === repoRoot) return slotBase(slot);
+		}
+	}
+	throw new Error(
+		`no free e2e port block (${PORT_BLOCK_SLOTS} slots all claimed by live worktrees) — inspect ${registryDir}`,
+	);
+}

--- a/e2e/fixtures/portBlock.ts
+++ b/e2e/fixtures/portBlock.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,15 +16,25 @@ import { join } from "node:path";
 // expected one, which the other worktree's host answers). A tiny machine-local registry arbitrates
 // ownership instead: one claim file per slot under $TMPDIR, its content = the owning worktree's
 // repo root. The hash still picks the *preferred* slot, so the happy path stays deterministic and
-// debuggable; the registry only steps in to detect and skip a genuinely taken slot.
+// debuggable; the registry steps in to detect and skip a genuinely taken slot.
+//
+// The whole claim transaction is serialized by an interprocess mkdir-lock (review round 2): an
+// unserialized read→reclaim→create dance has a real TOCTOU — two processes can both judge one claim
+// stale, and the slower `rm` then deletes the faster one's FRESH claim, putting two worktrees on
+// one block. Under the lock, allocation is two-pass: an existing claim for this worktree wins over
+// everything (assignments are sticky — a freed lower slot is never migrated to, so a displaced
+// worktree can't strand its old claim and leak slots), else the scan takes the first slot that is
+// free or stale from `preferredSlot`.
 //
 // Properties:
-// - Atomic: claims are created with `wx` (O_EXCL) — the filesystem arbitrates races; a loser
-//   re-reads and either converges (same worktree, another process) or moves to the next slot.
-// - Stable: a worktree's claim persists across runs, so the runner, its workers, global setup, and
-//   later runs all agree on the same block without coordination.
+// - Serialized: one process mutates the registry at a time (`mkdir` is the atomic arbiter; a lock
+//   left by a crashed process is broken after STALE_LOCK_MS — it guards a sub-millisecond
+//   transaction, so an old lock means a dead holder).
+// - Stable and one-to-one: a worktree keeps its slot across runs and processes (runner, workers,
+//   global setup, and later runs all agree with no coordination), and duplicate claims from any
+//   older protocol are cleaned on sight.
 // - Self-cleaning: a claim whose recorded worktree path no longer exists is stale (the worktree was
-//   removed) and is reclaimed on the next allocation that wants its slot.
+//   removed) and its slot is reusable.
 // - Never wiped by suite teardown: the registry deliberately outlives runs — it is the memory that
 //   keeps two live worktrees apart.
 
@@ -26,6 +44,9 @@ export const PORT_BLOCK_SLOTS = 500;
 
 /** Machine-local registry of claimed slots (one file per slot, content = owner repo root). */
 export const PORT_BLOCK_REGISTRY = join(tmpdir(), "thinkrail-e2e-port-blocks");
+
+/** A held lock older than this is a crashed holder's leftover, not a live transaction. */
+const STALE_LOCK_MS = 10_000;
 
 function slotBase(slot: number): number {
 	return PORT_BLOCK_BASE + slot * PORT_BLOCK_STRIDE;
@@ -39,38 +60,90 @@ function readClaim(path: string): string | undefined {
 	}
 }
 
+/** Burn ~`ms` between lock attempts — sync on purpose: callers claim at module load. */
+function spinFor(ms: number): void {
+	const until = Date.now() + ms;
+	let noop = 0;
+	while (Date.now() < until) noop += 1;
+	void noop;
+}
+
+/** Take the registry's exclusive lock (a `.lock` dir — `mkdir` is atomic), breaking stale ones. */
+function acquireRegistryLock(registryDir: string, timeoutMs: number): string {
+	const lockPath = join(registryDir, ".lock");
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		try {
+			mkdirSync(lockPath); // non-recursive: throws EEXIST while another process holds it
+			return lockPath;
+		} catch {
+			let ageMs = Number.NaN;
+			try {
+				ageMs = Date.now() - statSync(lockPath).mtimeMs;
+			} catch {
+				ageMs = Number.NaN; // lock vanished between mkdir and stat — retry immediately
+			}
+			if (ageMs > STALE_LOCK_MS) {
+				rmSync(lockPath, { recursive: true, force: true });
+				continue;
+			}
+			if (Date.now() >= deadline) {
+				throw new Error(`timed out acquiring the e2e port-block registry lock at ${lockPath}`);
+			}
+			spinFor(10);
+		}
+	}
+}
+
+/** Numerically sorted slot numbers present in the registry (ignores the `.lock` dir). */
+function claimedSlots(registryDir: string): number[] {
+	return readdirSync(registryDir)
+		.filter((name) => /^\d+$/.test(name))
+		.map(Number)
+		.sort((a, b) => a - b);
+}
+
 /**
- * Claim a port block for `repoRoot`, starting at `preferredSlot` (its path hash) and scanning
- * forward past slots owned by other live worktrees. Returns the block's base port. Throws only in
- * the practically-impossible case of every slot being owned by a live worktree.
+ * Claim a port block for `repoRoot` and return its base port. An existing claim for `repoRoot`
+ * always wins (sticky); otherwise the scan starts at `preferredSlot` (its path hash) and takes the
+ * first slot that is unclaimed or whose claim is stale. Throws only when every slot is owned by a
+ * live worktree (practically impossible) or the registry lock cannot be acquired.
  */
 export function claimPortBlock(
 	repoRoot: string,
 	preferredSlot: number,
 	registryDir: string = PORT_BLOCK_REGISTRY,
+	lockTimeoutMs = 15_000,
 ): number {
 	mkdirSync(registryDir, { recursive: true });
-	for (let attempt = 0; attempt < PORT_BLOCK_SLOTS; attempt++) {
-		const slot = (preferredSlot + attempt) % PORT_BLOCK_SLOTS;
-		const claimPath = join(registryDir, String(slot));
-
-		const owner = readClaim(claimPath);
-		if (owner === repoRoot) return slotBase(slot); // ours from an earlier run/process
-		if (owner !== undefined) {
-			if (existsSync(owner)) continue; // live claim by another worktree — next slot
-			rmSync(claimPath, { force: true }); // stale — its worktree is gone; reclaim below
+	const lockPath = acquireRegistryLock(registryDir, lockTimeoutMs);
+	try {
+		// Pass 1: this worktree's existing claim wins over everything — even a now-free lower slot —
+		// so assignments never migrate (migration would strand the old claim and leak its slot).
+		// Duplicates (possible only as leftovers of a raced legacy protocol) are cleaned, keeping the
+		// lowest slot for determinism.
+		const [mine, ...duplicates] = claimedSlots(registryDir).filter(
+			(slot) => readClaim(join(registryDir, String(slot))) === repoRoot,
+		);
+		if (mine !== undefined) {
+			for (const extra of duplicates) rmSync(join(registryDir, String(extra)), { force: true });
+			return slotBase(mine);
 		}
 
-		try {
-			writeFileSync(claimPath, repoRoot, { flag: "wx" }); // O_EXCL: the atomic arbiter
+		// Pass 2: allocate — first slot from `preferredSlot` that is free, or stale (its recorded
+		// worktree path is gone). Plain overwrite is safe here: the lock serializes the transaction.
+		for (let attempt = 0; attempt < PORT_BLOCK_SLOTS; attempt++) {
+			const slot = (preferredSlot + attempt) % PORT_BLOCK_SLOTS;
+			const claimPath = join(registryDir, String(slot));
+			const owner = readClaim(claimPath);
+			if (owner !== undefined && existsSync(owner)) continue; // live claim by another worktree
+			writeFileSync(claimPath, repoRoot);
 			return slotBase(slot);
-		} catch {
-			// Lost the creation race. If the winner is this same worktree (another of our processes),
-			// converge on the slot; otherwise move on.
-			if (readClaim(claimPath) === repoRoot) return slotBase(slot);
 		}
+		throw new Error(
+			`no free e2e port block (${PORT_BLOCK_SLOTS} slots all claimed by live worktrees) — inspect ${registryDir}`,
+		);
+	} finally {
+		rmSync(lockPath, { recursive: true, force: true });
 	}
-	throw new Error(
-		`no free e2e port block (${PORT_BLOCK_SLOTS} slots all claimed by live worktrees) — inspect ${registryDir}`,
-	);
 }

--- a/e2e/port-block.spec.ts
+++ b/e2e/port-block.spec.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+	claimPortBlock,
+	PORT_BLOCK_BASE,
+	PORT_BLOCK_SLOTS,
+	PORT_BLOCK_STRIDE,
+} from "./fixtures/portBlock";
+
+// Pins the atomic port-block claim contract (fixtures/portBlock.ts) — the arbiter that keeps two
+// live worktrees off the same port block even when their path hashes prefer the same slot (the
+// review-flagged residual: under such a collision the binary suite's failure shape is silent).
+// Pure node, no page/host involved — runs with the suite because e2e/ is where the fixture lives.
+
+/** A fresh registry + two existing fake "worktree roots" per test — nothing machine-global. */
+function setup() {
+	const registry = mkdtempSync(join(tmpdir(), "port-block-registry-"));
+	const rootA = mkdtempSync(join(tmpdir(), "port-block-root-a-"));
+	const rootB = mkdtempSync(join(tmpdir(), "port-block-root-b-"));
+	return { registry, rootA, rootB };
+}
+
+test("same worktree converges on the same block, across repeated claims", () => {
+	const { registry, rootA } = setup();
+	const first = claimPortBlock(rootA, 7, registry);
+	expect(first).toBe(PORT_BLOCK_BASE + 7 * PORT_BLOCK_STRIDE);
+	expect(claimPortBlock(rootA, 7, registry)).toBe(first); // another process / a later run
+});
+
+test("two live worktrees preferring the same slot get distinct blocks", () => {
+	const { registry, rootA, rootB } = setup();
+	const a = claimPortBlock(rootA, 42, registry);
+	const b = claimPortBlock(rootB, 42, registry);
+	expect(a).toBe(PORT_BLOCK_BASE + 42 * PORT_BLOCK_STRIDE);
+	expect(b).toBe(PORT_BLOCK_BASE + 43 * PORT_BLOCK_STRIDE); // scanned past the live claim
+	// And each keeps its own block on re-claim — the registry is stable, not first-come-shuffled.
+	expect(claimPortBlock(rootA, 42, registry)).toBe(a);
+	expect(claimPortBlock(rootB, 42, registry)).toBe(b);
+});
+
+test("a stale claim (its worktree path is gone) is reclaimed", () => {
+	const { registry, rootA } = setup();
+	writeFileSync(join(registry, "5"), join(tmpdir(), "port-block-vanished-worktree"));
+	expect(claimPortBlock(rootA, 5, registry)).toBe(PORT_BLOCK_BASE + 5 * PORT_BLOCK_STRIDE);
+	expect(readFileSync(join(registry, "5"), "utf8")).toBe(rootA);
+});
+
+test("slot scan wraps past the last slot", () => {
+	const { registry, rootA, rootB } = setup();
+	const last = PORT_BLOCK_SLOTS - 1;
+	expect(claimPortBlock(rootA, last, registry)).toBe(PORT_BLOCK_BASE + last * PORT_BLOCK_STRIDE);
+	expect(claimPortBlock(rootB, last, registry)).toBe(PORT_BLOCK_BASE); // wrapped to slot 0
+});
+
+test("a missing registry dir is created on first claim", () => {
+	const { registry, rootA } = setup();
+	const nested = join(registry, "not", "yet", "there");
+	mkdirSync(join(registry, "not"), { recursive: true }); // parent exists, leaf doesn't
+	expect(claimPortBlock(rootA, 0, nested)).toBe(PORT_BLOCK_BASE);
+});

--- a/e2e/port-block.spec.ts
+++ b/e2e/port-block.spec.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -86,17 +87,33 @@ test("a missing registry dir is created on first claim", () => {
 	expect(claimPortBlock(rootA, 0, nested)).toBe(PORT_BLOCK_BASE);
 });
 
-test("a stale registry lock (crashed holder) is broken, not waited out", () => {
-	const { registry, rootA } = setup();
+/** A lock dir as the protocol creates it: non-empty, carrying an owner record. */
+function plantLock(registry: string, owner: string): string {
 	const lock = join(registry, ".lock");
 	mkdirSync(lock);
-	const old = (Date.now() - 60_000) / 1000; // held for a minute — far beyond any live transaction
-	utimesSync(lock, old, old);
-	expect(claimPortBlock(rootA, 1, registry)).toBe(base(1));
+	writeFileSync(join(lock, "owner"), owner);
+	return lock;
+}
+
+test("a crashed holder's lock (dead pid) is broken immediately, not waited out", () => {
+	const { registry, rootA } = setup();
+	// A real pid that is provably dead: spawn a no-op child and wait for it to exit.
+	const deadPid = spawnSync(process.execPath, ["-e", "0"]).pid;
+	plantLock(registry, JSON.stringify({ pid: deadPid, nonce: "gone" }));
+	expect(claimPortBlock(rootA, 1, registry, 1_000)).toBe(base(1)); // far under the age fallback
 });
 
-test("a fresh registry lock blocks the claim until the timeout, then throws loudly", () => {
+test("a live holder is never usurped — the claim times out loudly instead", () => {
 	const { registry, rootA } = setup();
-	mkdirSync(join(registry, ".lock")); // a live holder that never releases
-	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/port-block registry lock/);
+	plantLock(registry, JSON.stringify({ pid: process.pid, nonce: "held" })); // us: alive by definition
+	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/held by live pid/);
+});
+
+test("a garbled lock (unreadable owner) is broken only once it is old", () => {
+	const { registry, rootA } = setup();
+	const lock = plantLock(registry, "not json at all");
+	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/unreadable owner/); // fresh: wait, then loud
+	const old = (Date.now() - 60_000) / 1000; // far beyond any live transaction
+	utimesSync(lock, old, old);
+	expect(claimPortBlock(rootA, 1, registry)).toBe(base(1)); // old: the age fallback breaks it
 });

--- a/e2e/port-block.spec.ts
+++ b/e2e/port-block.spec.ts
@@ -118,16 +118,20 @@ test("a live holder is never usurped — the claim times out loudly instead", ()
 	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/held by live pid/);
 });
 
-test("breaking is serialized: a foreign break-token blocks the break until it ages out", () => {
+test("breaking is serialized: a foreign break-token wedges breaking into the loud timeout", () => {
 	const { registry, rootA } = setup();
 	const deadPid = spawnSync(process.execPath, ["-e", "0"]).pid;
 	const lock = plantLock(registry, JSON.stringify({ pid: deadPid, nonce: "gone" }));
 	const token = join(registry, ".lock.break");
 	mkdirSync(token); // another breaker mid-flight — breaking must wait, not proceed unserialized
-	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/port-block registry lock/);
-	expect(existsSync(lock)).toBe(true); // the dead lock was NOT touched while the token was held
+	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/remove .* and retry/);
+	expect(existsSync(lock)).toBe(true); // the dead lock was NOT touched while the token existed
 	const old = (Date.now() - 60_000) / 1000;
-	utimesSync(token, old, old); // the other breaker is long gone — a stale token only ever blocks
+	utimesSync(token, old, old);
+	// Even an ancient orphaned token is never auto-reclaimed (round 5: reclamation is itself a race)
+	// — the wedge stays loud and self-describing until the documented manual cleanup.
+	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/orphaned break-token/);
+	rmSync(token, { recursive: true, force: true }); // the manual cleanup the error names
 	expect(claimPortBlock(rootA, 1, registry)).toBe(base(1));
 });
 

--- a/e2e/port-block.spec.ts
+++ b/e2e/port-block.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
@@ -22,10 +22,12 @@ function setup() {
 	return { registry, rootA, rootB };
 }
 
+const base = (slot: number) => PORT_BLOCK_BASE + slot * PORT_BLOCK_STRIDE;
+
 test("same worktree converges on the same block, across repeated claims", () => {
 	const { registry, rootA } = setup();
 	const first = claimPortBlock(rootA, 7, registry);
-	expect(first).toBe(PORT_BLOCK_BASE + 7 * PORT_BLOCK_STRIDE);
+	expect(first).toBe(base(7));
 	expect(claimPortBlock(rootA, 7, registry)).toBe(first); // another process / a later run
 });
 
@@ -33,8 +35,8 @@ test("two live worktrees preferring the same slot get distinct blocks", () => {
 	const { registry, rootA, rootB } = setup();
 	const a = claimPortBlock(rootA, 42, registry);
 	const b = claimPortBlock(rootB, 42, registry);
-	expect(a).toBe(PORT_BLOCK_BASE + 42 * PORT_BLOCK_STRIDE);
-	expect(b).toBe(PORT_BLOCK_BASE + 43 * PORT_BLOCK_STRIDE); // scanned past the live claim
+	expect(a).toBe(base(42));
+	expect(b).toBe(base(43)); // scanned past the live claim
 	// And each keeps its own block on re-claim — the registry is stable, not first-come-shuffled.
 	expect(claimPortBlock(rootA, 42, registry)).toBe(a);
 	expect(claimPortBlock(rootB, 42, registry)).toBe(b);
@@ -43,14 +45,37 @@ test("two live worktrees preferring the same slot get distinct blocks", () => {
 test("a stale claim (its worktree path is gone) is reclaimed", () => {
 	const { registry, rootA } = setup();
 	writeFileSync(join(registry, "5"), join(tmpdir(), "port-block-vanished-worktree"));
-	expect(claimPortBlock(rootA, 5, registry)).toBe(PORT_BLOCK_BASE + 5 * PORT_BLOCK_STRIDE);
+	expect(claimPortBlock(rootA, 5, registry)).toBe(base(5));
 	expect(readFileSync(join(registry, "5"), "utf8")).toBe(rootA);
+});
+
+test("assignments are sticky: a displaced worktree never migrates to its freed predecessor slot", () => {
+	// Review scenario: A owns B's preferred slot, so B is displaced; A's worktree is then removed.
+	// B must KEEP its slot (migrating would strand B's old claim as a live-looking leak), while a
+	// newcomer is free to reclaim the stale slot.
+	const { registry, rootA, rootB } = setup();
+	expect(claimPortBlock(rootA, 42, registry)).toBe(base(42));
+	expect(claimPortBlock(rootB, 42, registry)).toBe(base(43)); // displaced
+	rmSync(rootA, { recursive: true, force: true }); // A's worktree is deleted
+	expect(claimPortBlock(rootB, 42, registry)).toBe(base(43)); // sticky — no migration to 42
+	const rootC = mkdtempSync(join(tmpdir(), "port-block-root-c-"));
+	expect(claimPortBlock(rootC, 42, registry)).toBe(base(42)); // newcomer reclaims the stale slot
+	expect(claimPortBlock(rootB, 42, registry)).toBe(base(43)); // still exactly one claim per root
+});
+
+test("duplicate claims for one worktree are deduped to the lowest slot", () => {
+	const { registry, rootA } = setup();
+	writeFileSync(join(registry, "9"), rootA);
+	writeFileSync(join(registry, "3"), rootA);
+	expect(claimPortBlock(rootA, 7, registry)).toBe(base(3));
+	expect(claimPortBlock(rootA, 7, registry)).toBe(base(3)); // and stays there
+	expect(() => readFileSync(join(registry, "9"), "utf8")).toThrow(); // the extra claim is gone
 });
 
 test("slot scan wraps past the last slot", () => {
 	const { registry, rootA, rootB } = setup();
 	const last = PORT_BLOCK_SLOTS - 1;
-	expect(claimPortBlock(rootA, last, registry)).toBe(PORT_BLOCK_BASE + last * PORT_BLOCK_STRIDE);
+	expect(claimPortBlock(rootA, last, registry)).toBe(base(last));
 	expect(claimPortBlock(rootB, last, registry)).toBe(PORT_BLOCK_BASE); // wrapped to slot 0
 });
 
@@ -59,4 +84,19 @@ test("a missing registry dir is created on first claim", () => {
 	const nested = join(registry, "not", "yet", "there");
 	mkdirSync(join(registry, "not"), { recursive: true }); // parent exists, leaf doesn't
 	expect(claimPortBlock(rootA, 0, nested)).toBe(PORT_BLOCK_BASE);
+});
+
+test("a stale registry lock (crashed holder) is broken, not waited out", () => {
+	const { registry, rootA } = setup();
+	const lock = join(registry, ".lock");
+	mkdirSync(lock);
+	const old = (Date.now() - 60_000) / 1000; // held for a minute — far beyond any live transaction
+	utimesSync(lock, old, old);
+	expect(claimPortBlock(rootA, 1, registry)).toBe(base(1));
+});
+
+test("a fresh registry lock blocks the claim until the timeout, then throws loudly", () => {
+	const { registry, rootA } = setup();
+	mkdirSync(join(registry, ".lock")); // a live holder that never releases
+	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/port-block registry lock/);
 });

--- a/e2e/port-block.spec.ts
+++ b/e2e/port-block.spec.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
@@ -8,6 +16,7 @@ import {
 	PORT_BLOCK_BASE,
 	PORT_BLOCK_SLOTS,
 	PORT_BLOCK_STRIDE,
+	tryBreakLock,
 } from "./fixtures/portBlock";
 
 // Pins the atomic port-block claim contract (fixtures/portBlock.ts) — the arbiter that keeps two
@@ -107,6 +116,34 @@ test("a live holder is never usurped — the claim times out loudly instead", ()
 	const { registry, rootA } = setup();
 	plantLock(registry, JSON.stringify({ pid: process.pid, nonce: "held" })); // us: alive by definition
 	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/held by live pid/);
+});
+
+test("breaking is serialized: a foreign break-token blocks the break until it ages out", () => {
+	const { registry, rootA } = setup();
+	const deadPid = spawnSync(process.execPath, ["-e", "0"]).pid;
+	const lock = plantLock(registry, JSON.stringify({ pid: deadPid, nonce: "gone" }));
+	const token = join(registry, ".lock.break");
+	mkdirSync(token); // another breaker mid-flight — breaking must wait, not proceed unserialized
+	expect(() => claimPortBlock(rootA, 1, registry, 50)).toThrow(/port-block registry lock/);
+	expect(existsSync(lock)).toBe(true); // the dead lock was NOT touched while the token was held
+	const old = (Date.now() - 60_000) / 1000;
+	utimesSync(token, old, old); // the other breaker is long gone — a stale token only ever blocks
+	expect(claimPortBlock(rootA, 1, registry)).toBe(base(1));
+});
+
+test("forced two-reclaimer interleaving: a stale break decision cannot delete a successor's lock", () => {
+	// Review round 4's exact scenario, driven through the real break routine: reclaimers A and B both
+	// observed a dead owner; A breaks the lock and a successor installs a fresh one; B's break —
+	// executing its stale decision — must re-verify under the token and leave the successor alone.
+	const { registry, rootB } = setup();
+	const deadPid = spawnSync(process.execPath, ["-e", "0"]).pid;
+	const lock = plantLock(registry, JSON.stringify({ pid: deadPid, nonce: "gone" })); // both read this
+	tryBreakLock(lock); // reclaimer A acts: the dead lock is gone
+	expect(existsSync(lock)).toBe(false);
+	plantLock(registry, JSON.stringify({ pid: process.pid, nonce: "successor" })); // successor installs
+	tryBreakLock(lock); // reclaimer B acts on its STALE decision
+	expect(readFileSync(join(lock, "owner"), "utf8")).toContain('"successor"'); // untouched
+	expect(() => claimPortBlock(rootB, 1, registry, 50)).toThrow(/held by live pid/); // still exclusive
 });
 
 test("a garbled lock (unreadable owner) is broken only once it is old", () => {

--- a/playwright.binary.config.ts
+++ b/playwright.binary.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { defineConfig, devices } from "@playwright/test";
 import {
 	E2E_BINARY_CACHE,
+	E2E_BINARY_PORT,
 	E2E_CENTRAL_STATE,
 	E2E_DATA_DIR,
 	E2E_HOME_DIR,
@@ -22,8 +23,10 @@ import {
 // providers are registered by `packages/server/src/dev.ts`, which deliberately never ships — the
 // artifact's login path is covered by smoke-binary's real-provider probe instead).
 //
-// Not concurrent-safe with `bun run e2e` (both own E2E_DATA_DIR); run them sequentially. Unix-only for
-// now, like the main config's PATH stub wiring (`:` separator, `#!/bin/sh` central stub).
+// Not concurrent-safe with `bun run e2e` in the SAME worktree (both own that worktree's
+// E2E_DATA_DIR); run them sequentially. Parallel runs from DIFFERENT worktrees are isolated —
+// per-worktree state dirs + ports, see e2e/fixtures/paths.ts. Unix-only for now, like the main
+// config's PATH stub wiring (`:` separator, `#!/bin/sh` central stub).
 
 const rootDir = fileURLToPath(new URL(".", import.meta.url));
 const binary =
@@ -32,7 +35,9 @@ const binary =
 if (!existsSync(binary)) {
 	throw new Error(`binary not found at ${binary} — run \`bun run build:binary\` first.`);
 }
-const PORT = 24272; // dev 24242 · e2e 24252 · smoke 24262 · e2e:binary 24272 — never collide
+// Per-worktree block (e2e/fixtures/paths.ts): main e2e +0 · this suite +2 · restart spec +4; the dev
+// host (24242) and smoke:binary (24262, free-scans + reads the served URL) stay clear of the block.
+const PORT = E2E_BINARY_PORT;
 const fakeBinDir = fileURLToPath(new URL("./e2e/fixtures/bin", import.meta.url));
 
 export default defineConfig({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,9 @@ const rootDir = fileURLToPath(new URL(".", import.meta.url));
 const staticDir = fileURLToPath(new URL("./apps/web/dist", import.meta.url));
 // Per-worktree derived port (e2e/fixtures/paths.ts) — parallel worktrees (this product's own working
 // model) run their suites concurrently without fighting over one port, zero config; the dev host
-// (24242) stays clear. Supersedes the manual THINKRAIL_E2E_PORT knob (THINKRAIL_E2E_PORT_BASE moves
-// the whole per-worktree block instead, should a derived slot ever clash).
+// (24242) stays clear. Slot clashes are auto-arbitrated by an atomic claim registry
+// (e2e/fixtures/portBlock.ts). Supersedes the manual THINKRAIL_E2E_PORT knob
+// (THINKRAIL_E2E_PORT_BASE pins the whole per-worktree block explicitly when ever needed).
 const PORT = E2E_PORT;
 // A stub `central` (JetBrains Central CLI) on the host's PATH so the JetBrains AI flow is drivable
 // deterministically — no real CLI, network, or JetBrains auth. Prepended so it wins over any real install.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,13 +6,16 @@ import {
 	E2E_HOME_DIR,
 	E2E_PI_AGENT_DIR,
 	E2E_PICK_DIR_POINTER,
+	E2E_PORT,
 } from "./e2e/fixtures/paths";
 
 const rootDir = fileURLToPath(new URL(".", import.meta.url));
 const staticDir = fileURLToPath(new URL("./apps/web/dist", import.meta.url));
-// Dedicated e2e port — never collides with dev:server (24242). Overridable so PARALLEL WORKTREES
-// (this product's own working model) can run their suites concurrently without fighting over one port.
-const PORT = Number(process.env.THINKRAIL_E2E_PORT ?? 24252);
+// Per-worktree derived port (e2e/fixtures/paths.ts) — parallel worktrees (this product's own working
+// model) run their suites concurrently without fighting over one port, zero config; the dev host
+// (24242) stays clear. Supersedes the manual THINKRAIL_E2E_PORT knob (THINKRAIL_E2E_PORT_BASE moves
+// the whole per-worktree block instead, should a derived slot ever clash).
+const PORT = E2E_PORT;
 // A stub `central` (JetBrains Central CLI) on the host's PATH so the JetBrains AI flow is drivable
 // deterministically — no real CLI, network, or JetBrains auth. Prepended so it wins over any real install.
 const fakeBinDir = fileURLToPath(new URL("./e2e/fixtures/bin", import.meta.url));


### PR DESCRIPTION
## Summary

Parallel e2e runs from **different worktrees** collided: every worktree resolved the same machine-global `$TMPDIR/thinkrail-e2e` and the same fixed ports. One run's `globalSetup`/`globalTeardown` would `rmSync` a sibling run's **live** host state (persistence, fixture repo, isolated HOME, pi agent dir, picker/central control files), and the fixed ports meant EADDRINUSE — or, during the build-phase race, two serial suites interleaving against one surviving host on the shared baseURL. The binary suite had the sneakiest shape: its CLI free-scans past a taken port while Playwright's `/health` poll can be answered by *another worktree's* host on the expected port.

Fix, centralized in the one seam every suite already imports (`e2e/fixtures/paths.ts`):

- **Per-worktree key** derived from the module's own repo root (sanitized basename + `sha256(realpath)` prefix, e.g. `workspace-16-64426154`) suffixes every machine-global dir: `E2E_DATA_DIR`, `E2E_BINARY_CACHE`, and the restart spec's data dir + host log (moved into `paths.ts` so all machine-global names live in one file).
- **Per-worktree port block** `25000 + (hash % 500) * 10` (clear of dev's 24242): main suite `+0`, `e2e:binary` `+2`, restart spec `+4`. Deterministic — the Playwright runner, its workers, and global setup each evaluate the module and must agree. `THINKRAIL_E2E_PORT_BASE` moves the whole block if a derived slot ever clashes (invalid values throw).
- **`smoke:binary` needs no change** — already collision-tolerant (CLI free-scans + the script reads the served URL from stdout); comment corrected.
- **Within one worktree the rule is unchanged:** the suites still share that worktree's state dir and run sequentially (documented in `playwright.binary.config.ts`); AGENTS.md's verification paragraph updated.

Notes for review:

- **Supersedes the manual `THINKRAIL_E2E_PORT` knob** that slipped into `playwright.config.ts` with #129 — it covered only the main suite's port, required per-worktree coordination, and left the data-dir hazard (the worse half) unaddressed. Derived ports make it redundant; `THINKRAIL_E2E_PORT_BASE` is the remaining escape hatch.
- Worktrees on branches **without** this change still run the old fixed paths and can collide with each other (old vs. new never collide — disjoint paths/ports). Rebase long-lived workspace branches to benefit.
- Rider commit: `apps/website/src/main.ts` failed biome's `useIndexOf` on main (pre-existing red lint); fixed with a typed `instanceof` narrow since the raw autofix would break typecheck.

## Related issues

None filed — investigated from a parallel-worktree e2e collision observed locally.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e` — 99/99 on the derived port/state dir, clean teardown; derivation checked deterministic per root and distinct across sibling worktrees)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change (AGENTS.md verification section; `e2e/fixtures/paths.ts` header records the isolation model; no spec node pins ports/paths)
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
