### PR TITLE
design: visual entity consistency across UI

### DIFF
--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -251,20 +251,22 @@ export function CenterTabs() {
 					data-testid="workspace-ready"
 					className="flex max-w-[440px] flex-col items-center gap-xs"
 				>
-					<span className="font-medium text-hint text-xs uppercase tracking-wider">
+					{/* A neutral status label: plain secondary text, sentence case — not an eyebrow. */}
+					<span className="text-muted text-sm">
 						{isDefault ? "Default workspace" : "Workspace ready"}
 					</span>
-					<h2 className="max-w-full truncate font-medium text-md text-text">
+					<h2 className="max-w-full truncate text-md text-text">
 						{isDefault ? (contextProject?.name ?? activeWorkspace.name) : activeWorkspace.name}
 					</h2>
-					<p className="flex max-w-full items-center gap-xs font-[var(--font-mono)] text-muted text-xs">
+					{/* Branch = metadata, never an entity name: proportional text-xs text-hint end to end. */}
+					<p className="flex max-w-full items-center gap-xs text-hint text-xs">
 						<GitBranch className="size-3.5 shrink-0" />
 						{isDefault ? (
 							<span className="truncate">on {activeWorkspace.branch}</span>
 						) : (
 							<>
 								<span className="truncate">{activeWorkspace.branch}</span>
-								<span className="shrink-0 text-hint">· from {activeWorkspace.baseBranch}</span>
+								<span className="shrink-0">· from {activeWorkspace.baseBranch}</span>
 							</>
 						)}
 					</p>

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -210,8 +210,9 @@ export function WelcomePanel() {
 }
 
 /**
- * One welcome card (Conductor-style: icon top-left, label + explainer bottom-left). The state's primary
- * is a filled-violet card carrying the stable `welcome-cta` hook; others are quiet outlined
+ * One welcome card: a chipless icon, then a top-anchored text block (title in the exact dialog-title
+ * style, muted text-base subtitle). The state's primary is a violet-tinted card carrying the stable
+ * `welcome-cta` hook; others are quiet outlined
  * `welcome-action`s. A `forwardRef` so it can serve as a Radix `asChild` trigger (the "Open project" card
  * hangs the `AddProjectMenu` dropdown off it).
  */
@@ -235,7 +236,9 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			data-testid={cta ? "welcome-cta" : "welcome-action"}
 			{...rest}
 			className={cn(
-				"relative flex h-[150px] w-[220px] flex-col items-start justify-between rounded-[var(--radius-lg)] border p-lg text-left transition-colors",
+				// gap-md without justify-between: the text block is top-anchored after the icon, so titles
+				// share the same start line regardless of subtitle length.
+				"relative flex min-h-[150px] w-[220px] flex-col items-start gap-md rounded-[var(--radius-lg)] border p-lg text-left transition-colors",
 				primary
 					? "border-[var(--primary-40)] bg-[var(--primary-10)] hover:bg-[var(--primary-20)]"
 					: "border-border2 bg-bg hover:border-[var(--primary-40)] hover:bg-elevated",
@@ -243,21 +246,16 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			)}
 		>
 			{tag ? (
-				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 font-[var(--font-mono)] text-[10px] text-primary uppercase tracking-wide">
+				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 text-mono text-primary uppercase tracking-wide">
 					{tag}
 				</span>
 			) : null}
-			<span
-				className={cn(
-					"flex size-9 items-center justify-center rounded-[10px]",
-					primary ? "bg-primary text-on-accent" : "bg-hover text-muted",
-				)}
-			>
-				<Icon className="size-4" />
-			</span>
+			{/* Icons render directly on the card surface — no background chips. */}
+			<Icon className={cn("size-4 shrink-0", primary ? "text-primary" : "text-muted")} />
 			<span className="w-full">
-				<span className="block font-medium text-sm text-text">{title}</span>
-				<span className="mt-0.5 block text-muted text-xs leading-snug">{subtitle}</span>
+				{/* Exact dialog-title style, so card titles and DialogTitle can't drift. */}
+				<span className="block font-semibold text-md text-text leading-none">{title}</span>
+				<span className="mt-xs block text-base text-muted leading-snug">{subtitle}</span>
 			</span>
 		</button>
 	);


### PR DESCRIPTION
Part 3 of 3 of the visual design system work. **Entity/status presentation consistency only** — one canonical rendering per entity role across the product. Based on current `main`.

**Depends on the Typography PR** for the `text-base` / `text-mono` tiers and the 14px `text-md`: this branch builds and passes e2e standalone, but those utilities only resolve to their intended values once the typography PR merges — merge that one first.

## Changes & why they're consistency work
- `panels/WelcomePanel.tsx`
  - Context row = the **project entity's page variant**: one colour for icon + name (`text-muted`), proportional name — mono removed from identity text
  - Cards: chipless icons directly on the card surface; text block top-anchored (`gap-md`, no `justify-between`) so **titles share the same start line** regardless of subtitle length; titles reuse the **exact dialog-title style** (`font-semibold text-md leading-none`) so card titles and `DialogTitle` can't drift; subtitles = muted supporting text; "spec-first" tag = the standard technical-badge pill
- `panels/CenterTabs.tsx` (empty workspace state)
  - "Workspace ready" = a **neutral status label** (sentence-case secondary text) instead of an eyebrow
  - Workspace name = a plain 400 **entity screen heading**
  - Branch row = `text-xs text-hint` metadata end to end — a **branch is metadata, never an entity name** (matches the header scope block)
- `panels/ProjectTree.tsx` — "No workspaces yet" joins the status-label tier (`text-sm text-muted`; deliberate exception to the panels' `text-xs text-hint` empty-state tier)

## Excluded
No token/utility changes (typography PR), no palette/border/surface changes (colour PR), no behaviour — all `data-testid` hooks unchanged.

