### PR TITLE
 Split the turn divider into specs vs changes, each linking the panel that owns it

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -39,7 +39,7 @@ convention; their boundary is held by convention + spec. Sibling edges live here
 | `components` | the app's single `ErrorBoundary` primitive (contains the `ui/` sub-module) | no | [components/SPEC.md](src/components/SPEC.md) |
 | `components/ui` | shadcn primitives, themed with our tokens | no | [components/ui/SPEC.md](src/components/ui/SPEC.md) |
 | `themes` | validated single-file manifests, bundled catalog + atomic token application | yes | [themes/SPEC.md](src/themes/SPEC.md) |
-| `lib` | `cn()` + small shared UI/highlighting helpers | yes | [lib/SPEC.md](src/lib/SPEC.md) |
+| `lib` | `cn()` + the shared UI/path/array primitives + highlighting | yes | [lib/SPEC.md](src/lib/SPEC.md) |
 
 Leaf utilities without their own spec: `constants/` (branding), `utils/` (font scaling), and `styles/`
 (the structural/derived CSS token contract — theme-specific values belong to `themes`). `main.tsx` is the
@@ -55,10 +55,10 @@ screen, not a blank root).
 - `chat` → `contracts` (pi message types, **type-only**), `components/ui`, `lib`; `store` + `transport`
   (**`ChatView` + `useHistorySearch.ts` + `TemplateEditorDialog.tsx` only** — the renderers stay store-free)
 - `auth` → `components/ui` (the dialog is store/transport-free — the panel integrates it; the state types need no imports)
-- `store` → `transport` (**type-only** — `ConnectionStatus`), `chat` (**type-only** — `ChatTurn`/`ToolResultState`), `auth` (**type-only** — `LoginState`; the `foldLoginFrame` reducer lives in `store`, like `reduceExtUi`), `contracts`
+- `store` → `transport` (**type-only** — `ConnectionStatus`), `chat` (**type-only** — `ChatTurn`/`ToolResultState`), `auth` (**type-only** — `LoginState`; the `foldLoginFrame` reducer lives in `store`, like `reduceExtUi`), `contracts`, `lib` (the shared path/array primitives — a leaf, so no cycle)
 - `transport` → `contracts`, `store` (welcome routing; the `store → transport` back-edge is type-only, so
   the runtime graph is acyclic)
-- `components` (`ErrorBoundary`) → none internal (React + `lucide-react` only, so any region can wrap in it); `components/ui` → `lib`
+- `components` (`ErrorBoundary`) → `lib` only (`shallowEqualArrays` for its reset keys — a leaf, so any region can still wrap in it); `components/ui` → `lib`
 - `lib` → `themes` (the lazy highlighter uses the one generic CSS-variable Shiki registration)
 - `themes` → `constants` (the branding storage prefix scopes the first-paint hint)
 - leaves (`constants`, `utils`, `styles`) → none internal

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -11,7 +11,14 @@ import { ArrowDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { Popover, PopoverAnchor, PopoverTrigger } from "@/components/ui/popover";
-import { EMPTY_RUNTIME, SettingsSection, selectSkillsStale, toast, useAppStore } from "@/store";
+import {
+	EMPTY_RUNTIME,
+	SettingsSection,
+	selectSkillsStale,
+	specPathMatcher,
+	toast,
+	useAppStore,
+} from "@/store";
 import { errorText, getTransport } from "@/transport";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { type ChatActions, ChatActionsContext } from "./ChatActions";
@@ -148,6 +155,12 @@ export default function ChatView({
 		}
 		return map;
 	}, [workspaces]);
