### PR TITLE
feat(welcome): truthful first-touch copy + a note for "Set up project"

### DIFF
--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -5,7 +5,15 @@ import type {
 	WireModel,
 	Workspace,
 } from "@thinkrail/contracts";
-import { Box, Check, ChevronDown, GitBranch, RefreshCw, TriangleAlert } from "lucide-react";
+import {
+	Box,
+	Check,
+	ChevronDown,
+	GitBranch,
+	RefreshCw,
+	Sparkles,
+	TriangleAlert,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
 import { SkillsButton } from "@/chat/SkillsButton";
@@ -54,6 +62,7 @@ export function NewWorkspaceDialog({
 	open,
 	projectId,
 	initialPrompt,
+	promptNote,
 	onOpenChange,
 	onCreated,
 }: {
@@ -62,6 +71,8 @@ export function NewWorkspaceDialog({
 	projectId: string;
 	/** Optional seed for the prompt hero (still fully editable) — e.g. Welcome's "Set up project". */
 	initialPrompt?: string;
+	/** Optional info strip above the prompt — e.g. what a seeded skill command does (copy owned by the opener). */
+	promptNote?: string;
 	onOpenChange: (open: boolean) => void;
 	onCreated: (workspace: Workspace) => void;
 }) {
@@ -390,6 +401,15 @@ export function NewWorkspaceDialog({
 
 				{/* hero: the prompt */}
 				<div className="relative">
+					{promptNote ? (
+						<p
+							data-testid="ws-prompt-note"
+							className="mb-xs flex items-start gap-sm rounded-[var(--radius-md)] border border-[var(--primary-40)] bg-[var(--primary-10)] px-md py-sm text-left text-muted text-xs leading-snug"
+						>
+							<Sparkles className="mt-0.5 size-3.5 shrink-0 text-primary" />
+							<span>{promptNote}</span>
+						</p>
+					) : null}
 					<Textarea
 						ref={promptRef}
 						data-testid="ws-prompt"

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -70,7 +70,10 @@ bottom-left; the primary is a filled-violet card carrying the stable `welcome-ct
 / Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Start building"** is the
 intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` (which cuts a
 worktree-isolated workspace + starts a chat); *workspace* is the mechanism, not the label. **"Set up
-project"** opens the same dialog with an `initialPrompt` seed — the `/skill:setting-up-a-project` command,
+project"** opens the same dialog with an `initialPrompt` seed **and a `promptNote`** — the note is the
+card's own copy (the dialog stays skill-agnostic), saying what the seeded command does: the agent drafts
+the project's specs (goal, architecture, modules) before building. The seed is the
+`/skill:setting-up-a-project` command,
 which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command syntax; expanded on the
 `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
 new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]). Which
@@ -100,7 +103,9 @@ pre-session half of the user's skill settings; the chat header opens the same di
 **“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new
 branch. Files, chats, changes, and terminals stay scoped to it.”** Its base-branch trigger reads **“From
 {base}”**, not an unexplained ref. An optional **`initialPrompt`** seeds the prompt hero (still editable;
-empty by default); while the prompt is non-empty, a secondary hint says ThinkRail will name the workspace
+empty by default) and an optional **`promptNote`** renders as a small info strip above it
+(`ws-prompt-note`) — the opener's chance to explain a seeded command, since the dialog's own header only
+ever describes creating a workspace; while the prompt is non-empty, a secondary hint says ThinkRail will name the workspace
 and branch from the request. The rest stays compact: the base-branch combobox (`git.listBranches`,
 degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
 a project picker, the prompt hero, and the reused

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -17,6 +17,12 @@ import { useOpenProject } from "./useOpenProject";
 // importing-a-codebase. Still editable in the dialog.
 const SETUP_PROMPT = "/skill:setting-up-a-project";
 
+// The dialog's info strip for "Set up project" — says what the seeded command actually does (the card
+// alone can't: the dialog it opens is the generic create surface). The copy lives here, with the card
+// that seeds it, so the dialog stays skill-agnostic.
+const SETUP_NOTE =
+	"Runs the setting-up-a-project skill — the agent drafts your project's specs (goal, architecture, modules) before building.";
+
 /**
  * The first-touch surface the shell mounts (centered, beside the projects rail) whenever no workspace is
  * active. The ThinkRail wordmark (topbar brand styling, scaled up) over a state-driven pitch and up-to-two
@@ -28,9 +34,13 @@ const SETUP_PROMPT = "/skill:setting-up-a-project";
 export function WelcomePanel() {
 	const projects = useAppStore((s) => s.projects);
 	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
-	// The New-Workspace dialog target (null = closed). `prompt` seeds the hero — "" for a plain create,
-	// the setup text for "Set up project".
-	const [dialog, setDialog] = useState<{ projectId: string; prompt: string } | null>(null);
+	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero — "" for a plain
+	// create, the setup command for "Set up project", which also carries the explanatory `note`.
+	const [dialog, setDialog] = useState<{
+		projectId: string;
+		prompt: string;
+		note?: string;
+	} | null>(null);
 	// Whether the shown project has any registered spec, fetched lazily (a full-tree walk — so it's
 	// requested only for this one project, on demand, never eagerly for every project on connect).
 	// null = pending/unknown (cards wait for it).
@@ -124,7 +134,7 @@ export function WelcomePanel() {
 			<p className="mt-lg max-w-[440px] text-md text-muted">
 				A spec-first way to build with AI. ThinkRail keeps your project's intent as a{" "}
 				<span className="text-text">connected spec graph</span> that the agent reads, plans, and
-				builds from, all in git worktree isolated workspaces.
+				builds from — each task in its own isolated git worktree.
 			</p>
 
 			<ProviderWarningBanner />
@@ -153,8 +163,10 @@ export function WelcomePanel() {
 							icon={Sparkles}
 							title="Set up project"
 							tag="spec-first"
-							subtitle="Prepare the specifications first with the agent before building."
-							onClick={() => setDialog({ projectId: project.id, prompt: SETUP_PROMPT })}
+							subtitle="Draft the project's specs with the agent first — goal, architecture, modules — before building."
+							onClick={() =>
+								setDialog({ projectId: project.id, prompt: SETUP_PROMPT, note: SETUP_NOTE })
+							}
 						/>
 						<Card
 							icon={Rocket}
@@ -172,6 +184,7 @@ export function WelcomePanel() {
 					open
 					projectId={dialog.projectId}
 					initialPrompt={dialog.prompt}
+					{...(dialog.note !== undefined ? { promptNote: dialog.note } : {})}
 					onOpenChange={(o) => {
 						if (!o) setDialog(null);
 					}}

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -19,6 +19,8 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	// and the IDE surfaces the user is about to enter are all scoped to it.
 	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
 	await expect(dialog).toContainText("A separate checkout on its own new branch");
+	// The note strip belongs to openers that seed a command (Welcome's "Set up project") — not the rail "+".
+	await expect(dialog.getByTestId("ws-prompt-note")).toHaveCount(0);
 	await expect(dialog).toContainText("Files, chats, changes, and terminals stay scoped to it");
 
 	// Project picker defaults to the project the "+" was clicked on.

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -207,11 +207,13 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 			page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
 		).toBeVisible();
 
-		// "Set up project" opens the New-Workspace dialog with the prompt hero pre-seeded.
+		// "Set up project" opens the New-Workspace dialog with the prompt hero pre-seeded, and the note
+		// strip explains what the seeded command will do (the dialog header only names the create op).
 		await page.getByTestId("welcome-cta").click();
 		const dialog = page.getByTestId("new-workspace-dialog");
 		await expect(dialog).toBeVisible();
 		await expect(dialog.getByTestId("ws-prompt")).toHaveValue(/^\/skill:setting-up-a-project\b/);
+		await expect(dialog.getByTestId("ws-prompt-note")).toContainText("setting-up-a-project skill");
 
 		// Clear the seed (no agent kick-off — keeps this in the no-agent suite) and create the worktree; it
 		// becomes active → the welcome unmounts and the full 3-column surface appears.


### PR DESCRIPTION
The quick-win half of #105: **copy only**, no behavior change, no wire change — split out so it can land immediately while the Default-workspace feature gets the deeper review.

### What changes

| Surface | Before | After |
| --- | --- | --- |
| Welcome hero | "…that the agent reads, plans, and builds from, **all in git worktree isolated workspaces**." | "…that the agent reads, plans, and builds from — **each task in its own isolated git worktree**." |
| "Set up project" card | "Prepare the specifications first with the agent before building." | **"Draft the project's specs with the agent first — goal, architecture, modules — before building."** |
| New-Workspace dialog | nothing explained the seeded `/skill:setting-up-a-project` | new info strip above the prompt: "Runs the setting-up-a-project skill — the agent drafts your project's specs (goal, architecture, modules) before building." |

The strip is a generic optional `promptNote` prop on `NewWorkspaceDialog` — the copy lives with the card that seeds the command, so the dialog stays skill-agnostic. It renders only when an opener passes one (the rail "+" path is untouched).

### Why

Three first-touch surfaces were saying either too little or something not quite true:

- the hero read as if ThinkRail *only* ever works in worktrees (it doesn't — see #105);
- the setup card promised "specifications" without naming what you get;
- "Set up project" dropped you into a dialog titled *Create workspace* with a cryptic `/skill:…` string in the prompt and no explanation of what pressing Create would do.

### Verification

`check:deps` + `lint` + `typecheck` + `bun run test` green; `bun run e2e` **99/99**. e2e asserts the note on the setup path and its **absence** on the plain rail "+" path. `apps/web/src/panels/SPEC.md` updated first.

---

Stacked below: **#105** (built-in Default workspace) now targets this branch.
