### PR TITLE
feat(website): route PostHog through the p.thinkrail.ai managed proxy

### DIFF
--- a/apps/website/SPEC.md
+++ b/apps/website/SPEC.md
@@ -36,7 +36,7 @@ binary.
 ## Analytics
 
 PostHog (the team's existing project, **EU** cloud). Loaded as **progressive enhancement, production
-only**: `src/analytics.ts` injects PostHog's `array.js` from `eu-assets.i.posthog.com` at runtime and
+only**: `src/analytics.ts` injects PostHog's `array.js` from the first-party proxy at runtime and
 calls `posthog.init()` **only when `location.hostname === "thinkrail.ai"`** — localhost, `vite dev`,
 `preview`, and the `jetbrains.github.io` apex send nothing. The prod gate + config are a pure
 `analyticsConfig(hostname)` function, unit-tested in `src/analytics.test.ts` (`bun:test`, no browser).
@@ -57,6 +57,21 @@ calls `posthog.init()` **only when `location.hostname === "thinkrail.ai"`** — 
     project settings** (Project Settings → Web analytics). If it is off, cookieless events are dropped.
   - Trade-off: the daily salt makes cross-day identity coarse (a visitor returning on a later day
     counts as new); pageview counts stay accurate, unique-visitor counts are approximate.
+- **First-party ingest via PostHog's managed reverse proxy** — `p.thinkrail.ai`, so ad blockers (which
+  match on `*.posthog.com`) don't drop the beacon. One host covers both PostHog EU origins: the proxy
+  routes `/static/*` + `/array/*` to `eu-assets.i.posthog.com` and everything else to
+  `eu.i.posthog.com`, so `api_host` **and** the injected `array.js` URL are the proxy. `ui_host:
+  "https://eu.posthog.com"` stays PostHog's real app origin — mandatory with a proxy, or in-app links
+  and the toolbar point at the proxy. Both are pinned in `analytics.test.ts`.
+  - **Managed, not self-hosted:** PostHog operates it (DNS `CNAME` → their Cloudflare edge; SSL +
+    routing theirs). Consequence: traffic also transits **Cloudflare**, a PostHog
+    [subprocessor](https://posthog.com/subprocessors) under their DPA — no new controller, still EU.
+    We run no proxy infrastructure; the site stays static on GitHub Pages.
+  - Cookieless server-hash identity is unaffected: the proxy forwards `X-Forwarded-For`, so the
+    daily-salt hash still sees the real client IP.
+  - **The host-side sink is deliberately NOT proxied** (`packages/server/src/analytics` keeps
+    `eu.i.posthog.com`): `posthog-node` runs in our own process, where no ad blocker exists — a proxy
+    would add a hop and a subprocessor for nothing.
 - The `phc_…` project key is **public/client-safe** by design (meant to ship in browser code) — not a
   secret, so embedding it in the static build is expected.
 

--- a/apps/website/src/analytics.test.ts
+++ b/apps/website/src/analytics.test.ts
@@ -21,4 +21,12 @@ describe("analyticsConfig", () => {
 		expect(config.disable_session_recording).toBe(true);
 		expect(settings?.key.startsWith("phc_")).toBe(true);
 	});
+
+	test("ingests through the first-party managed proxy, with ui_host still PostHog's app origin", () => {
+		const config = analyticsConfig("thinkrail.ai")?.config ?? {};
+		// A blocker-resistant first-party host: never a *.posthog.com ingest endpoint.
+		expect(config.api_host).toBe("https://p.thinkrail.ai");
+		// Required with a proxy: without it, in-app links/toolbar point at the proxy and break.
+		expect(config.ui_host).toBe("https://eu.posthog.com");
+	});
 });

--- a/apps/website/src/analytics.ts
+++ b/apps/website/src/analytics.ts
@@ -14,8 +14,12 @@
 // apps/website/SPEC.md.
 
 const PROD_HOST = "thinkrail.ai";
-const API_HOST = "https://eu.i.posthog.com";
-const ASSET_HOST = "https://eu-assets.i.posthog.com";
+// PostHog's MANAGED reverse proxy on our own domain (first-party, so ad blockers don't drop it). It
+// fronts both PostHog EU origins: `/static/*` + `/array/*` → eu-assets.i.posthog.com, everything else
+// → eu.i.posthog.com. Hence one host for ingest and assets. `ui_host` must stay the real PostHog app
+// origin so links/toolbar resolve. See apps/website/SPEC.md.
+const PROXY_HOST = "https://p.thinkrail.ai";
+const UI_HOST = "https://eu.posthog.com";
 const PROJECT_KEY = "phc_AFJBcKraEUrfpTrSSMjBGXMHTusYudtFfxWqdevchy8X"; // public/client-safe key
 
 interface PostHogLike {
@@ -41,7 +45,8 @@ export function analyticsConfig(hostname: string): AnalyticsInit | null {
 	return {
 		key: PROJECT_KEY,
 		config: {
-			api_host: API_HOST,
+			api_host: PROXY_HOST,
+			ui_host: UI_HOST,
 			defaults: "2026-05-30",
 			person_profiles: "identified_only",
 			cookieless_mode: "always", // no cookie / local / session storage — identity is a server-side hash
@@ -56,7 +61,7 @@ export function initAnalytics(): void {
 	if (settings === null) return;
 
 	const script = document.createElement("script");
-	script.src = `${ASSET_HOST}/static/array.js`;
+	script.src = `${PROXY_HOST}/static/array.js`;
 	script.async = true;
 	script.crossOrigin = "anonymous";
 	script.addEventListener("load", () => {


### PR DESCRIPTION
PostHog provisioned a **managed reverse proxy** at `p.thinkrail.ai`. This points the website's analytics at it, so the beacon is first-party and ad blockers (which match `*.posthog.com`) stop dropping it.

Verified the proxy is live and fronts both EU origins:

```
$ dig +short p.thinkrail.ai   → …cf-prod-eu-proxy.europehog.com (Cloudflare)
$ curl -sI https://p.thinkrail.ai/static/array.js → HTTP/2 200, application/javascript, 230 kB
```

## Changes

- `apps/website/src/analytics.ts` — one `PROXY_HOST` for **both** `api_host` and the injected
  `array.js` URL (the proxy routes `/static/*` + `/array/*` → `eu-assets.i.posthog.com`, everything
  else → `eu.i.posthog.com`), plus `ui_host: "https://eu.posthog.com"` — mandatory with a proxy, or
  in-app links and the toolbar point at the proxy.
- `apps/website/src/analytics.test.ts` — pins both hosts, so an ingest endpoint can't silently drift
  back to a blockable `*.posthog.com` domain.
- `apps/website/SPEC.md` — records the proxy and its consequences: **managed, not self-hosted** (we
  run no infrastructure; traffic also transits Cloudflare, a PostHog subprocessor under their DPA —
  no new controller, still EU), cookieless server-hash identity unaffected (the proxy forwards
  `X-Forwarded-For`), and why the **host-side `posthog-node` sink stays direct** (in-process, no ad
  blocker exists there — a proxy would add a hop and a subprocessor for nothing).

## Verification

`bun test apps/website` (3 pass) · `bun run lint` · `bun run typecheck` · `bun run check:deps` ·
`bun run --filter @thinkrail/website build`. No app (`apps/web`/host) code is touched, so the e2e
browser suite is unaffected. No UI-visible change — config only.

## Note

The privacy posture is unchanged: still `cookieless_mode: "always"`, `respect_dnt`, no session
recording, no consent banner needed. The "Cookieless server hash mode" project setting remains the
operational dependency.