### PR TITLE
fix(dialog): the Windows picker takes the keyboard, not just the z-order

### DIFF
--- a/packages/server/src/dialog/SPEC.md
+++ b/packages/server/src/dialog/SPEC.md
@@ -15,8 +15,7 @@ The host's native directory picker, so the browser "Open project" gets a real OS
 
 - **Owns:** `selectDirectory()` — the host's native folder picker, per OS via `pickersFor(platform)`:
   macOS `osascript` (`choose folder`), Linux `zenity` then `kdialog` (whichever is installed), Windows a
-  PowerShell `FolderBrowserDialog` (owned by an invisible top-most form — a background process can't take
-  the foreground, so an unowned dialog opens behind the browser). `THINKRAIL_PICK_DIR` overrides it for
+  PowerShell `FolderBrowserDialog`. `THINKRAIL_PICK_DIR` overrides it for
   dev/e2e; returns `null` when the user cancels. A missing binary falls through to the next candidate; a
   non-zero exit is a cancel for `osascript`/`zenity`/`kdialog` but a **failure** for PowerShell (it exits 0
   on cancel) — each `Picker` declares which. A failed picker, or no runnable candidate at all, **throws**:
@@ -25,6 +24,21 @@ The host's native directory picker, so the browser "Open project" gets a real OS
   *file*, the returned path is that file's trimmed contents, **re-read per call** — so one shared e2e host
   can hand different folders to different tests by rewriting the pointer (a directory value is returned
   as-is).
+- **Windows: the dialog must come up focused, in front of the browser.** The host is a background
+  process, and Windows only lets the process that *owns* the foreground call `SetForegroundWindow` — so a
+  plain `ShowDialog()` opens behind the browser, unfocused, reading as "the button does nothing". An
+  invisible top-most owner form is **not sufficient on its own**: measured on Windows 11 with an unrelated
+  app in front, the dialog came up unfocused in 3/3 runs — visible, but the keyboard still belonged to the
+  browser. What works is the documented way past the foreground lock: the script `AttachThreadInput`s to
+  the foreground window's thread (sharing its input queue makes our `SetForegroundWindow` legal),
+  foregrounds the owner form, detaches, then shows the dialog **owned** by that now-foreground form.
+  Measured on Windows 11: focused and on top in 3/3 runs, Enter selects the highlighted folder, Escape
+  returns `null` at exit 0. The whole grab is **best-effort** — wrapped so a host that can't compile the
+  P/Invoke, or an elevated foreground app that refuses the steal, degrades to the old behaviour (the
+  dialog still opens, just behind) instead of failing the pick.
+  The script is handed over as `-EncodedCommand` (base64/UTF-16LE), not `-Command`: it is multi-line and
+  contains the double quotes of P/Invoke signatures, which Windows argv quoting plus PowerShell's own
+  re-parse do not preserve.
 - **Public surface (barrel):** `selectDirectory` (+ `pickersFor` / `Picker` and the two message builders
   `pickerFailure` / `noPickerMessage`, exposed for unit tests).
 - **Allowed deps:** Bun (spawn), `process.env`.

--- a/packages/server/src/dialog/dialog.test.ts
+++ b/packages/server/src/dialog/dialog.test.ts
@@ -23,10 +23,17 @@ test("Windows picker: a PowerShell FolderBrowserDialog, -Sta, owned by a top-mos
 	expect(pickers.map((p) => p.cmd[0])).toEqual(["powershell.exe", "pwsh.exe"]);
 	for (const picker of pickers) {
 		expect(picker.cmd).toContain("-Sta");
-		expect(picker.cmd.join(" ")).toContain("FolderBrowserDialog");
-		// Owned by a top-most form, or the dialog opens behind the browser and reads as a dead button.
-		expect(picker.cmd.join(" ")).toContain("$owner.TopMost = $true");
-		expect(picker.cmd.join(" ")).toContain("$d.ShowDialog($owner)");
+		// The script travels base64 UTF-16LE (`-EncodedCommand`), so its C# survives the command line.
+		const flag = picker.cmd.indexOf("-EncodedCommand");
+		expect(flag).toBeGreaterThan(-1);
+		const script = Buffer.from(picker.cmd[flag + 1] ?? "", "base64").toString("utf16le");
+		expect(script).toContain("FolderBrowserDialog");
+		// Owned by a top-most form, or the dialog opens behind the browser and reads as a dead button…
+		expect(script).toContain("$owner.TopMost = $true");
+		expect(script).toContain("$d.ShowDialog($owner)");
+		// …and top-most alone leaves the browser active, so the dialog would open without the keyboard.
+		expect(script).toContain("AttachThreadInput");
+		expect(script).toContain("SetForegroundWindow($owner.Handle)");
 	}
 });
 

