### PR TITLE
feat(cli): real Windows self-update + `thinkrail uninstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ set "THINKRAIL_VERSION=0.2.0" && powershell -c "irm https://raw.githubuserconten
 ```
 
 Then run `thinkrail` (add a git repo path to open it as a project: `thinkrail ~/code/my-repo`). To update
-later, run `thinkrail update` (re-installs the latest build for your channel; macOS/Linux only — on
-Windows, re-run the installer). `thinkrail --help` lists the flags; `thinkrail --version` prints the
-build.
+later, run `thinkrail update` on any platform — it re-runs the installer for your channel (on Windows it
+replaces the running `thinkrail.exe` in place). To remove it, run `thinkrail uninstall`: it takes out the
+executable, the PATH entry the installer added, and the install metadata, and asks whether to delete your
+`~/.thinkrail` app state (kept by default — pass `--remove-data` to delete it, `-y` to skip the
+questions). `thinkrail --help` lists the flags; `thinkrail --version` prints the build.
 
 **Prebuilt platforms:** macOS (Apple Silicon), Linux arm64 + x64, Windows x64 (`.exe`). Intel macOS isn't
 prebuilt — use Apple Silicon or build from source.

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -29,9 +29,12 @@ its URL. It is a thin launcher — all engine logic lives in `packages/server`.
 
 ## Interface
 
-`bin` = `./src/index.ts` (bun runs the TS source directly). A leading `update` positional is a
-**subcommand** (`thinkrail update [--channel stable|nightly] [--version X.Y.Z]`) intercepted before the
-launch flags — see *Self-update* below. Otherwise the launch args: `--port` (stable default 24242,
+`bin` = `./src/index.ts` (bun runs the TS source directly). A leading `update` or `uninstall` positional
+is a **subcommand** (`thinkrail update [--channel stable|nightly] [--version X.Y.Z]`,
+`thinkrail uninstall [--remove-data|--keep-data] [-y]`) intercepted before the launch flags — see
+*Self-update* / *Uninstall* below. The set lives in `args.ts` (`parseSubcommand`) because the compiled
+entry needs it too: a subcommand never boots the host, so it must not pay for (or, in `uninstall`'s case,
+re-create) the staged asset cache. Otherwise the launch args: `--port` (stable default 24242,
 scans upward to the next free port on collision), `--host` (default `localhost`), `--no-open`,
 `--no-analytics` (**per-run mute** for anonymous usage analytics — this run sends nothing; the
 durable switch is the app's Settings → Privacy toggle, see `submodule-server-analytics`),
@@ -41,23 +44,74 @@ git repo to open as a project on boot, best-effort). Env defaults: `THINKRAIL_PO
 
 ## Self-update (`thinkrail update`)
 
-`src/update.ts` ports the old repo's `thinkrail upgrade` (renamed): it re-invokes the published
-`install.sh` for the binary's channel, so the installer stays the single source of the download →
-checksum → replace → PATH logic. Channel/prefix resolve as flag > `~/.config/thinkrail/install.json` >
-baked channel (from `version.ts`; `dev` → `stable`) / `~/.local`. Unix-only execution (in-place
-self-replace on Windows is deferred → prints the `install.ps1` command, with the releases page as the
-manual fallback). The Windows message resolves the **same** channel + prefix the Unix plan would, then
-spells the command out **per shell** (`windowsUpdateMessage`): cmd's `set "X=v" &&` and PowerShell's
-`$env:X='v';` are not interchangeable — one shell's syntax shown to the other silently re-installs the
-wrong build, and a dropped `THINKRAIL_PREFIX` would put a second copy under `.local` while the
-PATH-resolved exe stays stale. `resolveWindowsPrefix` owns that seam: it omits the installer's own
-default, and refuses a metadata prefix that isn't a rooted Windows path or can't be safely quoted
-(Windows needs its own charset — `PREFIX_FORBIDDEN_RE` rejects the backslash every Windows path is made
-of). The arg parse + channel/prefix resolution are pure (`parseUpdateArgs` / `resolveUpdateChannel` /
-`resolveWindowsPrefix` / `resolveUpdatePlan`, unit-tested); only fetch (`curl`) + run (`bash -s`) touch
-IO.
-`THINKRAIL_INSTALL_SCRIPT_URL` overrides the installer URL (testing / forks). See `module-ci-release`
-for the installer itself.
+`src/update.ts` ports the old repo's `thinkrail upgrade` (renamed): it re-invokes the **published
+installer** for the binary's channel — `install.sh` on macOS/Linux, `install.ps1` on Windows — so the
+installer stays the single source of the download → checksum → replace → PATH logic. Channel/prefix
+resolve the same way on both: flag > `~/.config/thinkrail/install.json` > baked channel (from
+`version.ts`; `dev` → `stable`) / `~/.local`.
+
+- **Unix:** `curl` the script, feed it to `bash -s -- --channel … --prefix … [--version …]`.
+- **Windows:** fetch `install.ps1`, write it to a temp `.ps1`, and run it through the first available
+  PowerShell host (`powershell.exe`, else `pwsh.exe`) as
+  `-NoProfile -NonInteractive -ExecutionPolicy Bypass -File <tmp> -Channel … -Version … -Prefix …`.
+  `-File` (not `irm | iex`, which needs a shell to pipe through, and not `-Command`, whose quoting is a
+  minefield) hands the installer's own params through argv. All three params are passed **always**,
+  including `-Version latest`: install.ps1's params *default from the `THINKRAIL_*` env vars*, which the
+  child would inherit, so being explicit is what makes an update deterministic for a user who has one
+  set. Replacing the *running* exe works because install.ps1's `Install-ThinkRailBinary` renames a locked
+  `thinkrail.exe` aside to `thinkrail.exe.<rand>.old` (Windows refuses to *delete* a running image but
+  permits *renaming* it) and drops the fresh one in; the next install sweeps the leftover.
+
+Any Windows failure (fetch, no PowerShell host, installer non-zero) falls back to *printing* the manual
+per-shell command (`windowsManualUpdateMessage`) with the releases page under it: cmd's `set "X=v" &&`
+and PowerShell's `$env:X='v';` are not interchangeable — one shell's syntax shown to the other silently
+re-installs the wrong build, and a dropped `THINKRAIL_PREFIX` would put a second copy under `.local`
+while the PATH-resolved exe stays stale. `resolveWindowsPrefix` owns that seam for the message (it omits
+the installer's own default as noise); `resolveWindowsInstallPrefix` is the same validation for the
+executed plan, and both refuse a metadata prefix that isn't a rooted Windows path or can't be safely
+quoted (Windows needs its own charset — `PREFIX_FORBIDDEN_RE` rejects the backslash every Windows path is
+made of). The arg parse + channel/prefix resolution are pure (`parseUpdateArgs` / `resolveUpdateChannel` /
+`resolveWindowsPrefix` / `resolveUpdatePlan` / `resolveWindowsUpdatePlan`, unit-tested); only fetch
+(`curl` / `fetch`) + run (`bash -s` / `powershell -File`) touch IO.
+`THINKRAIL_INSTALL_SCRIPT_URL` / `THINKRAIL_INSTALL_PS1_URL` override the installer URLs (testing /
+forks). See `module-ci-release` for the installers themselves.
+
+## Uninstall (`thinkrail uninstall`)
+
+`src/uninstall.ts` is the inverse of the installers, and only of them: it removes **the executable, the
+PATH edit the installer made, `install.json`, and the binary's staging cache** — then *asks* about the
+user's app state (the data dir), which is **kept by default** because it holds the workspace git
+worktrees and any uncommitted work in them. pi's own state (`~/.pi`) is never touched: it is not ours.
+
+- **Plan, then confirm, then act.** `resolveUninstallTargets` is pure (platform + home + install
+  metadata + `process.execPath` → the paths); an inspection pass narrows it to what actually exists (and
+  which rc files really carry the installer's block) so the printed plan is *true*; then the prompts;
+  then the removals, each reported as `removed` / `kept` / `not found` / `failed` (any `failed` → exit 1).
+- **Prompts** (`node:readline/promises`): the data-dir question (default *keep*), then a final confirm.
+  `-y`/`--yes` skips both and `--keep-data`/`--remove-data` answers the first one non-interactively; with
+  no TTY and no `--yes` the command refuses rather than guessing.
+- **Which executables:** `<prefix>/bin/thinkrail[.exe]` from the install metadata (else the installers'
+  `~/.local` default) **plus `process.execPath` when it is itself a `thinkrail` binary** — that covers a
+  custom prefix whose `install.json` is gone. Nothing else is ever deleted, whatever the metadata says.
+- **The PATH edit, per platform seam:** on Unix the installer's block is *self-identifying*
+  (`# >>> thinkrail PATH >>>` … `# <<< thinkrail PATH <<<`), so `stripRcPathBlock` removes it from every
+  candidate rc file that carries it (bash/zsh/`$ZDOTDIR`/`.profile`, and the fish `conf.d` file is
+  deleted when nothing but the block was in it) — and refuses to touch a file whose block has no end
+  marker rather than truncating it. On Windows the registry entry is *opaque* (nothing marks it as ours),
+  so it is removed **only when `install.json` proves we installed here**; otherwise the PATH is left
+  alone and the user is told which dir to check. The edit itself runs as an embedded PowerShell script —
+  the exact inverse of install.ps1's `Add-ThinkRailToUserPath` (same `HKCU\Environment` handling,
+  preserving the value's `REG_EXPAND_SZ` kind, comparing entries raw *and* `%VAR%`-expanded, then
+  broadcasting `WM_SETTINGCHANGE`) — because round-tripping a raw PATH value through a pipe would risk
+  mangling non-ASCII entries in the console code page.
+- **Deleting the running program:** Unix unlinks a running binary happily. Windows cannot, so the exe is
+  renamed to the same `thinkrail.exe.<rand>.old` name install.ps1's cleanup already recognizes, and a
+  detached PowerShell retries the delete for a few seconds after we exit; the report says which happened.
+  Stale `.old`/`.new` leftovers in the bin dir are swept too.
+- `src/powershell.ts` is the shared seam for both Windows paths (find a host, run a script text through
+  it, `psQuote` a value into a single-quoted literal). `src/paths.ts` owns the *installed* layout —
+  `install.json` (read by `update` + `uninstall`) and the staging cache root (written by
+  `compiled-entry`, deleted by `uninstall`) — so those three agree by construction.
 
 ## Version stamping (release seam)
 
@@ -128,13 +182,16 @@ extensions** (which the server path-loads out of `node_modules` in dev — impos
 
 ## Boundary
 
-- **Owns:** `src/args.ts` (pure `parseArgs(argv, env) → CliOptions` + `USAGE`), `src/index.ts` (the
-  run-from-source `bootstrap()`: shell env → server → browser open → signal handlers), and the binary build
-  + its boot smoke (`scripts/build-binary.ts`, `scripts/smoke-binary.ts`, `src/compiled-entry.ts`,
-  `src/web-assets.generated.*`, `src/bundled-extensions.generated.*`), `src/version.ts` (the release
-  version stamped in at build time), `src/update.ts` (the `update` subcommand), and `src/jbcentral.ts` (the
-  `jbcentral` subcommand — JetBrains Central CLI proxy wiring).
-- **Allowed deps:** `@thinkrail/server` (`createServer`, `registerBundledRuntime`),
+- **Owns:** `src/args.ts` (pure `parseArgs(argv, env) → CliOptions` + `parseSubcommand` + `USAGE`),
+  `src/index.ts` (the run-from-source `bootstrap()`: shell env → server → browser open → signal handlers),
+  and the binary build + its boot smoke (`scripts/build-binary.ts`, `scripts/smoke-binary.ts`,
+  `src/compiled-entry.ts`, `src/web-assets.generated.*`, `src/bundled-extensions.generated.*`),
+  `src/version.ts` (the release version stamped in at build time), `src/update.ts` (the `update`
+  subcommand), `src/uninstall.ts` (the `uninstall` subcommand), `src/paths.ts` (the installed layout:
+  `install.json` + the staging cache root), `src/powershell.ts` (the Windows PowerShell seam), and
+  `src/jbcentral.ts` (the `jbcentral` subcommand — JetBrains Central CLI proxy wiring).
+- **Allowed deps:** `@thinkrail/server` (`createServer`, `registerBundledRuntime`, `dataDir` — the
+  uninstaller has to name the app state dir, and must name the *same* one the host uses),
   `@thinkrail/shared/shellEnv` (`resolveShellEnv`), Bun/Node; the generated build module may
   value-import the bundled extension packages' entries (resolved via the server package — build-time
   only, deleted after compile).

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -98,8 +98,13 @@ worktrees and any uncommitted work in them. pi's own state (`~/.pi`) is never to
   candidate rc file that carries it (bash/zsh/`$ZDOTDIR`/`.profile`, and the fish `conf.d` file is
   deleted when nothing but the block was in it) — and refuses to touch a file whose block has no end
   marker rather than truncating it. On Windows the registry entry is *opaque* (nothing marks it as ours),