+	// The workspace's spec graph (fetched + kept fresh by the Specs panel): it tells the turn divider which
+	// of the round's written files are specs, so the two chips deep-link to the panel that can show them.
+	// Subscribed as the stored array (a stable ref) and turned into a matcher here — never a new Set/closure
+	// inside the selector, which would re-render on every store change.
+	const specNodes = useAppStore((s) => s.specsByWorkspace[workspaceId]);
+	const isSpec = useMemo(() => specPathMatcher(specNodes ?? []), [specNodes]);
 	const {
 		turns,
 		toolResults,
@@ -167,8 +180,8 @@ export default function ChatView({
 	// boundaries, so the row model is re-derived per snapshot (pure + memoized; stable row ids keep
 	// Virtuoso keys and fold state steady while streaming).
 	const rows = useMemo(
-		() => deriveRows(turns, toolResults, isStreaming),
-		[turns, toolResults, isStreaming],
+		() => deriveRows(turns, toolResults, isStreaming, isSpec),
+		[turns, toolResults, isStreaming, isSpec],
 	);
 
 	// The streaming loader lives as the list footer (so it forms where the next message will). Suppressed
@@ -502,14 +515,24 @@ export default function ChatView({
 		return () => clearTimeout(timer);
 	}, [flashRowId]);
 
-	// A turn-divider's "files changed" chip → deep-link the right panel to the first changed file (flip to
-	// Changes + highlight its row; the diff opens only on an explicit click). This is the one chat touch of
-	// the store outside the renderers, kept here in the integration layer.
-	const onOpenChanges = useCallback(
-		(paths: string[]) => {
-			const path = paths[0];
-			if (!path) return;
+	// A turn-divider's "files changed" chip → deep-link the right panel to the changed file (flip to Changes
+	// + highlight its row; the diff opens only on an explicit click). The divider hands over exactly one path
+	// — the round's only artifact, or the row the user picked from the expanded list — so nothing here has to
+	// guess which of several the user meant. These are the chat's touches of the store outside the renderers,
+	// kept here in the integration layer.
+	const onOpenChange = useCallback(
+		(path: string) => {
 			useAppStore.getState().requestChangesView(workspaceId, path);
+		},
+		[workspaceId],
+	);
+
+	// Its "N specs" twin → flip to Specs and open the rendered spec. Specs get the stronger treatment (open,
+	// not just highlight) because a spec doc has nothing to preview short of its content — and because a spec
+	// is often gitignored scratch, which the git-derived Changes view can't show at all.
+	const onOpenSpec = useCallback(
+		(path: string) => {
+			useAppStore.getState().requestSpecView(workspaceId, path);
 		},
 		[workspaceId],
 	);
@@ -602,7 +625,8 @@ export default function ChatView({
 									<ChatTurnView
 										row={row}
 										workspaceRoot={workspaceRoot}
-										onOpenChanges={onOpenChanges}
+										onOpenSpec={onOpenSpec}
+										onOpenChange={onOpenChange}
 									/>
 								</div>
 							)}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -537,6 +537,15 @@ export default function ChatView({
 		[workspaceId],
 	);
 
+	// A chip expanding its artifact list asks for the owning view alongside — no path, so nothing is opened
+	// or highlighted: the user is choosing which side of the round to look at, and the panel follows.
+	const onReveal = useCallback(
+		(tab: "specs" | "changes") => {
+			useAppStore.getState().requestRightTab(workspaceId, tab);
+		},
+		[workspaceId],
+	);
+
 	// The questionnaire cards' transcript-derived lifecycle (awaiting / answered / superseded) — provided
 	// as context so the presentational card stays store-free (see askState.ts).
 	const askStates = useMemo(
@@ -627,6 +636,7 @@ export default function ChatView({
 										workspaceRoot={workspaceRoot}
 										onOpenSpec={onOpenSpec}
 										onOpenChange={onOpenChange}
+										onReveal={onReveal}
 									/>
 								</div>
 							)}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -15,6 +15,7 @@ import {
 	EMPTY_RUNTIME,
 	SettingsSection,
 	selectSkillsStale,
+	selectWorkspaceById,
 	specPathMatcher,
 	toast,
 	useAppStore,
@@ -137,13 +138,9 @@ export default function ChatView({
 	// reload. Store-derived per session, so the badge survives tab-switch remounts (a fresh ChatView reads
 	// the same store state) and a reload clears only this chat (see selectSkillsStale / markSkillsSynced).
 	const skillsStale = useAppStore((s) => selectSkillsStale(s, workspaceId, sessionId));
-	const workspaceRoot = useAppStore((s) => {
-		for (const workspaces of Object.values(s.workspaces)) {
-			const workspace = workspaces.find((w) => w.id === workspaceId);
-			if (workspace) return workspace.worktreePath;
-		}
-		return undefined;
-	});
+	const workspaceRoot = useAppStore(
+		(s) => selectWorkspaceById(s, workspaceId)?.worktreePath ?? undefined,
+	);
 	// The raw record is a stable reference from zustand's perspective (unlike a fresh object/array
 	// literal, which would re-render this view on every unrelated store update); the workspaceId →
 	// display-name map the history overlay's cross-workspace chip needs is derived below in a `useMemo`.

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -24,8 +24,8 @@ a future `packages/chat-ui`). Built-in tool renderers live in the child
 The transcript is pi-canonical turns (`ChatTurn` in `types.ts`: user/assistant are pi messages; `system`,
 `error`, `retry` are web-local notices), but the list renders **derived rows, not raw turns** — folding
 spans assistant-message boundaries (pi emits one assistant message per tool round), so a per-turn item
-model can't group. The pure **`deriveRows(turns, toolResults, isStreaming)`** (`rows.ts`) walks blocks in
-order into rows; `ChatTurnView` dispatches on row kind:
+model can't group. The pure **`deriveRows(turns, toolResults, isStreaming, isSpec?)`** (`rows.ts`) walks
+blocks in order into rows; `ChatTurnView` dispatches on row kind:
 
 - `user` / `system` / `retry` — 1:1 renderers. The retry countdown carries a `source` (`turn` =
   pi `auto_retry_*`; `summarization` = compaction/branch-summary `summarization_retry_*`, pi ≥0.81.1) —
@@ -48,12 +48,27 @@ order into rows; `ChatTurnView` dispatches on row kind:
   Errored *routine* steps get **no special treatment** (deliberate — agents often recover; `ErrorTurn`
   and primary error-auto-expand are the safety nets).
 - `divider` — the round-end summary (`TurnDivider` + pure `turnDivider` deriver), anchored the instant a
-  round ends: elapsed time, tool-call count, a clickable "files changed" chip.
+  round ends: elapsed time, tool-call count, and the round's written files as **two chips split the way the
+  right panel is** — "N specs" and "N files changed". The split is a **partition** (a path lands on exactly
+  one side, never counted twice) computed in the deriver from the injected `isSpec` predicate — the store's
+  `specPathMatcher` over the workspace's spec graph, plus `spec_create`'s target, which is a spec by
+  construction even before the graph snapshot catches up. Why it matters: a spec is often **gitignored**
+  scratch (`.thinkrail/context/`), so counting it as a "changed file" deep-linked the user to a Changes view
+  that structurally cannot show it. Each chip now routes to the panel that owns the artifact.
+  **One artifact → the chip is a direct deep link; several → it is a disclosure** that expands the round's
+  set as a list right here in the transcript (`ArtifactChip` + `ArtifactList`), each row deep-linking one
+  path. The set is kept in the chat rather than framed over the panels on purpose: it belongs to *this
+  round*, while the panels show *now* — a round from days ago would mark rows that have since moved on (or,
+  for Changes, are no longer in the diff at all). It also keeps the count honest: clicking "5 files changed"
+  can never quietly surface just the first one, and the handlers take exactly ONE path, so nothing
+  downstream has to guess which of several the user meant.
 
 Row/step ids are stable across streaming snapshots (first step's `toolCallId`, or message-anchored index —
 pi appends, never reorders), so fold state survives re-derivation and virtualization: **every fold surface
-(activity groups, step rows, `ToolCard`) records manual toggles in the shared `foldState` cache**
-(`foldState.ts`, keyed by row/step id — the `AskUserQuestionCard` pattern, see tools/SPEC.md; deliberately
+(activity groups, step rows, `ToolCard`, the divider's multi-artifact chips) records manual toggles in the
+shared `foldState` cache**
+(`foldState.ts`, keyed by row/step id — the divider's two chips key off `${rowId}:specs` / `${rowId}:files`;
+the `AskUserQuestionCard` pattern, see tools/SPEC.md; deliberately
 never evicted — growth is bounded by manual toggles). A manual toggle always wins — over auto-expand
 defaults *and* over a virtualization remount.
 
@@ -469,10 +484,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `store`/`transport` (only `ChatView`, its integration hooks, and `TemplateEditorDialog` may — keep the
   renderers reusable).
 - **`ChatView`** is the primary app-integration file: wires this session's runtime
-  (`store.sessions[sessionId]`), the transport calls, the `ChatActions` + `AskStates` contexts, and the
-  divider's "files changed" → `requestChangesView` deep link — together with **`useHistorySearch.ts`**
-  (the Ctrl+R history-recall overlay's store/transport edge) and **`TemplateEditorDialog.tsx`** (the
-  shared template save form), the other two integration points. A
+  (`store.sessions[sessionId]`), the transport calls, the `ChatActions` + `AskStates` contexts, the
+  divider's deep links (`onOpenChange` → `requestChangesView`, `onOpenSpec` → `requestSpecView`; each
+  receives the single path the user picked), and the
+  `isSpec` classifier it builds from the store's `specsByWorkspace` snapshot (subscribed as the stored array
+  — a stable ref — and memoized into a matcher here, never a fresh Set inside the selector) — together with
+  **`useHistorySearch.ts`** (the Ctrl+R history-recall overlay's store/transport edge) and
+  **`TemplateEditorDialog.tsx`** (the shared template save form), the other two integration points. A
   **rejected** send (`prompt`/`steer`/`followUp`) lands in the chat via the store's `appendErrorTurn` —
   never swallowed; *streaming* faults arrive as pi events instead.
 

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -62,12 +62,20 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   for Changes, are no longer in the diff at all). It also keeps the count honest: clicking "5 files changed"
   can never quietly surface just the first one, and the handlers take exactly ONE path, so nothing
   downstream has to guess which of several the user meant.
+- The two chips are a **switch, not two independent folds**: at most one list is open, choosing the other
+  side replaces it, and re-choosing the open one clears the selection. That invariant is *structural* — the
+  divider stores the **selected key** (`useSelection`, one entry per divider row), so no state exists in
+  which both are expanded. Expanding also **reveals the owning right-panel view** (`onReveal` →
+  `requestRightTab`) without surfacing any path, which is what makes the pair read as switching between
+  Specs and Changes; closing is "never mind" and leaves the panel where the user last sent it.
 
 Row/step ids are stable across streaming snapshots (first step's `toolCallId`, or message-anchored index —
 pi appends, never reorders), so fold state survives re-derivation and virtualization: **every fold surface
 (activity groups, step rows, `ToolCard`, the divider's multi-artifact chips) records manual toggles in the
 shared `foldState` cache**
-(`foldState.ts`, keyed by row/step id — the divider's two chips key off `${rowId}:specs` / `${rowId}:files`;
+(`foldState.ts`, keyed by row/step id. Two hooks over that module: **`useFold`** for independent booleans,
+and **`useSelection`** for a single-choice group — the divider's chips, which store the *selected key* under
+`${rowId}:artifacts` rather than a boolean per side, so "only one list open" cannot be violated;
 the `AskUserQuestionCard` pattern, see tools/SPEC.md; deliberately
 never evicted — growth is bounded by manual toggles). A manual toggle always wins — over auto-expand
 defaults *and* over a virtualization remount.
@@ -486,7 +494,7 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 - **`ChatView`** is the primary app-integration file: wires this session's runtime
   (`store.sessions[sessionId]`), the transport calls, the `ChatActions` + `AskStates` contexts, the
   divider's deep links (`onOpenChange` → `requestChangesView`, `onOpenSpec` → `requestSpecView`; each
-  receives the single path the user picked), and the
+  receives the single path the user picked) plus its view switch (`onReveal` → `requestRightTab`), and the
   `isSpec` classifier it builds from the store's `specsByWorkspace` snapshot (subscribed as the stored array
   — a stable ref — and memoized into a matcher here, never a fresh Set inside the selector) — together with
   **`useHistorySearch.ts`** (the Ctrl+R history-recall overlay's store/transport edge) and

--- a/apps/web/src/chat/foldState.ts
+++ b/apps/web/src/chat/foldState.ts
@@ -28,3 +28,25 @@ export function useFold(id: string, fallback = false): [boolean, () => void] {
 	};
 	return [expanded, toggle];
 }
+
+/** Radio-valued sibling of {@link foldState}: which ONE key is open, per id. Same survival guarantees. */
+const selectionState = new Map<string, string | null>();
+
+/**
+ * A **single-choice** disclosure: at most one of an id's keys is open at a time, and re-choosing the open
+ * one closes it (nothing selected). Used by the turn divider, whose two artifact lists are alternatives
+ * rather than independent folds — storing the *selected key* instead of a boolean per side makes "only one
+ * is open" structural: there is no state in which both are.
+ *
+ * Nothing selected is the default, and a selection survives virtualization + streaming re-derivation like
+ * every other fold in the transcript.
+ */
+export function useSelection(id: string): [string | null, (key: string) => void] {
+	const [selected, setSelected] = useState<string | null>(() => selectionState.get(id) ?? null);
+	const select = (key: string) => {
+		const next = selected === key ? null : key;
+		selectionState.set(id, next);
+		setSelected(next);
+	};
+	return [selected, select];
+}

--- a/apps/web/src/chat/rows.test.ts
+++ b/apps/web/src/chat/rows.test.ts
@@ -336,6 +336,70 @@ test("turnDivider reports no changed files / zero tools for a plain Q&A round", 
 	const turns: ChatTurn[] = [user("u1", 0), assistantWithPaths("a1", [], 2_000), done("s1", 2_000)];
 	const d = turnDivider(turns, 2);
 	expect(d?.toolCount).toBe(0);
+	expect(d?.specs).toEqual([]);
 	expect(d?.changedFiles).toEqual([]);
 	expect(d?.elapsedMs).toBe(2_000);
+});
+
+// ---- the spec / code partition (the two divider chips) ----
+
+test("turnDivider splits specs from code changes via isSpec, each path on exactly one side", () => {
+	const turns: ChatTurn[] = [
+		user("u1", 0),
+		assistantWithPaths("a1", [
+			{ name: "write", path: "packages/pi-todos/SPEC.md" },
+			{ name: "edit", path: "packages/pi-todos/core/store.ts" },
+		]),
+		done("s1", 5_000),
+	];
+	const d = turnDivider(turns, 2, (p) => p.endsWith("SPEC.md"));
+	expect(d?.specs).toEqual(["packages/pi-todos/SPEC.md"]);
+	expect(d?.changedFiles).toEqual(["packages/pi-todos/core/store.ts"]);
+});
+
+test("turnDivider counts a gitignored scratch spec as a spec, not as a (never-visible) change", () => {
+	// The reported bug: a `.thinkrail/context/` task-spec has zero git footprint, so a "files changed"
+	// chip pointing at it deep-linked to an empty Changes view. It belongs on the Specs side.
+	const path = ".thinkrail/context/TASK-todo-linear-groups.md";
+	const turns: ChatTurn[] = [
+		user("u1", 0),
+		assistantWithPaths("a1", [
+			{ name: "spec_create", path },
+			{ name: "write", path },
+			{ name: "edit", path },
+		]),
+		done("s1", 5_000),
+	];
+	const d = turnDivider(turns, 2, () => false); // graph snapshot hasn't caught up yet
+	expect(d?.toolCount).toBe(3);
+	expect(d?.specs).toEqual([path]); // spec_create's target is a spec by construction
+	expect(d?.changedFiles).toEqual([]);
+});
+
+test("turnDivider lets the spec side win a tie — a path reached by both routes is never double-counted", () => {
+	// `edit` lands first (classified as code by a stale snapshot), then `spec_create` claims the same path.
+	const path = "docs/SPEC.md";
+	const turns: ChatTurn[] = [
+		user("u1", 0),
+		assistantWithPaths("a1", [
+			{ name: "edit", path },
+			{ name: "spec_create", path },
+		]),
+		done("s1", 5_000),
+	];
+	const d = turnDivider(turns, 2);
+	expect(d?.specs).toEqual([path]);
+	expect(d?.changedFiles).toEqual([]);
+});
+
+test("turnDivider treats every written file as a change when no classifier is supplied", () => {
+	// The presentational default: without a spec graph, the divider degrades to the old single-chip behavior.
+	const turns: ChatTurn[] = [
+		user("u1", 0),
+		assistantWithPaths("a1", [{ name: "write", path: "SPEC.md" }]),
+		done("s1", 5_000),
+	];
+	const d = turnDivider(turns, 2);
+	expect(d?.specs).toEqual([]);
+	expect(d?.changedFiles).toEqual(["SPEC.md"]);
 });

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -64,12 +64,14 @@ export type ChatRow =
  * a run is broken by non-empty answer text, a primary tool call, or any non-assistant turn. The trailing
  * run of a streaming transcript is marked `live` (the fold header becomes the ticker) — it stops being
  * trailing (and live) the moment answer text starts, which is what auto-collapses it. Round-end dividers
- * (the {@link turnDivider} deriver) are folded in as `divider` rows. Pure.
+ * (the {@link turnDivider} deriver, which `isSpec` lets split specs from code changes) are folded in as
+ * `divider` rows. Pure.
  */
 export function deriveRows(
 	turns: ChatTurn[],
 	toolResults: Record<string, ToolResultState>,
 	isStreaming: boolean,
+	isSpec?: (path: string) => boolean,
 ): ChatRow[] {
 	const rows: ChatRow[] = [];
 	let run: ActivityStep[] = [];
@@ -154,7 +156,7 @@ export function deriveRows(
 			(turns[i + 1]?.kind === "user" || (i === turns.length - 1 && !isStreaming));
 		if (roundEnded) {
 			flushRun(); // a round boundary always closes the run
-			const data = turnDivider(turns, i);
+			const data = turnDivider(turns, i, isSpec);
 			if (data) rows.push({ kind: "divider", id: `${turn.id}:divider`, data });
 		}
 	}
@@ -170,19 +172,51 @@ export interface TurnDividerData {
 	elapsedMs: number | null;
 	/** Tool calls made by the assistant turn(s) in this round. */
 	toolCount: number;
-	/** Distinct files written/edited by those tool calls (worktree-relative or absolute, as pi reported). */
+	/**
+	 * Distinct **spec** docs written by those tool calls — the round's Specs-side artifacts, deep-linked to
+	 * the Specs panel. A spec belongs here and NOT in `changedFiles`: the two are a partition, so one file is
+	 * never counted twice, and "files changed" reads as exactly "code changed".
+	 */
+	specs: string[];
+	/**
+	 * Distinct non-spec files written/edited by those tool calls (worktree-relative or absolute, as pi
+	 * reported) — the round's Changes-side artifacts.
+	 */
 	changedFiles: string[];
 }
 
 /**
- * Derive the divider that closes the round *ending* at `endIndex` (its "✓ Done" marker, or its last
- * assistant turn when hydrated): the round's tool calls + edited/written files, plus the elapsed wall-clock
- * from the round's user turn to its end. Anchored at the round end (not the next user turn) so the summary
- * appears the instant the turn finishes. The end time comes from the "✓ Done" marker's `endedAt` when
- * present (live), else the last assistant message's timestamp (hydrated) — stable either way, so the number
- * never jumps when a follow-up arrives. Returns null when there is no user turn starting the round. Pure.
+ * The tool whose `path` argument is a spec **by construction**: `spec_create`. Its target counts as a spec
+ * whatever the graph snapshot currently holds — which is what makes a spec *created this round* land on the
+ * Specs side even before the snapshot catches up with the filesystem. (`spec_update`/`spec_delete` are keyed
+ * by spec `id`, not path, so they carry no path to classify; a spec's prose is edited with `edit`, which the
+ * graph-backed classifier already routes here.)
  */
-export function turnDivider(turns: ChatTurn[], endIndex: number): TurnDividerData | null {
+const SPEC_WRITER_TOOL = "spec_create";
+
+/** Tools whose `path` argument is a file the agent wrote (as opposed to merely read). */
+const FILE_WRITER_TOOLS = new Set(["write", "edit"]);
+
+/**
+ * Derive the divider that closes the round *ending* at `endIndex` (its "✓ Done" marker, or its last
+ * assistant turn when hydrated): the round's tool calls + the files it wrote, **split into specs and code**,
+ * plus the elapsed wall-clock from the round's user turn to its end. Anchored at the round end (not the next
+ * user turn) so the summary appears the instant the turn finishes. The end time comes from the "✓ Done"
+ * marker's `endedAt` when present (live), else the last assistant message's timestamp (hydrated) — stable
+ * either way, so the number never jumps when a follow-up arrives. Returns null when there is no user turn
+ * starting the round.
+ *
+ * `isSpec` classifies an agent-reported path as a spec doc (the store's `specPathMatcher` over the
+ * workspace's spec graph); without it every written file counts as a code change. The split is a partition:
+ * each path lands in exactly one list, so the two chips deep-link to the panel that can actually show the
+ * file — the whole point being that a spec is often **gitignored** scratch (`.thinkrail/context/`) and would
+ * otherwise send the user to an empty Changes view. Pure.
+ */
+export function turnDivider(
+	turns: ChatTurn[],
+	endIndex: number,
+	isSpec: (path: string) => boolean = () => false,
+): TurnDividerData | null {
 	let userIdx = -1;
 	for (let i = endIndex; i >= 0; i--) {
 		if (turns[i]?.kind === "user") {
@@ -193,7 +227,9 @@ export function turnDivider(turns: ChatTurn[], endIndex: number): TurnDividerDat
 	if (userIdx < 0) return null;
 
 	let toolCount = 0;
-	const changedFiles: string[] = [];
+	// path → is it a spec. One entry per path makes the partition structural: a path cannot land on both
+	// sides, and first-write order is preserved (Map iterates in insertion order).
+	const written = new Map<string, boolean>();
 	let endMs: number | null = null;
 	for (let i = userIdx + 1; i <= endIndex; i++) {
 		const turn = turns[i];
@@ -202,10 +238,14 @@ export function turnDivider(turns: ChatTurn[], endIndex: number): TurnDividerDat
 			for (const block of turn.message.content) {
 				if (block.type !== "toolCall") continue;
 				toolCount++;
-				if (block.name === "edit" || block.name === "write") {
-					const path = strArg(block.arguments, "path");
-					if (path && !changedFiles.includes(path)) changedFiles.push(path);
-				}
+				const specWrite = block.name === SPEC_WRITER_TOOL;
+				if (!specWrite && !FILE_WRITER_TOOLS.has(block.name)) continue;
+				const path = strArg(block.arguments, "path");
+				if (!path) continue;
+				// A spec created this round stays a spec even if a later `edit` of it arrives before the graph
+				// snapshot refreshes (and vice versa) — the spec side wins the tie, so it only ever upgrades.
+				if (specWrite || isSpec(path)) written.set(path, true);
+				else if (!written.has(path)) written.set(path, false);
 			}
 		} else if (turn?.kind === "system" && turn.endedAt != null) {
 			endMs = turn.endedAt; // the live "✓ Done" marker carries the precise turn-end time
@@ -216,7 +256,10 @@ export function turnDivider(turns: ChatTurn[], endIndex: number): TurnDividerDat
 	const startMs = user?.kind === "user" ? user.message.timestamp : null;
 	const elapsedMs = startMs != null && endMs != null ? endMs - startMs : null;
 
-	return { elapsedMs, toolCount, changedFiles };
+	const specs: string[] = [];
+	const changedFiles: string[] = [];
+	for (const [path, isSpecPath] of written) (isSpecPath ? specs : changedFiles).push(path);
+	return { elapsedMs, toolCount, specs, changedFiles };
 }
 
 /** The first row rendering the turn a jump targets: the turn's own row (user/system/…) or its first

--- a/apps/web/src/chat/tools/EditCard.tsx
+++ b/apps/web/src/chat/tools/EditCard.tsx
@@ -1,7 +1,8 @@
 import { Pencil } from "lucide-react";
+import { projectRelativePath } from "@/lib";
 import type { ToolRenderProps } from "../toolRegistry";
 import { Collapsible } from "./Collapsible";
-import { projectRelativePath, resultText, strArg } from "./toolHelpers";
+import { resultText, strArg } from "./toolHelpers";
 
 /** Body for the `edit` tool: a simple removed/added line diff. */
 export function EditCard({ args, result, status, workspaceRoot }: ToolRenderProps) {

--- a/apps/web/src/chat/tools/ReadCard.tsx
+++ b/apps/web/src/chat/tools/ReadCard.tsx
@@ -1,8 +1,9 @@
 import { FileText } from "lucide-react";
+import { projectRelativePath } from "@/lib";
 import type { ToolRenderProps } from "../toolRegistry";
 import { CodeBlock } from "./CodeBlock";
 import { Collapsible, countLines } from "./Collapsible";
-import { languageFromPath, numArg, projectRelativePath, resultText, strArg } from "./toolHelpers";
+import { languageFromPath, numArg, resultText, strArg } from "./toolHelpers";
 
 /** Body for the `read` tool: file path + optional line range + highlighted content. */
 export function ReadCard({ args, result, status, workspaceRoot }: ToolRenderProps) {

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -59,7 +59,7 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 - **`web/`** — search/fetch renderers for `pi-web-access`; own child spec
   ([web/SPEC.md](web/SPEC.md)). Routine.
 - **Shared pieces** — `CodeBlock` (shiki), `Collapsible` ("Show all N lines" fold for long output),
-  pure `toolHelpers` (arg readers, `projectRelativePath`, `resultText`).
+  pure `toolHelpers` (arg readers, `resultText`, `languageFromPath`) + `lib`'s `projectRelativePath`.
 
 ## Boundary
 

--- a/apps/web/src/chat/tools/WriteCard.tsx
+++ b/apps/web/src/chat/tools/WriteCard.tsx
@@ -1,8 +1,9 @@
 import { FilePlus } from "lucide-react";
+import { projectRelativePath } from "@/lib";
 import type { ToolRenderProps } from "../toolRegistry";
 import { CodeBlock } from "./CodeBlock";
 import { Collapsible, countLines } from "./Collapsible";
-import { languageFromPath, projectRelativePath, resultText, strArg } from "./toolHelpers";
+import { languageFromPath, resultText, strArg } from "./toolHelpers";
 
 /** Body for the `write` tool: file header + highlighted preview of the written content. */
 export function WriteCard({ args, result, status, workspaceRoot }: ToolRenderProps) {

--- a/apps/web/src/chat/tools/register.ts
+++ b/apps/web/src/chat/tools/register.ts
@@ -1,11 +1,13 @@
 // Registers the built-in pi tool renderers. Imported for its side effect by ChatView (the app-integration
 // layer), so registration happens once when the chat module mounts. Idempotent: re-import is a no-op.
+
+import { projectRelativePath } from "@/lib";
 import { registerToolRenderer } from "../toolRegistry";
 import { AskUserQuestionCard } from "./AskUserQuestionCard";
 import { BashCard } from "./BashCard";
 import { EditCard } from "./EditCard";
 import { ReadCard } from "./ReadCard";
-import { projectRelativePath, strArg } from "./toolHelpers";
+import { strArg } from "./toolHelpers";
 import "./visualize/register";
 import "./web/register";
 import { WriteCard } from "./WriteCard";

--- a/apps/web/src/chat/tools/toolHelpers.test.ts
+++ b/apps/web/src/chat/tools/toolHelpers.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { languageFromPath, numArg, projectRelativePath, resultText, strArg } from "./toolHelpers";
+import { projectRelativePath } from "@/lib";
+import { languageFromPath, numArg, resultText, strArg } from "./toolHelpers";
 
 test("resultText joins the text blocks of an AgentToolResult-shaped value", () => {
 	expect(

--- a/apps/web/src/chat/tools/toolHelpers.ts
+++ b/apps/web/src/chat/tools/toolHelpers.ts
@@ -1,9 +1,7 @@
 // Pure helpers shared by the built-in tool renderers: pull text out of an `unknown` tool result, read
 // args defensively, and infer a shiki language from a file path. Kept tiny + side-effect-free so the
-// renderers stay small and these are unit-testable on their own. Path *primitives* (normalize, absolute?)
-// come from `lib`, which is where every module's path predicates share one definition.
-
-import { isAbsolutePath, normalizePath } from "@/lib";
+// renderers stay small and these are unit-testable on their own. Path helpers (normalize, absolute?,
+// worktree-relative display) live in `lib` — one definition for every module that touches a path.
 
 /** Best-effort plain text from a tool's `result` (an AgentToolResult-shaped value, typed `unknown`). */
 export function resultText(result: unknown): string {
@@ -38,32 +36,6 @@ export function strArg(args: Record<string, unknown>, key: string): string {
 export function numArg(args: Record<string, unknown>, key: string): number | null {
 	const v = args[key];
 	return typeof v === "number" ? v : null;
-}
-
-/** The last path segment, e.g. "/a/b/App.tsx" -> "App.tsx". */
-function fileName(path: string): string {
-	const parts = normalizePath(path).split("/").filter(Boolean);
-	return parts.at(-1) ?? path;
-}
-
-function trimTrailingSlashes(path: string): string {
-	return path.replace(/\/+$/, "");
-}
-
-/**
- * Display a file path relative to the workspace/project root when possible. Tool args may already be
- * relative; absolute paths are trimmed only when the host-provided root matches.
- */
-export function projectRelativePath(path: string, workspaceRoot?: string | undefined): string {
-	const normalized = normalizePath(path).replace(/^\.\/+/, "");
-	if (!normalized || !isAbsolutePath(normalized)) return normalized;
-
-	const root = workspaceRoot ? trimTrailingSlashes(normalizePath(workspaceRoot)) : "";
-	if (root && (normalized === root || normalized.startsWith(`${root}/`))) {
-		return normalized.slice(root.length).replace(/^\/+/, "") || fileName(normalized);
-	}
-
-	return normalized;
 }
 
 /** A shiki language id inferred from a file extension (falls back to "" -> plain text). */

--- a/apps/web/src/chat/tools/toolHelpers.ts
+++ b/apps/web/src/chat/tools/toolHelpers.ts
@@ -1,6 +1,9 @@
 // Pure helpers shared by the built-in tool renderers: pull text out of an `unknown` tool result, read
 // args defensively, and infer a shiki language from a file path. Kept tiny + side-effect-free so the
-// renderers stay small and these are unit-testable on their own.
+// renderers stay small and these are unit-testable on their own. Path *primitives* (normalize, absolute?)
+// come from `lib`, which is where every module's path predicates share one definition.
+
+import { isAbsolutePath, normalizePath } from "@/lib";
 
 /** Best-effort plain text from a tool's `result` (an AgentToolResult-shaped value, typed `unknown`). */
 export function resultText(result: unknown): string {
@@ -37,10 +40,6 @@ export function numArg(args: Record<string, unknown>, key: string): number | nul
 	return typeof v === "number" ? v : null;
 }
 
-function normalizePath(path: string): string {
-	return path.replaceAll("\\", "/");
-}
-
 /** The last path segment, e.g. "/a/b/App.tsx" -> "App.tsx". */
 function fileName(path: string): string {
 	const parts = normalizePath(path).split("/").filter(Boolean);
@@ -49,10 +48,6 @@ function fileName(path: string): string {
 
 function trimTrailingSlashes(path: string): string {
 	return path.replace(/\/+$/, "");
-}
-
-function isAbsolutePath(path: string): boolean {
-	return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
 }
 
 /**

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -10,8 +10,9 @@ import {
 	Wrench,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { cn } from "@/lib";
 import { ActivityGroup } from "./ActivityGroup";
-import { useFold } from "./foldState";
+import { useSelection } from "./foldState";
 import { Markdown } from "./Markdown";
 import type { ChatRow, TurnDividerData } from "./rows";
 import { ToolCard } from "./ToolCard";
@@ -23,19 +24,22 @@ import { projectRelativePath } from "./tools/toolHelpers";
  * activity can fold across assistant-message boundaries). Presentational + props-driven (no
  * store/transport) so the renderers stay reusable; `ChatView` derives the rows from the store and feeds
  * them here. `onOpenSpec` / `onOpenChange` are the divider's two deep links ("N specs" → the Specs panel,
- * "N files changed" → the Changes panel), each taking the ONE path the user picked — supplied by the
- * integration layer, no-op defaults keep the primitives standalone.
+ * "N files changed" → the Changes panel), each taking the ONE path the user picked; `onReveal` just shows a
+ * view (a chip expanding its list) — supplied by the integration layer, no-op defaults keep the primitives
+ * standalone.
  */
 export function ChatTurnView({
 	row,
 	workspaceRoot,
 	onOpenSpec,
 	onOpenChange,
+	onReveal,
 }: {
 	row: ChatRow;
 	workspaceRoot?: string | undefined;
 	onOpenSpec?: ((path: string) => void) | undefined;
 	onOpenChange?: ((path: string) => void) | undefined;
+	onReveal?: ((tab: "specs" | "changes") => void) | undefined;
 }) {
 	switch (row.kind) {
 		case "user":
@@ -78,6 +82,7 @@ export function ChatTurnView({
 					workspaceRoot={workspaceRoot}
 					onOpenSpec={onOpenSpec ?? (() => {})}
 					onOpenChange={onOpenChange ?? (() => {})}
+					onReveal={onReveal ?? (() => {})}
 				/>
 			);
 		default:
@@ -223,33 +228,40 @@ function formatElapsed(ms: number): string {
 }
 
 /**
- * One kind of artifact a round produced: the paths, how to name them, and where a click sends the user.
- * `TurnDivider` builds one per side (specs / changed files) so the two are described once instead of being
- * spelled out in parallel across chip and list.
+ * One kind of artifact a round produced: the paths, how to name them, which right-panel view owns them, and
+ * where a click sends the user. `TurnDivider` builds one per side (specs / changed files) so the two are
+ * described once instead of being spelled out in parallel across chip and list.
  */
 interface ArtifactGroup {
+	/** Selection key — also the chip's testid, and what makes the two sides mutually exclusive. */
 	testid: string;
 	icon: typeof FileText;
 	paths: string[];
 	/** Chip text for a count — each group owns its own singular/plural. */
 	label: (count: number) => string;
 	expanded: boolean;
-	toggle: () => void;
 	onOpen: (path: string) => void;
+	/** Show the right-panel view that owns this kind (the flip that rides along with expanding). */
+	reveal: () => void;
 }
 
 /**
  * One artifact chip of the round-end divider. A **single** artifact is an immediate deep link — one click
  * lands on the file, which is the common case and the whole point of the chip. **Several** turn it into a
- * disclosure instead: the round's set expands as a list right here in the transcript, and each row is the
- * same deep link. Why in the chat and not as a highlight over the panels: the set belongs to *this round*,
+ * disclosure: the round's set expands as a list right here in the transcript, each row the same deep link.
+ * The two chips are **alternatives, not independent folds** — opening one closes the other, and clicking the
+ * open one closes it (nothing selected), so the divider never grows two lists at once. Expanding also
+ * reveals the right-panel view that owns the kind, which is what makes the chip read as a switch between
+ * Specs and Changes rather than two unrelated toggles.
+ *
+ * Why the list lives in the chat and not as a highlight over the panels: the set belongs to *this round*,
  * while the panels show *now* — a round from days ago would frame rows that have since moved on (or, for
  * Changes, are no longer in the diff at all). It also keeps the count honest — clicking "5 files changed"
- * can't silently surface just the first one. Fold state rides `useFold`, so it survives virtualization and
- * streaming re-derivation like every other fold in the transcript.
+ * can't silently surface just the first one. Selection rides `useSelection`, so it survives virtualization
+ * and streaming re-derivation like every other fold in the transcript.
  */
-function ArtifactChip({ group }: { group: ArtifactGroup }) {
-	const { testid, icon: Icon, paths, label, expanded, toggle, onOpen } = group;
+function ArtifactChip({ group, onSelect }: { group: ArtifactGroup; onSelect: () => void }) {
+	const { testid, icon: Icon, paths, label, expanded, onOpen, reveal } = group;
 	const many = paths.length > 1;
 	const first = paths[0];
 	return (
@@ -259,10 +271,18 @@ function ArtifactChip({ group }: { group: ArtifactGroup }) {
 			data-expanded={many && expanded ? true : undefined}
 			aria-expanded={many ? expanded : undefined}
 			onClick={() => {
-				if (many) toggle();
-				else if (first) onOpen(first);
+				if (!many) {
+					if (first) onOpen(first); // its own deep link already reveals the owning view
+					return;
+				}
+				// Reveal the owning view when opening; a close is "never mind" and leaves the panel alone.
+				if (!expanded) reveal();
+				onSelect();
 			}}
-			className="flex items-center gap-xs rounded-[var(--radius-sm)] px-xs text-primary hover:bg-hover"
+			className={cn(
+				"flex items-center gap-xs rounded-[var(--radius-sm)] px-xs text-primary hover:bg-hover",
+				many && expanded && "bg-hover",
+			)}
 		>
 			<Icon className="size-3 shrink-0" />
 			{label(paths.length)}
@@ -317,10 +337,11 @@ function ArtifactList({
  * count, then the round's written artifacts as **two chips split the way the right panel is** — "N specs"
  * (deep-links the Specs panel, opening the rendered spec — via `onOpenSpec`) and "N files changed"
  * (deep-links the Changes panel to the file: flips to the tab and highlights its row, leaving the diff to an
- * explicit click — via `onOpenChange`) — and elapsed wall-clock. Each chip deep-links directly for a single
- * artifact and expands into a list for several (see `ArtifactChip`); `id` (the divider row's id) keys that
- * fold. Presentational — the store touches live in `ChatView`, which supplies both handlers. The data comes
- * from the pure `turnDivider` deriver in `rows.ts`, which owns the spec/code partition.
+ * explicit click — via `onOpenChange`) — and elapsed wall-clock. A single artifact deep-links outright;
+ * several make the chip a **single-choice** disclosure (see `ArtifactChip`) whose list replaces the other
+ * side's rather than joining it, keyed off `id` (the divider row's id). Presentational — the store touches
+ * live in `ChatView`, which supplies the open + reveal handlers. The data comes from the pure `turnDivider`
+ * deriver in `rows.ts`, which owns the spec/code partition.
  */
 export function TurnDivider({
 	id,
@@ -328,36 +349,38 @@ export function TurnDivider({
 	workspaceRoot,
 	onOpenSpec,
 	onOpenChange,
+	onReveal,
 }: {
 	id: string;
 	data: TurnDividerData;
 	workspaceRoot?: string | undefined;
 	onOpenSpec: (path: string) => void;
 	onOpenChange: (path: string) => void;
+	/** Show the right-panel view that owns a side, without surfacing any particular path. */
+	onReveal: (tab: "specs" | "changes") => void;
 }) {
 	const { elapsedMs, toolCount, specs, changedFiles } = data;
-	// One fold per side, keyed off the divider row id — both called unconditionally (hook order) even when
-	// the round wrote nothing of that kind.
-	const [specsOpen, toggleSpecs] = useFold(`${id}:specs`);
-	const [filesOpen, toggleFiles] = useFold(`${id}:files`);
+	// ONE selection per divider, not a fold per side: the two lists are alternatives, so "at most one open"
+	// is structural — there is no state where both are expanded.
+	const [selected, select] = useSelection(`${id}:artifacts`);
 	const sides: ArtifactGroup[] = [
 		{
 			testid: "turn-divider-specs",
 			icon: FileText,
 			paths: specs,
 			label: (n) => `${n} ${n === 1 ? "spec" : "specs"}`,
-			expanded: specsOpen,
-			toggle: toggleSpecs,
+			expanded: selected === "turn-divider-specs",
 			onOpen: onOpenSpec,
+			reveal: () => onReveal("specs"),
 		},
 		{
 			testid: "turn-divider-files",
 			icon: FileDiff,
 			paths: changedFiles,
 			label: (n) => `${n} ${n === 1 ? "file changed" : "files changed"}`,
-			expanded: filesOpen,
-			toggle: toggleFiles,
+			expanded: selected === "turn-divider-files",
 			onOpen: onOpenChange,
+			reveal: () => onReveal("changes"),
 		},
 	];
 	const groups = sides.filter((group) => group.paths.length > 0);
@@ -377,7 +400,7 @@ export function TurnDivider({
 					</span>
 				) : null}
 				{groups.map((group) => (
-					<ArtifactChip key={group.testid} group={group} />
+					<ArtifactChip key={group.testid} group={group} onSelect={() => select(group.testid)} />
 				))}
 				{elapsedMs != null && elapsedMs >= 1000 ? (
 					<span className="flex items-center gap-xs">

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -1,27 +1,41 @@
 import type { UserMessage } from "@thinkrail/contracts";
-import { Clock, FileDiff, RotateCw, TriangleAlert, Wrench } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronRight,
+	Clock,
+	FileDiff,
+	FileText,
+	RotateCw,
+	TriangleAlert,
+	Wrench,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { ActivityGroup } from "./ActivityGroup";
+import { useFold } from "./foldState";
 import { Markdown } from "./Markdown";
 import type { ChatRow, TurnDividerData } from "./rows";
 import { ToolCard } from "./ToolCard";
 import { getToolChrome, getToolRenderer } from "./toolRegistry";
+import { projectRelativePath } from "./tools/toolHelpers";
 
 /**
  * Render one derived chat row (see `rows.ts` — the transcript renders rows, not raw turns, so routine
  * activity can fold across assistant-message boundaries). Presentational + props-driven (no
  * store/transport) so the renderers stay reusable; `ChatView` derives the rows from the store and feeds
- * them here. `onOpenChanges` is the divider's "files changed" deep link — supplied by the integration
- * layer, a no-op default keeps the primitives standalone.
+ * them here. `onOpenSpec` / `onOpenChange` are the divider's two deep links ("N specs" → the Specs panel,
+ * "N files changed" → the Changes panel), each taking the ONE path the user picked — supplied by the
+ * integration layer, no-op defaults keep the primitives standalone.
  */
 export function ChatTurnView({
 	row,
 	workspaceRoot,
-	onOpenChanges,
+	onOpenSpec,
+	onOpenChange,
 }: {
 	row: ChatRow;
 	workspaceRoot?: string | undefined;
-	onOpenChanges?: ((paths: string[]) => void) | undefined;
+	onOpenSpec?: ((path: string) => void) | undefined;
+	onOpenChange?: ((path: string) => void) | undefined;
 }) {
 	switch (row.kind) {
 		case "user":
@@ -57,7 +71,15 @@ export function ChatTurnView({
 				/>
 			);
 		case "divider":
-			return <TurnDivider data={row.data} onOpenChanges={onOpenChanges ?? (() => {})} />;
+			return (
+				<TurnDivider
+					id={row.id}
+					data={row.data}
+					workspaceRoot={workspaceRoot}
+					onOpenSpec={onOpenSpec ?? (() => {})}
+					onOpenChange={onOpenChange ?? (() => {})}
+				/>
+			);
 		default:
 			return null;
 	}
@@ -201,51 +223,175 @@ function formatElapsed(ms: number): string {
 }
 
 /**
+ * One kind of artifact a round produced: the paths, how to name them, and where a click sends the user.
+ * `TurnDivider` builds one per side (specs / changed files) so the two are described once instead of being
+ * spelled out in parallel across chip and list.
+ */
+interface ArtifactGroup {
+	testid: string;
+	icon: typeof FileText;
+	paths: string[];
+	/** Chip text for a count — each group owns its own singular/plural. */
+	label: (count: number) => string;
+	expanded: boolean;
+	toggle: () => void;
+	onOpen: (path: string) => void;
+}
+
+/**
+ * One artifact chip of the round-end divider. A **single** artifact is an immediate deep link — one click
+ * lands on the file, which is the common case and the whole point of the chip. **Several** turn it into a
+ * disclosure instead: the round's set expands as a list right here in the transcript, and each row is the
+ * same deep link. Why in the chat and not as a highlight over the panels: the set belongs to *this round*,
+ * while the panels show *now* — a round from days ago would frame rows that have since moved on (or, for
+ * Changes, are no longer in the diff at all). It also keeps the count honest — clicking "5 files changed"
+ * can't silently surface just the first one. Fold state rides `useFold`, so it survives virtualization and
+ * streaming re-derivation like every other fold in the transcript.
+ */
+function ArtifactChip({ group }: { group: ArtifactGroup }) {
+	const { testid, icon: Icon, paths, label, expanded, toggle, onOpen } = group;
+	const many = paths.length > 1;
+	const first = paths[0];
+	return (
+		<button
+			type="button"
+			data-testid={testid}
+			data-expanded={many && expanded ? true : undefined}
+			aria-expanded={many ? expanded : undefined}
+			onClick={() => {
+				if (many) toggle();
+				else if (first) onOpen(first);
+			}}
+			className="flex items-center gap-xs rounded-[var(--radius-sm)] px-xs text-primary hover:bg-hover"
+		>
+			<Icon className="size-3 shrink-0" />
+			{label(paths.length)}
+			{many ? (
+				expanded ? (
+					<ChevronDown className="size-3 shrink-0" />
+				) : (
+					<ChevronRight className="size-3 shrink-0" />
+				)
+			) : null}
+		</button>
+	);
+}
+
+/**
+ * The expanded artifact set, listed under the divider rule — one deep-linking row per path. Paths render
+ * worktree-relative (`projectRelativePath`, the same normalization the tool cards use), since pi reports a
+ * `path` argument either way and an absolute one truncates to nothing useful.
+ */
+function ArtifactList({
+	group,
+	workspaceRoot,
+}: {
+	group: ArtifactGroup;
+	workspaceRoot?: string | undefined;
+}) {
+	const { testid, icon: Icon, paths, onOpen } = group;
+	return (
+		<ul data-testid={`${testid}-list`} className="flex flex-col">
+			{paths.map((path) => (
+				<li key={path}>
+					<button
+						type="button"
+						data-testid={`${testid}-list-item`}
+						onClick={() => onOpen(path)}
+						title={path}
+						className="flex w-full items-center gap-xs rounded-[var(--radius-sm)] px-xs py-[2px] text-left hover:bg-hover"
+					>
+						<Icon className="size-3 shrink-0 text-hint" />
+						<span className="min-w-0 flex-1 truncate text-muted">
+							{projectRelativePath(path, workspaceRoot)}
+						</span>
+					</button>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+/**
  * A subtle round-end divider (rendered right when the turn finishes, below its "✓ Done" marker): tool-call
- * count, a clickable "N files changed" chip (deep-links the Changes panel to the file — flips to the tab
- * and highlights its row, leaving the diff to an explicit click — via `onOpenChanges`), and elapsed
- * wall-clock. Presentational — the store touch lives in `ChatView`, which supplies `onOpenChanges`. The
- * data comes from the pure `turnDivider` deriver in `rows.ts`.
+ * count, then the round's written artifacts as **two chips split the way the right panel is** — "N specs"
+ * (deep-links the Specs panel, opening the rendered spec — via `onOpenSpec`) and "N files changed"
+ * (deep-links the Changes panel to the file: flips to the tab and highlights its row, leaving the diff to an
+ * explicit click — via `onOpenChange`) — and elapsed wall-clock. Each chip deep-links directly for a single
+ * artifact and expands into a list for several (see `ArtifactChip`); `id` (the divider row's id) keys that
+ * fold. Presentational — the store touches live in `ChatView`, which supplies both handlers. The data comes
+ * from the pure `turnDivider` deriver in `rows.ts`, which owns the spec/code partition.
  */
 export function TurnDivider({
+	id,
 	data,
-	onOpenChanges,
+	workspaceRoot,
+	onOpenSpec,
+	onOpenChange,
 }: {
+	id: string;
 	data: TurnDividerData;
-	onOpenChanges: (paths: string[]) => void;
+	workspaceRoot?: string | undefined;
+	onOpenSpec: (path: string) => void;
+	onOpenChange: (path: string) => void;
 }) {
-	const { elapsedMs, toolCount, changedFiles } = data;
-	if (toolCount === 0 && changedFiles.length === 0 && (elapsedMs == null || elapsedMs < 1000)) {
+	const { elapsedMs, toolCount, specs, changedFiles } = data;
+	// One fold per side, keyed off the divider row id — both called unconditionally (hook order) even when
+	// the round wrote nothing of that kind.
+	const [specsOpen, toggleSpecs] = useFold(`${id}:specs`);
+	const [filesOpen, toggleFiles] = useFold(`${id}:files`);
+	const sides: ArtifactGroup[] = [
+		{
+			testid: "turn-divider-specs",
+			icon: FileText,
+			paths: specs,
+			label: (n) => `${n} ${n === 1 ? "spec" : "specs"}`,
+			expanded: specsOpen,
+			toggle: toggleSpecs,
+			onOpen: onOpenSpec,
+		},
+		{
+			testid: "turn-divider-files",
+			icon: FileDiff,
+			paths: changedFiles,
+			label: (n) => `${n} ${n === 1 ? "file changed" : "files changed"}`,
+			expanded: filesOpen,
+			toggle: toggleFiles,
+			onOpen: onOpenChange,
+		},
+	];
+	const groups = sides.filter((group) => group.paths.length > 0);
+
+	if (toolCount === 0 && groups.length === 0 && (elapsedMs == null || elapsedMs < 1000)) {
 		// Nothing worth noting between these turns — just a hairline rule.
 		return <div data-testid="turn-divider" className="my-sm h-px bg-border2" />;
 	}
 	return (
-		<div data-testid="turn-divider" className="my-sm flex items-center gap-sm text-hint text-xs">
-			<span className="h-px flex-1 bg-border2" />
-			{toolCount > 0 ? (
-				<span className="flex items-center gap-xs">
-					<Wrench className="size-3 shrink-0" />
-					{toolCount} {toolCount === 1 ? "tool call" : "tool calls"}
-				</span>
-			) : null}
-			{changedFiles.length > 0 ? (
-				<button
-					type="button"
-					data-testid="turn-divider-files"
-					onClick={() => onOpenChanges(changedFiles)}
-					className="flex items-center gap-xs rounded-[var(--radius-sm)] px-xs text-primary hover:bg-hover"
-				>
-					<FileDiff className="size-3 shrink-0" />
-					{changedFiles.length} {changedFiles.length === 1 ? "file changed" : "files changed"}
-				</button>
-			) : null}
-			{elapsedMs != null && elapsedMs >= 1000 ? (
-				<span className="flex items-center gap-xs">
-					<Clock className="size-3 shrink-0" />
-					{formatElapsed(elapsedMs)}
-				</span>
-			) : null}
-			<span className="h-px flex-1 bg-border2" />
+		<div data-testid="turn-divider" className="my-sm flex flex-col gap-xs text-hint text-xs">
+			<div className="flex items-center gap-sm">
+				<span className="h-px flex-1 bg-border2" />
+				{toolCount > 0 ? (
+					<span className="flex items-center gap-xs">
+						<Wrench className="size-3 shrink-0" />
+						{toolCount} {toolCount === 1 ? "tool call" : "tool calls"}
+					</span>
+				) : null}
+				{groups.map((group) => (
+					<ArtifactChip key={group.testid} group={group} />
+				))}
+				{elapsedMs != null && elapsedMs >= 1000 ? (
+					<span className="flex items-center gap-xs">
+						<Clock className="size-3 shrink-0" />
+						{formatElapsed(elapsedMs)}
+					</span>
+				) : null}
+				<span className="h-px flex-1 bg-border2" />
+			</div>
+			{groups
+				.filter((group) => group.paths.length > 1 && group.expanded)
+				.map((group) => (
+					<ArtifactList key={group.testid} group={group} workspaceRoot={workspaceRoot} />
+				))}
 		</div>
 	);
 }

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -10,14 +10,13 @@ import {
 	Wrench,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { cn } from "@/lib";
+import { cn, projectRelativePath } from "@/lib";
 import { ActivityGroup } from "./ActivityGroup";
 import { useSelection } from "./foldState";
 import { Markdown } from "./Markdown";
 import type { ChatRow, TurnDividerData } from "./rows";
 import { ToolCard } from "./ToolCard";
 import { getToolChrome, getToolRenderer } from "./toolRegistry";
-import { projectRelativePath } from "./tools/toolHelpers";
 
 /**
  * Render one derived chat row (see `rows.ts` — the transcript renders rows, not raw turns, so routine
@@ -233,8 +232,8 @@ function formatElapsed(ms: number): string {
  * described once instead of being spelled out in parallel across chip and list.
  */
 interface ArtifactGroup {
-	/** Selection key — also the chip's testid, and what makes the two sides mutually exclusive. */
-	testid: string;
+	/** Which side this is: the selection key, and the stem of the chip's testid + the list's element id. */
+	id: "specs" | "files";
 	icon: typeof FileText;
 	paths: string[];
 	/** Chip text for a count — each group owns its own singular/plural. */
@@ -260,16 +259,26 @@ interface ArtifactGroup {
  * can't silently surface just the first one. Selection rides `useSelection`, so it survives virtualization
  * and streaming re-derivation like every other fold in the transcript.
  */
-function ArtifactChip({ group, onSelect }: { group: ArtifactGroup; onSelect: () => void }) {
-	const { testid, icon: Icon, paths, label, expanded, onOpen, reveal } = group;
+function ArtifactChip({
+	group,
+	listId,
+	onSelect,
+}: {
+	group: ArtifactGroup;
+	/** The list this chip discloses, so assistive tech can follow the pair. */
+	listId: string;
+	onSelect: () => void;
+}) {
+	const { id, icon: Icon, paths, label, expanded, onOpen, reveal } = group;
 	const many = paths.length > 1;
 	const first = paths[0];
 	return (
 		<button
 			type="button"
-			data-testid={testid}
+			data-testid={`turn-divider-${id}`}
 			data-expanded={many && expanded ? true : undefined}
 			aria-expanded={many ? expanded : undefined}
+			aria-controls={many && expanded ? listId : undefined}
 			onClick={() => {
 				if (!many) {
 					if (first) onOpen(first); // its own deep link already reveals the owning view
@@ -304,14 +313,17 @@ function ArtifactChip({ group, onSelect }: { group: ArtifactGroup; onSelect: () 
  */
 function ArtifactList({
 	group,
+	listId,
 	workspaceRoot,
 }: {
 	group: ArtifactGroup;
+	listId: string;
 	workspaceRoot?: string | undefined;
 }) {
-	const { testid, icon: Icon, paths, onOpen } = group;
+	const { id, icon: Icon, paths, onOpen } = group;
+	const testid = `turn-divider-${id}`;
 	return (
-		<ul data-testid={`${testid}-list`} className="flex flex-col">
+		<ul id={listId} data-testid={`${testid}-list`} className="flex flex-col">
 			{paths.map((path) => (
 				<li key={path}>
 					<button
@@ -365,20 +377,20 @@ export function TurnDivider({
 	const [selected, select] = useSelection(`${id}:artifacts`);
 	const sides: ArtifactGroup[] = [
 		{
-			testid: "turn-divider-specs",
+			id: "specs",
 			icon: FileText,
 			paths: specs,
 			label: (n) => `${n} ${n === 1 ? "spec" : "specs"}`,
-			expanded: selected === "turn-divider-specs",
+			expanded: selected === "specs",
 			onOpen: onOpenSpec,
 			reveal: () => onReveal("specs"),
 		},
 		{
-			testid: "turn-divider-files",
+			id: "files",
 			icon: FileDiff,
 			paths: changedFiles,
 			label: (n) => `${n} ${n === 1 ? "file changed" : "files changed"}`,
-			expanded: selected === "turn-divider-files",
+			expanded: selected === "files",
 			onOpen: onOpenChange,
 			reveal: () => onReveal("changes"),
 		},
@@ -400,7 +412,12 @@ export function TurnDivider({
 					</span>
 				) : null}
 				{groups.map((group) => (
-					<ArtifactChip key={group.testid} group={group} onSelect={() => select(group.testid)} />
+					<ArtifactChip
+						key={group.id}
+						group={group}
+						listId={`${id}-${group.id}-list`}
+						onSelect={() => select(group.id)}
+					/>
 				))}
 				{elapsedMs != null && elapsedMs >= 1000 ? (
 					<span className="flex items-center gap-xs">
@@ -413,7 +430,12 @@ export function TurnDivider({
 			{groups
 				.filter((group) => group.paths.length > 1 && group.expanded)
 				.map((group) => (
-					<ArtifactList key={group.testid} group={group} workspaceRoot={workspaceRoot} />
+					<ArtifactList
+						key={group.id}
+						group={group}
+						listId={`${id}-${group.id}-list`}
+						workspaceRoot={workspaceRoot}
+					/>
 				))}
 		</div>
 	);

--- a/apps/web/src/components/ErrorBoundary.test.ts
+++ b/apps/web/src/components/ErrorBoundary.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { isChunkLoadError, keysEqual } from "./ErrorBoundary";
+import { shallowEqualArrays } from "../lib";
+import { isChunkLoadError } from "./ErrorBoundary";
 
 test("classifies failed dynamic imports (stale Vite chunk / 504) as chunk-load errors", () => {
 	expect(
@@ -25,25 +26,14 @@ test("tolerates non-Error throwables", () => {
 	expect(isChunkLoadError(undefined)).toBe(false);
 });
 
-// `keysEqual` gates auto-recovery: a caught error clears only when the resetKeys array changes
-// (wired to workspace/tab id), so a stale key must read as equal and a changed one as unequal.
+// `resetKeys` gate auto-recovery: a caught error clears only when the array changes (it is wired to the
+// workspace/tab id), so a stale key must keep the fallback up and a changed one must drop it. The
+// comparison itself is `lib`'s `shallowEqualArrays`, tested there — this pins the boundary's *use* of it.
 test("resetKeys recovery: equal keys keep the error, a changed key clears it", () => {
-	// A changed value in the array → not equal → boundary resets and re-renders children.
-	expect(keysEqual(["ws-1"], ["ws-2"])).toBe(false);
-	expect(keysEqual([1, "tab-a"], [1, "tab-b"])).toBe(false);
-	// Same values (even across distinct array instances) → equal → error stays until identity changes.
-	expect(keysEqual(["ws-1"], ["ws-1"])).toBe(true);
-	const same: readonly unknown[] = ["ws-1"];
-	expect(keysEqual(same, same)).toBe(true);
-});
-
-test("resetKeys recovery: undefined and length changes are handled", () => {
-	expect(keysEqual(undefined, undefined)).toBe(true); // no resetKeys on either side → never auto-resets
-	expect(keysEqual(undefined, ["ws-1"])).toBe(false);
-	expect(keysEqual(["ws-1"], undefined)).toBe(false);
-	expect(keysEqual([], [])).toBe(true);
-	expect(keysEqual(["ws-1"], ["ws-1", "ws-2"])).toBe(false);
-	// `Object.is` semantics: NaN equals NaN, +0 ≠ -0.
-	expect(keysEqual([Number.NaN], [Number.NaN])).toBe(true);
-	expect(keysEqual([0], [-0])).toBe(false);
+	expect(shallowEqualArrays(["ws-1"], ["ws-2"])).toBe(false); // navigated → reset and re-render children
+	expect(shallowEqualArrays([1, "tab-a"], [1, "tab-b"])).toBe(false);
+	// Same values across distinct array instances → equal → the error stays until the id really changes.
+	expect(shallowEqualArrays(["ws-1"], ["ws-1"])).toBe(true);
+	// A boundary mounted without `resetKeys` never auto-resets.
+	expect(shallowEqualArrays(undefined, undefined)).toBe(true);
 });

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -40,7 +40,7 @@ export class ErrorBoundary extends Component<Props, State> {
 	}
 
 	override componentDidUpdate(prev: Props): void {
-		if (this.state.error && !keysEqual(prev.resetKeys, this.props.resetKeys)) {
+		if (this.state.error && !shallowEqualArrays(prev.resetKeys, this.props.resetKeys)) {
 			this.reset();
 		}
 	}
@@ -62,9 +62,6 @@ export class ErrorBoundary extends Component<Props, State> {
 		);
 	}
 }
-
-/** Shallow (`Object.is`) equality of two `resetKeys` arrays — a caught error clears only when this returns false. */
-export const keysEqual = shallowEqualArrays;
 
 /** Themed, self-contained fallback — token utilities only, so it wears any theme. */
 function PanelErrorFallback({

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, RefreshCw, RotateCcw } from "lucide-react";
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { shallowEqualArrays } from "../lib";
 
 // Our single boundary primitive: contains a panel's render/lazy-import crash to that region instead of unmounting the root (bare gray `--bg-dark`); a rejected lazy `import()` (stale Vite chunk → 504) throws through Suspense into here, and we steer that case to a reload.
 
@@ -62,15 +63,8 @@ export class ErrorBoundary extends Component<Props, State> {
 	}
 }
 
-/** Shallow (`Object.is`) equality of two `resetKeys` arrays — a caught error clears only when this returns false. Pure so it's unit-testable. */
-export function keysEqual(
-	a: readonly unknown[] | undefined,
-	b: readonly unknown[] | undefined,
-): boolean {
-	if (a === b) return true;
-	if (!a || !b || a.length !== b.length) return false;
-	return a.every((value, i) => Object.is(value, b[i]));
-}
+/** Shallow (`Object.is`) equality of two `resetKeys` arrays — a caught error clears only when this returns false. */
+export const keysEqual = shallowEqualArrays;
 
 /** Themed, self-contained fallback — token utilities only, so it wears any theme. */
 function PanelErrorFallback({

--- a/apps/web/src/components/SPEC.md
+++ b/apps/web/src/components/SPEC.md
@@ -26,8 +26,9 @@ which has its own spec.
 - **Public surface:** `ErrorBoundary`, `isChunkLoadError` — imported directly via
   `@/components/ErrorBoundary` (no barrel). The `ui/` primitives are their own sub-module
   ([components/ui/SPEC.md](ui/SPEC.md)).
-- **Allowed deps:** React, `lucide-react`. **Nothing else internal** — kept dependency-light on purpose so
-  *any* region (shell, panels, `main.tsx`) can wrap in it without creating a cycle.
+- **Allowed deps:** React, `lucide-react`, `lib` (`shallowEqualArrays` — the reset-keys comparison, shared
+  rather than re-stated). Kept dependency-light on purpose, and `lib` is a leaf, so *any* region (shell,
+  panels, `main.tsx`) can still wrap in it without creating a cycle.
 - **Forbidden:** `store`/`transport`/`panels`/`shell`/`chat`/`contracts`; `server`/`shared`/`pi`; inline
   `style` objects or raw hex (fallback is themed with token utilities only).
 

--- a/apps/web/src/lib/SPEC.md
+++ b/apps/web/src/lib/SPEC.md
@@ -28,7 +28,7 @@ Tiny UI helpers shared across components.
   CSS-variable registration. It is imported per-file (`@/lib/highlighter`) from lazy chunks only; theme
   identity/palettes never live in `lib`.
 - **Public surface (barrel):** `cn`, `isMarkdownPath`, `stripFrontmatter`, `cssColorToHex`,
-  `normalizePath`, `isAbsolutePath`, `shallowEqualArrays`.
+  `normalizePath`, `isAbsolutePath`, `projectRelativePath`, `shallowEqualArrays`.
 - **Allowed deps:** `clsx`, `tailwind-merge`; `shiki`/`@shikijs/*` (the per-file shiki modules only —
   never reachable through the barrel).
 - **Forbidden:** every app-internal module — this is a leaf.

--- a/apps/web/src/lib/SPEC.md
+++ b/apps/web/src/lib/SPEC.md
@@ -17,12 +17,18 @@ Tiny UI helpers shared across components.
   `.md`/`.markdown` gate for the rendered-preview view) + `stripFrontmatter()` (drop a leading YAML `---`
   block so the rendered view doesn't render spec metadata as a heading) + `cssColorToHex()` (canonicalize
   a CSS color to hex — minified CSS serves `#fff`/`gray`-style equivalents, which strict consumers like
-  Monaco and xterm reject; `""` when unparseable). Also the shared
+  Monaco and xterm reject; `""` when unparseable). Plus the primitives that more than one module needs and
+  none should re-state: **`normalizePath()`** / **`isAbsolutePath()`** (a path from a pi tool call or the
+  host may use either separator and may be relative or absolute — every path predicate in the app starts
+  from these, so `chat`'s display helpers and `store`'s worktree matcher share one definition) and
+  **`shallowEqualArrays()`** (element-wise `Object.is` — the "did this really change?" test behind the
+  store's snapshot-identity guard and `ErrorBoundary`'s reset keys). Also the shared
   Shiki highlighter, **kept out of the barrel** so the eager `@/lib` import stays shiki-free:
   `highlighter.ts` loads the curated grammars + JS regex engine and renders with `themes`' one generic
   CSS-variable registration. It is imported per-file (`@/lib/highlighter`) from lazy chunks only; theme
   identity/palettes never live in `lib`.
-- **Public surface (barrel):** `cn`, `isMarkdownPath`, `stripFrontmatter`, `cssColorToHex`.
+- **Public surface (barrel):** `cn`, `isMarkdownPath`, `stripFrontmatter`, `cssColorToHex`,
+  `normalizePath`, `isAbsolutePath`, `shallowEqualArrays`.
 - **Allowed deps:** `clsx`, `tailwind-merge`; `shiki`/`@shikijs/*` (the per-file shiki modules only —
   never reachable through the barrel).
 - **Forbidden:** every app-internal module — this is a leaf.

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "bun:test";
-import { cssColorToHex, isMarkdownPath, stripFrontmatter } from "./utils";
+import {
+	cssColorToHex,
+	isAbsolutePath,
+	isMarkdownPath,
+	normalizePath,
+	shallowEqualArrays,
+	stripFrontmatter,
+} from "./utils";
 
 test("isMarkdownPath matches .md/.markdown case-insensitively, nothing else", () => {
 	expect(isMarkdownPath("README.md")).toBe(true);
@@ -41,4 +48,31 @@ test("cssColorToHex reads unparseable values as unset", () => {
 	// e2e spec. Under bun (no DOM) they fall back to "" (unset), same as genuinely invalid input.
 	expect(cssColorToHex("")).toBe("");
 	expect(cssColorToHex("not-a-color")).toBe("");
+});
+
+test("normalizePath brings both separator styles to one form", () => {
+	expect(normalizePath("src/foo.ts")).toBe("src/foo.ts");
+	expect(normalizePath("C:\\wt\\src\\foo.ts")).toBe("C:/wt/src/foo.ts");
+});
+
+test("isAbsolutePath accepts posix and Windows roots, in either separator style", () => {
+	expect(isAbsolutePath("/wt/src/foo.ts")).toBe(true);
+	expect(isAbsolutePath("C:/wt/foo.ts")).toBe(true);
+	expect(isAbsolutePath("C:\\wt\\foo.ts")).toBe(true); // normalized before the test
+	expect(isAbsolutePath("src/foo.ts")).toBe(false);
+	expect(isAbsolutePath("./src/foo.ts")).toBe(false);
+	expect(isAbsolutePath("")).toBe(false);
+});
+
+test("shallowEqualArrays compares element-wise and treats absent as unequal", () => {
+	const same = ["a", "b"];
+	expect(shallowEqualArrays(same, same)).toBe(true); // identity short-circuit
+	expect(shallowEqualArrays(["a", "b"], ["a", "b"])).toBe(true);
+	expect(shallowEqualArrays(["a", "b"], ["a", "c"])).toBe(false);
+	expect(shallowEqualArrays(["a"], ["a", "b"])).toBe(false);
+	expect(shallowEqualArrays([], [])).toBe(true);
+	// `Object.is`, so a NaN key equals itself — the reason it isn't `===`.
+	expect(shallowEqualArrays([Number.NaN], [Number.NaN])).toBe(true);
+	expect(shallowEqualArrays(undefined, [])).toBe(false);
+	expect(shallowEqualArrays(undefined, undefined)).toBe(true);
 });

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -4,6 +4,7 @@ import {
 	isAbsolutePath,
 	isMarkdownPath,
 	normalizePath,
+	projectRelativePath,
 	shallowEqualArrays,
 	stripFrontmatter,
 } from "./utils";
@@ -50,9 +51,30 @@ test("cssColorToHex reads unparseable values as unset", () => {
 	expect(cssColorToHex("not-a-color")).toBe("");
 });
 
-test("normalizePath brings both separator styles to one form", () => {
+test("normalizePath brings both separator styles to one form and drops a leading ./", () => {
 	expect(normalizePath("src/foo.ts")).toBe("src/foo.ts");
 	expect(normalizePath("C:\\wt\\src\\foo.ts")).toBe("C:/wt/src/foo.ts");
+	// The `./` strip is a *comparison* concern, not cosmetics: pi reports this form, and without it the
+	// path matches neither a Changes entry nor a spec-graph node.
+	expect(normalizePath("./src/foo.ts")).toBe("src/foo.ts");
+	expect(normalizePath(".//src/foo.ts")).toBe("src/foo.ts");
+	expect(normalizePath(".\\src\\foo.ts")).toBe("src/foo.ts");
+	// A bare "." is a path, not a prefix — left alone.
+	expect(normalizePath(".")).toBe(".");
+	expect(normalizePath("../src/foo.ts")).toBe("../src/foo.ts");
+});
+
+test("projectRelativePath yields the worktree-relative tab identity from every reported form", () => {
+	const root = "/wt/ws";
+	expect(projectRelativePath("src/foo.ts", root)).toBe("src/foo.ts");
+	expect(projectRelativePath("./src/foo.ts", root)).toBe("src/foo.ts");
+	expect(projectRelativePath("/wt/ws/src/foo.ts", root)).toBe("src/foo.ts");
+	expect(projectRelativePath("/wt/ws/src/foo.ts", `${root}/`)).toBe("src/foo.ts"); // trailing slash
+	// One file, one identity: every form above collapses to the same string, which is what keeps
+	// `openFileInTab` from opening a second tab for an already-open file.
+	// Outside the root (or with no root known) it stays as reported — the read then fails loudly.
+	expect(projectRelativePath("/elsewhere/foo.ts", root)).toBe("/elsewhere/foo.ts");
+	expect(projectRelativePath("/wt/ws/src/foo.ts")).toBe("/wt/ws/src/foo.ts");
 });
 
 test("isAbsolutePath accepts posix and Windows roots, in either separator style", () => {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -12,12 +12,14 @@ export function isMarkdownPath(path: string): boolean {
 }
 
 /**
- * Path separators as one form (`/`). Every path the app compares or displays arrives from a pi tool call or
- * the host, either of which may use the platform's separator — so normalizing is the first step of any path
- * predicate here, and it lives once for all of them.
+ * One canonical form for a path: `/` separators and no leading `./`. Every path the app compares or displays
+ * arrives from a pi tool call or the host, either of which may use the platform's separator and may prefix a
+ * relative path with `./` — so normalizing is the first step of any path predicate here, and it lives once
+ * for all of them. The `./` strip matters to *comparison*, not just display: without it a reported
+ * `./src/foo.ts` matches neither the entry `src/foo.ts` nor any spec-graph node.
  */
 export function normalizePath(path: string): string {
-	return path.replaceAll("\\", "/");
+	return path.replaceAll("\\", "/").replace(/^\.\/+/, "");
 }
 
 /** Posix or Windows absolute path — the two forms a tool call's `path` argument can arrive in. */
@@ -38,6 +40,37 @@ export function shallowEqualArrays(
 	if (a === b) return true;
 	if (!a || !b || a.length !== b.length) return false;
 	return a.every((value, i) => Object.is(value, b[i]));
+}
+
+/** The last path segment, e.g. "/a/b/App.tsx" -> "App.tsx". */
+function fileName(path: string): string {
+	const parts = normalizePath(path).split("/").filter(Boolean);
+	return parts.at(-1) ?? path;
+}
+
+function trimTrailingSlashes(path: string): string {
+	return path.replace(/\/+$/, "");
+}
+
+/**
+ * A file path as the app addresses it: **worktree-relative** when the given root matches, else the
+ * normalized input. Tool args may already be relative; absolute ones are trimmed only when the
+ * host-provided root prefixes them.
+ *
+ * This is both the display form (tool cards, the turn divider's artifact list) and the **tab identity**
+ * (`openFileInTab` keys tabs by it), so one file can never end up under two ids — which is why it belongs
+ * here rather than in any one consumer.
+ */
+export function projectRelativePath(path: string, workspaceRoot?: string | undefined): string {
+	const normalized = normalizePath(path); // already strips a leading `./`
+	if (!normalized || !isAbsolutePath(normalized)) return normalized;
+
+	const root = workspaceRoot ? trimTrailingSlashes(normalizePath(workspaceRoot)) : "";
+	if (root && (normalized === root || normalized.startsWith(`${root}/`))) {
+		return normalized.slice(root.length).replace(/^\/+/, "") || fileName(normalized);
+	}
+
+	return normalized;
 }
 
 let colorCanvas: CanvasRenderingContext2D | null | undefined;

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -11,6 +11,35 @@ export function isMarkdownPath(path: string): boolean {
 	return /\.(md|markdown)$/i.test(path);
 }
 
+/**
+ * Path separators as one form (`/`). Every path the app compares or displays arrives from a pi tool call or
+ * the host, either of which may use the platform's separator — so normalizing is the first step of any path
+ * predicate here, and it lives once for all of them.
+ */
+export function normalizePath(path: string): string {
+	return path.replaceAll("\\", "/");
+}
+
+/** Posix or Windows absolute path — the two forms a tool call's `path` argument can arrive in. */
+export function isAbsolutePath(path: string): boolean {
+	const normalized = normalizePath(path);
+	return normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized);
+}
+
+/**
+ * Element-wise (`Object.is`) equality of two arrays — the "did this really change?" test shared by the
+ * places that must not treat an equal-but-new array as a change (a re-read's snapshot, an `ErrorBoundary`'s
+ * reset keys). `Object.is` rather than `===` so `NaN` keys compare equal to themselves.
+ */
+export function shallowEqualArrays(
+	a: readonly unknown[] | undefined,
+	b: readonly unknown[] | undefined,
+): boolean {
+	if (a === b) return true;
+	if (!a || !b || a.length !== b.length) return false;
+	return a.every((value, i) => Object.is(value, b[i]));
+}
+
 let colorCanvas: CanvasRenderingContext2D | null | undefined;
 
 function canvasNormalize(color: string): string {

--- a/apps/web/src/panels/ChangesPanel.tsx
+++ b/apps/web/src/panels/ChangesPanel.tsx
@@ -1,6 +1,6 @@
 import type { GitStatus } from "@thinkrail/contracts";
 import { useEffect, useState } from "react";
-import { useAppStore } from "../store";
+import { matchesWorktreePath, useAppStore } from "../store";
 import { getTransport } from "../transport";
 import { ChangesTree } from "./ChangesTree";
 import { diffTabId, isDiffTabId, statusNameClass } from "./changesModel";
@@ -75,14 +75,12 @@ export function ChangesPanel({ workspaceId }: { workspaceId: string }) {
 	};
 
 	// A chat deep-link (turn-divider chip) targeting this workspace: highlight the requested row once the
-	// status list is loaded — the diff opens only on the user's explicit click. Match by suffix so an
-	// absolute pi path still resolves to the relative entry.
+	// status list is loaded — the diff opens only on the user's explicit click. `matchesWorktreePath` resolves
+	// an absolute pi path to its relative entry (the same helper the spec classifier uses).
 	useEffect(() => {
 		if (!status || changesRequest?.workspaceId !== workspaceId) return;
 		const want = changesRequest.path;
-		// Anchor the suffix at a path separator so an absolute pi path resolves to its relative entry
-		// without `a-foo.ts` spuriously matching the entry `foo.ts`.
-		const match = status.changes.find((c) => c.path === want || want.endsWith(`/${c.path}`));
+		const match = status.changes.find((c) => matchesWorktreePath(want, c.path));
 		setHighlighted(match ? match.path : want);
 	}, [changesRequest, status, workspaceId]);
 

--- a/apps/web/src/panels/ChangesPanel.tsx
+++ b/apps/web/src/panels/ChangesPanel.tsx
@@ -1,11 +1,12 @@
 import type { GitStatus } from "@thinkrail/contracts";
 import { useEffect, useState } from "react";
-import { matchesWorktreePath, useAppStore } from "../store";
+import { matchesWorktreePath, selectWorkspaceTick, useAppStore } from "../store";
 import { getTransport } from "../transport";
 import { ChangesTree } from "./ChangesTree";
 import { diffTabId, isDiffTabId, statusNameClass } from "./changesModel";
 import { DiffStatBadge } from "./DiffStatBadge";
 import { ToggleSegment } from "./ToggleSegment";
+import { useWorkspaceRead } from "./useWorkspaceRead";
 
 /**
  * Changes for the active worktree: the changed-file list (vs base). Clicking a file opens (or focuses)
@@ -22,31 +23,18 @@ export function ChangesPanel({ workspaceId }: { workspaceId: string }) {
 	const changesRequest = useAppStore((s) => s.changesRequest);
 	const changesView = useAppStore((s) => s.changesView);
 	const setChangesView = useAppStore((s) => s.setChangesView);
-	const fsTick = useAppStore((s) => s.fsChangesByWorkspace[workspaceId]?.tick ?? 0);
 	const activeTabId = useAppStore((s) => s.activeTabByWorkspace[workspaceId] ?? null);
 
-	// Hard reset only on workspace switch — a tick refresh keeps the old list until the re-read lands.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is the trigger (reset-on-switch), not a body input
-	useEffect(() => {
-		setStatus(null);
-		setHighlighted(null);
-	}, [workspaceId]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: fsTick is the live-refresh trigger, not a body input
-	useEffect(() => {
-		let cancelled = false;
-		getTransport()
-			.request("git.status", { workspaceId })
-			.then((s) => {
-				if (!cancelled) setStatus(s);
-			})
-			.catch(() => {
-				if (!cancelled) setStatus((prev) => prev ?? { branch: "", changes: [] });
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [workspaceId, fsTick]);
+	// The changed-file list, re-read on the workspace's fs tick; a switch clears the list and its deep-link
+	// highlight, a failed re-read keeps the last good list (a failed first read reads as "no changes").
+	useWorkspaceRead(workspaceId, (id) => getTransport().request("git.status", { workspaceId: id }), {
+		onResult: (result) => setStatus(result),
+		onFailure: () => setStatus((prev) => prev ?? { branch: "", changes: [] }),
+		onSwitch: () => {
+			setStatus(null);
+			setHighlighted(null);
+		},
+	});
 
 	// Open (or focus) the file's Monaco diff tab in the center.
 	const openDiff = async (path: string) => {
@@ -65,7 +53,7 @@ export function ChangesPanel({ workspaceId }: { workspaceId: string }) {
 			const name = path.split("/").pop() || path;
 			// Stamp the workspace's current fs tick: the contents are fresh as of now, so DiffPane's live
 			// re-read only fires for ticks arriving AFTER this open.
-			const loadedTick = useAppStore.getState().fsChangesByWorkspace[workspaceId]?.tick ?? 0;
+			const loadedTick = selectWorkspaceTick(useAppStore.getState(), workspaceId);
 			useAppStore
 				.getState()
 				.openTab({ kind: "diff", id, workspaceId, path, name, original, modified, loadedTick });

--- a/apps/web/src/panels/FileTree.tsx
+++ b/apps/web/src/panels/FileTree.tsx
@@ -1,9 +1,9 @@
 import type { FileNode } from "@thinkrail/contracts";
-import { useEffect, useState } from "react";
-import { useAppStore } from "../store";
+import { useState } from "react";
 import { getTransport } from "../transport";
 import { openFileInTab } from "./openFile";
 import { TreeRow } from "./TreeRow";
+import { useWorkspaceRead } from "./useWorkspaceRead";
 
 /**
  * Lazy file tree of the active worktree. Double-click a file to open it as a center editor tab.
@@ -13,72 +13,47 @@ import { TreeRow } from "./TreeRow";
  */
 export function FileTree({ workspaceId }: { workspaceId: string }) {
 	const [nodes, setNodes] = useState<FileNode[] | null>(null);
-	const fsTick = useAppStore((s) => s.fsChangesByWorkspace[workspaceId]?.tick ?? 0);
 
-	// Hard reset only on workspace switch — a tick refresh keeps the old tree until the re-read lands.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is the trigger (reset-on-switch), not a body input
-	useEffect(() => {
-		setNodes(null);
-	}, [workspaceId]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: fsTick is the live-refresh trigger, not a body input
-	useEffect(() => {
-		let cancelled = false;
-		getTransport()
-			.request("fs.readDir", { workspaceId, path: "." })
-			.then((result) => {
-				if (!cancelled) setNodes(result);
-			})
-			.catch(() => {
-				if (!cancelled) setNodes((prev) => prev ?? []);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [workspaceId, fsTick]);
+	// The root listing, re-read on the workspace's fs tick; a switch clears the old tree, a failed re-read
+	// keeps it (and a failed *first* read shows an empty tree rather than a permanent "Loading…").
+	useWorkspaceRead(
+		workspaceId,
+		(id) => getTransport().request("fs.readDir", { workspaceId: id, path: "." }),
+		{
+			onResult: (result) => setNodes(result),
+			onFailure: () => setNodes((prev) => prev ?? []),
+			onSwitch: () => setNodes(null),
+		},
+	);
 
 	if (nodes === null) return <p className="px-xs py-xs text-xs text-hint">Loading…</p>;
 	if (nodes.length === 0) return <p className="px-xs py-xs text-xs text-hint">Empty</p>;
 	return (
 		<ul className="flex flex-col">
 			{nodes.map((node) => (
-				<FileNodeRow key={node.path} node={node} workspaceId={workspaceId} fsTick={fsTick} />
+				<FileNodeRow key={node.path} node={node} workspaceId={workspaceId} />
 			))}
 		</ul>
 	);
 }
 
-function FileNodeRow({
-	node,
-	workspaceId,
-	fsTick,
-}: {
-	node: FileNode;
-	workspaceId: string;
-	fsTick: number;
-}) {
+function FileNodeRow({ node, workspaceId }: { node: FileNode; workspaceId: string }) {
 	const isDir = node.kind === "dir";
 	const [expanded, setExpanded] = useState(false);
 	const [children, setChildren] = useState<FileNode[] | null>(null);
 
-	// An expanded dir (re-)fetches its listing on expansion AND on every fs tick, silently keeping the
-	// previous children on failure (e.g. the dir vanished — the parent's own refetch drops this row).
-	// biome-ignore lint/correctness/useExhaustiveDependencies: fsTick is the live-refresh trigger, not a body input
-	useEffect(() => {
-		if (!isDir || !expanded) return;
-		let cancelled = false;
-		getTransport()
-			.request("fs.readDir", { workspaceId, path: node.path })
-			.then((result) => {
-				if (!cancelled) setChildren(result);
-			})
-			.catch(() => {
-				if (!cancelled) setChildren((prev) => prev ?? []);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [isDir, expanded, workspaceId, node.path, fsTick]);
+	// An expanded dir (re-)reads its listing on expansion AND on every fs tick, silently keeping the
+	// previous children on failure (e.g. the dir vanished — the parent's own re-read drops this row).
+	// Collapsed reads nothing: `null` is the shared hook's "no workspace to read for", which is exactly the
+	// paused state here — so the row needs no tick prop threaded down from the tree.
+	useWorkspaceRead(
+		isDir && expanded ? workspaceId : null,
+		(id) => getTransport().request("fs.readDir", { workspaceId: id, path: node.path }),
+		{
+			onResult: (result) => setChildren(result),
+			onFailure: () => setChildren((prev) => prev ?? []),
+		},
+	);
 
 	const open = () => void openFileInTab(workspaceId, node.path);
 
@@ -95,7 +70,7 @@ function FileNodeRow({
 			{isDir && expanded && children && (
 				<ul className="flex flex-col pl-md">
 					{children.map((child) => (
-						<FileNodeRow key={child.path} node={child} workspaceId={workspaceId} fsTick={fsTick} />
+						<FileNodeRow key={child.path} node={child} workspaceId={workspaceId} />
 					))}
 				</ul>
 			)}

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -19,7 +19,9 @@ export function RightPanel() {
 	// by the chat deep-links too), so the flip is decided in a single place rather than inferred from each
 	// path request — and a chip that only reveals its own artifact list needs no path to do it.
 	useEffect(() => {
-		if (rightTabRequest?.workspaceId === activeWorkspaceId) setTab(rightTabRequest.tab);
+		if (rightTabRequest?.workspaceId !== activeWorkspaceId) return;
+		setTab(rightTabRequest.tab);
+		useAppStore.getState().clearRightTabRequest(); // one flip per request; never replayed on re-activation
 	}, [rightTabRequest, activeWorkspaceId]);
 
 	return (

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../store";
 import { ChangesPanel } from "./ChangesPanel";
 import { FileTree } from "./FileTree";
 import { SpecsPanel } from "./SpecsPanel";
+import { useWorkspaceSpecs } from "./useWorkspaceSpecs";
 
 type RightTab = "specs" | "files" | "changes";
 
@@ -11,13 +12,22 @@ type RightTab = "specs" | "files" | "changes";
 export function RightPanel() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 	const changesRequest = useAppStore((s) => s.changesRequest);
+	const specRequest = useAppStore((s) => s.specRequest);
 	const [tab, setTab] = useState<RightTab>("specs");
 	const [specsRefresh, setSpecsRefresh] = useState(0);
+	// Owned here, not in the tab body: the spec graph is app-wide state (the chat classifies its artifacts
+	// with it), and this panel outlives any one tab. See `useWorkspaceSpecs`.
+	const specsFailed = useWorkspaceSpecs(activeWorkspaceId, specsRefresh);
 
-	// A deep-link from chat (turn-divider chip) targeting this workspace flips us to the Changes view.
+	// A deep-link from chat (a turn-divider chip) targeting this workspace flips us to the view that owns the
+	// artifact: the "files changed" chip to Changes, the "specs" chip to Specs. Two effects, not one, so a
+	// stale request of the other kind can never win the flip.
 	useEffect(() => {
 		if (changesRequest?.workspaceId === activeWorkspaceId) setTab("changes");
 	}, [changesRequest, activeWorkspaceId]);
+	useEffect(() => {
+		if (specRequest?.workspaceId === activeWorkspaceId) setTab("specs");
+	}, [specRequest, activeWorkspaceId]);
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
@@ -53,7 +63,7 @@ export function RightPanel() {
 					<p className="p-sm text-xs text-hint">Select a workspace to browse files.</p>
 				) : tab === "specs" ? (
 					<div className="p-xs">
-						<SpecsPanel workspaceId={activeWorkspaceId} refreshToken={specsRefresh} />
+						<SpecsPanel workspaceId={activeWorkspaceId} failed={specsFailed} />
 					</div>
 				) : tab === "files" ? (
 					<div className="p-xs">

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -1,33 +1,27 @@
 import { RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useAppStore } from "../store";
+import { type RightPanelTab, useAppStore } from "../store";
 import { ChangesPanel } from "./ChangesPanel";
 import { FileTree } from "./FileTree";
 import { SpecsPanel } from "./SpecsPanel";
 import { useWorkspaceSpecs } from "./useWorkspaceSpecs";
 
-type RightTab = "specs" | "files" | "changes";
-
 /** Right panel for the active worktree: Specs (read-only spec-graph tree), All-files tree, and Changes (git diff vs base). Checks/Review = V2. */
 export function RightPanel() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
-	const changesRequest = useAppStore((s) => s.changesRequest);
-	const specRequest = useAppStore((s) => s.specRequest);
-	const [tab, setTab] = useState<RightTab>("specs");
+	const rightTabRequest = useAppStore((s) => s.rightTabRequest);
+	const [tab, setTab] = useState<RightPanelTab>("specs");
 	const [specsRefresh, setSpecsRefresh] = useState(0);
 	// Owned here, not in the tab body: the spec graph is app-wide state (the chat classifies its artifacts
 	// with it), and this panel outlives any one tab. See `useWorkspaceSpecs`.
 	const specsFailed = useWorkspaceSpecs(activeWorkspaceId, specsRefresh);
 
-	// A deep-link from chat (a turn-divider chip) targeting this workspace flips us to the view that owns the
-	// artifact: the "files changed" chip to Changes, the "specs" chip to Specs. Two effects, not one, so a
-	// stale request of the other kind can never win the flip.
+	// Anything outside the panel that wants a view shown raises one intent (`requestRightTab`, carried along
+	// by the chat deep-links too), so the flip is decided in a single place rather than inferred from each
+	// path request — and a chip that only reveals its own artifact list needs no path to do it.
 	useEffect(() => {
-		if (changesRequest?.workspaceId === activeWorkspaceId) setTab("changes");
-	}, [changesRequest, activeWorkspaceId]);
-	useEffect(() => {
-		if (specRequest?.workspaceId === activeWorkspaceId) setTab("specs");
-	}, [specRequest, activeWorkspaceId]);
+		if (rightTabRequest?.workspaceId === activeWorkspaceId) setTab(rightTabRequest.tab);
+	}, [rightTabRequest, activeWorkspaceId]);
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -11,10 +11,9 @@ export function RightPanel() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 	const rightTabRequest = useAppStore((s) => s.rightTabRequest);
 	const [tab, setTab] = useState<RightPanelTab>("specs");
-	const [specsRefresh, setSpecsRefresh] = useState(0);
 	// Owned here, not in the tab body: the spec graph is app-wide state (the chat classifies its artifacts
 	// with it), and this panel outlives any one tab. See `useWorkspaceSpecs`.
-	const specsFailed = useWorkspaceSpecs(activeWorkspaceId, specsRefresh);
+	const { failed: specsFailed, reload: reloadSpecs } = useWorkspaceSpecs(activeWorkspaceId);
 
 	// Anything outside the panel that wants a view shown raises one intent (`requestRightTab`, carried along
 	// by the chat deep-links too), so the flip is decided in a single place rather than inferred from each
@@ -45,7 +44,7 @@ export function RightPanel() {
 						data-testid="specs-refresh"
 						aria-label="Refresh specs"
 						title="Refresh specs"
-						onClick={() => setSpecsRefresh((n) => n + 1)}
+						onClick={reloadSpecs}
 						className="ml-auto text-hint hover:text-muted"
 					>
 						<RefreshCw className="size-3.5" />

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -352,8 +352,10 @@ a project picker, the prompt hero, and the reused
   file's row (resolved with `matchesWorktreePath` against `git.status`) — deliberately without opening its
   diff tab; the diff opens only on the user's explicit click, so a chat chip never steals the center area.
   `SpecsPanel` watches **`specRequest`** (the "N specs" chip) and **opens the rendered spec**
-  (`openFileInTab`, resolving the reported path through the graph, falling
-  back to the raw request for a spec created seconds ago) — a spec has nothing to preview short of its
+  (`openFileInTab`, which canonicalizes the reported path — pi may report it absolute or `./`-prefixed — to
+  the worktree-relative **tab identity**, so a deep link can never open a second tab for a file already open
+  under its relative path; that lives in the choke point, not in each caller, and it means a spec created
+  seconds ago and not yet in the graph opens just the same) — a spec has nothing to preview short of its
   content, and the tree row lights up on its own since rows key off the active tab id. That intent is
   **consumed** (`clearSpecRequest`) once handled: unlike the highlight-only Changes link, it opens a center
   tab, so replaying it on a remount or a graph refetch would yank the user's tab back mid-edit. Two intents, two

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -300,8 +300,16 @@ a project picker, the prompt hero, and the reused
   so scoping is natural; a degraded watcher just means back to read-on-demand. Deliberately **not**
   live (deferred): the project-rail workspace diffStats badges; editable-file conflict handling waits
   for `fs.writeFile` (the viewer is read-only today).
-- `SpecsPanel` is the read-only spec-graph viewer: one `spec.graph` fetch per workspace-activation /
-  tab-visit, refetched on the fs tick, plus a header **Refresh** button re-fetching on demand (the
+- **`useWorkspaceSpecs` owns the `spec.graph` read** (one fetcher, one definition of "this file is a spec"):
+  the snapshot lands in the store (`specsByWorkspace`), not panel state, because the chat's turn divider
+  needs the same answer to route its chips. It is called by **`RightPanel`**, not by `SpecsPanel` — the
+  panel body only exists while its tab is showing, so owning the read there would mean a user sitting on
+  Changes stops the graph tracking the worktree, and every spec the agent writes gets counted as a changed
+  file (the split silently undone by a tab selection). Being keyed per workspace, a switch shows that
+  workspace's last known tree while the re-read is in flight (there is nothing to reset), and the failed-read
+  flag is workspace-scoped so it can't leak a hint over a sibling's good tree.
+- `SpecsPanel` is the read-only spec-graph viewer — a pure reader of that snapshot. One fetch per
+  workspace-activation, refetched on the fs tick, plus a header **Refresh** button re-fetching on demand (the
   manual escape hatch if the host's watcher degraded; the host side revalidates per read), rendered as
   the **`parent` tree** (roots = no/dangling parent; default-expanded). A fetch **failure renders a distinct error hint** (pointing at Refresh), never the
   "No specs" empty state — offline and empty are different answers. The tree build (`specTree.ts`)
@@ -322,11 +330,23 @@ a project picker, the prompt hero, and the reused
   feature, not speculative dots or reused status chrome. This remains a restrained hierarchy — no hero,
   duplicate root, preview, or graph canvas. `FileTree` keeps its own gesture model (whole-row click
   toggles dirs — no collision there).
-- `RightPanel`/`ChangesPanel` watch the store's `changesRequest` deep-link (set by a chat turn-divider's
-  "files changed" chip): when it targets the active workspace, `RightPanel` flips to the Changes tab and
-  `ChangesPanel` **highlights** the requested file's row (matched by path suffix against `git.status`) —
-  deliberately without opening its diff tab; the diff opens only on the user's explicit click, so a chat
-  chip never steals the center area.
+- **The two chat deep-links mirror the tab split.** `RightPanel`/`ChangesPanel` watch the store's
+  `changesRequest` (set by a chat turn-divider's "files changed" chip): when it targets the active workspace,
+  `RightPanel` flips to the Changes tab and `ChangesPanel` **highlights** the requested file's row (resolved
+  with `matchesWorktreePath` against `git.status`) — deliberately without opening its diff tab; the diff
+  opens only on the user's explicit click, so a chat chip never steals the center area.
+  `RightPanel`/`SpecsPanel` watch **`specRequest`** (the "N specs" chip) the same way, but flip to **Specs**
+  and **open the rendered spec** (`openFileInTab`, resolving the reported path through the graph, falling
+  back to the raw request for a spec created seconds ago) — a spec has nothing to preview short of its
+  content, and the tree row lights up on its own since rows key off the active tab id. That intent is
+  **consumed** (`clearSpecRequest`) once handled: unlike the highlight-only Changes link, it opens a center
+  tab, so replaying it on a remount or a graph refetch would yank the user's tab back mid-edit. Two intents, two
+  effects: a spec chip must never land in the git-derived Changes view, which structurally cannot show a
+  gitignored `.thinkrail/context/` scratch spec — the empty-Changes bug that motivated the split.
+  Both intents carry **exactly one path**: a round that wrote several artifacts resolves the ambiguity in the
+  chat (the chip expands into a list there — see chat/SPEC.md), so no panel ever has to mark a *set*. That is
+  deliberate — a second, round-scoped marking vocabulary over these workspace-scoped trees would reintroduce
+  the two-rows-read-as-selected ambiguity the single-selection rule above exists to prevent.
 - **The diff is a center tab, not a rail inset.** Clicking a Changes row fetches `git.diffFile` (both
   sides: base branch vs worktree) and opens a **`DiffTab`** (`${workspaceId}:diff:${path}` — one tab per
   file; a re-click focuses the existing tab). `DiffPane` renders a slim header (the path + a per-tab

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -330,13 +330,16 @@ a project picker, the prompt hero, and the reused
   feature, not speculative dots or reused status chrome. This remains a restrained hierarchy — no hero,
   duplicate root, preview, or graph canvas. `FileTree` keeps its own gesture model (whole-row click
   toggles dirs — no collision there).
-- **The two chat deep-links mirror the tab split.** `RightPanel`/`ChangesPanel` watch the store's
-  `changesRequest` (set by a chat turn-divider's "files changed" chip): when it targets the active workspace,
-  `RightPanel` flips to the Changes tab and `ChangesPanel` **highlights** the requested file's row (resolved
-  with `matchesWorktreePath` against `git.status`) — deliberately without opening its diff tab; the diff
-  opens only on the user's explicit click, so a chat chip never steals the center area.
-  `RightPanel`/`SpecsPanel` watch **`specRequest`** (the "N specs" chip) the same way, but flip to **Specs**
-  and **open the rendered spec** (`openFileInTab`, resolving the reported path through the graph, falling
+- **The chat deep-links mirror the tab split.** `RightPanel` decides *which view is showing* from exactly one
+  store field — **`rightTabRequest`** (`requestRightTab`, which both path intents below set in the same
+  action) — so the flip is one concept rather than something re-derived per request type, and a divider chip
+  that only reveals a view (expanding its artifact list, no path picked) needs no path to do it.
+  `ChangesPanel` watches
+  `changesRequest` (set by a chat turn-divider's "files changed" chip) and **highlights** the requested
+  file's row (resolved with `matchesWorktreePath` against `git.status`) — deliberately without opening its
+  diff tab; the diff opens only on the user's explicit click, so a chat chip never steals the center area.
+  `SpecsPanel` watches **`specRequest`** (the "N specs" chip) and **opens the rendered spec**
+  (`openFileInTab`, resolving the reported path through the graph, falling
   back to the raw request for a spec created seconds ago) — a spec has nothing to preview short of its
   content, and the tree row lights up on its own since rows key off the active tab id. That intent is
   **consumed** (`clearSpecRequest`) once handled: unlike the highlight-only Changes link, it opens a center

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -282,11 +282,23 @@ a project picker, the prompt hero, and the reused
 
 - `RightPanel` tabs are **Specs | All files | Changes** (Specs leftmost and the **default** — specs are
   the project's ground truth, so the rail leads with them).
-- **Live refresh (the worktree panels follow the disk).** `FileTree` / `ChangesPanel` / `SpecsPanel` /
-  `FilePane` watch the store's `fsChangesByWorkspace` tick for their workspace (fed by the host's
-  debounced `workspace.fsChanged` push — see [[submodule-server-watch]]) and silently refetch through
-  the same read methods they mount with — agent edits, terminal commands, and Finder changes all land
-  without a manual step. Refetches **preserve view state**: `FileTree` re-reads the root + every
+- **Live refresh (the worktree panels follow the disk).** Every workspace-scoped read goes through one
+  hook — **`useWorkspaceRead(workspaceId, read, handlers) → { reload }`** — which owns *when* to read
+  (workspace change, that workspace's `fsChangesByWorkspace` tick, or `reload()` for a manual Refresh) while
+  the caller owns *what to do* with the outcome (`onResult` / `onFailure` / `onSwitch`). Centralized because
+  each site was otherwise re-implementing the **stale-response guard**: an answer in flight when the caller
+  moves on must not land in the new workspace's view (reads are generation-stamped — latest wins, abandoned
+  ones stay silent). A `null` workspaceId reads nothing, which is also how a *paused* read is expressed (a
+  collapsed `FileTree` dir), so no tick has to be threaded down as a prop.
+  Its users — `FileTree` (root + each expanded dir), `ChangesPanel` (`git.status`), `useWorkspaceSpecs`
+  (`spec.graph`) — plus `FilePane`/`DiffPane`, which follow the same tick contract per open tab. Agent edits,
+  terminal commands, and Finder changes all land without a manual step.
+  Three shapes keep its effect's dependency list **honest** (no exhaustive-deps exemption anywhere in it):
+  the fs tick is consumed as an **event** (`useAppStore.subscribe`) rather than selected into the component —
+  so it triggers a re-read without being a render input, and consumers stop re-rendering on unrelated
+  worktree churn; the **reset is the effect's cleanup**, which closes over the workspace being *left* (the id
+  a reset actually needs — a plain effect keyed on `workspaceId` runs with the *new* id already in scope);
+  and a manual refresh is an **imperative `reload()`**, not a nonce dependency. Refetches **preserve view state**: `FileTree` re-reads the root + every
   expanded dir (rows keyed by path; vanished dirs drop out via their parent), `ChangesPanel` re-reads
   `git.status` (list-only — the diff renders in the center tab, not under the list), `SpecsPanel`
   refetches without remounting (expansion survives), and `FilePane`/`DiffPane` re-read an
@@ -307,7 +319,8 @@ a project picker, the prompt hero, and the reused
   Changes stops the graph tracking the worktree, and every spec the agent writes gets counted as a changed
   file (the split silently undone by a tab selection). Being keyed per workspace, a switch shows that
   workspace's last known tree while the re-read is in flight (there is nothing to reset), and the failed-read
-  flag is workspace-scoped so it can't leak a hint over a sibling's good tree.
+  flag is workspace-scoped so it can't leak a hint over a sibling's good tree. It returns `{ failed, reload }`
+  — the header's Refresh calls `reload` directly, so no refresh counter has to be held in panel state.
 - `SpecsPanel` is the read-only spec-graph viewer — a pure reader of that snapshot. One fetch per
   workspace-activation, refetched on the fs tick, plus a header **Refresh** button re-fetching on demand (the
   manual escape hatch if the host's watcher degraded; the host side revalidates per read), rendered as

--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { cn } from "../lib";
-import { matchesWorktreePath, useAppStore } from "../store";
+import { useAppStore } from "../store";
 import { openFileInTab } from "./openFile";
 import { buildSpecTree, type SpecTreeNode, specRoleLabel, specRoleTag } from "./specTree";
 
@@ -39,18 +39,13 @@ export function SpecsPanel({
 	const specRequest = useAppStore((s) => s.specRequest);
 
 	// A chat deep-link targeting this workspace: open the requested spec as a rendered doc tab, then clear
-	// the request. The path arrives as pi reported it (possibly absolute), so it resolves through the graph
-	// to the worktree-relative path the fs read wants — read via `getState` rather than the subscribed
-	// `nodes`, keeping the graph out of the deps so a refetch can't re-fire the open.
+	// the request. The path arrives as pi reported it (possibly absolute) — `openFileInTab` canonicalizes it
+	// to the worktree-relative tab identity, so no graph lookup is needed here (and a spec created seconds
+	// ago, not yet in the snapshot, opens just the same).
 	useEffect(() => {
 		if (specRequest?.workspaceId !== workspaceId) return;
-		const want = specRequest.path;
-		const store = useAppStore.getState();
-		const known = store.specsByWorkspace[workspaceId]?.find((node) =>
-			matchesWorktreePath(want, node.path),
-		);
-		void openFileInTab(workspaceId, known?.path ?? want);
-		store.clearSpecRequest();
+		void openFileInTab(workspaceId, specRequest.path);
+		useAppStore.getState().clearSpecRequest();
 	}, [specRequest, workspaceId]);
 
 	const roots = useMemo(() => (nodes ? buildSpecTree(nodes) : null), [nodes]);

--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -1,4 +1,3 @@
-import type { SpecGraphNode } from "@thinkrail/contracts";
 import {
 	BookOpen,
 	Box,
@@ -9,66 +8,54 @@ import {
 	ListChecks,
 	Network,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "../lib";
-import { useAppStore } from "../store";
-import { getTransport } from "../transport";
+import { matchesWorktreePath, useAppStore } from "../store";
 import { openFileInTab } from "./openFile";
 import { buildSpecTree, type SpecTreeNode, specRoleLabel, specRoleTag } from "./specTree";
 
 /**
  * Read-only spec-graph viewer for the active worktree, rendered as a compact document-first `parent`
- * tree. Fetches `spec.graph` on mount and re-fetches WITHOUT remounting on the store's per-workspace
- * fs tick (the host's `workspace.fsChanged` nudge) and on the header Refresh button (`refreshToken`
- * from `RightPanel`) — rows are keyed by spec id, so expansion state survives a silent refresh. A
- * refetch failure keeps the last good tree; the error hint shows only when there is nothing to show.
- * The chevron expands children and one click on the document row opens its rendered spec.
+ * tree — a pure reader of the store snapshot that `useWorkspaceSpecs` (owned by `RightPanel`, so it
+ * outlives this tab) keeps current. Rows are keyed by spec id, so expansion state survives a silent
+ * refresh; a failed re-read keeps the last good tree and `failed` renders the hint only when there is
+ * nothing to show. The chevron expands children and one click on the document row opens its rendered spec.
+ *
+ * Being keyed per workspace, a switch shows that workspace's last known tree while the re-read is in
+ * flight — there is nothing to reset. A `specRequest` deep link (the divider's "N specs" chip) opens the
+ * rendered spec and is **consumed**: it opens a center tab, so replaying it on a remount or a refetch would
+ * yank the user's tab back. The row lights up on its own, since rows key off the active tab id.
  */
 export function SpecsPanel({
 	workspaceId,
-	refreshToken = 0,
+	failed = false,
 }: {
 	workspaceId: string;
-	refreshToken?: number;
+	/** The current workspace's spec read failed (from `useWorkspaceSpecs`, which owns the fetch). */
+	failed?: boolean;
 }) {
-	const [nodes, setNodes] = useState<SpecGraphNode[] | null>(null);
-	const [failed, setFailed] = useState(false);
+	const nodes = useAppStore((s) => s.specsByWorkspace[workspaceId]) ?? null;
 	const activeTabId = useAppStore((state) => state.activeTabByWorkspace[workspaceId] ?? null);
-	const fsTick = useAppStore((s) => s.fsChangesByWorkspace[workspaceId]?.tick ?? 0);
-	// Mirrors `nodes` so the async catch can tell "nothing loaded yet" without re-running the effect.
-	const nodesRef = useRef<SpecGraphNode[] | null>(null);
+	const specRequest = useAppStore((s) => s.specRequest);
 
-	// Hard reset only on workspace switch — tick/Refresh refetches keep the old tree until the read lands.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is the trigger (reset-on-switch), not a body input
+	// A chat deep-link targeting this workspace: open the requested spec as a rendered doc tab, then clear
+	// the request. The path arrives as pi reported it (possibly absolute), so it resolves through the graph
+	// to the worktree-relative path the fs read wants — read via `getState` rather than the subscribed
+	// `nodes`, keeping the graph out of the deps so a refetch can't re-fire the open.
 	useEffect(() => {
-		setNodes(null);
-		nodesRef.current = null;
-		setFailed(false);
-	}, [workspaceId]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: fsTick + refreshToken are refetch triggers, not body inputs
-	useEffect(() => {
-		let cancelled = false;
-		getTransport()
-			.request("spec.graph", { workspaceId })
-			.then((result) => {
-				if (cancelled) return;
-				nodesRef.current = result.nodes;
-				setNodes(result.nodes);
-				setFailed(false);
-			})
-			.catch(() => {
-				// Keep a previously-loaded tree on a failed refresh; only an empty panel shows the hint.
-				if (!cancelled && nodesRef.current === null) setFailed(true);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [workspaceId, fsTick, refreshToken]);
+		if (specRequest?.workspaceId !== workspaceId) return;
+		const want = specRequest.path;
+		const store = useAppStore.getState();
+		const known = store.specsByWorkspace[workspaceId]?.find((node) =>
+			matchesWorktreePath(want, node.path),
+		);
+		void openFileInTab(workspaceId, known?.path ?? want);
+		store.clearSpecRequest();
+	}, [specRequest, workspaceId]);
 
 	const roots = useMemo(() => (nodes ? buildSpecTree(nodes) : null), [nodes]);
 
-	if (failed)
+	if (failed && !nodes)
 		return (
 			<p data-testid="specs-error" className="px-xs py-xs text-xs text-hint">
 				Couldn't load specs — Refresh to retry.

--- a/apps/web/src/panels/openFile.ts
+++ b/apps/web/src/panels/openFile.ts
@@ -1,4 +1,4 @@
-import { useAppStore } from "../store";
+import { selectWorkspaceTick, useAppStore } from "../store";
 import { getTransport } from "../transport";
 
 /**
@@ -18,7 +18,7 @@ export async function openFileInTab(workspaceId: string, path: string): Promise<
 		const name = path.split("/").pop() || path;
 		// Stamp the workspace's current fs tick: the content is fresh as of now, so FilePane's live
 		// re-read only fires for ticks arriving AFTER this open.
-		const loadedTick = useAppStore.getState().fsChangesByWorkspace[workspaceId]?.tick ?? 0;
+		const loadedTick = selectWorkspaceTick(useAppStore.getState(), workspaceId);
 		useAppStore
 			.getState()
 			.openTab({ kind: "file", id, workspaceId, path, name, content, loadedTick });

--- a/apps/web/src/panels/openFile.ts
+++ b/apps/web/src/panels/openFile.ts
@@ -1,14 +1,22 @@
-import { selectWorkspaceTick, useAppStore } from "../store";
+import { projectRelativePath } from "../lib";
+import { selectWorkspaceById, selectWorkspaceTick, useAppStore } from "../store";
 import { getTransport } from "../transport";
 
 /**
  * Open a worktree file as a center editor tab: focus it if already open, else read its content and open
- * a new tab. `path` is worktree-relative. Shared by the file tree and rendered-markdown relative links,
- * so both get identical de-dupe/focus behavior. A read failure (missing file / not text) is a no-op.
+ * a new tab. Shared by the file tree, rendered-markdown relative links, and the chat's spec deep link, so
+ * all of them get identical de-dupe/focus behavior. A read failure (missing file / not text) is a no-op.
+ *
+ * `path` may arrive **absolute or `./`-prefixed** (a pi tool call reports whichever the agent passed), so it
+ * is canonicalized to the worktree-relative form here — the tab id is derived from it, and the host resolves
+ * an in-worktree absolute path happily, so a caller passing one would otherwise silently open a SECOND tab
+ * for a file already open under its relative path. The choke point is the only place that can guarantee one
+ * file = one tab identity, which is why it normalizes rather than trusting each caller.
  */
-export async function openFileInTab(workspaceId: string, path: string): Promise<void> {
-	const id = `${workspaceId}:${path}`;
+export async function openFileInTab(workspaceId: string, reported: string): Promise<void> {
 	const store = useAppStore.getState();
+	const path = projectRelativePath(reported, selectWorkspaceById(store, workspaceId)?.worktreePath);
+	const id = `${workspaceId}:${path}`;
 	if ((store.tabsByWorkspace[workspaceId] ?? []).some((t) => t.id === id)) {
 		store.setActiveTab(id);
 		return;

--- a/apps/web/src/panels/useWorkspaceRead.ts
+++ b/apps/web/src/panels/useWorkspaceRead.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef } from "react";
+import { selectWorkspaceTick, useAppStore } from "../store";
+
+/** What a caller does with each outcome of the read; the hook owns *when*, these own *what*. */
+interface WorkspaceReadHandlers<T> {
+	/** A landed read (never called for a response the hook has since abandoned). */
+	onResult: (value: T, workspaceId: string) => void;
+	/** A failed read. Every current caller keeps its last good value and degrades the empty case. */
+	onFailure?: (workspaceId: string) => void;
+	/** The workspace being **left**: drop whatever belonged to it, before the next one's read lands. */
+	onSwitch?: (workspaceId: string) => void;
+}
+
+/**
+ * Read something for a workspace and keep it live: on workspace change, on that workspace's fs tick (the
+ * host's debounced `workspace.fsChanged` nudge), and on demand through the returned `reload` (a manual
+ * Refresh). A null `workspaceId` reads nothing — which is also how a *paused* read is expressed (a collapsed
+ * `FileTree` dir), so no tick has to be threaded down as a prop.
+ *
+ * This is the one place the worktree-scoped panel reads share, so none of them re-implements the guard that
+ * makes a switch safe: a response in flight when the caller has moved on must not land in the new
+ * workspace's view. Reads are generation-stamped — the latest one wins, abandoned ones stay silent.
+ *
+ * Two deliberate shapes keep the effect's dependency list **honest**, every entry genuinely read in the body,
+ * so nothing here needs an exhaustive-deps exemption:
+ * - the **fs tick is consumed as an event** (`useAppStore.subscribe`) rather than selected into the
+ *   component: it triggers a re-read without being a render input, and consumers stop re-rendering on
+ *   unrelated worktree churn;
+ * - the **reset is the effect's cleanup**, which closes over the workspace being *left* — the id a reset
+ *   actually needs (a plain effect keyed on `workspaceId` runs with the *new* id already in scope);
+ * - a manual refresh is an **imperative `reload()`**, not a nonce dependency.
+ */
+export function useWorkspaceRead<T>(
+	workspaceId: string | null,
+	read: (workspaceId: string) => Promise<T>,
+	handlers: WorkspaceReadHandlers<T>,
+): { reload: () => void } {
+	const latest = useRef({ read, handlers });
+	latest.current = { read, handlers };
+	// Stamps each read. A newer read — or a switch/unmount — invalidates the ones before it, so a slow
+	// response can tell it is stale without a per-call-site cancellation flag.
+	const generation = useRef(0);
+
+	const runRead = useCallback((id: string) => {
+		const mine = ++generation.current;
+		const live = () => generation.current === mine;
+		latest.current
+			.read(id)
+			.then((value) => {
+				if (live()) latest.current.handlers.onResult(value, id);
+			})
+			.catch(() => {
+				if (live()) latest.current.handlers.onFailure?.(id);
+			});
+	}, []);
+
+	useEffect(() => {
+		if (!workspaceId) return;
+		runRead(workspaceId);
+		let tick = selectWorkspaceTick(useAppStore.getState(), workspaceId);
+		const unsubscribe = useAppStore.subscribe((state) => {
+			const next = selectWorkspaceTick(state, workspaceId);
+			if (next === tick) return;
+			tick = next;
+			runRead(workspaceId);
+		});
+		return () => {
+			unsubscribe();
+			generation.current += 1; // abandon this workspace's in-flight read
+			latest.current.handlers.onSwitch?.(workspaceId);
+		};
+	}, [workspaceId, runRead]);
+
+	return {
+		reload: () => {
+			if (workspaceId) runRead(workspaceId);
+		},
+	};
+}

--- a/apps/web/src/panels/useWorkspaceSpecs.ts
+++ b/apps/web/src/panels/useWorkspaceSpecs.ts
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useAppStore } from "../store";
 import { getTransport } from "../transport";
+import { useWorkspaceRead } from "./useWorkspaceRead";
 
 /**
- * Own the active workspace's `spec.graph` snapshot in the store: read it on workspace change, re-read on the
- * workspace's fs tick (the host's debounced `workspace.fsChanged` nudge) and on an explicit `refreshToken`
- * bump (the panel header's Refresh — the escape hatch if the watcher degraded).
+ * Own the active workspace's `spec.graph` snapshot in the store, kept current by `useWorkspaceRead` (so the
+ * re-read triggers and the stale-response guard are the shared ones, not a third copy).
  *
  * It lives in a hook called by the always-mounted `RightPanel`, NOT inside `SpecsPanel`, because the
  * snapshot is app-wide: the chat's turn divider classifies a round's written files as specs with it
@@ -15,33 +15,27 @@ import { getTransport } from "../transport";
  * That is the exact bug the specs/changes split exists to fix, so the fetch has to outlive the tab.
  *
  * Returns whether **this** workspace's read failed — scoped to the id, so a failure can never leak a
- * "couldn't load" hint over a sibling workspace's tree. A failed re-read keeps the last good snapshot; the
- * caller shows the hint only when there is nothing to show.
+ * "couldn't load" hint over a sibling workspace's tree — plus the `reload` behind the panel header's
+ * Refresh. A failed re-read keeps the last good snapshot (the store holds it per workspace, so there is
+ * nothing to reset on a switch); the caller shows the hint only when there is nothing to show.
  */
-export function useWorkspaceSpecs(workspaceId: string | null, refreshToken = 0): boolean {
+export function useWorkspaceSpecs(workspaceId: string | null): {
+	failed: boolean;
+	reload: () => void;
+} {
 	const [failedFor, setFailedFor] = useState<string | null>(null);
-	const fsTick = useAppStore(
-		(s) => (workspaceId ? s.fsChangesByWorkspace[workspaceId]?.tick : 0) ?? 0,
+
+	const { reload } = useWorkspaceRead(
+		workspaceId,
+		(id) => getTransport().request("spec.graph", { workspaceId: id }),
+		{
+			onResult: (result, id) => {
+				useAppStore.getState().setWorkspaceSpecs(id, result.nodes);
+				setFailedFor(null);
+			},
+			onFailure: (id) => setFailedFor(id),
+		},
 	);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: fsTick + refreshToken are refetch triggers, not body inputs
-	useEffect(() => {
-		if (!workspaceId) return;
-		let cancelled = false;
-		getTransport()
-			.request("spec.graph", { workspaceId })
-			.then((result) => {
-				if (cancelled) return;
-				useAppStore.getState().setWorkspaceSpecs(workspaceId, result.nodes);
-				setFailedFor(null);
-			})
-			.catch(() => {
-				if (!cancelled) setFailedFor(workspaceId);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [workspaceId, fsTick, refreshToken]);
-
-	return failedFor !== null && failedFor === workspaceId;
+	return { failed: failedFor !== null && failedFor === workspaceId, reload };
 }

--- a/apps/web/src/panels/useWorkspaceSpecs.ts
+++ b/apps/web/src/panels/useWorkspaceSpecs.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { useAppStore } from "../store";
+import { getTransport } from "../transport";
+
+/**
+ * Own the active workspace's `spec.graph` snapshot in the store: read it on workspace change, re-read on the
+ * workspace's fs tick (the host's debounced `workspace.fsChanged` nudge) and on an explicit `refreshToken`
+ * bump (the panel header's Refresh — the escape hatch if the watcher degraded).
+ *
+ * It lives in a hook called by the always-mounted `RightPanel`, NOT inside `SpecsPanel`, because the
+ * snapshot is app-wide: the chat's turn divider classifies a round's written files as specs with it
+ * (`specPathMatcher`). `SpecsPanel` only exists while its tab is showing, so owning the read there would
+ * mean a user sitting on Changes silently un-teaches the chat what a spec is — and every spec the agent
+ * writes gets counted as a changed file, deep-linking to the git view that cannot show a gitignored one.
+ * That is the exact bug the specs/changes split exists to fix, so the fetch has to outlive the tab.
+ *
+ * Returns whether **this** workspace's read failed — scoped to the id, so a failure can never leak a
+ * "couldn't load" hint over a sibling workspace's tree. A failed re-read keeps the last good snapshot; the
+ * caller shows the hint only when there is nothing to show.
+ */
+export function useWorkspaceSpecs(workspaceId: string | null, refreshToken = 0): boolean {
+	const [failedFor, setFailedFor] = useState<string | null>(null);
+	const fsTick = useAppStore(
+		(s) => (workspaceId ? s.fsChangesByWorkspace[workspaceId]?.tick : 0) ?? 0,
+	);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: fsTick + refreshToken are refetch triggers, not body inputs
+	useEffect(() => {
+		if (!workspaceId) return;
+		let cancelled = false;
+		getTransport()
+			.request("spec.graph", { workspaceId })
+			.then((result) => {
+				if (cancelled) return;
+				useAppStore.getState().setWorkspaceSpecs(workspaceId, result.nodes);
+				setFailedFor(null);
+			})
+			.catch(() => {
+				if (!cancelled) setFailedFor(workspaceId);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [workspaceId, fsTick, refreshToken]);
+
+	return failedFor !== null && failedFor === workspaceId;
+}

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -129,7 +129,8 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   contract in `DiffPane`. The transient **`rightTabRequest`** +
   **`requestRightTab(workspaceId, tab)`** are the ONE intent for "show a right-panel view" (`RightPanelTab`
   lives here, since the intent does): `RightPanel` watches that single field instead of inferring a flip from
-  each path request, which is what lets a divider chip reveal a view while merely expanding its own artifact
+  each path request, and **consumes** it (`clearRightTabRequest`) — an unconsumed flip would re-fire on every
+  re-activation of the workspace, moving the tab the user has since chosen; which is what lets a divider chip reveal a view while merely expanding its own artifact
   list — no path picked yet. The transient **`changesRequest`** +
   **`requestChangesView(workspaceId, path)`** are a UI deep-link intent (a chat turn-divider asking the
   right panel to surface a file in its Changes view — **highlight the row**, without
@@ -175,7 +176,9 @@ paths only; opened by `ChangesPanel`). The transient **`chatLocationRequest`** �
   `SessionRuntime` types. (Chat *render* types + renderers live in the `chat` module.) The pure context
   selectors in `selectors.ts` resolve the active `Workspace`, its owning project id, and the shell's context
   project from those canonical ids and collections; derived active-project state is never stored separately.
-- **Public surface (barrel):** `useAppStore`; `selectActiveWorkspace`,
+- **Public surface (barrel):** `useAppStore`; `selectActiveWorkspace`, `selectWorkspaceById` (the
+  one lookup for "the workspace with this id" — `selectActiveWorkspace` is it applied to the active id, and
+  `openFileInTab`/`ChatView` read the worktree root through it),
   `selectActiveWorkspaceProjectId`, `selectHistoryTarget` + `HistoryTarget` (the shell's `Ctrl+R` routing
   target: the active chat tab, or the workspace's newest chat when a file/diff/doc tab is active),
   `selectContextProject`, `selectSkillsStale`, `selectWorkspaceTick` (the

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -126,12 +126,18 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   tick)`** — a `FileTab` carries the `tick` its content was loaded at, so `FilePane` detects staleness
   (`workspaceTick > tab.loadedTick`) across tab switches, and its diff twin
   **`updateDiffTabContent(id, original, modified, tick)`** — a `DiffTab` follows the same staleness
-  contract in `DiffPane`. The transient **`changesRequest`** +
+  contract in `DiffPane`. The transient **`rightTabRequest`** +
+  **`requestRightTab(workspaceId, tab)`** are the ONE intent for "show a right-panel view" (`RightPanelTab`
+  lives here, since the intent does): `RightPanel` watches that single field instead of inferring a flip from
+  each path request, which is what lets a divider chip reveal a view while merely expanding its own artifact
+  list — no path picked yet. The transient **`changesRequest`** +
   **`requestChangesView(workspaceId, path)`** are a UI deep-link intent (a chat turn-divider asking the
-  right panel to surface a file in its Changes view — flip to the tab and **highlight the row**, without
+  right panel to surface a file in its Changes view — **highlight the row**, without
   opening the diff; that waits for an explicit click); the panels watch it, scoped by workspace. Its Specs
-  twin **`specRequest`** + **`requestSpecView(workspaceId, path)`** flips to the Specs tab and **opens the
+  twin **`specRequest`** + **`requestSpecView(workspaceId, path)`** **opens the
   rendered spec** — the stronger treatment, because a spec doc has nothing to preview short of its content.
+  Both path intents set `rightTabRequest` **in the same action**: the panel is never asked to surface a path
+  in a view it was not also told to show.
   Two separate fields, never one: the panel that can show a *gitignored* spec is not the git-derived one, and
   that confusion is exactly the bug the split fixes. The spec intent is additionally **consumed**
   (**`clearSpecRequest`**) by whoever handles it — it opens a center tab, so a replay would steal the user's

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -190,7 +190,9 @@ paths only; opened by `ChangesPanel`). The transient **`chatLocationRequest`** â
   `EMPTY_RUNTIME` (ChatView's pre-creation fallback), `ChatLocationRequest` (type), `reduceSessionEvent`.
 - **Allowed deps:** `contracts` (`Project`/`Workspace`/`Model`/`ThinkingLevel`/`SessionStats`/
   `SlashCommandInfo`/`ExtUiRequest`/`LoginPush`/`WorkspaceFsChangedPayload`/`AppConfig`/`ThemeId`;
-  `DEFAULT_CONFIG` for the pre-welcome default; `PiEvent`/`LoginFrame`, **type-only**); `chat`
+  `DEFAULT_CONFIG` for the pre-welcome default; `PiEvent`/`LoginFrame`, **type-only**); `lib` (the shared
+  path + array primitives â€” `normalizePath`/`isAbsolutePath` for `matchesWorktreePath`, `shallowEqualArrays`
+  for the snapshot-identity guard; a leaf, so the edge adds no cycle); `chat`
   (`ChatTurn`/`ToolResultState`, **type-only**); `auth` (`LoginState`, **type-only**); `transport`
   (`ConnectionStatus`, **type-only**); `zustand`.
 - **Forbidden:** `server`/`shared`/`pi`; importing `panels`/`shell` or transport runtime.

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -129,7 +129,20 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   contract in `DiffPane`. The transient **`changesRequest`** +
   **`requestChangesView(workspaceId, path)`** are a UI deep-link intent (a chat turn-divider asking the
   right panel to surface a file in its Changes view — flip to the tab and **highlight the row**, without
-  opening the diff; that waits for an explicit click); the panels watch it, scoped by workspace.
+  opening the diff; that waits for an explicit click); the panels watch it, scoped by workspace. Its Specs
+  twin **`specRequest`** + **`requestSpecView(workspaceId, path)`** flips to the Specs tab and **opens the
+  rendered spec** — the stronger treatment, because a spec doc has nothing to preview short of its content.
+  Two separate fields, never one: the panel that can show a *gitignored* spec is not the git-derived one, and
+  that confusion is exactly the bug the split fixes. The spec intent is additionally **consumed**
+  (**`clearSpecRequest`**) by whoever handles it — it opens a center tab, so a replay would steal the user's
+  tab; the Changes intent only highlights, so it stays fire-and-forget. **`specsByWorkspace`** +
+  **`setWorkspaceSpecs`** hold each workspace's `spec.graph` snapshot (fetched by `panels`'
+  `useWorkspaceSpecs`, kept fresh on the workspace fs tick) so
+  the chat's turn divider can classify a written path as a spec off the very snapshot the Specs panel
+  renders — one definition of "this file is a spec", via the **`specPathMatcher(nodes)`** selector; dropped
+  with the workspace in `applyWorkspaceRemoved`. `setWorkspaceSpecs` **keeps the previous array identity when
+  the re-read found no change** — most fs ticks touch no spec, and a fresh identity would invalidate
+  `ChatView`'s matcher memo and re-derive every open chat's whole transcript about once a second.
   **`openDoc(tab)`** opens
   (or refreshes + focuses) an ephemeral **`DocTab`** — inline rendered-markdown content, never backed by a
   file on disk (no fs re-read / source toggle) — used for on-demand snapshots like the plan-as-markdown
@@ -160,7 +173,12 @@ paths only; opened by `ChangesPanel`). The transient **`chatLocationRequest`** �
   `selectActiveWorkspaceProjectId`, `selectHistoryTarget` + `HistoryTarget` (the shell's `Ctrl+R` routing
   target: the active chat tab, or the workspace's newest chat when a file/diff/doc tab is active),
   `selectContextProject`, `selectSkillsStale`, `selectWorkspaceTick` (the
-  sync-baseline snapshot; + the `isSkillPath` path predicate it shares with `noteFsChanged`); `toast` (the
+  sync-baseline snapshot; + the `isSkillPath` path predicate it shares with `noteFsChanged`);
+  `matchesWorktreePath` (line an agent-reported path — relative or absolute — up against a worktree-relative
+  one; shared by the Changes deep link and the spec classifier. The suffix rule is for **absolute reports
+  only** and is anchored at a separator: unanchored, `/wt/src/a-foo.ts` would match `src/foo.ts`; applied to
+  relative reports, `module-b/SPEC.md` would match the *root* `SPEC.md`) + `specPathMatcher` (is a written
+  path a spec-graph node?); `toast` (the
   fire-from-anywhere helper),
   `Toast` (type), `EditorTab` (`FileTab`/`ChatTab`/`DocTab`), `TerminalTab`, `ClosedChat`, `SessionRuntime` +
   `EMPTY_RUNTIME` (ChatView's pre-creation fallback), `ChatLocationRequest` (type), `reduceSessionEvent`.

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -741,9 +741,10 @@ test("applyWorkspaceRemoved drops the removed workspace's cached spec graph", ()
 // --- the right-panel deep links (chat turn-divider chips) ------------------------------------------
 
 test("requestChangesView / requestSpecView are independent, workspace-scoped intents", () => {
-	useAppStore.setState({ changesRequest: null, specRequest: null });
+	useAppStore.setState({ changesRequest: null, specRequest: null, rightTabRequest: null });
 
 	useAppStore.getState().requestChangesView("w1", "src/a.ts");
+	expect(useAppStore.getState().rightTabRequest).toEqual({ workspaceId: "w1", tab: "changes" });
 	useAppStore.getState().requestSpecView("w1", ".thinkrail/context/TASK-x.md");
 
 	const s = useAppStore.getState();
@@ -751,12 +752,34 @@ test("requestChangesView / requestSpecView are independent, workspace-scoped int
 	// The spec intent is a separate field, so a spec chip can never be mistaken for a changes chip (which
 	// would flip the right panel to a view that can't show a gitignored spec).
 	expect(s.specRequest).toEqual({ workspaceId: "w1", path: ".thinkrail/context/TASK-x.md" });
+	// The path intent and the flip are one action: the panel is never asked to surface a path in a view it
+	// was not also told to show.
+	expect(s.rightTabRequest).toEqual({ workspaceId: "w1", tab: "specs" });
 
 	// A fresh object each call, so re-clicking the same chip re-fires the watching effects.
 	const first = useAppStore.getState().specRequest;
 	useAppStore.getState().requestSpecView("w1", ".thinkrail/context/TASK-x.md");
 	expect(useAppStore.getState().specRequest).not.toBe(first);
 	expect(useAppStore.getState().specRequest).toEqual(first);
+});
+
+test("requestRightTab flips a view without surfacing any path", () => {
+	// The divider's chips use this when they expand their own list: the panel follows the side the user
+	// chose, but nothing is opened or highlighted (no path was picked yet).
+	useAppStore.setState({ rightTabRequest: null, changesRequest: null, specRequest: null });
+
+	useAppStore.getState().requestRightTab("w1", "specs");
+
+	const s = useAppStore.getState();
+	expect(s.rightTabRequest).toEqual({ workspaceId: "w1", tab: "specs" });
+	expect(s.specRequest).toBeNull();
+	expect(s.changesRequest).toBeNull();
+
+	// A fresh object each call, so re-choosing the same side after a manual tab switch still flips back.
+	const first = s.rightTabRequest;
+	useAppStore.getState().requestRightTab("w1", "specs");
+	expect(useAppStore.getState().rightTabRequest).not.toBe(first);
+	expect(useAppStore.getState().rightTabRequest).toEqual(first);
 });
 
 test("clearSpecRequest consumes the spec intent once — it opens a tab, so it must not replay", () => {

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, expect, test } from "bun:test";
-import type { ExtUiRequest, PiEvent, SessionSummary, Workspace } from "@thinkrail/contracts";
+import type {
+	ExtUiRequest,
+	PiEvent,
+	SessionSummary,
+	SpecGraphNode,
+	Workspace,
+} from "@thinkrail/contracts";
 import { type SessionRuntime, toast, useAppStore } from "./appStore";
 import { selectSkillsStale, selectWorkspaceTick } from "./selectors";
 
@@ -714,6 +720,106 @@ test("applyWorkspaceRemoved on a non-active workspace drops the row silently (no
 	expect(s.workspaces.p1?.map((w) => w.id)).toEqual(["other"]);
 	expect(s.activeWorkspaceId).toBe("other"); // a background removal doesn't move the client
 	expect(s.toasts).toHaveLength(0);
+});
+
+test("applyWorkspaceRemoved drops the removed workspace's cached spec graph", () => {
+	const keep = pushedWorkspace({ id: "other", name: "workspace-2", branch: "workspace-2" });
+	useAppStore.setState({
+		workspaces: { p1: [pushedWorkspace(), keep] },
+		activeWorkspaceId: "other",
+		specsByWorkspace: { w1: [], other: [] },
+		toasts: [],
+	});
+
+	useAppStore.getState().applyWorkspaceRemoved("p1", "w1");
+
+	const s = useAppStore.getState();
+	expect(s.specsByWorkspace.w1).toBeUndefined(); // the worktree is gone; its graph must not linger
+	expect(s.specsByWorkspace.other).toEqual([]); // a sibling's snapshot is untouched
+});
+
+// --- the right-panel deep links (chat turn-divider chips) ------------------------------------------
+
+test("requestChangesView / requestSpecView are independent, workspace-scoped intents", () => {
+	useAppStore.setState({ changesRequest: null, specRequest: null });
+
+	useAppStore.getState().requestChangesView("w1", "src/a.ts");
+	useAppStore.getState().requestSpecView("w1", ".thinkrail/context/TASK-x.md");
+
+	const s = useAppStore.getState();
+	expect(s.changesRequest).toEqual({ workspaceId: "w1", path: "src/a.ts" });
+	// The spec intent is a separate field, so a spec chip can never be mistaken for a changes chip (which
+	// would flip the right panel to a view that can't show a gitignored spec).
+	expect(s.specRequest).toEqual({ workspaceId: "w1", path: ".thinkrail/context/TASK-x.md" });
+
+	// A fresh object each call, so re-clicking the same chip re-fires the watching effects.
+	const first = useAppStore.getState().specRequest;
+	useAppStore.getState().requestSpecView("w1", ".thinkrail/context/TASK-x.md");
+	expect(useAppStore.getState().specRequest).not.toBe(first);
+	expect(useAppStore.getState().specRequest).toEqual(first);
+});
+
+test("clearSpecRequest consumes the spec intent once — it opens a tab, so it must not replay", () => {
+	useAppStore.setState({ specRequest: null, changesRequest: null });
+	useAppStore.getState().requestSpecView("w1", "docs/SPEC.md");
+
+	useAppStore.getState().clearSpecRequest();
+
+	expect(useAppStore.getState().specRequest).toBeNull();
+	// Idempotent: a second consume (a remount racing the first) is a no-op, not a resurrect.
+	useAppStore.getState().clearSpecRequest();
+	expect(useAppStore.getState().specRequest).toBeNull();
+	// It clears only its own intent — the Changes deep link is a separate, non-consuming field.
+	useAppStore.getState().requestChangesView("w1", "src/a.ts");
+	useAppStore.getState().clearSpecRequest();
+	expect(useAppStore.getState().changesRequest).toEqual({ workspaceId: "w1", path: "src/a.ts" });
+});
+
+const specNode = (over: Partial<SpecGraphNode> = {}): SpecGraphNode => ({
+	id: "task-x",
+	type: "task-spec",
+	title: "X",
+	path: ".thinkrail/context/TASK-x.md",
+	dependsOn: [],
+	references: [],
+	implements: [],
+	tags: [],
+	...over,
+});
+
+test("setWorkspaceSpecs records a snapshot per workspace without touching its siblings", () => {
+	const node = specNode();
+	useAppStore.setState({ specsByWorkspace: { other: [] } });
+
+	useAppStore.getState().setWorkspaceSpecs("w1", [node]);
+
+	const s = useAppStore.getState();
+	expect(s.specsByWorkspace.w1).toEqual([node]);
+	expect(s.specsByWorkspace.other).toEqual([]);
+});
+
+test("setWorkspaceSpecs keeps the previous array identity when the re-read found no change", () => {
+	// The Specs read refetches on every worktree fs tick and most ticks touch no spec. A new array identity
+	// would invalidate ChatView's `isSpec` memo and re-derive every open chat's whole transcript, ~1/s.
+	useAppStore.setState({ specsByWorkspace: {} });
+	useAppStore.getState().setWorkspaceSpecs("w1", [specNode()]);
+	const first = useAppStore.getState().specsByWorkspace.w1;
+
+	useAppStore.getState().setWorkspaceSpecs("w1", [specNode()]); // equal, freshly-allocated wire objects
+	expect(useAppStore.getState().specsByWorkspace.w1).toBe(first);
+
+	// Any field the DTO carries counts as a change — including the link lists the tree doesn't render yet,
+	// so a stale snapshot can never survive here.
+	useAppStore.getState().setWorkspaceSpecs("w1", [specNode({ status: "active" })]);
+	expect(useAppStore.getState().specsByWorkspace.w1).not.toBe(first);
+
+	const withStatus = useAppStore.getState().specsByWorkspace.w1;
+	useAppStore.getState().setWorkspaceSpecs("w1", [specNode({ status: "active", tags: ["v1"] })]);
+	expect(useAppStore.getState().specsByWorkspace.w1).not.toBe(withStatus);
+
+	// A shorter/longer graph is a change too (a spec was deleted or added).
+	useAppStore.getState().setWorkspaceSpecs("w1", []);
+	expect(useAppStore.getState().specsByWorkspace.w1).toEqual([]);
 });
 
 // --- in-app login (flat, session-less) -------------------------------------------------------------

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -9,6 +9,7 @@ import type {
 	SessionStats,
 	SessionSummary,
 	SlashCommandInfo,
+	SpecGraphNode,
 	ThemeId,
 	ThinkingLevel,
 	WireModel,
@@ -468,6 +469,21 @@ interface AppState {
 	 */
 	historyOpenRequest: { sessionId: string } | null;
 	/**
+	 * A request to surface a spec in the right-panel Specs view (e.g. a chat turn-divider's "specs" chip).
+	 * The panels watch it and, when it targets the active workspace, switch to the Specs tab and **open the
+	 * rendered spec** — unlike a diff, a spec doc has nothing to preview short of opening it, and the tree
+	 * row lights up on its own (rows key off the active tab id). A fresh object each call so identical
+	 * re-requests still fire.
+	 */
+	specRequest: { workspaceId: string; path: string } | null;
+	/**
+	 * Each workspace's spec-graph snapshot (`spec.graph`), fetched by the Specs panel and kept here so the
+	 * chat can classify a written path as a spec without a second read — the ONE definition of "this file is
+	 * a spec", shared by the panel that lists them and the turn divider that counts them. Absent until the
+	 * first fetch lands; the panel refetches on the workspace fs tick, so it tracks the filesystem.
+	 */
+	specsByWorkspace: Record<string, SpecGraphNode[]>;
+	/**
 	 * The live-refresh signal, per workspace: `tick` increments on every `workspace.fsChanged` push (the
 	 * host's debounced worktree change notifier); `paths`/`truncated` are the LAST batch only. Panels
 	 * select their workspace's entry and silently refetch on `tick` change — the store holds only the
@@ -654,12 +670,50 @@ interface AppState {
 	requestHistoryOpen: (target: HistoryTarget) => void;
 	/** Dismiss the history-open request once `ChatView` has acted on it. */
 	clearHistoryOpen: () => void;
+	/** Ask the right panel to open `path` in its Specs view (deep-link from chat). */
+	requestSpecView: (workspaceId: string, path: string) => void;
+	/** Drop the spec deep-link once a panel has acted on it (it opens a tab — it must fire exactly once). */
+	clearSpecRequest: () => void;
+	/** Record a workspace's fetched spec-graph snapshot (`useWorkspaceSpecs`' read lands here). */
+	setWorkspaceSpecs: (workspaceId: string, nodes: SpecGraphNode[]) => void;
 	/** Enqueue a toast; returns its id so a caller can dismiss it early. An identical live toast (same
 	 * variant/title/message — e.g. a retried failure) coalesces: no twin is added, the existing id returns.
 	 * The queue caps at `MAX_TOASTS` (oldest drop). Prefer the `toast` helper. */
 	pushToast: (toast: Omit<Toast, "id">) => string;
 	/** Drop a toast (user dismiss or the Toaster's auto-timeout). A missing id is a no-op. */
 	dismissToast: (id: string) => void;
+}
+
+/** Field-wise equality of two spec-graph nodes — every field the DTO carries, so "unchanged" is honest. */
+function sameSpecNode(a: SpecGraphNode, b: SpecGraphNode): boolean {
+	const sameList = (x: string[], y: string[]) =>
+		x.length === y.length && x.every((item, i) => item === y[i]);
+	return (
+		a.id === b.id &&
+		a.type === b.type &&
+		a.title === b.title &&
+		a.status === b.status &&
+		a.path === b.path &&
+		a.parent === b.parent &&
+		sameList(a.dependsOn, b.dependsOn) &&
+		sameList(a.references, b.references) &&
+		sameList(a.implements, b.implements) &&
+		sameList(a.tags, b.tags)
+	);
+}
+
+/**
+ * Whether a re-read produced the same graph. The Specs read refetches on every worktree fs tick, and most
+ * ticks change no spec at all — keeping the previous array identity on those makes the refetch free for
+ * `ChatView`, whose `isSpec` memo (and with it `deriveRows` over the whole transcript, for every open chat)
+ * would otherwise be invalidated about once a second during any file activity.
+ */
+function sameSpecGraph(prev: SpecGraphNode[] | undefined, next: SpecGraphNode[]): boolean {
+	if (!prev || prev.length !== next.length) return false;
+	return prev.every((node, i) => {
+		const candidate = next[i];
+		return candidate !== undefined && sameSpecNode(node, candidate);
+	});
 }
 
 /** Apply an immutable update to one session's runtime; a no-op (and no new `sessions` object) if it's gone. */
@@ -747,6 +801,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 	models: [],
 	templatesVersion: 0,
 	changesRequest: null,
+	specRequest: null,
+	specsByWorkspace: {},
 	changesView: "list",
 	chatLocationRequest: null,
 	historyOpenRequest: null,
@@ -808,11 +864,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 		const name = s.workspaces[projectId]?.find((w) => w.id === workspaceId)?.name;
 		s.removeWorkspace(projectId, workspaceId);
 		s.clearWorkspaceTabs(workspaceId); // drops the row's tabs + terminals + chat runtimes
-		// Drop the live-refresh signal too — a removed workspace's fs tick record must not linger.
+		// Drop the live-refresh signal + the cached spec graph too — a removed workspace's records must not
+		// linger (the worktree is gone; a same-id workspace can never come back).
 		set((state) => {
 			const { [workspaceId]: _gone, ...rest } = state.fsChangesByWorkspace;
 			const { [workspaceId]: _skillGone, ...skillRest } = state.skillChangeTickByWorkspace;
-			return { fsChangesByWorkspace: rest, skillChangeTickByWorkspace: skillRest };
+			const { [workspaceId]: _specsGone, ...specsRest } = state.specsByWorkspace;
+			return {
+				fsChangesByWorkspace: rest,
+				skillChangeTickByWorkspace: skillRest,
+				specsByWorkspace: specsRest,
+			};
 		});
 		if (wasActive) {
 			s.selectProject(projectId); // atomically fall back to the removed workspace's Project Home
@@ -1304,6 +1366,14 @@ export const useAppStore = create<AppState>((set, get) => ({
 			activeTabByWorkspace: { ...s.activeTabByWorkspace, [target.workspaceId]: target.tabId },
 		})),
 	clearHistoryOpen: () => set({ historyOpenRequest: null }),
+	requestSpecView: (workspaceId, path) => set({ specRequest: { workspaceId, path } }),
+	clearSpecRequest: () => set({ specRequest: null }),
+	setWorkspaceSpecs: (workspaceId, nodes) =>
+		set((s) =>
+			sameSpecGraph(s.specsByWorkspace[workspaceId], nodes)
+				? {}
+				: { specsByWorkspace: { ...s.specsByWorkspace, [workspaceId]: nodes } },
+		),
 	pushToast: (toast) => {
 		const twin = get().toasts.find(
 			(t) => t.variant === toast.variant && t.title === toast.title && t.message === toast.message,

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -94,6 +94,12 @@ export const SettingsSection = {
 } as const;
 export type SettingsSection = (typeof SettingsSection)[keyof typeof SettingsSection];
 
+/**
+ * The right panel's views. The id lives here, not in `panels`, because the *intent* to show one is store
+ * state (`rightTabRequest`) that chat raises and the panel obeys — `RightPanel` reads the union back.
+ */
+export type RightPanelTab = "specs" | "files" | "changes";
+
 /** A transient notification. `error` persists until dismissed; `success`/`info` auto-dismiss (the Toaster
  * owns the timer). `title` is optional — a bare `message` is the common case. */
 export interface Toast {
@@ -447,10 +453,18 @@ interface AppState {
 	 * the counter, never fetches (see `chat/SPEC.md`'s Template slots bullet). */
 	templatesVersion: number;
 	/**
+	 * Which right-panel view to show, when something outside it asks (a chat turn-divider chip). The panel
+	 * watches this ONE field, so "flip to a view" is a single concept rather than a side effect read off
+	 * each path intent below — a chip that only *reveals* a view (expanding its artifact list) needs no path
+	 * at all. Workspace-scoped, so a request from another workspace's chat can't move the active panel; a
+	 * fresh object each call so identical re-requests still fire.
+	 */
+	rightTabRequest: { workspaceId: string; tab: RightPanelTab } | null;
+	/**
 	 * A request to surface a file in the right-panel Changes view (e.g. a chat turn-divider's "files
-	 * changed" chip). The panels watch it and, when it targets the active workspace, switch to the Changes
-	 * tab and **highlight** the file's row — the diff opens only on an explicit click. A fresh object each
-	 * call so identical re-requests still fire.
+	 * changed" chip). The panels watch it and **highlight** the file's row — the diff opens only on an
+	 * explicit click. Travels with a `rightTabRequest` for the flip. A fresh object each call so identical
+	 * re-requests still fire.
 	 */
 	changesRequest: { workspaceId: string; path: string } | null;
 	/**
@@ -470,10 +484,10 @@ interface AppState {
 	historyOpenRequest: { sessionId: string } | null;
 	/**
 	 * A request to surface a spec in the right-panel Specs view (e.g. a chat turn-divider's "specs" chip).
-	 * The panels watch it and, when it targets the active workspace, switch to the Specs tab and **open the
-	 * rendered spec** — unlike a diff, a spec doc has nothing to preview short of opening it, and the tree
-	 * row lights up on its own (rows key off the active tab id). A fresh object each call so identical
-	 * re-requests still fire.
+	 * The panels watch it and **open the rendered spec** — unlike a diff, a spec doc has nothing to preview
+	 * short of opening it, and the tree row lights up on its own (rows key off the active tab id). Travels
+	 * with a `rightTabRequest` for the flip, and is **consumed** once handled (it opens a center tab, so a
+	 * replay would steal the user's tab). A fresh object each call so identical re-requests still fire.
 	 */
 	specRequest: { workspaceId: string; path: string } | null;
 	/**
@@ -653,7 +667,9 @@ interface AppState {
 	setSettingsSection: (section: SettingsSection) => void;
 	/** Fold the server-synced app config in (from `server.welcome` / the `settings.changed` broadcast). */
 	applyConfig: (config: AppConfig) => void;
-	/** Ask the right panel to open `path`'s diff in its Changes view (deep-link from chat). */
+	/** Ask the right panel to show one of its views — no path, just the flip (a chip revealing its list). */
+	requestRightTab: (workspaceId: string, tab: RightPanelTab) => void;
+	/** Ask the right panel to surface `path` in its Changes view (deep-link from chat); flips to it too. */
 	requestChangesView: (workspaceId: string, path: string) => void;
 	/**
 	 * Open a history-search hit: sets `chatLocationRequest` AND switches `activeWorkspaceId` (the hit's
@@ -670,7 +686,7 @@ interface AppState {
 	requestHistoryOpen: (target: HistoryTarget) => void;
 	/** Dismiss the history-open request once `ChatView` has acted on it. */
 	clearHistoryOpen: () => void;
-	/** Ask the right panel to open `path` in its Specs view (deep-link from chat). */
+	/** Ask the right panel to open `path` in its Specs view (deep-link from chat); flips to it too. */
 	requestSpecView: (workspaceId: string, path: string) => void;
 	/** Drop the spec deep-link once a panel has acted on it (it opens a tab — it must fire exactly once). */
 	clearSpecRequest: () => void;
@@ -800,6 +816,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	sessions: {},
 	models: [],
 	templatesVersion: 0,
+	rightTabRequest: null,
 	changesRequest: null,
 	specRequest: null,
 	specsByWorkspace: {},
@@ -1348,7 +1365,13 @@ export const useAppStore = create<AppState>((set, get) => ({
 	closeSettings: () => set({ settingsOpen: false }),
 	setSettingsSection: (section) => set({ settingsSection: section }),
 	applyConfig: (config) => set({ theme: config.theme, analyticsEnabled: config.analyticsEnabled }),
-	requestChangesView: (workspaceId, path) => set({ changesRequest: { workspaceId, path } }),
+	requestRightTab: (workspaceId, tab) => set({ rightTabRequest: { workspaceId, tab } }),
+	// The path intent and the flip always travel together — one action, so no call site can send half of it.
+	requestChangesView: (workspaceId, path) =>
+		set({
+			changesRequest: { workspaceId, path },
+			rightTabRequest: { workspaceId, tab: "changes" },
+		}),
 	// Activate project + workspace together (the same atomicity `activateWorkspace` upholds) so a jump into
 	// another project can never leave `selectedProjectId` on the source while `activeWorkspaceId` points
 	// elsewhere. The caller (`useHistorySearch.openMessage`) ensures the target project's workspaces are
@@ -1366,7 +1389,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 			activeTabByWorkspace: { ...s.activeTabByWorkspace, [target.workspaceId]: target.tabId },
 		})),
 	clearHistoryOpen: () => set({ historyOpenRequest: null }),
-	requestSpecView: (workspaceId, path) => set({ specRequest: { workspaceId, path } }),
+	requestSpecView: (workspaceId, path) =>
+		set({ specRequest: { workspaceId, path }, rightTabRequest: { workspaceId, tab: "specs" } }),
 	clearSpecRequest: () => set({ specRequest: null }),
 	setWorkspaceSpecs: (workspaceId, nodes) =>
 		set((s) =>

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -21,6 +21,7 @@ import { create } from "zustand";
 import type { LoginState } from "../auth";
 import type { HydratedRuntime } from "../chat/hydrate";
 import type { ChatTurn, ExtUiDialogRequest, ToolResultState } from "../chat/types";
+import { shallowEqualArrays } from "../lib";
 import type { ConnectionStatus } from "../transport";
 import { type HistoryTarget, isSkillPath, selectWorkspaceTick } from "./selectors";
 
@@ -411,17 +412,13 @@ function reduceExtUi(
 				turns: [...rt.turns, { kind: "system", id: crypto.randomUUID(), text: request.message }],
 			};
 		case "setStatus": {
-			if (request.text === null) {
-				const { [request.key]: _drop, ...extUiStatus } = rt.extUiStatus;
-				return { ...rt, extUiStatus };
-			}
+			if (request.text === null)
+				return { ...rt, extUiStatus: omitKey(rt.extUiStatus, request.key) };
 			return { ...rt, extUiStatus: { ...rt.extUiStatus, [request.key]: request.text } };
 		}
 		case "setWidget": {
-			if (request.content === null) {
-				const { [request.key]: _drop, ...extUiWidget } = rt.extUiWidget;
-				return { ...rt, extUiWidget };
-			}
+			if (request.content === null)
+				return { ...rt, extUiWidget: omitKey(rt.extUiWidget, request.key) };
 			return { ...rt, extUiWidget: { ...rt.extUiWidget, [request.key]: request.content } };
 		}
 		default:
@@ -700,10 +697,18 @@ interface AppState {
 	dismissToast: (id: string) => void;
 }
 
+/**
+ * A record without `key` — the immutable delete behind every per-workspace / per-session cleanup here
+ * (`applyWorkspaceRemoved`, `clearWorkspaceTabs`, `closeSession`, the ext-UI request drops). One helper so a
+ * new keyed map added to the state can be cleaned up with a single readable line.
+ */
+function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+	const { [key]: _dropped, ...rest } = record;
+	return rest;
+}
+
 /** Field-wise equality of two spec-graph nodes — every field the DTO carries, so "unchanged" is honest. */
 function sameSpecNode(a: SpecGraphNode, b: SpecGraphNode): boolean {
-	const sameList = (x: string[], y: string[]) =>
-		x.length === y.length && x.every((item, i) => item === y[i]);
 	return (
 		a.id === b.id &&
 		a.type === b.type &&
@@ -711,10 +716,10 @@ function sameSpecNode(a: SpecGraphNode, b: SpecGraphNode): boolean {
 		a.status === b.status &&
 		a.path === b.path &&
 		a.parent === b.parent &&
-		sameList(a.dependsOn, b.dependsOn) &&
-		sameList(a.references, b.references) &&
-		sameList(a.implements, b.implements) &&
-		sameList(a.tags, b.tags)
+		shallowEqualArrays(a.dependsOn, b.dependsOn) &&
+		shallowEqualArrays(a.references, b.references) &&
+		shallowEqualArrays(a.implements, b.implements) &&
+		shallowEqualArrays(a.tags, b.tags)
 	);
 }
 
@@ -883,16 +888,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 		s.clearWorkspaceTabs(workspaceId); // drops the row's tabs + terminals + chat runtimes
 		// Drop the live-refresh signal + the cached spec graph too — a removed workspace's records must not
 		// linger (the worktree is gone; a same-id workspace can never come back).
-		set((state) => {
-			const { [workspaceId]: _gone, ...rest } = state.fsChangesByWorkspace;
-			const { [workspaceId]: _skillGone, ...skillRest } = state.skillChangeTickByWorkspace;
-			const { [workspaceId]: _specsGone, ...specsRest } = state.specsByWorkspace;
-			return {
-				fsChangesByWorkspace: rest,
-				skillChangeTickByWorkspace: skillRest,
-				specsByWorkspace: specsRest,
-			};
-		});
+		set((state) => ({
+			fsChangesByWorkspace: omitKey(state.fsChangesByWorkspace, workspaceId),
+			skillChangeTickByWorkspace: omitKey(state.skillChangeTickByWorkspace, workspaceId),
+			specsByWorkspace: omitKey(state.specsByWorkspace, workspaceId),
+		}));
 		if (wasActive) {
 			s.selectProject(projectId); // atomically fall back to the removed workspace's Project Home
 			toast.info(`Workspace "${name ?? "?"}" was removed`);
@@ -1063,19 +1063,13 @@ export const useAppStore = create<AppState>((set, get) => ({
 				delete sessions[closed.sessionId];
 				delete skillsSyncedTickBySession[closed.sessionId];
 			}
-			const { [workspaceId]: _tabs, ...tabsByWorkspace } = s.tabsByWorkspace;
-			const { [workspaceId]: _activeTab, ...activeTabByWorkspace } = s.activeTabByWorkspace;
-			const { [workspaceId]: _closed, ...closedChatsByWorkspace } = s.closedChatsByWorkspace;
-			// Dropping the terminals unmounts their instances, which close the PTYs server-side.
-			const { [workspaceId]: _terms, ...terminalsByWorkspace } = s.terminalsByWorkspace;
-			const { [workspaceId]: _activeTerm, ...activeTerminalByWorkspace } =
-				s.activeTerminalByWorkspace;
 			return {
-				tabsByWorkspace,
-				activeTabByWorkspace,
-				closedChatsByWorkspace,
-				terminalsByWorkspace,
-				activeTerminalByWorkspace,
+				tabsByWorkspace: omitKey(s.tabsByWorkspace, workspaceId),
+				activeTabByWorkspace: omitKey(s.activeTabByWorkspace, workspaceId),
+				closedChatsByWorkspace: omitKey(s.closedChatsByWorkspace, workspaceId),
+				// Dropping the terminals unmounts their instances, which close the PTYs server-side.
+				terminalsByWorkspace: omitKey(s.terminalsByWorkspace, workspaceId),
+				activeTerminalByWorkspace: omitKey(s.activeTerminalByWorkspace, workspaceId),
 				sessions,
 				skillsSyncedTickBySession,
 			};
@@ -1141,9 +1135,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 	closeChatRuntime: (sessionId) =>
 		set((s) => {
 			if (!s.sessions[sessionId]) return {};
-			const { [sessionId]: _drop, ...sessions } = s.sessions;
-			const { [sessionId]: _syncDrop, ...skillsSyncedTickBySession } = s.skillsSyncedTickBySession;
-			return { sessions, skillsSyncedTickBySession };
+			return {
+				sessions: omitKey(s.sessions, sessionId),
+				skillsSyncedTickBySession: omitKey(s.skillsSyncedTickBySession, sessionId),
+			};
 		}),
 	closeChatToHistory: (sessionId) =>
 		set((s) => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -454,7 +454,9 @@ interface AppState {
 	 * watches this ONE field, so "flip to a view" is a single concept rather than a side effect read off
 	 * each path intent below — a chip that only *reveals* a view (expanding its artifact list) needs no path
 	 * at all. Workspace-scoped, so a request from another workspace's chat can't move the active panel; a
-	 * fresh object each call so identical re-requests still fire.
+	 * fresh object each call so identical re-requests still fire, and **consumed** by the panel that obeys it
+	 * (`clearRightTabRequest`) — an unconsumed flip would re-fire whenever the workspace is re-activated,
+	 * moving the tab the user has since chosen.
 	 */
 	rightTabRequest: { workspaceId: string; tab: RightPanelTab } | null;
 	/**
@@ -687,6 +689,8 @@ interface AppState {
 	requestSpecView: (workspaceId: string, path: string) => void;
 	/** Drop the spec deep-link once a panel has acted on it (it opens a tab — it must fire exactly once). */
 	clearSpecRequest: () => void;
+	/** Drop the view request once the panel has flipped, so re-activating a workspace can't replay it. */
+	clearRightTabRequest: () => void;
 	/** Record a workspace's fetched spec-graph snapshot (`useWorkspaceSpecs`' read lands here). */
 	setWorkspaceSpecs: (workspaceId: string, nodes: SpecGraphNode[]) => void;
 	/** Enqueue a toast; returns its id so a caller can dismiss it early. An identical live toast (same
@@ -1387,6 +1391,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	requestSpecView: (workspaceId, path) =>
 		set({ specRequest: { workspaceId, path }, rightTabRequest: { workspaceId, tab: "specs" } }),
 	clearSpecRequest: () => set({ specRequest: null }),
+	clearRightTabRequest: () => set({ rightTabRequest: null }),
 	setWorkspaceSpecs: (workspaceId, nodes) =>
 		set((s) =>
 			sameSpecGraph(s.specsByWorkspace[workspaceId], nodes)

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -185,6 +185,9 @@ test("matchesWorktreePath accepts the relative form and an absolute report, anch
 	// Anchored: a sibling whose name merely ends with the entry must not match.
 	expect(matchesWorktreePath("/wt/src/a-foo.ts", "src/foo.ts")).toBe(false);
 	expect(matchesWorktreePath("src/other.ts", "src/foo.ts")).toBe(false);
+	// A `./`-prefixed report is the same file (the old suffix rule absorbed the prefix by accident; the
+	// anchored rule would drop it, so `normalizePath` strips it for every predicate).
+	expect(matchesWorktreePath("./src/foo.ts", "src/foo.ts")).toBe(true);
 });
 
 test("matchesWorktreePath does not let a RELATIVE report match a shorter entry by suffix", () => {

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -3,11 +3,13 @@ import type { Project, Workspace } from "@thinkrail/contracts";
 import type { EditorTab } from "./appStore";
 import {
 	isSkillPath,
+	matchesWorktreePath,
 	selectActiveWorkspace,
 	selectActiveWorkspaceProjectId,
 	selectContextProject,
 	selectHistoryTarget,
 	selectSkillsStale,
+	specPathMatcher,
 } from "./selectors";
 
 const projects: Project[] = [
@@ -174,4 +176,44 @@ test("selectHistoryTarget is null only with no chat to open", () => {
 			activeTabByWorkspace: { w1: "w2:s1" },
 		}),
 	).toBeNull();
+});
+
+test("matchesWorktreePath accepts the relative form and an absolute report, anchored at a separator", () => {
+	expect(matchesWorktreePath("src/foo.ts", "src/foo.ts")).toBe(true);
+	expect(matchesWorktreePath("/wt/src/foo.ts", "src/foo.ts")).toBe(true);
+	expect(matchesWorktreePath("C:\\wt\\src/foo.ts", "src/foo.ts")).toBe(true);
+	// Anchored: a sibling whose name merely ends with the entry must not match.
+	expect(matchesWorktreePath("/wt/src/a-foo.ts", "src/foo.ts")).toBe(false);
+	expect(matchesWorktreePath("src/other.ts", "src/foo.ts")).toBe(false);
+});
+
+test("matchesWorktreePath does not let a RELATIVE report match a shorter entry by suffix", () => {
+	// The suffix rule exists to absorb an absolute report; letting it apply to relative ones made every
+	// `<module>/SPEC.md` in a repo match the ROOT `SPEC.md` entry — one spec impersonating all of them.
+	expect(matchesWorktreePath("module-b/SPEC.md", "SPEC.md")).toBe(false);
+	expect(matchesWorktreePath("packages/server/SPEC.md", "SPEC.md")).toBe(false);
+	// The absolute form of the same pair still resolves, since there the prefix IS the worktree root.
+	expect(matchesWorktreePath("/wt/ws/SPEC.md", "SPEC.md")).toBe(true);
+});
+
+test("specPathMatcher recognizes a spec by graph membership, in either reported form", () => {
+	const nodes = [
+		{
+			id: "task-x",
+			type: "task-spec",
+			title: "X",
+			path: ".thinkrail/context/TASK-x.md",
+			dependsOn: [],
+			references: [],
+			implements: [],
+			tags: [],
+		},
+	];
+	const isSpec = specPathMatcher(nodes);
+
+	expect(isSpec(".thinkrail/context/TASK-x.md")).toBe(true);
+	expect(isSpec("/wt/ws/.thinkrail/context/TASK-x.md")).toBe(true);
+	expect(isSpec("packages/server/src/todos/todos.ts")).toBe(false);
+	// An empty graph (never fetched) classifies nothing as a spec — the single-chip fallback.
+	expect(specPathMatcher([])(".thinkrail/context/TASK-x.md")).toBe(false);
 });

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,4 +1,4 @@
-import type { Project, Workspace } from "@thinkrail/contracts";
+import type { Project, SpecGraphNode, Workspace } from "@thinkrail/contracts";
 import type { EditorTab } from "./appStore";
 
 interface ActiveWorkspaceState {
@@ -78,6 +78,41 @@ export function selectHistoryTarget(state: {
 /** Whether a worktree-relative path is inside a skill directory — the auto-detect trigger for a reload. */
 export function isSkillPath(path: string): boolean {
 	return /(^|\/)\.(claude|github|gemini|pi|agents)\/skills(\/|$)/.test(path);
+}
+
+/**
+ * Whether a path **as pi reported it** (worktree-relative or absolute — a tool call's `path` argument is
+ * whichever the agent passed) designates the worktree-relative `rel`. Shared by every consumer that has to
+ * line an agent-reported path up against a worktree-relative one (the Changes deep link, the spec
+ * classifier).
+ *
+ * The suffix rule applies to **absolute reports only**, and is anchored at a separator. Both halves matter:
+ * unanchored, `/wt/src/a-foo.ts` would match the entry `src/foo.ts`; applied to relative reports,
+ * `module-b/SPEC.md` would match the *root* entry `SPEC.md` — turning every module spec in a repo into the
+ * root one, and every nested file into whatever short entry it happens to end with.
+ */
+export function matchesWorktreePath(reported: string, rel: string): boolean {
+	// Separators normalized first, then the absolute check — the same shape as `chat/tools/toolHelpers`
+	// (re-stated rather than imported: the store may not depend on `chat` beyond types).
+	const path = reported.replaceAll("\\", "/");
+	if (path === rel) return true;
+	return isAbsolutePath(path) && path.endsWith(`/${rel}`);
+}
+
+/** Posix or Windows absolute path — the two forms a pi tool call's `path` can arrive in. */
+function isAbsolutePath(path: string): boolean {
+	return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
+}
+
+/**
+ * A predicate over agent-reported paths: is this file a **spec** — i.e. a node of the workspace's spec
+ * graph? This is the one definition the app uses to route an agent-written file to the Specs side rather
+ * than the Changes side (see `chat`'s turn divider), and it deliberately reuses the very snapshot the Specs
+ * panel renders, so the two can never disagree. Closes over the paths alone, not the nodes.
+ */
+export function specPathMatcher(nodes: SpecGraphNode[]): (path: string) => boolean {
+	const paths = nodes.map((node) => node.path);
+	return (reported) => paths.some((rel) => matchesWorktreePath(reported, rel));
 }
 
 /**

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,5 +1,5 @@
 import type { Project, SpecGraphNode, Workspace } from "@thinkrail/contracts";
-import { isAbsolutePath, normalizePath } from "@/lib";
+import { isAbsolutePath, normalizePath } from "../lib";
 import type { EditorTab } from "./appStore";
 
 interface ActiveWorkspaceState {
@@ -22,9 +22,16 @@ export function isDefaultWorkspace(workspace: Pick<Workspace, "kind">): boolean 
 
 /** Resolve the active workspace from the project-grouped collection without duplicating it in state. */
 export function selectActiveWorkspace(state: ActiveWorkspaceState): Workspace | null {
-	if (!state.activeWorkspaceId) return null;
+	return state.activeWorkspaceId ? selectWorkspaceById(state, state.activeWorkspaceId) : null;
+}
+
+/** The workspace with this id, wherever it sits in the project-grouped collection. */
+export function selectWorkspaceById(
+	state: ActiveWorkspaceState,
+	workspaceId: string,
+): Workspace | null {
 	for (const workspaces of Object.values(state.workspaces)) {
-		const workspace = workspaces.find((candidate) => candidate.id === state.activeWorkspaceId);
+		const workspace = workspaces.find((candidate) => candidate.id === workspaceId);
 		if (workspace) return workspace;
 	}
 	return null;

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,4 +1,5 @@
 import type { Project, SpecGraphNode, Workspace } from "@thinkrail/contracts";
+import { isAbsolutePath, normalizePath } from "@/lib";
 import type { EditorTab } from "./appStore";
 
 interface ActiveWorkspaceState {
@@ -92,16 +93,9 @@ export function isSkillPath(path: string): boolean {
  * root one, and every nested file into whatever short entry it happens to end with.
  */
 export function matchesWorktreePath(reported: string, rel: string): boolean {
-	// Separators normalized first, then the absolute check — the same shape as `chat/tools/toolHelpers`
-	// (re-stated rather than imported: the store may not depend on `chat` beyond types).
-	const path = reported.replaceAll("\\", "/");
+	const path = normalizePath(reported);
 	if (path === rel) return true;
 	return isAbsolutePath(path) && path.endsWith(`/${rel}`);
-}
-
-/** Posix or Windows absolute path — the two forms a pi tool call's `path` can arrive in. */
-function isAbsolutePath(path: string): boolean {
-	return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
 }
 
 /**

--- a/e2e/turn-divider.live.spec.ts
+++ b/e2e/turn-divider.live.spec.ts
@@ -5,6 +5,8 @@ import { openWorkspaceChat, waitForDone } from "./fixtures/app";
 // chat turn-divider (Task 9) — it appears the instant the turn ends (no follow-up needed), and its "files
 // changed" chip deep-links the right panel's Changes view, highlighting the edited file's row (the diff
 // itself opens only on an explicit click — the chip never steals the center area; see panels/SPEC.md).
+// The second spec covers the divider's OTHER chip: a written spec is counted and routed as a spec, never as
+// a change — the two chips mirror the Specs/Changes tab split.
 
 test("turn-divider files-changed chip highlights the file's row in the Changes panel", {
 	tag: "@agent",
@@ -42,4 +44,130 @@ test("turn-divider files-changed chip highlights the file's row in the Changes p
 	await expect(row).toBeVisible();
 	await expect(row).toHaveAttribute("data-active", "true");
 	await expect(page.getByTestId("diff-pane")).toHaveCount(0);
+});
+
+test("turn-divider counts a scratch task-spec as a spec and opens it from the Specs panel", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(150_000);
+	await openWorkspaceChat(page);
+
+	// A task-spec in the workspace's gitignored scratch dir: real work, zero git footprint. This is the
+	// regression — it used to be reported as a "changed file", deep-linking to a Changes view that
+	// structurally cannot show it (`.thinkrail/context/.gitignore` is a lone `*`).
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			"Use the spec_create tool to create a spec at path .thinkrail/context/TASK-divider-demo.md " +
+				"with id task-divider-demo, type task-spec, title Divider demo, status draft. " +
+				"Then stop — do not edit any other file.",
+		);
+	await page.getByTestId("chat-send").click();
+	await expect(
+		page
+			.locator('[data-testid="activity-group"], [data-testid="activity-step"]')
+			.filter({ hasText: "spec_create" })
+			.first(),
+	).toBeVisible({ timeout: 90_000 });
+	await waitForDone(page);
+
+	// The round reports a spec — and NO changed file, since the scratch dir has no git footprint.
+	const specChip = page.getByTestId("turn-divider-specs").first();
+	await expect(specChip).toBeVisible({ timeout: 30_000 });
+	await expect(specChip).toContainText("1 spec");
+	await expect(page.getByTestId("turn-divider-files")).toHaveCount(0);
+
+	// Clicking it flips to Specs and opens the rendered spec (the stronger deep link: a spec doc has nothing
+	// to preview short of its content), and the tree row marks the location.
+	await specChip.click();
+	await expect(page.getByTestId("tab-specs")).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("editor-pane")).toContainText("Divider demo");
+	await expect(
+		page.locator('[data-testid="spec-node"][data-spec-id="task-divider-demo"]'),
+	).toHaveAttribute("data-active", "true");
+});
+
+test("a multi-artifact chip expands into the round's list instead of guessing which one to open", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(150_000);
+	await openWorkspaceChat(page);
+
+	// Two written files in one round: the chip can no longer stand for a single deep link.
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			"Use the write tool twice: create alpha.txt containing the single line alpha, then create " +
+				"beta.txt containing the single line beta. Then stop.",
+		);
+	await page.getByTestId("chat-send").click();
+	await waitForDone(page);
+
+	const chip = page.getByTestId("turn-divider-files").first();
+	await expect(chip).toBeVisible({ timeout: 30_000 });
+	await expect(chip).toContainText("2 files changed");
+
+	// Collapsed by default, and clicking discloses the set rather than deep-linking the first path — the
+	// right panel stays put (the chip never steals the center area or picks for the user).
+	await expect(page.getByTestId("turn-divider-files-list")).toHaveCount(0);
+	await chip.click();
+	const list = page.getByTestId("turn-divider-files-list");
+	await expect(list).toBeVisible();
+	await expect(list.getByTestId("turn-divider-files-list-item")).toHaveCount(2);
+	await expect(page.getByTestId("tab-changes")).not.toHaveAttribute("data-active", "true");
+
+	// A row is the deep link: it flips to Changes and highlights that file — the one the user picked.
+	await list.getByTestId("turn-divider-files-list-item").filter({ hasText: "beta.txt" }).click();
+	await expect(page.getByTestId("tab-changes")).toHaveAttribute("data-active", "true");
+	const row = page.getByTestId("change-item").filter({ hasText: "beta.txt" });
+	await expect(row).toHaveAttribute("data-active", "true");
+	await expect(
+		page.getByTestId("change-item").filter({ hasText: "alpha.txt" }),
+	).not.toHaveAttribute("data-active", "true");
+});
+
+test("a spec written while the Specs tab is closed still counts as a spec", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(150_000);
+	await openWorkspaceChat(page);
+
+	// Park the right panel on Changes, so the Specs tab body is UNMOUNTED for the whole round. The graph
+	// that classifies the round's artifacts has to keep tracking the worktree anyway (the read is owned by
+	// the always-mounted panel — see panels/useWorkspaceSpecs); if it stopped at the tab, a user who lives
+	// in Changes would get every spec counted as a changed file, silently undoing the split.
+	await page.getByTestId("tab-changes").click();
+	await expect(page.getByTestId("tab-changes")).toHaveAttribute("data-active", "true");
+
+	// Written with `write` — NOT `spec_create`, whose target counts as a spec by tool name alone — so fresh
+	// graph membership is the only thing that can classify it: the snapshot has to refresh while the panel
+	// rendering it is off screen.
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			"Use the write tool once to create module-b/SPEC.md with exactly this content:\n" +
+				"---\nid: sample-module-b\ntype: module-design\ntitle: Sample Module B\nparent: sample-root\n---\n\n" +
+				"## Responsibility\n\nA second fixture module spec.\n" +
+				"Do NOT use the spec_create tool — use write. Then stop.",
+		);
+	await page.getByTestId("chat-send").click();
+	// Pin the tool actually used: if the agent reached for `spec_create`, the classification would come from
+	// the tool name and this spec would pass without ever exercising the graph refresh it exists to cover.
+	await expect(
+		page
+			.locator('[data-testid="activity-group"], [data-testid="activity-step"]')
+			.filter({ hasText: "write" })
+			.first(),
+	).toBeVisible({ timeout: 90_000 });
+	await expect(
+		page.locator('[data-testid="activity-group"], [data-testid="activity-step"]').filter({
+			hasText: "spec_create",
+		}),
+	).toHaveCount(0);
+	await waitForDone(page);
+
+	const specChip = page.getByTestId("turn-divider-specs").first();
+	await expect(specChip).toBeVisible({ timeout: 30_000 });
+	await expect(specChip).toContainText("1 spec");
+	await expect(page.getByTestId("turn-divider-files")).toHaveCount(0);
 });

--- a/e2e/turn-divider.live.spec.ts
+++ b/e2e/turn-divider.live.spec.ts
@@ -107,14 +107,20 @@ test("a multi-artifact chip expands into the round's list instead of guessing wh
 	await expect(chip).toBeVisible({ timeout: 30_000 });
 	await expect(chip).toContainText("2 files changed");
 
-	// Collapsed by default, and clicking discloses the set rather than deep-linking the first path — the
-	// right panel stays put (the chip never steals the center area or picks for the user).
+	// Collapsed by default, and clicking discloses the set rather than deep-linking the first path. The
+	// owning view is revealed alongside (that is what makes the chips read as a switch), but nothing is
+	// surfaced in it yet: no diff tab, no highlighted row — the chip never picks a file for the user.
 	await expect(page.getByTestId("turn-divider-files-list")).toHaveCount(0);
 	await chip.click();
 	const list = page.getByTestId("turn-divider-files-list");
 	await expect(list).toBeVisible();
 	await expect(list.getByTestId("turn-divider-files-list-item")).toHaveCount(2);
-	await expect(page.getByTestId("tab-changes")).not.toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("tab-changes")).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("diff-pane")).toHaveCount(0);
+	await expect(page.getByTestId("change-item").filter({ hasText: "beta.txt" })).not.toHaveAttribute(
+		"data-active",
+		"true",
+	);
 
 	// A row is the deep link: it flips to Changes and highlights that file — the one the user picked.
 	await list.getByTestId("turn-divider-files-list-item").filter({ hasText: "beta.txt" }).click();
@@ -170,4 +176,50 @@ test("a spec written while the Specs tab is closed still counts as a spec", {
 	await expect(specChip).toBeVisible({ timeout: 30_000 });
 	await expect(specChip).toContainText("1 spec");
 	await expect(page.getByTestId("turn-divider-files")).toHaveCount(0);
+});
+
+test("the two artifact chips are a switch: one list at a time, and re-clicking clears the selection", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(180_000);
+	await openWorkspaceChat(page);
+
+	// A round with several artifacts on BOTH sides, so the two chips are genuine alternatives.
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			"Use the write tool four times, then stop. 1) alpha.txt containing: alpha. 2) beta.txt " +
+				"containing: beta. 3) docs/one/SPEC.md containing:\n" +
+				"---\nid: sample-doc-one\ntype: module-design\ntitle: Doc One\nparent: sample-root\n---\n\n## Responsibility\n\nOne.\n" +
+				"4) docs/two/SPEC.md containing:\n" +
+				"---\nid: sample-doc-two\ntype: module-design\ntitle: Doc Two\nparent: sample-root\n---\n\n## Responsibility\n\nTwo.\n",
+		);
+	await page.getByTestId("chat-send").click();
+	await waitForDone(page);
+
+	const specsChip = page.getByTestId("turn-divider-specs").first();
+	const filesChip = page.getByTestId("turn-divider-files").first();
+	await expect(specsChip).toContainText("2 specs", { timeout: 30_000 });
+	await expect(filesChip).toContainText("2 files changed");
+	const specsList = page.getByTestId("turn-divider-specs-list");
+	const filesList = page.getByTestId("turn-divider-files-list");
+
+	// Choosing the specs side opens its list and reveals Specs.
+	await specsChip.click();
+	await expect(specsList).toBeVisible();
+	await expect(filesList).toHaveCount(0);
+	await expect(page.getByTestId("tab-specs")).toHaveAttribute("data-active", "true");
+
+	// Choosing the other side REPLACES the open list (never two at once) and follows with its own view.
+	await filesChip.click();
+	await expect(filesList).toBeVisible();
+	await expect(specsList).toHaveCount(0);
+	await expect(page.getByTestId("tab-changes")).toHaveAttribute("data-active", "true");
+
+	// Re-clicking the chosen side clears the selection: nothing expanded, and the panel is left where the
+	// user last sent it (a close is "never mind", not another navigation).
+	await filesChip.click();
+	await expect(filesList).toHaveCount(0);
+	await expect(specsList).toHaveCount(0);
+	await expect(page.getByTestId("tab-changes")).toHaveAttribute("data-active", "true");
 });


### PR DESCRIPTION
## Why                                                                                                                                                                                                         
                                                                                                                                                                                                                 
  A round that wrote only a spec said "1 file changed" and linked to Changes — which is git-derived and                                                                                                          
  can't show it: task-specs live in the gitignored `.thinkrail/context/`. The click landed on an empty view.                                                                                                     
                                                                                                                                                                                                                 
  ## What                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  - Two chips instead of one: **specs** and **files changed**, each linking the panel that owns the artifact                                                                                                     
    ("is it a spec?" = membership in the same spec graph the Specs panel renders).                                                                                                                               
  - They act as a switch: one list open at a time, re-click clears, expanding reveals the owning view.                                                                                                           
  - Several artifacts expand inline in the chat — the set belongs to that round, not to the panels' *now*.                                                                                                       
  - Reuse pass: four copies of "read per workspace, re-read on fs tick" → `useWorkspaceRead`; path/array                                                                                                         
    primitives → `lib`; 12 destructure-deletes → `omitKey`. Net −4 lint suppressions.                                                                                                                            
                                                                                                                                                                                                                 
  ## Review notes                                                                                                                                                                                                
                                                                                                                                                                                                                 
  - `matchesWorktreePath` bug the new e2e caught: the suffix rule applied to relative paths too, so every                                                                                                        
    `<module>/SPEC.md` matched the root `SPEC.md`. Now absolute-only — also fixes a wrong-row highlight in Changes.                                                                                              
  - The `spec.graph` read moved to `RightPanel`: owned by the tab body it stopped tracking the worktree while                                                                                                    
    the user sat on Changes, silently undoing the split. Pinned by an `@agent` spec that fails without the fix.  