--- a/packages/server/src/dialog/dialog.test.ts
+++ b/packages/server/src/dialog/dialog.test.ts
@@ -34,6 +34,12 @@ test("Windows picker: a PowerShell FolderBrowserDialog, -Sta, owned by a top-mos
 		// …and top-most alone leaves the browser active, so the dialog would open without the keyboard.
 		expect(script).toContain("AttachThreadInput");
 		expect(script).toContain("SetForegroundWindow($owner.Handle)");
+		// Attach and detach in pairs: leaving our input thread joined to another process' would make that
+		// app's keyboard state ours for as long as the picker lives.
+		expect(script).toContain("AttachThreadInput($me, $fg, $true)");
+		expect(script).toContain("AttachThreadInput($me, $fg, $false)");
+		// The grab is best-effort — a host that can't compile the P/Invoke still gets a dialog.
+		expect(script).toContain("} catch { }");
 	}
 });
 

--- a/packages/server/src/dialog/dialog.ts
+++ b/packages/server/src/dialog/dialog.ts
@@ -23,9 +23,14 @@ const toPath = (stdout: string): string | null => stdout.trim().replace(/[/\\]+$
 // PowerShell folder picker: a WinForms FolderBrowserDialog; prints the path on OK, nothing on cancel.
 // The dialog is **owned by an invisible top-most form**: we spawn it from a background process, which
 // Windows forbids from taking the foreground, so an unowned dialog opens *behind* the browser the user
-// is looking at — indistinguishable from "the button does nothing". `$ErrorActionPreference = 'Stop'`
-// turns a blocked `Add-Type`/`New-Object` (ConstrainedLanguage mode on a locked-down host) into a
-// non-zero exit with a real message on stderr, instead of printing nothing and looking like a cancel.
+// is looking at — indistinguishable from "the button does nothing". Top-most alone only wins the
+// z-order, though: the browser stays the *active* window, so the dialog opens without the keyboard.
+// `SetForegroundWindow` is subject to the same foreground lock — unless our input thread is attached
+// to the current foreground one first, which is what the P/Invoke block does. Best-effort: a host that
+// can't compile it still gets the top-most dialog, just unfocused, rather than no dialog at all.
+// `$ErrorActionPreference = 'Stop'` turns a blocked `Add-Type`/`New-Object` (ConstrainedLanguage mode on
+// a locked-down host) into a non-zero exit with a real message on stderr, instead of printing nothing
+// and looking like a cancel.
 const WINDOWS_PICKER = [
 	"$ErrorActionPreference = 'Stop'",
 	"Add-Type -AssemblyName System.Windows.Forms",
@@ -34,12 +39,35 @@ const WINDOWS_PICKER = [
 	"$owner.ShowInTaskbar = $false",
 	"$owner.Opacity = 0",
 	"$owner.Show()",
+	"try {",
+	"  Add-Type -Namespace ThinkRail -Name Fg -MemberDefinition '",
+	'    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();',
+	'    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr w, IntPtr p);',
+	'    [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool join);',
+	'    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr w);',
+	'    [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();\'',
+	// A null `lpdwProcessId` is allowed, so `IntPtr` spares us an out-param marshal; a zero thread id
+	// (no foreground window at all) just makes the attach a harmless no-op.
+	"  $fg = [ThinkRail.Fg]::GetWindowThreadProcessId([ThinkRail.Fg]::GetForegroundWindow(), [IntPtr]::Zero)",
+	"  $me = [ThinkRail.Fg]::GetCurrentThreadId()",
+	"  [void][ThinkRail.Fg]::AttachThreadInput($me, $fg, $true)",
+	"  [void][ThinkRail.Fg]::SetForegroundWindow($owner.Handle)",
+	"  [void][ThinkRail.Fg]::AttachThreadInput($me, $fg, $false)",
+	"} catch { }",
 	"$d = New-Object System.Windows.Forms.FolderBrowserDialog",
 	"$d.Description = 'Open project'",
 	"$ok = $d.ShowDialog($owner) -eq [System.Windows.Forms.DialogResult]::OK",
 	"$owner.Close()",
 	"if ($ok) { Write-Output $d.SelectedPath }",
-].join("; ");
+].join("\n");
+
+/**
+ * The picker as `-EncodedCommand` payload (base64 UTF-16LE, what PowerShell expects). Not `-Command`:
+ * the script carries C# string literals, and quoting embedded double quotes through a Windows command
+ * line into PowerShell's own parser is a known minefield — `apps/cli/src/powershell.ts` sidesteps the
+ * same problem with a temp `.ps1` file. Encoding keeps it a single, quote-proof argv element.
+ */
+const ENCODED_WINDOWS_PICKER = Buffer.from(WINDOWS_PICKER, "utf16le").toString("base64");
 
 /**
  * The ordered native pickers to try for a platform. Multiple entries are fallbacks tried only when the
@@ -73,7 +101,7 @@ export function pickersFor(platform: NodeJS.Platform): Picker[] {
 			// dialog needs a single-threaded apartment: both hosts already default to STA on Windows, so this
 			// only pins the requirement at the spawn site.
 			return ["powershell.exe", "pwsh.exe"].map((shell) => ({
-				cmd: [shell, "-NoProfile", "-Sta", "-Command", WINDOWS_PICKER],
+				cmd: [shell, "-NoProfile", "-Sta", "-EncodedCommand", ENCODED_WINDOWS_PICKER],
 				parse: toPath,
 				nonZeroExit: "error" as const,
 			}));


### PR DESCRIPTION
Follow-up to #141 (merged). The dialog now opens **in front** of the browser, but without focus — you have to click it before typing or arrowing around.

## Why top-most wasn't enough

`TopMost` wins the **z-order**; it doesn't make the window **active**. The browser stays the foreground window, so the folder dialog opens on top of it with no keyboard.

`SetForegroundWindow` is blocked by the same foreground lock that put the dialog behind the browser to begin with — a process that isn't already foreground can't just take it. The documented way past it is to attach our input thread to the current foreground thread first:

```powershell
$fg = GetWindowThreadProcessId(GetForegroundWindow(), $null)
$me = GetCurrentThreadId()
AttachThreadInput($me, $fg, $true)
SetForegroundWindow($owner.Handle)
AttachThreadInput($me, $fg, $false)
```

**Best-effort, in a `try/catch`:** a host that can't compile the P/Invoke (ConstrainedLanguage, no compiler) still gets the top-most dialog — just unfocused, as today — rather than no dialog at all.

## `-Command` → `-EncodedCommand`

That block needs C# string literals, and quoting embedded double quotes through a Windows command line into PowerShell's own parser is exactly the minefield `apps/cli/src/powershell.ts` documents and avoids with a temp `.ps1`. The script now travels as `-EncodedCommand` (base64 UTF-16LE): one quote-proof argv element, no temp file to write or clean up. Newlines come free with it, so the script reads as a script instead of a `;`-joined one-liner.

## Verified on Windows 11

Measured on a real Windows 11 host, driving `selectDirectory()` from a background Bun process with an unrelated app holding the foreground — the same conditions that make the bug visible:

| | dialog visible | **focused** | keyboard |
|---|---|---|---|
| `main` (#141, top-most owner only) | yes | **no — 3/3 runs** | goes to the browser |
| this PR | yes | **yes — 3/3 runs** | goes to the dialog |

Focus was read with `GetForegroundWindow()` against the dialog's `hwnd`, filtered to a live picker process (so windows left behind by earlier runs can't be mistaken for a fresh one). Keyboard delivery was checked end to end, not just inferred from the focus flag: `{ENTER}` sent to no particular window returned the highlighted folder (`{"path":"C:\Users\danya\Desktop"}`), and `{ESC}` returned `{"path":null}` at exit 0 — cancel still reads as cancel, not as a failure.

Also green: `typecheck`, `lint`, unit tests (10/10 in the dialog suite), and — from #141's run — 115/115 e2e on Linux.

## Scope

Three files. The two source files, plus `dialog/SPEC.md` — taking you up on the offer in the last revision: the spec had credited the invisible top-most owner for getting the picker in front, which the table above shows isn't what does it. It now records the foreground lock, both measurements, and that the grab is best-effort by design, so the next person doesn't re-derive it from the P/Invoke.

The unit test decodes the base64 payload before asserting on the script, and pins `AttachThreadInput` / `SetForegroundWindow($owner.Handle)`, the **paired** attach/detach (a stuck attachment would hand us another app's keyboard state for as long as the picker lives), and the `catch` that keeps the grab optional.
