### PR TITLE
feat: built-in Default workspace + an explicit choice between the two working modes

### DIFF
--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -21,6 +21,7 @@ import {
 	type DocTab,
 	type EditorTab,
 	selectActiveWorkspace,
+	selectContextProject,
 	selectWorkspaceTick,
 	toast,
 	useAppStore,
@@ -95,6 +96,7 @@ function ChatHistoryMenu({
 export function CenterTabs() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 	const activeWorkspace = useAppStore(selectActiveWorkspace);
+	const contextProject = useAppStore(selectContextProject);
 	const tabsByWorkspace = useAppStore((s) => s.tabsByWorkspace);
 	const activeTabByWorkspace = useAppStore((s) => s.activeTabByWorkspace);
 	const closedChatsByWorkspace = useAppStore((s) => s.closedChatsByWorkspace);
@@ -238,6 +240,9 @@ export function CenterTabs() {
 		else closeTab(tab.id);
 	};
 
+	// The Default workspace is the project folder itself — its receipt must tell the truth ("runs
+	// directly in your project folder") instead of promising worktree isolation.
+	const isDefaultWorkspace = activeWorkspace?.kind === "default";
 	const placeholder = (
 		<div className="flex h-full flex-col items-center justify-center gap-md px-lg text-center text-hint">
 			{activeWorkspace ? (
@@ -246,18 +251,28 @@ export function CenterTabs() {
 					className="flex max-w-[440px] flex-col items-center gap-xs"
 				>
 					<span className="font-medium text-hint text-xs uppercase tracking-wider">
-						Workspace ready
+						{isDefaultWorkspace ? "Default workspace" : "Workspace ready"}
 					</span>
 					<h2 className="max-w-full truncate font-medium text-md text-text">
-						{activeWorkspace.name}
+						{isDefaultWorkspace
+							? (contextProject?.name ?? activeWorkspace.name)
+							: activeWorkspace.name}
 					</h2>
 					<p className="flex max-w-full items-center gap-xs font-[var(--font-mono)] text-muted text-xs">
 						<GitBranch className="size-3.5 shrink-0" />
-						<span className="truncate">{activeWorkspace.branch}</span>
-						<span className="shrink-0 text-hint">· from {activeWorkspace.baseBranch}</span>
+						{isDefaultWorkspace ? (
+							<span className="truncate">on {activeWorkspace.branch}</span>
+						) : (
+							<>
+								<span className="truncate">{activeWorkspace.branch}</span>
+								<span className="shrink-0 text-hint">· from {activeWorkspace.baseBranch}</span>
+							</>
+						)}
 					</p>
 					<p className="mt-xs text-muted text-sm">
-						Files, chats, changes, and terminals are scoped to this workspace.
+						{isDefaultWorkspace
+							? "Chats, changes, and terminals run directly in your project folder."
+							: "Files, chats, changes, and terminals are scoped to this workspace."}
 					</p>
 				</div>
 			) : (

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -20,6 +20,7 @@ import {
 	type ClosedChat,
 	type DocTab,
 	type EditorTab,
+	isDefaultWorkspace,
 	selectActiveWorkspace,
 	selectContextProject,
 	selectWorkspaceTick,
@@ -242,7 +243,7 @@ export function CenterTabs() {
 
 	// The Default workspace is the project folder itself — its receipt must tell the truth ("runs
 	// directly in your project folder") instead of promising worktree isolation.
-	const isDefaultWorkspace = activeWorkspace?.kind === "default";
+	const isDefault = activeWorkspace != null && isDefaultWorkspace(activeWorkspace);
 	const placeholder = (
 		<div className="flex h-full flex-col items-center justify-center gap-md px-lg text-center text-hint">
 			{activeWorkspace ? (
@@ -251,16 +252,14 @@ export function CenterTabs() {
 					className="flex max-w-[440px] flex-col items-center gap-xs"
 				>
 					<span className="font-medium text-hint text-xs uppercase tracking-wider">
-						{isDefaultWorkspace ? "Default workspace" : "Workspace ready"}
+						{isDefault ? "Default workspace" : "Workspace ready"}
 					</span>
 					<h2 className="max-w-full truncate font-medium text-md text-text">
-						{isDefaultWorkspace
-							? (contextProject?.name ?? activeWorkspace.name)
-							: activeWorkspace.name}
+						{isDefault ? (contextProject?.name ?? activeWorkspace.name) : activeWorkspace.name}
 					</h2>
 					<p className="flex max-w-full items-center gap-xs font-[var(--font-mono)] text-muted text-xs">
 						<GitBranch className="size-3.5 shrink-0" />
-						{isDefaultWorkspace ? (
+						{isDefault ? (
 							<span className="truncate">on {activeWorkspace.branch}</span>
 						) : (
 							<>
@@ -270,7 +269,7 @@ export function CenterTabs() {
 						)}
 					</p>
 					<p className="mt-xs text-muted text-sm">
-						{isDefaultWorkspace
+						{isDefault
 							? "Chats, changes, and terminals run directly in your project folder."
 							: "Files, chats, changes, and terminals are scoped to this workspace."}
 					</p>

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -61,9 +61,10 @@ const PILL =
  * The start-working surface: a **target control** chooses where the work runs — an isolated worktree
  * ("Create workspace": pick a base branch, cut a worktree from it) or the project folder itself ("Work
  * in project folder": nothing is created, submit enters the built-in Default workspace). Either way:
- * say what to work on, pick a model + effort, submit → enter the target and (with a prompt) open a chat
- * there and send it. With an empty prompt it just creates/enters the target — the fast path for poking
- * at files. The header is mode-aware so it always names the operation truthfully.
+ * say what to work on, pick a model + effort, submit → enter the target and **open a fresh chat there**
+ * — a typed prompt is sent as its first message, an empty one leaves the composer ready (submitting the
+ * start-working surface always lands in a chat, never on a bare receipt). The header is mode-aware so
+ * it always names the operation truthfully.
  *
  * The only app-integration piece here: it wires the store + transport. `onCreated(ws)` fires **only when
  * a worktree was created** (folder mode creates nothing — it enters via `enterDefaultWorkspace`, whose
@@ -314,8 +315,8 @@ export function NewWorkspaceDialog({
 			}
 		}
 
-		// The target exists — the intent is fulfilled, so close the dialog *now* and run the
-		// (slower, optional) chat kick-off in the background. This keeps the dialog from lingering while pi
+		// The target exists — the intent is fulfilled, so close the dialog *now* and run the (slower)
+		// chat kick-off in the background. This keeps the dialog from lingering while pi
 		// spins up a session, and a kick-off failure can't strand the dialog open.
 		const store = useAppStore.getState();
 		if (target === "worktree") {
@@ -326,8 +327,10 @@ export function NewWorkspaceDialog({
 		}
 		onOpenChange(false);
 
+		// Submitting the start-working surface always lands in a ready chat: create the session (the
+		// picked model + effort apply even without a prompt) and open its tab; a typed prompt is
+		// additionally sent as the first message — an empty one just leaves the composer focused.
 		const text = prompt.trim();
-		if (!text) return;
 		// Snapshot the sync baseline before the create round-trip (see selectWorkspaceTick / openChatSession).
 		const syncedTick = selectWorkspaceTick(useAppStore.getState(), workspace.id);
 		try {
@@ -343,6 +346,7 @@ export function NewWorkspaceDialog({
 				session.thinkingLevel,
 				syncedTick,
 			);
+			if (!text) return;
 			store.appendUserMessage(session.sessionId, text);
 			// Fire-and-forget the turn (it resolves only when the turn ends); the now-open chat tab streams it.
 			// A rejected send (bad model / no API key) surfaces as an error turn in the just-opened chat rather

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -5,7 +5,15 @@ import type {
 	WireModel,
 	Workspace,
 } from "@thinkrail/contracts";
-import { Box, Check, ChevronDown, GitBranch, RefreshCw, TriangleAlert } from "lucide-react";
+import {
+	Box,
+	Check,
+	ChevronDown,
+	GitBranch,
+	RefreshCw,
+	Sparkles,
+	TriangleAlert,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
 import { SkillsButton } from "@/chat/SkillsButton";
@@ -54,6 +62,7 @@ export function NewWorkspaceDialog({
 	open,
 	projectId,
 	initialPrompt,
+	promptNote,
 	onOpenChange,
 	onCreated,
 }: {
@@ -62,6 +71,8 @@ export function NewWorkspaceDialog({
 	projectId: string;
 	/** Optional seed for the prompt hero (still fully editable) — e.g. Welcome's "Set up project". */
 	initialPrompt?: string;
+	/** Optional info strip above the prompt — e.g. what a seeded skill command does (copy owned by the opener). */
+	promptNote?: string;
 	onOpenChange: (open: boolean) => void;
 	onCreated: (workspace: Workspace) => void;
 }) {
@@ -417,6 +428,15 @@ export function NewWorkspaceDialog({
 
 				{/* hero: the prompt */}
 				<div className="relative">
+					{promptNote ? (
+						<p
+							data-testid="ws-prompt-note"
+							className="mb-xs flex items-start gap-sm rounded-[var(--radius-md)] border border-[var(--primary-40)] bg-[var(--primary-10)] px-md py-sm text-left text-muted text-xs leading-snug"
+						>
+							<Sparkles className="mt-0.5 size-3.5 shrink-0 text-primary" />
+							<span>{promptNote}</span>
+						</p>
+					) : null}
 					<Textarea
 						ref={promptRef}
 						data-testid="ws-prompt"

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -16,7 +16,7 @@ import {
 	Sparkles,
 	TriangleAlert,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
 import { SkillsButton } from "@/chat/SkillsButton";
 import { SkillsDialog } from "@/chat/SkillsDialog";
@@ -48,10 +48,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { selectWorkspaceTick, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
-import { resolveDefaultWorkspace } from "./defaultWorkspace";
+import { enterDefaultWorkspace } from "./defaultWorkspace";
 
 /** Where the work runs: cut an isolated worktree, or enter the project folder (Default workspace). */
-export type WorkspaceTarget = "worktree" | "default";
+type WorkspaceTarget = "worktree" | "default";
 
 /** A shared pill-trigger look for the project + branch pickers (mockup `.pill`). */
 const PILL =
@@ -65,14 +65,15 @@ const PILL =
  * there and send it. With an empty prompt it just creates/enters the target — the fast path for poking
  * at files. The header is mode-aware so it always names the operation truthfully.
  *
- * The only app-integration piece here: it wires the store + transport. `onCreated(ws)` lets the parent
- * (ProjectTree) expand + reload its list; the dialog itself sets the active workspace + kicks off the chat.
+ * The only app-integration piece here: it wires the store + transport. `onCreated(ws)` fires **only when
+ * a worktree was created** (folder mode creates nothing — it enters via `enterDefaultWorkspace`, whose
+ * list is already fresh and whose activation drives the rail's auto-expand); it lets the parent
+ * (ProjectTree) reload its list. The dialog itself kicks off the optional chat.
  */
 export function NewWorkspaceDialog({
 	open,
 	projectId,
 	initialPrompt,
-	initialTarget,
 	promptNote,
 	onOpenChange,
 	onCreated,
@@ -82,8 +83,6 @@ export function NewWorkspaceDialog({
 	projectId: string;
 	/** Optional seed for the prompt hero (still fully editable) — e.g. Welcome's "Set up project". */
 	initialPrompt?: string;
-	/** The preselected target (the control stays visible either way). Defaults to "worktree". */
-	initialTarget?: WorkspaceTarget;
 	/** Optional info strip above the prompt — e.g. what a seeded skill command does (copy owned by the opener). */
 	promptNote?: string;
 	onOpenChange: (open: boolean) => void;
@@ -93,7 +92,9 @@ export function NewWorkspaceDialog({
 	const models = useAppStore((s) => s.models);
 
 	const [selectedProjectId, setSelectedProjectId] = useState(projectId);
-	const [target, setTarget] = useState<WorkspaceTarget>(initialTarget ?? "worktree");
+	// Every opener starts on the isolated-worktree side (task-welcome-trim made the entry points
+	// uniform — no opener-chosen target exists); the folder alternative is the in-dialog toggle.
+	const [target, setTarget] = useState<WorkspaceTarget>("worktree");
 	const [branches, setBranches] = useState<BranchList | null>(null);
 	const [baseRef, setBaseRef] = useState<string>("");
 	const [refreshing, setRefreshing] = useState(false);
@@ -106,6 +107,8 @@ export function NewWorkspaceDialog({
 	const [trusting, setTrusting] = useState(false);
 	const [manageSkills, setManageSkills] = useState(false);
 	const promptRef = useRef<HTMLTextAreaElement>(null);
+	// Ties the two target radios into one native group, unique per dialog instance.
+	const targetGroupName = useId();
 	// The dialog content node — popovers portal into it so their lists stay scrollable under the Dialog's
 	// scroll lock (react-remove-scroll blocks wheel/trackpad on body-portaled content).
 	const [dialogEl, setDialogEl] = useState<HTMLElement | null>(null);
@@ -129,15 +132,15 @@ export function NewWorkspaceDialog({
 		},
 	});
 
-	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on, any
-	// seed prompt (empty by default), and the opener's preselected target.
+	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on and any
+	// seed prompt (empty by default).
 	useEffect(() => {
 		if (!open) return;
 		setSelectedProjectId(projectId);
 		setPrompt(initialPrompt ?? "");
-		setTarget(initialTarget ?? "worktree");
+		setTarget("worktree");
 		setCreating(false);
-	}, [open, projectId, initialPrompt, initialTarget]);
+	}, [open, projectId, initialPrompt]);
 
 	// Skills are previewed from the selected project's current checkout; the created worktree/session is
 	// authoritative if its base ref differs. Autocomplete is an enhancement, so failure degrades to empty.
@@ -288,9 +291,9 @@ export function NewWorkspaceDialog({
 		setCreating(true);
 		let workspace: Workspace;
 		if (target === "default") {
-			// Folder mode: nothing is created — resolve + enter the project's built-in Default workspace
-			// (the shared helper folds the fresh list into the store and toasts on failure).
-			const def = await resolveDefaultWorkspace(selectedProjectId);
+			// Folder mode: nothing is created — the shared helper lists, stores, and activates the project's
+			// built-in Default workspace in one atomic entry (and toasts + returns null on failure).
+			const def = await enterDefaultWorkspace(selectedProjectId);
 			if (!def) {
 				setCreating(false);
 				return;
@@ -315,8 +318,12 @@ export function NewWorkspaceDialog({
 		// (slower, optional) chat kick-off in the background. This keeps the dialog from lingering while pi
 		// spins up a session, and a kick-off failure can't strand the dialog open.
 		const store = useAppStore.getState();
-		onCreated(workspace);
-		store.activateWorkspace(workspace);
+		if (target === "worktree") {
+			// Only a real create notifies the parent + activates here — folder mode already entered via the
+			// helper (its list is fresh; a re-list would just repeat the host's git work).
+			onCreated(workspace);
+			store.activateWorkspace(workspace);
+		}
 		onOpenChange(false);
 
 		const text = prompt.trim();
@@ -408,25 +415,28 @@ export function NewWorkspaceDialog({
 				</DialogHeader>
 
 				{/* where: the target control — both modes always visible, the two-mode model in one glance */}
-				<div
+				<fieldset
 					data-testid="ws-target"
 					className="flex w-fit items-center gap-0.5 rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] p-0.5"
 				>
-					<TargetButton
+					<legend className="sr-only">Where the work runs</legend>
+					<TargetOption
 						icon={GitBranch}
 						label="Isolated workspace"
+						name={targetGroupName}
 						active={isolated}
 						testid="ws-target-worktree"
-						onClick={() => setTarget("worktree")}
+						onSelect={() => setTarget("worktree")}
 					/>
-					<TargetButton
+					<TargetOption
 						icon={House}
 						label="Project folder"
+						name={targetGroupName}
 						active={!isolated}
 						testid="ws-target-default"
-						onClick={() => setTarget("default")}
+						onSelect={() => setTarget("default")}
 					/>
-				</div>
+				</fieldset>
 
 				{/* controls-top: project + (worktree mode) base-branch pickers */}
 				<div className="flex flex-wrap items-center gap-sm">
@@ -567,35 +577,41 @@ export function NewWorkspaceDialog({
 	);
 }
 
-/** One option of the target control — a toggle button styled like the app's active-nav pattern. */
-function TargetButton({
+/**
+ * One option of the target control — a **native radio** (the two choices are one mutually-exclusive
+ * group, which independent toggle buttons would misrepresent to assistive tech), its input visually
+ * hidden and the wrapping label wearing the app's active-nav styling. The testid + `data-active` hooks
+ * stay on the clickable label; keyboard follows native radio-group behavior.
+ */
+function TargetOption({
 	icon: Icon,
 	label,
+	name,
 	active,
 	testid,
-	onClick,
+	onSelect,
 }: {
 	icon: LucideIcon;
 	label: string;
+	/** The radio group name tying the options together (unique per dialog instance). */
+	name: string;
 	active: boolean;
 	testid: string;
-	onClick: () => void;
+	onSelect: () => void;
 }) {
 	return (
-		<button
-			type="button"
-			aria-pressed={active}
+		<label
 			data-testid={testid}
 			data-active={active}
-			onClick={onClick}
 			className={cn(
-				"flex h-7 items-center gap-sm rounded-[7px] px-md text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+				"flex h-7 cursor-pointer items-center gap-sm rounded-[7px] px-md text-sm transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary",
 				active ? "bg-[var(--primary-10)] font-medium text-primary" : "text-muted hover:text-text",
 			)}
 		>
+			<input type="radio" name={name} className="sr-only" checked={active} onChange={onSelect} />
 			<Icon className="size-3.5 shrink-0" />
 			{label}
-		</button>
+		</label>
 	);
 }
 

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -10,6 +10,8 @@ import {
 	Check,
 	ChevronDown,
 	GitBranch,
+	House,
+	type LucideIcon,
 	RefreshCw,
 	Sparkles,
 	TriangleAlert,
@@ -43,17 +45,25 @@ import {
 } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import { selectWorkspaceTick, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
+import { resolveDefaultWorkspace } from "./defaultWorkspace";
+
+/** Where the work runs: cut an isolated worktree, or enter the project folder (Default workspace). */
+export type WorkspaceTarget = "worktree" | "default";
 
 /** A shared pill-trigger look for the project + branch pickers (mockup `.pill`). */
 const PILL =
 	"flex h-8 min-w-0 items-center gap-sm rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-sm text-sm text-text outline-none transition-colors hover:bg-hover focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-[var(--primary-60)] data-[open=true]:bg-hover";
 
 /**
- * The New-Workspace "create + kick-off" surface: pick a base branch, say what to work on, pick a
- * model + effort, then Create → cut a worktree from that base, open a chat in it, and send the prompt.
- * With an empty prompt it just creates the workspace (no chat) — the fast path for poking at files.
+ * The start-working surface: a **target control** chooses where the work runs — an isolated worktree
+ * ("Create workspace": pick a base branch, cut a worktree from it) or the project folder itself ("Work
+ * in project folder": nothing is created, submit enters the built-in Default workspace). Either way:
+ * say what to work on, pick a model + effort, submit → enter the target and (with a prompt) open a chat
+ * there and send it. With an empty prompt it just creates/enters the target — the fast path for poking
+ * at files. The header is mode-aware so it always names the operation truthfully.
  *
  * The only app-integration piece here: it wires the store + transport. `onCreated(ws)` lets the parent
  * (ProjectTree) expand + reload its list; the dialog itself sets the active workspace + kicks off the chat.
@@ -62,6 +72,7 @@ export function NewWorkspaceDialog({
 	open,
 	projectId,
 	initialPrompt,
+	initialTarget,
 	promptNote,
 	onOpenChange,
 	onCreated,
@@ -71,6 +82,8 @@ export function NewWorkspaceDialog({
 	projectId: string;
 	/** Optional seed for the prompt hero (still fully editable) — e.g. Welcome's "Set up project". */
 	initialPrompt?: string;
+	/** The preselected target (the control stays visible either way). Defaults to "worktree". */
+	initialTarget?: WorkspaceTarget;
 	/** Optional info strip above the prompt — e.g. what a seeded skill command does (copy owned by the opener). */
 	promptNote?: string;
 	onOpenChange: (open: boolean) => void;
@@ -80,6 +93,7 @@ export function NewWorkspaceDialog({
 	const models = useAppStore((s) => s.models);
 
 	const [selectedProjectId, setSelectedProjectId] = useState(projectId);
+	const [target, setTarget] = useState<WorkspaceTarget>(initialTarget ?? "worktree");
 	const [branches, setBranches] = useState<BranchList | null>(null);
 	const [baseRef, setBaseRef] = useState<string>("");
 	const [refreshing, setRefreshing] = useState(false);
@@ -115,14 +129,15 @@ export function NewWorkspaceDialog({
 		},
 	});
 
-	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on and any
-	// seed prompt (empty by default).
+	// Reset the form each time the dialog opens, anchored to the project the "+" was clicked on, any
+	// seed prompt (empty by default), and the opener's preselected target.
 	useEffect(() => {
 		if (!open) return;
 		setSelectedProjectId(projectId);
 		setPrompt(initialPrompt ?? "");
+		setTarget(initialTarget ?? "worktree");
 		setCreating(false);
-	}, [open, projectId, initialPrompt]);
+	}, [open, projectId, initialPrompt, initialTarget]);
 
 	// Skills are previewed from the selected project's current checkout; the created worktree/session is
 	// authoritative if its base ref differs. Autocomplete is an enhancement, so failure degrades to empty.
@@ -272,20 +287,31 @@ export function NewWorkspaceDialog({
 		if (creating) return;
 		setCreating(true);
 		let workspace: Workspace;
-		try {
-			workspace = await getTransport().request("workspace.create", {
-				projectId: selectedProjectId,
-				...(baseRef ? { baseRef } : {}),
-			});
-		} catch (err) {
-			// Worktree creation failed (bad ref, etc.) — keep the dialog open so the user can retry/adjust,
-			// and surface the reason (it's otherwise invisible — the dialog just refuses to close).
-			toast.error(errorText(err), "Couldn't create workspace");
-			setCreating(false);
-			return;
+		if (target === "default") {
+			// Folder mode: nothing is created — resolve + enter the project's built-in Default workspace
+			// (the shared helper folds the fresh list into the store and toasts on failure).
+			const def = await resolveDefaultWorkspace(selectedProjectId);
+			if (!def) {
+				setCreating(false);
+				return;
+			}
+			workspace = def;
+		} else {
+			try {
+				workspace = await getTransport().request("workspace.create", {
+					projectId: selectedProjectId,
+					...(baseRef ? { baseRef } : {}),
+				});
+			} catch (err) {
+				// Worktree creation failed (bad ref, etc.) — keep the dialog open so the user can retry/adjust,
+				// and surface the reason (it's otherwise invisible — the dialog just refuses to close).
+				toast.error(errorText(err), "Couldn't create workspace");
+				setCreating(false);
+				return;
+			}
 		}
 
-		// The worktree exists — the "new workspace" intent is fulfilled, so close the dialog *now* and run the
+		// The target exists — the intent is fulfilled, so close the dialog *now* and run the
 		// (slower, optional) chat kick-off in the background. This keeps the dialog from lingering while pi
 		// spins up a session, and a kick-off failure can't strand the dialog open.
 		const store = useAppStore.getState();
@@ -350,6 +376,7 @@ export function NewWorkspaceDialog({
 	};
 
 	const selectedProject = projects.find((p) => p.id === selectedProjectId);
+	const isolated = target === "worktree";
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -372,14 +399,36 @@ export function NewWorkspaceDialog({
 				}}
 			>
 				<DialogHeader>
-					<DialogTitle>Create workspace</DialogTitle>
+					<DialogTitle>{isolated ? "Create workspace" : "Work in project folder"}</DialogTitle>
 					<DialogDescription>
-						A separate checkout on its own new branch. Files, chats, changes, and terminals stay
-						scoped to it.
+						{isolated
+							? "A separate checkout on its own new branch. Files, chats, changes, and terminals stay scoped to it."
+							: "Runs directly in your project folder — no isolation. Changes land on the current branch."}
 					</DialogDescription>
 				</DialogHeader>
 
-				{/* controls-top: project + base-branch pickers */}
+				{/* where: the target control — both modes always visible, the two-mode model in one glance */}
+				<div
+					data-testid="ws-target"
+					className="flex w-fit items-center gap-0.5 rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] p-0.5"
+				>
+					<TargetButton
+						icon={GitBranch}
+						label="Isolated workspace"
+						active={isolated}
+						testid="ws-target-worktree"
+						onClick={() => setTarget("worktree")}
+					/>
+					<TargetButton
+						icon={House}
+						label="Project folder"
+						active={!isolated}
+						testid="ws-target-default"
+						onClick={() => setTarget("default")}
+					/>
+				</div>
+
+				{/* controls-top: project + (worktree mode) base-branch pickers */}
 				<div className="flex flex-wrap items-center gap-sm">
 					<ProjectPicker
 						projects={projects}
@@ -387,14 +436,16 @@ export function NewWorkspaceDialog({
 						container={dialogEl}
 						onSelect={setSelectedProjectId}
 					/>
-					<BranchPicker
-						branches={branches}
-						baseRef={baseRef}
-						refreshing={refreshing}
-						container={dialogEl}
-						onSelect={selectBaseRef}
-						onRefresh={() => void refreshBranches()}
-					/>
+					{isolated ? (
+						<BranchPicker
+							branches={branches}
+							baseRef={baseRef}
+							refreshing={refreshing}
+							container={dialogEl}
+							onSelect={selectBaseRef}
+							onRefresh={() => void refreshBranches()}
+						/>
+					) : null}
 					<SkillsButton
 						onOpen={() => setManageSkills(true)}
 						testId="ws-manage-skills"
@@ -462,7 +513,7 @@ export function NewWorkspaceDialog({
 							onSelect={slashCompletion.pick}
 							className="absolute top-full left-sm z-50 mt-xs"
 						/>
-					) : prompt.trim() ? (
+					) : prompt.trim() && isolated ? (
 						<p data-testid="workspace-naming-hint" className="px-xs text-hint text-xs">
 							ThinkRail will name the workspace and branch from your request.
 						</p>
@@ -500,7 +551,7 @@ export function NewWorkspaceDialog({
 						onClick={() => void create()}
 						className="flex h-8 shrink-0 items-center gap-sm rounded-[var(--radius-md)] bg-primary px-md font-medium text-on-accent text-sm outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50"
 					>
-						Create
+						{isolated ? "Create" : "Start"}
 						<span className="inline-flex h-4 min-w-4 items-center justify-center rounded-[3px] bg-[var(--on-accent-16)] px-1 font-[var(--font-mono)] text-xs">
 							↵
 						</span>
@@ -513,6 +564,38 @@ export function NewWorkspaceDialog({
 				/>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+/** One option of the target control — a toggle button styled like the app's active-nav pattern. */
+function TargetButton({
+	icon: Icon,
+	label,
+	active,
+	testid,
+	onClick,
+}: {
+	icon: LucideIcon;
+	label: string;
+	active: boolean;
+	testid: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={active}
+			data-testid={testid}
+			data-active={active}
+			onClick={onClick}
+			className={cn(
+				"flex h-7 items-center gap-sm rounded-[7px] px-md text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+				active ? "bg-[var(--primary-10)] font-medium text-primary" : "text-muted hover:text-text",
+			)}
+		>
+			<Icon className="size-3.5 shrink-0" />
+			{label}
+		</button>
 	);
 }
 

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, ChevronRight, Folder, GitBranch, House, Plus, Trash2 } fro
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
-import { selectActiveWorkspaceProjectId, toast, useAppStore } from "../store";
+import { isDefaultWorkspace, selectActiveWorkspaceProjectId, toast, useAppStore } from "../store";
 import { errorText, getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmPopover } from "./ConfirmPopover";
@@ -115,33 +115,33 @@ export function ProjectTree() {
 			<ul className="flex flex-col">
 				{projects.map((project) => {
 					const isExpanded = expanded.has(project.id);
-					const list = workspaces[project.id] ?? [];
+					// `undefined` = not fetched yet (render nothing — once fetched the list always holds at
+					// least the ensured Default row, so there is no persistent "empty" state to name).
+					const list = workspaces[project.id];
 					return (
 						<li key={project.id}>
 							<ProjectRow
 								project={project}
 								isSelected={selectedProjectId === project.id}
 								isExpanded={isExpanded}
-								workspaceCount={list.length}
+								// Worktrees only: the always-present Default would make the badge a constant "≥1",
+								// destroying its meaning ("you have N workspaces here").
+								workspaceCount={(list ?? []).filter((w) => !isDefaultWorkspace(w)).length}
 								onToggle={() => toggleExpand(project.id)}
 								onSelect={() => void selectProject(project.id)}
 								onAddWorkspace={() => setDialogProjectId(project.id)}
 							/>
-							{isExpanded && (
+							{isExpanded && list !== undefined && (
 								<ul className="flex flex-col">
-									{list.length === 0 ? (
-										<li className="py-xs pr-sm pl-xl text-xs text-hint">No workspaces yet</li>
-									) : (
-										list.map((ws) => (
-											<WorkspaceRow
-												key={ws.id}
-												workspace={ws}
-												isActive={activeWorkspaceId === ws.id}
-												onSelect={() => selectWorkspace(ws)}
-												onRemove={() => removeWorkspace(ws.id)}
-											/>
-										))
-									)}
+									{list.map((ws) => (
+										<WorkspaceRow
+											key={ws.id}
+											workspace={ws}
+											isActive={activeWorkspaceId === ws.id}
+											onSelect={() => selectWorkspace(ws)}
+											onRemove={() => removeWorkspace(ws.id)}
+										/>
+									))}
 								</ul>
 							)}
 						</li>
@@ -238,7 +238,7 @@ function WorkspaceRow({
 	const stats = workspace.diffStats;
 	// The built-in Default workspace (the project folder itself) is non-removable — the server enforces
 	// it; the UI simply offers nothing. It wears a House icon in place of the branch glyph.
-	const isDefault = workspace.kind === "default";
+	const isDefault = isDefaultWorkspace(workspace);
 	const Icon = isDefault ? House : GitBranch;
 	// Confirm-before-remove lives on the row so the popover anchors right beneath it (contextual to the
 	// workspace being removed) rather than as a centered modal.

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -1,5 +1,5 @@
 import type { Project, Workspace } from "@thinkrail/contracts";
-import { ChevronDown, ChevronRight, Folder, GitBranch, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Folder, GitBranch, House, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
@@ -236,9 +236,70 @@ function WorkspaceRow({
 	onRemove: () => void;
 }) {
 	const stats = workspace.diffStats;
+	// The built-in Default workspace (the project folder itself) is non-removable — the server enforces
+	// it; the UI simply offers nothing. It wears a House icon in place of the branch glyph.
+	const isDefault = workspace.kind === "default";
+	const Icon = isDefault ? House : GitBranch;
 	// Confirm-before-remove lives on the row so the popover anchors right beneath it (contextual to the
 	// workspace being removed) rather than as a centered modal.
 	const [confirmOpen, setConfirmOpen] = useState(false);
+	const row = (
+		<div
+			data-testid="workspace-item"
+			data-active={isActive}
+			data-kind={workspace.kind ?? "worktree"}
+			className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
+				isActive ? "bg-hover" : "hover:bg-hover"
+			}`}
+		>
+			<button
+				type="button"
+				onClick={onSelect}
+				className="flex min-w-0 flex-1 items-center gap-sm text-left"
+			>
+				<Icon className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
+				{/* Name on top, the git branch on a second line beneath it — the display name is decoupled
+				    from the branch, so surface both without crowding one line. The branch line is hidden when
+				    they coincide, so pristine/legacy rows stay a single compact line. */}
+				<span className="flex min-w-0 flex-1 flex-col">
+					<span
+						data-testid="workspace-name"
+						className={`truncate text-sm leading-tight ${isActive ? "font-medium text-primary" : "text-muted"}`}
+					>
+						{workspace.name}
+					</span>
+					{workspace.branch !== workspace.name && (
+						<span
+							data-testid="workspace-branch"
+							className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
+						>
+							{workspace.branch}
+						</span>
+					)}
+				</span>
+			</button>
+			<DiffStatBadge
+				added={stats?.added ?? 0}
+				removed={stats?.removed ?? 0}
+				className="group-hover:hidden"
+			/>
+			{!isDefault && (
+				<PopoverTrigger asChild>
+					<button
+						type="button"
+						data-testid="workspace-remove"
+						aria-label="Remove workspace"
+						className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-red group-hover:opacity-100 data-[state=open]:opacity-100"
+					>
+						<Trash2 className="size-4" />
+					</button>
+				</PopoverTrigger>
+			)}
+		</div>
+	);
+	// No ConfirmPopover for the Default row — there is nothing to confirm (and PopoverTrigger only
+	// renders inside the popover context of the removable branch below).
+	if (isDefault) return row;
 	return (
 		<ConfirmPopover
 			open={confirmOpen}
@@ -257,55 +318,7 @@ function WorkspaceRow({
 			align="end"
 		>
 			{/* Anchored to the Remove button (the PopoverTrigger), right border aligned via align="end". */}
-			<div
-				data-testid="workspace-item"
-				data-active={isActive}
-				className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
-					isActive ? "bg-hover" : "hover:bg-hover"
-				}`}
-			>
-				<button
-					type="button"
-					onClick={onSelect}
-					className="flex min-w-0 flex-1 items-center gap-sm text-left"
-				>
-					<GitBranch className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-hint"}`} />
-					{/* Name on top, the git branch on a second line beneath it — the display name is decoupled
-					    from the branch, so surface both without crowding one line. The branch line is hidden when
-					    they coincide, so pristine/legacy rows stay a single compact line. */}
-					<span className="flex min-w-0 flex-1 flex-col">
-						<span
-							data-testid="workspace-name"
-							className={`truncate text-sm leading-tight ${isActive ? "font-medium text-primary" : "text-muted"}`}
-						>
-							{workspace.name}
-						</span>
-						{workspace.branch !== workspace.name && (
-							<span
-								data-testid="workspace-branch"
-								className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
-							>
-								{workspace.branch}
-							</span>
-						)}
-					</span>
-				</button>
-				<DiffStatBadge
-					added={stats?.added ?? 0}
-					removed={stats?.removed ?? 0}
-					className="group-hover:hidden"
-				/>
-				<PopoverTrigger asChild>
-					<button
-						type="button"
-						data-testid="workspace-remove"
-						aria-label="Remove workspace"
-						className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-muted opacity-0 transition hover:bg-elevated hover:text-red group-hover:opacity-100 data-[state=open]:opacity-100"
-					>
-						<Trash2 className="size-4" />
-					</button>
-				</PopoverTrigger>
-			</div>
+			{row}
 		</ConfirmPopover>
 	);
 }

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -26,14 +26,24 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   surfaces an error toast, leaving the row in place). Each **workspace row** is **two-line**: the display
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
-  name is decoupled from the git branch (see [[submodule-server-workspaces]]). The active workspace must
+  name is decoupled from the git branch (see [[submodule-server-workspaces]]). The **Default workspace**
+  (`kind === "default"` — the project folder itself) renders **pinned first** (the server pins it in
+  `workspace.list`; `addWorkspace` appends created worktree rows after it), with a **`House` icon** in
+  place of the `GitBranch` glyph and **no Remove button** (non-removable — the server enforces it; the UI
+  simply offers nothing). Its branch line shows the folder's real current branch. The active workspace must
   also stay visible: when `ProjectTree` mounts with an active workspace, or the active workspace's derived
   owning project changes or first becomes resolvable, it expands that parent project. A manual collapse
   remains respected while the owning project is unchanged; ordinary `workspace.updated` snapshots and
   same-project workspace switches do not force it open again. Workspace creation expands its project
   explicitly. Selecting or creating a workspace also selects its owning project, keeping project-home and
   active-workspace context coherent even when the create dialog's project picker targets another project.
-  **Opening a project** goes through the shared **`useOpenProject`** hook (reused by `ProjectTree` **and**
+  **Opening a project** ends by **auto-entering that project's Default workspace**: after a successful
+  open the hook lists the project's workspaces and activates the `kind === "default"` row (store's
+  existing activate action), so the user lands in the IDE view — files, changes, terminals — of their
+  project folder, not on Welcome. (No Default in the list — an older host — degrades to the previous
+  select-project behavior.) Clicking an already-listed **project row** keeps the "project home" gesture
+  below — Welcome, with the spec-first cards, stays one click away. Opening goes through the shared
+  **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
   (confirm → `project.init`) — when it's `initable`, or surfaces the error in a **`NoticeDialog`** — so a
@@ -200,7 +210,9 @@ a project picker, the prompt hero, and the reused
   When the active workspace has no open center tab, `CenterTabs` uses the empty surface as a persistent
   creation/orientation receipt rather than a generic placeholder: **“Workspace ready”**, the display name,
   `branch · from baseBranch`, and **“Files, chats, changes, and terminals are scoped to this workspace,”**
-  followed by the existing **New chat** action. It is neither one-time nor dismissible, so it also helps
+  followed by the existing **New chat** action. For the **Default workspace** the receipt tells the truth
+  instead of promising isolation: **“Default workspace”**, the project name, `on <branch>`, and “Chats,
+  changes, and terminals run directly in your project folder.” It is neither one-time nor dismissible, so it also helps
   after the last tab closes without introducing onboarding state. `CenterTabs` also renders ephemeral
   **`doc`** tabs (`DocTab` — inline rendered markdown, no file on disk) via its own
   `DocPane`→`MarkdownPreview`; used for the plan-as-markdown snapshot (see the `chat` module). `CenterTabs`

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -70,7 +70,10 @@ bottom-left; the primary is a filled-violet card carrying the stable `welcome-ct
 / Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Start building"** is the
 intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` (which cuts a
 worktree-isolated workspace + starts a chat); *workspace* is the mechanism, not the label. **"Set up
-project"** opens the same dialog with an `initialPrompt` seed — the `/skill:setting-up-a-project` command,
+project"** opens the same dialog with an `initialPrompt` seed **and a `promptNote`** — the note is the
+card's own copy (the dialog stays skill-agnostic), saying what the seeded command does: the agent drafts
+the project's specs (goal, architecture, modules) before building. The seed is the
+`/skill:setting-up-a-project` command,
 which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command syntax; expanded on the
 `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
 new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]). Which
@@ -100,7 +103,9 @@ pre-session half of the user's skill settings; the chat header opens the same di
 **“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new
 branch. Files, chats, changes, and terminals stay scoped to it.”** Its base-branch trigger reads **“From
 {base}”**, not an unexplained ref. An optional **`initialPrompt`** seeds the prompt hero (still editable;
-empty by default); while the prompt is non-empty, a secondary hint says ThinkRail will name the workspace
+empty by default) and an optional **`promptNote`** renders as a small info strip above it
+(`ws-prompt-note`) — the opener's chance to explain a seeded command, since the dialog's own header only
+ever describes creating a workspace; while the prompt is non-empty, a secondary hint says ThinkRail will name the workspace
 and branch from the request. The rest stays compact: the base-branch combobox (`git.listBranches`,
 degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
 a project picker, the prompt hero, and the reused

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -139,7 +139,7 @@ rail's auto-expand follows activation; error toast + `null` if an older host has
 behind the Welcome fork card, so the enter + degrade path lives once; **`onCreated` does not fire** —
 nothing was created and the helper's list is already fresh))
 and the submit button reads **Start** instead of **Create**; the branch-list fetch + background base
-prefetch still run (fire-and-forget, keeps a toggle back to worktree instant); the optional chat
+prefetch still run (fire-and-forget, keeps a toggle back to worktree instant); the chat
 kick-off tail is identical in both modes. An optional **`promptNote`** renders as a small info strip above
 the prompt (used by "Set up project" to say what the seeded skill command does). The worktree mode's
 base-branch trigger reads **“From
@@ -166,9 +166,12 @@ a project picker, the prompt hero, and the reused
   *Trust project* button — the repo's skills stay withheld until granted (`project.setTrust`, which folds the
   updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter submits** (matching the submit button's
   `↵` affordance) and
-  **Shift+Enter** inserts a newline. Worktree-mode submit = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
-  `session.create({ model, thinkingLevel })` + fire-and-forget `prompt`; with an empty prompt it just
-  creates the workspace (folder mode: just enters Default). A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a
+  **Shift+Enter** inserts a newline. Worktree-mode submit = `workspace.create({ projectId, baseRef })` → set active → **always open a
+  fresh chat** (`session.create({ model, thinkingLevel })` — the picked model + effort apply even
+  without a prompt) → a typed prompt is additionally sent as the first message (fire-and-forget
+  `prompt`); an **empty prompt leaves the just-opened composer ready** — submitting the start-working
+  surface always lands the user in a chat, never on a bare receipt (folder mode: the same tail after
+  entering Default). A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a
   nonexistent model) surfaces as an `error` turn in the just-opened chat via `store.appendErrorTurn` (with
   `transport`'s `errorText`) rather than vanishing. The two rejections with **no chat to host a turn** raise a
   `store.toast.error` instead: a failed **`workspace.create`** (keeps the dialog open to retry) and a failed

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -93,9 +93,11 @@ the project's specs, starting from its goal, before building — deliberately **
 artifacts, since the dispatcher's routes differ (starting-a-new-project stops at goal-and-requirements;
 only importing-a-codebase drafts architecture + module SPECs) and the card can't know the route up
 front. The seed is the
-`/skill:setting-up-a-project` command,
-which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command syntax; expanded on the
-`session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
+`/skill:setting-up-a-project` command **with a trailing space** — the same insertion format the
+slash-command completion writes (`chat`'s `selectedSlashCommandValue`), so the seeded hero reads as a
+*completed* command and the completion menu stays closed over it (pi's parser treats the arg tail as
+optional). The command **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command
+syntax; expanded on the `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
 new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]) — plus a
 **`promptNote`** ("Runs the setting-up-a-project skill — the agent drafts your project's specs…", copy
 owned here so the dialog stays skill-agnostic). **Every Welcome entry point preselects the Isolated

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -82,9 +82,9 @@ only possible action; once a project is shown, opening another is the projects-r
 dropdown), so Welcome stays the *work-in-this-project* surface. That card hangs the shared
 **`AddProjectMenu`** dropdown off it (same menu as the projects-rail "+": Open project / Open GitHub (soon)
 / Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Work in project folder"**
-(`House` icon, matching the rail's Default row) **direct-enters** the Default workspace — no dialog: it
-lists the project's workspaces, stores them, and activates the `kind === "default"` row; an older host
-with no Default row degrades to an error toast. **"Start building"** is the
+(`House` icon, matching the rail's Default row) **direct-enters** the Default workspace — no dialog: the
+shared `enterDefaultWorkspace` helper lists the project's workspaces, stores them, and activates the
+`kind === "default"` row; an older host with no Default row degrades to an error toast. **"Start building"** is the
 intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` preselected to the
 **Isolated workspace** target; *workspace* is the mechanism, not the label. **"Set up
 project"** opens the same dialog with an `initialPrompt` seed **and a `promptNote`** — the note is the
@@ -98,11 +98,11 @@ slash-command completion writes (`chat`'s `selectedSlashCommandValue`), so the s
 *completed* command and the completion menu stays closed over it (pi's parser treats the arg tail as
 optional). The command **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command
 syntax; expanded on the `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
-new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]) — plus a
-**`promptNote`** ("Runs the setting-up-a-project skill — the agent drafts your project's specs…", copy
-owned here so the dialog stays skill-agnostic). **Every Welcome entry point preselects the Isolated
+new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]). **Every Welcome entry point preselects the Isolated
 workspace target** — setup included, so spec drafting is reviewable on its own branch like any other work
-and the mode story stays uniform; the Project-folder alternative stays one click away in the dialog. Which
+and the mode story stays uniform; the Project-folder alternative stays one click away in the dialog.
+(Uniformity made an opener-chosen target dead API — the dialog owns its target state and always opens
+on the worktree side; there is no `initialTarget` prop.) Which
 project drives the has-specs states = `selectedProjectId ?? projects[0]`, read reactively (so the visible
 nav's selection updates it). Its `hasSpecs` is **fetched lazily** via `project.hasSpecs` for that one
 project (a full-tree walk, kept off the connect handshake) — pending until it resolves, so the cards wait
@@ -125,20 +125,22 @@ skills' (attacker-controlled) names before trust. The full manager (`chat/Skills
 pre-session half of the user's skill settings; the chat header opens the same dialog in workspace mode
 (with Reload).
 
-**`NewWorkspaceDialog`** is the start-working surface: **a target control** (a two-option segment, both
-always visible — the two-mode model in one glance) chooses **where** the work runs, and the header is
+**`NewWorkspaceDialog`** is the start-working surface: **a target control** (a two-option segment — a
+native radio group, `fieldset` + sr-only `legend` over visually-hidden radio inputs, so assistive tech
+hears one mutually-exclusive choice — both always visible: the two-mode model in one glance) chooses **where** the work runs, and the header is
 **mode-aware** so it always names the operation truthfully: **Isolated workspace** → title **“Create
 workspace”**, description **“A separate checkout on its own new branch. Files, chats, changes, and
 terminals stay scoped to it.”**; **Project folder** → title **“Work in project folder”**, description
 **“Runs directly in your project folder — no isolation. Changes land on the current branch.”** In folder
 mode the base-branch picker and the naming hint are hidden (nothing is created — submit **enters** the
-project's Default workspace via the shared **`resolveDefaultWorkspace`** helper (`defaultWorkspace.ts`:
-`workspace.list` → fold into the store → the `kind === "default"` row; error toast + null if an older
-host has none — the same helper behind the Welcome fork card, so the resolve + degrade path lives once))
+project's Default workspace via the shared **`enterDefaultWorkspace`** helper (`defaultWorkspace.ts`:
+`workspace.list` → fold into the store → activate the `kind === "default"` row, one atomic entry — the
+rail's auto-expand follows activation; error toast + `null` if an older host has none — the same helper
+behind the Welcome fork card, so the enter + degrade path lives once; **`onCreated` does not fire** —
+nothing was created and the helper's list is already fresh))
 and the submit button reads **Start** instead of **Create**; the branch-list fetch + background base
 prefetch still run (fire-and-forget, keeps a toggle back to worktree instant); the optional chat
-kick-off tail is identical in both modes. Openers preselect the target (rail "+" / "Start building" →
-worktree; "Set up project" → folder). An optional **`promptNote`** renders as a small info strip above
+kick-off tail is identical in both modes. An optional **`promptNote`** renders as a small info strip above
 the prompt (used by "Set up project" to say what the seeded skill command does). The worktree mode's
 base-branch trigger reads **“From
 {base}”**, not an unexplained ref. An optional **`initialPrompt`** seeds the prompt hero (still editable;

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -86,7 +86,10 @@ intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceD
 **Isolated workspace** target; *workspace* is the mechanism, not the label. **"Set up
 project"** opens the same dialog with an `initialPrompt` seed **and a `promptNote`** — the note is the
 card's own copy (the dialog stays skill-agnostic), saying what the seeded command does: the agent drafts
-the project's specs (goal, architecture, modules) before building. The seed is the
+the project's specs, starting from its goal, before building — deliberately **not** an enumeration of
+artifacts, since the dispatcher's routes differ (starting-a-new-project stops at goal-and-requirements;
+only importing-a-codebase drafts architecture + module SPECs) and the card can't know the route up
+front. The seed is the
 `/skill:setting-up-a-project` command,
 which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command syntax; expanded on the
 `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -66,17 +66,20 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   per-folder counts. `ChangesTree`'s tree build + `+/−` aggregation + shared status glyphs live in the pure
   **`changesModel.ts`** (unit-tested; no store/transport — `ChangesTree` is presentational, fed `changes` +
   `onOpen`/`isActive` by `ChangesPanel`). **`WelcomePanel`** is the first-touch surface the shell mounts (centered, left-nav beside it) whenever no
-workspace is active. The `PRODUCT_NAME` wordmark as the hero (the topbar's brand styling — accent font,
-`text-primary` — enlarged), with the **active project's name as a small eyebrow** (folder icon) above it
-once a project is selected, over a **constant** spec-first pitch (not spec-conditional) and
-**one-to-four cards** (Conductor-inspired: icon top-left, label + explainer
-bottom-left; the primary is a filled-violet card carrying the stable `welcome-cta` hook, others quiet
-`welcome-action`s). Welcome is **the mode fork**: with a project shown it always pairs **"Start
-building"** (isolated worktree) with **"Work in project folder"** (the Default workspace) so the two
-working modes are a visible choice, not a hidden default. The cards by state: **no projects** → **"Open
-project"** (one card); **project + `hasSpecs`** → **"Start building"** (primary) + "Work in project
-folder" + "Open project"; **project + no specs** → a spec-first **"Set up project"** (primary) + "Start
-building" + "Work in project folder" + "Open project". The **"Open project"** card hangs the shared
+workspace is active. **One hero heading** (`welcome-title`, the topbar's brand styling — accent font,
+`text-primary` — enlarged): the **shown project's name**, or `PRODUCT_NAME` when no project is shown —
+the wordmark is the empty-state identity, a project's own name is the identity once one is open (so no
+separate project eyebrow). **No pitch prose in any state** — the marketing paragraph was removed as
+unread; the screen is heading → banners → **one-to-three cards** (Conductor-inspired: icon top-left,
+label + explainer bottom-left; the primary is a filled-violet card carrying the stable `welcome-cta`
+hook, others quiet `welcome-action`s). Welcome is **the mode fork**: with a project shown it always pairs
+**"Start building"** (isolated worktree) with **"Work in project folder"** (the Default workspace) so the
+two working modes are a visible choice, not a hidden default. The cards by state: **no projects** →
+**"Open project"** (one card); **project + `hasSpecs`** → **"Start building"** (primary) + "Work in
+project folder"; **project + no specs** → a spec-first **"Set up project"** (primary) + "Start building"
++ "Work in project folder". **"Open project" appears only in the no-projects state** — where it's the
+only possible action; once a project is shown, opening another is the projects-rail **"+"** (the same
+dropdown), so Welcome stays the *work-in-this-project* surface. That card hangs the shared
 **`AddProjectMenu`** dropdown off it (same menu as the projects-rail "+": Open project / Open GitHub (soon)
 / Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Work in project folder"**
 (`House` icon, matching the rail's Default row) **direct-enters** the Default workspace — no dialog: it
@@ -95,8 +98,9 @@ which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-c
 `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
 new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]) — plus a
 **`promptNote`** ("Runs the setting-up-a-project skill — the agent drafts your project's specs…", copy
-owned here so the dialog stays skill-agnostic) and the **Project folder** target preselected (specs are
-ground truth — they land in place, no merge-back; the worktree alternative stays one click away). Which
+owned here so the dialog stays skill-agnostic). **Every Welcome entry point preselects the Isolated
+workspace target** — setup included, so spec drafting is reviewable on its own branch like any other work
+and the mode story stays uniform; the Project-folder alternative stays one click away in the dialog. Which
 project drives the has-specs states = `selectedProjectId ?? projects[0]`, read reactively (so the visible
 nav's selection updates it). Its `hasSpecs` is **fetched lazily** via `project.hasSpecs` for that one
 project (a full-tree walk, kept off the connect handshake) — pending until it resolves, so the cards wait

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -37,12 +37,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   same-project workspace switches do not force it open again. Workspace creation expands its project
   explicitly. Selecting or creating a workspace also selects its owning project, keeping project-home and
   active-workspace context coherent even when the create dialog's project picker targets another project.
-  **Opening a project** ends by **auto-entering that project's Default workspace**: after a successful
-  open the hook lists the project's workspaces and activates the `kind === "default"` row (store's
-  existing activate action), so the user lands in the IDE view — files, changes, terminals — of their
-  project folder, not on Welcome. (No Default in the list — an older host — degrades to the previous
-  select-project behavior.) Clicking an already-listed **project row** keeps the "project home" gesture
-  below — Welcome, with the spec-first cards, stays one click away. Opening goes through the shared
+  **Opening a project lands on that project's Welcome** — deliberately **no auto-enter** into any
+  workspace: Welcome is the fork where the two working modes (isolated worktree vs the project folder's
+  Default workspace) are presented as an explicit choice (see `WelcomePanel`), so opening and the
+  "project home" gesture converge on the same surface. Opening goes through the shared
   **`useOpenProject`** hook (reused by `ProjectTree` **and**
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
@@ -71,22 +69,31 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
 workspace is active. The `PRODUCT_NAME` wordmark as the hero (the topbar's brand styling — accent font,
 `text-primary` — enlarged), with the **active project's name as a small eyebrow** (folder icon) above it
 once a project is selected, over a **constant** spec-first pitch (not spec-conditional) and
-**one-to-three cards** (Conductor-inspired: icon top-left, label + explainer
+**one-to-four cards** (Conductor-inspired: icon top-left, label + explainer
 bottom-left; the primary is a filled-violet card carrying the stable `welcome-cta` hook, others quiet
-`welcome-action`s). The cards by state: **no projects** → **"Open project"** (one card); **project +
-`hasSpecs`** → **"Start building"** (primary) + "Open project"; **project + no specs** → a spec-first
-**"Set up project"** (primary) + "Start building" + "Open project". The **"Open project"** card hangs the shared
+`welcome-action`s). Welcome is **the mode fork**: with a project shown it always pairs **"Start
+building"** (isolated worktree) with **"Work in project folder"** (the Default workspace) so the two
+working modes are a visible choice, not a hidden default. The cards by state: **no projects** → **"Open
+project"** (one card); **project + `hasSpecs`** → **"Start building"** (primary) + "Work in project
+folder" + "Open project"; **project + no specs** → a spec-first **"Set up project"** (primary) + "Start
+building" + "Work in project folder" + "Open project". The **"Open project"** card hangs the shared
 **`AddProjectMenu`** dropdown off it (same menu as the projects-rail "+": Open project / Open GitHub (soon)
-/ Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Start building"** is the
-intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` (which cuts a
-worktree-isolated workspace + starts a chat); *workspace* is the mechanism, not the label. **"Set up
+/ Recents), so `Card` is a `forwardRef` usable as a Radix `asChild` trigger. **"Work in project folder"**
+(`House` icon, matching the rail's Default row) **direct-enters** the Default workspace — no dialog: it
+lists the project's workspaces, stores them, and activates the `kind === "default"` row; an older host
+with no Default row degrades to an error toast. **"Start building"** is the
+intent-first framing of the create-and-kick-off flow — it opens `NewWorkspaceDialog` preselected to the
+**Isolated workspace** target; *workspace* is the mechanism, not the label. **"Set up
 project"** opens the same dialog with an `initialPrompt` seed **and a `promptNote`** — the note is the
 card's own copy (the dialog stays skill-agnostic), saying what the seeded command does: the agent drafts
 the project's specs (goal, architecture, modules) before building. The seed is the
 `/skill:setting-up-a-project` command,
 which **forces** the setting-up-a-project dispatcher skill to load (pi's skill-command syntax; expanded on the
 `session.prompt` path) rather than hoping the model auto-matches it; the dispatcher then detects
-new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]). Which
+new-vs-existing and drafts the specs accordingly (see [[module-thinkrail-workflow]]) — plus a
+**`promptNote`** ("Runs the setting-up-a-project skill — the agent drafts your project's specs…", copy
+owned here so the dialog stays skill-agnostic) and the **Project folder** target preselected (specs are
+ground truth — they land in place, no merge-back; the worktree alternative stays one click away). Which
 project drives the has-specs states = `selectedProjectId ?? projects[0]`, read reactively (so the visible
 nav's selection updates it). Its `hasSpecs` is **fetched lazily** via `project.hasSpecs` for that one
 project (a full-tree walk, kept off the connect handshake) — pending until it resolves, so the cards wait
@@ -109,13 +116,24 @@ skills' (attacker-controlled) names before trust. The full manager (`chat/Skills
 pre-session half of the user's skill settings; the chat header opens the same dialog in workspace mode
 (with Reload).
 
-**`NewWorkspaceDialog`** is the create-and-kick-off surface. It names the operation visibly — title
-**“Create workspace”** — and states the model without adding a step: **“A separate checkout on its own new
-branch. Files, chats, changes, and terminals stay scoped to it.”** Its base-branch trigger reads **“From
+**`NewWorkspaceDialog`** is the start-working surface: **a target control** (a two-option segment, both
+always visible — the two-mode model in one glance) chooses **where** the work runs, and the header is
+**mode-aware** so it always names the operation truthfully: **Isolated workspace** → title **“Create
+workspace”**, description **“A separate checkout on its own new branch. Files, chats, changes, and
+terminals stay scoped to it.”**; **Project folder** → title **“Work in project folder”**, description
+**“Runs directly in your project folder — no isolation. Changes land on the current branch.”** In folder
+mode the base-branch picker and the naming hint are hidden (nothing is created — submit **enters** the
+project's Default workspace via the shared **`resolveDefaultWorkspace`** helper (`defaultWorkspace.ts`:
+`workspace.list` → fold into the store → the `kind === "default"` row; error toast + null if an older
+host has none — the same helper behind the Welcome fork card, so the resolve + degrade path lives once))
+and the submit button reads **Start** instead of **Create**; the branch-list fetch + background base
+prefetch still run (fire-and-forget, keeps a toggle back to worktree instant); the optional chat
+kick-off tail is identical in both modes. Openers preselect the target (rail "+" / "Start building" →
+worktree; "Set up project" → folder). An optional **`promptNote`** renders as a small info strip above
+the prompt (used by "Set up project" to say what the seeded skill command does). The worktree mode's
+base-branch trigger reads **“From
 {base}”**, not an unexplained ref. An optional **`initialPrompt`** seeds the prompt hero (still editable;
-empty by default) and an optional **`promptNote`** renders as a small info strip above it
-(`ws-prompt-note`) — the opener's chance to explain a seeded command, since the dialog's own header only
-ever describes creating a workspace; while the prompt is non-empty, a secondary hint says ThinkRail will name the workspace
+empty by default); while the prompt is non-empty (worktree mode), a secondary hint says ThinkRail will name the workspace
 and branch from the request. The rest stays compact: the base-branch combobox (`git.listBranches`,
 degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
 a project picker, the prompt hero, and the reused
@@ -135,11 +153,11 @@ a project picker, the prompt hero, and the reused
   authoritative if the selected base branch differs). When the selected project is **untrusted AND ships
   committed skills** (a count from `project.aliasSkills`, never their names), a **trust notice** shows a
   *Trust project* button — the repo's skills stay withheld until granted (`project.setTrust`, which folds the
-  updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter creates** (matching the Create button's
+  updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter submits** (matching the submit button's
   `↵` affordance) and
-  **Shift+Enter** inserts a newline. Create = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
+  **Shift+Enter** inserts a newline. Worktree-mode submit = `workspace.create({ projectId, baseRef })` → set active → (with a prompt) open a chat +
   `session.create({ model, thinkingLevel })` + fire-and-forget `prompt`; with an empty prompt it just
-  creates the workspace. A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a
+  creates the workspace (folder mode: just enters Default). A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a
   nonexistent model) surfaces as an `error` turn in the just-opened chat via `store.appendErrorTurn` (with
   `transport`'s `errorText`) rather than vanishing. The two rejections with **no chat to host a turn** raise a
   `store.toast.error` instead: a failed **`workspace.create`** (keeps the dialog open to retry) and a failed

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -1,5 +1,5 @@
 import type { Workspace } from "@thinkrail/contracts";
-import { Folder, FolderOpen, House, type LucideIcon, Rocket, Sparkles } from "lucide-react";
+import { FolderOpen, House, type LucideIcon, Rocket, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, forwardRef, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { PRODUCT_NAME } from "../constants/branding";
@@ -26,9 +26,11 @@ const SETUP_NOTE =
 
 /**
  * The first-touch surface the shell mounts (centered, beside the projects rail) whenever no workspace is
- * active. The ThinkRail wordmark (topbar brand styling, scaled up) over a state-driven pitch and up-to-four
- * cards, adaptive across three states: no projects → "Open project"; a project with specs → "Start
- * building"; a project without a goal-and-requirements.md → a spec-first "Set up project". With a
+ * active. A single hero heading — the shown project's name, or the ThinkRail wordmark with no project
+ * (topbar brand styling, scaled up) — over one-to-three cards, no pitch prose: adaptive across three
+ * states: no projects → "Open project" (the only card, and the only state that carries it — with a
+ * project shown, opening another lives on the projects-rail "+"); a project with specs → "Start
+ * building"; a project without any registered spec → a spec-first "Set up project". With a
  * project shown, Welcome is **the mode fork**: "Start building" (an isolated worktree — the intent-first
  * framing of create + kick off a chat) always sits beside "Work in project folder" (direct-enters the
  * built-in Default workspace), so the two working modes are a visible choice, not a hidden default.
@@ -37,8 +39,9 @@ export function WelcomePanel() {
 	const projects = useAppStore((s) => s.projects);
 	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
 	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero ("" for a plain
-	// create; the setup command for "Set up project", which also carries the explanatory `note` and
-	// preselects the project-folder target — specs are ground truth, they belong in place).
+	// create; the setup command for "Set up project", which also carries the explanatory `note`). Every
+	// Welcome entry point preselects the isolated-worktree target; the dialog keeps the folder alternative
+	// one click away.
 	const [dialog, setDialog] = useState<{
 		projectId: string;
 		prompt: string;
@@ -114,14 +117,9 @@ export function WelcomePanel() {
 		/>
 	);
 
-	// The "Open project" card triggers the same dropdown as the projects-rail "+".
-	const openProjectCard = ({
-		primary = false,
-		subtitle,
-	}: {
-		primary?: boolean;
-		subtitle: string;
-	}) => (
+	// The "Open project" card — only rendered in the no-projects state (with a project shown, the
+	// projects-rail "+" carries this same dropdown). Triggers the same menu as that "+".
+	const openProjectCard = () => (
 		<AddProjectMenu
 			projects={projects}
 			onOpen={() => void pickAndOpen()}
@@ -129,11 +127,11 @@ export function WelcomePanel() {
 			align="start"
 		>
 			<Card
-				cta={primary}
-				primary={primary}
+				cta
+				primary
 				icon={FolderOpen}
 				title="Open project"
-				subtitle={subtitle}
+				subtitle="Choose a local git repository to work in."
 			/>
 		</AddProjectMenu>
 	);
@@ -143,28 +141,19 @@ export function WelcomePanel() {
 			data-testid="welcome"
 			className="flex h-full min-h-0 flex-col items-center justify-center overflow-auto px-xl py-xl text-center"
 		>
-			{project ? (
-				<p className="mb-sm flex max-w-full items-center gap-xs px-md text-muted text-sm">
-					<Folder className="size-3.5 shrink-0 text-hint" />
-					<span className="truncate font-[var(--font-mono)]">{project.name}</span>
-				</p>
-			) : null}
-			<h1 className="font-[var(--font-accent)] font-extrabold text-[44px] text-primary leading-tight tracking-[0.5px]">
-				{PRODUCT_NAME}
+			<h1
+				data-testid="welcome-title"
+				className="max-w-[640px] break-words font-[var(--font-accent)] font-extrabold text-[44px] text-primary leading-tight tracking-[0.5px]"
+			>
+				{project ? project.name : PRODUCT_NAME}
 			</h1>
-
-			<p className="mt-lg max-w-[440px] text-md text-muted">
-				A spec-first way to build with AI. ThinkRail keeps your project's intent as a{" "}
-				<span className="text-text">connected spec graph</span> that the agent reads, plans, and
-				builds from — in your project folder, or an isolated git worktree per task.
-			</p>
 
 			<ProviderWarningBanner />
 			{project ? <ProjectSkillsNotice projectId={project.id} /> : null}
 
 			<div className="mt-xl flex flex-wrap justify-center gap-md">
 				{noProjects ? (
-					openProjectCard({ primary: true, subtitle: "Choose a local git repository to work in." })
+					openProjectCard()
 				) : hasSpecs === null ? null : hasSpecs ? (
 					<>
 						<Card
@@ -176,7 +165,6 @@ export function WelcomePanel() {
 							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
 						/>
 						{projectFolderCard(project.id)}
-						{openProjectCard({ subtitle: "Add another local git repository." })}
 					</>
 				) : (
 					<>
@@ -191,7 +179,7 @@ export function WelcomePanel() {
 								setDialog({
 									projectId: project.id,
 									prompt: SETUP_PROMPT,
-									target: "default",
+									target: "worktree",
 									note: SETUP_NOTE,
 								})
 							}
@@ -203,7 +191,6 @@ export function WelcomePanel() {
 							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
 						/>
 						{projectFolderCard(project.id)}
-						{openProjectCard({ subtitle: "Add another local git repository." })}
 					</>
 				)}
 			</div>

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -17,6 +17,12 @@ import { useOpenProject } from "./useOpenProject";
 // importing-a-codebase. Still editable in the dialog.
 const SETUP_PROMPT = "/skill:setting-up-a-project";
 
+// The dialog's info strip for "Set up project" — says what the seeded command actually does (the card
+// alone can't: the dialog it opens is the generic create surface). The copy lives here, with the card
+// that seeds it, so the dialog stays skill-agnostic.
+const SETUP_NOTE =
+	"Runs the setting-up-a-project skill — the agent drafts your project's specs (goal, architecture, modules) before building.";
+
 /**
  * The first-touch surface the shell mounts (centered, beside the projects rail) whenever no workspace is
  * active. The ThinkRail wordmark (topbar brand styling, scaled up) over a state-driven pitch and up-to-two
@@ -28,9 +34,13 @@ const SETUP_PROMPT = "/skill:setting-up-a-project";
 export function WelcomePanel() {
 	const projects = useAppStore((s) => s.projects);
 	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
-	// The New-Workspace dialog target (null = closed). `prompt` seeds the hero — "" for a plain create,
-	// the setup text for "Set up project".
-	const [dialog, setDialog] = useState<{ projectId: string; prompt: string } | null>(null);
+	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero — "" for a plain
+	// create, the setup command for "Set up project", which also carries the explanatory `note`.
+	const [dialog, setDialog] = useState<{
+		projectId: string;
+		prompt: string;
+		note?: string;
+	} | null>(null);
 	// Whether the shown project has any registered spec, fetched lazily (a full-tree walk — so it's
 	// requested only for this one project, on demand, never eagerly for every project on connect).
 	// null = pending/unknown (cards wait for it).
@@ -124,7 +134,7 @@ export function WelcomePanel() {
 			<p className="mt-lg max-w-[440px] text-md text-muted">
 				A spec-first way to build with AI. ThinkRail keeps your project's intent as a{" "}
 				<span className="text-text">connected spec graph</span> that the agent reads, plans, and
-				builds from, all in git worktree isolated workspaces.
+				builds from — each task in its own isolated git worktree.
 			</p>
 
 			<ProviderWarningBanner />
@@ -153,8 +163,10 @@ export function WelcomePanel() {
 							icon={Sparkles}
 							title="Set up project"
 							tag="spec-first"
-							subtitle="Prepare the specifications first with the agent before building."
-							onClick={() => setDialog({ projectId: project.id, prompt: SETUP_PROMPT })}
+							subtitle="Draft the project's specs with the agent first — goal, architecture, modules — before building."
+							onClick={() =>
+								setDialog({ projectId: project.id, prompt: SETUP_PROMPT, note: SETUP_NOTE })
+							}
 						/>
 						<Card
 							icon={Rocket}
@@ -172,6 +184,7 @@ export function WelcomePanel() {
 					open
 					projectId={dialog.projectId}
 					initialPrompt={dialog.prompt}
+					{...(dialog.note !== undefined ? { promptNote: dialog.note } : {})}
 					onOpenChange={(o) => {
 						if (!o) setDialog(null);
 					}}

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -6,8 +6,8 @@ import { PRODUCT_NAME } from "../constants/branding";
 import { useAppStore } from "../store";
 import { getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
-import { resolveDefaultWorkspace } from "./defaultWorkspace";
-import { NewWorkspaceDialog, type WorkspaceTarget } from "./NewWorkspaceDialog";
+import { enterDefaultWorkspace } from "./defaultWorkspace";
+import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { ProjectSkillsNotice } from "./ProjectSkillsNotice";
 import { ProviderWarningBanner } from "./ProviderWarningBanner";
 import { useOpenProject } from "./useOpenProject";
@@ -44,13 +44,11 @@ export function WelcomePanel() {
 	const projects = useAppStore((s) => s.projects);
 	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
 	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero ("" for a plain
-	// create; the setup command for "Set up project", which also carries the explanatory `note`). Every
-	// Welcome entry point preselects the isolated-worktree target; the dialog keeps the folder alternative
-	// one click away.
+	// create; the setup command for "Set up project", which also carries the explanatory `note`). The
+	// dialog always opens on the isolated-worktree target and keeps the folder alternative one click away.
 	const [dialog, setDialog] = useState<{
 		projectId: string;
 		prompt: string;
-		target: WorkspaceTarget;
 		note?: string;
 	} | null>(null);
 	// Whether the shown project has any registered spec, fetched lazily (a full-tree walk — so it's
@@ -102,23 +100,18 @@ export function WelcomePanel() {
 			);
 	};
 
-	// The Welcome fork's "no isolation" side: direct-enter the project's built-in Default workspace —
-	// no dialog (it's navigation; the Default receipt + New chat cover kick-off). Degrades to the
-	// helper's error toast on an older host with no Default.
-	const enterProjectFolder = async (projectId: string) => {
-		const def = await resolveDefaultWorkspace(projectId);
-		if (def) useAppStore.getState().activateWorkspace(def);
-	};
-
 	const noProjects = project == null;
 
-	// The fork's "no isolation" card — identical in both project states, so it's built once.
+	// The fork's "no isolation" card — identical in both project states, so it's built once. It
+	// direct-enters the project's built-in Default workspace, no dialog (it's navigation; the Default
+	// receipt + New chat cover kick-off): the shared helper lists, stores, and activates in one step,
+	// degrading to its error toast on an older host with no Default.
 	const projectFolderCard = (projectId: string) => (
 		<Card
 			icon={House}
 			title="Work in project folder"
 			subtitle="Chats, changes, and terminals run directly in your project folder — no isolation."
-			onClick={() => void enterProjectFolder(projectId)}
+			onClick={() => void enterDefaultWorkspace(projectId)}
 		/>
 	);
 
@@ -167,7 +160,7 @@ export function WelcomePanel() {
 							icon={Rocket}
 							title="Start building"
 							subtitle="Cut an isolated worktree + branch, then pair with the agent to build it."
-							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
+							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
 						/>
 						{projectFolderCard(project.id)}
 					</>
@@ -184,7 +177,6 @@ export function WelcomePanel() {
 								setDialog({
 									projectId: project.id,
 									prompt: SETUP_PROMPT,
-									target: "worktree",
 									note: SETUP_NOTE,
 								})
 							}
@@ -193,7 +185,7 @@ export function WelcomePanel() {
 							icon={Rocket}
 							title="Start building"
 							subtitle="Cut an isolated worktree + branch and pair with the agent."
-							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
+							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
 						/>
 						{projectFolderCard(project.id)}
 					</>
@@ -205,7 +197,6 @@ export function WelcomePanel() {
 					open
 					projectId={dialog.projectId}
 					initialPrompt={dialog.prompt}
-					initialTarget={dialog.target}
 					{...(dialog.note !== undefined ? { promptNote: dialog.note } : {})}
 					onOpenChange={(o) => {
 						if (!o) setDialog(null);

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -22,7 +22,7 @@ const SETUP_PROMPT = "/skill:setting-up-a-project";
 // alone can't: the dialog it opens is the generic create surface). The copy lives here, with the card
 // that seeds it, so the dialog stays skill-agnostic.
 const SETUP_NOTE =
-	"Runs the setting-up-a-project skill — the agent drafts your project's specs (goal, architecture, modules) before building.";
+	"Runs the setting-up-a-project skill — the agent drafts your project's specs, starting from its goal, before building.";
 
 /**
  * The first-touch surface the shell mounts (centered, beside the projects rail) whenever no workspace is
@@ -186,7 +186,7 @@ export function WelcomePanel() {
 							icon={Sparkles}
 							title="Set up project"
 							tag="spec-first"
-							subtitle="Draft the project's specs with the agent first — goal, architecture, modules — before building."
+							subtitle="Draft the project's specs with the agent before building, starting from its goal."
 							onClick={() =>
 								setDialog({
 									projectId: project.id,

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -156,7 +156,7 @@ export function WelcomePanel() {
 			<p className="mt-lg max-w-[440px] text-md text-muted">
 				A spec-first way to build with AI. ThinkRail keeps your project's intent as a{" "}
 				<span className="text-text">connected spec graph</span> that the agent reads, plans, and
-				builds from — each task in its own isolated git worktree.
+				builds from — in your project folder, or an isolated git worktree per task.
 			</p>
 
 			<ProviderWarningBanner />

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -16,7 +16,12 @@ import { useOpenProject } from "./useOpenProject";
 // which FORCES the setting-up-a-project dispatcher to load (vs. hoping the model auto-matches its
 // description). The dispatcher then detects new-vs-existing and routes to starting-a-new-project /
 // importing-a-codebase. Still editable in the dialog.
-const SETUP_PROMPT = "/skill:setting-up-a-project";
+//
+// The **trailing space** is load-bearing: it's the same insertion format the slash-command completion
+// produces (`selectedSlashCommandValue`), so the seeded value reads as a *completed* command — the
+// completion popup stays closed over the seeded hero instead of opening on a bare `/skill:…` query.
+// pi's command parser tolerates it (the arg tail is optional).
+const SETUP_PROMPT = "/skill:setting-up-a-project ";
 
 // The dialog's info strip for "Set up project" — says what the seeded command actually does (the card
 // alone can't: the dialog it opens is the generic create surface). The copy lives here, with the card

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -1,12 +1,13 @@
 import type { Workspace } from "@thinkrail/contracts";
-import { Folder, FolderOpen, type LucideIcon, Rocket, Sparkles } from "lucide-react";
+import { Folder, FolderOpen, House, type LucideIcon, Rocket, Sparkles } from "lucide-react";
 import { type ComponentPropsWithoutRef, forwardRef, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { PRODUCT_NAME } from "../constants/branding";
 import { useAppStore } from "../store";
 import { getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
-import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { resolveDefaultWorkspace } from "./defaultWorkspace";
+import { NewWorkspaceDialog, type WorkspaceTarget } from "./NewWorkspaceDialog";
 import { ProjectSkillsNotice } from "./ProjectSkillsNotice";
 import { ProviderWarningBanner } from "./ProviderWarningBanner";
 import { useOpenProject } from "./useOpenProject";
@@ -25,20 +26,23 @@ const SETUP_NOTE =
 
 /**
  * The first-touch surface the shell mounts (centered, beside the projects rail) whenever no workspace is
- * active. The ThinkRail wordmark (topbar brand styling, scaled up) over a state-driven pitch and up-to-two
+ * active. The ThinkRail wordmark (topbar brand styling, scaled up) over a state-driven pitch and up-to-four
  * cards, adaptive across three states: no projects → "Open project"; a project with specs → "Start
- * building"; a project without a goal-and-requirements.md → a spec-first "Set up project". "Start
- * building" is the intent-first framing of creating a worktree-isolated workspace + kicking off a chat
- * (workspace is the mechanism, not the label).
+ * building"; a project without a goal-and-requirements.md → a spec-first "Set up project". With a
+ * project shown, Welcome is **the mode fork**: "Start building" (an isolated worktree — the intent-first
+ * framing of create + kick off a chat) always sits beside "Work in project folder" (direct-enters the
+ * built-in Default workspace), so the two working modes are a visible choice, not a hidden default.
  */
 export function WelcomePanel() {
 	const projects = useAppStore((s) => s.projects);
 	const selectedProjectId = useAppStore((s) => s.selectedProjectId);
-	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero — "" for a plain
-	// create, the setup command for "Set up project", which also carries the explanatory `note`.
+	// The New-Workspace dialog opener state (null = closed). `prompt` seeds the hero ("" for a plain
+	// create; the setup command for "Set up project", which also carries the explanatory `note` and
+	// preselects the project-folder target — specs are ground truth, they belong in place).
 	const [dialog, setDialog] = useState<{
 		projectId: string;
 		prompt: string;
+		target: WorkspaceTarget;
 		note?: string;
 	} | null>(null);
 	// Whether the shown project has any registered spec, fetched lazily (a full-tree walk — so it's
@@ -90,7 +94,25 @@ export function WelcomePanel() {
 			);
 	};
 
+	// The Welcome fork's "no isolation" side: direct-enter the project's built-in Default workspace —
+	// no dialog (it's navigation; the Default receipt + New chat cover kick-off). Degrades to the
+	// helper's error toast on an older host with no Default.
+	const enterProjectFolder = async (projectId: string) => {
+		const def = await resolveDefaultWorkspace(projectId);
+		if (def) useAppStore.getState().activateWorkspace(def);
+	};
+
 	const noProjects = project == null;
+
+	// The fork's "no isolation" card — identical in both project states, so it's built once.
+	const projectFolderCard = (projectId: string) => (
+		<Card
+			icon={House}
+			title="Work in project folder"
+			subtitle="Chats, changes, and terminals run directly in your project folder — no isolation."
+			onClick={() => void enterProjectFolder(projectId)}
+		/>
+	);
 
 	// The "Open project" card triggers the same dropdown as the projects-rail "+".
 	const openProjectCard = ({
@@ -151,8 +173,9 @@ export function WelcomePanel() {
 							icon={Rocket}
 							title="Start building"
 							subtitle="Cut an isolated worktree + branch, then pair with the agent to build it."
-							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
+							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
 						/>
+						{projectFolderCard(project.id)}
 						{openProjectCard({ subtitle: "Add another local git repository." })}
 					</>
 				) : (
@@ -165,15 +188,21 @@ export function WelcomePanel() {
 							tag="spec-first"
 							subtitle="Draft the project's specs with the agent first — goal, architecture, modules — before building."
 							onClick={() =>
-								setDialog({ projectId: project.id, prompt: SETUP_PROMPT, note: SETUP_NOTE })
+								setDialog({
+									projectId: project.id,
+									prompt: SETUP_PROMPT,
+									target: "default",
+									note: SETUP_NOTE,
+								})
 							}
 						/>
 						<Card
 							icon={Rocket}
 							title="Start building"
 							subtitle="Cut an isolated worktree + branch and pair with the agent."
-							onClick={() => setDialog({ projectId: project.id, prompt: "" })}
+							onClick={() => setDialog({ projectId: project.id, prompt: "", target: "worktree" })}
 						/>
+						{projectFolderCard(project.id)}
 						{openProjectCard({ subtitle: "Add another local git repository." })}
 					</>
 				)}
@@ -184,6 +213,7 @@ export function WelcomePanel() {
 					open
 					projectId={dialog.projectId}
 					initialPrompt={dialog.prompt}
+					initialTarget={dialog.target}
 					{...(dialog.note !== undefined ? { promptNote: dialog.note } : {})}
 					onOpenChange={(o) => {
 						if (!o) setDialog(null);

--- a/apps/web/src/panels/defaultWorkspace.ts
+++ b/apps/web/src/panels/defaultWorkspace.ts
@@ -1,0 +1,24 @@
+import type { Workspace } from "@thinkrail/contracts";
+import { toast, useAppStore } from "@/store";
+import { errorText, getTransport } from "@/transport";
+
+/**
+ * Resolve a project's built-in Default workspace (the project folder itself): list the project's
+ * workspaces (the host's list *ensures* the Default exists — see submodule-server-workspaces), fold the
+ * fresh list into the store, and return the `kind === "default"` row. Shared by the Welcome "Work in
+ * project folder" fork card and the NewWorkspaceDialog's folder mode, so the resolve + degrade path
+ * lives once. On failure — a transport error, or an older host that serves no Default — raises the
+ * error toast and returns null (the caller decides what to do with its surface).
+ */
+export async function resolveDefaultWorkspace(projectId: string): Promise<Workspace | null> {
+	try {
+		const workspaces = await getTransport().request("workspace.list", { projectId });
+		useAppStore.getState().setWorkspaces(projectId, workspaces);
+		const def = workspaces.find((w) => w.kind === "default");
+		if (!def) throw new Error("This host has no Default workspace for this project.");
+		return def;
+	} catch (err) {
+		toast.error(errorText(err), "Couldn't open the project folder");
+		return null;
+	}
+}

--- a/apps/web/src/panels/defaultWorkspace.ts
+++ b/apps/web/src/panels/defaultWorkspace.ts
@@ -1,24 +1,33 @@
 import type { Workspace } from "@thinkrail/contracts";
-import { toast, useAppStore } from "@/store";
+import { isDefaultWorkspace, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 
 /**
- * Resolve a project's built-in Default workspace (the project folder itself): list the project's
- * workspaces (the host's list *ensures* the Default exists — see submodule-server-workspaces), fold the
- * fresh list into the store, and return the `kind === "default"` row. Shared by the Welcome "Work in
- * project folder" fork card and the NewWorkspaceDialog's folder mode, so the resolve + degrade path
- * lives once. On failure — a transport error, or an older host that serves no Default — raises the
- * error toast and returns null (the caller decides what to do with its surface).
+ * Enter a project's built-in Default workspace (the project folder itself) as **one atomic step**: list
+ * the project's workspaces (the host's list *ensures* the Default exists — see
+ * submodule-server-workspaces), fold the fresh list into the store, and activate the
+ * `kind === "default"` row — the fold + activation always travel together, so they live here once, never
+ * repeated at call sites (the rail's auto-expand follows the activation). Shared by the Welcome "Work in
+ * project folder" fork card and the NewWorkspaceDialog's folder mode. On failure — a transport error, or
+ * an older host that serves no Default — raises the error toast and returns null (the caller decides
+ * what to do with its surface).
  */
-export async function resolveDefaultWorkspace(projectId: string): Promise<Workspace | null> {
+export async function enterDefaultWorkspace(projectId: string): Promise<Workspace | null> {
+	const title = "Couldn't open the project folder";
+	let workspaces: Workspace[];
 	try {
-		const workspaces = await getTransport().request("workspace.list", { projectId });
-		useAppStore.getState().setWorkspaces(projectId, workspaces);
-		const def = workspaces.find((w) => w.kind === "default");
-		if (!def) throw new Error("This host has no Default workspace for this project.");
-		return def;
+		workspaces = await getTransport().request("workspace.list", { projectId });
 	} catch (err) {
-		toast.error(errorText(err), "Couldn't open the project folder");
+		toast.error(errorText(err), title);
 		return null;
 	}
+	const def = workspaces.find(isDefaultWorkspace);
+	if (!def) {
+		toast.error("This host has no Default workspace for this project.", title);
+		return null;
+	}
+	const store = useAppStore.getState();
+	store.setWorkspaces(projectId, workspaces);
+	store.activateWorkspace(def);
+	return def;
 }

--- a/apps/web/src/panels/useOpenProject.tsx
+++ b/apps/web/src/panels/useOpenProject.tsx
@@ -25,10 +25,22 @@ export function useOpenProject(onOpened: (project: Project) => void | Promise<vo
 	// A non-actionable open failure to surface (a stale recent, a broken path). null = no notice.
 	const [openError, setOpenError] = useState<string | null>(null);
 
-	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project.
+	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project,
+	// then auto-enter the project's built-in **Default workspace** (the project folder itself) so opening
+	// a project lands in the IDE view — files, changes, terminals — not on Welcome. The list also ensures
+	// the Default exists host-side. Best-effort: no Default row (an older host) or a failed list degrades
+	// to the caller's select-project behavior (Welcome) — the open itself already succeeded.
 	const adopt = async (project: Project) => {
 		useAppStore.getState().setProjects(await getTransport().request("project.list", {}));
 		await onOpened(project);
+		try {
+			const workspaces = await getTransport().request("workspace.list", { projectId: project.id });
+			useAppStore.getState().setWorkspaces(project.id, workspaces);
+			const def = workspaces.find((w) => w.kind === "default");
+			if (def) useAppStore.getState().activateWorkspace(def);
+		} catch {
+			// Entering Default is additive — a failure leaves the caller's selection (Welcome) in place.
+		}
 	};
 
 	const openProject = async (rawPath: string) => {

--- a/apps/web/src/panels/useOpenProject.tsx
+++ b/apps/web/src/panels/useOpenProject.tsx
@@ -25,22 +25,13 @@ export function useOpenProject(onOpened: (project: Project) => void | Promise<vo
 	// A non-actionable open failure to surface (a stale recent, a broken path). null = no notice.
 	const [openError, setOpenError] = useState<string | null>(null);
 
-	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project,
-	// then auto-enter the project's built-in **Default workspace** (the project folder itself) so opening
-	// a project lands in the IDE view — files, changes, terminals — not on Welcome. The list also ensures
-	// the Default exists host-side. Best-effort: no Default row (an older host) or a failed list degrades
-	// to the caller's select-project behavior (Welcome) — the open itself already succeeded.
+	// Refresh the store's project list, then let the caller adopt (select/expand) the opened project.
+	// Deliberately NO auto-enter into any workspace: opening lands on the project's Welcome — the fork
+	// where the two working modes (isolated worktree vs the project folder's Default workspace) are an
+	// explicit choice (see task-workspace-mode-clarity).
 	const adopt = async (project: Project) => {
 		useAppStore.getState().setProjects(await getTransport().request("project.list", {}));
 		await onOpened(project);
-		try {
-			const workspaces = await getTransport().request("workspace.list", { projectId: project.id });
-			useAppStore.getState().setWorkspaces(project.id, workspaces);
-			const def = workspaces.find((w) => w.kind === "default");
-			if (def) useAppStore.getState().activateWorkspace(def);
-		} catch {
-			// Entering Default is additive — a failure leaves the caller's selection (Welcome) in place.
-		}
 	};
 
 	const openProject = async (rawPath: string) => {

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -10,7 +10,12 @@ import { SettingsDialog } from "../panels/SettingsDialog";
 import { TerminalsPanel } from "../panels/TerminalsPanel";
 import { Toaster } from "../panels/Toaster";
 import { WelcomePanel } from "../panels/WelcomePanel";
-import { selectActiveWorkspace, selectContextProject, useAppStore } from "../store";
+import {
+	isDefaultWorkspace,
+	selectActiveWorkspace,
+	selectContextProject,
+	useAppStore,
+} from "../store";
 import { applyTheme, writeThemeHint } from "../themes";
 import type { ConnectionStatus } from "../transport";
 import { useGlobalHotkeys } from "./useGlobalHotkeys";
@@ -75,9 +80,14 @@ export function Shell() {
 									<span data-testid="scope-branch" className="truncate">
 										{activeWorkspace.branch}
 									</span>
-									<span data-testid="scope-base" className="hidden shrink-0 md:inline">
-										· from {activeWorkspace.baseBranch}
-									</span>
+									{/* The Default workspace has no isolation base — "from <base>" would promise one
+									    (and read "main · from main" on the default branch), so the spine shows only the
+									    live branch, matching the CenterTabs receipt. */}
+									{isDefaultWorkspace(activeWorkspace) ? null : (
+										<span data-testid="scope-base" className="hidden shrink-0 md:inline">
+											· from {activeWorkspace.baseBranch}
+										</span>
+									)}
 								</div>
 							) : null}
 						</div>

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -11,6 +11,14 @@ interface ProjectContextState extends ActiveWorkspaceState {
 	projects: Project[];
 }
 
+/**
+ * The built-in Default workspace — the project folder itself. Clients key off the wire's `kind` field
+ * only; this predicate is the single place it's read (rail row, receipt, scope spine, folder-mode entry).
+ */
+export function isDefaultWorkspace(workspace: Pick<Workspace, "kind">): boolean {
+	return workspace.kind === "default";
+}
+
 /** Resolve the active workspace from the project-grouped collection without duplicating it in state. */
 export function selectActiveWorkspace(state: ActiveWorkspaceState): Workspace | null {
 	if (!state.activeWorkspaceId) return null;

--- a/architecture.md
+++ b/architecture.md
@@ -57,7 +57,11 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    tabs + chat tabs**. The shell arranges panels by layout mode: desktop multi-pane /
    mobile single-view-with-switcher. Both modes share the same panels and store.
 6. **Workspaces are git worktrees (V1).** project (git repo) → workspace (`git worktree` on its own
-   branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. The shell is built first,
+   branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. **One deliberate
+   exception:** every project carries exactly one built-in **Default workspace** (`kind: "default"`)
+   whose cwd is the project folder itself (git's *main working tree*) — auto-entered on open,
+   non-removable, non-renamable — the "just work in my project folder" anchor for users lost in the
+   worktree model (see [[submodule-server-workspaces]]). The shell is built first,
    `pi` connected last. Real PR / Checks / Review stay V2.
 7. **Auth is external.** Tailscale ACLs / device identity are the auth; the app carries an `owner` field,
    not a login UI.

--- a/architecture.md
+++ b/architecture.md
@@ -59,8 +59,9 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
 6. **Workspaces are git worktrees (V1).** project (git repo) → workspace (`git worktree` on its own
    branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. **One deliberate
    exception:** every project carries exactly one built-in **Default workspace** (`kind: "default"`)
-   whose cwd is the project folder itself (git's *main working tree*) — auto-entered on open,
-   non-removable, non-renamable — the "just work in my project folder" anchor for users lost in the
+   whose cwd is the project folder itself (git's *main working tree*) — non-removable, non-renamable,
+   and entered explicitly from the project's Welcome fork ("Work in project folder"), never
+   auto-entered — the "just work in my project folder" anchor for users lost in the
    worktree model (see [[submodule-server-workspaces]]). The shell is built first,
    `pi` connected last. Real PR / Checks / Review stay V2.
 7. **Auth is external.** Tailscale ACLs / device identity are the auth; the app carries an `owner` field,

--- a/e2e/agent.live.spec.ts
+++ b/e2e/agent.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent: excluded from the default `bun run e2e` (--grep-invert @agent); run via `bun run
 // e2e:agent` (or `bun run e2e:full`). It drives a REAL pi agent using pi's **default auth** (the model
@@ -10,7 +10,7 @@ test("streams an assistant reply from a real provider", { tag: "@agent" }, async
 
 	// Create a workspace → it becomes active → chat is scoped to it.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	// Start a chat from the empty-state button, then send a tiny prompt.
 	await page.getByTestId("start-chat").click();

--- a/e2e/agent.live.spec.ts
+++ b/e2e/agent.live.spec.ts
@@ -12,8 +12,7 @@ test("streams an assistant reply from a real provider", { tag: "@agent" }, async
 	await createWorkspaceViaDialog(page);
 	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
-	// Start a chat from the empty-state button, then send a tiny prompt.
-	await page.getByTestId("start-chat").click();
+	// The create landed in a fresh chat (empty prompt → ready composer); send a tiny prompt.
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await page.getByTestId("chat-input").fill("Reply with the single word: pong");
 	await page.getByTestId("chat-send").click();

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
+import { worktreeRows } from "./fixtures/app";
 import { E2E_PI_AGENT_DIR } from "./fixtures/paths";
 
 // Tagged @agent: drives a real pi agent. THE restart test — the one scenario the shared-host suite
@@ -160,8 +161,8 @@ test("a pending questionnaire survives a host kill -9: reboot, reopen, answer, a
 	await page.getByTestId("project-item").first().click();
 	// The workspace persisted; its session is now DISK-ONLY (the live one died with the host), so it
 	// surfaces in chat history and re-opens through the hydration path.
-	await expect(page.getByTestId("workspace-item").first()).toBeVisible({ timeout: 15_000 });
-	await page.getByTestId("workspace-item").first().click();
+	await expect(worktreeRows(page).first()).toBeVisible({ timeout: 15_000 });
+	await worktreeRows(page).first().click();
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -130,7 +130,6 @@ test("a pending questionnaire survives a host kill -9: reboot, reopen, answer, a
 	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1, {
 		timeout: 20_000,
 	});
-	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 
 	await page

--- a/e2e/changes.spec.ts
+++ b/e2e/changes.spec.ts
@@ -8,7 +8,7 @@ import { largeRepetitiveMarkdownEdited } from "./fixtures/repo";
 test("Changes tab shows the active worktree's diff and swaps per workspace", async ({ page }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(page.getByTestId("workspace-item")).toHaveCount(2); // the built-in Default + the worktree
 
 	// Edit a tracked file inside the worktree (outside the app), then surface it in the Changes tab.
 	const worktree = join(E2E_DATA_DIR, "worktrees", "sample-project", "workspace-1");
@@ -56,7 +56,7 @@ test("Changes tab shows the active worktree's diff and swaps per workspace", asy
 
 	// A fresh second workspace has its own (empty) change set.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(2);
+	await expect(page.getByTestId("workspace-item")).toHaveCount(3);
 	await expect(page.getByTestId("changes-empty")).toBeVisible();
 });
 

--- a/e2e/changes.spec.ts
+++ b/e2e/changes.spec.ts
@@ -1,14 +1,14 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 import { E2E_DATA_DIR } from "./fixtures/paths";
 import { largeRepetitiveMarkdownEdited } from "./fixtures/repo";
 
 test("Changes tab shows the active worktree's diff and swaps per workspace", async ({ page }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(2); // the built-in Default + the worktree
+	await expect(worktreeRows(page)).toHaveCount(1); // the always-present Default is counted separately
 
 	// Edit a tracked file inside the worktree (outside the app), then surface it in the Changes tab.
 	const worktree = join(E2E_DATA_DIR, "worktrees", "sample-project", "workspace-1");
@@ -56,7 +56,7 @@ test("Changes tab shows the active worktree's diff and swaps per workspace", asy
 
 	// A fresh second workspace has its own (empty) change set.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(3);
+	await expect(worktreeRows(page)).toHaveCount(2);
 	await expect(page.getByTestId("changes-empty")).toBeVisible();
 });
 

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -17,7 +17,6 @@ async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await expect(trustDialog.getByTestId("ws-trust-notice")).toBeHidden();
 	await createWorkspaceViaDialog(page);
 	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
-	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 }

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): excluded from the default `bun run e2e`; run via
 // `bun run e2e:agent`. These exercise the Composer + cheap wins against a REAL pi agent + pi's
@@ -16,7 +16,7 @@ async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await trustDialog.getByTestId("ws-trust-project").click();
 	await expect(trustDialog.getByTestId("ws-trust-notice")).toBeHidden();
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await expect(page.getByTestId("chat-input")).toBeVisible();

--- a/e2e/default-workspace.spec.ts
+++ b/e2e/default-workspace.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import {
+	createWorkspaceViaDialog,
+	defaultWorkspaceRow,
+	goProjectHome,
+	openFixtureProject,
+	runInTerminal,
+	visibleTerminalScreen,
+	waitTerminalReady,
+	worktreeRows,
+} from "./fixtures/app";
+
+// The built-in Default workspace: every project carries exactly one (kind: "default") whose cwd is the
+// project folder itself. It appears as soon as the project opens, is pinned first, and is non-removable
+// and non-renamable — the "just work in my project folder" anchor for people lost in the worktree model.
+
+test("opening a project auto-enters its Default workspace — the project folder itself", async ({
+	page,
+}) => {
+	await openFixtureProject(page); // asserts the Default row is active (the auto-enter)
+
+	// The IDE surface is mounted (not the Welcome screen), scoped to the Default workspace on `main`.
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+	await expect(page.getByTestId("scope-name")).toHaveText("Default");
+	await expect(page.getByTestId("scope-branch")).toHaveText("main");
+
+	// Pinned first, labeled Default, with the folder's real branch on the second line.
+	const row = defaultWorkspaceRow(page);
+	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-kind", "default");
+	await expect(row.getByTestId("workspace-name")).toHaveText("Default");
+	await expect(row.getByTestId("workspace-branch")).toHaveText("main");
+
+	// The empty-center receipt tells the truth: this is the project folder, not an isolated worktree.
+	const ready = page.getByTestId("workspace-ready");
+	await expect(ready).toContainText("Default workspace");
+	await expect(ready).toContainText("sample-project");
+	await expect(ready).toContainText("on main");
+	await expect(ready).toContainText("run directly in your project folder");
+
+	// The file tree shows the repo's own files (the workspace cwd is the project folder)…
+	await page.getByTestId("tab-files").click();
+	await expect(page.getByTestId("file-node").filter({ hasText: "README.md" })).toBeVisible();
+
+	// …the Changes tab measures vs the repo's default branch (on main with a clean tree → empty)…
+	await page.getByTestId("tab-changes").click();
+	await expect(page.getByTestId("changes-empty")).toBeVisible();
+
+	// …and the auto-opened terminal is rooted in the project folder itself.
+	await waitTerminalReady(page);
+	await runInTerminal(page, 'basename "$(pwd)"');
+	await expect(visibleTerminalScreen(page)).toContainText("sample-project");
+});
+
+test("the Default workspace is non-removable and unique; project home stays reachable", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+
+	// No Remove affordance on the Default row — while a worktree row offers one on hover.
+	await createWorkspaceViaDialog(page);
+	const row = defaultWorkspaceRow(page);
+	await row.hover();
+	await expect(row.getByTestId("workspace-remove")).toHaveCount(0);
+	await worktreeRows(page).first().hover();
+	await expect(worktreeRows(page).first().getByTestId("workspace-remove")).toBeVisible();
+
+	// Re-opening the same project (the picker points at the same repo) does not duplicate the Default.
+	await page.getByTestId("add-project-menu").click();
+	await page.getByTestId("menu-open-project").click();
+	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await expect(defaultWorkspaceRow(page)).toHaveCount(1);
+
+	// The project-home gesture still works: click the project row → Welcome; click Default → back in.
+	await goProjectHome(page);
+	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
+	await defaultWorkspaceRow(page).getByRole("button").first().click();
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+});

--- a/e2e/default-workspace.spec.ts
+++ b/e2e/default-workspace.spec.ts
@@ -29,6 +29,9 @@ test("the Welcome fork's “Work in project folder” enters the Default workspa
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 	await expect(page.getByTestId("scope-name")).toHaveText("Default");
 	await expect(page.getByTestId("scope-branch")).toHaveText("main");
+	// No isolation base to promise: the spine must not render "· from <base>" for the Default
+	// (it would read "main · from main" here), matching the receipt's truthful framing.
+	await expect(page.getByTestId("scope-base")).toHaveCount(0);
 
 	// Pinned first, labeled Default, with the folder's real branch on the second line.
 	const row = defaultWorkspaceRow(page);

--- a/e2e/default-workspace.spec.ts
+++ b/e2e/default-workspace.spec.ts
@@ -60,6 +60,28 @@ test("the Welcome fork's “Work in project folder” enters the Default workspa
 	await expect(visibleTerminalScreen(page)).toContainText("sample-project");
 });
 
+test("a terminal branch switch converges every Default branch label live", async ({ page }) => {
+	// The Default workspace's branch is folder-truth that moves out-of-band: it is the one workspace whose
+	// branch a user can change from under the app (`git switch` in its own terminal). Every label reading it
+	// must converge on the push — no manual project reload.
+	await openFixtureProject(page);
+	await enterDefaultWorkspace(page);
+
+	const row = defaultWorkspaceRow(page);
+	await expect(page.getByTestId("scope-branch")).toHaveText("main");
+	await expect(row.getByTestId("workspace-branch")).toHaveText("main");
+
+	// A *content-identical* switch: nothing in the worktree changes, so only `.git/HEAD` moves — the
+	// narrowest case the live path has to catch.
+	await waitTerminalReady(page);
+	await runInTerminal(page, "git switch -c live-branch");
+
+	// The rail row, the top-bar spine and the empty-center receipt all follow the folder.
+	await expect(row.getByTestId("workspace-branch")).toHaveText("live-branch");
+	await expect(page.getByTestId("scope-branch")).toHaveText("live-branch");
+	await expect(page.getByTestId("workspace-ready")).toContainText("on live-branch");
+});
+
 test("the Default workspace is non-removable and unique; project home stays reachable", async ({
 	page,
 }) => {

--- a/e2e/default-workspace.spec.ts
+++ b/e2e/default-workspace.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
 	defaultWorkspaceRow,
+	enterDefaultWorkspace,
 	goProjectHome,
 	openFixtureProject,
 	runInTerminal,
@@ -13,13 +14,18 @@ import {
 // The built-in Default workspace: every project carries exactly one (kind: "default") whose cwd is the
 // project folder itself. It appears as soon as the project opens, is pinned first, and is non-removable
 // and non-renamable — the "just work in my project folder" anchor for people lost in the worktree model.
+// Opening a project deliberately does NOT auto-enter it: the Welcome screen is the fork where working
+// in the project folder is an explicit choice beside cutting an isolated worktree.
 
-test("opening a project auto-enters its Default workspace — the project folder itself", async ({
+test("the Welcome fork's “Work in project folder” enters the Default workspace — the project folder itself", async ({
 	page,
 }) => {
-	await openFixtureProject(page); // asserts the Default row is active (the auto-enter)
+	await openFixtureProject(page); // lands on the project's Welcome — nothing auto-entered
 
-	// The IDE surface is mounted (not the Welcome screen), scoped to the Default workspace on `main`.
+	// The fork card direct-enters the built-in Default workspace (no dialog).
+	await enterDefaultWorkspace(page);
+
+	// The IDE surface is mounted, scoped to the Default workspace on `main`.
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 	await expect(page.getByTestId("scope-name")).toHaveText("Default");
 	await expect(page.getByTestId("scope-branch")).toHaveText("main");
@@ -64,16 +70,18 @@ test("the Default workspace is non-removable and unique; project home stays reac
 	await worktreeRows(page).first().hover();
 	await expect(worktreeRows(page).first().getByTestId("workspace-remove")).toBeVisible();
 
-	// Re-opening the same project (the picker points at the same repo) does not duplicate the Default.
+	// Re-opening the same project (the picker points at the same repo) does not duplicate the Default,
+	// and lands back on the Welcome fork (deselecting the active workspace — the project-home surface).
 	await page.getByTestId("add-project-menu").click();
 	await page.getByTestId("menu-open-project").click();
-	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("welcome")).toBeVisible();
 	await expect(defaultWorkspaceRow(page)).toHaveCount(1);
 
-	// The project-home gesture still works: click the project row → Welcome; click Default → back in.
-	await goProjectHome(page);
-	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
+	// The Default stays one click away in the rail: click its row → the IDE surface; the project-home
+	// gesture then returns to Welcome.
 	await defaultWorkspaceRow(page).getByRole("button").first().click();
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await goProjectHome(page);
+	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
 });

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -4,8 +4,13 @@ import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 test("opens a file in a center Monaco tab, focuses on re-open, and closes", async ({ page }) => {
 	await openFixtureProject(page);
 
-	// Create a workspace → its worktree files populate the All-files tree.
+	// Create a workspace → its worktree files populate the All-files tree. The create lands in its
+	// auto-opened chat; close it — this spec exercises *file* tabs and the last-tab receipt.
 	await createWorkspaceViaDialog(page);
+	const chatTab = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
+	await chatTab.hover();
+	await chatTab.getByTestId("editor-tab-close").click();
+	await expect(chatTab).toHaveCount(0);
 	await page.getByTestId("tab-files").click();
 	const readme = page.getByTestId("file-node").filter({ hasText: "README.md" });
 	await expect(readme).toBeVisible();

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 test("shows the active worktree's files in the All-files tree", async ({ page }) => {
 	await openFixtureProject(page);
 
 	// Create a workspace → it becomes active → its worktree files populate the All-files tree.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toBeVisible();
+	// The created *worktree* row — `.first()` of all rows would match the pinned Default and pass
+	// even if the new workspace never rendered.
+	await expect(worktreeRows(page).first()).toBeVisible();
 
 	// Specs is the right rail's default tab; files live one tab over.
 	await page.getByTestId("tab-files").click();

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -119,12 +119,33 @@ export async function openAppFresh(page: Page): Promise<void> {
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 }
 
-/** Reset state, then open the fixture repo as a project via the (stubbed) picker; auto-selects + expands. */
+/**
+ * Reset state, then open the fixture repo as a project via the (stubbed) picker; auto-selects + expands
+ * — and, per the open flow, **auto-enters the project's built-in Default workspace** (the project folder
+ * itself), so the page lands on the IDE surface, not the Welcome screen.
+ */
 export async function openFixtureProject(page: Page): Promise<void> {
 	await openAppFresh(page);
 	await page.getByTestId("add-project-menu").click();
 	await page.getByTestId("menu-open-project").click();
 	await expect(page.getByTestId("project-item").first()).toBeVisible();
+	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+}
+
+/** The built-in Default workspace's row (exactly one per open project in the rail). */
+export function defaultWorkspaceRow(page: Page): Locator {
+	return page.locator('[data-testid="workspace-item"][data-kind="default"]');
+}
+
+/** The *worktree* workspace rows — every workspace row minus the always-present Default. */
+export function worktreeRows(page: Page): Locator {
+	return page.locator('[data-testid="workspace-item"]:not([data-kind="default"])');
+}
+
+/** The "project home" gesture: click the project row to deselect the workspace → its Welcome screen. */
+export async function goProjectHome(page: Page): Promise<void> {
+	await page.getByTestId("project-item").first().getByText("sample-project").click();
+	await expect(page.getByTestId("welcome")).toBeVisible();
 }
 
 /**
@@ -135,16 +156,20 @@ export async function openFixtureProject(page: Page): Promise<void> {
  */
 export async function openWorkspaceChat(page: Page): Promise<void> {
 	await openFixtureProject(page);
+	// Chat in a *worktree* workspace, not the auto-entered Default (the fixture repo itself): agent specs
+	// run bash/edits in the workspace cwd, and worktree isolation is what keeps them off the shared repo.
 	await expect(async () => {
-		if ((await page.getByTestId("workspace-item").count()) === 0) {
+		if ((await worktreeRows(page).count()) === 0) {
 			await createWorkspaceViaDialog(page);
 		}
-		await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(
-			1,
-			{
-				timeout: 5_000,
-			},
-		);
+		// Activate it explicitly (a no-op when the dialog's create already did) — the auto-entered Default
+		// must not stay active, and a lost activation would otherwise never self-heal.
+		await worktreeRows(page).first().getByRole("button").first().click();
+		await expect(
+			page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+		).toHaveCount(1, {
+			timeout: 5_000,
+		});
 	}).toPass({ timeout: 30_000 });
 	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -121,15 +121,27 @@ export async function openAppFresh(page: Page): Promise<void> {
 
 /**
  * Reset state, then open the fixture repo as a project via the (stubbed) picker; auto-selects + expands
- * — and, per the open flow, **auto-enters the project's built-in Default workspace** (the project folder
- * itself), so the page lands on the IDE surface, not the Welcome screen.
+ * — landing on the project's **Welcome screen** (the mode fork: isolated worktree vs project folder).
+ * Deliberately no workspace is auto-entered; the rail lists the built-in Default row (the list ensures
+ * it host-side).
  */
 export async function openFixtureProject(page: Page): Promise<void> {
 	await openAppFresh(page);
 	await page.getByTestId("add-project-menu").click();
 	await page.getByTestId("menu-open-project").click();
 	await expect(page.getByTestId("project-item").first()).toBeVisible();
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+}
+
+/**
+ * From the project's Welcome, take the "Work in project folder" fork card — direct-enters the built-in
+ * Default workspace (the project folder itself) and lands on the IDE surface.
+ */
+export async function enterDefaultWorkspace(page: Page): Promise<void> {
+	await page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }).click();
 	await expect(defaultWorkspaceRow(page)).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
 }
 
 /** The built-in Default workspace's row (exactly one per open project in the rail). */
@@ -156,14 +168,14 @@ export async function goProjectHome(page: Page): Promise<void> {
  */
 export async function openWorkspaceChat(page: Page): Promise<void> {
 	await openFixtureProject(page);
-	// Chat in a *worktree* workspace, not the auto-entered Default (the fixture repo itself): agent specs
-	// run bash/edits in the workspace cwd, and worktree isolation is what keeps them off the shared repo.
+	// Chat in a *worktree* workspace, never the project-folder Default (the shared fixture repo itself):
+	// agent specs run bash/edits in the workspace cwd, and worktree isolation keeps them off the repo.
 	await expect(async () => {
 		if ((await worktreeRows(page).count()) === 0) {
 			await createWorkspaceViaDialog(page);
 		}
-		// Activate it explicitly (a no-op when the dialog's create already did) — the auto-entered Default
-		// must not stay active, and a lost activation would otherwise never self-heal.
+		// Activate it explicitly (a no-op when the dialog's create already did) — a lost activation would
+		// otherwise never self-heal.
 		await worktreeRows(page).first().getByRole("button").first().click();
 		await expect(
 			page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -107,7 +107,9 @@ export async function createWorkspaceViaDialog(page: Page): Promise<Workspace> {
 	}).toPass({ timeout: 30_000 });
 	await page.getByTestId("create-workspace").click();
 	await expect(dialog).toBeHidden();
-	const created = loadPersistedWorkspaces().find((w) => !before.has(w.id));
+	// Never the Default: the ensure can materialize its record mid-operation, and callers expect the
+	// created *worktree*, not the project folder.
+	const created = loadPersistedWorkspaces().find((w) => !before.has(w.id) && w.kind !== "default");
 	if (!created) throw new Error("Workspace was not persisted after creation");
 	return created;
 }
@@ -154,6 +156,11 @@ export function worktreeRows(page: Page): Locator {
 	return page.locator('[data-testid="workspace-item"]:not([data-kind="default"])');
 }
 
+/** The *active* worktree row — the active workspace, excluding the always-present Default. */
+export function activeWorktreeRow(page: Page): Locator {
+	return worktreeRows(page).and(page.locator('[data-active="true"]'));
+}
+
 /** The "project home" gesture: click the project row to deselect the workspace → its Welcome screen. */
 export async function goProjectHome(page: Page): Promise<void> {
 	await page.getByTestId("project-item").first().getByText("sample-project").click();
@@ -177,9 +184,7 @@ export async function openWorkspaceChat(page: Page): Promise<void> {
 		// Activate it explicitly (a no-op when the dialog's create already did) — a lost activation would
 		// otherwise never self-heal.
 		await worktreeRows(page).first().getByRole("button").first().click();
-		await expect(
-			page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
-		).toHaveCount(1, {
+		await expect(activeWorktreeRow(page)).toHaveCount(1, {
 			timeout: 5_000,
 		});
 	}).toPass({ timeout: 30_000 });

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -46,6 +46,22 @@ function resetState(): void {
 	// the blast radius stays that one spec.
 	if (!fixtureRepoHealthy()) seedFixtureRepo();
 
+	// A test can leave the shared repo on another branch (a terminal `git switch` — see
+	// default-workspace.spec.ts). Restore `main` first: a checked-out branch can't be deleted by the sweep
+	// below, so every later test would inherit both the branch and any dirt on it. Guarded by the branch
+	// check — an unconditional `checkout -f` would also resurrect files a test deliberately deleted from
+	// the fixture *on main* (welcome.spec.ts strips the seed specs, then re-opens the project).
+	try {
+		const head = execFileSync("git", ["-C", E2E_FIXTURE_REPO, "symbolic-ref", "--short", "HEAD"], {
+			encoding: "utf8",
+		}).trim();
+		if (head !== "main") {
+			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "checkout", "-f", "main"], { stdio: "ignore" });
+		}
+	} catch {
+		// Unreadable HEAD (detached / mid-operation) — the branch sweep below is the backstop.
+	}
+
 	execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "prune"]);
 	for (let sweep = 0; sweep < 2; sweep += 1) {
 		const branches = execFileSync(

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -107,6 +107,10 @@ export async function createWorkspaceViaDialog(page: Page): Promise<Workspace> {
 	}).toPass({ timeout: 30_000 });
 	await page.getByTestId("create-workspace").click();
 	await expect(dialog).toBeHidden();
+	// Submitting the dialog always lands in a fresh chat (empty prompt → ready composer). Wait for the
+	// auto-opened tab before returning so every caller sees a settled center — the async session.create
+	// must not activate a chat tab mid-assertion later in a spec.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]').first()).toBeVisible();
 	// Never the Default: the ensure can materialize its record mid-operation, and callers expect the
 	// created *worktree*, not the project folder.
 	const created = loadPersistedWorkspaces().find((w) => !before.has(w.id) && w.kind !== "default");
@@ -168,8 +172,9 @@ export async function goProjectHome(page: Page): Promise<void> {
 }
 
 /**
- * Open the fixture project, create a workspace, and start a chat — leaving the composer ready. Creation
- * is retried: when the `@agent` suite shares one host under load, an `add-workspace` click can
+ * Open the fixture project and create a workspace — leaving the dialog's auto-opened chat with its
+ * composer ready (submitting the dialog always lands in a fresh chat; no separate start-chat step).
+ * Creation is retried: when the `@agent` suite shares one host under load, an `add-workspace` click can
  * occasionally not register, so we re-click until a workspace becomes active (re-clicking only while none
  * exists, so we never spawn duplicates). Use this for any chat-driven spec.
  */
@@ -188,7 +193,6 @@ export async function openWorkspaceChat(page: Page): Promise<void> {
 			timeout: 5_000,
 		});
 	}).toPass({ timeout: 30_000 });
-	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 }

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
 
 // Selecting a message hit in the Ctrl+R history overlay (A7) jumps to it: `useHistorySearch`'s
@@ -50,8 +50,10 @@ test("selecting a same-workspace message hit opens the chat and flashes the matc
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	// A fresh chat (not the seeded one) so a composer exists; the seeded session stays unopened — jumping
 	// to it must open a *second* tab, not reuse this one.
@@ -108,7 +110,7 @@ test("selecting a cross-workspace message hit switches the active workspace and 
 
 	// Workspace B: created second, so it's the active one — the search below runs from *its* chat, not A's.
 	await createWorkspaceViaDialog(page);
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
 	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
@@ -177,7 +179,7 @@ test("an unmapped message hit is a no-op — the overlay stays open and the acti
 	// No-op: overlay stays open, no new tab, active workspace unchanged (still B).
 	await expect(overlay).toBeVisible();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
 	await expect(workspaces.nth(0)).not.toHaveAttribute("data-active", "true");
 });
@@ -331,7 +333,7 @@ test("an unmapped prompt hit shows no jump icon, and Shift+Enter on it is a no-o
 	// No-op: overlay stays open, no new tab, active workspace unchanged (still B).
 	await expect(overlay).toBeVisible();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
 	await expect(workspaces.nth(0)).not.toHaveAttribute("data-active", "true");
 });

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -139,9 +139,10 @@ test("selecting a cross-workspace message hit switches the active workspace and 
 	// Active workspace switched from B (index 1) to A (index 0).
 	await expect(workspaces.nth(0)).toHaveAttribute("data-active", "true");
 	await expect(workspaces.nth(1)).not.toHaveAttribute("data-active", "true");
-	// Workspace A's tab strip now shows only the just-opened seeded chat (B's own started-but-empty chat is
-	// a different workspace's tab list, hidden now that A is active).
-	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	// Workspace A's tab strip settles on two chats: its own auto-opened one (created with A, restored
+	// live from the host on entering A) plus the just-opened seeded chat. B's own chat belongs to a
+	// different workspace's tab list, hidden now that A is active.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(2);
 	const flashRow = page.locator("[data-flash]");
 	await expect(flashRow).toBeVisible();
 	await expect(flashRow).toContainText("migration notes");

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+import {
+	activeWorktreeRow,
+	createWorkspaceViaDialog,
+	openFixtureProject,
+	worktreeRows,
+} from "./fixtures/app";
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
 
 // Selecting a message hit in the Ctrl+R history overlay (A7) jumps to it: `useHistorySearch`'s
@@ -51,9 +56,7 @@ test("selecting a same-workspace message hit opens the chat and flashes the matc
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
-	await expect(
-		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
-	).toHaveCount(1);
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
 	// A fresh chat (not the seeded one) so a composer exists; the seeded session stays unopened — jumping
 	// to it must open a *second* tab, not reuse this one.

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -58,9 +58,9 @@ test("selecting a same-workspace message hit opens the chat and flashes the matc
 	await worktreeRows(page).first().click();
 	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
-	// A fresh chat (not the seeded one) so a composer exists; the seeded session stays unopened — jumping
-	// to it must open a *second* tab, not reuse this one.
-	await page.getByTestId("start-chat").click();
+	// The create's auto-opened chat (still live in the host) auto-restores after the reload — a composer
+	// exists without any start-chat step; the seeded session stays unopened, so jumping to it must open a
+	// *second* tab, not reuse this one.
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
@@ -115,7 +115,6 @@ test("selecting a cross-workspace message hit switches the active workspace and 
 	await createWorkspaceViaDialog(page);
 	const workspaces = worktreeRows(page);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
-	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 
 	await page.getByTestId("chat-input").press("Control+r");
@@ -159,7 +158,6 @@ test("an unmapped message hit is a no-op — the overlay stays open and the acti
 	seedExternalCwdSessions();
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 
 	await page.getByTestId("chat-input").press("Control+r");
@@ -215,7 +213,6 @@ test("searching a prompt's own words that an assistant reply also echoes shows o
 	});
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 
 	await page.getByTestId("chat-input").press("Control+r");
@@ -264,7 +261,6 @@ test("Shift+Enter on the selected prompt row jumps to the chat and flashes the m
 	});
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
@@ -311,7 +307,6 @@ test("an unmapped prompt hit shows no jump icon, and Shift+Enter on it is a no-o
 	seedExternalCwdSessions();
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 
 	await page.getByTestId("chat-input").press("Control+r");

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -6,6 +6,7 @@ import {
 	openWorkspaceChat,
 	visibleTerminal,
 	visibleTerminalScreen,
+	worktreeRows,
 } from "./fixtures/app";
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
 
@@ -280,8 +281,10 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -359,8 +362,10 @@ test("a recall step immediately followed by a full-value replace never doubles t
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -414,8 +419,10 @@ test("a prompt repeated earlier in the chat recalls at its most recent position,
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+	activeWorktreeRow,
 	createWorkspaceViaDialog,
 	openFixtureProject,
 	openTerminal,
@@ -282,9 +283,7 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
-	await expect(
-		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
-	).toHaveCount(1);
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -363,9 +362,7 @@ test("a recall step immediately followed by a full-value replace never doubles t
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
-	await expect(
-		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
-	).toHaveCount(1);
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -420,9 +417,7 @@ test("a prompt repeated earlier in the chat recalls at its most recent position,
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
-	await expect(
-		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
-	).toHaveCount(1);
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -12,7 +12,7 @@ import {
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
 
 // No-agent (see composer.live.spec.ts for the @agent-tagged composer suite): the Ctrl+R history-recall
-// overlay never touches the agent — `openWorkspaceChat` creates a chat session but sends nothing to it.
+// overlay never touches the agent â `openWorkspaceChat` creates a chat session but sends nothing to it.
 // `history.search` runs against the two deterministic sessions `seedExternalCwdSessions` seeds for the
 // deliberately unmapped `E2E_EXTERNAL_CWD` (see fixtures/sessions.ts): "deploy the docs site" / "fix the
 // flaky watcher test" (+ an assistant reply containing "the debounce window overlaps") and, in a second
@@ -20,18 +20,18 @@ import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessio
 //
 // Deviation from the brief's literal wording: Step 2 describes querying "flaky" and expecting BOTH a
 // prompt hit ("fix the flaky watcher test") and a message hit ("...debounce window overlaps...") to
-// surface for the same query. That pair isn't reachable — `historyIndex.ts`'s `matchesTerms` matches each
+// surface for the same query. That pair isn't reachable â `historyIndex.ts`'s `matchesTerms` matches each
 // transcript entry independently, and "flaky" only appears in the user prompt, never in the assistant
 // reply. Querying "fix" instead matches both entries (a direct substring of the prompt, and a
 // case-insensitive substring of "Fixed" in the reply) and otherwise exercises the exact same scenario the
-// brief describes — see task-A7-report.md for the full writeup.
+// brief describes â see task-A7-report.md for the full writeup.
 
 test("Ctrl+R opens history recall, cycles scope to all, zooms to messages, inserts a prompt, and Esc preserves the draft", async ({
 	page,
 }) => {
 	await openWorkspaceChat(page);
-	// `openWorkspaceChat` → `openAppFresh` → `resetState()` unconditionally wipes `E2E_PI_AGENT_DIR/sessions`
-	// (see its jsdoc: stale sessions must be cleared so they don't resurface in a reused worktree) — which
+	// `openWorkspaceChat` â `openAppFresh` â `resetState()` unconditionally wipes `E2E_PI_AGENT_DIR/sessions`
+	// (see its jsdoc: stale sessions must be cleared so they don't resurface in a reused worktree) â which
 	// also empties the external-cwd fixture `globalSetup` seeded once for the whole run. Re-seed per-test,
 	// the same way `seedWorkspaceSession`'s own doc comment describes doing "during a test"; the write is
 	// idempotent (same ids/timestamps every call), so re-seeding here never duplicates or drifts the fixture.
@@ -52,7 +52,7 @@ test("Ctrl+R opens history recall, cycles scope to all, zooms to messages, inser
 	await expect(query).toBeFocused();
 	await expect(scopeBadge).toHaveAttribute("data-scope", "workspace");
 
-	// Query "fix" (see file-header deviation note), then cycle scope workspace → project → all (2 presses)
+	// Query "fix" (see file-header deviation note), then cycle scope workspace â project â all (2 presses)
 	// so the deliberately-unmapped external-cwd fixture sessions are in scope.
 	await query.fill("fix");
 	await query.press("Control+r");
@@ -60,30 +60,30 @@ test("Ctrl+R opens history recall, cycles scope to all, zooms to messages, inser
 	await expect(scopeBadge).toHaveAttribute("data-scope", "all");
 	await expect(scopeBadge).toContainText("All");
 	await expect(promptItems.filter({ hasText: "fix the flaky watcher test" })).toBeVisible();
-	// Exactly one prompt matches "fix" across the seeded fixtures — the Prompts counter is "shown/total".
+	// Exactly one prompt matches "fix" across the seeded fixtures â the Prompts counter is "shown/total".
 	await expect(page.getByTestId("history-counts")).toHaveText("1/1");
 
 	// Tab zooms to `zoomed` (both sections); the assistant reply surfaces as a message hit, flagged as not
-	// belonging to a ThinkRail workspace (the fixture's cwd is deliberately unmapped — see the file header).
+	// belonging to a ThinkRail workspace (the fixture's cwd is deliberately unmapped â see the file header).
 	await query.press("Tab");
 	await expect(overlay).toHaveAttribute("data-stage", "zoomed");
 	const debounceHit = messageItems.filter({ hasText: "debounce window overlaps" });
 	await expect(debounceHit).toBeVisible();
 	await expect(debounceHit).toContainText("not a ThinkRail workspace");
-	// messages is assistant-only — "fix the flaky watcher test" (user-role) no longer reappears as a
+	// messages is assistant-only â "fix the flaky watcher test" (user-role) no longer reappears as a
 	// message (its jump anchor lives on the prompt hit above instead); only the assistant reply
 	// matches "fix" (via "Fixed"). The Messages counter is the second `history-counts` (Prompts renders
 	// first).
 	await expect(page.getByTestId("history-counts").last()).toHaveText("1/1");
 
-	// ↓ moves the flat-list selection off the prompt and onto that (unmapped) message hit; Enter on an
-	// unmapped message hit is a deliberate no-op — the overlay stays open and the draft is untouched.
+	// â moves the flat-list selection off the prompt and onto that (unmapped) message hit; Enter on an
+	// unmapped message hit is a deliberate no-op â the overlay stays open and the draft is untouched.
 	await query.press("ArrowDown");
 	await query.press("Enter");
 	await expect(overlay).toBeVisible();
 	await expect(input).toHaveValue("");
 
-	// ↑ moves the selection back onto the prompt hit. Enter now inserts it into the composer, focuses it,
+	// â moves the selection back onto the prompt hit. Enter now inserts it into the composer, focuses it,
 	// and closes the overlay.
 	await query.press("ArrowUp");
 	await query.press("Enter");
@@ -91,7 +91,7 @@ test("Ctrl+R opens history recall, cycles scope to all, zooms to messages, inser
 	await expect(input).toHaveValue("fix the flaky watcher test");
 	await expect(input).toBeFocused();
 
-	// Draft preservation: a fresh draft survives Ctrl+R → mutating the query → Esc leaves it untouched.
+	// Draft preservation: a fresh draft survives Ctrl+R â mutating the query â Esc leaves it untouched.
 	await input.fill("my draft");
 	await input.press("Control+r");
 	await expect(overlay).toBeVisible();
@@ -101,12 +101,12 @@ test("Ctrl+R opens history recall, cycles scope to all, zooms to messages, inser
 	await expect(overlay).toBeHidden();
 	await expect(input).toHaveValue("my draft");
 
-	// Cmd/Ctrl+Enter on a selected prompt hit inserts AND submits, reusing the composer's own send path —
+	// Cmd/Ctrl+Enter on a selected prompt hit inserts AND submits, reusing the composer's own send path â
 	// cheap to cover with no agent: `onSubmit` appends the user message optimistically *before* the (here,
-	// rejected — no auth in this suite) transport call, so the sent text lands in the transcript regardless
+	// rejected â no auth in this suite) transport call, so the sent text lands in the transcript regardless
 	// of what the host does next. Re-open + re-navigate to the same prompt hit rather than reusing the
 	// overlay instance closed by the Enter-insert above. `ControlOrMeta` is Playwright's cross-platform
-	// modifier alias (Meta on macOS, Control elsewhere) — it matches the app's own check on both the
+	// modifier alias (Meta on macOS, Control elsewhere) â it matches the app's own check on both the
 	// Composer's and the overlay's key handlers (`e.metaKey || e.ctrlKey`), so this exercises the same
 	// gesture a real user would make on either platform.
 	await input.press("Control+r");
@@ -129,10 +129,10 @@ test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the r
 	page,
 }) => {
 	// Regression (Air review): the overlay's insert-and-send used to call ChatView's `onSubmit` directly,
-	// bypassing the composer's own submit seam — the pending image was silently dropped from the send and
+	// bypassing the composer's own submit seam â the pending image was silently dropped from the send and
 	// its stale thumbnail stayed attached to the next message. Tap the app's WebSocket before it connects
 	// (the live-refresh spec's pattern, `framesent` side) so the assertion covers the actual wire payload
-	// — a `session.prompt` request carrying `images` — not just the thumbnails' visible state.
+	// â a `session.prompt` request carrying `images` â not just the thumbnails' visible state.
 	const sentFrames: string[] = [];
 	page.on("websocket", (ws) => {
 		ws.on("framesent", (frame) => {
@@ -141,14 +141,14 @@ test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the r
 	});
 
 	await openWorkspaceChat(page);
-	seedExternalCwdSessions(); // re-seed after resetState — see the first test's note
+	seedExternalCwdSessions(); // re-seed after resetState â see the first test's note
 
 	const input = page.getByTestId("chat-input");
 	const overlay = page.getByTestId("history-overlay");
 	const query = page.getByTestId("history-query");
 	const thumbnails = page.getByTestId("composer-images");
 
-	// Attach an image the way a user does — paste. A constructed ClipboardEvent must be dispatched in
+	// Attach an image the way a user does â paste. A constructed ClipboardEvent must be dispatched in
 	// page context (Playwright's keyboard can't carry files); React's onPaste reads `e.clipboardData`.
 	await input.evaluate((el) => {
 		const dt = new DataTransfer();
@@ -176,7 +176,7 @@ test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the r
 	await expect(overlay).toBeHidden();
 
 	// The send went through the composer's own seam: the text is in the transcript, the draft is empty,
-	// and the thumbnail strip is cleared with it — nothing stale left attached to the next message.
+	// and the thumbnail strip is cleared with it â nothing stale left attached to the next message.
 	await expect(
 		page
 			.locator('[data-testid="chat-message"][data-role="user"]')
@@ -186,7 +186,7 @@ test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the r
 	await expect(thumbnails).toBeHidden();
 
 	// And the wire request really carried the attachment (the frame may land a beat after the UI
-	// updates — poll). The request itself is rejected by the unauthenticated host, which is fine: the
+	// updates â poll). The request itself is rejected by the unauthenticated host, which is fine: the
 	// payload already proves the image went with the text.
 	await expect(() => {
 		const prompt = sentFrames.find(
@@ -212,13 +212,13 @@ test("empty query in chat scope shows the empty state for a session with no hist
 	await expect(overlay).toBeVisible();
 
 	// `openOverlay` always resets scope to `workspace`; reaching `chat` takes 3 forward cycles:
-	// workspace → project → all → chat.
+	// workspace â project â all â chat.
 	await query.press("Control+r");
 	await query.press("Control+r");
 	await query.press("Control+r");
 	await expect(scopeBadge).toHaveAttribute("data-scope", "chat");
 
-	// This chat session was just created and never sent to — no prompts/messages of its own, so an empty
+	// This chat session was just created and never sent to â no prompts/messages of its own, so an empty
 	// query (which otherwise matches everything) still turns up nothing.
 	await expect(overlay).toContainText("no matches");
 });
@@ -230,7 +230,7 @@ test("Ctrl+R dismisses an open mention menu instead of overlapping it", async ({
 	const overlay = page.getByTestId("history-overlay");
 	const mentionMenu = page.getByTestId("mention-menu");
 
-	// `@` alone matches every root-level entry (`fs.readDir` with an empty prefix) — the fixture repo
+	// `@` alone matches every root-level entry (`fs.readDir` with an empty prefix) â the fixture repo
 	// always has files at its root, so the mention menu is guaranteed to have candidates to show.
 	await input.fill("@");
 	await expect(mentionMenu).toBeVisible();
@@ -243,12 +243,12 @@ test("Ctrl+R dismisses an open mention menu instead of overlapping it", async ({
 	await expect(mentionMenu).not.toBeVisible();
 });
 
-// A9: plain `↑`/`↓` recall (no Ctrl+R, no query typing) steps through *this chat's own* prior prompts — it
+// A9: plain `â`/`â` recall (no Ctrl+R, no query typing) steps through *this chat's own* prior prompts â it
 // needs a chat whose runtime actually has prior user turns, so `openWorkspaceChat`'s brand-new session
 // (never sent to) doesn't do; seed one via `seedWorkspaceSession` on a real workspace `worktreePath` (see
 // the comment at its first use in `history-jump.spec.ts` for why that path, not some arbitrary string, is
 // the seed target) and open it. Simplest way in: the `chat-history` / `closed-chat-item` reopen flow
-// (`CenterTabs.tsx`) rather than the search-and-jump flow `history-jump.spec.ts` already covers — a
+// (`CenterTabs.tsx`) rather than the search-and-jump flow `history-jump.spec.ts` already covers â a
 // disk-only session surfaces there the moment its workspace becomes active. No `historyIndex` revalidation
 // wait is needed here (contrast the 2.1s waits in `history-jump.spec.ts`): `session.list` reads pi's
 // `SessionManager.list` straight off disk on every call, it isn't behind the throttled `HistoryIndex`
@@ -259,12 +259,12 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 	await openFixtureProject(page);
 	const workspace = await createWorkspaceViaDialog(page);
 	// No explicit `id`: this test never references the seeded session by id again (it reopens via the
-	// `chat-history` → `closed-chat-item` UI flow below), so the default fresh-per-call id is enough —
+	// `chat-history` â `closed-chat-item` UI flow below), so the default fresh-per-call id is enough â
 	// and, unlike a fixed literal id, survives a Playwright retry within the same `webServer` lifetime.
 	seedWorkspaceSession(workspace.worktreePath, {
 		messages: [
 			{ role: "user", text: "audit the retry backoff", timestamp: 1_700_400_000_000 },
-			{ role: "assistant", text: "Audited it — looks fine.", timestamp: 1_700_400_001_000 },
+			{ role: "assistant", text: "Audited it â looks fine.", timestamp: 1_700_400_001_000 },
 			{
 				role: "user",
 				text: "add a jittered ceiling to the backoff",
@@ -276,7 +276,7 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 		],
 	});
 
-	// A reload doesn't auto-restore the active project/workspace (see `history-jump.spec.ts`) — re-pick both
+	// A reload doesn't auto-restore the active project/workspace (see `history-jump.spec.ts`) â re-pick both
 	// so `CenterTabs`'s hydrate-on-connect effect re-lists this workspace's sessions from a cold client and
 	// discovers the disk-only seeded one.
 	await page.reload();
@@ -284,12 +284,15 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
 	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	// The create's auto-opened chat (live in the host) auto-restores — wait for it so the restore
+	// can't land mid-flow and steal the center while the closed chat below is being reopened.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
 	const input = page.getByTestId("chat-input");
 	await expect(input).toBeVisible();
-	// The reopened chat's transcript is restored, but its *draft* is fresh — recall must start from empty.
+	// The reopened chat's transcript is restored, but its *draft* is fresh â recall must start from empty.
 	await expect(input).toHaveValue("");
 
 	// Newest first: ArrowUp on the empty field recalls the latest prompt, then steps older.
@@ -299,7 +302,7 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 	await expect(input).toHaveValue("add a jittered ceiling to the backoff");
 	await input.press("ArrowUp");
 	await expect(input).toHaveValue("audit the retry backoff");
-	// Clamped at the oldest entry — one more ArrowUp doesn't wrap around.
+	// Clamped at the oldest entry â one more ArrowUp doesn't wrap around.
 	await input.press("ArrowUp");
 	await expect(input).toHaveValue("audit the retry backoff");
 
@@ -311,32 +314,32 @@ test("plain ArrowUp/ArrowDown recall steps through this chat's own prior prompts
 	await input.press("ArrowDown");
 	await expect(input).toHaveValue("");
 
-	// A diverging edit (the composer's own `fill`, exactly like a real keystroke — Playwright's `fill`
+	// A diverging edit (the composer's own `fill`, exactly like a real keystroke â Playwright's `fill`
 	// dispatches a native `input` event React's controlled `onChange` reacts to) exits the recall session:
-	// the next ArrowUp must not step — the value is unchanged besides the edit itself.
+	// the next ArrowUp must not step â the value is unchanged besides the edit itself.
 	await input.press("ArrowUp");
 	await expect(input).toHaveValue("write a test for the jitter");
 	await input.fill("write a test for the jitter!");
 	await input.press("ArrowUp");
 	await expect(input).toHaveValue("write a test for the jitter!");
 
-	// The history button — the tap path on mobile, a discoverability affordance on desktop — opens the
+	// The history button â the tap path on mobile, a discoverability affordance on desktop â opens the
 	// exact same overlay `Ctrl+R` does.
 	await page.getByTestId("history-open").click();
 	await expect(page.getByTestId("history-overlay")).toBeVisible();
 });
 
 // Regression for a real flake caught in the test above: `Composer`'s `focusCaret` used to move the caret
-// via a bare `requestAnimationFrame`, which only guarantees "before the next paint" — leaving a gap after
+// via a bare `requestAnimationFrame`, which only guarantees "before the next paint" â leaving a gap after
 // the triggering keystroke's task ends where another actor touching the same textarea's selection (e.g.
 // Playwright's `fill`, which does select-all then insert-text as separate steps) could run first. If that
 // stale RAF fired between `fill`'s select-all and insert steps, its `setSelectionRange(pos, pos)` collapsed
-// the select-all to a bare caret, so the insert appended instead of replacing — producing a doubled
+// the select-all to a bare caret, so the insert appended instead of replacing â producing a doubled
 // `oldValue + newValue` (seen as `"write a test for the jitterwrite a test for the jitter!"` under
 // parallel-worker contention). `focusCaret` now moves the caret from a `useLayoutEffect`, which commits
-// synchronously in the same task as the triggering keystroke — there's no longer a gap for `fill` (or any
-// other follow-up interaction) to land in. This mechanism doesn't depend on Playwright specifically — any
-// fast selection-replacing interaction right after a recall step could have raced the old stale RAF — so
+// synchronously in the same task as the triggering keystroke â there's no longer a gap for `fill` (or any
+// other follow-up interaction) to land in. This mechanism doesn't depend on Playwright specifically â any
+// fast selection-replacing interaction right after a recall step could have raced the old stale RAF â so
 // this is a real feature fix, not test-only synchronization; CPU-throttling below only makes an already-
 // closed race window observable within a short, deterministic test rather than needing rare real-world
 // timing (see `Composer.tsx`'s `focusCaret` comment for the fuller mechanism writeup).
@@ -350,7 +353,7 @@ test("a recall step immediately followed by a full-value replace never doubles t
 	// under `--repeat-each` to prove the race stays closed. A fixed literal id would collide with an
 	// in-memory session entry from an earlier repeat's (differently-`workspaceId`'d) run within the same
 	// shared webServer lifetime, failing with "Unknown session" before ever reaching the code path this
-	// test exists to exercise — the default fresh-per-call id (`seedWorkspaceSession`) sidesteps that.
+	// test exists to exercise â the default fresh-per-call id (`seedWorkspaceSession`) sidesteps that.
 	seedWorkspaceSession(workspace.worktreePath, {
 		messages: [
 			{ role: "user", text: "write a test for the jitter", timestamp: 1_700_500_000_000 },
@@ -363,6 +366,9 @@ test("a recall step immediately followed by a full-value replace never doubles t
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
 	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	// The create's auto-opened chat (live in the host) auto-restores — wait for it so the restore
+	// can't land mid-flow and steal the center while the closed chat below is being reopened.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -371,7 +377,7 @@ test("a recall step immediately followed by a full-value replace never doubles t
 	await expect(input).toHaveValue("");
 
 	// Throttle the main thread so any reintroduced deferred-callback gap (RAF or otherwise) would widen
-	// enough to be caught reliably within a handful of iterations — this is what let the old RAF-based
+	// enough to be caught reliably within a handful of iterations â this is what let the old RAF-based
 	// code reproduce the doubled value in ~3% of iterations during root-cause diagnosis. `press` and
 	// `fill` still auto-wait/retry as usual; only real wall-clock CPU speed is reduced.
 	const client = await page.context().newCDPSession(page);
@@ -384,23 +390,23 @@ test("a recall step immediately followed by a full-value replace never doubles t
 		await input.fill(replacement);
 		// A snapshot read, not the auto-retrying `toHaveValue` matcher: the corruption this pins is an
 		// immediate, permanent doubling at `fill`-completion time, not a transient state that later
-		// settles — polling could mask a regression that briefly shows the wrong value.
+		// settles â polling could mask a regression that briefly shows the wrong value.
 		expect(await input.inputValue()).toBe(replacement);
 		await input.fill("");
 	}
 });
 
 // Regression: `recentPrompts`'s dedup must keep a repeated prompt's NEWEST occurrence (recency-first,
-// matching the server history index's own ranking rule and the atuin/fzf convention) — not its oldest.
+// matching the server history index's own ranking rule and the atuin/fzf convention) â not its oldest.
 // "alpha" is said twice, "beta" once, in between: the first ArrowUp must recall "alpha" (the most recent
-// prompt), the second must recall "beta", and a third must stay clamped on "beta" — proving "alpha" backs
+// prompt), the second must recall "beta", and a third must stay clamped on "beta" â proving "alpha" backs
 // exactly one recall slot (its newest), not two.
 test("a prompt repeated earlier in the chat recalls at its most recent position, deduped to one entry", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
 	const workspace = await createWorkspaceViaDialog(page);
-	// No explicit `id` — same reasoning as the recall test above: this test never references the seeded
+	// No explicit `id` â same reasoning as the recall test above: this test never references the seeded
 	// session by id, so the default fresh-per-call id (survives a same-process retry) is enough.
 	seedWorkspaceSession(workspace.worktreePath, {
 		messages: [
@@ -418,6 +424,9 @@ test("a prompt repeated earlier in the chat recalls at its most recent position,
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
 	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	// The create's auto-opened chat (live in the host) auto-restores — wait for it so the restore
+	// can't land mid-flow and steal the center while the closed chat below is being reopened.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	await page.getByTestId("chat-history").click();
 	await page.getByTestId("closed-chat-item").first().click();
@@ -429,7 +438,7 @@ test("a prompt repeated earlier in the chat recalls at its most recent position,
 	await expect(input).toHaveValue("alpha");
 	await input.press("ArrowUp");
 	await expect(input).toHaveValue("beta");
-	// Clamped at "beta" — if the earlier "alpha" occurrence were a distinct entry, this would step to it.
+	// Clamped at "beta" â if the earlier "alpha" occurrence were a distinct entry, this would step to it.
 	await input.press("ArrowUp");
 	await expect(input).toHaveValue("beta");
 });
@@ -437,7 +446,7 @@ test("a prompt repeated earlier in the chat recalls at its most recent position,
 // A9's mobile-discoverability half: `HistoryOverlay` sizes itself with `left-sm right-sm` insets (see
 // `HistoryOverlay.tsx`) rather than a fixed pixel width, specifically so it can't overflow a narrow
 // container. The app's three-pane layout (`shell/Shell.tsx`) isn't itself the "mobile single-view shell"
-// `architecture.md` describes — that's a separate, not-yet-built concern — so this only isolates what IS
+// `architecture.md` describes â that's a separate, not-yet-built concern â so this only isolates what IS
 // this task's concern: the overlay's own sizing at a narrow (~390px, a small-phone width) viewport. Resize
 // only for the check itself (after the normal desktop-sized setup) so a squeezed three-pane layout can't
 // make the setup flow itself flaky.
@@ -467,7 +476,7 @@ test("the history overlay stays inside the viewport and its query stays focusabl
 });
 
 // Reviewer-flagged regression: the results list itself scrolls (mouse wheel, drag), but before this fix
-// keyboard-only navigation never moved that scroll position on its own — repeatedly pressing ArrowDown
+// keyboard-only navigation never moved that scroll position on its own â repeatedly pressing ArrowDown
 // could walk `selected` well past the bottom of what's currently visible, leaving the highlighted row
 // entirely offscreen inside the `overflow-y-auto` results container. `HistoryOverlay` now scrolls the
 // selected row into view (`Element.scrollIntoView({ block: "nearest" })`) whenever the selection changes.
@@ -476,7 +485,7 @@ test("ArrowDown repeatedly scrolls the keyboard-selected row into view inside th
 }) => {
 	await openFixtureProject(page);
 	const workspace = await createWorkspaceViaDialog(page);
-	// 30 distinct prompts, all in this workspace's own cwd — comfortably more than fit inside the compact
+	// 30 distinct prompts, all in this workspace's own cwd â comfortably more than fit inside the compact
 	// stage's `max-h-[40vh]`. An empty query in the default "workspace" scope (no scope cycling needed)
 	// surfaces every one of them as a recent prompt (see `historyIndex.test.ts`'s "(d) empty query returns
 	// recent prompts"), well under the 50-item server cap, so none get paged out.
@@ -489,7 +498,6 @@ test("ArrowDown repeatedly scrolls the keyboard-selected row into view inside th
 	});
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	const input = page.getByTestId("chat-input");
 	await expect(input).toBeVisible();
 
@@ -502,14 +510,14 @@ test("ArrowDown repeatedly scrolls the keyboard-selected row into view inside th
 	const results = page.getByTestId("history-results");
 	const selectedRow = page.locator('[data-testid="history-item"][data-selected="true"]');
 
-	// Walk the selection deep into the list — well past what the compact stage can show without scrolling.
+	// Walk the selection deep into the list â well past what the compact stage can show without scrolling.
 	for (let i = 0; i < 25; i++) {
 		await query.press("ArrowDown");
 	}
 	await expect(selectedRow).toHaveCount(1);
 
 	// The selected row's own layout box (real position, regardless of the container's overflow-clipping)
-	// must sit entirely within the results container's box — i.e. the container actually scrolled to bring
+	// must sit entirely within the results container's box â i.e. the container actually scrolled to bring
 	// it into view, rather than leaving it below the visible range.
 	const resultsBox = await results.boundingBox();
 	const rowBox = await selectedRow.boundingBox();
@@ -522,7 +530,7 @@ test("ArrowDown repeatedly scrolls the keyboard-selected row into view inside th
 });
 
 // R1: the zoomed stage's two-pane preview (`data-testid="history-preview"`) shows the keyboard-selected
-// item's FULL text — never the row's truncated first line — with query terms highlighted the same way a
+// item's FULL text â never the row's truncated first line â with query terms highlighted the same way a
 // row highlights its own text (`Highlight` is reused verbatim, never forked). The compact stage has no
 // preview pane in the DOM at all (not merely hidden), and moving the keyboard selection swaps the preview
 // to match the newly-selected item.
@@ -531,7 +539,7 @@ test("the zoomed stage's preview pane shows the selected item's full text, inclu
 }) => {
 	await openFixtureProject(page);
 	const workspace = await createWorkspaceViaDialog(page);
-	// A 3-line, >200-char prompt whose FIRST line never mentions the tail marker "zephyr9000" —
+	// A 3-line, >200-char prompt whose FIRST line never mentions the tail marker "zephyr9000" â
 	// `PromptRow` shows only `hit.text.split("\n")[0]`, so a hit whose full text matched the query can
 	// still show a row whose visible first line doesn't contain the very term that matched. That's the
 	// "truncated in the row" case R1's preview pane exists for.
@@ -549,7 +557,6 @@ test("the zoomed stage's preview pane shows the selected item's full text, inclu
 	});
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	const input = page.getByTestId("chat-input");
 	await expect(input).toBeVisible();
 
@@ -567,7 +574,7 @@ test("the zoomed stage's preview pane shows the selected item's full text, inclu
 		.locator('[data-testid="history-item"][data-kind="prompt"]')
 		.filter({ hasText: "Investigate the deployment pipeline" });
 	await expect(longRow).toBeVisible();
-	// The row shows only the truncated first line — the tail term that actually matched never appears.
+	// The row shows only the truncated first line â the tail term that actually matched never appears.
 	await expect(longRow).not.toContainText("zephyr9000");
 
 	await query.press("Tab");
@@ -578,22 +585,22 @@ test("the zoomed stage's preview pane shows the selected item's full text, inclu
 	await expect(preview).toContainText("Investigate the deployment pipeline failure");
 
 	// Broaden to an empty query so both seeded prompts are in the flat list; newest first ("a shorter
-	// unrelated prompt", seeded one second later) is selected initially — the preview follows.
+	// unrelated prompt", seeded one second later) is selected initially â the preview follows.
 	await query.fill("");
 	await expect(page.locator('[data-testid="history-item"][data-kind="prompt"]')).toHaveCount(2);
 	await expect(preview).toContainText("a shorter unrelated prompt");
 	await expect(preview).not.toContainText("zephyr9000");
 
-	// ArrowDown moves the keyboard selection onto the long prompt — the preview updates to match.
+	// ArrowDown moves the keyboard selection onto the long prompt â the preview updates to match.
 	await query.press("ArrowDown");
 	await expect(preview).toContainText("zephyr9000");
 	await expect(preview).toContainText("Investigate the deployment pipeline failure");
 });
 
 // R1: at a narrow (~390px) viewport, the zoomed stage's preview pane stacks BELOW the results list
-// instead of beside it — the two-pane wrapper switches to a column flex layout under the `md` breakpoint
+// instead of beside it â the two-pane wrapper switches to a column flex layout under the `md` breakpoint
 // (the same convention `SettingsDialog`'s own two-pane shell uses). Keeps the existing 390px overlay-
-// sizing e2e (above) passing unmodified — this is a separate assertion about the *zoomed* stage only.
+// sizing e2e (above) passing unmodified â this is a separate assertion about the *zoomed* stage only.
 test("at a narrow (~390px) viewport, the zoomed stage's preview pane stacks below the results list, both visible", async ({
 	page,
 }) => {
@@ -610,7 +617,6 @@ test("at a narrow (~390px) viewport, the zoomed stage's preview pane stacks belo
 	});
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	const input = page.getByTestId("chat-input");
 	await expect(input).toBeVisible();
 	await page.setViewportSize({ width: 390, height: 844 });
@@ -636,9 +642,9 @@ test("at a narrow (~390px) viewport, the zoomed stage's preview pane stacks belo
 	}
 });
 
-// R2: the scope badge is now a dropdown picker (the discoverable mouse path — atuin's "cycling is
+// R2: the scope badge is now a dropdown picker (the discoverable mouse path â atuin's "cycling is
 // invisible" lesson) alongside the unchanged `Ctrl+R` cycle. Also proves the brief's sharp edge: while
-// the picker is open, ArrowDown belongs to the menu, never to the overlay's own results selection —
+// the picker is open, ArrowDown belongs to the menu, never to the overlay's own results selection â
 // Radix's portaled content is a sibling of the query `<input>` the overlay's key handler is bound to,
 // never its descendant, so there's nothing for the two handlers to double up on; this test is the proof.
 test("the scope badge opens a picker that selects a scope directly without disturbing the results selection, returns focus to the query input, and Ctrl+R still cycles afterward", async ({
@@ -659,7 +665,6 @@ test("the scope badge opens a picker that selects a scope directly without distu
 	seedExternalCwdSessions();
 	await page.waitForTimeout(2_100);
 
-	await page.getByTestId("start-chat").click();
 	const input = page.getByTestId("chat-input");
 	await expect(input).toBeVisible();
 
@@ -671,11 +676,11 @@ test("the scope badge opens a picker that selects a scope directly without distu
 	const scopeOptions = page.getByTestId("history-scope-option");
 	const selectedRow = page.locator('[data-testid="history-item"][data-selected="true"]');
 
-	// Default "workspace" scope, empty query: both seeded prompts, newest ("beta…") first and selected.
+	// Default "workspace" scope, empty query: both seeded prompts, newest ("betaâ¦") first and selected.
 	await expect(page.locator('[data-testid="history-item"][data-kind="prompt"]')).toHaveCount(2);
 	await expect(selectedRow).toContainText("beta prompt for the scope picker test");
 
-	// Click the badge → 4 options, correct data-scopes, in cycle order.
+	// Click the badge â 4 options, correct data-scopes, in cycle order.
 	await scopeBadge.click();
 	await expect(scopeOptions).toHaveCount(4);
 	await expect(scopeOptions.nth(0)).toHaveAttribute("data-scope", "chat");
@@ -698,12 +703,12 @@ test("the scope badge opens a picker that selects a scope directly without distu
 			.filter({ hasText: "deploy the docs site" }),
 	).toBeVisible();
 
-	// Ctrl+R still cycles after the mouse pick — from "all" it wraps forward to "chat".
+	// Ctrl+R still cycles after the mouse pick â from "all" it wraps forward to "chat".
 	await query.press("Control+r");
 	await expect(scopeBadge).toHaveAttribute("data-scope", "chat");
 });
 
-// The chord and the dismissal both had exactly one handler, and both were bound to a single element —
+// The chord and the dismissal both had exactly one handler, and both were bound to a single element â
 // `Ctrl+R` to the composer textarea, `Escape` to the overlay's query input. So with focus anywhere else
 // the browser reloaded the page on Ctrl+R, and an overlay whose input had lost focus (a click back into
 // the composer, an errant click on the page) could not be dismissed by keyboard at all. Both are now
@@ -712,7 +717,7 @@ test("the scope badge opens a picker that selects a scope directly without distu
 //
 // One caveat this suite cannot assert: that the *browser* no longer reloads. Playwright's synthetic
 // key events are delivered to the renderer and never reach Chromium's own shortcut layer, so Ctrl+R in a
-// test never reloaded in the first place. What is covered here is the functional half — the chord being
+// test never reloaded in the first place. What is covered here is the functional half â the chord being
 // seen, and acted on, from outside the composer.
 test("Ctrl+R and Escape are owned app-wide: both work with focus outside the composer", async ({
 	page,
@@ -724,7 +729,7 @@ test("Ctrl+R and Escape are owned app-wide: both work with focus outside the com
 	const overlay = page.getByTestId("history-overlay");
 	const query = page.getByTestId("history-query");
 	const scopeBadge = page.getByTestId("history-scope");
-	// An inert bit of the topbar — clicking it parks focus well outside the chat subtree without
+	// An inert bit of the topbar â clicking it parks focus well outside the chat subtree without
 	// triggering anything.
 	const outside = page.getByTestId("scope-context");
 
@@ -735,12 +740,12 @@ test("Ctrl+R and Escape are owned app-wide: both work with focus outside the com
 	await expect(overlay).toBeVisible();
 	await expect(query).toBeFocused();
 
-	// Escape with focus back in the composer — the reported bug: the overlay used to stay open forever.
+	// Escape with focus back in the composer â the reported bug: the overlay used to stay open forever.
 	await input.click();
 	await page.keyboard.press("Escape");
 	await expect(overlay).toBeHidden();
 
-	// Escape with focus nowhere in particular closes it too — and lands focus back in the prompt field,
+	// Escape with focus nowhere in particular closes it too â and lands focus back in the prompt field,
 	// so typing just continues. (Without the refocus, closing unmounts the query input and focus falls to
 	// `<body>`: the overlay is gone but every keystroke after it is silently dropped.)
 	await page.keyboard.press("Control+r");
@@ -752,7 +757,7 @@ test("Ctrl+R and Escape are owned app-wide: both work with focus outside the com
 	await page.keyboard.type("still typing");
 	await expect(input).toHaveValue("still typing");
 
-	// …and the caret comes back where it was, not at the end: park it mid-draft, round-trip the overlay,
+	// â¦and the caret comes back where it was, not at the end: park it mid-draft, round-trip the overlay,
 	// and the next keystrokes land at that same spot.
 	await input.click();
 	await page.keyboard.press("Home");
@@ -764,7 +769,7 @@ test("Ctrl+R and Escape are owned app-wide: both work with focus outside the com
 	await expect(input).toHaveValue("i am still typing");
 	await input.fill("");
 
-	// While the overlay is open, Ctrl+R still means "cycle the scope" — including from outside it, since
+	// While the overlay is open, Ctrl+R still means "cycle the scope" â including from outside it, since
 	// the chord no longer depends on the query input holding focus.
 	await page.keyboard.press("Control+r");
 	await expect(scopeBadge).toHaveAttribute("data-scope", "workspace");
@@ -797,7 +802,7 @@ test("Ctrl+R inside a terminal belongs to the shell, not to history search", asy
 	await visibleTerminal(page).locator(".xterm-helper-textarea").focus();
 	await page.keyboard.press("Control+r");
 
-	// No overlay — and the byte really reached the PTY: depending on what the CI/dev machine's login
+	// No overlay â and the byte really reached the PTY: depending on what the CI/dev machine's login
 	// shell binds `^R` to, the screen shows either its reverse-search prompt (`bck-i-search`/
 	// `reverse-i-search`) or the literal `^R` echo. Either way the keystroke was the shell's, not ours;
 	// asserting only "no overlay" would also pass if the chord had been swallowed and dropped.
@@ -806,7 +811,7 @@ test("Ctrl+R inside a terminal belongs to the shell, not to history search", asy
 });
 
 // The Air review's blocking finding: routing that resolves only "the active tab, if it's a chat" makes the
-// app-wide swallow *worse* than the bug it fixes over a file/diff tab — Ctrl+R is prevented, nothing opens,
+// app-wide swallow *worse* than the bug it fixes over a file/diff tab â Ctrl+R is prevented, nothing opens,
 // and the shortcut silently dies exactly where Monaco and diffs live. The target now falls back to the
 // workspace's most recently opened chat and the request activates that tab atomically with itself.
 test("Ctrl+R from an active file tab switches to the chat and opens history search", async ({

--- a/e2e/markdown-links.spec.ts
+++ b/e2e/markdown-links.spec.ts
@@ -24,9 +24,10 @@ test("relative links, images, and heading anchors work in the rendered markdown 
 		.poll(async () => img.evaluate((el: HTMLImageElement) => el.naturalWidth))
 		.toBeGreaterThan(0);
 
-	// An in-doc anchor click stays on this tab (no navigation, no new tab).
+	// An in-doc anchor click stays on this tab (no navigation, no new tab — just the create's
+	// auto-opened chat plus this LINKS.md tab).
 	await preview.getByRole("link", { name: "Section two" }).click();
-	await expect(page.getByTestId("editor-tab")).toHaveCount(1);
+	await expect(page.getByTestId("editor-tab")).toHaveCount(2);
 	await expect(preview).toBeVisible();
 
 	// A relative file link opens the target file as its own editor tab.

--- a/e2e/multi-chat.live.spec.ts
+++ b/e2e/multi-chat.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): runs a REAL pi agent. Proves several chats in one
 // workspace, each its own runtime, streaming concurrently; switching is an instant swap; closing one
@@ -10,7 +10,7 @@ test("two chats in one workspace stream independently; closing one keeps the oth
 	test.setTimeout(120_000);
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	const chatTabs = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
 	const doneNotice = page

--- a/e2e/multi-chat.live.spec.ts
+++ b/e2e/multi-chat.live.spec.ts
@@ -18,7 +18,6 @@ test("two chats in one workspace stream independently; closing one keeps the oth
 		.filter({ hasText: "Done" });
 
 	// Chat A — start a turn…
-	await page.getByTestId("start-chat").click();
 	await expect(chatTabs).toHaveCount(1);
 	await page.getByTestId("chat-input").fill("Reply with the single word: alpha");
 	await page.getByTestId("chat-send").click();

--- a/e2e/multi-tab.live.spec.ts
+++ b/e2e/multi-tab.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): a REAL pi agent + two browser tabs against ONE host. Proves
 // hydrate-then-stream: a second client reconstructs the workspace's chats + transcript on connect, and
@@ -14,7 +14,7 @@ test("a second tab hydrates the same workspace's chats and then sees live update
 	// --- Tab A: create a workspace, open a chat, run a turn -----------------------------------------
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await page.getByTestId("chat-input").fill("Reply with the single word: alpha");
@@ -30,7 +30,7 @@ test("a second tab hydrates the same workspace's chats and then sees live update
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	// Navigate to the workspace tab A created (it's persisted + listed) → activating it triggers hydration.
 	await page2.getByTestId("project-expand").first().click(); // expand → load workspaces
-	await page2.getByTestId("workspace-item").first().click(); // activate → hydrate-on-connect
+	await worktreeRows(page2).first().click(); // activate → hydrate-on-connect
 
 	// Tab B rebuilds the chat tab + its transcript purely from the host (it never witnessed the turn).
 	await expect(page2.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1, {

--- a/e2e/multi-tab.live.spec.ts
+++ b/e2e/multi-tab.live.spec.ts
@@ -15,7 +15,6 @@ test("a second tab hydrates the same workspace's chats and then sees live update
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
 	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
-	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await page.getByTestId("chat-input").fill("Reply with the single word: alpha");
 	await page.getByTestId("chat-send").click();

--- a/e2e/new-workspace.live.spec.ts
+++ b/e2e/new-workspace.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openFixtureProject } from "./fixtures/app";
+import { openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): drives a REAL pi agent. Proves the New-Workspace headline — the
 // New-Workspace dialog's "create + kick-off": Create with a prompt cuts a worktree, opens a chat in it,
@@ -64,7 +64,7 @@ test("Create with a prompt cuts a worktree and streams the answer in a new chat"
 	await kickOff(page, "Reply with the single word: pong");
 
 	// A worktree appears + becomes active, and a chat tab opened with the prompt already sent.
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await expect(
 		page.locator('[data-testid="chat-message"][data-role="user"]').filter({ hasText: "pong" }),
@@ -88,16 +88,16 @@ test("two dialog kick-offs in separate workspaces stream concurrently", {
 
 	// Workspace A — kick off a turn…
 	await kickOff(page, "Reply with the single word: alpha");
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// …then immediately spin up workspace B with its own kick-off, before A necessarily finishes.
 	await kickOff(page, "Reply with the single word: bravo");
-	await expect(page.getByTestId("workspace-item")).toHaveCount(2);
+	await expect(worktreeRows(page)).toHaveCount(2);
 
 	// B (now active) reaches its turn-completion notice while A streamed in the background.
 	await expect(doneNotice).toBeVisible({ timeout: 90_000 });
 
 	// Switch back to workspace A → its chat streamed to completion concurrently (background runtime).
-	await page.getByTestId("workspace-item").nth(0).getByRole("button").first().click();
+	await worktreeRows(page).nth(0).getByRole("button").first().click();
 	await expect(doneNotice).toBeVisible({ timeout: 90_000 });
 });

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -179,12 +179,14 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 	await expect(worktreeRows(page)).toHaveCount(0);
 
 	// Plain Enter submits, matching the Create button's ↵ affordance. Clearing the prompt first keeps this
-	// in the no-agent suite (an empty prompt creates a bare worktree with no chat kick-off) while still
+	// in the no-agent suite (an empty prompt opens the fresh chat but sends nothing) while still
 	// exercising the same keydown→create() path the bug lived in.
 	await prompt.fill("");
 	await expect(dialog.getByTestId("workspace-naming-hint")).toHaveCount(0);
 	await prompt.press("Enter");
 	await expect(dialog).toBeHidden();
 	await expect(worktreeRows(page)).toHaveCount(1);
-	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
+	// Enter-submit lands in the fresh chat like the button does — the tab arrives async, so wait for it.
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(0);
 });

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openFixtureProject } from "./fixtures/app";
+import { openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // The New-Workspace dialog, no agent required: project + base-branch pickers, the effort picker, and
 // the bare-create flow. The agent kick-off (Create with a prompt → streaming chat) and the model-list
@@ -58,18 +58,18 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	if (modelResolved) await expect(effort).toBeEnabled();
 	else await expect(effort).toBeDisabled();
 
-	// Dismissing the dialog (Escape) creates nothing.
+	// Dismissing the dialog (Escape) creates nothing (only the built-in Default row is present).
 	await page.keyboard.press("Escape");
 	await expect(dialog).toBeHidden();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page)).toHaveCount(0);
 
 	// Reopen and Create with an empty prompt → a worktree is created (no chat), and it becomes active.
 	await page.getByTestId("add-workspace").first().click();
 	await expect(dialog).toBeVisible();
 	await page.getByTestId("create-workspace").click();
 	await expect(dialog).toBeHidden();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page)).toHaveCount(1);
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	// The active scope stays visible after the Welcome → IDE remount, both in the tree and the global
 	// context spine. The empty center is a persistent receipt, not a generic blank-state prompt.
@@ -121,7 +121,8 @@ test("a project's committed skills are gated behind trust, then autocomplete", a
 	await prompt.press("Enter");
 	await expect(prompt).toHaveValue("/skill:e2e-portable ");
 	await expect(dialog).toBeVisible();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	// Nothing was created — only the project's built-in Default row exists.
+	await expect(worktreeRows(page)).toHaveCount(0);
 });
 
 test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page }) => {
@@ -142,7 +143,7 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 	await prompt.pressSequentially("second line");
 	await expect(prompt).toHaveValue("first line\nsecond line");
 	await expect(dialog).toBeVisible();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page)).toHaveCount(0);
 
 	// Plain Enter submits, matching the Create button's ↵ affordance. Clearing the prompt first keeps this
 	// in the no-agent suite (an empty prompt creates a bare worktree with no chat kick-off) while still
@@ -151,6 +152,6 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 	await expect(dialog.getByTestId("workspace-naming-hint")).toHaveCount(0);
 	await prompt.press("Enter");
 	await expect(dialog).toBeHidden();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
 });

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -78,7 +78,8 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(dialog).toBeHidden();
 	await expect(worktreeRows(page)).toHaveCount(0);
 
-	// Reopen and Create with an empty prompt → a worktree is created (no chat), and it becomes active.
+	// Reopen and Create with an empty prompt → a worktree is created and becomes active — and submit
+	// still lands in a fresh chat with a ready composer (nothing sent; the prompt was empty).
 	await page.getByTestId("add-workspace").first().click();
 	await expect(dialog).toBeVisible();
 	await page.getByTestId("create-workspace").click();
@@ -87,20 +88,37 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	// The active scope stays visible after the Welcome → IDE remount, both in the tree and the global
-	// context spine. The empty center is a persistent receipt, not a generic blank-state prompt.
+	// context spine.
 	const scope = page.getByTestId("scope-context");
 	await expect(scope).toHaveAttribute("data-context", "workspace");
 	await expect(scope).toContainText("sample-project");
 	await expect(scope).toContainText("workspace-1");
 	await expect(scope).toContainText("from main");
-	const ready = page.getByTestId("workspace-ready");
-	await expect(ready).toContainText("Workspace ready");
-	await expect(ready).toContainText("workspace-1");
-	await expect(ready).toContainText("from main");
-	await expect(ready).toContainText("Files, chats, changes, and terminals are scoped");
 
-	// No prompt → no chat tab was opened.
-	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
+	// Submitting the start-working surface always lands in a chat: one fresh tab, composer ready,
+	// and no user turn (the empty prompt sent nothing).
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(0);
+});
+
+test("folder-mode Start with an empty prompt lands in a fresh chat in the Default workspace", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await page.getByTestId("add-workspace").first().click();
+	const dialog = page.getByTestId("new-workspace-dialog");
+	await expect(dialog).toBeVisible();
+	await dialog.getByTestId("ws-target-default").click();
+	await page.getByTestId("create-workspace").click();
+	await expect(dialog).toBeHidden();
+
+	// Entered the Default (nothing was created) — and submit still lands in a ready chat there.
+	await expect(page.getByTestId("scope-name")).toHaveText("Default");
+	await expect(worktreeRows(page)).toHaveCount(0);
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(0);
 });
 
 test("a project's committed skills are gated behind trust, then autocomplete", async ({ page }) => {

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -19,6 +19,8 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	// and the IDE surfaces the user is about to enter are all scoped to it.
 	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
 	await expect(dialog).toContainText("A separate checkout on its own new branch");
+	// The note strip belongs to openers that seed a command (Welcome's "Set up project") — not the rail "+".
+	await expect(dialog.getByTestId("ws-prompt-note")).toHaveCount(0);
 	await expect(dialog).toContainText("Files, chats, changes, and terminals stay scoped to it");
 
 	// Project picker defaults to the project the "+" was clicked on.

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -16,12 +16,27 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(dialog).toBeVisible();
 
 	// The operation and its scope are explicit before any controls: this is a separate checkout/branch,
-	// and the IDE surfaces the user is about to enter are all scoped to it.
+	// and the IDE surfaces the user is about to enter are all scoped to it. The rail's "+" preselects the
+	// isolated-workspace target.
 	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
 	await expect(dialog).toContainText("A separate checkout on its own new branch");
 	// The note strip belongs to openers that seed a command (Welcome's "Set up project") — not the rail "+".
 	await expect(dialog.getByTestId("ws-prompt-note")).toHaveCount(0);
 	await expect(dialog).toContainText("Files, chats, changes, and terminals stay scoped to it");
+	await expect(dialog.getByTestId("ws-target-worktree")).toHaveAttribute("data-active", "true");
+
+	// The target control makes the two working modes one visible choice: toggling to "Project folder"
+	// swaps the header to the truthful no-isolation copy, hides the base-branch picker (nothing gets
+	// created), and relabels the submit — and toggling back restores the worktree form.
+	await dialog.getByTestId("ws-target-default").click();
+	await expect(dialog.getByRole("heading", { name: "Work in project folder" })).toBeVisible();
+	await expect(dialog).toContainText("no isolation");
+	await expect(dialog.getByTestId("ws-branch-picker")).toHaveCount(0);
+	await expect(page.getByTestId("create-workspace")).toHaveText(/Start/);
+	await dialog.getByTestId("ws-target-worktree").click();
+	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
+	await expect(dialog.getByTestId("ws-branch-picker")).toBeVisible();
+	await expect(page.getByTestId("create-workspace")).toHaveText(/Create/);
 
 	// Project picker defaults to the project the "+" was clicked on.
 	await expect(dialog.getByTestId("ws-project-picker")).toContainText("sample-project");

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,6 +1,6 @@
 import { basename } from "node:path";
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, stagePlainFolder } from "./fixtures/app";
+import { createWorkspaceViaDialog, stagePlainFolder, worktreeRows } from "./fixtures/app";
 import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
 test("opens a git repo as a project via the directory picker", async ({ page }) => {
@@ -39,5 +39,7 @@ test("opening a non-git folder offers to initialise a repo, then opens it end-to
 	// …and it's usable end-to-end: a workspace (git worktree) can be created, which needs the HEAD the
 	// initial commit gave the fresh repo.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toBeVisible();
+	// The created *worktree* row — `.first()` of all rows would match the pinned Default and pass
+	// even if the new workspace never rendered.
+	await expect(worktreeRows(page).first()).toBeVisible();
 });

--- a/e2e/reopen-chat.live.spec.ts
+++ b/e2e/reopen-chat.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): needs a real session. Proves the "reopen closed chat" feature —
 // closing a chat moves it to history (its session/runtime stay alive); reopening restores the full
@@ -10,7 +10,7 @@ test("a closed chat reopens from history with its transcript intact", { tag: "@a
 	test.setTimeout(90_000);
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 
 	const chatTabs = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
 	const history = page.getByTestId("chat-history");

--- a/e2e/reopen-chat.live.spec.ts
+++ b/e2e/reopen-chat.live.spec.ts
@@ -18,8 +18,7 @@ test("a closed chat reopens from history with its transcript intact", { tag: "@a
 		.locator('[data-testid="chat-message"][data-role="user"]')
 		.filter({ hasText: "pong" });
 
-	// Start a chat and run a turn so it has content worth restoring.
-	await page.getByTestId("start-chat").click();
+	// The create landed in a fresh chat; run a turn so it has content worth restoring.
 	await expect(chatTabs).toHaveCount(1);
 	await page.getByTestId("chat-input").fill("Reply with the single word: pong");
 	await page.getByTestId("chat-send").click();

--- a/e2e/setting-up-a-project.live.spec.ts
+++ b/e2e/setting-up-a-project.live.spec.ts
@@ -74,9 +74,8 @@ test("`/skill:setting-up-a-project` routes an existing codebase to import and dr
 		"// The image-resizing pipeline — the core domain. Never imports from cli.\nexport function resize(files: string[]): void {\n\tvoid files;\n}\n",
 	);
 
-	// The dialog set this workspace active on create; start a chat in it.
+	// The dialog set this workspace active on create and landed in a fresh chat there.
 	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
-	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 
 	// The SAME command the button seeds, plus a no-questions instruction so the interview can't block the

--- a/e2e/skills-reload.live.spec.ts
+++ b/e2e/skills-reload.live.spec.ts
@@ -20,7 +20,6 @@ test("skills badge: flags a worktree skill change, clears on reload, and survive
 	const worktree = workspace.worktreePath;
 
 	// Chat A — its header carries the Skills trigger. No prompt sent, so it never streams (Reload stays enabled).
-	await page.getByTestId("start-chat").click();
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	const skillsBtn = page.getByTestId("open-skills");
 	await expect(skillsBtn).toBeVisible();

--- a/e2e/templates.live.spec.ts
+++ b/e2e/templates.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openWorkspaceChat, waitForDone } from "./fixtures/app";
+import { openWorkspaceChat, waitForDone, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): drives a REAL pi agent against the seeded prompt-template
 // fixtures (`e2e/fixtures/templates.ts`). The no-agent `templates-compose.spec.ts` already covers the
@@ -85,8 +85,10 @@ test("a typed-through /name command is expanded by pi itself, not the composer's
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
-	await page.getByTestId("workspace-item").first().click();
-	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(1);
+	await worktreeRows(page).first().click();
+	await expect(
+		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
+	).toHaveCount(1);
 
 	// The session is still live in the host's memory (never closed), so it auto-restores as the active
 	// tab — no history entry to reopen from.

--- a/e2e/templates.live.spec.ts
+++ b/e2e/templates.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openWorkspaceChat, waitForDone, worktreeRows } from "./fixtures/app";
+import { activeWorktreeRow, openWorkspaceChat, waitForDone, worktreeRows } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): drives a REAL pi agent against the seeded prompt-template
 // fixtures (`e2e/fixtures/templates.ts`). The no-agent `templates-compose.spec.ts` already covers the
@@ -86,9 +86,7 @@ test("a typed-through /name command is expanded by pi itself, not the composer's
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page.getByTestId("project-item").first().click();
 	await worktreeRows(page).first().click();
-	await expect(
-		page.locator('[data-testid="workspace-item"][data-active="true"]:not([data-kind="default"])'),
-	).toHaveCount(1);
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
 	// The session is still live in the host's memory (never closed), so it auto-restores as the active
 	// tab — no history entry to reopen from.

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -6,6 +6,7 @@ import {
 	runInTerminal,
 	visibleTerminalScreen,
 	waitTerminalReady,
+	worktreeRows,
 } from "./fixtures/app";
 
 test("a workspace opens a terminal automatically, rooted in the worktree, with working I/O", async ({
@@ -13,7 +14,7 @@ test("a workspace opens a terminal automatically, rooted in the worktree, with w
 }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// No click needed — landing on the workspace opens a terminal on its own.
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
@@ -38,13 +39,13 @@ test("terminals are workspace-scoped and survive workspace switches", async ({ p
 
 	// A fresh second workspace gets its own auto terminal — not workspace 1's.
 	await createWorkspaceViaDialog(page); // workspace 2 (now active)
-	await expect(page.getByTestId("workspace-item")).toHaveCount(2);
+	await expect(worktreeRows(page)).toHaveCount(2);
 	await waitTerminalReady(page);
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
 	await expect(visibleTerminalScreen(page)).not.toContainText("TR_WS1_BUFFER");
 
 	// Back to workspace 1 → its terminal and buffer are restored (never unmounted).
-	await page.getByTestId("workspace-item").nth(0).getByRole("button").first().click();
+	await worktreeRows(page).nth(0).getByRole("button").first().click();
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
 	await expect(visibleTerminalScreen(page)).toContainText("TR_WS1_BUFFER");
 });

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -207,11 +207,13 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 			page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
 		).toBeVisible();
 
-		// "Set up project" opens the New-Workspace dialog with the prompt hero pre-seeded.
+		// "Set up project" opens the New-Workspace dialog with the prompt hero pre-seeded, and the note
+		// strip explains what the seeded command will do (the dialog header only names the create op).
 		await page.getByTestId("welcome-cta").click();
 		const dialog = page.getByTestId("new-workspace-dialog");
 		await expect(dialog).toBeVisible();
 		await expect(dialog.getByTestId("ws-prompt")).toHaveValue(/^\/skill:setting-up-a-project\b/);
+		await expect(dialog.getByTestId("ws-prompt-note")).toContainText("setting-up-a-project skill");
 
 		// Clear the seed (no agent kick-off — keeps this in the no-agent suite) and create the worktree; it
 		// becomes active → the welcome unmounts and the full 3-column surface appears.

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -4,9 +4,11 @@ import { basename, join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
+	goProjectHome,
 	openAppFresh,
 	openFixtureProject,
 	stagePlainFolder,
+	worktreeRows,
 } from "./fixtures/app";
 import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
@@ -172,6 +174,8 @@ test("a project with specs offers Start building over Set up", async ({ page }) 
 	// The fixture repo already carries SPEC.md files → the host reports it has specs.
 	await openFixtureProject(page);
 
+	// Opening auto-entered the Default workspace; the Welcome cards live one project-row click away.
+	await goProjectHome(page);
 	await expect(page.getByTestId("welcome")).toBeVisible();
 	// The active project's name shows as the eyebrow above the wordmark.
 	await expect(page.getByTestId("welcome")).toContainText("sample-project");
@@ -196,6 +200,8 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 	try {
 		await openFixtureProject(page);
 
+		// Opening auto-entered the Default workspace — back to the project home for the spec-first cards.
+		await goProjectHome(page);
 		await expect(page.getByTestId("welcome")).toBeVisible();
 		await expect(page.getByTestId("welcome")).toContainText("sample-project");
 		// Three cards: Set up project (primary) + Start building + Open project.
@@ -247,10 +253,17 @@ test("opening a non-git folder from the Welcome screen offers to initialise a re
 	await expect(confirmInit).toBeVisible();
 	await confirmInit.click();
 
-	// It initialises + opens → the folder now shows up as a project in the rail.
+	// It initialises + opens → the folder now shows up as a project in the rail…
 	await expect(
 		page.getByTestId("project-item").filter({ hasText: basename(E2E_PLAIN_DIR) }),
 	).toBeVisible();
+	// …and the open auto-enters its built-in Default workspace (the folder itself): the IDE surface
+	// mounts, and the just-initialised repo's file is already browsable.
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+	await expect(page.locator('[data-testid="workspace-item"][data-kind="default"]')).toHaveAttribute(
+		"data-active",
+		"true",
+	);
 });
 
 test("clicking a project returns to its Welcome, deselecting the active workspace", async ({
@@ -269,6 +282,6 @@ test("clicking a project returns to its Welcome, deselecting the active workspac
 	await expect(page.locator('[data-testid="workspace-item"][data-active="true"]')).toHaveCount(0);
 
 	// Re-selecting the workspace restores the IDE (its tabs/session survive the deselect).
-	await page.getByTestId("workspace-item").first().getByRole("button").first().click();
+	await worktreeRows(page).first().getByRole("button").first().click();
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 });

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -4,7 +4,6 @@ import { basename, join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
-	goProjectHome,
 	openAppFresh,
 	openFixtureProject,
 	stagePlainFolder,
@@ -13,10 +12,13 @@ import {
 import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
 // The first-touch Welcome screen. It replaces the center/right/terminal surface until a workspace is
-// active, and its cards adapt across three states:
+// active — and with a project shown it is THE MODE FORK: "Start building" (isolated worktree) always
+// sits beside "Work in project folder" (the built-in Default workspace), so the two working modes are a
+// visible choice, not a hidden default. Opening a project lands here (no auto-enter). Cards by state:
 //   1. no projects        → one "Open project" card (opens the same dropdown as the projects-rail "+")
-//   2. project, has specs → "Start building" + "Open project"
-//   3. project, no specs  → spec-first "Set up project" + "Start building" + "Open project"
+//   2. project, has specs → "Start building" + "Work in project folder" + "Open project"
+//   3. project, no specs  → spec-first "Set up project" + "Start building" + "Work in project folder"
+//                           + "Open project"
 // "Has specs" = the repo has ANY registered spec (a file with id+type frontmatter), via the spec index —
 // not a lowercased goal-and-requirements.md filename. The fixture ships SPEC.md files, so it's "has specs"
 // by default; state 3 is exercised by stripping those specs for the duration of one test.
@@ -170,23 +172,24 @@ test("Settings → Providers offers JetBrains AI, guiding install when the centr
 	}
 });
 
-test("a project with specs offers Start building over Set up", async ({ page }) => {
-	// The fixture repo already carries SPEC.md files → the host reports it has specs.
+test("a project with specs offers Start building over Set up, beside the project-folder fork", async ({
+	page,
+}) => {
+	// The fixture repo already carries SPEC.md files → the host reports it has specs. Opening lands
+	// directly on the project's Welcome — the fork surface (no auto-enter).
 	await openFixtureProject(page);
-
-	// Opening auto-entered the Default workspace; the Welcome cards live one project-row click away.
-	await goProjectHome(page);
-	await expect(page.getByTestId("welcome")).toBeVisible();
 	// The active project's name shows as the eyebrow above the wordmark.
 	await expect(page.getByTestId("welcome")).toContainText("sample-project");
-	// The global context makes the selected-but-not-active state explicit instead of making a project-row
-	// click look like the workspace silently disappeared.
+	// The global context makes the selected-but-not-active state explicit.
 	const scope = page.getByTestId("scope-context");
 	await expect(scope).toHaveAttribute("data-context", "project-home");
 	await expect(scope).toContainText("sample-project");
 	await expect(scope).toContainText("Project home");
-	// Two cards: Start building (primary) + Open project — and no "Set up project".
+	// Three cards: Start building (primary) + the project-folder fork + Open project — no "Set up project".
 	await expect(page.getByTestId("welcome-cta")).toContainText("Start building");
+	await expect(
+		page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
+	).toBeVisible();
 	await expect(
 		page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
 	).toBeVisible();
@@ -198,38 +201,49 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 	// serial — workers: 1 — so this can't race, and git restores the exact committed content).
 	for (const spec of FIXTURE_SPECS) rmSync(join(E2E_FIXTURE_REPO, spec), { force: true });
 	try {
-		await openFixtureProject(page);
-
-		// Opening auto-entered the Default workspace — back to the project home for the spec-first cards.
-		await goProjectHome(page);
-		await expect(page.getByTestId("welcome")).toBeVisible();
+		await openFixtureProject(page); // lands on the project's Welcome — the spec-first cards
 		await expect(page.getByTestId("welcome")).toContainText("sample-project");
-		// Three cards: Set up project (primary) + Start building + Open project.
+		// Four cards: Set up project (primary) + Start building + the project-folder fork + Open project.
 		await expect(page.getByTestId("welcome-cta")).toContainText("Set up project");
 		await expect(
 			page.getByTestId("welcome-action").filter({ hasText: "Start building" }),
 		).toBeVisible();
 		await expect(
+			page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
+		).toBeVisible();
+		await expect(
 			page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
 		).toBeVisible();
 
-		// "Set up project" opens the New-Workspace dialog with the prompt hero pre-seeded, and the note
-		// strip explains what the seeded command will do (the dialog header only names the create op).
+		// "Set up project" opens the dialog pre-seeded with the skill command, preselected to the
+		// project-folder target (specs are ground truth — they land in place), with the explanatory note
+		// (the header only names the create op) and the mode-aware header; the base-branch picker is
+		// hidden (nothing gets created).
 		await page.getByTestId("welcome-cta").click();
 		const dialog = page.getByTestId("new-workspace-dialog");
 		await expect(dialog).toBeVisible();
 		await expect(dialog.getByTestId("ws-prompt")).toHaveValue(/^\/skill:setting-up-a-project\b/);
+		await expect(dialog.getByTestId("ws-target-default")).toHaveAttribute("data-active", "true");
+		await expect(dialog.getByRole("heading", { name: "Work in project folder" })).toBeVisible();
+		await expect(dialog).toContainText("no isolation");
 		await expect(dialog.getByTestId("ws-prompt-note")).toContainText("setting-up-a-project skill");
+		await expect(dialog.getByTestId("ws-branch-picker")).toHaveCount(0);
 
-		// Clear the seed (no agent kick-off — keeps this in the no-agent suite) and create the worktree; it
-		// becomes active → the welcome unmounts and the full 3-column surface appears.
+		// Clear the seed (no agent kick-off — keeps this in the no-agent suite) and Start → no worktree is
+		// created; the project's built-in Default workspace becomes active → the welcome unmounts and the
+		// full 3-column surface appears, scoped to the project folder itself.
 		await dialog.getByTestId("ws-prompt").fill("");
+		await expect(page.getByTestId("create-workspace")).toHaveText(/Start/);
 		await page.getByTestId("create-workspace").click();
 		await expect(dialog).toBeHidden();
 		await expect(page.getByTestId("welcome")).toHaveCount(0);
 		await expect(page.getByTestId("center-tabs")).toBeVisible();
 		await expect(page.getByTestId("right-panel")).toBeVisible();
 		await expect(page.getByTestId("terminal-panel")).toBeVisible();
+		await expect(
+			page.locator('[data-testid="workspace-item"][data-kind="default"]'),
+		).toHaveAttribute("data-active", "true");
+		await expect(worktreeRows(page)).toHaveCount(0);
 	} finally {
 		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "checkout", "--", ...FIXTURE_SPECS]);
 	}
@@ -257,13 +271,15 @@ test("opening a non-git folder from the Welcome screen offers to initialise a re
 	await expect(
 		page.getByTestId("project-item").filter({ hasText: basename(E2E_PLAIN_DIR) }),
 	).toBeVisible();
-	// …and the open auto-enters its built-in Default workspace (the folder itself): the IDE surface
-	// mounts, and the just-initialised repo's file is already browsable.
-	await expect(page.getByTestId("center-tabs")).toBeVisible();
-	await expect(page.locator('[data-testid="workspace-item"][data-kind="default"]')).toHaveAttribute(
-		"data-active",
-		"true",
-	);
+	// …and lands on the fresh project's Welcome (no auto-enter): the just-initialised repo has no specs,
+	// so the spec-first funnel leads, with the project-folder fork beside it.
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
+	await expect(page.getByTestId("welcome")).toContainText(basename(E2E_PLAIN_DIR));
+	await expect(page.getByTestId("welcome-cta")).toContainText("Set up project");
+	await expect(
+		page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
+	).toBeVisible();
 });
 
 test("clicking a project returns to its Welcome, deselecting the active workspace", async ({

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -14,11 +14,13 @@ import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 // The first-touch Welcome screen. It replaces the center/right/terminal surface until a workspace is
 // active — and with a project shown it is THE MODE FORK: "Start building" (isolated worktree) always
 // sits beside "Work in project folder" (the built-in Default workspace), so the two working modes are a
-// visible choice, not a hidden default. Opening a project lands here (no auto-enter). Cards by state:
+// visible choice, not a hidden default. Opening a project lands here (no auto-enter). The hero heading is
+// the shown project's name (the ThinkRail wordmark only with no project), and there is no pitch prose.
+// Cards by state:
 //   1. no projects        → one "Open project" card (opens the same dropdown as the projects-rail "+")
-//   2. project, has specs → "Start building" + "Work in project folder" + "Open project"
+//   2. project, has specs → "Start building" + "Work in project folder"
 //   3. project, no specs  → spec-first "Set up project" + "Start building" + "Work in project folder"
-//                           + "Open project"
+// "Open project" is NOT offered once a project is shown — that gesture lives on the projects-rail "+".
 // "Has specs" = the repo has ANY registered spec (a file with id+type frontmatter), via the spec index —
 // not a lowercased goal-and-requirements.md filename. The fixture ships SPEC.md files, so it's "has specs"
 // by default; state 3 is exercised by stripping those specs for the duration of one test.
@@ -35,7 +37,8 @@ test("opens a clean ThinkRail with no projects imported", async ({ page }) => {
 	await expect(page.getByTestId("right-panel")).toHaveCount(0);
 	await expect(page.getByTestId("terminal-panel")).toHaveCount(0);
 
-	// State 1: a single "Open project" card, and no project eyebrow (no project selected yet).
+	// State 1: the wordmark hero (no project) and a single "Open project" card.
+	await expect(page.getByTestId("welcome-title")).toHaveText("ThinkRail");
 	await expect(page.getByTestId("welcome-cta")).toContainText("Open project");
 	await expect(page.getByTestId("welcome-action")).toHaveCount(0);
 
@@ -178,22 +181,22 @@ test("a project with specs offers Start building over Set up, beside the project
 	// The fixture repo already carries SPEC.md files → the host reports it has specs. Opening lands
 	// directly on the project's Welcome — the fork surface (no auto-enter).
 	await openFixtureProject(page);
-	// The active project's name shows as the eyebrow above the wordmark.
-	await expect(page.getByTestId("welcome")).toContainText("sample-project");
+	// The active project's name IS the hero heading (the wordmark only shows with no project).
+	await expect(page.getByTestId("welcome-title")).toHaveText("sample-project");
 	// The global context makes the selected-but-not-active state explicit.
 	const scope = page.getByTestId("scope-context");
 	await expect(scope).toHaveAttribute("data-context", "project-home");
 	await expect(scope).toContainText("sample-project");
 	await expect(scope).toContainText("Project home");
-	// Three cards: Start building (primary) + the project-folder fork + Open project — no "Set up project".
+	// Two cards: Start building (primary) + the project-folder fork — no "Set up project", and no "Open
+	// project" (that gesture is the projects-rail "+" once a project is shown).
 	await expect(page.getByTestId("welcome-cta")).toContainText("Start building");
+	await expect(page.getByTestId("welcome-action")).toHaveCount(1);
 	await expect(
 		page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
 	).toBeVisible();
-	await expect(
-		page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
-	).toBeVisible();
 	await expect(page.getByText("Set up project")).toHaveCount(0);
+	await expect(page.getByTestId("welcome").getByText("Open project")).toHaveCount(0);
 });
 
 test("a project without specs suggests setting it up", async ({ page }) => {
@@ -202,31 +205,34 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 	for (const spec of FIXTURE_SPECS) rmSync(join(E2E_FIXTURE_REPO, spec), { force: true });
 	try {
 		await openFixtureProject(page); // lands on the project's Welcome — the spec-first cards
-		await expect(page.getByTestId("welcome")).toContainText("sample-project");
-		// Four cards: Set up project (primary) + Start building + the project-folder fork + Open project.
+		await expect(page.getByTestId("welcome-title")).toHaveText("sample-project");
+		// Three cards: Set up project (primary) + Start building + the project-folder fork (no "Open project").
 		await expect(page.getByTestId("welcome-cta")).toContainText("Set up project");
+		await expect(page.getByTestId("welcome-action")).toHaveCount(2);
 		await expect(
 			page.getByTestId("welcome-action").filter({ hasText: "Start building" }),
 		).toBeVisible();
 		await expect(
 			page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),
 		).toBeVisible();
-		await expect(
-			page.getByTestId("welcome-action").filter({ hasText: "Open project" }),
-		).toBeVisible();
 
 		// "Set up project" opens the dialog pre-seeded with the skill command, preselected to the
-		// project-folder target (specs are ground truth — they land in place), with the explanatory note
-		// (the header only names the create op) and the mode-aware header; the base-branch picker is
-		// hidden (nothing gets created).
+		// isolated-worktree target (like every other Welcome entry point) with its base-branch picker, plus
+		// the explanatory note (the header only names the create op).
 		await page.getByTestId("welcome-cta").click();
 		const dialog = page.getByTestId("new-workspace-dialog");
 		await expect(dialog).toBeVisible();
 		await expect(dialog.getByTestId("ws-prompt")).toHaveValue(/^\/skill:setting-up-a-project\b/);
-		await expect(dialog.getByTestId("ws-target-default")).toHaveAttribute("data-active", "true");
+		await expect(dialog.getByTestId("ws-target-worktree")).toHaveAttribute("data-active", "true");
+		await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
+		await expect(dialog.getByTestId("ws-branch-picker")).toBeVisible();
+		await expect(dialog.getByTestId("ws-prompt-note")).toContainText("setting-up-a-project skill");
+
+		// The folder alternative stays one click away: switching to Project folder swaps the header and
+		// hides the branch picker (nothing gets created in that mode).
+		await dialog.getByTestId("ws-target-default").click();
 		await expect(dialog.getByRole("heading", { name: "Work in project folder" })).toBeVisible();
 		await expect(dialog).toContainText("no isolation");
-		await expect(dialog.getByTestId("ws-prompt-note")).toContainText("setting-up-a-project skill");
 		await expect(dialog.getByTestId("ws-branch-picker")).toHaveCount(0);
 
 		// Clear the seed (no agent kick-off — keeps this in the no-agent suite) and Start → no worktree is
@@ -275,7 +281,7 @@ test("opening a non-git folder from the Welcome screen offers to initialise a re
 	// so the spec-first funnel leads, with the project-folder fork beside it.
 	await expect(page.getByTestId("welcome")).toBeVisible();
 	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
-	await expect(page.getByTestId("welcome")).toContainText(basename(E2E_PLAIN_DIR));
+	await expect(page.getByTestId("welcome-title")).toHaveText(basename(E2E_PLAIN_DIR));
 	await expect(page.getByTestId("welcome-cta")).toContainText("Set up project");
 	await expect(
 		page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }),

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -222,7 +222,10 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 		await page.getByTestId("welcome-cta").click();
 		const dialog = page.getByTestId("new-workspace-dialog");
 		await expect(dialog).toBeVisible();
-		await expect(dialog.getByTestId("ws-prompt")).toHaveValue(/^\/skill:setting-up-a-project\b/);
+		// The seed is a *completed* command (trailing space, the completion's own insertion format), so the
+		// slash-command menu doesn't pop open over the seeded hero.
+		await expect(dialog.getByTestId("ws-prompt")).toHaveValue("/skill:setting-up-a-project ");
+		await expect(dialog.getByTestId("slash-menu")).toHaveCount(0);
 		await expect(dialog.getByTestId("ws-target-worktree")).toHaveAttribute("data-active", "true");
 		await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
 		await expect(dialog.getByTestId("ws-branch-picker")).toBeVisible();

--- a/e2e/workspace-lifecycle.spec.ts
+++ b/e2e/workspace-lifecycle.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 // Two tabs on ONE host, no agent. Registry membership is backend-owned shared domain state (architecture
 // #9), so a create/remove in one tab streams to the other via the workspace lifecycle pushes — every
@@ -10,26 +10,26 @@ test("workspace removal propagates — no zombie row in a second tab", async ({ 
 	// Tab A: open the project + create a workspace (it becomes A's active workspace).
 	await openFixtureProject(page);
 	const created = await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// Tab B: a second tab on the same host — expand the project (loads the list) + activate the workspace.
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page2.getByTestId("project-expand").first().click();
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(1);
-	await page2.getByTestId("workspace-item").first().click();
-	await expect(page2.getByTestId("workspace-item").first()).toHaveAttribute("data-active", "true");
+	await expect(worktreeRows(page2)).toHaveCount(1);
+	await worktreeRows(page2).first().click();
+	await expect(worktreeRows(page2).first()).toHaveAttribute("data-active", "true");
 
 	// Tab A: remove the workspace (confirm-popover → confirm).
-	await page.getByTestId("workspace-item").first().hover();
-	await page.getByTestId("workspace-item").first().getByTestId("workspace-remove").click();
+	await worktreeRows(page).first().hover();
+	await worktreeRows(page).first().getByTestId("workspace-remove").click();
 	await page.getByTestId("confirm-remove").click();
-	await expect(page.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page)).toHaveCount(0);
 
 	// Tab B converges purely by reacting to the `workspace.removed` push: the row disappears (no zombie),
 	// and — since it was B's active workspace — B returns to the Welcome screen with a neutral toast.
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page2)).toHaveCount(0);
 	await expect(page2.getByTestId("welcome")).toBeVisible();
 	await expect(page2.getByTestId("toast").filter({ hasText: created.name })).toBeVisible();
 });
@@ -43,12 +43,12 @@ test("workspace creation propagates to a second tab's rail", async ({ page, cont
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page2.getByTestId("project-expand").first().click();
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(0);
+	await expect(worktreeRows(page2)).toHaveCount(0); // only the built-in Default row so far
 
 	// Tab A: create a workspace.
 	await createWorkspaceViaDialog(page);
-	await expect(page.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page)).toHaveCount(1);
 
 	// Tab B sees it appear via the `workspace.created` push — no manual re-list, no focus stolen.
-	await expect(page2.getByTestId("workspace-item")).toHaveCount(1);
+	await expect(worktreeRows(page2)).toHaveCount(1);
 });

--- a/e2e/workspace-tabs.spec.ts
+++ b/e2e/workspace-tabs.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
 test("editor tabs are scoped to the active workspace", async ({ page }) => {
 	await openFixtureProject(page);
 	const tabs = page.getByTestId("editor-tab");
-	const workspaces = page.getByTestId("workspace-item");
+	const workspaces = worktreeRows(page);
 
 	// Workspace 1: open README.md in a center tab.
 	await createWorkspaceViaDialog(page);

--- a/e2e/workspace-tabs.spec.ts
+++ b/e2e/workspace-tabs.spec.ts
@@ -6,27 +6,28 @@ test("editor tabs are scoped to the active workspace", async ({ page }) => {
 	const tabs = page.getByTestId("editor-tab");
 	const workspaces = worktreeRows(page);
 
-	// Workspace 1: open README.md in a center tab.
+	// Workspace 1: the create lands in its auto-opened chat; open README.md beside it.
 	await createWorkspaceViaDialog(page);
 	await expect(workspaces).toHaveCount(1);
+	await expect(tabs).toHaveCount(1); // the fresh chat the create landed in
 	await page.getByTestId("tab-files").click();
 	await page.getByTestId("file-node").filter({ hasText: "README.md" }).dblclick();
-	await expect(tabs).toHaveCount(1);
+	await expect(tabs).toHaveCount(2);
 
-	// Workspace 2 is brand new → it must show none of workspace 1's tabs.
+	// Workspace 2 is brand new → only its own fresh chat, none of workspace 1's tabs.
 	await createWorkspaceViaDialog(page);
 	await expect(workspaces).toHaveCount(2);
 	await expect(workspaces.nth(1)).toHaveAttribute("data-active", "true");
-	await expect(tabs).toHaveCount(0);
-	await expect(page.getByTestId("workspace-ready")).toContainText("workspace-2");
+	await expect(tabs).toHaveCount(1);
+	await expect(tabs.filter({ hasText: "README.md" })).toHaveCount(0);
 	await expect(page.getByTestId("scope-name")).toHaveText("workspace-2");
 	await expect(page.getByTestId("scope-branch")).toHaveText("workspace-2");
 
-	// Switching back to workspace 1 restores its tab.
+	// Switching back to workspace 1 restores its tab set (its chat + README).
 	await workspaces.nth(0).getByRole("button").first().click();
 	await expect(workspaces.nth(0)).toHaveAttribute("data-active", "true");
 	await expect(page.getByTestId("scope-name")).toHaveText("workspace-1");
 	await expect(page.getByTestId("scope-branch")).toHaveText("workspace-1");
-	await expect(tabs).toHaveCount(1);
+	await expect(tabs).toHaveCount(2);
 	await expect(tabs.filter({ hasText: "README.md" })).toBeVisible();
 });

--- a/e2e/workspaces.spec.ts
+++ b/e2e/workspaces.spec.ts
@@ -1,13 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
 
 test("creates, removes, and re-creates worktree workspaces (no branch collision)", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
-	const items = page.getByTestId("workspace-item");
+	const items = worktreeRows(page);
 
 	// Create a workspace via the New-Workspace dialog — a real git worktree appears.
 	await createWorkspaceViaDialog(page);

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -25,7 +25,9 @@ A ThinkRail, git-worktree IDE, driven by a CLI you run that opens a browser UI.
 The shell is built first, `pi` connected last:
 
 - **Projects → workspaces**: open a git repo as a project; a workspace is a `git worktree` (own branch +
-  cwd) under `~/.thinkrail/worktrees`.
+  cwd) under `~/.thinkrail/worktrees` — plus one built-in, non-removable **Default workspace** per
+  project (the project folder itself), auto-entered on open so newcomers aren't lost in the worktree
+  model.
 - **Center**: a tabbed area — Monaco file tabs + (once `pi` lands) chat tabs.
 - **Right**: an All-files tree of the active worktree + a Changes (git diff) tab; terminals below,
   scoped to the worktree.

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -26,8 +26,8 @@ The shell is built first, `pi` connected last:
 
 - **Projects → workspaces**: open a git repo as a project; a workspace is a `git worktree` (own branch +
   cwd) under `~/.thinkrail/worktrees` — plus one built-in, non-removable **Default workspace** per
-  project (the project folder itself), auto-entered on open so newcomers aren't lost in the worktree
-  model.
+  project (the project folder itself), offered as an explicit choice on the project's Welcome so
+  newcomers aren't lost in the worktree model.
 - **Center**: a tabbed area — Monaco file tabs + (once `pi` lands) chat tabs.
 - **Right**: an All-files tree of the active worktree + a Changes (git diff) tab; terminals below,
   scoped to the worktree.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -93,7 +93,10 @@ of the host.
   optional **`renamed`** flag is the naming lifecycle — absent = **not yet locked** (either pristine
   `workspace-N`, or a *provisional* non-agentic name the host applied from the first prompt), so still
   eligible for the agentic auto-rename; `true` = deliberately named (agentic or user), never auto-touched
-  again), `Session` (chat tab),
+  again; its optional **`kind: "default"`** marks the built-in per-project **Default workspace** — the
+  project folder itself as a workspace, exactly one per project, pinned first in `workspace.list`,
+  non-removable and non-renamable server-side; absent = a normal worktree workspace — an explicit wire
+  field, never an id convention), `Session` (chat tab),
   `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types; **`ProviderStatus`/`ProviderStatusReport`**
   — the auth-provider status rows the Welcome strip renders (per-provider `configured` + auth `kind`:
   oauth / api-key / env / central / other — never credential values; plus `canOAuth`/`canApiKey`/`canLogout`,

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -53,6 +53,13 @@ export interface Workspace {
 	id: string;
 	projectId: string;
 	/**
+	 * `"default"` marks the built-in per-project **Default workspace** — the project folder itself
+	 * (git's main working tree) surfaced as a workspace. Exactly one per project, pinned first in
+	 * `workspace.list`, non-removable and non-renamable (enforced server-side). Absent = a normal
+	 * worktree workspace. An explicit wire field — clients must never detect it by id convention.
+	 */
+	kind?: "default";
+	/**
 	 * Human-readable display label shown in the UI (Title Case, spaces) — decoupled from `branch`. May
 	 * repeat across workspaces; the branch is what's uniqued. Equals `branch` only for the auto
 	 * `workspace-N` placeholder.

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -79,7 +79,10 @@ import type {
 // pi-ai `getSupportedThinkingLevels`) so the effort picker offers only what the active model can do;
 // `model.clampThinking` exposes pi's own `clampThinkingLevel` for a `{model, level}` pair, so the
 // pre-session picker adjusts effort the same way `model.default` and live sessions already do.
-export const PROTOCOL_VERSION = 17;
+// v18: the built-in Default workspace — `Workspace.kind: "default"` marks the project folder itself as
+// a per-project, non-removable, non-renamable workspace, ensured lazily and pinned first in
+// `workspace.list`; `workspace.remove` rejects it.
+export const PROTOCOL_VERSION = 18;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -28,11 +28,20 @@ warms a remote base ref off the workspace-create critical path.
   added, or a renamed file's new path, degrading to an add-style diff; `modified` = the worktree file,
   empty when deleted; the path is escape-checked against the worktree root); `listBranches(projectId)` → `{ local, remote,
   defaultBranch }` (local `refs/heads`, remote `refs/remotes/origin` minus `origin/HEAD`, default =
-  `origin/HEAD`→`origin/main`→repo `HEAD`); `prefetchBranch(projectId, ref)` — best-effort background
+  `origin/HEAD`→`origin/main`→repo `HEAD`); **`resolveDefaultBranch(repoPath)`** — that default-branch
+  resolution factored out (named once), shared by `listBranches` and the `workspaces` module's
+  Default-workspace ensure (its `baseBranch`); `prefetchBranch(projectId, ref)` — best-effort background
   `git fetch` of a remote ref (via `gitAsync`, branch passed after `--` so a `-`-prefixed name can't be
   parsed as a git option), so a later `createWorkspace` branches off a fresh tip without the network
   round-trip on its critical path (non-`origin/` ref / offline → no-op).
-- **Public surface (barrel):** `git`, `gitAsync`, `gitStatus`, `gitDiffFile`, `listBranches`, `prefetchBranch`.
+- **Public surface (barrel):** `git`, `gitAsync`, `gitStatus`, `gitDiffFile`, `listBranches`,
+  `resolveDefaultBranch`, `prefetchBranch`.
+
+## Get right
+
+- `gitStatus` reports the **live** current branch for a `kind: "default"` workspace (the project
+  folder's branch moves out-of-band — a terminal `git checkout` — and the persisted snapshot self-heals
+  only at list time; the Changes header must not lag).
 - **Allowed deps:** `persistence` (workspace + project lookup); `contracts` (`Git*`/`BranchList` types);
   Bun (spawn).
 - **Forbidden:** `host`; sibling features.

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -30,18 +30,22 @@ warms a remote base ref off the workspace-create critical path.
   defaultBranch }` (local `refs/heads`, remote `refs/remotes/origin` minus `origin/HEAD`, default =
   `origin/HEAD`→`origin/main`→repo `HEAD`); **`resolveDefaultBranch(repoPath)`** — that default-branch
   resolution factored out (named once), shared by `listBranches` and the `workspaces` module's
-  Default-workspace ensure (its `baseBranch`); `prefetchBranch(projectId, ref)` — best-effort background
+  Default-workspace ensure (its `baseBranch`); its last fallback is `currentBranch`, so an unborn `HEAD`
+  resolves to the branch name it will become, never the literal `"HEAD"` (which would persist into a
+  user-visible `baseBranch`); **`currentBranch(repoPath)`** — the branch a checkout currently has out
+  (`symbolic-ref --short HEAD`, unborn-safe; detached → literal `HEAD`), consumed by the `workspaces`
+  module for the Default workspace's folder-truth `branch`; `prefetchBranch(projectId, ref)` — best-effort background
   `git fetch` of a remote ref (via `gitAsync`, branch passed after `--` so a `-`-prefixed name can't be
   parsed as a git option), so a later `createWorkspace` branches off a fresh tip without the network
   round-trip on its critical path (non-`origin/` ref / offline → no-op).
 - **Public surface (barrel):** `git`, `gitAsync`, `gitStatus`, `gitDiffFile`, `listBranches`,
-  `resolveDefaultBranch`, `prefetchBranch`.
+  `resolveDefaultBranch`, `currentBranch`, `prefetchBranch`.
+- **Allowed deps:** `persistence` (workspace + project lookup); `contracts` (`Git*`/`BranchList` types);
+  Bun (spawn).
+- **Forbidden:** `host`; sibling features.
 
 ## Get right
 
 - `gitStatus` reports the **live** current branch for a `kind: "default"` workspace (the project
   folder's branch moves out-of-band — a terminal `git checkout` — and the persisted snapshot self-heals
   only at list time; the Changes header must not lag).
-- **Allowed deps:** `persistence` (workspace + project lookup); `contracts` (`Git*`/`BranchList` types);
-  Bun (spawn).
-- **Forbidden:** `host`; sibling features.

--- a/packages/server/src/git/git.test.ts
+++ b/packages/server/src/git/git.test.ts
@@ -181,3 +181,24 @@ test("prefetchBranch fetches a remote ref and no-ops on a local ref or unknown p
 	expect(await prefetchBranch("p1", "main")).toEqual({ ok: false });
 	expect(await prefetchBranch("nope", "origin/main")).toEqual({ ok: false });
 });
+
+test("gitStatus reads the Default workspace's branch live, not the persisted snapshot", () => {
+	// A default-kind record whose persisted branch is already stale (the folder moved on).
+	writeFileSync(
+		join(dataDir, "workspaces.json"),
+		JSON.stringify([
+			{
+				id: "w-default",
+				projectId: "p1",
+				kind: "default",
+				name: "Default",
+				branch: "main", // stale — the checkout below moves to feature/live
+				worktreePath: repo,
+				baseBranch: "main",
+				renamed: true,
+			},
+		]),
+	);
+	git(repo, "switch", "-c", "feature/live");
+	expect(gitStatus("w-default").branch).toBe("feature/live");
+});

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -44,16 +44,32 @@ export function listBranches(projectId: string): BranchList {
 		.map((parts) => parts[0] ?? "")
 		.filter(Boolean);
 
-	let defaultBranch: string;
-	const head = git(repo, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
-	if (head.ok && head.out) defaultBranch = head.out;
-	else if (remote.includes("origin/main")) defaultBranch = "origin/main";
-	else {
-		const repoHead = git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]);
-		defaultBranch = repoHead.ok && repoHead.out ? repoHead.out : "HEAD";
-	}
+	return { local, remote, defaultBranch: resolveDefaultBranch(repo) };
+}
 
-	return { local, remote, defaultBranch };
+/**
+ * The repo's default branch, resolved from what git knows locally: `origin/HEAD`'s target →
+ * `origin/main` → the repo's current `HEAD` branch. Named once — shared by `listBranches` (the base
+ * picker's preselection) and the `workspaces` module's Default-workspace ensure (its `baseBranch`).
+ */
+export function resolveDefaultBranch(repoPath: string): string {
+	const head = git(repoPath, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+	if (head.ok && head.out) return head.out;
+	if (git(repoPath, ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"]).ok)
+		return "origin/main";
+	const repoHead = git(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+	return repoHead.ok && repoHead.out ? repoHead.out : "HEAD";
+}
+
+/**
+ * The branch a checkout currently has out — `symbolic-ref --short HEAD`, which (unlike `rev-parse
+ * --abbrev-ref`) also answers on an unborn HEAD (a repo with no commits yet). Detached HEAD → the
+ * literal `"HEAD"`. Used for the Default workspace, whose branch is whatever the project folder has
+ * checked out (it moves out-of-band — a terminal `git checkout` — unlike a worktree's pinned branch).
+ */
+export function currentBranch(repoPath: string): string {
+	const head = git(repoPath, ["symbolic-ref", "--short", "HEAD"]);
+	return head.ok && head.out ? head.out : "HEAD";
 }
 
 /**
@@ -177,7 +193,9 @@ export function gitStatus(workspaceId: string): GitStatus {
 	}
 
 	changes.sort((a, b) => a.path.localeCompare(b.path));
-	return { branch: ws.branch, changes };
+	// The Default workspace's branch is folder-truth that moves out-of-band (a terminal `git checkout`);
+	// the persisted snapshot self-heals only at list time, so the Changes header reads it live.
+	return { branch: ws.kind === "default" ? currentBranch(ws.worktreePath) : ws.branch, changes };
 }
 
 /**

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -57,8 +57,9 @@ export function resolveDefaultBranch(repoPath: string): string {
 	if (head.ok && head.out) return head.out;
 	if (git(repoPath, ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"]).ok)
 		return "origin/main";
-	const repoHead = git(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
-	return repoHead.ok && repoHead.out ? repoHead.out : "HEAD";
+	// Last resort: the checkout's own branch. `currentBranch` answers even on an unborn HEAD (a repo
+	// with no commits yet), so the literal "HEAD" never leaks into a persisted, user-visible baseBranch.
+	return currentBranch(repoPath);
 }
 
 /**

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -81,7 +81,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
     **in-flight set** (independent of the naive one — the two passes can overlap on a short turn) dedupes
     concurrent turns/sessions.
   - The **workspace-archive teardown** — the other composition of `agent` + `terminal` + `workspaces` only
-    the host may make. `workspace.remove` reaps *everything* rooted in the worktree but is **non-blocking**:
+    the host may make. `workspace.remove` **rejects a `kind: "default"` workspace loudly, before any
+    side-effect** (the record's `worktreePath` is the project folder — the reclaim's `rm -rf` fallback
+    must never see it; the UI hides Remove, this guard is for buggy/rogue clients). Otherwise it
+    reaps *everything* rooted in the worktree but is **non-blocking**:
     it does the fast part synchronously — `forgetWorkspace` (drop the record → gone from `workspace.list`
     immediately) → `evictSpecIndex` (drop the spec cache) → `closeWorkspaceTerminals` (kill its PTYs) —
     **acks**, then runs the slow reclamation in the **background** (`archiveTeardown`, fire-and-forget):
@@ -92,6 +95,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
     a failed background teardown is `console.warn`ed, never thrown into the void (nothing awaits it), like
     the auto-rename tee. **Archive keeps the branch but not the chat:** the git branch stays (code is
     recoverable), yet chat history is purged with the worktree — a deliberate scope choice, not a leak.
+- **Scratch-dir seeding on chat start:** the `session.create` handler calls `workspaces`'
+  `ensureWorkspaceScratchDir` before creating the session — the Default workspace's gitignored
+  `.thinkrail/context/` lands in the user's repo only when a chat actually starts there (and a
+  worktree's deleted scratch dir self-heals). Host-composed — no new module edges.
 - **Workspace lifecycle fan-out:** `createServer` installs the `workspaces` module's publisher
   (`setWorkspacePublisher`), mapping each domain event `kind` → its `WS_CHANNELS.workspace*` channel
   (`created`/`updated` → the full record; `removed` → `{ projectId, id }`) and `server.publish`ing it. This

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -22,7 +22,11 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `index.html` fallback, the `server.welcome` push, `terminal.data` topic subscribe + `server.publish`,
   the **`provider.login`** channel publish (the `auth` module's session-less login-frame bridge, wired like
   `pi.extensionUi`) and the `provider.*` login handlers, the **`watch` wiring** (inject the
-  `workspace.fsChanged` publish callback into `watch`; call `ensureWatch(workspaceId)` from the
+  `workspace.fsChanged` publish callback into `watch`, plus its **repo-metadata** callback
+  (`setRepoMetaPublisher` → `refreshDefaultWorkspace`) so a `.git` write in a watched worktree **re-syncs a
+  Default workspace's folder-truth branch** — host-mediated, since `watch` has no `workspaces` edge, and
+  self-publishing through the workspace-lifecycle tee; call
+  `ensureWatch(workspaceId)` from the
   workspace-read handlers (`fs.*`, `git.status`/`git.diffFile`, `spec.graph`) — a read is the "a client is
   looking" signal; `stopWatch` in `workspace.remove`'s fast path beside `evictSpecIndex`;
   `stopAllWatches()` in `stop()`), `cancelAllLogins()` in `stop()` before the socket close,

--- a/packages/server/src/host/autoRename.test.ts
+++ b/packages/server/src/host/autoRename.test.ts
@@ -12,6 +12,11 @@ import {
 	maybeNaiveNameWorkspace,
 } from "./autoRename";
 
+/** The project's worktree workspaces — `listWorkspaces` minus the always-ensured Default. */
+function worktrees(projectId = "p1") {
+	return listWorkspaces(projectId).filter((w) => w.kind !== "default");
+}
+
 let dataDir: string;
 let repo: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
@@ -81,7 +86,7 @@ test("renames the workspace off the first settled turn and flags it", async () =
 	expect(renamed?.renamed).toBe(true);
 	expect(renamed?.worktreePath).toBe(ws.worktreePath);
 	expect(runner.calls()).toBe(1);
-	expect(listWorkspaces("p1")[0]?.name).toBe("Add Login Flow");
+	expect(worktrees()[0]?.name).toBe("Add Login Flow");
 });
 
 test("a renamed workspace is never touched again", async () => {
@@ -106,7 +111,7 @@ test("a failed suggestion leaves the flag unset so a later turn retries", async 
 	fakeRunner("!!! ???"); // slugs to nothing → suggestion degrades to null
 
 	expect(await maybeAutoRenameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 
 	fakeRunner("Fix The Parser");
 	const retried = await maybeAutoRenameWorkspace("s1", ws.id, firstTurn);
@@ -120,7 +125,7 @@ test("a throwing runner degrades to null", async () => {
 	});
 
 	expect(await maybeAutoRenameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 });
 
 test("an errored or aborted run never names the workspace", async () => {
@@ -169,7 +174,7 @@ test("a workspace archived during the one-shot is not renamed or resurrected", a
 	release();
 
 	expect(await pending).toBeNull();
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 });
 
 test("a user rename landing during the one-shot wins; the late suggestion is dropped", async () => {
@@ -188,7 +193,7 @@ test("a user rename landing during the one-shot wins; the late suggestion is dro
 	release();
 
 	expect(await pending).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("user picked this");
+	expect(worktrees()[0]?.name).toBe("user picked this");
 });
 
 test("naive-rename names the workspace instantly from the first prompt, provisionally", async () => {
@@ -202,7 +207,7 @@ test("naive-rename names the workspace instantly from the first prompt, provisio
 	expect(named?.worktreePath).toBe(ws.worktreePath); // dir never moves
 	// Provisional: `renamed` stays unset so the agentic pass still refines it.
 	expect(named?.renamed).toBeUndefined();
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 });
 
 test("naive-rename fires only while the name is pristine (workspace-N)", async () => {
@@ -211,14 +216,14 @@ test("naive-rename fires only while the name is pristine (workspace-N)", async (
 
 	// Second turn start: the branch is no longer `workspace-N`, so it never re-fires.
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("Add A Login Form To");
+	expect(worktrees()[0]?.name).toBe("Add A Login Form To");
 });
 
 test("naive-rename never touches a user-named workspace", async () => {
 	const ws = await createWorkspace("p1", "chosen name");
 
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("chosen name");
+	expect(worktrees()[0]?.name).toBe("chosen name");
 });
 
 test("the agentic pass refines a provisional naive name and locks it", async () => {
@@ -236,7 +241,7 @@ test("the agentic pass refines a provisional naive name and locks it", async () 
 
 	// And the now-locked name is inert to a further turn start.
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, firstTurn)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("Add Login Flow");
+	expect(worktrees()[0]?.name).toBe("Add Login Flow");
 });
 
 test("naive-rename resolves null when the first prompt is blank or unusable", async () => {
@@ -244,7 +249,7 @@ test("naive-rename resolves null when the first prompt is blank or unusable", as
 	const punctOnly = async (): Promise<Message[]> => [user("!!! ??? ..."), assistant("hm")];
 
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, punctOnly)).toBeNull();
-	expect(listWorkspaces("p1")[0]?.name).toBe("workspace-1");
+	expect(worktrees()[0]?.name).toBe("workspace-1");
 	expect(await maybeNaiveNameWorkspace("s1", ws.id, async () => [])).toBeNull();
 });
 

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Workspace } from "@thinkrail/contracts";
+import { handleRequest } from "./handlers";
+
+let dataDir: string;
+let repo: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+function git(cwd: string, ...args: string[]): void {
+	const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "ignore", stderr: "ignore" });
+	if (!result.success) throw new Error(`git ${args.join(" ")} failed`);
+}
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-handlers-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	repo = join(dataDir, "repo");
+	mkdirSync(repo);
+	git(repo, "init", "-b", "main");
+	git(repo, "config", "user.email", "t@thinkrail.test");
+	git(repo, "config", "user.name", "test");
+	writeFileSync(join(repo, "README.md"), "# repo\n");
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "init");
+	writeFileSync(
+		join(dataDir, "projects.json"),
+		JSON.stringify([{ id: "p1", name: "repo", path: repo, slug: "repo", lastOpened: 1 }]),
+	);
+});
+
+afterEach(() => {
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("workspace.remove rejects the Default at the handler level, before any teardown side-effect", async () => {
+	// The wire-level guarantee the module guards alone can't pin: the handler must reject a Default
+	// removal *first* — `forgetWorkspace` is its opening statement and throws — so the archive teardown
+	// (spec-cache eviction, watcher stop, PTY kill, background worktree reclaim) never runs for it.
+	const rows = (await handleRequest("workspace.list", { projectId: "p1" })) as Workspace[];
+	const def = rows[0];
+	if (def?.kind !== "default")
+		throw new Error("expected the ensured Default workspace pinned first");
+
+	await expect(handleRequest("workspace.remove", { id: def.id })).rejects.toThrow(
+		"The Default workspace cannot be removed",
+	);
+
+	// The record survived, same id — nothing was torn down or re-minted.
+	const after = (await handleRequest("workspace.list", { projectId: "p1" })) as Workspace[];
+	expect(after.filter((w) => w.kind === "default")).toHaveLength(1);
+	expect(after[0]?.id).toBe(def.id);
+});

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -84,6 +84,7 @@ import { addTodo, listTodos, removeTodo, updateTodo } from "../todos";
 import { ensureWatch, stopWatch } from "../watch";
 import {
 	createWorkspace,
+	ensureWorkspaceScratchDir,
 	forgetWorkspace,
 	getWorkspace,
 	listWorkspaceRecords,
@@ -305,6 +306,9 @@ const handlers: Record<string, Handler> = {
 			thinkingLevel?: ThinkingLevel;
 		};
 		const ws = getWorkspace(p.workspaceId);
+		// Chat start is what seeds the gitignored scratch dir — for the Default workspace this is the one
+		// moment ThinkRail may write into the user's repo (worktrees self-heal a deleted dir the same way).
+		ensureWorkspaceScratchDir(ws);
 		const created = await createSession({
 			cwd: ws.worktreePath,
 			workspaceId: p.workspaceId,

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -19,8 +19,8 @@ import { resolveWorktreeFile } from "../fs";
 import { listProjects, openProject } from "../projects";
 import { getConfig, setSettingsPublisher } from "../settings";
 import { closeAllTerminals, setTerminalPublisher } from "../terminal";
-import { setWatchPublisher, stopAllWatches } from "../watch";
-import { getWorkspace, setWorkspacePublisher } from "../workspaces";
+import { setRepoMetaPublisher, setWatchPublisher, stopAllWatches } from "../watch";
+import { getWorkspace, refreshDefaultWorkspace, setWorkspacePublisher } from "../workspaces";
 import {
 	isPromptCommitted,
 	isSettledTurn,
@@ -169,6 +169,14 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 			JSON.stringify({ channel: WS_CHANNELS.workspaceFsChanged, data: payload }),
 		);
 	});
+
+	// The notifier's second seam, host-mediated (`watch` has no `workspaces` edge): a `.git` write in a
+	// watched worktree re-syncs a **Default** workspace's folder-truth branch, so a `git switch` in its
+	// terminal converges the rail, the top bar and the receipt live instead of only at the next
+	// `workspace.list` — including a branch switch that leaves the working tree byte-identical, which
+	// produces no `fsChanged` frame at all. Cheap and self-publishing (`refreshDefaultWorkspace` emits
+	// `workspace.updated` through the lifecycle tee above); a no-op for worktree workspaces (pinned branch).
+	setRepoMetaPublisher(refreshDefaultWorkspace);
 
 	// Broadcast a server-synced settings change (the full `AppConfig`) to every client so they converge —
 	// the initiator applies on this push too, never optimistically (the workspace-lifecycle pattern). The

--- a/packages/server/src/watch/SPEC.md
+++ b/packages/server/src/watch/SPEC.md
@@ -32,6 +32,14 @@ truth) and visible-panel polling (laggy, wasteful over Tailscale).
   nudge** — a fresh watcher publishes one synthetic wildcard batch after the platform stream's
   registration window (~750ms), because a write landing inside that window is otherwise lost forever
   (an invalidation nudge is idempotent, so the cost is one cheap no-op refetch).
+- **Repo-metadata nudge (second seam):** a `.git` write is *metadata, not content*, so it never becomes
+  an `fsChanged` path (the blackout stands — plumbing storms must not turn into frames). It instead arms a
+  separately debounced (300ms), **pathless** `setRepoMetaPublisher(workspaceId)` nudge, which `host` wires
+  to `refreshDefaultWorkspace` so a **Default** workspace's branch labels converge live. This is the only
+  signal for a change that leaves the working tree byte-identical — `git switch -c <new-branch>` writes
+  nothing outside `.git` — and it is deliberately **not** matched on specific paths (`.git/HEAD`,
+  `.git/logs/HEAD`, …): the platform streams coalesce and report *a* representative path per burst, so
+  which git-internal path surfaces is not reliable. A wildcard event (null filename) nudges it too.
 - **Publish seam:** never imports `host` — `host` injects the publish callback at wiring time (the
   session-publisher tee pattern).
 - **Self-healing per read (out-of-band worktree churn is normal — e2e resets, `rm -rf` in a terminal):**
@@ -42,7 +50,7 @@ truth) and visible-panel polling (laggy, wasteful over Tailscale).
   marker). A watcher that errors mid-flight (ENOSPC, root deleted) is `console.warn`ed and dropped —
   panels fall back to read-on-demand until a later read re-creates it. No idle-stop in V1 (bounded by
   workspaces actually visited).
-- **Public surface (barrel):** `ensureWatch`, `stopWatch`, `stopAllWatches` (+ the publish-callback
-  setter/factory as implemented).
+- **Public surface (barrel):** `ensureWatch`, `stopWatch`, `stopAllWatches`, `setWatchPublisher`,
+  `setRepoMetaPublisher`.
 - **Allowed deps:** `persistence` (workspace lookup); `contracts` (payload type); Bun/Node.
 - **Forbidden:** `host`; sibling features; any pi package.

--- a/packages/server/src/watch/index.ts
+++ b/packages/server/src/watch/index.ts
@@ -1,2 +1,9 @@
 /** Worktree change notifier: lazy per-workspace fs watchers → debounced `workspace.fsChanged` push. */
-export { ensureWatch, isIgnoredPath, setWatchPublisher, stopAllWatches, stopWatch } from "./watch";
+export {
+	ensureWatch,
+	isIgnoredPath,
+	setRepoMetaPublisher,
+	setWatchPublisher,
+	stopAllWatches,
+	stopWatch,
+} from "./watch";

--- a/packages/server/src/watch/watch.test.ts
+++ b/packages/server/src/watch/watch.test.ts
@@ -4,7 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WorkspaceFsChangedPayload } from "@thinkrail/contracts";
 import { createCoalescer } from "./coalesce";
-import { ensureWatch, isIgnoredPath, setWatchPublisher, stopAllWatches, stopWatch } from "./watch";
+import {
+	ensureWatch,
+	isIgnoredPath,
+	setRepoMetaPublisher,
+	setWatchPublisher,
+	stopAllWatches,
+	stopWatch,
+} from "./watch";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -98,6 +105,10 @@ test("isIgnoredPath skips .git and node_modules subtrees and .DS_Store noise", (
 	expect(isIgnoredPath("docs/.DS_Store")).toBe(true);
 	expect(isIgnoredPath("src/index.ts")).toBe(false);
 	expect(isIgnoredPath("SPEC.md")).toBe(false);
+	// `.git` stays fully blacked out for *paths* — its churn reaches the host only as the pathless
+	// repo-metadata nudge (see the `setRepoMetaPublisher` test below).
+	expect(isIgnoredPath(".git/HEAD")).toBe(true);
+	expect(isIgnoredPath(".git/logs/HEAD")).toBe(true);
 	// Similar names that are NOT the ignored segments stay live.
 	expect(isIgnoredPath("src/gitignore-parser.ts")).toBe(false);
 	expect(isIgnoredPath("my_node_modules_tool/a.ts")).toBe(false);
@@ -135,6 +146,7 @@ beforeEach(() => {
 afterEach(() => {
 	stopAllWatches();
 	setWatchPublisher(null);
+	setRepoMetaPublisher(null);
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
@@ -149,6 +161,31 @@ test("a watched worktree publishes a debounced fsChanged batch for a new file", 
 	expect(payloads[0]?.workspaceId).toBe("ws1");
 	expect(payloads[0]?.truncated).toBe(false);
 	expect(payloads[0]?.paths).toContain("hello.ts");
+});
+
+test("a .git write nudges the repo-meta sink without ever becoming an fsChanged path", async () => {
+	const nudges: string[] = [];
+	setRepoMetaPublisher((id) => nudges.push(id));
+	ensureWatch("ws1");
+	await sleep(100);
+
+	// Stand in for git's plumbing churn (a `git switch` between content-identical branches writes only
+	// here): the worktree's content never changes, so this is the ONLY signal the branch may have moved.
+	mkdirSync(join(worktree, ".git"), { recursive: true });
+	writeFileSync(join(worktree, ".git", "HEAD"), "ref: refs/heads/live\n");
+	writeFileSync(join(worktree, ".git", "index"), "x\n");
+
+	await waitFor(() => nudges.length > 0);
+	expect(nudges).toEqual(["ws1"]); // debounced: one nudge for the burst
+	// …and nothing under `.git` ever leaks into a client-facing batch.
+	await sleep(600);
+	expect(payloads.filter((p) => p.paths.some((x) => x.includes(".git")))).toHaveLength(0);
+
+	// A stopped watcher's pending nudge is dropped, and later churn stays silent.
+	stopWatch("ws1");
+	writeFileSync(join(worktree, ".git", "HEAD"), "ref: refs/heads/other\n");
+	await sleep(600);
+	expect(nudges).toEqual(["ws1"]);
 });
 
 test("ignored churn (node_modules) never publishes", async () => {

--- a/packages/server/src/watch/watch.ts
+++ b/packages/server/src/watch/watch.ts
@@ -25,14 +25,58 @@ const STARTUP_NUDGE_MS = 750;
 const IGNORED_SEGMENTS = new Set([".git", "node_modules"]);
 /** Exact file names that are pure noise. */
 const IGNORED_NAMES = new Set([".DS_Store"]);
+/**
+ * Debounce for the repo-metadata nudge (below). Its own timer, not the file coalescer's: git plumbing
+ * churns in bursts (a checkout, a commit, a rebase), and the nudge is a single "re-read the repo's HEAD"
+ * signal — nothing to accumulate.
+ */
+const REPO_META_DEBOUNCE_MS = 300;
 
 type WatchPublisher = (payload: WorkspaceFsChangedPayload) => void;
+/** The repo-metadata nudge: "this workspace's git metadata moved" — no paths, it isn't file data. */
+type RepoMetaPublisher = (workspaceId: string) => void;
 
 let publish: WatchPublisher | null = null;
+let publishRepoMeta: RepoMetaPublisher | null = null;
 
 /** Host injects the `workspace.fsChanged` publish callback at wiring time (the tee pattern). */
 export function setWatchPublisher(publisher: WatchPublisher | null): void {
 	publish = publisher;
+}
+
+/**
+ * Install (or clear) the **repo-metadata** sink: fired, debounced, whenever a watched worktree's own
+ * `.git` metadata churns (a `git switch`/`commit`/`rebase` in a terminal) — the *only* signal for a
+ * change that leaves the working tree byte-identical, e.g. `git switch -c <new-branch>`, which writes
+ * nothing outside `.git` and would otherwise be invisible to this module. The host uses it to re-sync a
+ * **Default** workspace's folder-truth branch (`refreshDefaultWorkspace`) so every branch label converges
+ * live. Deliberately NOT a client push: `.git` internals are not worktree content, and the app's clients
+ * re-read state through the workspace-lifecycle event the host emits from this.
+ */
+export function setRepoMetaPublisher(publisher: RepoMetaPublisher | null): void {
+	publishRepoMeta = publisher;
+}
+
+/** Whether a watch event belongs to the worktree's own git metadata (its `.git` dir), not its content. */
+function isRepoMetaPath(relPath: string): boolean {
+	return relPath.split(/[\\/]/)[0] === ".git";
+}
+
+/**
+ * (Re)arm the debounced repo-metadata nudge for a workspace — fired once a burst of `.git` writes goes
+ * quiet, and only while this watcher is still the live one (a torn-down watcher never publishes).
+ */
+function scheduleRepoMeta(workspaceId: string, watcher: FSWatcher): void {
+	const entry = entries.get(workspaceId);
+	if (entry && entry.watcher !== watcher) return;
+	if (entry?.metaTimer) clearTimeout(entry.metaTimer);
+	const timer = setTimeout(() => {
+		const live = entries.get(workspaceId);
+		if (!live || live.watcher !== watcher) return;
+		live.metaTimer = null;
+		publishRepoMeta?.(workspaceId);
+	}, REPO_META_DEBOUNCE_MS);
+	if (entry) entry.metaTimer = timer;
 }
 
 /** True when a watch event's relative path should not notify anyone. */
@@ -51,6 +95,8 @@ interface WatchEntry {
 	rootIno: number;
 	/** The pending one-shot startup nudge, cleared on stop so a torn-down watcher never publishes. */
 	nudgeTimer: ReturnType<typeof setTimeout>;
+	/** The pending debounced repo-metadata nudge (see `setRepoMetaPublisher`), cleared on stop. */
+	metaTimer: ReturnType<typeof setTimeout> | null;
 }
 
 const entries = new Map<string, WatchEntry>();
@@ -98,6 +144,10 @@ export function ensureWatch(workspaceId: string): void {
 		const watcher = watch(ws.worktreePath, { recursive: true }, (_event, filename) => {
 			// `filename` can be null (platform edge) → treat as wildcard rather than dropping the signal.
 			const rel = typeof filename === "string" ? filename.replaceAll("\\", "/") : null;
+			// A `.git` write is metadata, not content: it never reaches clients as a path (the blackout below
+			// stands — plumbing storms must not become fsChanged frames), it only nudges the repo-meta sink.
+			// A wildcard (unknown path) nudges both, since it may well *be* a metadata change.
+			if (rel === null || isRepoMetaPath(rel)) scheduleRepoMeta(workspaceId, watcher);
 			if (rel !== null && isIgnoredPath(rel)) return;
 			coalescer.add(rel);
 		});
@@ -112,7 +162,7 @@ export function ensureWatch(workspaceId: string): void {
 				publish?.({ workspaceId, paths: [], truncated: true });
 			}
 		}, STARTUP_NUDGE_MS);
-		entries.set(workspaceId, { watcher, coalescer, rootIno, nudgeTimer });
+		entries.set(workspaceId, { watcher, coalescer, rootIno, nudgeTimer, metaTimer: null });
 	} catch (err) {
 		coalescer.dispose();
 		console.warn(`could not watch worktree for ${workspaceId}: ${err}`);
@@ -125,6 +175,7 @@ export function stopWatch(workspaceId: string): void {
 	if (!entry) return;
 	entries.delete(workspaceId);
 	clearTimeout(entry.nudgeTimer);
+	if (entry.metaTimer) clearTimeout(entry.metaTimer);
 	entry.coalescer.dispose();
 	entry.watcher.close();
 }

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -79,7 +79,10 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   scratch dir (mkdir + self-ignoring `*` `.gitignore`); the host calls it on **session create** for
   every workspace, so the Default workspace writes into the user's repo only when a chat actually
   starts there (worktree creation still seeds eagerly at create; this also self-heals a worktree
-  whose scratch dir was deleted).
+  whose scratch dir was deleted). The `.gitignore` write is **non-clobbering — only when the file is
+  absent**: in the Default workspace that path is inside the user's own repo, where an existing
+  (possibly tracked, possibly customized) file is theirs to keep; seeding fills the gap, never
+  overwrites (pinned by a regression test).
 - **Lifecycle events:** every membership mutation — `createWorkspace` (`created`), `renameWorkspace`
   (`updated`, both the naive and agentic auto-rename passes since both go through it), `forgetWorkspace`
   (`removed`) — emits a `WorkspaceLifecycleEvent` through an **injected publisher** (`setWorkspacePublisher`,

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -36,7 +36,9 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   [[submodule-workflow-skills]]'s artifacts rules); a **user-supplied name is the display name** (casing +
   punctuation preserved via `toDisplayName`; the branch is derived from it) and **sets `renamed: true`** at
   create — the user already chose, so the auto-namer never touches it; auto-`workspace-N` leaves it unset,
-  where `name === branch`),
+  where `name === branch`; **re-reads the registry after the awaited fallback fetch** before appending —
+  the pre-await snapshot is stale by then, and saving it would clobber a concurrent list's Default-ensure
+  (same discipline as `renameWorkspace`'s re-load after its git subprocess)),
   `renameWorkspace` (**sync**; sets the **display `name`** (sanitized, casing preserved) and derives the
   **git branch** from it via `toBranch`, uniqued against refs + worktree dirs, `git branch -m` from the
   project repo — the branch ref moves and the worktree's HEAD follows, but the **worktree dir never moves**
@@ -58,19 +60,30 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   and the slow git reclaim are separable (the host archives off the request's critical path):
   `forgetWorkspace(id)` (drop the persistence record, return the removed record or `null` — gone from
   `listWorkspaces` immediately), `reclaimWorktree(ws)` (the slow half — `git worktree remove --force`,
-  keeps the branch; hardened: rm + `prune` if git fails), and `removeWorkspace(id)` (the synchronous
+  keeps the branch; hardened: rm + `prune` if git fails; **refuses the Default and, defense-in-depth,
+  any record whose `worktreePath` resolves to the project folder** — the rm-fallback must never see the
+  user's repo, however a corrupt/hand-edited record got there), and `removeWorkspace(id)` (the synchronous
   composition of the two, kept for callers/tests that want the whole archive in one call).
 - **Default workspace (`kind: "default"`):** exactly one per project. `listWorkspaces` **ensures** it
   — find-or-create by `projectId`+`kind` (id a plain `randomUUID`; the `kind` field is the marker,
   never an id convention), **collapsing duplicates** defensively if out-of-band state churn ever
-  produced two — and returns it **pinned first**. No `git worktree add` (the folder already is the
+  produced two — and returns it **pinned first**. The in-list ensure is a **deliberate CQS exception**:
+  the query performs a registry write + lifecycle emit so that *any* caller self-heals out-of-band state
+  churn (backfills projects opened before the feature; the e2e reset rewrites `workspaces.json` mid-run)
+  — the write is to the app's registry under the data dir, never into the user's repo. No `git worktree
+  add` (the folder already is the
   main working tree) and **no scratch-dir seeding at ensure** — merely listing a project must never
-  write into the user's repo (see `ensureWorkspaceScratchDir`). Fields are folder-truth, refreshed
-  quietly at list time when drifted (no lifecycle event — membership didn't change): `branch` = the
+  write into the user's repo (see `ensureWorkspaceScratchDir`). Fields are folder-truth, refreshed at
+  list time when drifted — **emitting `updated`** so every client's rail converges instead of one tab
+  staying stale after a terminal `git checkout` (`renameWorkspace` uses the same channel for the same
+  fields; the store's merge triggers no re-list, so there's no feedback loop): `branch` = the
   folder's current HEAD (`symbolic-ref --short`, unborn-safe; detached → literal `HEAD`), `baseBranch`
-  = the repo's default branch via `git`'s `resolveDefaultBranch` — so Default's Changes measure like
+  = the repo's default branch via `git`'s `resolveDefaultBranch` (unborn-safe — its last fallback is
+  `currentBranch`, so the literal `"HEAD"` never persists) — so Default's Changes measure like
   any workspace, degenerating to uncommitted work when the folder sits on the default branch itself.
-  First materialization emits `created` (idempotent for stores). **Non-removable + non-renamable,
+  First materialization emits `created` (idempotent for stores); a drift-free list emits nothing. Every
+  ensure emit — `created`, `updated`, the collapse's `removed`s — happens **after** the save, matching
+  the module's persist-then-publish order everywhere else. **Non-removable + non-renamable,
   enforced here, not just hidden in the UI:** `forgetWorkspace` and `renameWorkspace` **throw** on
   `kind: "default"` — forget would hand the archive teardown's `rm -rf` fallback the project folder,
   rename would `git branch -m` the user's real branch; the record carries `renamed: true` so both
@@ -79,10 +92,14 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   scratch dir (mkdir + self-ignoring `*` `.gitignore`); the host calls it on **session create** for
   every workspace, so the Default workspace writes into the user's repo only when a chat actually
   starts there (worktree creation still seeds eagerly at create; this also self-heals a worktree
-  whose scratch dir was deleted). The `.gitignore` write is **non-clobbering — only when the file is
-  absent**: in the Default workspace that path is inside the user's own repo, where an existing
-  (possibly tracked, possibly customized) file is theirs to keep; seeding fills the gap, never
-  overwrites (pinned by a regression test).
+  whose scratch dir was deleted). Hardened, because in the Default workspace it runs against
+  **repository-controlled content**: it **throws when the workspace root is missing** (an externally
+  deleted worktree must fail the session loudly, not be resurrected as an empty non-git dir); it
+  **refuses symlinked path components** (`lstat`, never followed — a malicious checkout can't redirect
+  the seed outside the workspace); and the `.gitignore` write is **exclusive-create (`wx`) — only when
+  the file is absent**: in the Default workspace that path is inside the user's own repo, where an
+  existing (possibly tracked, possibly customized) file is theirs to keep, and `O_EXCL` never follows
+  a (possibly dangling) symlink; seeding fills the gap, never overwrites (pinned by regression tests).
 - **Lifecycle events:** every membership mutation — `createWorkspace` (`created`), `renameWorkspace`
   (`updated`, both the naive and agentic auto-rename passes since both go through it), `forgetWorkspace`
   (`removed`) — emits a `WorkspaceLifecycleEvent` through an **injected publisher** (`setWorkspacePublisher`,

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -15,6 +15,10 @@ chats. Its **display `name` is decoupled from its git `branch`**: `name` is a hu
 (Title Case, spaces) and `branch` is a kebab slug derived from it — they were once held equal, and still
 coincide for the auto `workspace-N` placeholder, but a named workspace carries both distinctly.
 
+Every project also carries **exactly one built-in Default workspace** (`kind: "default"`) whose
+`worktreePath` is the project folder itself (git's *main working tree*) — the "just work in my project
+folder" anchor, ensured lazily, **non-removable and non-renamable**.
+
 ## Boundary
 
 - **Owns:** `createWorkspace` (**async**; off `baseRef` when given — branched with `worktree add -b`, never a detached
@@ -56,6 +60,26 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   `listWorkspaces` immediately), `reclaimWorktree(ws)` (the slow half — `git worktree remove --force`,
   keeps the branch; hardened: rm + `prune` if git fails), and `removeWorkspace(id)` (the synchronous
   composition of the two, kept for callers/tests that want the whole archive in one call).
+- **Default workspace (`kind: "default"`):** exactly one per project. `listWorkspaces` **ensures** it
+  — find-or-create by `projectId`+`kind` (id a plain `randomUUID`; the `kind` field is the marker,
+  never an id convention), **collapsing duplicates** defensively if out-of-band state churn ever
+  produced two — and returns it **pinned first**. No `git worktree add` (the folder already is the
+  main working tree) and **no scratch-dir seeding at ensure** — merely listing a project must never
+  write into the user's repo (see `ensureWorkspaceScratchDir`). Fields are folder-truth, refreshed
+  quietly at list time when drifted (no lifecycle event — membership didn't change): `branch` = the
+  folder's current HEAD (`symbolic-ref --short`, unborn-safe; detached → literal `HEAD`), `baseBranch`
+  = the repo's default branch via `git`'s `resolveDefaultBranch` — so Default's Changes measure like
+  any workspace, degenerating to uncommitted work when the folder sits on the default branch itself.
+  First materialization emits `created` (idempotent for stores). **Non-removable + non-renamable,
+  enforced here, not just hidden in the UI:** `forgetWorkspace` and `renameWorkspace` **throw** on
+  `kind: "default"` — forget would hand the archive teardown's `rm -rf` fallback the project folder,
+  rename would `git branch -m` the user's real branch; the record carries `renamed: true` so both
+  auto-rename passes stay away as belt-and-suspenders.
+- **`ensureWorkspaceScratchDir(ws)`** — idempotent seed of the gitignored `WORKSPACE_CONTEXT_DIR`
+  scratch dir (mkdir + self-ignoring `*` `.gitignore`); the host calls it on **session create** for
+  every workspace, so the Default workspace writes into the user's repo only when a chat actually
+  starts there (worktree creation still seeds eagerly at create; this also self-heals a worktree
+  whose scratch dir was deleted).
 - **Lifecycle events:** every membership mutation — `createWorkspace` (`created`), `renameWorkspace`
   (`updated`, both the naive and agentic auto-rename passes since both go through it), `forgetWorkspace`
   (`removed`) — emits a `WorkspaceLifecycleEvent` through an **injected publisher** (`setWorkspacePublisher`,
@@ -66,6 +90,7 @@ coincide for the auto `workspace-N` placeholder, but a named workspace carries b
   self-publishes), so registry membership stays shared domain state across every client (architecture #9).
 - **Public surface (barrel):** `createWorkspace`, `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`,
   `reclaimWorktree`, `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`,
+  `ensureWorkspaceScratchDir`,
   `setWorkspacePublisher`, `WorkspaceLifecycleEvent`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -81,6 +81,14 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   = the repo's default branch via `git`'s `resolveDefaultBranch` (unborn-safe — its last fallback is
   `currentBranch`, so the literal `"HEAD"` never persists) — so Default's Changes measure like
   any workspace, degenerating to uncommitted work when the folder sits on the default branch itself.
+  Drift is **not** only a list-time discovery: `refreshDefaultWorkspace(workspaceId)` is the same
+  re-sync **without** the diff-stat listing (two cheap git reads; unknown id / a worktree workspace /
+  no drift → no save, no emit), which the host wires to `watch`'s **repo-metadata nudge** (host-mediated,
+  `watch` has no `workspaces` edge — see [[submodule-server-watch]]). So a `git switch` in the Default
+  workspace's terminal converges the rail, the top bar and the empty receipt live, instead of leaving
+  them on the old branch until a manual project reload — including a switch that leaves the working tree
+  byte-identical (`git switch -c`), which writes nothing outside `.git` (`gitStatus` reads its header branch live for
+  the same reason — see [[submodule-server-git]]).
   First materialization emits `created` (idempotent for stores); a drift-free list emits nothing. Every
   ensure emit — `created`, `updated`, the collapse's `removed`s — happens **after** the save, matching
   the module's persist-then-publish order everywhere else. **Non-removable + non-renamable,
@@ -110,7 +118,7 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   self-publishes), so registry membership stays shared domain state across every client (architecture #9).
 - **Public surface (barrel):** `createWorkspace`, `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`,
   `reclaimWorktree`, `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`,
-  `ensureWorkspaceScratchDir`,
+  `refreshDefaultWorkspace`, `ensureWorkspaceScratchDir`,
   `setWorkspacePublisher`, `WorkspaceLifecycleEvent`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	createWorkspace,
+	ensureWorkspaceScratchDir,
 	forgetWorkspace,
 	listWorkspaces,
 	reclaimWorktree,
@@ -25,6 +26,11 @@ const savedDataDir = process.env.THINKRAIL_DATA_DIR;
 function git(cwd: string, ...args: string[]): void {
 	const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "ignore", stderr: "ignore" });
 	if (!result.success) throw new Error(`git ${args.join(" ")} failed`);
+}
+
+/** The project's worktree workspaces — `listWorkspaces` minus the always-ensured Default. */
+function worktrees(projectId = "p1") {
+	return listWorkspaces(projectId).filter((w) => w.kind !== "default");
 }
 
 beforeEach(() => {
@@ -127,8 +133,8 @@ test("renameWorkspace moves the branch in place: record + git follow, the worktr
 		"workspace-1",
 	);
 	// And the record on disk agrees.
-	expect(listWorkspaces("p1")[0]?.name).toBe("add login flow");
-	expect(listWorkspaces("p1")[0]?.branch).toBe("add-login-flow");
+	expect(worktrees()[0]?.name).toBe("add login flow");
+	expect(worktrees()[0]?.branch).toBe("add-login-flow");
 });
 
 test("renameWorkspace with lock:false renames name + branch but leaves renamed unset (provisional)", async () => {
@@ -139,7 +145,7 @@ test("renameWorkspace with lock:false renames name + branch but leaves renamed u
 	expect(renamed.branch).toBe("add-login-flow");
 	expect(renamed.renamed).toBeUndefined(); // still eligible for the agentic refinement
 	expect(gitOut(ws.worktreePath, "rev-parse", "--abbrev-ref", "HEAD")).toBe("add-login-flow");
-	expect(listWorkspaces("p1")[0]?.renamed).toBeUndefined();
+	expect(worktrees()[0]?.renamed).toBeUndefined();
 
 	// A later default (lock) rename still moves the branch and now locks it.
 	const locked = renameWorkspace(ws.id, "final name");
@@ -197,12 +203,12 @@ test("creating after a rename skips the freed name whose worktree dir is still o
 
 test("forgetWorkspace drops the record + returns it, but leaves the worktree for a separate reclaim", async () => {
 	const ws = await createWorkspace("p1");
-	expect(listWorkspaces("p1")).toHaveLength(1);
+	expect(worktrees()).toHaveLength(1);
 
 	// forgetWorkspace removes the record synchronously (gone from the list) and hands back the record…
 	const forgotten = forgetWorkspace(ws.id);
 	expect(forgotten?.id).toBe(ws.id);
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 	// …but the worktree is still registered with git (the slow reclaim runs separately, e.g. backgrounded).
 	const before = Bun.spawnSync(["git", "-C", repo, "worktree", "list"], { stdout: "pipe" });
 	expect(new TextDecoder().decode(before.stdout)).toContain(ws.worktreePath);
@@ -238,20 +244,117 @@ test("a null publisher makes lifecycle emits silent no-ops", async () => {
 	setWorkspacePublisher(null);
 	const ws = await createWorkspace("p1");
 	expect(() => removeWorkspace(ws.id)).not.toThrow();
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 });
 
 test("removeWorkspace cleans up even when the worktree dir is already gone", async () => {
 	const ws = await createWorkspace("p1");
-	expect(listWorkspaces("p1")).toHaveLength(1);
+	expect(worktrees()).toHaveLength(1);
 
 	// Simulate drift: delete the worktree dir behind git's back so `git worktree remove` can't.
 	rmSync(ws.worktreePath, { recursive: true, force: true });
 
 	expect(() => removeWorkspace(ws.id)).not.toThrow();
-	expect(listWorkspaces("p1")).toHaveLength(0);
+	expect(worktrees()).toHaveLength(0);
 
 	// git's worktree registration is pruned — no orphan left behind.
 	const list = Bun.spawnSync(["git", "-C", repo, "worktree", "list"], { stdout: "pipe" });
 	expect(new TextDecoder().decode(list.stdout)).not.toContain(ws.worktreePath);
+});
+
+// ─── The built-in Default workspace (kind: "default") ────────────────────────────────────────────
+
+test("listWorkspaces ensures exactly one Default workspace, pinned first, with folder-truth fields", async () => {
+	const first = listWorkspaces("p1");
+	const def = first[0];
+	expect(def?.kind).toBe("default");
+	expect(def?.name).toBe("Default");
+	expect(def?.worktreePath).toBe(repo); // the project folder itself — no worktree was added
+	expect(def?.branch).toBe("main");
+	expect(def?.baseBranch).toBe("main"); // no remote → the repo HEAD branch
+	expect(def?.renamed).toBe(true); // the auto-namer must never touch it
+
+	// Idempotent: repeated lists neither duplicate it nor mint a new id.
+	const again = listWorkspaces("p1");
+	expect(again.filter((w) => w.kind === "default")).toHaveLength(1);
+	expect(again[0]?.id).toBe(def?.id);
+
+	// A later worktree create stays behind the pinned Default.
+	await createWorkspace("p1");
+	const rows = listWorkspaces("p1");
+	expect(rows[0]?.kind).toBe("default");
+	expect(rows).toHaveLength(2);
+});
+
+test("the Default workspace's branch and base refresh from the folder on each list", async () => {
+	// A bare remote with main pushed: the default branch resolves to origin/main from here on.
+	const remoteRepo = join(dataDir, "remote.git");
+	git(repo, "init", "--bare", remoteRepo);
+	git(repo, "remote", "add", "origin", remoteRepo);
+	git(repo, "push", "origin", "main");
+	git(repo, "fetch", "origin");
+
+	expect(listWorkspaces("p1")[0]?.baseBranch).toBe("origin/main");
+
+	// The user switches branches in a terminal — the next list reflects the folder, quietly.
+	git(repo, "switch", "-c", "feature/x");
+	const def = listWorkspaces("p1")[0];
+	expect(def?.branch).toBe("feature/x");
+	expect(def?.baseBranch).toBe("origin/main");
+
+	// Committed work on the branch counts against the default branch (the Changes semantics).
+	writeFileSync(join(repo, "new.txt"), "one\ntwo\n");
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "feature work");
+	expect(listWorkspaces("p1")[0]?.diffStats?.added).toBe(2);
+});
+
+test("the Default workspace is non-removable and non-renamable — loud server-side guards", () => {
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+
+	expect(() => forgetWorkspace(def.id)).toThrow("The Default workspace cannot be removed");
+	expect(() => removeWorkspace(def.id)).toThrow("The Default workspace cannot be removed");
+	expect(() => renameWorkspace(def.id, "anything")).toThrow(
+		"The Default workspace cannot be renamed",
+	);
+	// Defense in depth: even handed the record directly, reclaim must never touch the project folder.
+	reclaimWorktree(def);
+	expect(existsSync(join(repo, "README.md"))).toBe(true);
+	// And the record survived every attempt.
+	expect(listWorkspaces("p1")[0]?.id).toBe(def.id);
+});
+
+test("duplicate Default records (out-of-band corruption) collapse to the oldest", () => {
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+
+	// Simulate corruption: a second default record appears behind the module's back.
+	const raw = JSON.parse(readFileSync(join(dataDir, "workspaces.json"), "utf8"));
+	raw.push({ ...def, id: "dupe" });
+	writeFileSync(join(dataDir, "workspaces.json"), JSON.stringify(raw));
+
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
+	const rows = listWorkspaces("p1");
+	expect(rows.filter((w) => w.kind === "default")).toHaveLength(1);
+	expect(rows[0]?.id).toBe(def.id); // the oldest record wins
+	expect(events).toEqual([{ kind: "removed", projectId: "p1", id: "dupe" }]);
+});
+
+test("ensuring the Default emits created once; listing never writes into the project folder", () => {
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
+
+	listWorkspaces("p1");
+	listWorkspaces("p1");
+	expect(events.map((e) => e.kind)).toEqual(["created"]); // once, not per list
+
+	// Listing/entering must not seed the scratch dir in the user's repo — only a chat start does.
+	expect(existsSync(join(repo, ".thinkrail"))).toBe(false);
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+	ensureWorkspaceScratchDir(def); // what the host runs on session.create
+	expect(readFileSync(join(repo, ".thinkrail", "context", ".gitignore"), "utf8")).toBe("*\n");
+	expect(gitOut(repo, "status", "--porcelain")).not.toContain(".thinkrail");
 });

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -108,6 +108,27 @@ test("createWorkspace seeds a self-ignoring .thinkrail/context scratch dir kept 
 	expect(gitOut(ws.worktreePath, "status", "--porcelain")).not.toContain(".thinkrail");
 });
 
+test("ensureWorkspaceScratchDir never clobbers an existing .gitignore (the Default workspace is the user's repo)", async () => {
+	// The Default workspace's scratch dir lives inside the user's own project folder, where a
+	// pre-existing (possibly tracked, possibly customized) .thinkrail/context/.gitignore is theirs.
+	const contextDir = join(repo, ".thinkrail", "context");
+	mkdirSync(contextDir, { recursive: true });
+	const gitignore = join(contextDir, ".gitignore");
+	writeFileSync(gitignore, "# mine\n!keep.md\n");
+
+	const def = (await listWorkspaces("p1")).find((w) => w.kind === "default");
+	expect(def?.worktreePath).toBe(repo);
+	if (def) ensureWorkspaceScratchDir(def);
+
+	// Preserved byte for byte — seeding only fills the gap, it never overwrites.
+	expect(readFileSync(gitignore, "utf8")).toBe("# mine\n!keep.md\n");
+
+	// And with the file absent, seeding still writes the self-ignoring default.
+	rmSync(gitignore);
+	if (def) ensureWorkspaceScratchDir(def);
+	expect(readFileSync(gitignore, "utf8")).toBe("*\n");
+});
+
 test("createWorkspace marks a user-named workspace renamed; an auto-named one stays eligible", async () => {
 	const auto = await createWorkspace("p1");
 	expect(auto.name).toBe("workspace-1");

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -317,11 +325,23 @@ test("the Default workspace's branch and base refresh from the folder on each li
 
 	expect(listWorkspaces("p1")[0]?.baseBranch).toBe("origin/main");
 
-	// The user switches branches in a terminal — the next list reflects the folder, quietly.
+	// The user switches branches in a terminal — the next list reflects the folder and broadcasts
+	// `updated` so every other client's rail converges (rename uses the same channel).
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
 	git(repo, "switch", "-c", "feature/x");
 	const def = listWorkspaces("p1")[0];
 	expect(def?.branch).toBe("feature/x");
 	expect(def?.baseBranch).toBe("origin/main");
+	expect(events).toHaveLength(1);
+	expect(events[0]).toMatchObject({
+		kind: "updated",
+		workspace: { branch: "feature/x", kind: "default" },
+	});
+
+	// A drift-free list emits nothing further.
+	listWorkspaces("p1");
+	expect(events).toHaveLength(1);
 
 	// Committed work on the branch counts against the default branch (the Changes semantics).
 	writeFileSync(join(repo, "new.txt"), "one\ntwo\n");
@@ -361,6 +381,85 @@ test("duplicate Default records (out-of-band corruption) collapse to the oldest"
 	expect(rows.filter((w) => w.kind === "default")).toHaveLength(1);
 	expect(rows[0]?.id).toBe(def.id); // the oldest record wins
 	expect(events).toEqual([{ kind: "removed", projectId: "p1", id: "dupe" }]);
+});
+
+test("a concurrent list's Default-ensure survives createWorkspace's awaited fallback fetch", async () => {
+	// A remote branch that exists on origin but has no local remote-tracking ref — createWorkspace must
+	// take the awaited-fetch fallback path (its only await, where a concurrent write can interleave).
+	const remoteRepo = join(dataDir, "remote.git");
+	git(repo, "init", "--bare", remoteRepo);
+	git(repo, "remote", "add", "origin", remoteRepo);
+	git(repo, "push", "origin", "main");
+	git(repo, "push", "origin", "main:feature-x");
+	git(repo, "update-ref", "-d", "refs/remotes/origin/feature-x"); // push updated it — drop it again
+
+	const pending = createWorkspace("p1", undefined, "origin/feature-x"); // parked at the fetch await
+	const def = listWorkspaces("p1")[0]; // materializes the Default while the create is in flight
+	expect(def?.kind).toBe("default");
+
+	const ws = await pending;
+	expect(ws.baseBranch).toBe("origin/feature-x");
+	// The Default survived with its original id — the create re-read the registry after its await
+	// instead of saving a stale pre-await snapshot (which would re-mint the Default with a new id).
+	const rows = listWorkspaces("p1");
+	expect(rows.filter((w) => w.kind === "default")).toHaveLength(1);
+	expect(rows[0]?.id).toBe(def?.id);
+	expect(rows).toHaveLength(2);
+});
+
+test("ensureWorkspaceScratchDir refuses a missing workspace root instead of resurrecting it", async () => {
+	const ws = await createWorkspace("p1");
+	rmSync(ws.worktreePath, { recursive: true, force: true });
+	// An externally-deleted worktree must fail the session loudly — not come back as an empty non-git
+	// dir the agent then silently works in.
+	expect(() => ensureWorkspaceScratchDir(ws)).toThrow("Workspace directory is missing");
+	expect(existsSync(ws.worktreePath)).toBe(false);
+});
+
+test("ensureWorkspaceScratchDir never follows symlinks — the checkout controls these paths", () => {
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+	const outside = join(dataDir, "outside");
+	mkdirSync(outside);
+
+	// A symlinked owned component is refused outright — nothing is created through the link.
+	symlinkSync(outside, join(repo, ".thinkrail"));
+	expect(() => ensureWorkspaceScratchDir(def)).toThrow("not a real directory");
+	expect(existsSync(join(outside, "context"))).toBe(false);
+	rmSync(join(repo, ".thinkrail"));
+
+	// A dangling symlink where .gitignore belongs is not followed into a file-create: the exclusive
+	// (`wx`) open refuses symlinks, and the resulting EEXIST is treated as "already seeded".
+	mkdirSync(join(repo, ".thinkrail", "context"), { recursive: true });
+	const planted = join(outside, "planted");
+	symlinkSync(planted, join(repo, ".thinkrail", "context", ".gitignore"));
+	expect(() => ensureWorkspaceScratchDir(def)).not.toThrow();
+	expect(existsSync(planted)).toBe(false);
+});
+
+test("reclaimWorktree refuses a record pointing at the project folder even without the kind flag", () => {
+	const def = listWorkspaces("p1")[0];
+	if (!def) throw new Error("expected the ensured Default workspace");
+	// A corrupt/hand-edited registry record: the `kind` marker lost, the path still the user's repo.
+	// The path-equality guard (not just the flag) must keep the rm-fallback off the project folder.
+	const { kind: _dropped, ...corrupt } = def;
+	reclaimWorktree(corrupt);
+	expect(existsSync(join(repo, "README.md"))).toBe(true);
+});
+
+test("an unborn repo's Default never persists the literal HEAD as its base", () => {
+	// A project whose repo has no commits yet (init'd elsewhere — project.init would commit): the
+	// unborn symbolic-ref still names the branch-to-be, and baseBranch must fall back to it.
+	const bare = join(dataDir, "unborn");
+	mkdirSync(bare);
+	git(bare, "init", "-b", "main");
+	const projects = JSON.parse(readFileSync(join(dataDir, "projects.json"), "utf8"));
+	projects.push({ id: "p2", name: "unborn", path: bare, slug: "unborn", lastOpened: 1 });
+	writeFileSync(join(dataDir, "projects.json"), JSON.stringify(projects));
+
+	const def = listWorkspaces("p2")[0];
+	expect(def?.branch).toBe("main");
+	expect(def?.baseBranch).toBe("main"); // not "HEAD"
 });
 
 test("ensuring the Default emits created once; listing never writes into the project folder", () => {

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -14,8 +14,10 @@ import {
 	createWorkspace,
 	ensureWorkspaceScratchDir,
 	forgetWorkspace,
+	listWorkspaceRecords,
 	listWorkspaces,
 	reclaimWorktree,
+	refreshDefaultWorkspace,
 	removeWorkspace,
 	renameWorkspace,
 	setWorkspacePublisher,
@@ -348,6 +350,33 @@ test("the Default workspace's branch and base refresh from the folder on each li
 	git(repo, "add", "-A");
 	git(repo, "commit", "-m", "feature work");
 	expect(listWorkspaces("p1")[0]?.diffStats?.added).toBe(2);
+});
+
+test("refreshDefaultWorkspace re-syncs and publishes Default drift off the list path", async () => {
+	listWorkspaces("p1"); // ensures the Default
+	const def = listWorkspaceRecords("p1").find((w) => w.kind === "default");
+	if (!def) throw new Error("expected the ensured Default workspace");
+	const worktree = await createWorkspace("p1", "Iso");
+
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
+
+	// No drift → no save, no emit (the live path runs on every worktree-change batch: it must be quiet).
+	refreshDefaultWorkspace(def.id);
+	expect(events).toHaveLength(0);
+
+	// A terminal `git checkout` in the project folder converges without any `workspace.list`.
+	git(repo, "switch", "-c", "feature/live");
+	refreshDefaultWorkspace(def.id);
+	expect(events).toEqual([
+		{ kind: "updated", workspace: { ...def, branch: "feature/live", baseBranch: "feature/live" } },
+	]);
+	expect(listWorkspaceRecords("p1").find((w) => w.id === def.id)?.branch).toBe("feature/live");
+
+	// A worktree workspace's branch is pinned — and an unknown id is a no-op, never a throw.
+	refreshDefaultWorkspace(worktree.id);
+	refreshDefaultWorkspace("nope");
+	expect(events).toHaveLength(1);
 });
 
 test("the Default workspace is non-removable and non-renamable — loud server-side guards", () => {

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -172,11 +172,16 @@ export async function createWorkspace(
  * only node_modules/.git/dist/build, not .gitignore). Worktree creation seeds eagerly; the host also
  * calls this on session create, which is what seeds the **Default** workspace — merely listing or
  * entering it must never write into the user's repo, starting a chat there may.
+ *
+ * The `.gitignore` is written **only when absent**: in the Default workspace this path lives inside the
+ * user's own repo, where a pre-existing (possibly tracked, possibly customized) file is theirs — we
+ * never clobber it, we only fill the gap.
  */
 export function ensureWorkspaceScratchDir(ws: Workspace): void {
 	const contextDir = join(ws.worktreePath, WORKSPACE_CONTEXT_DIR);
 	mkdirSync(contextDir, { recursive: true });
-	writeFileSync(join(contextDir, ".gitignore"), "*\n");
+	const ignoreFile = join(contextDir, ".gitignore");
+	if (!existsSync(ignoreFile)) writeFileSync(ignoreFile, "*\n");
 }
 
 /**

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, lstatSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import type { DiffStats, Project, Workspace } from "@thinkrail/contracts";
 import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
 import { currentBranch, git, gitAsync, resolveDefaultBranch } from "../git";
@@ -114,7 +114,6 @@ export async function createWorkspace(
 	const project = getProjects().find((p) => p.id === projectId);
 	if (!project) throw new Error(`Unknown project: ${projectId}`);
 
-	const all = loadWorkspaces();
 	// A user-supplied name is the display name (casing/punctuation preserved); the branch is derived from
 	// it. Omitted (or unusable) → the auto `workspace-N` placeholder, where name === branch.
 	const displayName = name ? toDisplayName(name) : null;
@@ -159,6 +158,10 @@ export async function createWorkspace(
 		...(displayName ? { renamed: true } : {}),
 	};
 	ensureWorkspaceScratchDir(workspace);
+	// Load the registry only now — after the awaited fallback fetch. A concurrent `workspace.list` may
+	// have written meanwhile (materializing/refreshing the Default); appending to a pre-await snapshot
+	// would clobber that write (same discipline as renameWorkspace's re-load after its git subprocess).
+	const all = loadWorkspaces();
 	all.push(workspace);
 	saveWorkspaces(all);
 	emit({ kind: "created", workspace });
@@ -173,15 +176,32 @@ export async function createWorkspace(
  * calls this on session create, which is what seeds the **Default** workspace — merely listing or
  * entering it must never write into the user's repo, starting a chat there may.
  *
- * The `.gitignore` is written **only when absent**: in the Default workspace this path lives inside the
- * user's own repo, where a pre-existing (possibly tracked, possibly customized) file is theirs — we
- * never clobber it, we only fill the gap.
+ * Hardened — in the Default workspace this runs against **repository-controlled content** inside the
+ * user's own repo:
+ * - The workspace root must already exist: an externally-deleted worktree must fail the session loudly,
+ *   not be silently resurrected as an empty non-git directory.
+ * - Owned path components are walked with `lstat` (never followed) — a malicious checkout can't symlink
+ *   `.thinkrail`/`context` and redirect the seed outside the workspace.
+ * - The `.gitignore` is an **exclusive create** (`wx`): a pre-existing (possibly tracked, possibly
+ *   customized) file is the user's — never clobbered — and `O_EXCL` refuses to follow a (possibly
+ *   dangling) symlink, so the file lands only on a truly vacant path.
  */
 export function ensureWorkspaceScratchDir(ws: Workspace): void {
-	const contextDir = join(ws.worktreePath, WORKSPACE_CONTEXT_DIR);
-	mkdirSync(contextDir, { recursive: true });
-	const ignoreFile = join(contextDir, ".gitignore");
-	if (!existsSync(ignoreFile)) writeFileSync(ignoreFile, "*\n");
+	if (!statSync(ws.worktreePath, { throwIfNoEntry: false })?.isDirectory())
+		throw new Error(`Workspace directory is missing: ${ws.worktreePath}`);
+	let dir = ws.worktreePath;
+	for (const part of WORKSPACE_CONTEXT_DIR.split("/")) {
+		dir = join(dir, part);
+		const entry = lstatSync(dir, { throwIfNoEntry: false });
+		if (!entry) mkdirSync(dir);
+		else if (!entry.isDirectory())
+			throw new Error(`Refusing to seed the scratch dir: not a real directory: ${dir}`);
+	}
+	try {
+		writeFileSync(join(dir, ".gitignore"), "*\n", { flag: "wx" });
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+	}
 }
 
 /**
@@ -193,8 +213,11 @@ export function ensureWorkspaceScratchDir(ws: Workspace): void {
  * already is a working tree) and no scratch-dir seeding (see `ensureWorkspaceScratchDir`).
  *
  * Fields are folder-truth: `branch` = whatever the folder has checked out, `baseBranch` = the repo's
- * default branch — both refreshed **quietly** when they drifted out-of-band (no lifecycle event;
- * membership didn't change). `renamed: true` keeps the auto-rename passes away, belt-and-suspenders on
+ * default branch — both refreshed when they drifted out-of-band, **emitting `updated`** so every
+ * client's rail converges (a terminal `git checkout` must not leave another tab stale; rename uses the
+ * same channel for the same fields, and the store's merge triggers no re-list, so no feedback loop).
+ * Every emit happens **after** the save — persist-then-publish, like every other mutation path.
+ * `renamed: true` keeps the auto-rename passes away, belt-and-suspenders on
  * top of the hard guards in `renameWorkspace`/`forgetWorkspace`.
  */
 function ensureDefaultWorkspace(project: Project): Workspace {
@@ -205,22 +228,22 @@ function ensureDefaultWorkspace(project: Project): Workspace {
 
 	const existing = defaults[0];
 	if (existing) {
-		let dirty = false;
-		if (defaults.length > 1) {
+		const extras = defaults.slice(1);
+		if (extras.length > 0) {
 			// Duplicates are corruption (the ensure is the only writer) — collapse to the oldest record.
-			const extras = defaults.slice(1);
 			const keep = all.filter((w) => !extras.includes(w));
 			all.length = 0;
 			all.push(...keep);
-			dirty = true;
-			for (const extra of extras) emit({ kind: "removed", projectId: project.id, id: extra.id });
 		}
-		if (existing.branch !== branch || existing.baseBranch !== baseBranch) {
+		const drifted = existing.branch !== branch || existing.baseBranch !== baseBranch;
+		if (drifted) {
 			existing.branch = branch;
 			existing.baseBranch = baseBranch;
-			dirty = true;
 		}
-		if (dirty) saveWorkspaces(all);
+		if (extras.length > 0 || drifted) saveWorkspaces(all);
+		// Persist-then-publish: a failed save must not tear down (or update) records still on disk.
+		for (const extra of extras) emit({ kind: "removed", projectId: project.id, id: extra.id });
+		if (drifted) emit({ kind: "updated", workspace: existing });
 		return existing;
 	}
 
@@ -366,6 +389,9 @@ export function reclaimWorktree(ws: Workspace): void {
 	if (ws.kind === "default") return;
 	const project = loadProjects().find((p) => p.id === ws.projectId);
 	if (!project) return;
+	// Defense in depth: never reclaim the repo's main working tree, however the record got here (a
+	// corrupt or hand-edited registry) — git would refuse it, but the rm-fallback below would not.
+	if (resolve(ws.worktreePath) === resolve(project.path)) return;
 	const removed = git(project.path, ["worktree", "remove", "--force", ws.worktreePath]);
 	if (!removed.ok) {
 		rmSync(ws.worktreePath, { recursive: true, force: true });

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { DiffStats, Project, Workspace } from "@thinkrail/contracts";
 import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
-import { git, gitAsync } from "../git";
+import { currentBranch, git, gitAsync, resolveDefaultBranch } from "../git";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
 import { getProjects } from "../projects";
 
@@ -147,13 +147,6 @@ export async function createWorkspace(
 	const added = git(project.path, ["worktree", "add", worktreePath, "-b", branch, baseBranch]);
 	if (!added.ok) throw new Error(`git worktree add failed: ${added.err}`);
 
-	// Ephemeral per-workspace scratch dir for temp docs (task-specs / working files). Its `.gitignore` is
-	// a lone `*` — which matches the `.gitignore` itself — so the whole dir has zero git footprint yet
-	// stays scannable by the spec tools (they ignore only node_modules/.git/dist/build, not .gitignore).
-	const contextDir = join(worktreePath, WORKSPACE_CONTEXT_DIR);
-	mkdirSync(contextDir, { recursive: true });
-	writeFileSync(join(contextDir, ".gitignore"), "*\n");
-
 	const workspace: Workspace = {
 		id: randomUUID(),
 		projectId,
@@ -164,6 +157,77 @@ export async function createWorkspace(
 		// A user-chosen name is a deliberate one — the auto-namer must never touch it. Auto `workspace-N`
 		// leaves the flag unset: eligible for one assist rename.
 		...(displayName ? { renamed: true } : {}),
+	};
+	ensureWorkspaceScratchDir(workspace);
+	all.push(workspace);
+	saveWorkspaces(all);
+	emit({ kind: "created", workspace });
+	return workspace;
+}
+
+/**
+ * Idempotently seed a workspace's ephemeral scratch dir (`WORKSPACE_CONTEXT_DIR`) for temp docs
+ * (task-specs / working files). Its `.gitignore` is a lone `*` — which matches the `.gitignore`
+ * itself — so the whole dir has zero git footprint yet stays scannable by the spec tools (they ignore
+ * only node_modules/.git/dist/build, not .gitignore). Worktree creation seeds eagerly; the host also
+ * calls this on session create, which is what seeds the **Default** workspace — merely listing or
+ * entering it must never write into the user's repo, starting a chat there may.
+ */
+export function ensureWorkspaceScratchDir(ws: Workspace): void {
+	const contextDir = join(ws.worktreePath, WORKSPACE_CONTEXT_DIR);
+	mkdirSync(contextDir, { recursive: true });
+	writeFileSync(join(contextDir, ".gitignore"), "*\n");
+}
+
+/**
+ * Ensure the project's built-in **Default workspace** (`kind: "default"`) — the project folder itself
+ * (git's main working tree) surfaced as a workspace. Exactly one per project: find-or-create keyed by
+ * `projectId` + `kind` (the id is a plain `randomUUID` — the `kind` field is the marker, never an id
+ * convention), collapsing duplicates defensively if out-of-band state churn ever produced two (keep
+ * the oldest, emit `removed` for the rest so clients converge). No `git worktree add` (the folder
+ * already is a working tree) and no scratch-dir seeding (see `ensureWorkspaceScratchDir`).
+ *
+ * Fields are folder-truth: `branch` = whatever the folder has checked out, `baseBranch` = the repo's
+ * default branch — both refreshed **quietly** when they drifted out-of-band (no lifecycle event;
+ * membership didn't change). `renamed: true` keeps the auto-rename passes away, belt-and-suspenders on
+ * top of the hard guards in `renameWorkspace`/`forgetWorkspace`.
+ */
+function ensureDefaultWorkspace(project: Project): Workspace {
+	const all = loadWorkspaces();
+	const defaults = all.filter((w) => w.projectId === project.id && w.kind === "default");
+	const branch = currentBranch(project.path);
+	const baseBranch = resolveDefaultBranch(project.path);
+
+	const existing = defaults[0];
+	if (existing) {
+		let dirty = false;
+		if (defaults.length > 1) {
+			// Duplicates are corruption (the ensure is the only writer) — collapse to the oldest record.
+			const extras = defaults.slice(1);
+			const keep = all.filter((w) => !extras.includes(w));
+			all.length = 0;
+			all.push(...keep);
+			dirty = true;
+			for (const extra of extras) emit({ kind: "removed", projectId: project.id, id: extra.id });
+		}
+		if (existing.branch !== branch || existing.baseBranch !== baseBranch) {
+			existing.branch = branch;
+			existing.baseBranch = baseBranch;
+			dirty = true;
+		}
+		if (dirty) saveWorkspaces(all);
+		return existing;
+	}
+
+	const workspace: Workspace = {
+		id: randomUUID(),
+		projectId: project.id,
+		kind: "default",
+		name: "Default",
+		branch,
+		worktreePath: project.path,
+		baseBranch,
+		renamed: true,
 	};
 	all.push(workspace);
 	saveWorkspaces(all);
@@ -197,6 +261,8 @@ export function renameWorkspace(
 	const project = getProjects().find((p) => p.id === ws.projectId);
 	if (!project) throw new Error(`Unknown project: ${ws.projectId}`);
 
+	// The Default workspace's branch is the user's real branch — renaming would `git branch -m` it.
+	if (ws.kind === "default") throw new Error("The Default workspace cannot be renamed");
 	const displayName = toDisplayName(requestedName);
 	if (!displayName) throw new Error(`Invalid workspace name: ${requestedName}`);
 	const wanted = toBranch(displayName);
@@ -246,9 +312,15 @@ export function setWorkspaceSkillOverride(
 }
 
 export function listWorkspaces(projectId: string): Workspace[] {
-	return loadWorkspaces()
-		.filter((w) => w.projectId === projectId)
-		.map((w) => ({ ...w, diffStats: diffStats(w.worktreePath, w.baseBranch) }));
+	// Lazily ensure the built-in Default workspace on every list: find-or-create is idempotent, backfills
+	// projects opened before the feature existed, and self-heals out-of-band state churn (the e2e reset
+	// rewrites workspaces.json mid-run). Unknown project → no ensure, the filter returns [] as before.
+	const project = getProjects().find((p) => p.id === projectId);
+	if (project) ensureDefaultWorkspace(project);
+	const rows = loadWorkspaces().filter((w) => w.projectId === projectId);
+	// Pin the Default workspace first (creation order would put a backfilled one last).
+	rows.sort((a, b) => (a.kind === "default" ? -1 : 0) - (b.kind === "default" ? -1 : 0));
+	return rows.map((w) => ({ ...w, diffStats: diffStats(w.worktreePath, w.baseBranch) }));
 }
 
 /**
@@ -269,6 +341,10 @@ export function forgetWorkspace(id: string): Workspace | null {
 	const all = loadWorkspaces();
 	const ws = all.find((w) => w.id === id);
 	if (!ws) return null;
+	// Loud, before any side-effect: the record's worktreePath is the project folder — forgetting it
+	// would hand the archive teardown's `rm -rf` fallback the user's repo. The UI offers no Remove for
+	// it; this guard is for buggy/rogue clients.
+	if (ws.kind === "default") throw new Error("The Default workspace cannot be removed");
 	saveWorkspaces(all.filter((w) => w.id !== id));
 	emit({ kind: "removed", projectId: ws.projectId, id: ws.id });
 	return ws;
@@ -280,6 +356,9 @@ export function forgetWorkspace(id: string): Workspace | null {
  * dir if it lingers then `prune` the stale registration so `git worktree list` never orphans it.
  */
 export function reclaimWorktree(ws: Workspace): void {
+	// Defense in depth: never reclaim the project folder itself (`git worktree remove` would refuse the
+	// main working tree, but the hardened rm-fallback below would not).
+	if (ws.kind === "default") return;
 	const project = loadProjects().find((p) => p.id === ws.projectId);
 	if (!project) return;
 	const removed = git(project.path, ["worktree", "remove", "--force", ws.worktreePath]);

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -86,6 +86,24 @@ function nextAutoBranch(project: Project): string {
 	return `workspace-${n}`;
 }
 
+/**
+ * The **Default workspace's** folder-truth fields, read from the project folder itself: `branch` = what it
+ * has checked out, `baseBranch` = the repo's default branch. Both move out-of-band (a terminal `git
+ * switch`), so they are re-read — never trusted from the record — by both sync paths below. Two sync git
+ * spawns: callers read them BEFORE loading the registry snapshot they intend to save (see the call sites).
+ */
+function folderTruth(repoPath: string): { branch: string; baseBranch: string } {
+	return { branch: currentBranch(repoPath), baseBranch: resolveDefaultBranch(repoPath) };
+}
+
+/** Write folder-truth onto a record; `true` when it actually drifted (i.e. a save + `updated` is due). */
+function applyFolderTruth(ws: Workspace, truth: { branch: string; baseBranch: string }): boolean {
+	if (ws.branch === truth.branch && ws.baseBranch === truth.baseBranch) return false;
+	ws.branch = truth.branch;
+	ws.baseBranch = truth.baseBranch;
+	return true;
+}
+
 /** Working-tree changes of a worktree vs its base branch. */
 function diffStats(worktreePath: string, baseBranch: string): DiffStats {
 	const result = git(worktreePath, ["diff", "--shortstat", baseBranch]);
@@ -221,10 +239,13 @@ export function ensureWorkspaceScratchDir(ws: Workspace): void {
  * top of the hard guards in `renameWorkspace`/`forgetWorkspace`.
  */
 function ensureDefaultWorkspace(project: Project): Workspace {
+	// Folder-truth FIRST: these are sync git spawns that block the JS thread, and another process can
+	// rewrite workspaces.json while we sit in them (see `renameWorkspace` below — the e2e reset does
+	// exactly that). Loading after them keeps load→mutate→save one uninterrupted synchronous block.
+	const truth = folderTruth(project.path);
+	const { branch, baseBranch } = truth;
 	const all = loadWorkspaces();
 	const defaults = all.filter((w) => w.projectId === project.id && w.kind === "default");
-	const branch = currentBranch(project.path);
-	const baseBranch = resolveDefaultBranch(project.path);
 
 	const existing = defaults[0];
 	if (existing) {
@@ -235,11 +256,7 @@ function ensureDefaultWorkspace(project: Project): Workspace {
 			all.length = 0;
 			all.push(...keep);
 		}
-		const drifted = existing.branch !== branch || existing.baseBranch !== baseBranch;
-		if (drifted) {
-			existing.branch = branch;
-			existing.baseBranch = baseBranch;
-		}
+		const drifted = applyFolderTruth(existing, truth);
 		if (extras.length > 0 || drifted) saveWorkspaces(all);
 		// Persist-then-publish: a failed save must not tear down (or update) records still on disk.
 		for (const extra of extras) emit({ kind: "removed", projectId: project.id, id: extra.id });
@@ -261,6 +278,30 @@ function ensureDefaultWorkspace(project: Project): Workspace {
 	saveWorkspaces(all);
 	emit({ kind: "created", workspace });
 	return workspace;
+}
+
+/**
+ * Re-sync one **Default workspace** record against folder-truth and publish it when it drifted — the
+ * *live* half of the ensure above, off the `workspace.list` path: cheap (two `symbolic-ref`-class git
+ * reads, **no** diff-stat listing) so the host can call it on `watch`'s debounced **repo-metadata nudge**
+ * (a `.git` write in the worktree). A `git switch` in the Default terminal therefore converges the rail,
+ * the top bar and the empty receipt in every client — including a switch that leaves the working tree
+ * byte-identical — instead of leaving them on the old branch until a manual project reload.
+ * Unknown id / a worktree workspace (its branch is pinned) / no drift → a no-op, no save, no emit.
+ */
+export function refreshDefaultWorkspace(workspaceId: string): void {
+	// A peek decides whether this id is even a Default (only those drift) — nothing is mutated from it.
+	const peek = loadWorkspaces().find((w) => w.id === workspaceId);
+	if (peek?.kind !== "default") return;
+	// Folder-truth, THEN the snapshot we mutate: the git reads block the JS thread and another process can
+	// rewrite workspaces.json meanwhile, so load→mutate→save stays one uninterrupted block (as above).
+	const truth = folderTruth(peek.worktreePath);
+	const all = loadWorkspaces();
+	const ws = all.find((w) => w.id === workspaceId);
+	if (ws?.kind !== "default") return;
+	if (!applyFolderTruth(ws, truth)) return;
+	saveWorkspaces(all);
+	emit({ kind: "updated", workspace: ws });
 }
 
 /**


### PR DESCRIPTION
<img width="1280" height="720" alt="after-no-projects" src="https://github.com/user-attachments/assets/84426c7f-1e07-403a-97fd-90efb5a4f78e" />
<img width="1280" height="720" alt="after-project-nospecs" src="https://github.com/user-attachments/assets/f7e1d01f-c9e4-4b55-b80e-939ff46ae9b9" />
<img width="1280" height="720" alt="after-project-specs" src="https://github.com/user-attachments/assets/a0f684da-f665-446e-80a6-e72892f4a6fd" />
<img width="1280" height="720" alt="after-setup-dialog" src="https://github.com/user-attachments/assets/f7735cd3-e756-4001-b738-07f201f5d1c1" />