-  so it is removed **only when `install.json` proves we installed here**; otherwise the PATH is left
-  alone and the user is told which dir to check. The edit itself runs as an embedded PowerShell script —
+  so install.ps1 **records whether it added the entry** (`install.json`'s `path_entry_added`, sticky across
+  re-installs of the same prefix — an update sees `already` precisely because an earlier run of ours added
+  it) and the uninstaller removes it **only for that flag, and only for the prefix it was recorded
+  against**. Being installed is not the same as having added the entry: `-NoModifyPath`, an entry that was
+  already present, a failed registry write and a Git-Bash `install.sh` install all record an install
+  without touching the Windows PATH, and legacy metadata predates the flag — all of those are *not ours*,
+  so the PATH is left alone and the user is told which dir to check. The edit itself runs as an embedded PowerShell script —
   the exact inverse of install.ps1's `Add-ThinkRailToUserPath` (same `HKCU\Environment` handling,
   preserving the value's `REG_EXPAND_SZ` kind, comparing entries raw *and* `%VAR%`-expanded, then
   broadcasting `WM_SETTINGCHANGE`) — because round-tripping a raw PATH value through a pipe would risk

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -39,6 +39,26 @@ function within<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
 }
 
 mkdirSync(homeDir, { recursive: true });
+
+// The install-management subcommands must run *without* the boot path: they never serve the UI or open a
+// session, and `uninstall` deleting the very cache it had just re-extracted would be a nasty surprise. Only
+// the artifact can show this (the branch lives in `compiled-entry`), and `--help` touches nothing on disk.
+{
+	const subCache = join(tmp, "subcommand-cache");
+	const run = Bun.spawnSync([binary, "uninstall", "--help"], {
+		env: { ...process.env, XDG_CACHE_HOME: subCache, HOME: homeDir },
+		stdout: "pipe",
+		stderr: "inherit",
+	});
+	if (run.exitCode !== 0) fail(`\`uninstall --help\` exited ${run.exitCode}`);
+	if (!run.stdout.toString().includes("thinkrail uninstall")) {
+		fail("`uninstall --help` printed no usage");
+	}
+	if (existsSync(join(subCache, "thinkrail"))) {
+		fail("a subcommand staged the embedded assets — compiled-entry should skip staging for it");
+	}
+}
+
 const skillDir = join(projectDir, ".claude", "skills", "compiled-portable");
 mkdirSync(skillDir, { recursive: true });
 writeFileSync(

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { DEFAULT_HOST, DEFAULT_PORT, parseArgs } from "./args";
+import { DEFAULT_HOST, DEFAULT_PORT, parseArgs, parseSubcommand } from "./args";
+
+describe("parseSubcommand", () => {
+	test("only a leading, exact subcommand counts", () => {
+		expect(parseSubcommand(["update"])).toBe("update");
+		expect(parseSubcommand(["uninstall", "--yes"])).toBe("uninstall");
+		expect(parseSubcommand([])).toBeUndefined();
+		expect(parseSubcommand(["--no-open"])).toBeUndefined();
+		// A repo that happens to be named after a subcommand is a project dir, not a command.
+		expect(parseSubcommand(["./update"])).toBeUndefined();
+		expect(parseSubcommand(["--port", "80", "update"])).toBeUndefined();
+	});
+
+	test("a launch is not a subcommand — the host boot path must stay reachable", () => {
+		// `compiled-entry` skips asset staging on a subcommand, so a false positive here would boot a
+		// host with no UI staged.
+		expect(parseSubcommand(["/home/u/code/repo"])).toBeUndefined();
+		expect(parseSubcommand(["--version"])).toBeUndefined();
+	});
+});
 
 describe("parseArgs", () => {
 	test("defaults when no args or env", () => {

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -24,11 +24,28 @@ export interface CliOptions {
 
 export type ParseEnv = Record<string, string | undefined>;
 
+/**
+ * Positionals intercepted *before* the launch flags: each is its own command with its own arg parser, and
+ * none of them boots the host. Named here because the compiled entry needs the set too — a subcommand
+ * must not pay for staging the embedded assets (and `uninstall` would be re-creating the cache it deletes).
+ */
+const SUBCOMMANDS = ["update", "uninstall"] as const;
+
+export type Subcommand = (typeof SUBCOMMANDS)[number];
+
+/** The leading subcommand of `argv` (the slice after the runtime + script), or `undefined` for a launch. */
+export function parseSubcommand(argv: readonly string[]): Subcommand | undefined {
+	return SUBCOMMANDS.find((name) => name === argv[0]);
+}
+
 export const USAGE = `Usage: thinkrail [options] [project-dir]
        thinkrail update [--channel stable|nightly] [--version X.Y.Z]
+       thinkrail uninstall [--remove-data|--keep-data] [-y]
 
 Boots the ThinkRail engine host in-process and opens the browser to the app.
-The \`update\` subcommand re-downloads + installs the latest build for your channel.
+The \`update\` subcommand re-downloads + installs the latest build for your channel;
+\`uninstall\` removes ThinkRail from this machine (your ~/.thinkrail app state is kept
+unless you ask for it to go). Both take \`--help\`.
 
 Options:
   --port <n>     Listen port (default ${DEFAULT_PORT}; falls back to a free port if taken).

--- a/apps/cli/src/compiled-entry.ts
+++ b/apps/cli/src/compiled-entry.ts
@@ -7,31 +7,25 @@
 // server's `registerBundledRuntime` seam — which also injects the extensions themselves as value-imported
 // factories, since a binary has no `node_modules` to path-load them from, and registers pi's statically-
 // bundled provider flows: OAuth sign-in + Bedrock reach Node-only code through dynamic imports a compiled
-// binary can't resolve), then hand off to the normal bootstrap (`index.ts`).
+// binary can't resolve), then hand off to the normal bootstrap (`index.ts`). An install-management
+// subcommand skips all of that and hands off straight away — see the branch at the bottom.
 //
 // Run-from-source uses `index.ts` directly and never touches this file. (Image-read needs no photon wasm
 // here: the agent's read tool is configured to send images raw — see server `buildSessionSettings`.)
 
 import { existsSync, mkdirSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { parseSubcommand } from "./args";
 import {
 	bundledExtensionFactories,
 	bundledSkillsVersion,
 	embeddedSkillFiles,
 } from "./bundled-extensions.generated";
+import { stagingRoot } from "./paths";
 import { embeddedWebAssets, webAssetsVersion } from "./web-assets.generated";
 
-/** A writable cache root: `$XDG_CACHE_HOME`, else `~/.cache`, else the OS temp dir. */
-function cacheRoot(): string {
-	const xdg = process.env.XDG_CACHE_HOME;
-	if (xdg) return xdg;
-	const home = homedir();
-	return home ? join(home, ".cache") : tmpdir();
-}
-
 /**
- * Stage embedded files to `<cacheRoot>/thinkrail/<kind>/<version>` (idempotent). Files are written
+ * Stage embedded files to `<stagingRoot>/<kind>/<version>` (idempotent). Files are written
  * straight into the versioned dir and a sibling `<dir>.complete` marker is written **last**; readiness
  * is gated on the marker, not mere dir existence — so an interrupted extraction (partial dir, no marker)
  * is simply re-extracted on the next launch instead of being trusted. Returns the dir.
@@ -46,7 +40,7 @@ async function stage(
 	version: string,
 	files: { route: string; data: string }[],
 ): Promise<string> {
-	const dir = join(cacheRoot(), "thinkrail", kind, version);
+	const dir = join(stagingRoot(), kind, version);
 	const marker = `${dir}.complete`;
 	if (existsSync(marker)) return dir;
 	await Promise.all(
@@ -60,10 +54,15 @@ async function stage(
 	return dir;
 }
 
-const staticDir = await stage("web", webAssetsVersion, embeddedWebAssets);
-const skillsDir = await stage("skills", bundledSkillsVersion, embeddedSkillFiles);
-// Respect an explicit override (e.g. pointing at a dev build); otherwise serve the staged UI.
-process.env.THINKRAIL_STATIC_DIR ??= staticDir;
-const { registerBundledRuntime } = await import("@thinkrail/server");
-await registerBundledRuntime({ factories: bundledExtensionFactories, skillsDir });
+// An install-management subcommand (`update` / `uninstall`) never boots a host or a session, so it needs
+// neither the staged assets nor the pi registrations — and `uninstall` would otherwise re-extract the very
+// cache dir it is about to delete. Hand straight off to the normal bootstrap.
+if (parseSubcommand(Bun.argv.slice(2)) === undefined) {
+	const staticDir = await stage("web", webAssetsVersion, embeddedWebAssets);
+	const skillsDir = await stage("skills", bundledSkillsVersion, embeddedSkillFiles);
+	// Respect an explicit override (e.g. pointing at a dev build); otherwise serve the staged UI.
+	process.env.THINKRAIL_STATIC_DIR ??= staticDir;
+	const { registerBundledRuntime } = await import("@thinkrail/server");
+	await registerBundledRuntime({ factories: bundledExtensionFactories, skillsDir });
+}
 await import("./index");

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -6,7 +6,8 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { bootHost } from "@thinkrail/server";
 import { posthogApiKey } from "./analytics-keys";
-import { type CliOptions, parseArgs, USAGE } from "./args";
+import { type CliOptions, parseArgs, parseSubcommand, USAGE } from "./args";
+import { runUninstall } from "./uninstall";
 import { runUpdate } from "./update";
 import { channel, version } from "./version";
 
@@ -30,9 +31,11 @@ function openBrowser(url: string): void {
 
 async function bootstrap(): Promise<void> {
 	const argv = Bun.argv.slice(2);
-	// `update` is a subcommand, not a launch flag: re-install the latest build, then exit.
-	if (argv[0] === "update") {
-		process.exit(await runUpdate(argv.slice(1), process.env));
+	// Subcommands, not launch flags: install-management commands that run and exit without a host.
+	const subcommand = parseSubcommand(argv);
+	if (subcommand) {
+		const run = subcommand === "update" ? runUpdate : runUninstall;
+		process.exit(await run(argv.slice(1), process.env));
 	}
 
 	let options: CliOptions;

--- a/apps/cli/src/paths.test.ts
+++ b/apps/cli/src/paths.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installConfigDir, installMetaFile, readInstallMeta } from "./paths";
+
+test("installMetaFile is where both installers write install.json", () => {
+	expect(installMetaFile("/home/u")).toBe("/home/u/.config/thinkrail/install.json");
+	expect(installConfigDir("/home/u")).toBe("/home/u/.config/thinkrail");
+});
+
+test("readInstallMeta reads the installers' file and degrades to {} on anything else", () => {
+	const home = mkdtempSync(join(tmpdir(), "thinkrail-paths-"));
+	try {
+		// Absent.
+		expect(readInstallMeta(home)).toEqual({});
+
+		mkdirSync(installConfigDir(home), { recursive: true });
+		writeFileSync(
+			installMetaFile(home),
+			JSON.stringify({ channel: "nightly", prefix: "/opt/tr", version: "1.2.3" }),
+		);
+		expect(readInstallMeta(home)).toEqual({
+			channel: "nightly",
+			prefix: "/opt/tr",
+			version: "1.2.3",
+		});
+
+		// Hand-mangled: a reader must never throw here — `update` and `uninstall` both have to run
+		// against a broken install, which is exactly when the file is likely to be junk.
+		writeFileSync(installMetaFile(home), "{not json");
+		expect(readInstallMeta(home)).toEqual({});
+		writeFileSync(installMetaFile(home), '"a string"');
+		expect(readInstallMeta(home)).toEqual({});
+		writeFileSync(installMetaFile(home), "null");
+		expect(readInstallMeta(home)).toEqual({});
+	} finally {
+		rmSync(home, { recursive: true, force: true });
+	}
+});

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -1,0 +1,57 @@
+// Where an *installed* ThinkRail keeps its own files: the metadata the installers record
+// (`install.json`) and the cache the compiled binary self-extracts into. One module so the three
+// readers can't drift — `compiled-entry` stages into the cache, `update` reads the channel/prefix it
+// was installed with, and `uninstall` removes both. (The user's *app state* is a different thing
+// entirely: that lives under the server's `dataDir()`.)
+
+import { readFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * What `install.sh` / `install.ps1` write into `install.json`. Every field is `unknown` on purpose: the
+ * file is plain JSON in the user's home, so a reader must validate before trusting it (see
+ * `resolveUpdatePlan` / `resolveWindowsInstallPrefix`).
+ */
+export interface InstallMeta {
+	channel?: unknown;
+	version?: unknown;
+	tag?: unknown;
+	prefix?: unknown;
+}
+
+/** `<home>/.config/thinkrail` — where both installers record the install. */
+export function installConfigDir(home: string): string {
+	return join(home, ".config", "thinkrail");
+}
+
+/** `<home>/.config/thinkrail/install.json`. */
+export function installMetaFile(home: string): string {
+	return join(installConfigDir(home), "install.json");
+}
+
+/** Parsed `install.json`, or `{}` when it's absent, unreadable, or not a JSON object. */
+export function readInstallMeta(home: string): InstallMeta {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(installMetaFile(home), "utf8"));
+		return typeof parsed === "object" && parsed !== null ? (parsed as InstallMeta) : {};
+	} catch {
+		return {};
+	}
+}
+
+/** A writable cache root: `$XDG_CACHE_HOME`, else `~/.cache`, else the OS temp dir. */
+function cacheRoot(): string {
+	const xdg = process.env.XDG_CACHE_HOME;
+	if (xdg) return xdg;
+	const home = homedir();
+	return home ? join(home, ".cache") : tmpdir();
+}
+
+/**
+ * `<cacheRoot>/thinkrail` — everything the compiled binary self-extracts (the web assets + the bundled
+ * skills, each under a content-hashed subdir). Disposable: a launch re-creates whatever is missing.
+ */
+export function stagingRoot(): string {
+	return join(cacheRoot(), "thinkrail");
+}

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -18,6 +18,13 @@ export interface InstallMeta {
 	version?: unknown;
 	tag?: unknown;
 	prefix?: unknown;
+	/**
+	 * Windows only: did *that* install put `<prefix>\bin` on the user PATH? Written by install.ps1 (sticky
+	 * across re-installs of the same prefix) and read only by `uninstall`, which will not remove a registry
+	 * PATH entry it can't prove is ours. Absent — legacy metadata, or an install.sh/Git-Bash install, which
+	 * never touches the Windows PATH — means **not ours**.
+	 */
+	path_entry_added?: unknown;
 }
 
 /** `<home>/.config/thinkrail` — where both installers record the install. */

--- a/apps/cli/src/powershell.ts
+++ b/apps/cli/src/powershell.ts
@@ -1,0 +1,97 @@
+// The Windows PowerShell seam: find a host, run a script *text* through it, quote a value into it.
+// Shared by `update` (runs the fetched `install.ps1`) and `uninstall` (edits the PATH registry value +
+// deletes the exe that is still running). Nothing here is Windows-*only* mechanically — the callers gate
+// on `process.platform` — but nothing here makes sense elsewhere either.
+
+import { randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Hosts to try, in order: `powershell.exe` (Windows PowerShell 5.1) ships with every Windows, so it is
+ * the default; `pwsh.exe` (PowerShell 7+) covers a box where the inbox one was stripped or removed.
+ */
+const HOSTS = ["powershell.exe", "pwsh.exe"];
+
+/** Flags every invocation wants: no user profile, no prompts, and a policy that lets our temp file run. */
+const FLAGS = ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass"];
+
+/** UTF-8 byte-order mark — what tells Windows PowerShell 5.1 a script file isn't ANSI. */
+const BOM = "\uFEFF";
+
+/** Escape `value` for a PowerShell single-quoted literal (`'` doubles; everything else is literal). */
+export function psQuote(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+export interface PowerShellResult {
+	exitCode: number;
+	/** The script's stdout — empty unless `capture` was set. */
+	stdout: string;
+}
+
+export interface RunPowerShellOptions {
+	/** Env for the child (defaults to ours). */
+	env?: Record<string, string | undefined>;
+	/** Capture stdout instead of letting the script write to ours. */
+	capture?: boolean;
+}
+
+/**
+ * Run `script` (PowerShell source) with `args` appended after `-File`, so the script's own `param()`
+ * block receives them through argv — no shell, no quoting. Returns the result, or `undefined` when no
+ * PowerShell host could be launched at all (the caller decides what to tell the user).
+ *
+ * The script goes to a temp file rather than `-Command`: `-Command` quoting is a minefield and cannot
+ * carry named params. A UTF-8 BOM is prepended when absent because Windows PowerShell 5.1 reads a
+ * BOM-less file as ANSI, which would mangle any non-ASCII character in it.
+ */
+export async function runPowerShellScript(
+	script: string,
+	args: readonly string[] = [],
+	options: RunPowerShellOptions = {},
+): Promise<PowerShellResult | undefined> {
+	const path = join(tmpdir(), `thinkrail-${randomUUID()}.ps1`);
+	await Bun.write(path, script.startsWith(BOM) ? script : `${BOM}${script}`);
+	try {
+		for (const host of HOSTS) {
+			let run: ReturnType<typeof Bun.spawnSync>;
+			try {
+				run = Bun.spawnSync([host, ...FLAGS, "-File", path, ...args], {
+					stdout: options.capture ? "pipe" : "inherit",
+					stderr: "inherit",
+					...(options.env ? { env: options.env } : {}),
+				});
+			} catch {
+				// Not on PATH (or not executable) — try the next host.
+				continue;
+			}
+			return { exitCode: run.exitCode ?? 1, stdout: run.stdout?.toString() ?? "" };
+		}
+		return undefined;
+	} finally {
+		rmSync(path, { force: true });
+	}
+}
+
+/**
+ * Start `command` (a one-liner) in a PowerShell that outlives us, best-effort — the only way to finish a
+ * job that can't complete while this process is alive (deleting our own exe). Returns whether a host
+ * could be started at all; the command's own outcome is unobservable by design.
+ */
+export function spawnDetachedPowerShell(command: string): boolean {
+	for (const host of HOSTS) {
+		try {
+			Bun.spawn([host, ...FLAGS, "-WindowStyle", "Hidden", "-Command", command], {
+				stdin: "ignore",
+				stdout: "ignore",
+				stderr: "ignore",
+			}).unref();
+			return true;
+		} catch {
+			// Not on PATH — try the next host.
+		}
+	}
+	return false;
+}

--- a/apps/cli/src/uninstall.test.ts
+++ b/apps/cli/src/uninstall.test.ts
@@ -121,14 +121,36 @@ describe("resolveUninstallTargets", () => {
 		expect(targets.fishFile).toBe("");
 	});
 
-	test("metaFound is the Windows PATH-edit gate: no install.json, no registry write", () => {
-		expect(resolveUninstallTargets({ ...base, platform: "win32", installMeta: {} }).metaFound).toBe(
-			false,
-		);
+	test("the Windows PATH edit is licensed only by install.ps1's own ownership flag", () => {
+		const owned = (installMeta: Record<string, unknown>) =>
+			resolveUninstallTargets({
+				...base,
+				platform: "win32",
+				home: "C:\\Users\\u",
+				installMeta,
+			}).pathEntryOwned;
+		expect(owned({ prefix: "D:\\tools", path_entry_added: true })).toBe(true);
+		// Being installed is not adding the entry: -NoModifyPath, an entry that was already there, a failed
+		// registry write and a Git-Bash install.sh install all write metadata without touching the PATH.
+		expect(owned({ prefix: "D:\\tools", path_entry_added: false })).toBe(false);
+		// Legacy metadata (written before the flag existed) counts as not ours.
+		expect(owned({ prefix: "D:\\tools" })).toBe(false);
+		expect(owned({})).toBe(false);
+		// A flag we can't tie to the prefix we're acting on proves nothing.
+		expect(owned({ prefix: "relative\\dir", path_entry_added: true })).toBe(false);
+		expect(owned({ path_entry_added: true })).toBe(false);
+		// Truthy-but-not-true JSON is not a yes.
+		expect(owned({ prefix: "D:\\tools", path_entry_added: "yes" })).toBe(false);
+	});
+
+	test("Unix never consults the flag — the rc block is its own proof", () => {
 		expect(
-			resolveUninstallTargets({ ...base, platform: "win32", installMeta: { channel: "stable" } })
-				.metaFound,
-		).toBe(true);
+			resolveUninstallTargets({
+				...base,
+				platform: "linux",
+				installMeta: { prefix: "/opt/tools", path_entry_added: true },
+			}).pathEntryOwned,
+		).toBe(false);
 	});
 
 	test("scans every rc file install.sh could have written, plus $ZDOTDIR", () => {

--- a/apps/cli/src/uninstall.test.ts
+++ b/apps/cli/src/uninstall.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+	parseUninstallArgs,
+	parseYesNo,
+	RC_BLOCK_BEGIN,
+	RC_BLOCK_END,
+	resolveUninstallTargets,
+	stripRcPathBlock,
+} from "./uninstall";
+
+describe("parseUninstallArgs", () => {
+	test("defaults to asking about the data dir and confirming", () => {
+		expect(parseUninstallArgs([])).toEqual({ yes: false, data: undefined, help: false });
+	});
+
+	test("reads the data choice and -y", () => {
+		expect(parseUninstallArgs(["--remove-data"]).data).toBe("remove");
+		expect(parseUninstallArgs(["--keep-data"]).data).toBe("keep");
+		expect(parseUninstallArgs(["-y"]).yes).toBe(true);
+		expect(parseUninstallArgs(["--yes", "--remove-data"])).toEqual({
+			yes: true,
+			data: "remove",
+			help: false,
+		});
+		expect(parseUninstallArgs(["--help"]).help).toBe(true);
+	});
+
+	test("rejects a contradictory or unknown flag rather than guessing", () => {
+		expect(() => parseUninstallArgs(["--keep-data", "--remove-data"])).toThrow(
+			"mutually exclusive",
+		);
+		expect(() => parseUninstallArgs(["--purge"])).toThrow("Unknown option: --purge");
+		// Repeating the same choice is not a contradiction.
+		expect(parseUninstallArgs(["--keep-data", "--keep-data"]).data).toBe("keep");
+	});
+});
+
+describe("parseYesNo", () => {
+	test("an empty or unrecognized answer keeps the offered default", () => {
+		expect(parseYesNo("", false)).toBe(false);
+		expect(parseYesNo("  ", true)).toBe(true);
+		expect(parseYesNo("maybe", false)).toBe(false);
+	});
+
+	test("reads y/yes/n/no in any casing", () => {
+		expect(parseYesNo("y", false)).toBe(true);
+		expect(parseYesNo(" YES ", false)).toBe(true);
+		expect(parseYesNo("N", true)).toBe(false);
+		expect(parseYesNo("no", true)).toBe(false);
+	});
+});
+
+describe("resolveUninstallTargets", () => {
+	const base = {
+		home: "/home/u",
+		env: {} as Record<string, string | undefined>,
+		execPath: "/usr/bin/bun",
+		dataDir: "/home/u/.thinkrail",
+		stagingRoot: "/home/u/.cache/thinkrail",
+	};
+
+	test("uses the recorded prefix, and the installers' default without one", () => {
+		expect(
+			resolveUninstallTargets({
+				...base,
+				platform: "linux",
+				installMeta: { prefix: "/opt/tools" },
+			}).binaries,
+		).toEqual([join("/opt/tools", "bin", "thinkrail")]);
+		expect(
+			resolveUninstallTargets({ ...base, platform: "linux", installMeta: {} }).binaries,
+		).toEqual([join("/home/u/.local", "bin", "thinkrail")]);
+	});
+
+	test("ignores a relative or non-string prefix instead of trusting it", () => {
+		for (const prefix of ["relative/dir", "", 7, null]) {
+			expect(
+				resolveUninstallTargets({ ...base, platform: "linux", installMeta: { prefix } }).binDir,
+			).toBe(join("/home/u/.local", "bin"));
+		}
+	});
+
+	test("adds our own binary when we *are* one — the lost-install.json case", () => {
+		// Running from source (execPath = the Bun runtime) must never make Bun a removal candidate.
+		expect(
+			resolveUninstallTargets({ ...base, platform: "linux", installMeta: {} }).binaries,
+		).not.toContain("/usr/bin/bun");
+		const targets = resolveUninstallTargets({
+			...base,
+			platform: "linux",
+			execPath: "/opt/elsewhere/bin/thinkrail",
+			installMeta: {},
+		});
+		expect(targets.binaries).toEqual([
+			join("/home/u/.local", "bin", "thinkrail"),
+			"/opt/elsewhere/bin/thinkrail",
+		]);
+		// …and isn't listed twice when it is the recorded install.
+		expect(
+			resolveUninstallTargets({
+				...base,
+				platform: "linux",
+				execPath: join("/home/u/.local", "bin", "thinkrail"),
+				installMeta: {},
+			}).binaries,
+		).toHaveLength(1);
+	});
+
+	test("Windows: the .exe name, a rooted recorded prefix, and no rc files", () => {
+		const targets = resolveUninstallTargets({
+			...base,
+			platform: "win32",
+			home: "C:\\Users\\u",
+			execPath: "D:\\tools\\bin\\thinkrail.exe",
+			installMeta: { prefix: "D:\\tools" },
+		});
+		expect(targets.binaries).toEqual([join("D:\\tools", "bin", "thinkrail.exe")]);
+		// install.sh never writes an rc block on Windows, and install.ps1 edits the registry instead.
+		expect(targets.rcFiles).toEqual([]);
+		expect(targets.fishFile).toBe("");
+	});
+
+	test("metaFound is the Windows PATH-edit gate: no install.json, no registry write", () => {
+		expect(resolveUninstallTargets({ ...base, platform: "win32", installMeta: {} }).metaFound).toBe(
+			false,
+		);
+		expect(
+			resolveUninstallTargets({ ...base, platform: "win32", installMeta: { channel: "stable" } })
+				.metaFound,
+		).toBe(true);
+	});
+
+	test("scans every rc file install.sh could have written, plus $ZDOTDIR", () => {
+		const targets = resolveUninstallTargets({
+			...base,
+			platform: "darwin",
+			env: { ZDOTDIR: "/home/u/.config/zsh" },
+			installMeta: {},
+		});
+		expect(targets.rcFiles).toEqual([
+			"/home/u/.bashrc",
+			"/home/u/.bash_profile",
+			"/home/u/.profile",
+			"/home/u/.zshrc",
+			"/home/u/.config/zsh/.zshrc",
+		]);
+		expect(targets.fishFile).toBe("/home/u/.config/fish/conf.d/thinkrail.fish");
+	});
+
+	test("a $ZDOTDIR of $HOME doesn't double-list .zshrc", () => {
+		const targets = resolveUninstallTargets({
+			...base,
+			platform: "linux",
+			env: { ZDOTDIR: "/home/u" },
+			installMeta: {},
+		});
+		expect(targets.rcFiles.filter((file) => file.endsWith(".zshrc"))).toEqual(["/home/u/.zshrc"]);
+	});
+});
+
+describe("stripRcPathBlock", () => {
+	const block = `${RC_BLOCK_BEGIN}\nexport PATH="$PATH:/home/u/.local/bin"\n${RC_BLOCK_END}`;
+
+	test("removes the block install.sh appended, blank line included", () => {
+		const before = `export EDITOR=vim\n\n${block}\n`;
+		expect(stripRcPathBlock(before)).toEqual({
+			next: "export EDITOR=vim\n",
+			removed: true,
+			unterminated: false,
+		});
+	});
+
+	test("keeps everything around it, and only eats one blank line", () => {
+		const before = `a=1\n\n\n${block}\nb=2\n`;
+		expect(stripRcPathBlock(before).next).toBe("a=1\n\nb=2\n");
+	});
+
+	test("removes a repeated block (an older install left one behind)", () => {
+		const result = stripRcPathBlock(`a=1\n${block}\nb=2\n${block}\n`);
+		expect(result.next).toBe("a=1\nb=2\n");
+		expect(result.removed).toBe(true);
+	});
+
+	test("a file without the block is left byte-for-byte alone", () => {
+		const before = 'export PATH="$PATH:/home/u/.local/bin"\n';
+		expect(stripRcPathBlock(before)).toEqual({
+			next: before,
+			removed: false,
+			unterminated: false,
+		});
+	});
+
+	test("refuses to rewrite a block with no end marker instead of truncating the file", () => {
+		const before = `a=1\n${RC_BLOCK_BEGIN}\nexport PATH="$PATH:/x"\nb=2\n`;
+		expect(stripRcPathBlock(before)).toEqual({
+			next: before,
+			removed: false,
+			unterminated: true,
+		});
+	});
+});

--- a/apps/cli/src/uninstall.ts
+++ b/apps/cli/src/uninstall.ts
@@ -115,10 +115,13 @@ async function askYesNo(
 export interface UninstallTargets {
 	/** Executables to remove: the recorded install, plus our own binary when it is one. Deduped. */
 	binaries: string[];
-	/** `<prefix>/bin` — the dir the installer put on PATH. */
+	/** `<prefix>/bin` — the dir the installer puts on PATH. */
 	binDir: string;
-	/** Whether `install.json` was found: on Windows it's the proof that we may edit the user PATH. */
-	metaFound: boolean;
+	/**
+	 * Windows: did *our* installer put `binDir` on the user PATH (`install.json`'s `path_entry_added`, for
+	 * this same prefix)? The only thing that licenses a registry PATH edit — see `removeWindowsPathEntry`.
+	 */
+	pathEntryOwned: boolean;
 	/** Shell rc files that may carry the installer's block (Unix). */
 	rcFiles: string[];
 	/** The fish `conf.d` snippet install.sh creates — deleted outright once only the block is left. */
@@ -158,6 +161,11 @@ export function resolveUninstallTargets(input: ResolveUninstallInput): Uninstall
 			: join(input.home, ".local");
 	const binDir = join(prefix, "bin");
 
+	// Only the recorded flag proves the entry is ours, and only for the prefix it was recorded against: a
+	// fallback prefix means we are not looking at the install that flag describes.
+	const pathEntryOwned =
+		windows && prefix === recordedPrefix && input.installMeta.path_entry_added === true;
+
 	const binaries = [join(binDir, exeName)];
 	if (basename(input.execPath) === exeName && !binaries.includes(input.execPath)) {
 		binaries.push(input.execPath);
@@ -182,7 +190,7 @@ export function resolveUninstallTargets(input: ResolveUninstallInput): Uninstall
 	return {
 		binaries,
 		binDir,
-		metaFound: Object.keys(input.installMeta).length > 0,
+		pathEntryOwned,
 		rcFiles,
 		fishFile: windows ? "" : join(input.home, ".config", "fish", "conf.d", "thinkrail.fish"),
 		installMetaFile: installMetaFile(input.home),
@@ -431,17 +439,20 @@ function removeRcBlocks(targets: UninstallTargets): Step[] {
 }
 
 /**
- * Remove `<prefix>\bin` from the user PATH (Windows). Gated on `install.json`: unlike install.sh's marker
- * block, a registry PATH entry carries no proof that *we* added it, and a user who already had that dir on
- * PATH for other tools must not lose it because ThinkRail happened to be installed there too.
+ * Remove `<prefix>\bin` from the user PATH (Windows). Gated on install.ps1 having *recorded that it added
+ * that entry*: unlike install.sh's marker block, a registry PATH entry carries nothing that says it is
+ * ours, and a user who already had that dir on PATH for other tools must not lose it because ThinkRail
+ * happened to be installed there too. Being installed is not the same as having added the entry —
+ * `-NoModifyPath`, an entry that was already present, a failed registry write and a Git-Bash install.sh
+ * install all record an install without touching the Windows PATH, and legacy metadata predates the flag.
  */
 async function removeWindowsPathEntry(targets: UninstallTargets): Promise<Step> {
-	if (!targets.metaFound) {
+	if (!targets.pathEntryOwned) {
 		return step(
 			"PATH entry",
 			targets.binDir,
 			"kept",
-			"no install.json, so nothing proves we added it — check your PATH by hand",
+			"the installer never added it (or can't prove it did) — check your PATH by hand",
 		);
 	}
 	const run = await runPowerShellScript(REMOVE_FROM_USER_PATH_PS1, ["-Dir", targets.binDir], {
@@ -494,7 +505,7 @@ function rcCandidates(targets: UninstallTargets): string[] {
 
 /** Which of the plan's PATH edits are really there: an rc file carrying the block, or the Windows entry. */
 function findPathEdits(targets: UninstallTargets): string[] {
-	if (process.platform === "win32") return targets.metaFound ? [targets.binDir] : [];
+	if (process.platform === "win32") return targets.pathEntryOwned ? [targets.binDir] : [];
 	return rcCandidates(targets).filter((file) => {
 		try {
 			return readFileSync(file, "utf8").includes(RC_BLOCK_BEGIN);

--- a/apps/cli/src/uninstall.ts
+++ b/apps/cli/src/uninstall.ts
@@ -1,0 +1,657 @@
+// `thinkrail uninstall` — the inverse of install.sh / install.ps1, and only of them: the executable, the
+// PATH edit the installer made, `install.json`, and the cache the compiled binary self-extracts into. The
+// user's app state (the data dir) is a separate question the command *asks*, and keeps by default: it
+// holds the workspace git worktrees, so deleting it can destroy uncommitted work. pi's own state (`~/.pi`:
+// auth, models, sessions) is never touched — it isn't ours to remove.
+//
+// Shape: a pure plan (`resolveUninstallTargets`) → an inspection pass that narrows it to what really
+// exists, so the printed plan is true → the prompts → the removals, each reported.
+
+import { randomUUID } from "node:crypto";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmdirSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { dataDir } from "@thinkrail/server";
+import {
+	type InstallMeta,
+	installConfigDir,
+	installMetaFile,
+	readInstallMeta,
+	stagingRoot,
+} from "./paths";
+import { psQuote, runPowerShellScript, spawnDetachedPowerShell } from "./powershell";
+import { channel, version } from "./version";
+
+/** The marker block install.sh writes into a shell rc file — self-identifying, so removing it is safe. */
+export const RC_BLOCK_BEGIN = "# >>> thinkrail PATH >>>";
+export const RC_BLOCK_END = "# <<< thinkrail PATH <<<";
+
+export const UNINSTALL_USAGE = `Usage: thinkrail uninstall [options]
+
+Remove ThinkRail from this machine: the executable, the installer's PATH entry, the install
+metadata, and the binary's staging cache. Your app state (~/.thinkrail) is kept unless you ask
+for it to be removed. pi's own state (~/.pi) is never touched.
+
+Options:
+  --remove-data   Also delete the app state dir — projects, workspaces, and the git worktrees
+                  under it, including any uncommitted work in them.
+  --keep-data     Keep the app state dir (the default; skips the question).
+  -y, --yes       Don't ask anything (required when stdin isn't a terminal; keeps the app state
+                  unless --remove-data says otherwise).
+  -h, --help      Show this help.`;
+
+export interface UninstallArgs {
+	/** Skip every prompt. */
+	yes: boolean;
+	/** An explicit answer to the app-state question, or `undefined` to ask. */
+	data: "keep" | "remove" | undefined;
+	help: boolean;
+}
+
+/** Parse `uninstall`'s argv (the slice after `uninstall`). Throws on an unknown or contradictory flag. */
+export function parseUninstallArgs(argv: readonly string[]): UninstallArgs {
+	let yes = false;
+	let data: "keep" | "remove" | undefined;
+	let help = false;
+	for (const arg of argv) {
+		if (arg === "-y" || arg === "--yes") {
+			yes = true;
+		} else if (arg === "-h" || arg === "--help") {
+			help = true;
+		} else if (arg === "--remove-data" || arg === "--keep-data") {
+			const next = arg === "--remove-data" ? "remove" : "keep";
+			if (data !== undefined && data !== next) {
+				throw new Error("--keep-data and --remove-data are mutually exclusive");
+			}
+			data = next;
+		} else {
+			throw new Error(`Unknown option: ${arg}`);
+		}
+	}
+	return { yes, data, help };
+}
+
+/** Answer to a `[y/N]` question: an empty (or unrecognized) answer keeps the offered default. */
+export function parseYesNo(answer: string, fallback: boolean): boolean {
+	const normalized = answer.trim().toLowerCase();
+	if (normalized === "y" || normalized === "yes") return true;
+	if (normalized === "n" || normalized === "no") return false;
+	return fallback;
+}
+
+/**
+ * Ask a `[y/N]` question, reading from the interface's **line iterator** rather than `rl.question`: the
+ * iterator is attached once and buffers, so an answer typed ahead of the second prompt is still read (and
+ * `question`'s promise never settles on EOF at all — the command would exit silently having done nothing,
+ * the one outcome an uninstall must never have). A closed stdin (Ctrl+D) counts as the default answer.
+ */
+async function askYesNo(
+	rl: ReturnType<typeof createInterface>,
+	lines: AsyncIterator<string>,
+	question: string,
+	fallback: boolean,
+): Promise<boolean> {
+	// Via the interface, not a bare write, so line editing redraws the prompt with it.
+	rl.setPrompt(question);
+	rl.prompt();
+	const next = await lines.next();
+	if (next.done) {
+		process.stdout.write("\n");
+		return fallback;
+	}
+	return parseYesNo(next.value, fallback);
+}
+
+export interface UninstallTargets {
+	/** Executables to remove: the recorded install, plus our own binary when it is one. Deduped. */
+	binaries: string[];
+	/** `<prefix>/bin` — the dir the installer put on PATH. */
+	binDir: string;
+	/** Whether `install.json` was found: on Windows it's the proof that we may edit the user PATH. */
+	metaFound: boolean;
+	/** Shell rc files that may carry the installer's block (Unix). */
+	rcFiles: string[];
+	/** The fish `conf.d` snippet install.sh creates — deleted outright once only the block is left. */
+	fishFile: string;
+	installMetaFile: string;
+	installConfigDir: string;
+	stagingRoot: string;
+	dataDir: string;
+}
+
+export interface ResolveUninstallInput {
+	platform: string;
+	home: string;
+	env: Record<string, string | undefined>;
+	installMeta: InstallMeta;
+	/** `process.execPath` — the compiled binary when we *are* one, else the Bun/Node runtime. */
+	execPath: string;
+	dataDir: string;
+	stagingRoot: string;
+}
+
+/**
+ * The paths an uninstall touches — pure, so every rule below is unit-testable.
+ *
+ * The prefix comes from `install.json`, else the installers' own `~/.local` default; a relative or empty
+ * recorded prefix is ignored rather than trusted. Beyond that we add `process.execPath` **when it is
+ * itself a `thinkrail` binary** — that is what covers a custom-prefix install whose `install.json` is
+ * gone — and nothing else is ever a candidate, whatever the metadata says.
+ */
+export function resolveUninstallTargets(input: ResolveUninstallInput): UninstallTargets {
+	const windows = input.platform === "win32";
+	const exeName = windows ? "thinkrail.exe" : "thinkrail";
+	const recordedPrefix = input.installMeta.prefix;
+	const prefix =
+		typeof recordedPrefix === "string" && isAbsolutePath(recordedPrefix, windows)
+			? recordedPrefix
+			: join(input.home, ".local");
+	const binDir = join(prefix, "bin");
+
+	const binaries = [join(binDir, exeName)];
+	if (basename(input.execPath) === exeName && !binaries.includes(input.execPath)) {
+		binaries.push(input.execPath);
+	}
+
+	// Every rc file install.sh could have written, plus `.profile`/`.zshrc` regardless of `$SHELL` and
+	// `$ZDOTDIR` — the block is self-identifying, so scanning a file we never wrote costs nothing and
+	// catches a user who has since switched shells. (install.sh never writes one on Windows.)
+	const zdotdir = input.env.ZDOTDIR;
+	const rcFiles = windows
+		? []
+		: [
+				...new Set([
+					join(input.home, ".bashrc"),
+					join(input.home, ".bash_profile"),
+					join(input.home, ".profile"),
+					join(input.home, ".zshrc"),
+					...(zdotdir ? [join(zdotdir, ".zshrc")] : []),
+				]),
+			];
+
+	return {
+		binaries,
+		binDir,
+		metaFound: Object.keys(input.installMeta).length > 0,
+		rcFiles,
+		fishFile: windows ? "" : join(input.home, ".config", "fish", "conf.d", "thinkrail.fish"),
+		installMetaFile: installMetaFile(input.home),
+		installConfigDir: installConfigDir(input.home),
+		stagingRoot: input.stagingRoot,
+		dataDir: input.dataDir,
+	};
+}
+
+/** `path.isAbsolute` for the *target* platform, not ours (this module is unit-tested cross-platform). */
+function isAbsolutePath(path: string, windows: boolean): boolean {
+	return windows ? /^(?:[A-Za-z]:[\\/]|\\\\[^\\/]+[\\/])/.test(path) : path.startsWith("/");
+}
+
+/**
+ * Strip the installer's PATH block from an rc file's contents. Mirrors install.sh's own awk strip (drop
+ * `begin`..`end` inclusive) and additionally drops the single blank line install.sh printed before the
+ * block, so an uninstall leaves the file as it found it.
+ *
+ * `unterminated` means a `begin` marker with no `end` after it: the caller must then leave the file alone
+ * — a hand-edited or truncated rc file is not worth silently rewriting.
+ */
+export function stripRcPathBlock(content: string): {
+	next: string;
+	removed: boolean;
+	unterminated: boolean;
+} {
+	const kept: string[] = [];
+	let removed = false;
+	let skipping = false;
+	for (const line of content.split("\n")) {
+		if (skipping) {
+			if (line.trim() === RC_BLOCK_END) skipping = false;
+			continue;
+		}
+		if (line.trim() === RC_BLOCK_BEGIN) {
+			skipping = true;
+			removed = true;
+			if (kept.at(-1) === "") kept.pop();
+			continue;
+		}
+		kept.push(line);
+	}
+	if (skipping) return { next: content, removed: false, unterminated: true };
+	return { next: kept.join("\n"), removed, unterminated: false };
+}
+
+/**
+ * Remove `$Dir` from the persistent per-user PATH — the exact inverse of install.ps1's
+ * `Add-ThinkRailToUserPath`, and PowerShell for the same reasons it is: the registry value's
+ * `REG_EXPAND_SZ` kind must survive (`[Environment]::SetEnvironmentVariable` would rewrite it as `REG_SZ`
+ * and expand every other tool's `%VARS%`), entries must be compared both raw and expanded, and the value
+ * must never cross a pipe — a non-ASCII entry would come back mangled in the console code page. Prints
+ * one token: `removed`, `absent`, or `failed`.
+ */
+const REMOVE_FROM_USER_PATH_PS1 = String.raw`param([Parameter(Mandatory = $true)][string]$Dir)
+$ErrorActionPreference = 'Stop'
+
+function Get-NormalizedEntry([string]$p) { return $p.Replace('/', '\').TrimEnd('\') }
+
+function Get-PathWithoutEntry {
+    # The decision half, kept a pure function of its inputs: the ';'-delimited value minus every entry
+    # naming $Dir, compared raw *and* %VAR%-expanded (install.ps1 appends the prefix literally, but the
+    # entry that was already there may be written either way), separator- and case-insensitively. Every
+    # other entry -- an empty one included -- is kept verbatim, so the value is otherwise what it was.
+    # $null means "nothing named $Dir", which is not the same as the empty string (PATH was only us).
+    param([string]$Raw, [string]$Dir)
+    $target = Get-NormalizedEntry $Dir
+    $kept = @()
+    $removed = $false
+    foreach ($entry in ($Raw -split ';')) {
+        $e = Get-NormalizedEntry $entry.Trim()
+        if ($e) {
+            $expanded = Get-NormalizedEntry ([System.Environment]::ExpandEnvironmentVariables($e))
+            if (($e -ieq $target) -or ($expanded -ieq $target)) { $removed = $true; continue }
+        }
+        $kept += $entry
+    }
+    if (-not $removed) { return $null }
+    return ($kept -join ';')
+}
+
+function Send-ThinkRailSettingChange {
+    # Broadcast WM_SETTINGCHANGE "Environment" so terminals opened after this see the new PATH without a
+    # sign-out (the same best-effort call install.ps1 makes after adding the entry).
+    try {
+        if (-not ('ThinkRail.NativeMethods' -as [type])) {
+            Add-Type -Namespace ThinkRail -Name NativeMethods -MemberDefinition @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+        }
+        $result = [UIntPtr]::Zero
+        [void][ThinkRail.NativeMethods]::SendMessageTimeout([IntPtr]0xffff, 0x1a, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$result)
+    } catch {
+        # Non-fatal: the registry is already updated; new terminals see it after the next sign-in.
+    }
+}
+
+$key = $null
+try {
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+    if (-not $key) { 'failed'; return }
+    if (@($key.GetValueNames()) -notcontains 'Path') { 'absent'; return }
+    $kind = $key.GetValueKind('Path')
+    $raw = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+    $next = Get-PathWithoutEntry -Raw $raw -Dir $Dir
+    if ($null -eq $next) { 'absent'; return }
+    $key.SetValue('Path', $next, $kind)
+    Send-ThinkRailSettingChange
+    'removed'
+} catch {
+    'failed'
+} finally {
+    if ($key) { $key.Dispose() }
+}
+`;
+
+type Outcome = "removed" | "kept" | "absent" | "failed";
+
+/** What a step acted on. Typed rather than free text: the closing advice keys off `PATH entry`. */
+type StepKind =
+	| "executable"
+	| "leftover"
+	| "PATH entry"
+	| "install info"
+	| "staging cache"
+	| "app state";
+
+interface Step {
+	kind: StepKind;
+	path: string;
+	outcome: Outcome;
+	detail?: string;
+}
+
+function step(kind: StepKind, path: string, outcome: Outcome, detail?: string): Step {
+	return { kind, path, outcome, ...(detail ? { detail } : {}) };
+}
+
+function isMissing(err: unknown): boolean {
+	return (err as { code?: string } | null)?.code === "ENOENT";
+}
+
+function removeFile(path: string): Outcome {
+	try {
+		unlinkSync(path);
+		return "removed";
+	} catch (err) {
+		return isMissing(err) ? "absent" : "failed";
+	}
+}
+
+function removeTree(path: string): Outcome {
+	if (!existsSync(path)) return "absent";
+	try {
+		rmSync(path, { recursive: true, force: true });
+		return "removed";
+	} catch {
+		return "failed";
+	}
+}
+
+/**
+ * Remove an executable that may be *this* process. Unix unlinks a running binary happily; Windows refuses
+ * to delete a locked image but does allow renaming it, so we rename it to the very `thinkrail.exe.*.old`
+ * name install.ps1's own cleanup already sweeps, then let a detached PowerShell retry the delete once
+ * we've exited. Either way the report says what, if anything, is left behind.
+ */
+function removeExecutable(path: string): Step {
+	try {
+		unlinkSync(path);
+		return step("executable", path, "removed");
+	} catch (err) {
+		if (isMissing(err)) return step("executable", path, "absent");
+		if (process.platform !== "win32") {
+			return step("executable", path, "failed", err instanceof Error ? err.message : String(err));
+		}
+		const aside = `${path}.${randomUUID().slice(0, 8)}.old`;
+		try {
+			renameSync(path, aside);
+		} catch {
+			return step(
+				"executable",
+				path,
+				"failed",
+				"it is locked by a running ThinkRail — close it and try again",
+			);
+		}
+		const quoted = psQuote(aside);
+		// Retry for ~20s: the delete can only start succeeding once this process is gone.
+		const scheduled = spawnDetachedPowerShell(
+			`for ($i = 0; $i -lt 40; $i++) { Start-Sleep -Milliseconds 500; Remove-Item -LiteralPath ${quoted} -Force -ErrorAction SilentlyContinue; if (-not (Test-Path -LiteralPath ${quoted})) { break } }`,
+		);
+		return step(
+			"executable",
+			path,
+			"removed",
+			scheduled
+				? `Windows can't delete a running program: renamed to ${basename(aside)}, which goes once no ThinkRail is running`
+				: `Windows can't delete a running program: renamed to ${aside} — delete that file by hand`,
+		);
+	}
+}
+
+/** Strip the installer's block from the rc files that carry it (Unix). */
+function removeRcBlocks(targets: UninstallTargets): Step[] {
+	const steps: Step[] = [];
+	for (const file of rcCandidates(targets)) {
+		let content: string;
+		try {
+			content = readFileSync(file, "utf8");
+		} catch {
+			continue; // Not there (or not readable) — nothing of ours to undo.
+		}
+		if (!content.includes(RC_BLOCK_BEGIN)) continue;
+		const { next, removed, unterminated } = stripRcPathBlock(content);
+		if (unterminated) {
+			steps.push(
+				step(
+					"PATH entry",
+					file,
+					"failed",
+					`its "${RC_BLOCK_BEGIN}" block has no end marker — remove those lines by hand`,
+				),
+			);
+			continue;
+		}
+		if (!removed) continue;
+		try {
+			if (file === targets.fishFile && next.trim() === "") {
+				// A file install.sh created for us alone: with the block gone, so is its reason to exist.
+				unlinkSync(file);
+				steps.push(step("PATH entry", file, "removed"));
+			} else {
+				writeFileSync(file, next);
+				steps.push(step("PATH entry", file, "removed", `the "${RC_BLOCK_BEGIN}" block`));
+			}
+		} catch (err) {
+			steps.push(
+				step("PATH entry", file, "failed", err instanceof Error ? err.message : String(err)),
+			);
+		}
+	}
+	return steps;
+}
+
+/**
+ * Remove `<prefix>\bin` from the user PATH (Windows). Gated on `install.json`: unlike install.sh's marker
+ * block, a registry PATH entry carries no proof that *we* added it, and a user who already had that dir on
+ * PATH for other tools must not lose it because ThinkRail happened to be installed there too.
+ */
+async function removeWindowsPathEntry(targets: UninstallTargets): Promise<Step> {
+	if (!targets.metaFound) {
+		return step(
+			"PATH entry",
+			targets.binDir,
+			"kept",
+			"no install.json, so nothing proves we added it — check your PATH by hand",
+		);
+	}
+	const run = await runPowerShellScript(REMOVE_FROM_USER_PATH_PS1, ["-Dir", targets.binDir], {
+		capture: true,
+	});
+	if (run === undefined) {
+		return step(
+			"PATH entry",
+			targets.binDir,
+			"failed",
+			"no PowerShell found (looked for powershell.exe, then pwsh.exe)",
+		);
+	}
+	const token = run.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
+	if (token === "removed")
+		return step("PATH entry", targets.binDir, "removed", "from your user PATH");
+	if (token === "absent")
+		return step("PATH entry", targets.binDir, "absent", "not in your user PATH");
+	return step("PATH entry", targets.binDir, "failed", "could not update HKCU\\Environment");
+}
+
+/** Sweep the `.old`/`.new` leftovers a Windows install/update pair can leave beside the exe. */
+function removeWindowsLeftovers(targets: UninstallTargets): Step[] {
+	if (process.platform !== "win32") return [];
+	let entries: string[];
+	try {
+		entries = readdirSync(targets.binDir);
+	} catch {
+		return [];
+	}
+	const steps: Step[] = [];
+	for (const entry of entries) {
+		if (!entry.startsWith("thinkrail.exe.")) continue;
+		if (!entry.endsWith(".old") && !entry.endsWith(".new")) continue;
+		const path = join(targets.binDir, entry);
+		// A leftover that is still locked (an older copy someone is running, or the one we just renamed
+		// ourselves out of) is not this uninstall's problem — only report the ones that went.
+		if (removeFile(path) === "removed") steps.push(step("leftover", path, "removed"));
+	}
+	return steps;
+}
+
+function rcCandidates(targets: UninstallTargets): string[] {
+	return targets.fishFile ? [...targets.rcFiles, targets.fishFile] : targets.rcFiles;
+}
+
+/** Which of the plan's PATH edits are really there: an rc file carrying the block, or the Windows entry. */
+function findPathEdits(targets: UninstallTargets): string[] {
+	if (process.platform === "win32") return targets.metaFound ? [targets.binDir] : [];
+	return rcCandidates(targets).filter((file) => {
+		try {
+			return readFileSync(file, "utf8").includes(RC_BLOCK_BEGIN);
+		} catch {
+			return false;
+		}
+	});
+}
+
+/** The plan as printed before anything is touched — only what exists, so what it says can be trusted. */
+function describePlan(
+	targets: UninstallTargets,
+	present: { binaries: string[]; pathEdits: string[] },
+	dataNote: string,
+): string {
+	const rows: Array<[string, string]> = [];
+	for (const binary of present.binaries) rows.push(["executable", binary]);
+	for (const edit of present.pathEdits) rows.push(["PATH entry", edit]);
+	if (existsSync(targets.installMetaFile)) rows.push(["install info", targets.installMetaFile]);
+	if (existsSync(targets.stagingRoot)) rows.push(["staging cache", targets.stagingRoot]);
+	if (existsSync(targets.dataDir)) rows.push(["app state", `${targets.dataDir} (${dataNote})`]);
+	const width = Math.max(0, ...rows.map(([label]) => label.length));
+	const body = rows.length
+		? rows.map(([label, path]) => `  ${label.padEnd(width)}  ${path}`).join("\n")
+		: "  (nothing found — ThinkRail doesn't look installed from here)";
+	return `thinkrail ${version} (${channel}) — uninstall\n\n${body}\n`;
+}
+
+const OUTCOME_WORD: Record<Outcome, string> = {
+	removed: "removed",
+	kept: "kept",
+	absent: "not found",
+	failed: "FAILED",
+};
+
+function printSteps(steps: Step[]): void {
+	for (const item of steps) {
+		const detail = item.detail ? ` — ${item.detail}` : "";
+		console.log(`  ${OUTCOME_WORD[item.outcome].padEnd(9)}  ${item.path}${detail}`);
+	}
+}
+
+/** Run the `uninstall` subcommand. Returns a process exit code. */
+export async function runUninstall(
+	argv: readonly string[],
+	env: Record<string, string | undefined>,
+): Promise<number> {
+	let args: UninstallArgs;
+	try {
+		args = parseUninstallArgs(argv);
+	} catch (err) {
+		console.error(err instanceof Error ? err.message : String(err));
+		console.error(`\n${UNINSTALL_USAGE}`);
+		return 1;
+	}
+	if (args.help) {
+		console.log(UNINSTALL_USAGE);
+		return 0;
+	}
+
+	const home = homedir();
+	const targets = resolveUninstallTargets({
+		platform: process.platform,
+		home,
+		env,
+		installMeta: readInstallMeta(home),
+		execPath: process.execPath,
+		dataDir: dataDir(),
+		stagingRoot: stagingRoot(),
+	});
+
+	let removeData = args.data === "remove";
+	console.log(
+		describePlan(
+			targets,
+			{
+				binaries: targets.binaries.filter((path) => existsSync(path)),
+				pathEdits: findPathEdits(targets),
+			},
+			args.data === undefined ? "kept unless you say otherwise" : removeData ? "DELETE" : "keep",
+		),
+	);
+
+	if (!args.yes) {
+		if (!process.stdin.isTTY) {
+			console.error(
+				"error: uninstall needs a terminal to confirm — re-run with --yes (plus --remove-data to delete the app state too).",
+			);
+			return 1;
+		}
+		const rl = createInterface({ input: process.stdin, output: process.stdout });
+		const lines = rl[Symbol.asyncIterator]();
+		try {
+			if (args.data === undefined && existsSync(targets.dataDir)) {
+				console.log(
+					`Your app state at ${targets.dataDir} holds your projects, workspaces, and the git\nworktrees under them — deleting it destroys any uncommitted work in those worktrees.`,
+				);
+				removeData = await askYesNo(rl, lines, "Delete it too? [y/N] ", false);
+			}
+			const question = removeData
+				? "Uninstall ThinkRail and delete the app state? [y/N] "
+				: "Uninstall ThinkRail (keeping the app state)? [y/N] ";
+			if (!(await askYesNo(rl, lines, question, false))) {
+				console.log("\nAborted — nothing was removed.");
+				return 0;
+			}
+		} finally {
+			rl.close();
+		}
+		console.log("");
+	}
+
+	const steps: Step[] = [];
+	for (const binary of targets.binaries) steps.push(removeExecutable(binary));
+	steps.push(...removeWindowsLeftovers(targets));
+	steps.push(
+		...(process.platform === "win32"
+			? [await removeWindowsPathEntry(targets)]
+			: removeRcBlocks(targets)),
+	);
+	steps.push(step("install info", targets.installMetaFile, removeFile(targets.installMetaFile)));
+	try {
+		// Ours, but only while it's empty — another tool's `~/.config/thinkrail` file is not ours to drop.
+		rmdirSync(targets.installConfigDir);
+	} catch {
+		// Missing or not empty: nothing to do either way.
+	}
+	steps.push(step("staging cache", targets.stagingRoot, removeTree(targets.stagingRoot)));
+	steps.push(
+		step(
+			"app state",
+			targets.dataDir,
+			removeData ? removeTree(targets.dataDir) : existsSync(targets.dataDir) ? "kept" : "absent",
+		),
+	);
+
+	printSteps(steps);
+	console.log("");
+
+	const failed = steps.filter((item) => item.outcome === "failed");
+	console.log(
+		failed.length
+			? `Uninstall finished with ${failed.length} problem(s) — see FAILED above.`
+			: "ThinkRail is uninstalled.",
+	);
+	if (steps.some((item) => item.kind === "PATH entry" && item.outcome === "removed")) {
+		console.log("Open a new terminal for the PATH change to take effect.");
+	}
+	if (removeData) {
+		console.log(
+			"The workspace worktrees are gone with it — run `git worktree prune` in the repos you used if git still lists them.",
+		);
+	} else if (existsSync(targets.dataDir)) {
+		console.log(
+			`Your app state is still at ${targets.dataDir} — delete it by hand if you're done.`,
+		);
+	}
+	console.log("pi's own state (~/.pi: auth, models, sessions) was left alone.");
+	return failed.length ? 1 : 0;
+}

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
 	parseUpdateArgs,
 	resolveUpdatePlan,
+	resolveWindowsInstallPrefix,
 	resolveWindowsPrefix,
-	windowsUpdateMessage,
+	resolveWindowsUpdatePlan,
+	windowsManualUpdateMessage,
 } from "./update";
 
 describe("parseUpdateArgs", () => {
@@ -113,12 +115,87 @@ describe("resolveUpdatePlan", () => {
 	});
 });
 
-describe("windowsUpdateMessage", () => {
+describe("resolveWindowsUpdatePlan", () => {
+	const home = "C:\\Users\\u";
+
+	test("passes channel, version and prefix to install.ps1 — always all three", () => {
+		// install.ps1's params default from THINKRAIL_* env vars the child inherits, so an update that
+		// omitted one would silently obey a stray var instead of this install.
+		const plan = resolveWindowsUpdatePlan({
+			args: { version: "latest" },
+			installMeta: { channel: "nightly", prefix: "D:\\tools" },
+			baked: "stable",
+			home,
+		});
+		expect(plan.channel).toBe("nightly");
+		expect(plan.prefix).toBe("D:\\tools");
+		expect(plan.psArgs).toEqual([
+			"-Channel",
+			"nightly",
+			"-Version",
+			"latest",
+			"-Prefix",
+			"D:\\tools",
+		]);
+		// The fallback command must name the same custom prefix the attempt used.
+		expect(plan.manualPrefix).toBe("D:\\tools");
+	});
+
+	test("resolves the channel exactly like the Unix plan, and defaults the prefix", () => {
+		const plan = resolveWindowsUpdatePlan({
+			args: { channel: "stable", version: "0.3.0" },
+			installMeta: { channel: "nightly" },
+			baked: "nightly",
+			home,
+		});
+		expect(plan.channel).toBe("stable");
+		expect(plan.psArgs).toEqual([
+			"-Channel",
+			"stable",
+			"-Version",
+			"0.3.0",
+			"-Prefix",
+			"C:\\Users\\u\\.local",
+		]);
+		// …and stays out of the fallback command when it is the installer's own default.
+		expect(plan.manualPrefix).toBeUndefined();
+	});
+
+	test("refuses to install anywhere a tampered install.json points", () => {
+		expect(() =>
+			resolveWindowsUpdatePlan({
+				args: { version: "latest" },
+				installMeta: { prefix: 'D:\\a" && del /f /q C:\\Windows\\System32 && set "X=' },
+				baked: "stable",
+				home,
+			}),
+		).toThrow("suspicious install prefix");
+	});
+});
+
+describe("resolveWindowsInstallPrefix", () => {
+	const home = "C:\\Users\\u";
+
+	test("falls back to the installer's own default", () => {
+		expect(resolveWindowsInstallPrefix(undefined, home)).toBe("C:\\Users\\u\\.local");
+		expect(resolveWindowsInstallPrefix("", home)).toBe("C:\\Users\\u\\.local");
+		expect(resolveWindowsInstallPrefix(42, home)).toBe("C:\\Users\\u\\.local");
+	});
+
+	test("keeps a recorded prefix, refuses an unusable one", () => {
+		expect(resolveWindowsInstallPrefix("D:\\tools", home)).toBe("D:\\tools");
+		expect(() => resolveWindowsInstallPrefix("relative\\dir", home)).toThrow(
+			"suspicious install prefix",
+		);
+	});
+});
+
+describe("windowsManualUpdateMessage", () => {
 	const psLine = (msg: string) => msg.split("\n").find((l) => l.includes("PowerShell:")) ?? "";
 	const cmdLine = (msg: string) => msg.split("\n").find((l) => l.includes("cmd:")) ?? "";
 
 	test("stable/latest is one bare command per shell", () => {
-		const msg = windowsUpdateMessage("stable", "latest");
+		const msg = windowsManualUpdateMessage("stable", "latest");
 		expect(psLine(msg)).toContain(
 			"irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex",
 		);
@@ -128,7 +205,7 @@ describe("windowsUpdateMessage", () => {
 	});
 
 	test("carries the channel in each shell's own env syntax", () => {
-		const msg = windowsUpdateMessage("nightly", "latest");
+		const msg = windowsManualUpdateMessage("nightly", "latest");
 		// The bug this pins: a single cmd-syntax `set "X=v"` shown to PowerShell users, where `set` is
 		// Set-Variable and never reaches the child process -> a silent downgrade to stable.
 		expect(psLine(msg)).toContain("$env:THINKRAIL_CHANNEL='nightly';");
@@ -138,7 +215,7 @@ describe("windowsUpdateMessage", () => {
 	});
 
 	test("carries a pinned version too", () => {
-		const msg = windowsUpdateMessage("nightly", "0.2.0");
+		const msg = windowsManualUpdateMessage("nightly", "0.2.0");
 		expect(psLine(msg)).toContain(
 			"$env:THINKRAIL_CHANNEL='nightly'; $env:THINKRAIL_VERSION='0.2.0';",
 		);
@@ -150,20 +227,20 @@ describe("windowsUpdateMessage", () => {
 	test("carries a custom prefix, so the re-install lands where this one did", () => {
 		// Without it the user re-installs under the default `.local` while the PATH-resolved
 		// D:\tools\bin\thinkrail.exe stays on the old build.
-		const msg = windowsUpdateMessage("stable", "latest", "D:\\tools");
+		const msg = windowsManualUpdateMessage("stable", "latest", "D:\\tools");
 		expect(psLine(msg)).toContain("$env:THINKRAIL_PREFIX='D:\\tools';");
 		expect(cmdLine(msg)).toContain('set "THINKRAIL_PREFIX=D:\\tools" &&');
 	});
 
 	test("escapes a quote-bearing prefix for PowerShell", () => {
-		const msg = windowsUpdateMessage("stable", "latest", "D:\\o'brien\\tools");
+		const msg = windowsManualUpdateMessage("stable", "latest", "D:\\o'brien\\tools");
 		expect(psLine(msg)).toContain("$env:THINKRAIL_PREFIX='D:\\o''brien\\tools';");
 		expect(cmdLine(msg)).toContain('set "THINKRAIL_PREFIX=D:\\o\'brien\\tools" &&');
 	});
 
 	test("stays ASCII (legacy conhost code pages garble anything else)", () => {
 		for (const channel of ["stable", "nightly"] as const) {
-			const msg = windowsUpdateMessage(channel, "1.2.3", "D:\\tools");
+			const msg = windowsManualUpdateMessage(channel, "1.2.3", "D:\\tools");
 			// One UTF-8 byte per char <=> every char is ASCII.
 			expect(Buffer.byteLength(msg, "utf8")).toBe(msg.length);
 		}

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -1,13 +1,15 @@
-// `thinkrail update` — self-update by re-running the published install.sh for the binary's channel
-// (the Bun-native port of the old repo's `thinkrail upgrade`, renamed). The installer owns the
-// download → checksum → replace → PATH logic; update just fetches it and feeds it the resolved
-// channel/prefix (from `~/.config/thinkrail/install.json`, else the baked channel + `~/.local`). Unix
-// only — in-place self-replace on Windows is deferred, so we point there at the install.ps1 command
-// (which handles a locked running exe), spelled out per shell, with the releases page as the fallback.
+// `thinkrail update` — self-update by re-running the published installer for the binary's channel (the
+// Bun-native port of the old repo's `thinkrail upgrade`, renamed): `install.sh` through `bash -s` on
+// macOS/Linux, `install.ps1` through `powershell -File` on Windows. The installer owns the download →
+// checksum → replace → PATH logic; update just fetches it and feeds it the resolved channel/prefix (from
+// `~/.config/thinkrail/install.json`, else the baked channel + `~/.local`). Replacing the *running*
+// Windows exe is install.ps1's job too — it renames a locked `thinkrail.exe` aside and drops the new one
+// in. If any of that fails we fall back to printing the manual per-shell command.
 
-import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
+import { type InstallMeta, readInstallMeta } from "./paths";
+import { psQuote, runPowerShellScript } from "./powershell";
 import { channel as bakedChannel, version } from "./version";
 
 const DEFAULT_INSTALL_SCRIPT_URL =
@@ -65,7 +67,7 @@ export function parseUpdateArgs(argv: readonly string[]): UpdateArgs {
 export interface ResolveUpdateInput {
 	args: UpdateArgs;
 	/** Parsed `~/.config/thinkrail/install.json` (or `{}` when absent/unreadable). */
-	installMeta: { channel?: unknown; prefix?: unknown };
+	installMeta: InstallMeta;
 	/** The version module's baked channel (`stable` / `nightly` / `dev`). */
 	baked: string;
 	home: string;
@@ -114,7 +116,8 @@ export function resolveUpdatePlan(input: ResolveUpdateInput): UpdatePlan {
 	return { channel, prefix, bashArgs };
 }
 
-const INSTALL_PS1_URL = "https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1";
+const DEFAULT_INSTALL_PS1_URL =
+	"https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1";
 /** Rooted Windows path — `X:\…` or a UNC `\\server\share\…`; mirrors install.ps1's `IsPathRooted` gate. */
 const WINDOWS_ROOTED_RE = /^(?:[A-Za-z]:[\\/]|\\\\[^\\/]+[\\/])/;
 /**
@@ -126,32 +129,80 @@ const WINDOWS_ROOTED_RE = /^(?:[A-Za-z]:[\\/]|\\\\[^\\/]+[\\/])/;
  */
 const WINDOWS_PREFIX_FORBIDDEN_RE = /["%;\n\r]/;
 
-/**
- * The `THINKRAIL_PREFIX` the printed command needs, or `undefined` when the recorded prefix is already
- * the installer's own default (`<home>\.local`) and the var would be noise. Without this, a user who
- * installed under `D:\tools` would follow the command and get a *second* copy under `.local` while the
- * `thinkrail.exe` their PATH resolves stays on the old build. Throws on a prefix that isn't a rooted
- * Windows path or can't be safely quoted — a tampered `install.json` must not shape a command we hand
- * the user to paste (the Unix path refuses the same way).
- */
-export function resolveWindowsPrefix(metaPrefix: unknown, home: string): string | undefined {
-	if (typeof metaPrefix !== "string" || !metaPrefix) return undefined;
-	if (!WINDOWS_ROOTED_RE.test(metaPrefix) || WINDOWS_PREFIX_FORBIDDEN_RE.test(metaPrefix)) {
-		throw new Error(`Refusing suspicious install prefix from metadata: ${metaPrefix}`);
-	}
+/** Compare two Windows paths the way the filesystem does: separator- and case-insensitive, no trailing `\`. */
+function sameWindowsPath(a: string, b: string): boolean {
 	const norm = (p: string) => p.replace(/\//g, "\\").replace(/\\+$/, "").toLowerCase();
-	return norm(metaPrefix) === norm(`${home}\\.local`) ? undefined : metaPrefix;
+	return norm(a) === norm(b);
 }
 
 /**
- * What to print instead of self-updating on Windows: the `install.ps1` one-liner, spelled out **per
- * shell** — cmd's `set "X=v" &&` and PowerShell's `$env:X='v';` are not interchangeable, and a
- * PowerShell user pasting the cmd form would silently re-install the wrong channel/version (`set` there
- * is `Set-Variable`, which never reaches the child process). Carries every option that would otherwise
- * be lost, so re-running the installer reproduces *this* install rather than a default one. Env vars
- * appear only when they'd change the outcome, so the common case stays a single copyable command.
+ * The prefix a Windows re-install must target: the recorded one, else the installer's own default
+ * (`<home>\.local`). Throws on a prefix that isn't a rooted Windows path or can't be safely quoted — a
+ * tampered `install.json` must not steer where we install or shape a command we hand the user to paste
+ * (the Unix path refuses the same way).
  */
-export function windowsUpdateMessage(
+export function resolveWindowsInstallPrefix(metaPrefix: unknown, home: string): string {
+	const prefix = typeof metaPrefix === "string" && metaPrefix ? metaPrefix : `${home}\\.local`;
+	if (!WINDOWS_ROOTED_RE.test(prefix) || WINDOWS_PREFIX_FORBIDDEN_RE.test(prefix)) {
+		throw new Error(`Refusing suspicious install prefix from metadata: ${prefix}`);
+	}
+	return prefix;
+}
+
+/**
+ * The same prefix for the *printed* fallback command, or `undefined` when it is already the installer's
+ * own default and the `THINKRAIL_PREFIX` var would be noise. Without it, a user who installed under
+ * `D:\tools` would follow the command and get a *second* copy under `.local` while the `thinkrail.exe`
+ * their PATH resolves stays on the old build.
+ */
+export function resolveWindowsPrefix(metaPrefix: unknown, home: string): string | undefined {
+	const prefix = resolveWindowsInstallPrefix(metaPrefix, home);
+	return sameWindowsPath(prefix, `${home}\\.local`) ? undefined : prefix;
+}
+
+export interface WindowsUpdatePlan {
+	channel: "stable" | "nightly";
+	version: string;
+	prefix: string;
+	/** Params for `powershell -File install.ps1` — the installer's own `param()` block. */
+	psArgs: string[];
+	/**
+	 * The prefix the manual-fallback command has to name if this plan fails — `undefined` when it is the
+	 * installer's own default. Resolved here, next to the prefix it mirrors, so the printed command and
+	 * the attempted install can't disagree about where this install lives.
+	 */
+	manualPrefix: string | undefined;
+}
+
+/**
+ * Resolve the Windows re-install the same way `resolveUpdatePlan` resolves the Unix one. All three params
+ * are passed **always**, `-Version latest` included: install.ps1's params default from the `THINKRAIL_*`
+ * env vars, which the child inherits from us, so only being explicit makes the update deterministic for a
+ * user who happens to have one set.
+ */
+export function resolveWindowsUpdatePlan(input: ResolveUpdateInput): WindowsUpdatePlan {
+	const channel = resolveUpdateChannel(input.args, input.installMeta.channel, input.baked);
+	const prefix = resolveWindowsInstallPrefix(input.installMeta.prefix, input.home);
+	const version = input.args.version;
+	return {
+		channel,
+		version,
+		prefix,
+		psArgs: ["-Channel", channel, "-Version", version, "-Prefix", prefix],
+		manualPrefix: resolveWindowsPrefix(input.installMeta.prefix, input.home),
+	};
+}
+
+/**
+ * What to print when the Windows self-update can't run (or ran and failed): the `install.ps1` one-liner,
+ * spelled out **per shell** — cmd's `set "X=v" &&` and PowerShell's `$env:X='v';` are not
+ * interchangeable, and a PowerShell user pasting the cmd form would silently re-install the wrong
+ * channel/version (`set` there is `Set-Variable`, which never reaches the child process). Carries every
+ * option that would otherwise be lost, so re-running the installer reproduces *this* install rather than
+ * a default one. Env vars appear only when they'd change the outcome, so the common case stays a single
+ * copyable command.
+ */
+export function windowsManualUpdateMessage(
 	channel: "stable" | "nightly",
 	version: string,
 	prefix?: string,
@@ -160,27 +211,66 @@ export function windowsUpdateMessage(
 	if (channel !== "stable") vars.push(["THINKRAIL_CHANNEL", channel]);
 	if (version !== "latest") vars.push(["THINKRAIL_VERSION", version]);
 	if (prefix) vars.push(["THINKRAIL_PREFIX", prefix]);
-	// PowerShell's single quotes are literal except for `'` itself, which doubles to escape.
-	const psPrefix = vars.map(([k, v]) => `$env:${k}='${v.replace(/'/g, "''")}'; `).join("");
+	const psPrefix = vars.map(([k, v]) => `$env:${k}=${psQuote(v)}; `).join("");
 	const cmdPrefix = vars.map(([k, v]) => `set "${k}=${v}" && `).join("");
 	const what =
 		version === "latest" ? `the latest ${channel} build` : `ThinkRail ${version} (${channel})`;
 	// ASCII only: a legacy conhost code page would garble a dash/ellipsis in the copyable block.
 	return [
-		"Automatic in-place update isn't supported on Windows yet.",
-		`Re-run the installer to get ${what}. Pick the line for your shell:`,
-		`  PowerShell:  ${psPrefix}irm ${INSTALL_PS1_URL} | iex`,
-		`  cmd:         ${cmdPrefix}powershell -c "irm ${INSTALL_PS1_URL} | iex"`,
+		`Re-run the installer by hand to get ${what}. Pick the line for your shell:`,
+		`  PowerShell:  ${psPrefix}irm ${DEFAULT_INSTALL_PS1_URL} | iex`,
+		`  cmd:         ${cmdPrefix}powershell -c "irm ${DEFAULT_INSTALL_PS1_URL} | iex"`,
 		"Or download manually: https://github.com/JetBrains/thinkrail/releases",
 	].join("\n");
 }
 
-function readInstallMeta(home: string): { channel?: unknown; prefix?: unknown } {
+/**
+ * Fetch an installer script, or `undefined` (after reporting why) when it can't be had. `fetch`, not the
+ * Unix path's `curl`: Windows has no guaranteed `curl.exe`, and `-File` needs the script as text anyway.
+ */
+async function fetchInstaller(url: string): Promise<string | undefined> {
 	try {
-		return JSON.parse(readFileSync(join(home, ".config", "thinkrail", "install.json"), "utf8"));
-	} catch {
-		return {};
+		const response = await fetch(url);
+		if (!response.ok) throw new Error(`HTTP ${response.status}`);
+		const script = await response.text();
+		if (!script.trim()) throw new Error("empty response");
+		return script;
+	} catch (err) {
+		console.error(
+			`error: failed to fetch the installer (${err instanceof Error ? err.message : String(err)})`,
+		);
+		return undefined;
 	}
+}
+
+/**
+ * Windows self-update: run the published `install.ps1` with the resolved params. Every failure path ends
+ * at the manual command, so the user is never left with just an error.
+ */
+async function runWindowsUpdate(
+	plan: WindowsUpdatePlan,
+	env: Record<string, string | undefined>,
+): Promise<number> {
+	const manual = () => {
+		console.error(`\n${windowsManualUpdateMessage(plan.channel, plan.version, plan.manualPrefix)}`);
+	};
+	const script = await fetchInstaller(env.THINKRAIL_INSTALL_PS1_URL ?? DEFAULT_INSTALL_PS1_URL);
+	if (script === undefined) {
+		manual();
+		return 1;
+	}
+	const run = await runPowerShellScript(script, plan.psArgs, { env });
+	if (run === undefined) {
+		console.error("error: no PowerShell found (looked for powershell.exe, then pwsh.exe)");
+		manual();
+		return 1;
+	}
+	if (run.exitCode !== 0) {
+		console.error(`error: the installer exited with code ${run.exitCode}`);
+		manual();
+		return run.exitCode;
+	}
+	return 0;
 }
 
 /** Run the `update` subcommand. Returns a process exit code. */
@@ -192,20 +282,17 @@ export async function runUpdate(
 		console.log(UPDATE_USAGE);
 		return 0;
 	}
-	let plan: UpdatePlan;
+	const home = homedir();
+	let plan: UpdatePlan | WindowsUpdatePlan;
 	try {
-		const args = parseUpdateArgs(argv);
-		const home = homedir();
-		const installMeta = readInstallMeta(home);
-		if (process.platform === "win32") {
-			// Resolve channel + prefix the same way the Unix plan does, so the printed command re-installs
-			// *this* install instead of silently dropping the user onto stable under the default prefix.
-			const channel = resolveUpdateChannel(args, installMeta.channel, bakedChannel);
-			const prefix = resolveWindowsPrefix(installMeta.prefix, home);
-			console.error(windowsUpdateMessage(channel, args.version, prefix));
-			return 1;
-		}
-		plan = resolveUpdatePlan({ args, installMeta, baked: bakedChannel, home });
+		const input = {
+			args: parseUpdateArgs(argv),
+			installMeta: readInstallMeta(home),
+			baked: bakedChannel,
+			home,
+		};
+		plan =
+			process.platform === "win32" ? resolveWindowsUpdatePlan(input) : resolveUpdatePlan(input);
 	} catch (err) {
 		console.error(err instanceof Error ? err.message : String(err));
 		console.error(`\n${UPDATE_USAGE}`);
@@ -213,6 +300,8 @@ export async function runUpdate(
 	}
 
 	console.log(`Updating ThinkRail (current: ${version}, channel: ${plan.channel}) …`);
+
+	if ("psArgs" in plan) return await runWindowsUpdate(plan, env);
 
 	const url = env.THINKRAIL_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_SCRIPT_URL;
 	const fetched = Bun.spawnSync(["curl", "-fsSL", url], { stdout: "pipe", stderr: "inherit" });

--- a/install.ps1
+++ b/install.ps1
@@ -264,23 +264,23 @@ function Install-ThinkRail {
     }
 
     # Same file + shape install.sh writes; `thinkrail update` reads it (homedir()\.config\thinkrail).
+    # Written *after* the PATH section below, because it records whether that section added the entry.
     $configDir = Join-Path $env:USERPROFILE '.config\thinkrail'
-    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-    $meta = [ordered]@{
-        channel      = $channel
-        version      = ($tag -replace '^v', '')
-        tag          = $tag
-        prefix       = $prefix
-        installed_at = ((Get-Date).ToUniversalTime().ToString('s') + 'Z')
+    $metaFile = Join-Path $configDir 'install.json'
+    $previousMeta = $null
+    try {
+        if (Test-Path -LiteralPath $metaFile) {
+            $previousMeta = Get-Content -LiteralPath $metaFile -Raw | ConvertFrom-Json
+        }
+    } catch {
+        # Unreadable or not JSON -- treat as no previous install (the uninstaller does the same).
     }
-    # WriteAllText writes UTF-8 without BOM (PS 5.1's Set-Content -Encoding UTF8 adds one, which
-    # breaks the JSON.parse in `thinkrail update`).
-    [System.IO.File]::WriteAllText((Join-Path $configDir 'install.json'), ($meta | ConvertTo-Json))
 
     Write-Host ''
     Write-Host "ThinkRail $($tag -replace '^v', '') ($channel) installed."
 
     $pathAdvice = $null
+    $pathStatus = $null
     if ($NoModifyPath) {
         if (Test-ThinkRailOnPath -Dir $binDir -PathEntries (Get-ThinkRailPersistentPath)) {
             Write-Host 'PATH:           already configured'
@@ -304,6 +304,29 @@ function Install-ThinkRail {
             $env:Path = "$env:Path;$binDir"
         }
     }
+    # Did *we* put $binDir on the user PATH? `thinkrail uninstall` removes that entry only when this says
+    # yes: nothing else in the registry marks it as ours, and a user who already had this dir on PATH for
+    # other tools must not lose it. Sticky across re-installs of the same prefix -- an update sees
+    # 'already' precisely because an earlier run of ours added it, and that ownership must not decay.
+    $pathEntryAdded = $pathStatus -eq 'added'
+    if (-not $pathEntryAdded -and $previousMeta -and $previousMeta.path_entry_added -eq $true) {
+        $before = ([string]$previousMeta.prefix).Replace('/', '\').TrimEnd('\')
+        if ($before -and ($before -ieq $prefix.Replace('/', '\').TrimEnd('\'))) { $pathEntryAdded = $true }
+    }
+
+    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+    $meta = [ordered]@{
+        channel          = $channel
+        version          = ($tag -replace '^v', '')
+        tag              = $tag
+        prefix           = $prefix
+        path_entry_added = $pathEntryAdded
+        installed_at     = ((Get-Date).ToUniversalTime().ToString('s') + 'Z')
+    }
+    # WriteAllText writes UTF-8 without BOM (PS 5.1's Set-Content -Encoding UTF8 adds one, which
+    # breaks the JSON.parse in `thinkrail update`).
+    [System.IO.File]::WriteAllText($metaFile, ($meta | ConvertTo-Json))
+
     if ($pathAdvice) { Write-Host "Add to PATH:    $pathAdvice" }
     Write-Host 'Run:            thinkrail'
     Write-Host 'Update later:   thinkrail update'

--- a/install.ps1
+++ b/install.ps1
@@ -15,8 +15,8 @@
 #
 # A saved copy also takes params: .\install.ps1 -Channel nightly -Version 0.2.0 -Prefix D:\tools -NoModifyPath
 #
-# After install, run `thinkrail`. To update later, re-run this installer (`thinkrail update` is
-# macOS/Linux-only for now).
+# After install, run `thinkrail`. To update later, run `thinkrail update` (it re-runs this installer for
+# you, replacing the running exe); to remove it, run `thinkrail uninstall`.
 #
 # Kept ASCII-only on purpose: Windows PowerShell 5.1 parses a saved UTF-8 file without BOM as ANSI,
 # which would garble any non-ASCII character. Errors `throw` (never `exit`): under `irm | iex` the
@@ -306,7 +306,8 @@ function Install-ThinkRail {
     }
     if ($pathAdvice) { Write-Host "Add to PATH:    $pathAdvice" }
     Write-Host 'Run:            thinkrail'
-    Write-Host 'Update later:   re-run this installer'
+    Write-Host 'Update later:   thinkrail update'
+    Write-Host 'Uninstall:      thinkrail uninstall'
 }
 
 Install-ThinkRail -Channel $Channel -Version $Version -Prefix $Prefix -NoModifyPath:$NoModifyPath

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,8 @@
 #                              Allowed chars: A-Z a-z 0-9 _ - . / ~ and space.
 #   --no-modify-path           don't touch shell rc files; just print PATH advice
 #
-# After install, run `thinkrail`. To update later, run `thinkrail update` (or re-run this installer).
+# After install, run `thinkrail`. To update later, run `thinkrail update`; to remove it, run
+# `thinkrail uninstall`.
 
 set -euo pipefail
 
@@ -36,7 +37,8 @@ Options:
                              Allowed chars: A-Z a-z 0-9 _ - . / ~ and space.
   --no-modify-path           don't touch shell rc files; just print PATH advice
 
-After install, run `thinkrail`. To update later, run `thinkrail update` (or re-run this installer).
+After install, run `thinkrail`. To update later, run `thinkrail update`; to remove it, run
+`thinkrail uninstall`.
 EOF
     exit "${1:-0}"
 }
@@ -286,3 +288,4 @@ fi
 
 echo "Run:            thinkrail"
 echo "Update later:   thinkrail update"
+echo "Uninstall:      thinkrail uninstall"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,3 +6,6 @@ export {
 	registerBundledRuntime,
 } from "./agent";
 export * from "./host";
+// Where our app state lives (`~/.thinkrail` unless `THINKRAIL_DATA_DIR`). Exposed for `thinkrail
+// uninstall`, which has to name that dir — and must name the *same* one the host reads and writes.
+export { dataDir } from "./persistence";


### PR DESCRIPTION
## New

**`thinkrail uninstall`** — removes the executable, the installer's PATH edit, `install.json`, and the compiled binary's staging cache. Asks whether to delete `~/.thinkrail` (**kept by default** — it holds the workspace worktrees). `--remove-data` / `--keep-data` / `-y` answer non-interactively; no TTY and no `-y` → refuses. pi's own state (`~/.pi`) is never touched.

## Fixes

- `thinkrail update` on Windows never updated — it printed advice and exited 1. It now runs the published `install.ps1` via `powershell -File` (falling back to `pwsh`), with `-Channel`/`-Version`/`-Prefix` always passed explicitly so an inherited `THINKRAIL_*` env var can't redirect the update. Replacing the running exe is install.ps1's existing rename-aside path.
- Any Windows update failure (fetch, no PowerShell host, installer non-zero) falls back to printing the manual per-shell command instead of only an error.
- Install-management subcommands no longer stage the binary's embedded assets — `uninstall` was re-extracting the cache it then deletes.
- `install.sh` / `install.ps1` / README no longer say updating is macOS/Linux-only, and both installers now print the uninstall command.

## Verification

`check:deps`, `check:seams`, `lint`, `typecheck`, unit tests (+18 new), `e2e` (99), `build:binary` + `smoke:binary` (new assertion: a subcommand must not stage), `e2e:binary` (95). Plus sandboxed real uninstalls, the Windows paths driven through a fake `powershell.exe` to assert the exact argv, and the PATH-removal script's logic exercised in real PowerShell (11 cases: `%VAR%` expansion, casing, separators, duplicates, non-ASCII, prefix-of-another-dir).

Not covered: a real Windows machine, and the Windows-only *successful* rename-aside branch.