### PR TITLE
feat(models): order the model picker newest-first and adopt pi's enabledModels allowlist

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -14,6 +14,7 @@ import { Popover, PopoverAnchor, PopoverTrigger } from "@/components/ui/popover"
 import {
 	EMPTY_RUNTIME,
 	SettingsSection,
+	selectPickerTiers,
 	selectSkillsStale,
 	selectWorkspaceById,
 	specPathMatcher,
@@ -124,7 +125,8 @@ export default function ChatView({
 	// This tab's runtime — zustand only re-renders when *this* session's slice ref changes, so a background
 	// chat streaming into its own runtime never re-renders the foreground one.
 	const runtime = useAppStore((s) => s.sessions[sessionId]) ?? EMPTY_RUNTIME;
-	const models = useAppStore((s) => s.models);
+	const catalogSize = useAppStore((s) => s.modelCatalog.length);
+	const { primary: models, extra: extraModels } = useAppStore(selectPickerTiers);
 	// This chat's owning project (workspaces are keyed by project) — for the Skills manager's trust ops
 	// and the "project" / "all" history-search scopes.
 	const projectId = useAppStore(
@@ -245,14 +247,15 @@ export default function ChatView({
 	const chatLocationRequest = useAppStore((s) => s.chatLocationRequest);
 	const [flashRowId, setFlashRowId] = useState<string | null>(null);
 
-	// Models are global to the host — fetch once, then every chat's picker shares them.
+	// The catalog is global to the host — fetch once, then every chat's picker shares it (later writes
+	// arrive on the `model.catalogChanged` broadcast).
 	useEffect(() => {
-		if (models.length > 0) return;
+		if (catalogSize > 0) return;
 		getTransport()
 			.request("model.list", {})
-			.then((m) => useAppStore.getState().setModels(m))
+			.then((catalog) => useAppStore.getState().setModelCatalog(catalog))
 			.catch(() => {});
-	}, [models.length]);
+	}, [catalogSize]);
 
 	// The skill catalog is per-session; load it when the chat opens.
 	useEffect(() => {
@@ -680,6 +683,7 @@ export default function ChatView({
 							mentionCandidates={mentionCandidates}
 							recentPrompts={recentPrompts}
 							models={models}
+							extraModels={extraModels}
 							currentModel={currentModel}
 							thinkingLevel={thinkingLevel}
 							onMentionQuery={onMentionQuery}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -150,6 +150,8 @@ interface ComposerProps {
 	 * below; `ChatView` derives it from `turns` via `turnAnchorText`. */
 	recentPrompts: string[];
 	models: WireModel[];
+	/** The picker's second tier (out-of-allowlist + collapsed duplicates) — passed straight through. */
+	extraModels: WireModel[];
 	currentModel: WireModel | null;
 	thinkingLevel: ThinkingLevel;
 	onMentionQuery: (query: string | null) => void;
@@ -222,6 +224,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		mentionCandidates,
 		recentPrompts,
 		models,
+		extraModels,
 		currentModel,
 		thinkingLevel,
 		onMentionQuery,
@@ -788,7 +791,12 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				</div>
 				<div className="flex flex-wrap items-center gap-sm">
 					<div className="flex min-w-0 flex-1 flex-wrap items-center gap-sm">
-						<ModelSelector models={models} current={currentModel} onSelect={onSelectModel} />
+						<ModelSelector
+							models={models}
+							extra={extraModels}
+							current={currentModel}
+							onSelect={onSelectModel}
+						/>
 						<ThinkingSelector
 							level={thinkingLevel}
 							levels={currentModel?.thinkingLevels ?? []}

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -1,5 +1,5 @@
 import type { WireModel } from "@thinkrail/contracts";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, ChevronsDown } from "lucide-react";
 import { useState } from "react";
 import {
 	Command,
@@ -8,54 +8,95 @@ import {
 	CommandInput,
 	CommandItem,
 	CommandList,
+	CommandSeparator,
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { formatContextWindow } from "@/lib";
 
-/** A model's context window as a compact label, e.g. 1_000_000 → "1M", 200_000 → "200K". */
-function formatContext(tokens: number): string {
-	if (tokens >= 1_000_000) return `${Math.round(tokens / 100_000) / 10}M`.replace(".0", "");
-	if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
-	return String(tokens);
-}
-
-/** A data-derived sub-line for a model row: context window + whether it reasons. */
-function subLine(model: WireModel): string {
-	const parts = [`${formatContext(model.contextWindow)} context`];
+/** A data-derived sub-line for a model row: context window + whether it reasons (extras also name their provider). */
+function subLine(model: WireModel, withProvider: boolean): string {
+	const parts = withProvider ? [model.provider] : [];
+	parts.push(`${formatContextWindow(model.contextWindow)} context`);
 	if (model.reasoning) parts.push("reasoning");
 	return parts.join(" · ");
 }
 
 /**
- * The per-session model picker (cheap win #1): a pill trigger opening a searchable
- * `Command` list grouped by provider. Props-driven, no store — shared by the chat header and the
- * New-Workspace dialog (pre-session mode, where `current` may be null = the host default).
+ * The per-session model picker (cheap win #1): a pill trigger opening a searchable `Command` list.
+ *
+ * It renders the host's **two tiers** and decides neither: `models` is the everyday list (enabled by the
+ * user's allowlist, dated duplicates folded away) and `extra` is everything else, reachable through the
+ * "Show all" row — or, at any time, by typing, since a **query searches both tiers** so a legacy or pinned
+ * model is never unreachable. Curating the everyday tier lives in Settings → Models, not here.
+ *
+ * Props-driven, no store — shared by the chat header and the New-Workspace dialog (pre-session mode, where
+ * `current` may be null = the host default).
  */
 export function ModelSelector({
 	models,
+	extra,
 	current,
 	onSelect,
 	container,
 }: {
 	models: WireModel[];
+	/** Out-of-list + collapsed models — hidden until "Show all", always searchable. */
+	extra: WireModel[];
 	current: WireModel | null;
 	onSelect: (model: WireModel) => void;
 	/** Popover portal target — the host Dialog node when used inside a dialog (so the list scrolls). */
 	container?: HTMLElement | null;
 }) {
 	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const [showAll, setShowAll] = useState(false);
+	// Typing reveals the extra tier too: cmdk filters the rendered rows, so a search that can't see them
+	// would claim "No models found" for a model the host does offer.
+	const expanded = showAll || query.trim().length > 0;
 	const providers = [...new Set(models.map((m) => m.provider))];
+
+	const reset = (next: boolean) => {
+		setOpen(next);
+		setQuery("");
+		setShowAll(false);
+	};
 
 	const select = (model: WireModel) => {
 		onSelect(model);
-		setOpen(false);
+		reset(false);
+	};
+
+	const row = (model: WireModel, tier: "primary" | "extra") => {
+		const isCurrent = current?.provider === model.provider && current?.id === model.id;
+		return (
+			<CommandItem
+				key={`${model.provider}:${model.id}`}
+				value={`${model.provider} ${model.name} ${model.id}`}
+				data-testid="model-option"
+				data-model-id={model.id}
+				data-tier={tier}
+				onSelect={() => select(model)}
+			>
+				<span className="flex w-3.5 shrink-0 justify-center">
+					{isCurrent ? <Check className="size-3.5 text-primary" /> : null}
+				</span>
+				<span className="flex min-w-0 flex-col">
+					<span className="truncate">{model.name}</span>
+					<span className="truncate text-hint text-xs">{subLine(model, tier === "extra")}</span>
+				</span>
+				<span className="ml-auto shrink-0 font-[var(--font-mono)] text-hint text-xs">
+					{model.id}
+				</span>
+			</CommandItem>
+		);
 	};
 
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
+		<Popover open={open} onOpenChange={reset}>
 			<PopoverTrigger
 				data-testid="model-selector"
 				data-open={open}
-				disabled={models.length === 0}
+				disabled={models.length === 0 && extra.length === 0}
 				className="flex h-8 max-w-[220px] items-center gap-sm rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-sm text-sm text-text outline-none transition-colors hover:bg-hover focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50 data-[open=true]:border-[var(--primary-60)] data-[open=true]:bg-hover"
 			>
 				<span className="truncate font-[var(--font-mono)] text-muted text-xs">
@@ -65,38 +106,30 @@ export function ModelSelector({
 			</PopoverTrigger>
 			<PopoverContent align="start" container={container} className="w-[320px] p-0">
 				<Command>
-					<CommandInput placeholder="Search models…" />
+					<CommandInput placeholder="Search models…" value={query} onValueChange={setQuery} />
 					<CommandList>
 						<CommandEmpty>No models found.</CommandEmpty>
 						{providers.map((provider) => (
 							<CommandGroup key={provider} heading={provider}>
-								{models
-									.filter((m) => m.provider === provider)
-									.map((m) => {
-										const isCurrent = current?.provider === m.provider && current?.id === m.id;
-										return (
-											<CommandItem
-												key={`${m.provider}:${m.id}`}
-												value={`${m.provider} ${m.name} ${m.id}`}
-												data-testid="model-option"
-												data-model-id={m.id}
-												onSelect={() => select(m)}
-											>
-												<span className="flex w-3.5 shrink-0 justify-center">
-													{isCurrent ? <Check className="size-3.5 text-primary" /> : null}
-												</span>
-												<span className="flex min-w-0 flex-col">
-													<span className="truncate">{m.name}</span>
-													<span className="truncate text-hint text-xs">{subLine(m)}</span>
-												</span>
-												<span className="ml-auto shrink-0 font-[var(--font-mono)] text-hint text-xs">
-													{m.id}
-												</span>
-											</CommandItem>
-										);
-									})}
+								{models.filter((m) => m.provider === provider).map((m) => row(m, "primary"))}
 							</CommandGroup>
 						))}
+						{expanded && extra.length > 0 ? (
+							<CommandGroup heading="More models">{extra.map((m) => row(m, "extra"))}</CommandGroup>
+						) : null}
+						{!expanded && extra.length > 0 ? (
+							<>
+								<CommandSeparator />
+								<CommandItem
+									data-testid="model-show-all"
+									value="show all models"
+									onSelect={() => setShowAll(true)}
+								>
+									<ChevronsDown className="size-3.5 shrink-0 text-hint" />
+									<span className="text-muted">Show all {models.length + extra.length} models</span>
+								</CommandItem>
+							</>
+						) : null}
 					</CommandList>
 				</Command>
 			</PopoverContent>

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -146,7 +146,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   template** action on the selected prompt row — see the Save-as-template bullet below, and a
   **zoomed-stage preview pane** + **scope picker** — see the next bullet),
   `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
-  optional `container` prop portals their popovers into a host Dialog; `ThinkingSelector` takes
+  optional `container` prop portals their popovers into a host Dialog; `ModelSelector` renders **two
+  host-decided tiers** — `models` (the everyday rows: enabled, duplicates collapsed) and `extra`
+  (everything else, revealed by a **"Show all N models"** footer row). It decides neither tier: the split
+  is `store/selectors`' `selectPickerTiers` over the host's `enabled`/`collapsed` flags. A **non-empty
+  search query searches both tiers** (extras under a muted "More models" heading), so a legacy or pinned
+  model is always findable by name without leaving the picker; curating the everyday tier lives in
+  Settings → Models, never here. `ThinkingSelector` takes
   **`levels`** — `WireModel.thinkingLevels` verbatim, the host-computed support truth, already in pi's
   escalation order — and its rows **are** that list. The web keeps no enumeration of the level
   vocabulary: pi owns it, the host projects the per-model slice, and an empty list (no model resolved

--- a/apps/web/src/lib/SPEC.md
+++ b/apps/web/src/lib/SPEC.md
@@ -22,13 +22,15 @@ Tiny UI helpers shared across components.
   host may use either separator and may be relative or absolute — every path predicate in the app starts
   from these, so `chat`'s display helpers and `store`'s worktree matcher share one definition) and
   **`shallowEqualArrays()`** (element-wise `Object.is` — the "did this really change?" test behind the
-  store's snapshot-identity guard and `ErrorBoundary`'s reset keys). Also the shared
+  store's snapshot-identity guard and `ErrorBoundary`'s reset keys) and **`formatContextWindow()`** (a
+  model's context window as `1M`/`200K` — shared by `chat`'s model picker and `panels`' Settings → Models
+  so the two model lists render the same number the same way). Also the shared
   Shiki highlighter, **kept out of the barrel** so the eager `@/lib` import stays shiki-free:
   `highlighter.ts` loads the curated grammars + JS regex engine and renders with `themes`' one generic
   CSS-variable registration. It is imported per-file (`@/lib/highlighter`) from lazy chunks only; theme
   identity/palettes never live in `lib`.
 - **Public surface (barrel):** `cn`, `isMarkdownPath`, `stripFrontmatter`, `cssColorToHex`,
-  `normalizePath`, `isAbsolutePath`, `projectRelativePath`, `shallowEqualArrays`.
+  `normalizePath`, `isAbsolutePath`, `projectRelativePath`, `shallowEqualArrays`, `formatContextWindow`.
 - **Allowed deps:** `clsx`, `tailwind-merge`; `shiki`/`@shikijs/*` (the per-file shiki modules only —
   never reachable through the barrel).
 - **Forbidden:** every app-internal module — this is a leaf.

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import {
 	cssColorToHex,
+	formatContextWindow,
 	isAbsolutePath,
 	isMarkdownPath,
 	normalizePath,
@@ -97,4 +98,12 @@ test("shallowEqualArrays compares element-wise and treats absent as unequal", ()
 	expect(shallowEqualArrays([Number.NaN], [Number.NaN])).toBe(true);
 	expect(shallowEqualArrays(undefined, [])).toBe(false);
 	expect(shallowEqualArrays(undefined, undefined)).toBe(true);
+});
+
+test("formatContextWindow compacts a context window the way both model surfaces render it", () => {
+	expect(formatContextWindow(1_000_000)).toBe("1M");
+	expect(formatContextWindow(1_047_576)).toBe("1M"); // gpt-4.1's odd window rounds, never "1.0M"
+	expect(formatContextWindow(1_050_000)).toBe("1.1M");
+	expect(formatContextWindow(200_000)).toBe("200K");
+	expect(formatContextWindow(999)).toBe("999");
 });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -118,3 +118,13 @@ export function stripFrontmatter(text: string): string {
 	const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/.exec(text);
 	return match ? text.slice(match[0].length) : text;
 }
+
+/**
+ * A model's context window as a compact label: 1_000_000 → "1M", 200_000 → "200K". Shared by every
+ * surface that lists models (the picker's tiers, the Settings → Models manager) so the two can't drift.
+ */
+export function formatContextWindow(tokens: number): string {
+	if (tokens >= 1_000_000) return `${Math.round(tokens / 100_000) / 10}M`.replace(".0", "");
+	if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+	return String(tokens);
+}

--- a/apps/web/src/panels/ModelsSettings.tsx
+++ b/apps/web/src/panels/ModelsSettings.tsx
@@ -1,0 +1,140 @@
+import { type ModelCatalogEntry, modelRef } from "@thinkrail/contracts";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn, formatContextWindow } from "@/lib";
+import { toast, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+
+/** One provider's models, in the host's order (the catalog arrives grouped, newest first). */
+function groupByProvider(catalog: ModelCatalogEntry[]): [string, ModelCatalogEntry[]][] {
+	const groups = new Map<string, ModelCatalogEntry[]>();
+	for (const entry of catalog) {
+		const group = groups.get(entry.model.provider);
+		if (group) group.push(entry);
+		else groups.set(entry.model.provider, [entry]);
+	}
+	return [...groups];
+}
+
+/**
+ * The "Models" settings section: which models the picker offers day to day.
+ *
+ * This edits **pi's own `enabledModels` setting**, not a ThinkRail one — so a list curated here is the
+ * list `pi` honors in its CLI/TUI too (and vice versa). Every toggle sends the *whole* list
+ * (`model.setEnabled`) and the UI repaints from the host's `model.catalogChanged` broadcast, the same
+ * converge-on-broadcast pattern as the theme and analytics switches — so there is no dirty state and no
+ * Save button. Turning everything off means "all models available", which is how pi stores "no filter".
+ */
+export function ModelsSettings() {
+	const catalog = useAppStore((s) => s.modelCatalog);
+	const [busy, setBusy] = useState(false);
+
+	// The catalog is host-global and normally already loaded by a chat/dialog picker — fetch it if this
+	// panel is the first surface to need it (a user who opens Settings before any chat).
+	useEffect(() => {
+		if (catalog.length > 0) return;
+		getTransport()
+			.request("model.list", {})
+			.then((fresh) => useAppStore.getState().setModelCatalog(fresh))
+			.catch(() => {});
+	}, [catalog.length]);
+
+	const enabledCount = catalog.filter((entry) => entry.enabled).length;
+	const curated = enabledCount < catalog.length;
+
+	const save = (refs: string[] | null) => {
+		setBusy(true);
+		getTransport()
+			.request("model.setEnabled", { enabled: refs })
+			.catch(() => toast.error("Couldn't save your model selection"))
+			.finally(() => setBusy(false));
+	};
+
+	// Always send the WHOLE list, never a delta: pi's setting *is* the list. "Every model on" is sent as
+	// `null` (no filter), which is also what the host stores when the last enabled model is switched off.
+	const toggle = (entry: ModelCatalogEntry) => {
+		const next = catalog
+			.filter((candidate) => (candidate === entry ? !entry.enabled : candidate.enabled))
+			.map((candidate) => modelRef(candidate.model));
+		save(next.length === catalog.length ? null : next);
+	};
+
+	return (
+		<section data-testid="settings-models" className="flex flex-col gap-lg">
+			<div className="flex flex-col gap-xs">
+				<h3 className="font-medium text-md text-text">Available models</h3>
+				<p className="text-hint text-xs">
+					Pick the models you actually use — the chat picker offers those first and keeps the rest
+					behind “Show all”. This is pi's own{" "}
+					<span className="font-[var(--font-mono)]">enabledModels</span> setting, so the pi CLI
+					follows it too; patterns you wrote by hand are saved as explicit model ids, and selecting
+					none means every model is available.
+				</p>
+			</div>
+
+			<div className="flex items-center justify-between gap-md">
+				<span data-testid="models-enabled-count" className="text-muted text-sm">
+					{catalog.length === 0
+						? "No models yet — sign in to a provider first."
+						: curated
+							? `${enabledCount} of ${catalog.length} models enabled`
+							: `All ${catalog.length} models available`}
+				</span>
+				{curated ? (
+					<Button
+						size="sm"
+						variant="outline"
+						data-testid="models-enable-all"
+						disabled={busy}
+						onClick={() => save(null)}
+					>
+						Enable all
+					</Button>
+				) : null}
+			</div>
+
+			<div className="flex flex-col gap-md">
+				{groupByProvider(catalog).map(([provider, entries]) => (
+					<div key={provider} className="flex flex-col gap-xs">
+						<h4 className="font-medium text-hint text-xs uppercase tracking-wider">{provider}</h4>
+						<div className="flex flex-col divide-y divide-border rounded-[var(--radius-md)] border border-border2">
+							{entries.map((entry) => (
+								<div
+									key={modelRef(entry.model)}
+									data-testid="model-setting-row"
+									data-model-id={entry.model.id}
+									data-enabled={entry.enabled}
+									className="flex items-center justify-between gap-md px-md py-sm"
+								>
+									<div className="flex min-w-0 flex-col gap-0.5">
+										<span className="truncate text-sm text-text">{entry.model.name}</span>
+										<span className="truncate font-[var(--font-mono)] text-hint text-xs">
+											{entry.model.id} · {formatContextWindow(entry.model.contextWindow)} context
+											{entry.model.reasoning ? " · reasoning" : ""}
+										</span>
+									</div>
+									<button
+										type="button"
+										data-testid="model-toggle"
+										data-on={entry.enabled}
+										disabled={busy}
+										aria-label={`${entry.enabled ? "Disable" : "Enable"} ${entry.model.name}`}
+										onClick={() => toggle(entry)}
+										className={cn(
+											"shrink-0 rounded-[var(--radius-sm)] border px-sm py-0.5 text-xs transition-colors disabled:opacity-50",
+											entry.enabled
+												? "border-[var(--primary-40)] bg-[var(--primary-10)] text-primary"
+												: "border-border2 text-muted hover:bg-hover",
+										)}
+									>
+										{entry.enabled ? "on" : "off"}
+									</button>
+								</div>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -46,7 +46,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { selectWorkspaceTick, toast, useAppStore } from "@/store";
+import { selectPickerTiers, selectWorkspaceTick, toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 import { enterDefaultWorkspace } from "./defaultWorkspace";
 
@@ -90,7 +90,8 @@ export function NewWorkspaceDialog({
 	onCreated: (workspace: Workspace) => void;
 }) {
 	const projects = useAppStore((s) => s.projects);
-	const models = useAppStore((s) => s.models);
+	const catalogSize = useAppStore((s) => s.modelCatalog.length);
+	const { primary: models, extra: extraModels } = useAppStore(selectPickerTiers);
 
 	const [selectedProjectId, setSelectedProjectId] = useState(projectId);
 	// Every opener starts on the isolated-worktree side (task-welcome-trim made the entry points
@@ -176,14 +177,14 @@ export function NewWorkspaceDialog({
 		};
 	}, [open, selectedProjectId]);
 
-	// Models are global to the host — fetch once into the shared store; the picker reads them.
+	// The catalog is global to the host — fetch once into the shared store; the picker reads its tiers.
 	useEffect(() => {
-		if (!open || models.length > 0) return;
+		if (!open || catalogSize > 0) return;
 		getTransport()
 			.request("model.list", {})
-			.then((m) => useAppStore.getState().setModels(m))
+			.then((catalog) => useAppStore.getState().setModelCatalog(catalog))
 			.catch(() => {});
-	}, [open, models.length]);
+	}, [open, catalogSize]);
 
 	// Preselect the exact model + effort a fresh session would resolve to (so the picker shows the real
 	// model, not a placeholder). Passing it back at create time is a no-op vs. the host default.
@@ -544,6 +545,7 @@ export function NewWorkspaceDialog({
 					<div className="flex min-w-0 flex-1 flex-wrap items-center gap-sm">
 						<ModelSelector
 							models={models}
+							extra={extraModels}
 							current={model}
 							container={dialogEl}
 							onSelect={(m) => {

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -234,8 +234,18 @@ a project picker, the prompt hero, and the reused
   ever seeds global files. No server change. **`PrivacySettings`** is the **anonymous-usage-analytics
   toggle** — a switch over `store.analyticsEnabled`, fired via `settings.update { analyticsEnabled }`
   with the same converge-on-broadcast pattern as the theme, plus the what-is/isn't-collected copy; only
-  the boolean ever crosses the wire, see `submodule-server-analytics`. A single dimmed "General" nav item ("Soon") still signals the shell is
-  built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings`/`PrivacySettings` are the
+  the boolean ever crosses the wire, see `submodule-server-analytics`. **`ModelsSettings`** is the
+  **enabled-models manager**: every model the host reports (`store.modelCatalog`, already ordered
+  newest-first per provider) grouped by provider with an on/off pill per row (the `SkillsDialog` toggle
+  idiom, not a new primitive), a header state ("All models available" vs "N of M enabled"), and an
+  **Enable all** action. Each toggle fires
+  `model.setEnabled` with the **full** ref list and the UI converges on the `model.catalogChanged`
+  broadcast — no dirty state, no Save button, same pattern as the theme. Copy names the underlying
+  truth: this writes pi's own `settings.json` `enabledModels`, so the pi CLI honors it too, hand-written
+  globs are expanded to explicit ids on save, and turning everything off means "all models available"
+  (pi's semantics). This is the **only** entry point to the allowlist — the picker's "Show all" tier is an
+  escape hatch for one-off use, not a second editor. A single dimmed "General" nav item ("Soon") still signals the shell is
+  built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings`/`PrivacySettings`/`ModelsSettings` are the
   **integration pieces**
   (store + transport); the `LoginDialog` stays presentational (`auth` module).
 

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -1,4 +1,5 @@
 import {
+	Cpu,
 	GitBranch,
 	KeyRound,
 	LayoutTemplate,
@@ -12,6 +13,7 @@ import { cn } from "@/lib";
 import { SettingsSection, useAppStore } from "@/store";
 import { AppearanceSettings } from "./AppearanceSettings";
 import { GithubSettings } from "./GithubSettings";
+import { ModelsSettings } from "./ModelsSettings";
 import { PrivacySettings } from "./PrivacySettings";
 import { ProvidersSettings } from "./ProvidersSettings";
 import { TemplatesSettings } from "./TemplatesSettings";
@@ -19,6 +21,7 @@ import { TemplatesSettings } from "./TemplatesSettings";
 /** The live settings sections, in nav order. */
 const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
 	{ id: SettingsSection.Providers, label: "Providers", icon: KeyRound },
+	{ id: SettingsSection.Models, label: "Models", icon: Cpu },
 	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
 	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
 	{ id: SettingsSection.Templates, label: "Templates", icon: LayoutTemplate },
@@ -94,6 +97,8 @@ export function SettingsDialog() {
 					<div className="min-h-0 flex-1 overflow-y-auto p-lg">
 						{section === SettingsSection.Providers ? (
 							<ProvidersSettings />
+						) : section === SettingsSection.Models ? (
+							<ModelsSettings />
 						) : section === SettingsSection.Github ? (
 							<GithubSettings />
 						) : section === SettingsSection.Templates ? (

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -62,7 +62,15 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   chat is never clobbered. The
   pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime; **`handlePiEvent(event,
   sessionId)`** and **`applyExtUi(request)`** route by id via the `withRuntime` helper (a no-op for an
-  unknown session). The host-wide **`models`** list stays global (not per session). The **in-app login** state
+  unknown session). The host-wide **`modelCatalog`** (`ModelCatalogEntry[]` — pi's models in the
+  host's order, each tagged `enabled`/`collapsed`) stays global (not per session) and is replaced wholesale
+  by `setModelCatalog`, both on the `model.list` read and on the `model.catalogChanged` broadcast. Its two
+  derivations live in `selectors.ts` and nowhere else: **`selectPickerTiers`** (`primary` = `enabled &&
+  !collapsed`, `extra` = the rest — the picker's default rows vs its "Show all" tier) and
+  **`selectAllModels`** (the flat `WireModel[]` for ref lookups). Both **memoize on the catalog array's
+  identity** (a `WeakMap`): they build new arrays, and a selector that returns a fresh reference re-renders
+  its subscriber on every unrelated store write — which, with a chat streaming deltas, is constant. The
+  cache belongs here rather than as a `useMemo` at each call site. The **in-app login** state
   **`activeLogin: LoginState | null`** (type from `auth`) is **flat + session-less** (a login runs on the
   Welcome screen before any session exists — routing it through a session runtime would drop its frames):
   the pure **`foldLoginFrame`** reducer lives here (as `reduceExtUi`/`reduceSessionEvent` do — `auth` stays

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -4,6 +4,7 @@ import type {
 	ExtUiRequest,
 	LoginFrame,
 	LoginPush,
+	ModelCatalogEntry,
 	PiEvent,
 	Project,
 	SessionStats,
@@ -83,11 +84,12 @@ export type EditorTab = FileTab | ChatTab | DocTab | DiffTab;
 
 /**
  * A section of the settings dialog (a const-object "enum", the codebase convention). Extensible — the live
- * sections are providers, github, appearance (the theme picker), templates (prompt-template manager),
- * and privacy (the analytics toggle).
+ * sections are providers, models (pi's `enabledModels` allowlist), github, appearance (the theme picker),
+ * templates (prompt-template manager), and privacy (the analytics toggle).
  */
 export const SettingsSection = {
 	Providers: "providers",
+	Models: "models",
 	Github: "github",
 	Appearance: "appearance",
 	Templates: "templates",
@@ -443,8 +445,13 @@ interface AppState {
 	activeTerminalByWorkspace: Record<string, string | null>;
 	/** One runtime per live chat (keyed by `sessionId`) — many can stream at once; switching is a swap. */
 	sessions: Record<string, SessionRuntime>;
-	/** Models with configured auth (cheap win #1) — fetched once, shared by every chat's picker. */
-	models: WireModel[];
+	/**
+	 * The host's model catalog (cheap win #1) — every model with configured auth, in the host's order
+	 * (newest-first per provider) with its `enabled`/`collapsed` flags. Fetched once and refreshed by the
+	 * `model.catalogChanged` broadcast; shared by every chat's picker AND Settings → Models. Split into the
+	 * picker's tiers by `selectPickerTiers` — never re-derived in a component.
+	 */
+	modelCatalog: ModelCatalogEntry[];
 	/** Bare invalidation counter for the composer's `/`-menu template cache (`chat/ChatView.tsx`) — the
 	 * Templates settings panel (Task B6) bumps it after a `template.save`/`delete`; the store holds only
 	 * the counter, never fetches (see `chat/SPEC.md`'s Template slots bullet). */
@@ -641,7 +648,7 @@ interface AppState {
 	 */
 	appendErrorTurn: (sessionId: string, text: string) => void;
 	handlePiEvent: (event: PiEvent, sessionId: string) => void;
-	setModels: (models: WireModel[]) => void;
+	setModelCatalog: (catalog: ModelCatalogEntry[]) => void;
 	bumpTemplatesVersion: () => void;
 	setCurrentModel: (sessionId: string, model: WireModel) => void;
 	setThinkingLevel: (sessionId: string, level: ThinkingLevel) => void;
@@ -823,7 +830,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	terminalsByWorkspace: {},
 	activeTerminalByWorkspace: {},
 	sessions: {},
-	models: [],
+	modelCatalog: [],
 	templatesVersion: 0,
 	rightTabRequest: null,
 	changesRequest: null,
@@ -1296,7 +1303,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	// The event→store dispatcher: route each pi event to its session's runtime, so chats stream independently.
 	handlePiEvent: (event, sessionId) =>
 		set((s) => withRuntime(s, sessionId, (rt) => reduceSessionEvent(rt, event))),
-	setModels: (models) => set({ models }),
+	setModelCatalog: (catalog) => set({ modelCatalog: catalog }),
 	bumpTemplatesVersion: () => set((s) => ({ templatesVersion: s.templatesVersion + 1 })),
 	setCurrentModel: (sessionId, model) =>
 		set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, model }))),

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -1,13 +1,15 @@
 import { expect, test } from "bun:test";
-import type { Project, Workspace } from "@thinkrail/contracts";
+import type { ModelCatalogEntry, Project, WireModel, Workspace } from "@thinkrail/contracts";
 import type { EditorTab } from "./appStore";
 import {
 	isSkillPath,
 	matchesWorktreePath,
 	selectActiveWorkspace,
 	selectActiveWorkspaceProjectId,
+	selectAllModels,
 	selectContextProject,
 	selectHistoryTarget,
+	selectPickerTiers,
 	selectSkillsStale,
 	specPathMatcher,
 } from "./selectors";
@@ -219,4 +221,50 @@ test("specPathMatcher recognizes a spec by graph membership, in either reported 
 	expect(isSpec("packages/server/src/todos/todos.ts")).toBe(false);
 	// An empty graph (never fetched) classifies nothing as a spec — the single-chip fallback.
 	expect(specPathMatcher([])(".thinkrail/context/TASK-x.md")).toBe(false);
+});
+
+/** A catalog entry for the tier tests — only the fields the split reads. */
+function entry(
+	id: string,
+	flags: { enabled?: boolean; collapsed?: boolean } = {},
+): ModelCatalogEntry {
+	const model: WireModel = {
+		id,
+		name: id,
+		provider: "acme",
+		contextWindow: 200_000,
+		reasoning: false,
+		thinkingLevels: ["off"],
+	};
+	return { model, enabled: flags.enabled ?? true, collapsed: flags.collapsed ?? false };
+}
+
+test("selectPickerTiers keeps the host's order and sends out-of-list + collapsed models to the extra tier", () => {
+	const modelCatalog = [
+		entry("keep-2"),
+		entry("pinned-2-20251101", { collapsed: true }),
+		entry("disabled-1", { enabled: false }),
+		entry("keep-1"),
+	];
+
+	const { primary, extra } = selectPickerTiers({ modelCatalog });
+
+	// Primary = what the picker shows by default, in catalog order (the host already ordered it).
+	expect(primary.map((m) => m.id)).toEqual(["keep-2", "keep-1"]);
+	// Extra = the "Show all" tier: both reasons for hiding a row land here, and nothing is dropped.
+	expect(extra.map((m) => m.id)).toEqual(["pinned-2-20251101", "disabled-1"]);
+	expect(primary.length + extra.length).toBe(modelCatalog.length);
+});
+
+test("selectPickerTiers/selectAllModels return stable references per catalog (a store selector must not churn)", () => {
+	// Returned fresh each call, these would re-render every picker on ANY unrelated store write (a
+	// streaming chat writes constantly). Same catalog in → same object out; a new catalog invalidates it.
+	const modelCatalog = [entry("a"), entry("b", { enabled: false })];
+
+	expect(selectPickerTiers({ modelCatalog })).toBe(selectPickerTiers({ modelCatalog }));
+	expect(selectAllModels({ modelCatalog })).toBe(selectAllModels({ modelCatalog }));
+	expect(selectAllModels({ modelCatalog }).map((m) => m.id)).toEqual(["a", "b"]);
+	expect(selectPickerTiers({ modelCatalog: [...modelCatalog] })).not.toBe(
+		selectPickerTiers({ modelCatalog }),
+	);
 });

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,4 +1,10 @@
-import type { Project, SpecGraphNode, Workspace } from "@thinkrail/contracts";
+import type {
+	ModelCatalogEntry,
+	Project,
+	SpecGraphNode,
+	WireModel,
+	Workspace,
+} from "@thinkrail/contracts";
 import { isAbsolutePath, normalizePath } from "../lib";
 import type { EditorTab } from "./appStore";
 
@@ -151,4 +157,51 @@ export function selectSkillsStale(
 		(state.skillChangeTickByWorkspace[workspaceId] ?? 0) >
 		(state.skillsSyncedTickBySession[sessionId] ?? 0)
 	);
+}
+
+interface ModelCatalogState {
+	modelCatalog: ModelCatalogEntry[];
+}
+
+/** The model picker's two tiers, in the host's order. */
+export interface PickerTiers {
+	/** The everyday rows: enabled by the user's allowlist, dated duplicates folded away. */
+	primary: WireModel[];
+	/** Everything else — revealed by the picker's "Show all" row (and always searchable). */
+	extra: WireModel[];
+}
+
+// Derived-per-catalog caches. A zustand selector must return a **stable reference** or its subscriber
+// re-renders on every unrelated store write (a streaming chat writes constantly) — and these two build new
+// arrays. Keying the result on the catalog array's identity (it is replaced wholesale by `setModelCatalog`)
+// keeps the derivation here, in the selector, instead of pushing a `useMemo` onto every call site.
+const tiersCache = new WeakMap<ModelCatalogEntry[], PickerTiers>();
+const allModelsCache = new WeakMap<ModelCatalogEntry[], WireModel[]>();
+
+/**
+ * Split the host's catalog into the picker's tiers. Both facts are the **host's** (`enabled` mirrors pi's
+ * `enabledModels`, `collapsed` folds a dated snapshot under its alias) — this is the one place they're read,
+ * so the chat header, the New-Workspace dialog and any future picker cannot disagree about what "the
+ * everyday list" means.
+ */
+export function selectPickerTiers(state: ModelCatalogState): PickerTiers {
+	const cached = tiersCache.get(state.modelCatalog);
+	if (cached) return cached;
+	const primary: WireModel[] = [];
+	const extra: WireModel[] = [];
+	for (const entry of state.modelCatalog) {
+		(entry.enabled && !entry.collapsed ? primary : extra).push(entry.model);
+	}
+	const tiers = { primary, extra };
+	tiersCache.set(state.modelCatalog, tiers);
+	return tiers;
+}
+
+/** Every model the host reports, flat and in its order — for ref lookups (e.g. "is this model still there?"). */
+export function selectAllModels(state: ModelCatalogState): WireModel[] {
+	const cached = allModelsCache.get(state.modelCatalog);
+	if (cached) return cached;
+	const models = state.modelCatalog.map((entry) => entry.model);
+	allModelsCache.set(state.modelCatalog, models);
+	return models;
 }

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -2,6 +2,7 @@ import type {
 	AppConfig,
 	ExtUiRequest,
 	LoginPush,
+	ModelCatalogEntry,
 	ServerWelcome,
 	SessionEventPayload,
 	Workspace,
@@ -73,6 +74,12 @@ export function initTransport(): WsTransport {
 	// one that made the change (no optimistic apply).
 	transport.subscribe(WS_CHANNELS.settingsChanged, (data) => {
 		useAppStore.getState().applyConfig(data as AppConfig);
+	});
+
+	// The model catalog after an allowlist write (Settings → Models) — same converge-on-broadcast contract:
+	// the toggling client repaints from this frame, not from a local guess about what it just saved.
+	transport.subscribe(WS_CHANNELS.modelCatalogChanged, (data) => {
+		useAppStore.getState().setModelCatalog(data as ModelCatalogEntry[]);
 	});
 
 	transport.connect();

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -40,6 +40,19 @@ function resetState(): void {
 	else rmSync(modelsPath, { force: true });
 	rmSync(`${modelsPath}.bak`, { force: true });
 
+	// Drop any `enabledModels` allowlist a Settings → Models test wrote (`models.spec.ts`). It lives in the
+	// same pi settings.json that pins the suite's deterministic default model, and the host resolves that
+	// default *through* the allowlist — so a leftover list from a failed test would silently change which
+	// model a later @agent spec runs. Everything else in the file (the pinned default) is preserved.
+	const settingsPath = join(E2E_PI_AGENT_DIR, "settings.json");
+	if (existsSync(settingsPath)) {
+		const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as Record<string, unknown>;
+		if ("enabledModels" in settings) {
+			delete settings.enabledModels;
+			writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+		}
+	}
+
 	// Self-heal the shared fixture repo before pruning it. An @agent spec drives a real agent with `bash` in
 	// a worktree of this repo, so a stray destructive command can remove it out from under every later test
 	// (a single flaky run would otherwise cascade into the whole suite). Re-seed it when it's gone/damaged so

--- a/e2e/models.spec.ts
+++ b/e2e/models.spec.ts
@@ -1,0 +1,150 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { openFixtureProject } from "./fixtures/app";
+
+/**
+ * The model picker's two tiers + the Settings → Models manager (pi's `enabledModels` allowlist).
+ *
+ * No-agent suite: the picker only has rows when the host has an authenticated provider, which this suite
+ * deliberately does not require (CI runs without auth). So each case asserts what holds either way and
+ * skips the model-dependent half when nothing resolved — the same guard `new-workspace.spec.ts` uses for
+ * the effort pill. The ordering/collapse/allowlist rules themselves are pinned host-side in
+ * `packages/server/src/agent/modelCatalog.test.ts`, not through the browser.
+ *
+ * Nothing here may call a state-resetting fixture mid-test: `resetState` strips `enabledModels` (see
+ * fixtures/app.ts), which is exactly the setting these cases write.
+ */
+
+/** Did this locator show up within the budget? (A missing one is an answer here, not a failure.) */
+const appears = (locator: Locator, timeout = 8_000): Promise<boolean> =>
+	locator
+		.first()
+		.waitFor({ state: "visible", timeout })
+		.then(
+			() => true,
+			() => false,
+		);
+
+const primaryRows = (page: Page): Locator =>
+	page.locator('[data-testid="model-option"][data-tier="primary"]');
+const extraRows = (page: Page): Locator =>
+	page.locator('[data-testid="model-option"][data-tier="extra"]');
+
+/**
+ * Open the New-Workspace dialog's model picker in an already-open project (no state reset).
+ * Returns false when no provider is authenticated — the caller then skips.
+ */
+async function openPicker(page: Page): Promise<boolean> {
+	await page.getByTestId("add-workspace").first().click();
+	const dialog = page.getByTestId("new-workspace-dialog");
+	await expect(dialog).toBeVisible();
+
+	// The dialog resolves its default model over the wire, so "Select model" only means "no provider
+	// authenticated" once that read has had a chance to land.
+	const trigger = dialog.getByTestId("model-selector");
+	await expect(trigger).toBeVisible();
+	if (!(await appears(dialog.getByTestId("model-selector").filter({ hasNotText: "Select model" }))))
+		return false;
+	await trigger.click();
+	await expect(trigger).toHaveAttribute("data-open", "true");
+	return true;
+}
+
+/** Re-open the picker inside an already-open dialog (its query + "Show all" reset on close). */
+async function reopenPicker(page: Page): Promise<void> {
+	const trigger = page.getByTestId("new-workspace-dialog").getByTestId("model-selector");
+	await trigger.click();
+	await expect(trigger).toHaveAttribute("data-open", "true");
+}
+
+/** Close the picker popover, then the dialog. */
+async function closePicker(page: Page): Promise<void> {
+	await page.keyboard.press("Escape");
+	await page.keyboard.press("Escape");
+	await expect(page.getByTestId("new-workspace-dialog")).toBeHidden();
+}
+
+test("the picker shows an everyday tier, reveals the rest behind Show all, and searches both", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	if (!(await openPicker(page))) test.skip(true, "no authenticated provider — nothing to pick");
+
+	// The default tier is the everyday list: primary rows only, nothing from the extra tier.
+	const primaryCount = await primaryRows(page).count();
+	expect(primaryCount).toBeGreaterThan(0);
+	await expect(extraRows(page)).toHaveCount(0);
+
+	// A real pi catalog always has a second tier (the dated snapshots at least); if this host's doesn't,
+	// the row is correctly absent and there is nothing to reveal.
+	const showAll = page.getByTestId("model-show-all");
+	if (!(await showAll.isVisible())) {
+		await closePicker(page);
+		test.skip(true, "this host's catalog has no hidden models");
+	}
+	await showAll.click();
+	await expect(showAll).toBeHidden();
+	const hidden = await extraRows(page).count();
+	expect(hidden).toBeGreaterThan(0);
+	const hiddenId = await extraRows(page).first().getAttribute("data-model-id");
+
+	// Typing reaches the extra tier without expanding first — a hidden model is never unreachable.
+	await page.keyboard.press("Escape"); // close the popover, keep the dialog open
+	await reopenPicker(page);
+	await expect(extraRows(page)).toHaveCount(0); // reopening resets to the everyday tier
+	await page.getByPlaceholder("Search models…").fill(hiddenId ?? "");
+	await expect(
+		page.locator(`[data-testid="model-option"][data-model-id="${hiddenId}"]`),
+	).toBeVisible();
+	await expect(showAll).toBeHidden(); // a query expands the list, so the row has nothing left to do
+	await closePicker(page);
+});
+
+test("Settings → Models curates what the picker offers day to day", async ({ page }) => {
+	await openFixtureProject(page);
+
+	const openModelsSettings = async (): Promise<Locator> => {
+		await page.getByTestId("open-settings").click();
+		await expect(page.getByTestId("settings-dialog")).toBeVisible();
+		await page.getByTestId("settings-nav-models").click();
+		const panel = page.getByTestId("settings-models");
+		await expect(panel).toBeVisible();
+		return panel;
+	};
+
+	let panel = await openModelsSettings();
+	// Same asynchrony as the picker: the panel fetches `model.list` on mount.
+	const rows = panel.getByTestId("model-setting-row");
+	if (!(await appears(rows))) {
+		await expect(panel).toContainText("sign in to a provider first");
+		test.skip(true, "no authenticated provider — nothing to curate");
+	}
+
+	// Every model starts available (no allowlist), and the manager says exactly that.
+	await expect(panel.getByTestId("models-enabled-count")).toContainText("All ");
+	await expect(panel.getByTestId("models-enable-all")).toBeHidden();
+
+	// Turning one off is persisted host-side and broadcast back — the row and the header both repaint from
+	// the host's frame, never optimistically.
+	const total = await rows.count();
+	const victim = rows.first();
+	const victimId = await victim.getAttribute("data-model-id");
+	await victim.getByTestId("model-toggle").click();
+	await expect(victim).toHaveAttribute("data-enabled", "false");
+	await expect(panel.getByTestId("models-enabled-count")).toContainText(`${total - 1} of ${total}`);
+
+	// …and the picker follows: the disabled model leaves the everyday tier. It stays reachable under
+	// "Show all", which is what makes this a curation rather than a deletion.
+	await page.keyboard.press("Escape");
+	await expect(page.getByTestId("settings-dialog")).toBeHidden();
+	expect(await openPicker(page)).toBe(true);
+	await expect(primaryRows(page).filter({ hasText: victimId ?? "" })).toHaveCount(0);
+	await page.getByTestId("model-show-all").click();
+	await expect(extraRows(page).filter({ hasText: victimId ?? "" })).toHaveCount(1);
+	await closePicker(page);
+
+	// Enable all clears the allowlist entirely (pi stores "no filter" as an absent setting).
+	panel = await openModelsSettings();
+	await panel.getByTestId("models-enable-all").click();
+	await expect(panel.getByTestId("models-enabled-count")).toContainText("All ");
+	await expect(panel.getByTestId("models-enable-all")).toBeHidden();
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -11,8 +11,9 @@ tags: [v1, wire]
 ## Responsibility
 
 The browser↔host wire spine: the single source of truth for the protocol. Types-only, with the only
-runtime exports being the WS method/channel constants, the protocol version, and the small config default
-(`DEFAULT_CONFIG`). The one package `apps/web` may depend on—which is what lets the UI ship independently
+runtime exports being the WS method/channel constants, the protocol version, the small config default
+(`DEFAULT_CONFIG`), and **`modelRef`** — the one-line `"provider/id"` formatter *both* ends must produce
+identically (the host writes those refs into pi's settings; the client sends the list it wants enabled). The one package `apps/web` may depend on—which is what lets the UI ship independently
 of the host.
 
 ## Boundary
@@ -20,7 +21,7 @@ of the host.
 - **Owns:** the wire — entity types, the `pi` event/message types (re-exported), the WS method & channel
   registries, and the protocol version.
 - **Public surface (`index.ts`):** `export type *` of `piProtocol` + `domain`; the value re-exports
-  `DEFAULT_CONFIG` from `domain`; `export *` (value) of `wsProtocol`
+  `DEFAULT_CONFIG` from `domain` + `modelRef` from `piProtocol`; `export *` (value) of `wsProtocol`
   (`WS_METHODS`, `WS_CHANNELS`, the typed maps, `PROTOCOL_VERSION`).
 - **Allowed deps:** none at runtime. **Type-only** devDeps on `@earendil-works/pi-ai` +
   `@earendil-works/pi-agent-core`, imported **from their package roots** (type-only → erased at build).
@@ -43,6 +44,13 @@ of the host.
     is wired and `headers` can carry auth, and an allowlist **fails closed** — a future `Model` field (secret
     or not) is excluded by default. The host re-resolves the real `Model` from `{provider,id}` — so a client
     can neither read the secret nor inject a `baseUrl` for the agent to call (see the `agent` module SPEC);
+  - **`ModelCatalogEntry`** = `{ model: WireModel; enabled: boolean; collapsed: boolean }` — one row of
+    `model.list`, i.e. pi's model **plus the host's two presentation facts**: `enabled` (in the user's pi
+    `enabledModels` allowlist — all `true` when the setting is unset) and `collapsed` (a dated snapshot
+    hidden under its alias; always `false` once an allowlist is set, since an explicit list *is* the
+    curation). The flags stay **off `WireModel`** on purpose: that type also rides `session.create` /
+    `session.setModel` / `SessionSummary`, where allowlist membership is meaningless — catalog identity and
+    user preference are separate facts;
   - `@earendil-works/pi-agent-core`: `AgentEvent`, `AgentMessage`, `ThinkingLevel` (the
     `off`-inclusive one);
   - the local render union **`PiEvent`** — the real superset `AgentSessionEvent` lives in the Node-only
@@ -144,7 +152,11 @@ of the host.
   never eagerly for every project) / `workspace.*` / `fs.*` / `git.*` / **`spec.graph`**
   (the Specs-viewer whole-graph read, per workspace) / **`todo.*`** — **`list`**/**`add`**/**`update`**/
   **`remove`**, the chat's per-session TODO plan (keyed by `workspaceId` + `sessionId`; `add` tags the
-  item `origin:"user"`) / `terminal.*` / `model.list` / **`model.clampThinking`** (pi's `clampThinkingLevel` for a
+  item `origin:"user"`) / `terminal.*` / **`model.list`** (the ordered **`ModelCatalogEntry[]`** catalog — every
+  available model, newest-first per provider, each tagged `enabled`/`collapsed`, so the picker's default
+  tier and its "Show all" tier come from one read) / **`model.setEnabled`** (`{ enabled: string[] | null }` —
+  `"provider/id"` refs written into pi's own `settings.json` `enabledModels`; `null` clears the allowlist) /
+  **`model.clampThinking`** (pi's `clampThinkingLevel` for a
   `{model, level}` pair — the pre-session picker's effort adjustment, so no client re-derives pi's
   policy) / **`provider.status`**
 (the auth-provider status report; every read revalidates host-side) / the **`provider.*` in-app login**
@@ -178,7 +190,9 @@ of the host.
   read/write pi's prompt dirs (global + project), so templates stay CLI-portable,
   `WS_CHANNELS` (`server.welcome` — which carries the initial `config: AppConfig` alongside `projects` /
   `pi.event` / `pi.extensionUi` / **`settings.changed`** (the full `AppConfig`, broadcast so every client
-  converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`
+  converges) / **`model.catalogChanged`** (the full `ModelCatalogEntry[]` after a `model.setEnabled`,
+  broadcast for the same reason — the initiating client converges on the push, never on optimism) /
+  **`provider.login`** — the session-less in-app login stream (a `LoginPush`
   per frame, keyed by `loginId`; the sibling of `pi.extensionUi`, since a login runs on the Welcome screen
   before any session exists) / `terminal.data` / the **workspace lifecycle trio** — **`workspace.created`**
   / **`workspace.updated`** / **`workspace.removed`** — registry membership changes fanned out to every

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,8 @@
 // The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol), the
 // app-config default (`DEFAULT_CONFIG`), the history-search caps (`MAX_HISTORY_LIMIT`,
-// `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX`) — small
-// plain constants both sides must agree on. Theme catalogs stay browser-side; the wire carries an opaque id.
+// `MAX_HISTORY_QUERY_LENGTH`), the internal control-message marker (`TODO_NUDGE_PREFIX`) — small
+// plain constants both sides must agree on — and `modelRef`, the one-line `"provider/id"` formatter both
+// ends must produce identically. Theme catalogs stay browser-side; the wire carries an opaque id.
 
 export type * from "./domain";
 export {
@@ -11,4 +12,5 @@ export {
 	TODO_NUDGE_PREFIX,
 } from "./domain";
 export type * from "./piProtocol";
+export { modelRef } from "./piProtocol";
 export * from "./wsProtocol";

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -46,6 +46,39 @@ export type WireModel = Pick<
 	thinkingLevels: ThinkingLevel[];
 };
 
+/**
+ * One row of the model picker's catalog (`model.list`): pi's model **plus the host's two presentation
+ * facts**. The flags deliberately do NOT live on `WireModel` — that type also rides `session.create` /
+ * `session.setModel` / `SessionSummary`, where allowlist membership is meaningless. Catalog identity and
+ * user preference are separate facts.
+ *
+ * pi's `Model` carries no release date and no deprecation flag, and `getAvailable()` filters only by
+ * provider — so both facts below are computed host-side (see the `agent` module SPEC): the order of the
+ * array is the host's (newest-first per provider), `enabled` mirrors pi's own `settings.json`
+ * `enabledModels` allowlist, and `collapsed` folds a dated snapshot under its alias.
+ */
+export interface ModelCatalogEntry {
+	model: WireModel;
+	/** In the user's pi `enabledModels` allowlist — all `true` when that setting is unset. */
+	enabled: boolean;
+	/**
+	 * A dated snapshot (`claude-opus-4-5-20251101`) whose alias (`claude-opus-4-5`) is also listed, so the
+	 * picker hides it from its default tier. Always `false` once an allowlist is set — an explicit list is
+	 * the curation, and the host never second-guesses it.
+	 */
+	collapsed: boolean;
+}
+
+/**
+ * A model's canonical `"provider/id"` reference — the format **pi itself** stores in `enabledModels` and
+ * accepts in `--models`. It lives on the wire (not on either end) because both ends produce it: the host
+ * writes these refs into pi's settings, the client sends the list it wants enabled, and a second
+ * hand-rolled `${provider}/${id}` anywhere would be a silent way for the two to drift.
+ */
+export function modelRef(model: Pick<WireModel, "provider" | "id">): string {
+	return `${model.provider}/${model.id}`;
+}
+
 // The unified render union the UI switches on. The real superset (`AgentSessionEvent`) is declared in the
 // Node-only `pi-coding-agent` (it pulls node:fs), so it's MIRRORED here type-only, derived from the
 // imported `AgentEvent`. The members below are what `session.subscribe` emits. The mirror is NOT

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -28,6 +28,7 @@ import type {
 	AskUserQuestionResult,
 	ExtUiResponse,
 	ImageContent,
+	ModelCatalogEntry,
 	SessionStats,
 	SessionSummary,
 	SkillCatalogEntry,
@@ -82,7 +83,11 @@ import type {
 // v18: the built-in Default workspace — `Workspace.kind: "default"` marks the project folder itself as
 // a per-project, non-removable, non-renamable workspace, ensured lazily and pinned first in
 // `workspace.list`; `workspace.remove` rejects it.
-export const PROTOCOL_VERSION = 18;
+// v19: the model catalog — `model.list` now returns `ModelCatalogEntry[]` (pi's models in the host's
+// order, newest-first per provider, each tagged `enabled`/`collapsed`) instead of a bare `WireModel[]`,
+// `model.setEnabled` writes pi's own `settings.json` `enabledModels` allowlist, and
+// `model.catalogChanged` broadcasts the fresh catalog so every client converges.
+export const PROTOCOL_VERSION = 19;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -189,6 +194,9 @@ export const WS_METHODS = {
 	sessionList: "session.list",
 	sessionGetMessages: "session.getMessages",
 	modelList: "model.list",
+	// Write pi's `enabledModels` allowlist (the Settings → Models manager). Broadcasts
+	// `model.catalogChanged`; the caller converges on that push, not on optimism.
+	modelSetEnabled: "model.setEnabled",
 	modelDefault: "model.default",
 	// pi's own clamp for a `{model, desired-level}` pair. The pre-session picker has no session to ask,
 	// and re-deriving pi's clamp client-side would give that one path a policy of its own.
@@ -245,6 +253,9 @@ export const WS_CHANNELS = {
 	// The server-synced app settings changed (carries the full `AppConfig`), broadcast to every client so
 	// they converge — the initiator applies on this push too, never optimistically.
 	settingsChanged: "settings.changed",
+	// The model catalog changed (carries the full `ModelCatalogEntry[]`), broadcast to every client after a
+	// `model.setEnabled` — same converge-on-broadcast contract as `settings.changed`.
+	modelCatalogChanged: "model.catalogChanged",
 } as const;
 
 export type WsMethod = (typeof WS_METHODS)[keyof typeof WS_METHODS];
@@ -429,7 +440,13 @@ export interface WsMethodMap {
 		params: { sessionId: string; workspaceId: string };
 		result: { summary: SessionSummary; messages: TranscriptMessage[] };
 	};
-	"model.list": { params: Record<string, never>; result: WireModel[] };
+	// The model picker's catalog: every available model in the host's order (newest-first per provider),
+	// each tagged `enabled` (in pi's `enabledModels` allowlist) / `collapsed` (a dated snapshot hidden
+	// under its alias). One read serves both picker tiers AND the Settings → Models manager.
+	"model.list": { params: Record<string, never>; result: ModelCatalogEntry[] };
+	// Replace pi's `enabledModels` allowlist with these `"provider/id"` refs (`null` = clear it, i.e. every
+	// model available). Writes pi's own global settings, so the pi CLI/TUI honors the same list.
+	"model.setEnabled": { params: { enabled: string[] | null }; result: Ack };
 	// pi's `clampThinkingLevel` for a model the client is about to select, by `{provider,id}` ref. The
 	// host owns this so every path agrees: `model.default` clamps the same way, and a live session gets
 	// it from pi directly via `thinking_level_changed`. Throws if the ref isn't an available model.
@@ -437,8 +454,9 @@ export interface WsMethodMap {
 		params: { provider: string; id: string; level: ThinkingLevel };
 		result: { level: ThinkingLevel };
 	};
-	// The model/thinking a fresh session resolves to (settings default, else first available) — so the
-	// New-Workspace dialog shows the exact pre-session model, not a placeholder.
+	// The model/thinking a fresh session resolves to (settings default when available AND enabled, else
+	// the first enabled model, else the first available) — so the New-Workspace dialog shows the exact
+	// pre-session model, not a placeholder.
 	"model.default": {
 		params: Record<string, never>;
 		result: { model: WireModel | null; thinkingLevel: ThinkingLevel };

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -33,7 +33,7 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     checks with no timeout — on the `provider.status` and jbcentral-connect paths that stalls wherever
     egress is slow or blocked. The one deliberate opt-in to
     live catalogs is **`refreshCatalogsDetached(runtime)`** (issue #98, mirroring pi's own `/model`):
-    **triggered by `model.list` only** (`listAvailableModels` fires it, then serves the current snapshot
+    **triggered by `model.list` only** (`listModelCatalog` fires it, then serves the current snapshot
     — the picker read never awaits the network; a later read picks up what landed; broader triggers —
     `model.default`, host boot — were considered and declined). Fire-and-forget semantics: per-call
     `refresh({ allowNetwork: true })` — **no `force`**, so pi's provider freshness throttle decides
@@ -53,11 +53,12 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     the web UI downsizes user-attached images itself); a shared `registerSession` forwards each event tagged with its id +
     `bindExtensions({ mode:'rpc', uiContext })`; `prompt`/`steer`/`followUp` (with images) / `abort` /
     `setModel` / `setThinkingLevel` / `compact` / `getSessionStats` (+ contextUsage) / `getSessionCommands` /
-    `listAvailableModels` / **`clampThinkingForModel`** (pi's `clampThinkingLevel` for a `{model, level}`
+    **`clampThinkingForModel`** (pi's `clampThinkingLevel` for a `{model, level}`
     pair — `model.clampThinking`; the host owns it so the pre-session picker, `getDefaultModel`, and a live
-    session all adjust effort identically) / `getDefaultModel` (the model + thinking a fresh session resolves to — settings
-    default if available, else first available — so the New-Workspace dialog shows the exact pre-session
-    model). **Models cross the wire as `WireModel` (never pi's raw `Model`):** `toWireModel` projects a
+    session all adjust effort identically) / `getDefaultModel` (the model + thinking a fresh session resolves
+    to — the settings default when it is available **and enabled**, else the first **enabled** model, else the
+    first available (all three read the `modelCatalog` order) — so the New-Workspace dialog shows the exact
+    pre-session model, and a model the user disabled is never preselected). **Models cross the wire as `WireModel` (never pi's raw `Model`):** `toWireModel` projects a
     `Model` onto the wire's **allowlist** (see `WireModel`) — so `baseUrl` (the
     jbcentral proxy secret when JetBrains AI is wired), `headers`, and any other field are excluded by
     default — and the inbound side (`createSession`/`setModel`) **re-resolves** the ref by `{provider,id}`
@@ -88,6 +89,31 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     whose recorded `cwd` matches, never `rm -rf` the encoded dir since pi's cwd→dir encoding can alias
     distinct cwds; `cwd` omitted on a double-archive skips only the disk purge);
     `setSessionPublisher` + `setSessionManagerFactory` seams.
+  - `modelCatalog` — **everything model-shaped**, so session lifecycle holds no model policy:
+    `toWireModel` (the wire projection / secret choke point), `resolveWireModel` (inbound ref
+    re-resolution), `clampThinkingForModel` (pi's clamp for a `{model, level}` pair — `model.clampThinking`;
+    the host owns it so the pre-session picker, `getDefaultModel` and a live session adjust effort
+    identically), `getDefaultModel` (see below), plus the **picker's projection**: `listModelCatalog()`
+    (the `model.list` read) and `setEnabledModels(refs)` (the Settings → Models write, fanned out through
+    the **`setModelCatalogPublisher`** seam → `model.catalogChanged`). `agentSessionManager` imports from
+    here; the edge is **one-way** (this module never reaches back into session lifecycle). It holds no
+    presentation policy of its own beyond ordering: **order** = provider asc, then within a
+    provider `(version vector desc, dated-suffix below its alias, id asc)` — pi's `Model` carries no
+    release date or deprecation flag (verified against 0.82.1), so recency can only come from the id's
+    version digits; **enabled** = pi's own `settings.json` `enabledModels` allowlist, read merged
+    (global+project) via `SettingsManager.getEnabledModels()` at `process.cwd()` and resolved through pi's
+    **`resolveModelScopeWithDiagnostics`** (globs, dedupe, alias-over-dated), so the app and the pi
+    CLI/TUI share one setting; **collapsed** = a dated snapshot whose alias is also listed
+    (`claude-opus-4-5-20251101` under `claude-opus-4-5`), computed **only when no allowlist is set**.
+    Writes go to pi's **global** settings and persist `undefined` for "everything enabled" (`null`, `[]`,
+    and the full set all mean no filter — pi's semantics, matching its own `/models` manager).
+    Sessions are deliberately **not** scoped: we never pass `scopedModels` to `createAgentSession`, so pi's
+    per-session Ctrl+P cycling and its `scoped[0]`-beats-saved-default rule stay out of the host.
+    **Tradeoff, taken knowingly (pi-parity):** a write persists the client's list verbatim, so a provider
+    that is signed out (its models absent from `getAvailable()`) drops out of the stored list, and a
+    newly-authenticated provider's models start disabled while a list is set. Merge semantics (preserving
+    refs the client couldn't see) were considered and rejected: a preserved glob would silently
+    re-enable the very model the user had just switched off.
   - `oneshot` — one-shot LLM completions **without** an `AgentSession` (no tools/extensions/disk):
     `completeOnce(request)` picks a model from the shared runtime's authenticated set and dispatches a
     single `runtime.completeSimple()` — pi's canonical provider-agnostic request path, which resolves
@@ -218,10 +244,15 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   `reloadSessionResources(sessionId)` (active-chat reload); the **`setSkillAdmissionResolver`** seam (host
   wires `workspaceId` → the admission context);
   the compiled-binary seam (`registerBundledRuntime` +
-  `BundledExtensions`/`BundledExtensionFactory`).
+  `BundledExtensions`/`BundledExtensionFactory`); the `modelCatalog` surface — `listModelCatalog` /
+  `setEnabledModels` / `setModelCatalogPublisher` / `getDefaultModel` / `clampThinkingForModel` /
+  `toWireModel` / `resolveWireModel` (+ the pure `orderModels` / `collapsedRefs` / `parseModelSortKey`,
+  exported for the unit suite that pins the ordering rule).
 - **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (types + test
   fixtures + **pure catalog helpers value-imported from the package root** — today exactly
-  `getSupportedThinkingLevels` + `clampThinkingLevel`, data-only projections over `Model`; *dispatch*
+  `getSupportedThinkingLevels` + `clampThinkingLevel`, data-only projections over `Model`, plus
+  pi-coding-agent's **`resolveModelScopeWithDiagnostics`** — pi's own `enabledModels`/`--models` resolver,
+  so a stored pattern means the same thing here as in the pi CLI; *dispatch*
   still goes through the shared `ModelRuntime`, never pi-ai's stream/complete — plus the `/bun-oauth` + `/bedrock-provider`
   + `/compat` subpaths, value-imported **only** inside `registerBundledRuntime`'s dynamic imports); `pi-web-access` + `pi-visualize` + `pi-spec-graph` +
   `pi-thinkrail-workflow` + `pi-todos` (the bundled extensions — loaded by path, never value-imported here; the
@@ -244,6 +275,11 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   loud.
 - Share one `ModelRuntime` (each session gets it as `createAgentSession`'s `modelRuntime`); give each
   session its own `SessionManager`; `dispose()` on removal.
+- **The catalog projection fails open.** A stale/unmatched `enabledModels` pattern is a `console.warn`
+  (pi returns them as `diagnostics`, not throws) and never empties the picker; ordering and collapsing are
+  pure functions over the available list, so they cannot fail on a catalog shape we haven't seen. The
+  picker's escape hatch ("Show all") is a *client tier*, not a second host read: one `model.list` carries
+  every available model with its `enabled`/`collapsed` flags.
 - **A `pi` `Model` must never cross the wire raw** — its `baseUrl` carries the jbcentral proxy secret (and
   `headers` can carry auth). Every model-bearing frame (`model.list`/`model.default`, the `session.create`
   result, `SessionSummary.model`) goes through `toWireModel`; every inbound model ref (`session.create` /

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -1,34 +1,27 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-	InMemoryCredentialStore,
-	type Model,
-	type ModelsRefreshResult,
-} from "@earendil-works/pi-ai";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
 import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type { ExtUiRequest } from "@thinkrail/contracts";
 import {
 	buildSessionSettings,
-	clampThinkingForModel,
 	createSession,
 	disposeAllSessions,
-	getDefaultModel,
 	getSessionCommands,
 	getSessionMessages,
 	getSessionStats,
 	hasSession,
-	listAvailableModels,
 	listSessions,
 	promptSession,
 	removeSession,
 	removeWorkspaceSessions,
 	setSessionManagerFactory,
 	setSessionPublisher,
-	toWireModel,
 } from "./agentSessionManager";
+import { listModelCatalog } from "./modelCatalog";
 import { configurePiRuntime } from "./piRuntime";
 import {
 	cancelExtUiForSession,
@@ -63,13 +56,6 @@ const fauxB = createFauxCore({
 	models: [modelDef("fauxb")],
 	tokensPerSecond: 2000,
 });
-// Registered only DURING the catalog-refresh test below — the "newly shipped" model a refresh delivers.
-const fauxC = createFauxCore({
-	provider: "fauxc",
-	api: "fauxc",
-	models: [modelDef("fauxc")],
-	tokensPerSecond: 2000,
-});
 
 /** Provider config for `registerProvider` (baseUrl + apiKey are required when models are defined). */
 const cfg = (faux: typeof fauxA, id: string) => ({
@@ -99,8 +85,8 @@ beforeAll(async () => {
 	priorAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = tmpCwd("trpi-agentdir-");
 
-	// `listAvailableModels` fires a detached network catalog refresh (issue #98) — keep this suite
-	// hermetic the same way e2e is, via pi's own PI_OFFLINE convention. The refresh tests lift it locally.
+	// `listModelCatalog` fires a detached network catalog refresh (issue #98) — keep this suite hermetic
+	// the same way e2e is, via pi's own PI_OFFLINE convention (the refresh cases live in modelCatalog.test.ts).
 	priorOffline = process.env.PI_OFFLINE;
 	process.env.PI_OFFLINE = "1";
 
@@ -173,173 +159,9 @@ test("buildSessionSettings disables image autoResize (in-memory, so the read too
 	expect(buildSessionSettings(tmpCwd("trpi-settings-")).getImageAutoResize()).toBe(false);
 });
 
-test("listAvailableModels returns the configured (faux) models", async () => {
-	const ids = (await listAvailableModels()).map((m) => m.id);
-	expect(ids).toContain("fauxa");
-	expect(ids).toContain("fauxb");
-});
-
-/** Let a detached refresh task's `.then/.finally` chain settle (macrotask — nothing sleeps). */
-const refreshSettled = () => new Promise<void>((r) => setTimeout(r, 0));
-
-test("model.list is never blocked by a hanging catalog refresh (fire-and-forget, issue #98)", async () => {
-	delete process.env.PI_OFFLINE;
-	const originalRefresh = runtime.refresh.bind(runtime);
-	let releaseHang = () => {};
-	try {
-		runtime.refresh = () =>
-			new Promise<ModelsRefreshResult>((resolve) => {
-				releaseHang = () => resolve({ aborted: false, errors: new Map() });
-			});
-		// Resolves immediately from the snapshot while the "network" refresh hangs unresolved.
-		const ids = (await listAvailableModels()).map((m) => m.id);
-		expect(ids).toContain("fauxa");
-	} finally {
-		releaseHang(); // frees the single-flight slot so this test leaves no pending state behind
-		await refreshSettled();
-		runtime.refresh = originalRefresh;
-		process.env.PI_OFFLINE = "1";
-	}
-});
-
-test("a newly-shipped catalog model appears on a later model.list without a restart (issue #98)", async () => {
-	delete process.env.PI_OFFLINE;
-	const originalRefresh = runtime.refresh.bind(runtime);
-	let landRefresh = () => {};
-	let refreshCalls = 0;
-	try {
-		// The first "network" refresh delivers a new provider+model when it lands — deferred, so the first
-		// read provably serves the pre-refresh snapshot. Any later trigger settles instantly and delivers
-		// nothing, mirroring pi's freshness throttle.
-		runtime.refresh = () => {
-			refreshCalls += 1;
-			if (refreshCalls > 1) return Promise.resolve({ aborted: false, errors: new Map() });
-			return new Promise<ModelsRefreshResult>((resolve) => {
-				landRefresh = () => {
-					runtime.registerProvider("fauxc", cfg(fauxC, "fauxc"));
-					resolve({ aborted: false, errors: new Map() });
-				};
-			});
-		};
-
-		const before = (await listAvailableModels()).map((m) => m.id); // triggers the detached refresh
-		expect(before).not.toContain("fauxc");
-
-		landRefresh();
-		await refreshSettled();
-
-		const after = (await listAvailableModels()).map((m) => m.id);
-		expect(after).toContain("fauxc");
-	} finally {
-		await refreshSettled(); // let the second trigger's instant refresh settle before restoring
-		runtime.unregisterProvider("fauxc");
-		runtime.refresh = originalRefresh;
-		process.env.PI_OFFLINE = "1";
-	}
-});
-
-test("wire models expose only the allowlisted fields (no baseUrl/headers/other Model fields)", async () => {
-	// The faux providers register with baseUrl "http://faux.local"; when JetBrains AI is wired the real
-	// baseUrl is `.../wire/<SECRET>/...`. `toWireModel` is an allowlist projection, so a wire model carries
-	// EXACTLY these keys — this pins the DTO shut (widening it, incl. re-adding a secret field, fails here).
-	const models = await listAvailableModels();
-	expect(models.length).toBeGreaterThan(0);
-	for (const m of models) {
-		expect(Object.keys(m).sort()).toEqual([
-			"contextWindow",
-			"id",
-			"name",
-			"provider",
-			"reasoning",
-			"thinkingLevels",
-		]);
-		// Faux models declare `reasoning: false` — pi's support truth for those is exactly ["off"].
-		expect(m.thinkingLevels).toEqual(["off"]);
-	}
-});
-
-test("thinkingLevels is pi's per-model support truth, not a reasoning boolean widened to all seven", () => {
-	// Every registered faux model is non-reasoning, so `["off"]` alone can be satisfied by a constant.
-	// `toWireModel` is a pure projection, so pin the interesting half directly: a reasoning model exposes
-	// the escalation ladder, and `xhigh`/`max` appear ONLY when `thinkingLevelMap` maps them.
-	const reasoner: Model<string> = {
-		...modelDef("reasoner"),
-		provider: "fauxa",
-		api: "fauxa",
-		baseUrl: "http://faux.local",
-		reasoning: true,
-		thinkingLevelMap: { xhigh: "xhigh" },
-	};
-	expect(toWireModel(reasoner).thinkingLevels).toEqual([
-		"off",
-		"minimal",
-		"low",
-		"medium",
-		"high",
-		"xhigh",
-	]);
-
-	// A level the model explicitly cannot do is dropped, even on a reasoning model.
-	const alwaysThinks: Model<string> = { ...reasoner, thinkingLevelMap: { off: null } };
-	expect(toWireModel(alwaysThinks).thinkingLevels).not.toContain("off");
-});
-
-test("model.clampThinking answers with pi's clamp, not a plausible client-side policy", async () => {
-	// Review finding on the pre-session picker: any rule invented client-side diverges from pi. These are
-	// the two shapes that separate pi's upward-then-downward clamp from the likely local heuristics — a
-	// midpoint would say `medium` then `high`; "nearest below" would say `xhigh` then nothing.
-	// A reasoning provider has to be registered for this: `clampThinkingForModel` re-resolves the ref,
-	// and every other faux model is non-reasoning (supported set exactly `["off"]`, which every policy
-	// agrees on and so proves nothing).
-	const reasoning = (id: string, map: Record<string, string | null>) => ({
-		...cfg(fauxA, id),
-		models: [{ ...modelDef(id), api: fauxA.api, reasoning: true, thinkingLevelMap: map }],
-	});
-
-	runtime.registerProvider("clamp5", reasoning("clamp5", { xhigh: "xhigh" }));
-	runtime.registerProvider(
-		"clamp2",
-		reasoning("clamp2", { off: null, minimal: null, medium: null }),
-	);
-	try {
-		// `[off, minimal, low, medium, high, xhigh]` — `max` is unmapped, so upward is exhausted.
-		expect(await clampThinkingForModel({ provider: "clamp5", id: "clamp5" }, "max")).toBe("xhigh");
-		// `[low, high]` — nothing below `off`, so pi goes upward instead.
-		expect(await clampThinkingForModel({ provider: "clamp2", id: "clamp2" }, "off")).toBe("low");
-		// A level the model does support is returned untouched.
-		expect(await clampThinkingForModel({ provider: "clamp2", id: "clamp2" }, "high")).toBe("high");
-	} finally {
-		runtime.unregisterProvider("clamp5");
-		runtime.unregisterProvider("clamp2");
-	}
-});
-
-test("model.clampThinking refuses a model ref the host can't resolve", async () => {
-	await expect(clampThinkingForModel({ provider: "nope", id: "nope" }, "high")).rejects.toThrow(
-		/Unknown or unavailable model/,
-	);
-});
-
-test("model.default clamps the saved thinking level onto the resolved model's support set", async () => {
-	// A `high` saved from a reasoning model plus a non-reasoning default model must not surface as a
-	// disabled-but-selected level — the host returns a self-consistent pair, clamped with pi's own
-	// `clampThinkingLevel` (faux models don't reason → exactly ["off"]).
-	const agentDir = process.env.PI_CODING_AGENT_DIR;
-	if (!agentDir) throw new Error("agent dir not isolated");
-	const settingsPath = join(agentDir, "settings.json");
-	writeFileSync(settingsPath, `${JSON.stringify({ defaultThinkingLevel: "high" })}\n`);
-	try {
-		const d = await getDefaultModel();
-		expect(d.model?.thinkingLevels).toEqual(["off"]);
-		expect(d.thinkingLevel).toBe("off");
-	} finally {
-		rmSync(settingsPath, { force: true });
-	}
-});
-
 test("createSession re-resolves a wire model ref by {provider,id}, never trusting a client baseUrl", async () => {
 	fauxA.setResponses([fauxAssistantMessage("RESOLVED_REPLY")]);
-	const ref = (await listAvailableModels()).find((m) => m.id === "fauxa");
+	const ref = (await listModelCatalog()).find((e) => e.model.id === "fauxa")?.model;
 	if (!ref) throw new Error("faux model missing");
 	// `ref` has NO baseUrl — only host-side re-resolution against the registry can reach the faux provider.
 	const s = await createSession({
@@ -356,7 +178,7 @@ test("createSession re-resolves a wire model ref by {provider,id}, never trustin
 });
 
 test("createSession rejects an unknown/unavailable model ref (no arbitrary baseUrl injection)", async () => {
-	const ref = (await listAvailableModels()).find((m) => m.id === "fauxa");
+	const ref = (await listModelCatalog()).find((e) => e.model.id === "fauxa")?.model;
 	if (!ref) throw new Error("faux model missing");
 	// A client points provider/id at something not in the registry — the host refuses rather than call it.
 	const bogus = { ...ref, provider: "attacker", id: "evil" };

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -1,7 +1,4 @@
 import { rmSync } from "node:fs";
-// Value imports of PURE catalog helpers (data-only projections over `Model`) — the only root
-// value-imports the module boundary allows; dispatch stays on the shared `ModelRuntime` (SPEC §Allowed deps).
-import { clampThinkingLevel, getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import {
 	type AgentSession,
 	createAgentSession,
@@ -23,7 +20,10 @@ import type {
 } from "@thinkrail/contracts";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import { buildResourceLoader, toSkillCommands } from "./extensions";
-import { getPiRuntime, refreshCatalogsDetached } from "./piRuntime";
+// Everything model-shaped (the wire projection, inbound ref re-resolution, ordering, the allowlist) lives
+// in the `modelCatalog` sibling — a one-way edge: it never reaches back into session lifecycle.
+import { resolveWireModel, toWireModel } from "./modelCatalog";
+import { getPiRuntime } from "./piRuntime";
 import { repairDanglingToolCalls } from "./sessionRepair";
 import type { SkillAdmissionContext } from "./skillAdmission";
 import { cancelExtUiForSession, createWebUiContext, notifyExtUi } from "./webUiContext";
@@ -138,40 +138,6 @@ export interface CreateSessionResult {
 	sessionId: string;
 	model: WireModel | null;
 	thinkingLevel: ThinkingLevel;
-}
-
-/**
- * Project a `pi` `Model` down to the wire's **allowlist** (`WireModel`) — exactly the fields the UI renders.
- * An explicit projection (not a `{...rest}` denylist), so `baseUrl` (the jbcentral proxy secret when wired)
- * and `headers` (can carry auth) — and any future `Model` field — are excluded by default. The UI refers a
- * model back by `{provider,id}`, which the host re-resolves via `resolveWireModel`. This is the single choke
- * point that keeps secrets off every model-bearing wire frame (model.list/default, session.create result,
- * SessionSummary).
- */
-export function toWireModel(model: Model<string>): WireModel {
-	return {
-		id: model.id,
-		name: model.name,
-		provider: model.provider,
-		contextWindow: model.contextWindow,
-		reasoning: model.reasoning,
-		// Computed, not picked: pi's per-model effort-level truth (reasoning + thinkingLevelMap), so the
-		// picker disables unsupported levels instead of relying on pi's silent clamp.
-		thinkingLevels: getSupportedThinkingLevels(model),
-	};
-}
-
-/**
- * Re-resolve a wire model reference back to the real `Model` (with its `baseUrl`) from the registry, matching
- * the picker's universe (`getAvailable()`). **Never trust a client-supplied `baseUrl`** — pi's `setModel` /
- * `createAgentSession` use it verbatim, so accepting it would let a client (esp. a remote V2 one) point the
- * agent's model traffic at an arbitrary URL. Throws if the ref isn't an available model.
- */
-async function resolveWireModel(ref: Pick<WireModel, "provider" | "id">): Promise<Model<string>> {
-	const available = await (await getPiRuntime()).getAvailable();
-	const match = available.find((m) => m.provider === ref.provider && m.id === ref.id);
-	if (!match) throw new Error(`Unknown or unavailable model: ${ref.provider}/${ref.id}`);
-	return match as unknown as Model<string>;
 }
 
 /** Wire a freshly-created/opened session into the manager: forward its events + bind the extension-UI bridge. */
@@ -450,63 +416,6 @@ export function getSessionCommands(sessionId: string): SlashCommandInfo[] {
 	}));
 	const skill = toSkillCommands(session.resourceLoader.getSkills().skills);
 	return [...extension, ...prompt, ...skill];
-}
-
-/** Models with configured auth, for the model picker (cheap win #1). Redacted to `WireModel` — the raw
- * `Model.baseUrl` carries the jbcentral proxy secret when wired, and the picker only reads id/name/provider.
- * Also fires the detached catalog refresh (issue #98): the read below returns the current snapshot
- * immediately — never awaiting the network — and a later `model.list` picks up whatever the refresh landed. */
-export async function listAvailableModels(): Promise<WireModel[]> {
-	const runtime = await getPiRuntime();
-	refreshCatalogsDetached(runtime);
-	const available = await runtime.getAvailable();
-	return available.map((m) => toWireModel(m as unknown as Model<string>));
-}
-
-/** The model + thinking level a new session resolves to (settings default if available, else first available). */
-export interface DefaultModelResult {
-	model: WireModel | null;
-	thinkingLevel: ThinkingLevel;
-}
-
-/**
- * pi's own clamp for a `{model, desired-level}` pair — `model.clampThinking`. The pre-session picker has
- * no session to ask, so without this it would need a policy of its own, and that path would then adjust
- * effort differently from `model.default` (which clamps just below) and from a live session (which gets
- * pi's answer via `thinking_level_changed`). Re-resolves the ref host-side like every other inbound
- * model ref, so an unavailable one throws rather than being guessed at.
- */
-export async function clampThinkingForModel(
-	ref: Pick<WireModel, "provider" | "id">,
-	level: ThinkingLevel,
-): Promise<ThinkingLevel> {
-	return clampThinkingLevel(await resolveWireModel(ref), level);
-}
-
-/**
- * The default the *next* session would start with — so the New-Workspace dialog can show the exact model
- * pre-session (not a "Default" placeholder). Mirrors pi's resolution for a fresh session: the settings
- * default (if it's available), else the first available model. Passing it back to `session.create` is a
- * no-op vs. omitting it, so an `@agent` test that doesn't touch the picker still lands on the pinned model.
- *
- * The result is **self-consistent**: the settings' thinking level is clamped (pi's own
- * `clampThinkingLevel`) onto the resolved model's supported set, so the dialog never shows a level the
- * model can't do as selected (e.g. a `high` saved from a reasoning model while the default is a
- * non-reasoning one — pi would silently clamp the created session to `off` otherwise).
- */
-export async function getDefaultModel(): Promise<DefaultModelResult> {
-	const available = await (await getPiRuntime()).getAvailable();
-	const settings = SettingsManager.create(process.cwd());
-	const provider = settings.getDefaultProvider();
-	const modelId = settings.getDefaultModel();
-	const pinned =
-		provider && modelId
-			? available.find((m) => m.provider === provider && m.id === modelId)
-			: undefined;
-	const resolved = (pinned ?? available[0] ?? null) as Model<string> | null;
-	const saved = settings.getDefaultThinkingLevel() ?? "medium";
-	const thinkingLevel = resolved ? clampThinkingLevel(resolved, saved) : saved;
-	return { model: resolved ? toWireModel(resolved) : null, thinkingLevel };
 }
 
 export function isSessionStreaming(sessionId: string): boolean {

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -10,6 +10,7 @@ export {
 	listSkillCommands,
 	registerBundledRuntime,
 } from "./extensions";
+export * from "./modelCatalog";
 export * from "./oneshot";
 export * from "./piRuntime";
 export * from "./sessionRepair";

--- a/packages/server/src/agent/modelCatalog.test.ts
+++ b/packages/server/src/agent/modelCatalog.test.ts
@@ -1,0 +1,474 @@
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	InMemoryCredentialStore,
+	type Model,
+	type ModelsRefreshResult,
+} from "@earendil-works/pi-ai";
+import { createFauxCore } from "@earendil-works/pi-ai/providers/faux";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import type { ModelCatalogEntry } from "@thinkrail/contracts";
+import {
+	clampThinkingForModel,
+	collapsedRefs,
+	getDefaultModel,
+	listModelCatalog,
+	orderModels,
+	parseModelSortKey,
+	setEnabledModels,
+	setModelCatalogPublisher,
+	toWireModel,
+} from "./modelCatalog";
+import { configurePiRuntime } from "./piRuntime";
+
+/** A complete model definition for `registerProvider` (faux defaults are looser). */
+function modelDef(id: string) {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 4096,
+	};
+}
+
+// Two faux providers so provider grouping is observable; `catalog` carries the interesting id shapes
+// (alias + its dated twin, two versions, a legacy family) that the ordering/collapse rules key on.
+const CATALOG_IDS = ["alias-4-5", "alias-4-5-20251101", "alias-4-6", "legacy-2"];
+const fauxCat = createFauxCore({
+	provider: "catalog",
+	api: "catalog",
+	models: CATALOG_IDS.map(modelDef),
+	tokensPerSecond: 2000,
+});
+const fauxOther = createFauxCore({
+	provider: "aother",
+	api: "aother",
+	models: [modelDef("other-1")],
+	tokensPerSecond: 2000,
+});
+// Registered only DURING the catalog-refresh test — the "newly shipped" model a refresh delivers.
+const fauxNew = createFauxCore({
+	provider: "znew",
+	api: "znew",
+	models: [modelDef("znew-1")],
+	tokensPerSecond: 2000,
+});
+
+/** Provider config for `registerProvider` (baseUrl + apiKey are required when models are defined). */
+const cfg = (faux: typeof fauxCat, ids: string[]) => ({
+	api: faux.api,
+	baseUrl: "http://faux.local",
+	apiKey: "faux",
+	streamSimple: faux.streamSimple,
+	models: ids.map((id) => ({ ...modelDef(id), api: faux.api })),
+});
+
+/** This suite's own providers. A developer's ambient env auth (e.g. `ANTHROPIC_API_KEY`) adds real
+ * providers to the same runtime, so every runtime-backed assertion is scoped to these two — the exact
+ * ordering rule is pinned separately, on the pure `orderModels`. */
+const FAUX_PROVIDERS = ["aother", "catalog"];
+const fauxOnly = (catalog: ModelCatalogEntry[]) =>
+	catalog.filter((entry) => FAUX_PROVIDERS.includes(entry.model.provider));
+
+const tmpDirs: string[] = [];
+function tmpDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+let priorAgentDir: string | undefined;
+let priorOffline: string | undefined;
+let runtime: ModelRuntime;
+let settingsPath: string;
+
+/** pi's global settings file for this suite — where `enabledModels` and the model defaults live. */
+function writeSettings(settings: Record<string, unknown>): void {
+	writeFileSync(settingsPath, `${JSON.stringify(settings)}\n`);
+}
+function readSettings(): Record<string, unknown> {
+	return existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, "utf8")) : {};
+}
+
+beforeAll(async () => {
+	// Isolate pi's agent dir: `setEnabledModels` writes a REAL settings.json, never the developer's.
+	priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = tmpDir("trpi-catalog-agentdir-");
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	settingsPath = join(agentDir, "settings.json");
+
+	// `listModelCatalog` fires a detached network catalog refresh (issue #98) — keep this suite hermetic
+	// the same way e2e is, via pi's own PI_OFFLINE convention. The refresh tests lift it locally.
+	priorOffline = process.env.PI_OFFLINE;
+	process.env.PI_OFFLINE = "1";
+
+	// A REAL runtime (in-memory credentials, no models.json, no network) with the faux providers
+	// registered as extension providers.
+	runtime = await ModelRuntime.create({
+		credentials: new InMemoryCredentialStore(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	runtime.registerProvider("catalog", cfg(fauxCat, CATALOG_IDS));
+	runtime.registerProvider("aother", cfg(fauxOther, ["other-1"]));
+	configurePiRuntime(runtime);
+});
+
+afterEach(() => {
+	rmSync(settingsPath, { force: true }); // no allowlist / no default leaks into the next case
+	setModelCatalogPublisher(() => {});
+});
+
+afterAll(() => {
+	configurePiRuntime(null);
+	for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+	if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+	if (priorOffline === undefined) delete process.env.PI_OFFLINE;
+	else process.env.PI_OFFLINE = priorOffline;
+});
+
+// ─── ordering + collapsing (pure) ────────────────────────────────────────────────────────────────
+
+test("a dated suffix is stripped from the version key, not parsed as a version", () => {
+	// Both spellings pi's catalogs use. Without the strip, `-20251101` reads as a huge version component
+	// and the pinned snapshot would outrank its own alias.
+	expect(parseModelSortKey("claude-opus-4-5-20251101")).toEqual({
+		version: [4, 5],
+		dated: true,
+		id: "claude-opus-4-5-20251101",
+	});
+	expect(parseModelSortKey("gpt-4o-2024-05-13")).toEqual({
+		version: [4],
+		dated: true,
+		id: "gpt-4o-2024-05-13",
+	});
+	expect(parseModelSortKey("gpt-5.6-luna")).toEqual({
+		version: [5, 6],
+		dated: false,
+		id: "gpt-5.6-luna",
+	});
+});
+
+test("orderModels groups by provider and puts the newest version first", () => {
+	// A slice of the real catalogs, deliberately shuffled: what the user complained about is that this
+	// input order (pi's own) leads with gpt-4/o1-era models.
+	const models = [
+		{ provider: "openai", id: "gpt-4" },
+		{ provider: "openai", id: "o1" },
+		{ provider: "anthropic", id: "claude-opus-4-5-20251101" },
+		{ provider: "openai", id: "gpt-4o-2024-05-13" },
+		{ provider: "anthropic", id: "claude-opus-4-5" },
+		{ provider: "openai", id: "gpt-5" },
+		{ provider: "anthropic", id: "claude-opus-5" },
+		{ provider: "openai", id: "gpt-4o" },
+		{ provider: "openai", id: "o3-mini" },
+		{ provider: "anthropic", id: "claude-sonnet-4-6" },
+		{ provider: "openai", id: "gpt-5.1" },
+	];
+
+	expect(orderModels(models).map((m) => `${m.provider}/${m.id}`)).toEqual([
+		// anthropic first (provider asc); within it newest first, and the pinned snapshot sits directly
+		// under the alias it pins rather than above it.
+		"anthropic/claude-opus-5",
+		"anthropic/claude-sonnet-4-6",
+		"anthropic/claude-opus-4-5",
+		"anthropic/claude-opus-4-5-20251101",
+		// openai: 5.1 > 5 > the 4-series > the o-series, so the legacy families sink on their own.
+		// `gpt-4` and `gpt-4o` carry the same version digits ([4]) — the id tie-break decides, keeping the
+		// order stable across reads rather than dependent on pi's catalog order.
+		"openai/gpt-5.1",
+		"openai/gpt-5",
+		"openai/gpt-4",
+		"openai/gpt-4o",
+		"openai/gpt-4o-2024-05-13",
+		"openai/o3-mini",
+		"openai/o1",
+	]);
+});
+
+test("collapsedRefs folds a dated snapshot only when its alias is available under the same provider", () => {
+	const collapsed = collapsedRefs([
+		{ provider: "anthropic", id: "claude-opus-4-5" },
+		{ provider: "anthropic", id: "claude-opus-4-5-20251101" },
+		// No alias listed → the pinned build is the only way to reach this model, so it must stay visible.
+		{ provider: "anthropic", id: "claude-orphan-9-20240101" },
+		// Same id shape, different provider: the alias next door must not collapse it.
+		{ provider: "bedrock", id: "claude-opus-4-5-20251101" },
+	]);
+
+	expect([...collapsed]).toEqual(["anthropic/claude-opus-4-5-20251101"]);
+});
+
+// ─── the catalog read ────────────────────────────────────────────────────────────────────────────
+
+test("listModelCatalog returns the configured (faux) models, ordered, everything enabled", async () => {
+	const catalog = fauxOnly(await listModelCatalog());
+
+	// Provider asc, newest first, dated twin under its alias — and no allowlist means all enabled.
+	expect(catalog.map((e) => `${e.model.provider}/${e.model.id}`)).toEqual([
+		"aother/other-1",
+		"catalog/alias-4-6",
+		"catalog/alias-4-5",
+		"catalog/alias-4-5-20251101",
+		"catalog/legacy-2",
+	]);
+	expect(catalog.every((e) => e.enabled)).toBe(true);
+	// The dated twin is the one row the picker folds away by default.
+	expect(catalog.filter((e) => e.collapsed).map((e) => e.model.id)).toEqual(["alias-4-5-20251101"]);
+});
+
+test("wire models expose only the allowlisted fields (no baseUrl/headers/other Model fields)", async () => {
+	// The faux providers register with baseUrl "http://faux.local"; when JetBrains AI is wired the real
+	// baseUrl is `.../wire/<SECRET>/...`. `toWireModel` is an allowlist projection, so a wire model carries
+	// EXACTLY these keys — this pins the DTO shut (widening it, incl. re-adding a secret field, fails here).
+	const catalog = fauxOnly(await listModelCatalog());
+	expect(catalog.length).toBeGreaterThan(0);
+	for (const entry of catalog) {
+		expect(Object.keys(entry.model).sort()).toEqual([
+			"contextWindow",
+			"id",
+			"name",
+			"provider",
+			"reasoning",
+			"thinkingLevels",
+		]);
+		// Faux models declare `reasoning: false` — pi's support truth for those is exactly ["off"].
+		expect(entry.model.thinkingLevels).toEqual(["off"]);
+	}
+});
+
+test("thinkingLevels is pi's per-model support truth, not a reasoning boolean widened to all seven", () => {
+	// Every registered faux model is non-reasoning, so `["off"]` alone can be satisfied by a constant.
+	// `toWireModel` is a pure projection, so pin the interesting half directly: a reasoning model exposes
+	// the escalation ladder, and `xhigh`/`max` appear ONLY when `thinkingLevelMap` maps them.
+	const reasoner: Model<string> = {
+		...modelDef("reasoner"),
+		provider: "catalog",
+		api: "catalog",
+		baseUrl: "http://faux.local",
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh" },
+	};
+	expect(toWireModel(reasoner).thinkingLevels).toEqual([
+		"off",
+		"minimal",
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+	]);
+
+	// A level the model explicitly cannot do is dropped, even on a reasoning model.
+	const alwaysThinks: Model<string> = { ...reasoner, thinkingLevelMap: { off: null } };
+	expect(toWireModel(alwaysThinks).thinkingLevels).not.toContain("off");
+});
+
+/** Let a detached refresh task's `.then/.finally` chain settle (macrotask — nothing sleeps). */
+const refreshSettled = () => new Promise<void>((r) => setTimeout(r, 0));
+
+test("model.list is never blocked by a hanging catalog refresh (fire-and-forget, issue #98)", async () => {
+	delete process.env.PI_OFFLINE;
+	const originalRefresh = runtime.refresh.bind(runtime);
+	let releaseHang = () => {};
+	try {
+		runtime.refresh = () =>
+			new Promise<ModelsRefreshResult>((resolve) => {
+				releaseHang = () => resolve({ aborted: false, errors: new Map() });
+			});
+		// Resolves immediately from the snapshot while the "network" refresh hangs unresolved.
+		const ids = (await listModelCatalog()).map((e) => e.model.id);
+		expect(ids).toContain("alias-4-6");
+	} finally {
+		releaseHang(); // frees the single-flight slot so this test leaves no pending state behind
+		await refreshSettled();
+		runtime.refresh = originalRefresh;
+		process.env.PI_OFFLINE = "1";
+	}
+});
+
+test("a newly-shipped catalog model appears on a later model.list without a restart (issue #98)", async () => {
+	delete process.env.PI_OFFLINE;
+	const originalRefresh = runtime.refresh.bind(runtime);
+	let landRefresh = () => {};
+	let refreshCalls = 0;
+	try {
+		// The first "network" refresh delivers a new provider+model when it lands — deferred, so the first
+		// read provably serves the pre-refresh snapshot. Any later trigger settles instantly and delivers
+		// nothing, mirroring pi's freshness throttle.
+		runtime.refresh = () => {
+			refreshCalls += 1;
+			if (refreshCalls > 1) return Promise.resolve({ aborted: false, errors: new Map() });
+			return new Promise<ModelsRefreshResult>((resolve) => {
+				landRefresh = () => {
+					runtime.registerProvider("znew", cfg(fauxNew, ["znew-1"]));
+					resolve({ aborted: false, errors: new Map() });
+				};
+			});
+		};
+
+		const before = (await listModelCatalog()).map((e) => e.model.id); // triggers the detached refresh
+		expect(before).not.toContain("znew-1");
+
+		landRefresh();
+		await refreshSettled();
+
+		const after = (await listModelCatalog()).map((e) => e.model.id);
+		expect(after).toContain("znew-1");
+	} finally {
+		await refreshSettled(); // let the second trigger's instant refresh settle before restoring
+		runtime.unregisterProvider("znew");
+		runtime.refresh = originalRefresh;
+		process.env.PI_OFFLINE = "1";
+	}
+});
+
+// ─── the enabledModels allowlist ─────────────────────────────────────────────────────────────────
+
+test("pi's enabledModels allowlist decides `enabled`, glob patterns included", async () => {
+	// A glob and an explicit ref, i.e. both shapes pi's own `--models` / settings accept.
+	writeSettings({ enabledModels: ["catalog/alias-4-6", "aother/*"] });
+
+	const enabled = (await listModelCatalog()).filter((e) => e.enabled).map((e) => e.model.id);
+	expect(enabled.sort()).toEqual(["alias-4-6", "other-1"]);
+});
+
+test("an explicit allowlist is the curation: nothing is collapsed under it", async () => {
+	// The user asked for the alias AND its pinned build — folding one away would silently undo that.
+	writeSettings({ enabledModels: ["catalog/alias-4-5", "catalog/alias-4-5-20251101"] });
+
+	const catalog = await listModelCatalog();
+	expect(catalog.some((e) => e.collapsed)).toBe(false);
+	expect(catalog.filter((e) => e.enabled).map((e) => e.model.id)).toEqual([
+		"alias-4-5",
+		"alias-4-5-20251101",
+	]);
+});
+
+test("an allowlist whose patterns all went stale reads as no allowlist, never an empty picker", async () => {
+	// e.g. the provider those patterns named was signed out. pi returns diagnostics (it never throws);
+	// resolving to nothing must fail OPEN or the picker would offer no model at all.
+	writeSettings({ enabledModels: ["retired-provider/*", "gone-9"] });
+
+	const catalog = await listModelCatalog();
+	expect(catalog.length).toBeGreaterThan(0);
+	expect(catalog.every((e) => e.enabled)).toBe(true);
+});
+
+test("setEnabledModels writes pi's own settings and broadcasts the fresh catalog", async () => {
+	const published: ModelCatalogEntry[][] = [];
+	setModelCatalogPublisher((entries) => published.push(entries));
+
+	await setEnabledModels(["catalog/alias-4-6", "aother/other-1"]);
+
+	// Persisted where pi's CLI/TUI reads it, verbatim refs, in the order given.
+	expect(readSettings().enabledModels).toEqual(["catalog/alias-4-6", "aother/other-1"]);
+	// And every client hears about it — the initiator converges on this push, it doesn't guess.
+	expect(published).toHaveLength(1);
+	expect(
+		published[0]
+			?.filter((e) => e.enabled)
+			.map((e) => e.model.id)
+			.sort(),
+	).toEqual(["alias-4-6", "other-1"]);
+});
+
+test("setEnabledModels drops refs the host can't resolve — nothing unresolvable lands in pi's config", async () => {
+	await setEnabledModels(["catalog/alias-4-6", "attacker/evil"]);
+	expect(readSettings().enabledModels).toEqual(["catalog/alias-4-6"]);
+});
+
+test("'everything enabled' clears the setting instead of pinning today's catalog (pi's own semantics)", async () => {
+	writeSettings({ enabledModels: ["catalog/alias-4-6"] });
+
+	// null, [] and the full available set are all "no filter" — and a cleared setting is what lets a
+	// newly-authenticated provider's models show up without re-curating.
+	await setEnabledModels(null);
+	expect(readSettings().enabledModels).toBeUndefined();
+
+	const everything = (await listModelCatalog()).map((e) => `${e.model.provider}/${e.model.id}`);
+	await setEnabledModels(everything);
+	expect(readSettings().enabledModels).toBeUndefined();
+
+	await setEnabledModels([]);
+	expect(readSettings().enabledModels).toBeUndefined();
+});
+
+// ─── the default a new session resolves to ───────────────────────────────────────────────────────
+
+test("model.default prefers the saved default, then the first ENABLED model", async () => {
+	// Saved default in the allowlist → it wins.
+	writeSettings({
+		defaultProvider: "catalog",
+		defaultModel: "legacy-2",
+		enabledModels: ["catalog/legacy-2", "catalog/alias-4-6"],
+	});
+	expect((await getDefaultModel()).model?.id).toBe("legacy-2");
+
+	// Saved default disabled → the newest enabled model, NOT the disabled favourite and not the
+	// catalog's first row (`aother/other-1`, which is out of the list too).
+	writeSettings({
+		defaultProvider: "catalog",
+		defaultModel: "legacy-2",
+		enabledModels: ["catalog/alias-4-6"],
+	});
+	expect((await getDefaultModel()).model?.id).toBe("alias-4-6");
+});
+
+test("model.default clamps the saved thinking level onto the resolved model's support set", async () => {
+	// A `high` saved from a reasoning model plus a non-reasoning default model must not surface as a
+	// disabled-but-selected level — the host returns a self-consistent pair, clamped with pi's own
+	// `clampThinkingLevel` (faux models don't reason → exactly ["off"]).
+	writeSettings({
+		defaultProvider: "catalog",
+		defaultModel: "alias-4-6",
+		defaultThinkingLevel: "high",
+	});
+
+	const resolved = await getDefaultModel();
+	expect(resolved.model?.thinkingLevels).toEqual(["off"]);
+	expect(resolved.thinkingLevel).toBe("off");
+});
+
+// ─── pi's clamp for a model ref ──────────────────────────────────────────────────────────────────
+
+test("model.clampThinking answers with pi's clamp, not a plausible client-side policy", async () => {
+	// Review finding on the pre-session picker: any rule invented client-side diverges from pi. These are
+	// the two shapes that separate pi's upward-then-downward clamp from the likely local heuristics — a
+	// midpoint would say `medium` then `high`; "nearest below" would say `xhigh` then nothing.
+	// A reasoning provider has to be registered for this: `clampThinkingForModel` re-resolves the ref,
+	// and every other faux model is non-reasoning (supported set exactly `["off"]`, which every policy
+	// agrees on and so proves nothing).
+	const reasoning = (id: string, map: Record<string, string | null>) => ({
+		...cfg(fauxCat, [id]),
+		models: [{ ...modelDef(id), api: fauxCat.api, reasoning: true, thinkingLevelMap: map }],
+	});
+
+	runtime.registerProvider("clamp5", reasoning("clamp5", { xhigh: "xhigh" }));
+	runtime.registerProvider(
+		"clamp2",
+		reasoning("clamp2", { off: null, minimal: null, medium: null }),
+	);
+	try {
+		// `[off, minimal, low, medium, high, xhigh]` — `max` is unmapped, so upward is exhausted.
+		expect(await clampThinkingForModel({ provider: "clamp5", id: "clamp5" }, "max")).toBe("xhigh");
+		// `[low, high]` — nothing below `off`, so pi goes upward instead.
+		expect(await clampThinkingForModel({ provider: "clamp2", id: "clamp2" }, "off")).toBe("low");
+		// A level the model does support is returned untouched.
+		expect(await clampThinkingForModel({ provider: "clamp2", id: "clamp2" }, "high")).toBe("high");
+	} finally {
+		runtime.unregisterProvider("clamp5");
+		runtime.unregisterProvider("clamp2");
+	}
+});
+
+test("model.clampThinking refuses a model ref the host can't resolve", async () => {
+	await expect(clampThinkingForModel({ provider: "nope", id: "nope" }, "high")).rejects.toThrow(
+		/Unknown or unavailable model/,
+	);
+});

--- a/packages/server/src/agent/modelCatalog.ts
+++ b/packages/server/src/agent/modelCatalog.ts
@@ -1,0 +1,257 @@
+// Value imports of PURE catalog helpers (data-only projections over `Model`) plus pi's own model-scope
+// resolver — dispatch stays on the shared `ModelRuntime` (SPEC §Allowed deps).
+import { clampThinkingLevel, getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import {
+	type ModelRuntime,
+	resolveModelScopeWithDiagnostics,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import {
+	type Model,
+	type ModelCatalogEntry,
+	modelRef,
+	type ThinkingLevel,
+	type WireModel,
+} from "@thinkrail/contracts";
+import { getPiRuntime, refreshCatalogsDetached } from "./piRuntime";
+
+/**
+ * Project a `pi` `Model` down to the wire's **allowlist** (`WireModel`) — exactly the fields the UI renders.
+ * An explicit projection (not a `{...rest}` denylist), so `baseUrl` (the jbcentral proxy secret when wired)
+ * and `headers` (can carry auth) — and any future `Model` field — are excluded by default. The UI refers a
+ * model back by `{provider,id}`, which the host re-resolves via `resolveWireModel`. This is the single choke
+ * point that keeps secrets off every model-bearing wire frame (model.list/default, session.create result,
+ * SessionSummary).
+ */
+export function toWireModel(model: Model<string>): WireModel {
+	return {
+		id: model.id,
+		name: model.name,
+		provider: model.provider,
+		contextWindow: model.contextWindow,
+		reasoning: model.reasoning,
+		// Computed, not picked: pi's per-model effort-level truth (reasoning + thinkingLevelMap), so the
+		// picker disables unsupported levels instead of relying on pi's silent clamp.
+		thinkingLevels: getSupportedThinkingLevels(model),
+	};
+}
+
+/**
+ * Re-resolve a wire model reference back to the real `Model` (with its `baseUrl`) from the registry, matching
+ * the picker's universe (`getAvailable()`). **Never trust a client-supplied `baseUrl`** — pi's `setModel` /
+ * `createAgentSession` use it verbatim, so accepting it would let a client (esp. a remote V2 one) point the
+ * agent's model traffic at an arbitrary URL. Throws if the ref isn't an available model.
+ */
+export async function resolveWireModel(
+	ref: Pick<WireModel, "provider" | "id">,
+): Promise<Model<string>> {
+	const available = await (await getPiRuntime()).getAvailable();
+	const model = available.find((m) => m.provider === ref.provider && m.id === ref.id);
+	if (!model) throw new Error(`Unknown or unavailable model: ${ref.provider}/${ref.id}`);
+	return model as unknown as Model<string>;
+}
+
+/**
+ * pi's own clamp for a `{model, desired-level}` pair — `model.clampThinking`. The pre-session picker has
+ * no session to ask, so without this it would need a policy of its own, and that path would then adjust
+ * effort differently from `model.default` (which clamps just below) and from a live session (which gets
+ * pi's answer via `thinking_level_changed`). Re-resolves the ref host-side like every other inbound
+ * model ref, so an unavailable one throws rather than being guessed at.
+ */
+export async function clampThinkingForModel(
+	ref: Pick<WireModel, "provider" | "id">,
+	level: ThinkingLevel,
+): Promise<ThinkingLevel> {
+	return clampThinkingLevel(await resolveWireModel(ref), level);
+}
+
+/**
+ * A trailing dated snapshot on a model id: `-20251101` or `-2024-05-13`. pi's catalogs ship both an alias
+ * (`claude-opus-4-5`, named "… (latest)") and the pinned build it currently points at, which is what makes
+ * the raw list read as duplicated.
+ */
+const DATE_SUFFIX = /-(?:\d{8}|\d{4}-\d{2}-\d{2})$/;
+
+/** A model's ordering key: its version digits, whether it's a dated snapshot, and its id as tie-break. */
+interface ModelSortKey {
+	/** The numeric groups of the id, minus any dated suffix — `gpt-5.6-luna` → `[5, 6]`. */
+	version: number[];
+	dated: boolean;
+	id: string;
+}
+
+/** @internal Exported for the unit suite — the ordering rule is worth pinning directly. */
+export function parseModelSortKey(id: string): ModelSortKey {
+	const date = DATE_SUFFIX.exec(id);
+	const base = date ? id.slice(0, date.index) : id;
+	return { version: (base.match(/\d+/g) ?? []).map(Number), dated: date !== null, id };
+}
+
+/**
+ * Newest first. pi's `Model` carries **no release date and no deprecation flag** (and `getAvailable()`
+ * filters only by provider), so a model's version digits are the only recency signal that exists: compare
+ * them element-wise, descending, treating a missing element as lower (`gpt-5.1` [5,1] outranks `gpt-5` [5]).
+ * A dated snapshot then sits directly under its alias, and the id breaks remaining ties so the order is
+ * stable across reads.
+ */
+function compareSortKeys(a: ModelSortKey, b: ModelSortKey): number {
+	const depth = Math.max(a.version.length, b.version.length);
+	for (let i = 0; i < depth; i++) {
+		const av = a.version[i];
+		const bv = b.version[i];
+		if (av === bv) continue;
+		if (av === undefined) return 1;
+		if (bv === undefined) return -1;
+		return bv - av;
+	}
+	if (a.dated !== b.dated) return a.dated ? 1 : -1;
+	return a.id.localeCompare(b.id);
+}
+
+/** Group by provider (asc), newest first within each — the order every client renders. */
+export function orderModels<T extends { provider: string; id: string }>(models: readonly T[]): T[] {
+	return models
+		.map((model) => ({ model, key: parseModelSortKey(model.id) }))
+		.sort(
+			(a, b) => a.model.provider.localeCompare(b.model.provider) || compareSortKeys(a.key, b.key),
+		)
+		.map((entry) => entry.model);
+}
+
+/**
+ * Refs of dated snapshots whose alias is also available under the same provider
+ * (`anthropic/claude-opus-4-5-20251101` while `anthropic/claude-opus-4-5` is listed). The two entries are
+ * the same model, so the picker folds the pinned one into its "Show all" tier — no judgment about what is
+ * outdated, just de-duplication.
+ */
+export function collapsedRefs(models: readonly { provider: string; id: string }[]): Set<string> {
+	const refs = new Set(models.map(modelRef));
+	const collapsed = new Set<string>();
+	for (const model of models) {
+		const date = DATE_SUFFIX.exec(model.id);
+		if (!date) continue;
+		if (refs.has(modelRef({ provider: model.provider, id: model.id.slice(0, date.index) }))) {
+			collapsed.add(modelRef(model));
+		}
+	}
+	return collapsed;
+}
+
+/** pi's `enabledModels` patterns as configured (merged global + project), read at the host's cwd. */
+function enabledPatterns(): string[] | undefined {
+	return SettingsManager.create(process.cwd()).getEnabledModels();
+}
+
+/**
+ * The user's allowlist resolved to `"provider/id"` refs, or `null` for "no allowlist — everything is
+ * enabled". Resolution is **pi's own** (`resolveModelScopeWithDiagnostics`: globs over `provider/id` and
+ * bare ids, cross-pattern dedupe, alias preferred over dated snapshots), so the app and pi's CLI/TUI agree
+ * on what a stored pattern means.
+ *
+ * **Fails open.** Unmatched patterns come back as diagnostics (pi never throws here) — logged and
+ * swallowed; and an allowlist whose every pattern is stale (a provider signed out, a model retired)
+ * resolves to nothing, which must read as "no allowlist" rather than an empty picker.
+ */
+async function resolveEnabledRefs(runtime: ModelRuntime): Promise<Set<string> | null> {
+	const patterns = enabledPatterns();
+	if (!patterns || patterns.length === 0) return null;
+	const { scopedModels, diagnostics } = await resolveModelScopeWithDiagnostics(
+		[...patterns],
+		runtime,
+	);
+	for (const diagnostic of diagnostics) console.warn(`enabledModels: ${diagnostic.message}`);
+	if (scopedModels.length === 0) return null;
+	return new Set(scopedModels.map((scoped) => modelRef(scoped.model)));
+}
+
+/**
+ * The model picker's catalog (`model.list`): every model with configured auth, in the host's order, each
+ * tagged with the two facts the picker splits its tiers on — `enabled` (in pi's `enabledModels` allowlist)
+ * and `collapsed` (a dated snapshot folded under its alias). One read serves the picker's default tier, its
+ * "Show all" tier AND the Settings → Models manager, so those three can't disagree.
+ *
+ * Also fires the detached catalog refresh (issue #98): the read below returns the current snapshot
+ * immediately — never awaiting the network — and a later `model.list` picks up whatever the refresh landed.
+ */
+export async function listModelCatalog(): Promise<ModelCatalogEntry[]> {
+	const runtime = await getPiRuntime();
+	refreshCatalogsDetached(runtime);
+	const available = orderModels(await runtime.getAvailable());
+	const enabled = await resolveEnabledRefs(runtime);
+	// An explicit allowlist IS the curation — never fold entries the user asked for.
+	const collapsed = enabled ? new Set<string>() : collapsedRefs(available);
+	return available.map((model) => ({
+		model: toWireModel(model as unknown as Model<string>),
+		enabled: enabled ? enabled.has(modelRef(model)) : true,
+		collapsed: collapsed.has(modelRef(model)),
+	}));
+}
+
+let publishCatalog: (entries: ModelCatalogEntry[]) => void = () => {};
+/** Host seam: fan a catalog change out to every client (`model.catalogChanged`). */
+export function setModelCatalogPublisher(fn: (entries: ModelCatalogEntry[]) => void): void {
+	publishCatalog = fn;
+}
+
+/**
+ * Replace pi's `enabledModels` allowlist (the Settings → Models manager's write), then broadcast the fresh
+ * catalog so every client converges on the push instead of guessing locally.
+ *
+ * Semantics are pi's, deliberately: the refs are written to the **global** `settings.json` (the file pi's
+ * CLI/TUI reads), and "no filter" is stored as an absent setting — `null`, an empty list, and the full
+ * available set all clear it, exactly like pi's own `/models` manager. Refs are filtered against the
+ * available set first: this writes into the user's real pi config, so nothing unresolvable lands there.
+ *
+ * Consequence, matching pi: the list the client sends is the whole truth, so hand-written glob patterns are
+ * expanded into explicit ids on the first save (the manager's copy says so).
+ */
+export async function setEnabledModels(refs: string[] | null): Promise<void> {
+	const available = await (await getPiRuntime()).getAvailable();
+	const availableRefs = new Set(available.map(modelRef));
+	const next = (refs ?? []).filter((ref) => availableRefs.has(ref));
+	const clears = next.length === 0 || next.length === availableRefs.size;
+	SettingsManager.create(process.cwd()).setEnabledModels(clears ? undefined : next);
+	publishCatalog(await listModelCatalog());
+}
+
+/** The model + thinking level a new session resolves to (see `getDefaultModel`). */
+export interface DefaultModelResult {
+	model: WireModel | null;
+	thinkingLevel: ThinkingLevel;
+}
+
+/**
+ * The default the *next* session would start with — so the New-Workspace dialog can show the exact model
+ * pre-session (not a "Default" placeholder). Mirrors pi's resolution for a fresh session, with the
+ * allowlist folded in: the settings default when it's available **and enabled**, else the first **enabled**
+ * model, else the first available one (all reads over the catalog's order, so the fallback is the newest
+ * model rather than a catalog-order accident). Disabling a model in Settings → Models therefore also stops
+ * new chats from preselecting it. Passing the result back to `session.create` is a no-op vs. omitting it,
+ * so an `@agent` test that doesn't touch the picker still lands on the pinned model.
+ *
+ * The result is **self-consistent**: the settings' thinking level is clamped (pi's own
+ * `clampThinkingLevel`) onto the resolved model's supported set, so the dialog never shows a level the
+ * model can't do as selected (e.g. a `high` saved from a reasoning model while the default is a
+ * non-reasoning one — pi would silently clamp the created session to `off` otherwise).
+ */
+export async function getDefaultModel(): Promise<DefaultModelResult> {
+	const runtime = await getPiRuntime();
+	const available = orderModels(await runtime.getAvailable());
+	const enabledRefs = await resolveEnabledRefs(runtime);
+	const isEnabled = (model: { provider: string; id: string }) =>
+		!enabledRefs || enabledRefs.has(modelRef(model));
+	const settings = SettingsManager.create(process.cwd());
+	const provider = settings.getDefaultProvider();
+	const modelId = settings.getDefaultModel();
+	const pinned =
+		provider && modelId
+			? available.find((m) => m.provider === provider && m.id === modelId && isEnabled(m))
+			: undefined;
+	const resolved = (pinned ??
+		available.find(isEnabled) ??
+		available[0] ??
+		null) as Model<string> | null;
+	const saved = settings.getDefaultThinkingLevel() ?? "medium";
+	const thinkingLevel = resolved ? clampThinkingLevel(resolved, saved) : saved;
+	return { model: resolved ? toWireModel(resolved) : null, thinkingLevel };
+}

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -23,7 +23,7 @@ import {
 	getSessionMessages,
 	getSessionStats,
 	hasSession,
-	listAvailableModels,
+	listModelCatalog,
 	listProjectAliasSkillNames,
 	listSessions,
 	listSkillCatalog,
@@ -33,6 +33,7 @@ import {
 	removeSession,
 	removeWorkspaceSessions,
 	resolveExtUi,
+	setEnabledModels,
 	setSessionModel,
 	setSessionThinkingLevel,
 	steerSession,
@@ -392,7 +393,13 @@ const handlers: Record<string, Handler> = {
 		await ackSend(answerQuestion(p.sessionId, p.toolCallId, p.result));
 		return { ok: true } as const;
 	},
-	"model.list": () => listAvailableModels(),
+	"model.list": () => listModelCatalog(),
+	// Settings → Models: replace pi's `enabledModels` allowlist. The fresh catalog reaches every client on
+	// the `model.catalogChanged` broadcast (see `setModelCatalogPublisher`), so the caller never guesses.
+	"model.setEnabled": async (params) => {
+		await setEnabledModels((params as { enabled: string[] | null }).enabled);
+		return { ok: true } as const;
+	},
 	"model.clampThinking": async (params) => {
 		const p = params as { provider: string; id: string; level: ThinkingLevel };
 		return { level: await clampThinkingForModel({ provider: p.provider, id: p.id }, p.level) };

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -5,6 +5,7 @@ import {
 	disposeAllSessions,
 	getSessionWorkspaceId,
 	setExtUiPublisher,
+	setModelCatalogPublisher,
 	setSessionPublisher,
 	setSkillAdmissionResolver,
 } from "../agent";
@@ -92,6 +93,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				ws.subscribe(WS_CHANNELS.workspaceRemoved);
 				ws.subscribe(WS_CHANNELS.workspaceFsChanged);
 				ws.subscribe(WS_CHANNELS.settingsChanged);
+				ws.subscribe(WS_CHANNELS.modelCatalogChanged);
 				const welcome: ServerWelcome = {
 					protocolVersion: PROTOCOL_VERSION,
 					projects: listProjects(),
@@ -188,6 +190,16 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 			JSON.stringify({ channel: WS_CHANNELS.settingsChanged, data: config }),
 		);
 		setAnalyticsSending(config.analyticsEnabled);
+	});
+
+	// Broadcast the model catalog after a `model.setEnabled` write, for the same reason as the settings
+	// push: the allowlist is shared domain state (it lives in pi's own settings), so every client — the
+	// initiator included — converges on this frame instead of mutating optimistically.
+	setModelCatalogPublisher((entries) => {
+		server.publish(
+			WS_CHANNELS.modelCatalogChanged,
+			JSON.stringify({ channel: WS_CHANNELS.modelCatalogChanged, data: entries }),
+		);
 	});
 
 	// Stream each in-process AgentSession's events to subscribed clients over the pi.event channel, and


### PR DESCRIPTION
## Why

The model picker showed pi's catalog verbatim — on my machine that's **60 models**, with
`gpt-4` / `gpt-4-turbo` / `gpt-4o-2024-05-13` / `o1` leading the OpenAI group and **every Anthropic model
listed twice** (the alias plus its dated twin, e.g. `claude-opus-4-5` + `claude-opus-4-5-20251101`).

pi's SDK offers no help here, and I checked before inventing anything: `ModelRuntime.getAvailable()`
filters only by provider, and `Model` (pi-ai 0.82.1) carries **no release date and no deprecation flag** —
pi's own sorting is alphabetical (`--list-models`) or "current model first" (TUI). But pi *does* own an
allowlist for exactly this complaint: `settings.json` → **`enabledModels`** (ordered glob patterns, same
format as `--models`, editable from pi's `/models`), which this app never read.

So: order host-side, and adopt pi's allowlist rather than inventing a "what looks outdated" policy.

## What changed

**Host** — new `packages/server/src/agent/modelCatalog.ts`, which now owns *everything model-shaped*
(the wire projection, inbound ref re-resolution, pi's thinking clamp, default-model resolution) so
`agentSessionManager` is session lifecycle only; the edge between them is one-way.

- **Order**: provider asc, then `(version digits desc, dated snapshot directly under its alias, id asc)`.
  Version digits are the only recency signal that exists in pi's data.
- **`enabled`**: pi's `enabledModels`, resolved with pi's own `resolveModelScopeWithDiagnostics` (globs,
  dedupe, alias-over-dated) — so a stored pattern means the same thing in the app and in the pi CLI.
  **Fails open**: unmatched patterns warn and are swallowed; an all-stale list reads as "no allowlist"
  rather than an empty picker.
- **`collapsed`**: a dated snapshot whose alias is also listed — computed **only when no allowlist is
  set** (an explicit list is the curation; we never second-guess it).
- Writes go to pi's **global** settings; "everything enabled" is stored as an absent setting (pi's own
  semantics). `model.default` now skips a disabled model.

**Wire (v19)** — `model.list` → `ModelCatalogEntry[]` (`WireModel` stays clean: it also rides
`session.create` / `SessionSummary`, where allowlist membership is meaningless), new `model.setEnabled`,
new `model.catalogChanged` broadcast (converge-on-broadcast, like `settings.changed`). `modelRef()` is the
one `"provider/id"` formatter both ends share.

**Web** — the picker renders the two host-decided tiers (everyday list + a `Show all N models` row), and a
**search query crosses both tiers**, so a legacy or pinned model is never unreachable. New
**Settings → Models** section curates the list (per-model toggles, "Enable all"), saving through the
broadcast — no dirty state, no Save button. The tier split lives in a store selector, memoized on the
catalog's identity so it can't churn renders.

## Result on a real catalog

Dumped from the running UI (e2e):

- **Everyday tier** starts `claude-fable-5, claude-opus-5, claude-sonnet-5, claude-opus-4-8, …` then
  `gpt-5.6-luna … gpt-5.1, gpt-5, gpt-4.1, gpt-4, gpt-4o, o4-mini, o3, o1` — legacy families sink on their own.
- **Hidden behind "Show all"**: exactly the 7 dated duplicates (`claude-*-2025…` ×4, `gpt-4o-2024-*` ×3).

## Tradeoff, taken knowingly (pi parity)

A save persists the client's list verbatim, so a signed-out provider's refs drop out and a
newly-authenticated provider's models start disabled while a list is set — the same behavior as pi's own
`/models`. Merge semantics were considered and rejected: a preserved glob (`claude-*`) would silently
re-enable the very model the user just switched off. Recorded in the agent SPEC.

## Verification

- `packages/server/src/agent/modelCatalog.test.ts` — 18 cases: the exact ordering rule (incl. date-suffix
  stripping), the collapse rule, glob/stale allowlist resolution, `setEnabledModels` writing/clearing real
  pi settings in a temp agent dir + broadcasting, `model.default` preferring an enabled model.
- New `selectors.test.ts` cases (tier split + selector reference stability) and a `formatContextWindow` case.
- `e2e/models.spec.ts` — picker tiers, "Show all", search across tiers, and the Settings → Models
  round-trip; guarded on a resolved model, since the no-agent suite deliberately runs without provider auth.
- Full gates: `check:deps`, `check:seams`, `lint`, `typecheck`, `bun run test` (361 server), `bun run e2e`
  (**117 passed**).
- `resetState` now strips `enabledModels` from the isolated agent dir — it shares `settings.json` with the
  `@agent` suite's pinned default model, which `model.default` resolves *through* the allowlist.

## Specs

Spec-first, then code: `packages/server/src/agent/SPEC.md`, `packages/contracts/SPEC.md`,
`apps/web/src/{chat,panels,store,lib}/SPEC.md`.

## Screenshots

Captured from the real UI and waiting on disk at `/tmp/thinkrail-shots/` — drag them into this PR to
attach (the CLI can't upload binaries):

| shot | what it shows |
|---|---|
| `before/picker.png` | today's picker: `gpt-4`, `gpt-4-turbo`, `gpt-4o-2024-05-13` … up top, Claude models doubled |
| `after/picker.png` | the everyday tier: newest first per provider, duplicates gone, `Show all 53 models` row at the bottom |
| `after/picker-show-all.png` | expanded — the dated snapshots under a "More models" heading |
| `after/settings-models.png` | the new Settings → Models manager |
