### PR TITLE
fix(dialog): the Windows folder picker opens in front, and a failed picker says why

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -45,7 +45,9 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   `WelcomePanel`, so the flow is identical in the rail and the Welcome screen): `project.open`, and on
   failure `project.inspect` → either offers to bootstrap the folder into a repo — a modal **`ConfirmDialog`**
   (confirm → `project.init`) — when it's `initable`, or surfaces the error in a **`NoticeDialog`** — so a
-  non-git folder is never a silent no-op. Both are modals on `components/ui/dialog` (the init offer has no
+  non-git folder is never a silent no-op — and neither is a host that couldn't *show* a folder dialog (that
+  throws; the notice carries the reason, and the request runs on a raised `timeoutMs` since the picker waits
+  on a human). Both are modals on `components/ui/dialog` (the init offer has no
   on-screen anchor, unlike the Remove popover); `NoticeDialog` is a single-button info modal for failures
   with no yes/no follow-up. The hook returns a `dialogs` node each consumer renders. **Selecting a
   project** (clicking its row — the chevron expands/collapses separately) **deselects any active

--- a/apps/web/src/panels/useOpenProject.tsx
+++ b/apps/web/src/panels/useOpenProject.tsx
@@ -64,12 +64,16 @@ export function useOpenProject(onOpened: (project: Project) => void | Promise<vo
 
 	/** Ask the host for a directory via its native picker, then open it. */
 	const pickAndOpen = async () => {
+		let path: string | null;
 		try {
-			const { path } = await getTransport().request("dialog.selectDirectory", {});
-			if (path) await openProject(path);
-		} catch {
-			// Cancelled / unavailable — nothing to do.
+			({ path } = await getTransport().request("dialog.selectDirectory", {}));
+		} catch (err) {
+			// A cancel is a null path; a throw means the host couldn't *show* a dialog — surface it, or the
+			// only way to add a project reads as a dead button.
+			setOpenError(errorText(err, "Couldn't open the folder picker on the host."));
+			return;
 		}
+		if (path) await openProject(path);
 	};
 
 	const dialogs = (

--- a/apps/web/src/panels/useOpenProject.tsx
+++ b/apps/web/src/panels/useOpenProject.tsx
@@ -5,6 +5,11 @@ import { errorText, getTransport } from "../transport";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { NoticeDialog } from "./NoticeDialog";
 
+// The host answers `dialog.selectDirectory` only once the user has picked a folder or dismissed the
+// dialog, so it needs far more than the transport's 60s default: that would reject (and drop the reply)
+// while the picker is still on screen. Generous but finite, so a dead host still releases the request.
+const PICK_TIMEOUT_MS = 30 * 60_000;
+
 /**
  * The shared "open a project" flow, reused by the projects rail (`ProjectTree`) and the Welcome screen
  * (`WelcomePanel`) so the non-git handling is identical in both. Opens a folder as a project; when it
@@ -66,7 +71,11 @@ export function useOpenProject(onOpened: (project: Project) => void | Promise<vo
 	const pickAndOpen = async () => {
 		let path: string | null;
 		try {
-			({ path } = await getTransport().request("dialog.selectDirectory", {}));
+			({ path } = await getTransport().request(
+				"dialog.selectDirectory",
+				{},
+				{ timeoutMs: PICK_TIMEOUT_MS },
+			));
 		} catch (err) {
 			// A cancel is a null path; a throw means the host couldn't *show* a dialog — surface it, or the
 			// only way to add a project reads as a dead button.

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -14,7 +14,9 @@ The single WebSocket client to the host, and its app-wide singleton.
 
 ## Boundary
 
-- **Owns:** `transport.ts` (`WsTransport`: id-correlated `request`, channel `subscribe` with last-value
+- **Owns:** `transport.ts` (`WsTransport`: id-correlated `request` — replies time out after 60s unless the
+  caller raises `timeoutMs`, which a request the host answers *only once a human has* must do (an open
+  folder dialog: a fired timeout also drops the reply that follows it) —, channel `subscribe` with last-value
   replay, reconnect/backoff; `inferUrl` defaults to same-origin; **`httpBase()`** derives the host's HTTP origin
   from the WS `url` — for building host HTTP URLs like the `/files/<workspaceId>/<path>` worktree-file
   endpoint the markdown viewer points relative `<img>`s at, targeting the same host the transport dials); `wireTransport.ts` (`initTransport`/

--- a/apps/web/src/transport/transport.ts
+++ b/apps/web/src/transport/transport.ts
@@ -9,6 +9,19 @@ export interface TransportOptions {
 	onStatus?: (status: ConnectionStatus) => void;
 }
 
+/** How long a request waits for its reply before rejecting, unless the caller overrides it. */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface RequestOptions {
+	sessionId?: string;
+	/**
+	 * Override the reply deadline (ms). Raise it for a request the **host answers only once a human has**
+	 * — `dialog.selectDirectory` sits on an open folder dialog — where the default would reject while the
+	 * dialog is still on screen *and* drop the reply that follows (the pending entry is gone by then).
+	 */
+	timeoutMs?: number;
+}
+
 /** Single WebSocket to the host: id-correlated requests + channel subscriptions, with reconnect. */
 export class WsTransport {
 	private ws: WebSocket | null = null;
@@ -65,15 +78,16 @@ export class WsTransport {
 	request<M extends WsMethodName>(
 		method: M,
 		params: WsParams<M>,
-		sessionId?: string,
+		options: RequestOptions = {},
 	): Promise<WsResult<M>> {
+		const { sessionId, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
 		const id = `trpi_${++this.seq}`;
 		const frame = JSON.stringify({ id, method, params, ...(sessionId ? { sessionId } : {}) });
 		return new Promise<WsResult<M>>((resolve, reject) => {
 			const timer = setTimeout(() => {
 				this.pending.delete(id);
 				reject(new Error(`request "${method}" timed out`));
-			}, 60_000);
+			}, timeoutMs);
 			this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timer });
 			this.sendFrame(frame);
 		});

--- a/packages/server/src/dialog/SPEC.md
+++ b/packages/server/src/dialog/SPEC.md
@@ -25,6 +25,7 @@ The host's native directory picker, so the browser "Open project" gets a real OS
   *file*, the returned path is that file's trimmed contents, **re-read per call** — so one shared e2e host
   can hand different folders to different tests by rewriting the pointer (a directory value is returned
   as-is).
-- **Public surface (barrel):** `selectDirectory` (+ `pickersFor` / `Picker`, exposed for unit tests).
+- **Public surface (barrel):** `selectDirectory` (+ `pickersFor` / `Picker` and the two message builders
+  `pickerFailure` / `noPickerMessage`, exposed for unit tests).
 - **Allowed deps:** Bun (spawn), `process.env`.
 - **Forbidden:** `host`; sibling features; `contracts` (none needed).

--- a/packages/server/src/dialog/SPEC.md
+++ b/packages/server/src/dialog/SPEC.md
@@ -15,9 +15,13 @@ The host's native directory picker, so the browser "Open project" gets a real OS
 
 - **Owns:** `selectDirectory()` — the host's native folder picker, per OS via `pickersFor(platform)`:
   macOS `osascript` (`choose folder`), Linux `zenity` then `kdialog` (whichever is installed), Windows a
-  PowerShell `FolderBrowserDialog`. `THINKRAIL_PICK_DIR` overrides it for dev/e2e; returns `null` on
-  cancel or when no native picker is available. A missing binary falls through to the next candidate; a
-  non-zero exit is a user cancel. **File-indirection:** when `THINKRAIL_PICK_DIR` names an existing
+  PowerShell `FolderBrowserDialog` (owned by an invisible top-most form — a background process can't take
+  the foreground, so an unowned dialog opens behind the browser). `THINKRAIL_PICK_DIR` overrides it for
+  dev/e2e; returns `null` when the user cancels. A missing binary falls through to the next candidate; a
+  non-zero exit is a cancel for `osascript`/`zenity`/`kdialog` but a **failure** for PowerShell (it exits 0
+  on cancel) — each `Picker` declares which. A failed picker, or no runnable candidate at all, **throws**:
+  the picker is the only way to add a project, so a silent `null` is a dead button.
+  **File-indirection:** when `THINKRAIL_PICK_DIR` names an existing
   *file*, the returned path is that file's trimmed contents, **re-read per call** — so one shared e2e host
   can hand different folders to different tests by rewriting the pointer (a directory value is returned
   as-is).

--- a/packages/server/src/dialog/dialog.test.ts
+++ b/packages/server/src/dialog/dialog.test.ts
@@ -18,11 +18,22 @@ test("Linux picker tries zenity then kdialog, both as directory pickers", () => 
 	expect(pickers[1]?.cmd).toContain("--getexistingdirectory");
 });
 
-test("Windows picker uses a PowerShell FolderBrowserDialog", () => {
+test("Windows picker: a PowerShell FolderBrowserDialog, -Sta, owned by a top-most form", () => {
 	const pickers = pickersFor("win32");
-	expect(pickers).toHaveLength(1);
-	expect(pickers[0]?.cmd[0]).toBe("powershell");
-	expect(pickers[0]?.cmd.join(" ")).toContain("FolderBrowserDialog");
+	expect(pickers.map((p) => p.cmd[0])).toEqual(["powershell.exe", "pwsh.exe"]);
+	for (const picker of pickers) {
+		expect(picker.cmd).toContain("-Sta");
+		expect(picker.cmd.join(" ")).toContain("FolderBrowserDialog");
+		// Owned by a top-most form, or the dialog opens behind the browser and reads as a dead button.
+		expect(picker.cmd.join(" ")).toContain("$owner.TopMost = $true");
+		expect(picker.cmd.join(" ")).toContain("$d.ShowDialog($owner)");
+	}
+});
+
+test("only PowerShell reads a non-zero exit as a failure — the others cancel", () => {
+	expect(pickersFor("darwin").map((p) => p.nonZeroExit)).toEqual(["cancel"]);
+	expect(pickersFor("linux").map((p) => p.nonZeroExit)).toEqual(["cancel", "cancel"]);
+	expect(pickersFor("win32").map((p) => p.nonZeroExit)).toEqual(["error", "error"]);
 });
 
 test("unknown platform has no native picker", () => {

--- a/packages/server/src/dialog/dialog.test.ts
+++ b/packages/server/src/dialog/dialog.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { pickersFor, selectDirectory } from "./dialog";
+import { noPickerMessage, pickerFailure, pickersFor, selectDirectory } from "./dialog";
 
 test("macOS picker uses osascript 'choose folder'", () => {
 	const pickers = pickersFor("darwin");
@@ -38,6 +38,20 @@ test("only PowerShell reads a non-zero exit as a failure — the others cancel",
 
 test("unknown platform has no native picker", () => {
 	expect(pickersFor("sunos" as NodeJS.Platform)).toEqual([]);
+});
+
+test("a failed picker names a cause — never an empty message, never a stray CR", () => {
+	expect(pickerFailure("Add-Type : Cannot load assembly\r\n  At line:1\r\n", 1)).toBe(
+		"The folder picker failed: Add-Type : Cannot load assembly",
+	);
+	// A killed picker writes nothing to stderr — the exit code is all we have to show.
+	expect(pickerFailure("", 137)).toBe("The folder picker failed: exit 137");
+	expect(pickerFailure("   \r\n \n", 1)).toBe("The folder picker failed: exit 1");
+});
+
+test("no runnable picker points at the fix on Linux, names the platform elsewhere", () => {
+	expect(noPickerMessage("linux")).toContain("install zenity or kdialog");
+	expect(noPickerMessage("sunos" as NodeJS.Platform)).toContain("(sunos)");
 });
 
 test("picker output is trimmed, trailing separators dropped, empty → null", () => {

--- a/packages/server/src/dialog/dialog.ts
+++ b/packages/server/src/dialog/dialog.ts
@@ -69,8 +69,9 @@ export function pickersFor(platform: NodeJS.Platform): Picker[] {
 				},
 			];
 		case "win32":
-			// The same two hosts (and order) `apps/cli/src/powershell.ts` uses, and `-Sta` because a WinForms
-			// dialog needs a single-threaded apartment — the default for `powershell.exe`, *not* for `pwsh`.
+			// The same two hosts (and order) `apps/cli/src/powershell.ts` uses. `-Sta` because a WinForms
+			// dialog needs a single-threaded apartment: both hosts already default to STA on Windows, so this
+			// only pins the requirement at the spawn site.
 			return ["powershell.exe", "pwsh.exe"].map((shell) => ({
 				cmd: [shell, "-NoProfile", "-Sta", "-Command", WINDOWS_PICKER],
 				parse: toPath,
@@ -100,6 +101,22 @@ function resolveOverride(): string | null {
 }
 
 /**
+ * Why a picker that *ran* failed, for the notice the user sees: its first stderr line, else the exit code
+ * (a killed picker writes nothing). PowerShell's CRLF output would otherwise leave a trailing `\r`.
+ */
+export function pickerFailure(stderr: string, code: number): string {
+	const firstLine = stderr.replaceAll("\r", "").trim().split("\n")[0];
+	return `The folder picker failed: ${firstLine || `exit ${code}`}`;
+}
+
+/** Why we couldn't even start a picker — phrased so the user can act on it. */
+export function noPickerMessage(platform: NodeJS.Platform): string {
+	return platform === "linux"
+		? "No folder picker on this host — install zenity or kdialog."
+		: `No native folder picker is available on this host (${platform}).`;
+}
+
+/**
  * Pop the host's native folder picker and return the chosen path (`null` when the user cancelled).
  * A missing binary falls through to the next candidate; **throws** when a picker failed or none could
  * run at all — the picker is the only way to add a project, so a silent `null` is a dead button.
@@ -124,11 +141,7 @@ export async function selectDirectory(): Promise<{ path: string | null }> {
 		}
 		if (code === 0) return { path: picker.parse(out) };
 		if (picker.nonZeroExit === "cancel") return { path: null };
-		throw new Error(`The folder picker failed: ${err.trim().split("\n")[0] ?? `exit ${code}`}`);
+		throw new Error(pickerFailure(err, code));
 	}
-	throw new Error(
-		process.platform === "linux"
-			? "No folder picker on this host — install zenity or kdialog."
-			: `No native folder picker is available on this host (${process.platform}).`,
-	);
+	throw new Error(noPickerMessage(process.platform));
 }

--- a/packages/server/src/dialog/dialog.ts
+++ b/packages/server/src/dialog/dialog.ts
@@ -9,6 +9,11 @@ export interface Picker {
 	cmd: string[];
 	/** Map raw stdout to an absolute path, or `null` when nothing usable was returned. */
 	parse: (stdout: string) => string | null;
+	/**
+	 * What a non-zero exit means. `osascript` (-128), `zenity` and `kdialog` exit non-zero when the user
+	 * cancels; PowerShell exits **0** and prints nothing, so there it's a real failure, not a cancel.
+	 */
+	nonZeroExit: "cancel" | "error";
 }
 
 // Trim surrounding whitespace and any trailing path separator(s); empty → null. Shared across
@@ -16,11 +21,25 @@ export interface Picker {
 const toPath = (stdout: string): string | null => stdout.trim().replace(/[/\\]+$/, "") || null;
 
 // PowerShell folder picker: a WinForms FolderBrowserDialog; prints the path on OK, nothing on cancel.
-const WINDOWS_PICKER =
-	"Add-Type -AssemblyName System.Windows.Forms; " +
-	"$d = New-Object System.Windows.Forms.FolderBrowserDialog; " +
-	"$d.Description = 'Open project'; " +
-	"if ($d.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { Write-Output $d.SelectedPath }";
+// The dialog is **owned by an invisible top-most form**: we spawn it from a background process, which
+// Windows forbids from taking the foreground, so an unowned dialog opens *behind* the browser the user
+// is looking at — indistinguishable from "the button does nothing". `$ErrorActionPreference = 'Stop'`
+// turns a blocked `Add-Type`/`New-Object` (ConstrainedLanguage mode on a locked-down host) into a
+// non-zero exit with a real message on stderr, instead of printing nothing and looking like a cancel.
+const WINDOWS_PICKER = [
+	"$ErrorActionPreference = 'Stop'",
+	"Add-Type -AssemblyName System.Windows.Forms",
+	"$owner = New-Object System.Windows.Forms.Form",
+	"$owner.TopMost = $true",
+	"$owner.ShowInTaskbar = $false",
+	"$owner.Opacity = 0",
+	"$owner.Show()",
+	"$d = New-Object System.Windows.Forms.FolderBrowserDialog",
+	"$d.Description = 'Open project'",
+	"$ok = $d.ShowDialog($owner) -eq [System.Windows.Forms.DialogResult]::OK",
+	"$owner.Close()",
+	"if ($ok) { Write-Output $d.SelectedPath }",
+].join("; ");
 
 /**
  * The ordered native pickers to try for a platform. Multiple entries are fallbacks tried only when the
@@ -33,6 +52,7 @@ export function pickersFor(platform: NodeJS.Platform): Picker[] {
 				{
 					cmd: ["osascript", "-e", 'POSIX path of (choose folder with prompt "Open project")'],
 					parse: toPath,
+					nonZeroExit: "cancel",
 				},
 			];
 		case "linux":
@@ -40,14 +60,22 @@ export function pickersFor(platform: NodeJS.Platform): Picker[] {
 				{
 					cmd: ["zenity", "--file-selection", "--directory", "--title=Open project"],
 					parse: toPath,
+					nonZeroExit: "cancel",
 				},
 				{
 					cmd: ["kdialog", "--getexistingdirectory", ".", "--title", "Open project"],
 					parse: toPath,
+					nonZeroExit: "cancel",
 				},
 			];
 		case "win32":
-			return [{ cmd: ["powershell", "-NoProfile", "-Command", WINDOWS_PICKER], parse: toPath }];
+			// The same two hosts (and order) `apps/cli/src/powershell.ts` uses, and `-Sta` because a WinForms
+			// dialog needs a single-threaded apartment — the default for `powershell.exe`, *not* for `pwsh`.
+			return ["powershell.exe", "pwsh.exe"].map((shell) => ({
+				cmd: [shell, "-NoProfile", "-Sta", "-Command", WINDOWS_PICKER],
+				parse: toPath,
+				nonZeroExit: "error" as const,
+			}));
 		default:
 			return [];
 	}
@@ -72,23 +100,35 @@ function resolveOverride(): string | null {
 }
 
 /**
- * Pop the host's native folder picker and return the chosen path (`null` on cancel / no picker).
- * A missing binary falls through to the next candidate; a non-zero exit is a user cancel (stop).
+ * Pop the host's native folder picker and return the chosen path (`null` when the user cancelled).
+ * A missing binary falls through to the next candidate; **throws** when a picker failed or none could
+ * run at all — the picker is the only way to add a project, so a silent `null` is a dead button.
  */
 export async function selectDirectory(): Promise<{ path: string | null }> {
 	const override = resolveOverride();
 	if (override) return { path: override };
 
 	for (const picker of pickersFor(process.platform)) {
+		let out: string;
+		let err: string;
+		let code: number;
 		try {
-			const proc = Bun.spawn(picker.cmd, { stdout: "pipe", stderr: "ignore" });
-			const out = await new Response(proc.stdout).text();
-			const code = await proc.exited;
-			if (code !== 0) return { path: null }; // user cancelled the dialog
-			return { path: picker.parse(out) };
+			const proc = Bun.spawn(picker.cmd, { stdout: "pipe", stderr: "pipe" });
+			[out, err, code] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
 		} catch {
-			// Binary not installed (e.g. no zenity) — try the next candidate.
+			continue; // Binary not installed (e.g. no zenity) — try the next candidate.
 		}
+		if (code === 0) return { path: picker.parse(out) };
+		if (picker.nonZeroExit === "cancel") return { path: null };
+		throw new Error(`The folder picker failed: ${err.trim().split("\n")[0] ?? `exit ${code}`}`);
 	}
-	return { path: null };
+	throw new Error(
+		process.platform === "linux"
+			? "No folder picker on this host — install zenity or kdialog."
+			: `No native folder picker is available on this host (${process.platform}).`,
+	);
 }


### PR DESCRIPTION
## The report

On Windows, **Open project** does nothing: no folder dialog, no error.

## No merge broke this

The first suspicion was a regression in one of today's merges (two stable releases were cut today — v0.0.9 at 13:08, v0.0.10 at 21:09). It isn't. Across `v0.0.8 → v0.0.10` the entire picker path is untouched:

```
git diff v0.0.8 v0.0.10 -- packages/server/src/dialog \
    apps/web/src/panels/{AddProjectMenu,useOpenProject}.tsx apps/web/src/transport
 apps/web/src/panels/useOpenProject.tsx | 3 +++      <- a comment, nothing else
```

- `packages/server/src/dialog/**` last changed **2026-06-30** (#11); Windows binaries have shipped since **2026-07-07** (#73).
- `handlers.ts`'s `"dialog.selectDirectory"` line: unchanged. `AddProjectMenu`: unchanged since #49.
- Checked out `origin/main` in a scratch worktree and ran its own e2e for that exact click path (`projects.spec.ts` + `welcome.spec.ts`, 12 specs driving `add-project-menu` → `menu-open-project`): green.

So the picker has been broken on Windows since it was written. The one *related* change today is #135, which removed the "Open project" card from the Welcome screen when a project is shown — that moves **where** you click, not **how** the dialog is invoked.

## Two causes, both original

**1. Z-order.** We spawn the picker from a background process, which Windows forbids from taking the foreground — so an *unowned* `FolderBrowserDialog` opens **behind** the browser the user is looking at. Indistinguishable from a dead button. It's now owned by an invisible top-most form (`$d.ShowDialog($owner)`), which puts it in front.

**2. Silence.** Every failure read as "user cancelled": a non-zero exit was treated as a cancel, and `pickAndOpen` swallowed the rest with `// Cancelled / unavailable — nothing to do`. But PowerShell exits **0** on cancel — a non-zero exit there is a real failure (a blocked `Add-Type` under ConstrainedLanguage, no host on PATH). `Picker` now declares `nonZeroExit` per picker (`osascript` -128, `zenity`, `kdialog` genuinely do cancel that way); a failure, or no runnable candidate at all, **throws** with the reason, and the hook surfaces it in the existing `NoticeDialog`. The picker is the only way to add a project, so a silent `null` is a dead button.

Also `-Sta` (a WinForms dialog needs a single-threaded apartment — the default for `powershell.exe`, *not* for `pwsh`) and a `pwsh.exe` fallback, matching the hosts and order `apps/cli/src/powershell.ts` already uses.

## Not verified on Windows

No Windows box here, so the z-order fix is a best diagnosis of a symptom I can't reproduce. That's exactly why the error surfacing is in scope: if it still fails, the next report names a cause instead of nothing. Sanity check on a Windows terminal — if this shows a dialog but the app doesn't, the cause is elsewhere and the new error text will say so:

```
powershell.exe -NoProfile -Sta -Command "Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.FolderBrowserDialog; if ($d.ShowDialog() -eq 'OK') { $d.SelectedPath }"
```

## Test plan

`check:deps`, `check:seams`, `lint`, `typecheck`, `bun run test` (349), `bun run e2e` (115) — all green. Unit tests pin the two hosts, `-Sta`, the owner form, and the cancel-vs-failure split per platform.

UI-visible surface is the failure path only (the existing open-error notice, now also carrying picker failures) — happy to attach a forced-failure screenshot if useful.