### PR TITLE
design/typography: as-implemented audit + reconciliation into a minimal semantic set

### DIFF
--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -136,7 +136,7 @@ function PromptRow({
 					<Highlight text={firstLine} query={query} />
 				</span>
 				{showChip ? (
-					<span className="shrink-0 rounded-full border border-border2 bg-bg px-xs text-[10px] text-hint">
+					<span className="shrink-0 rounded-full border border-border2 bg-bg px-xs text-hint text-xs">
 						{workspaceName ?? "workspace"}
 					</span>
 				) : null}
@@ -148,7 +148,7 @@ function PromptRow({
 				// hover-revealed via `group-hover`/`isSelected` opacity; this glyph is the part a
 				// keyboard-only user (Shift+Enter's own audience) needs, so it can't be mouse-hover-gated
 				// the way the icon itself is.
-				<span data-testid="history-save-shortcut" className="shrink-0 text-[10px] text-hint">
+				<span data-testid="history-save-shortcut" className="shrink-0 text-hint text-xs">
 					{SAVE_SHORTCUT_LABEL}
 				</span>
 			) : null}
@@ -170,7 +170,7 @@ function PromptRow({
 			{target ? (
 				<>
 					{isSelected ? (
-						<span data-testid="history-jump-shortcut" className="shrink-0 text-[10px] text-hint">
+						<span data-testid="history-jump-shortcut" className="shrink-0 text-hint text-xs">
 							⇧⏎
 						</span>
 					) : null}

--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -281,7 +281,7 @@ function HistoryPreview({
 					<div className="min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap break-words p-sm text-sm text-text">
 						<Highlight text={item.hit.text} query={query} />
 					</div>
-					<div className="shrink-0 border-t border-border2 px-sm py-xs text-[11px] text-hint">
+					<div className="shrink-0 border-t border-border2 px-sm py-xs text-hint text-xs">
 						{item.kind === "prompt" ? (
 							<PromptPreviewFooter hit={item.hit} workspaceName={workspaceName} />
 						) : (
@@ -488,10 +488,7 @@ export function HistoryOverlay({
 	) : !result ? null : (
 		<>
 			{result.indexing ? (
-				<div
-					data-testid="history-indexing"
-					className="px-sm py-1 text-center text-hint text-[11px]"
-				>
+				<div data-testid="history-indexing" className="px-sm py-1 text-center text-hint text-xs">
 					indexing history…
 				</div>
 			) : null}
@@ -499,7 +496,7 @@ export function HistoryOverlay({
 				<div className="flex flex-col gap-xs p-xs">
 					{result.prompts.length > 0 ? (
 						<div className="flex flex-col gap-0.5">
-							<div className="flex items-center justify-between px-sm py-0.5 text-hint text-xs uppercase tracking-wide">
+							<div className="flex items-center justify-between px-sm py-0.5 text-eyebrow text-hint">
 								<span>Prompts</span>
 								<span data-testid="history-counts">
 									{promptCount}/{result.promptTotal}
@@ -522,7 +519,7 @@ export function HistoryOverlay({
 					) : null}
 					{stage === "zoomed" && result.messages.length > 0 ? (
 						<div className="flex flex-col gap-0.5">
-							<div className="flex items-center justify-between px-sm py-0.5 text-hint text-xs uppercase tracking-wide">
+							<div className="flex items-center justify-between px-sm py-0.5 text-eyebrow text-hint">
 								<span>Messages</span>
 								<span data-testid="history-counts">
 									{messageCount}/{result.messageTotal}
@@ -569,7 +566,7 @@ export function HistoryOverlay({
 					<DropdownMenuTrigger
 						data-testid="history-scope"
 						data-scope={scope.kind}
-						className="flex shrink-0 items-center gap-xs rounded-full border border-border2 bg-bg px-sm py-0.5 text-[11px] text-muted outline-none hover:bg-hover"
+						className="flex shrink-0 items-center gap-xs rounded-full border border-border2 bg-bg px-sm py-0.5 text-muted text-xs outline-none hover:bg-hover"
 					>
 						<span>{SCOPE_LABELS[scope.kind]}</span>
 						<span className="text-hint">⌃R</span>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -194,9 +194,7 @@ export function SkillsDialog({
 					)}
 				>
 					{group.isPlugin ? <Puzzle className="size-3.5 shrink-0 text-hint" aria-hidden /> : null}
-					<span className="font-medium text-text text-xs uppercase tracking-wide">
-						{group.label}
-					</span>
+					<span className="text-eyebrow text-text">{group.label}</span>
 					<span className="min-w-0 flex-1 truncate text-hint text-xs">{group.hint}</span>
 					<span className="shrink-0 rounded-full bg-hover px-1.5 text-hint text-xs">
 						{group.items.length}
@@ -310,9 +308,7 @@ export function SkillsDialog({
 									data-testid="skills-all-plugins"
 									className="sticky top-0 z-20 flex h-8 items-center gap-sm border-border2 border-y bg-bg-dark px-sm"
 								>
-									<span className="min-w-0 flex-1 font-medium text-text text-xs uppercase tracking-wide">
-										All plugins
-									</span>
+									<span className="min-w-0 flex-1 text-eyebrow text-text">All plugins</span>
 									<Toggle
 										on={!pluginsDisabled}
 										busy={busy}
@@ -391,7 +387,7 @@ function SkillRow({
 			className="flex items-center gap-sm py-1.5 pr-sm pl-md hover:bg-hover"
 		>
 			<span className="flex min-w-0 flex-1 flex-col">
-				<span className="truncate font-[var(--font-mono)] text-sm text-text">{entry.name}</span>
+				<span className="truncate text-sm text-text">{entry.name}</span>
 				{entry.description ? (
 					<span className="truncate text-hint text-xs">{entry.description}</span>
 				) : null}

--- a/apps/web/src/chat/ThinkingSelector.tsx
+++ b/apps/web/src/chat/ThinkingSelector.tsx
@@ -31,7 +31,7 @@ export function ThinkingSelector({
 				disabled={levels.length === 0}
 				className="flex h-8 items-center gap-sm rounded-[var(--radius-md)] border border-border2 bg-[var(--input-bg)] px-sm text-sm text-text outline-none transition-colors hover:bg-hover focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50 data-[open=true]:border-[var(--primary-60)] data-[open=true]:bg-hover"
 			>
-				<span className="text-hint text-xs uppercase tracking-wider">Effort</span>
+				<span className="text-eyebrow text-hint">Effort</span>
 				<span className="capitalize">{level}</span>
 				<ChevronDown className="size-3 shrink-0 text-hint" />
 			</PopoverTrigger>

--- a/apps/web/src/chat/TodoList.tsx
+++ b/apps/web/src/chat/TodoList.tsx
@@ -128,7 +128,7 @@ export function TodoRows({ plan, onRemove }: { plan: TodoPlan; onRemove: (id: st
 				const count = items.length + groups.reduce((n, g) => n + g.todos.length, 0);
 				return (
 					<div key={status} className="mb-sm">
-						<div className="px-xs py-xs text-[10px] text-hint uppercase tracking-wider">
+						<div className="px-xs py-xs text-hint text-xs uppercase tracking-wider">
 							{label} · {count}
 						</div>
 						{items.length > 0 ? (
@@ -169,7 +169,7 @@ function DoneGroup({ group, onRemove }: { group: TodoGroupItem; onRemove: (id: s
 				<span className="min-w-0 flex-1 truncate font-medium text-hint text-sm line-through">
 					{group.title}
 				</span>
-				<span className="shrink-0 text-[10px] text-hint uppercase tracking-wider">
+				<span className="shrink-0 text-hint text-xs uppercase tracking-wider">
 					{group.todos.length} done
 				</span>
 			</button>
@@ -204,7 +204,7 @@ function TodoRow({ todo, onRemove }: { todo: TodoItem; onRemove: () => void }) {
 					{todo.title}
 				</div>
 				{todo.note ? (
-					<div className="truncate font-[var(--font-mono)] text-[10px] text-hint">{todo.note}</div>
+					<div className="truncate font-[var(--font-mono)] text-hint text-xs">{todo.note}</div>
 				) : null}
 			</div>
 			{todo.origin === "user" ? (

--- a/apps/web/src/chat/TodoList.tsx
+++ b/apps/web/src/chat/TodoList.tsx
@@ -128,7 +128,7 @@ export function TodoRows({ plan, onRemove }: { plan: TodoPlan; onRemove: (id: st
 				const count = items.length + groups.reduce((n, g) => n + g.todos.length, 0);
 				return (
 					<div key={status} className="mb-sm">
-						<div className="px-xs py-xs text-hint text-xs uppercase tracking-wider">
+						<div className="px-xs py-xs text-eyebrow text-hint">
 							{label} · {count}
 						</div>
 						{items.length > 0 ? (
@@ -169,9 +169,7 @@ function DoneGroup({ group, onRemove }: { group: TodoGroupItem; onRemove: (id: s
 				<span className="min-w-0 flex-1 truncate font-medium text-hint text-sm line-through">
 					{group.title}
 				</span>
-				<span className="shrink-0 text-hint text-xs uppercase tracking-wider">
-					{group.todos.length} done
-				</span>
+				<span className="shrink-0 text-eyebrow text-hint">{group.todos.length} done</span>
 			</button>
 			{expanded ? (
 				<ul className="ml-md flex flex-col border-border2 border-l pl-sm">
@@ -203,9 +201,7 @@ function TodoRow({ todo, onRemove }: { todo: TodoItem; onRemove: () => void }) {
 				>
 					{todo.title}
 				</div>
-				{todo.note ? (
-					<div className="truncate font-[var(--font-mono)] text-hint text-xs">{todo.note}</div>
-				) : null}
+				{todo.note ? <div className="truncate text-hint text-xs">{todo.note}</div> : null}
 			</div>
 			{todo.origin === "user" ? (
 				<span

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -727,7 +727,7 @@ function OtherOptionRow({
 }
 
 const RECOMMENDED_PILL =
-	"inline-flex items-center rounded-full bg-primary/15 px-xs py-0 font-medium text-[11px] text-primary";
+	"inline-flex items-center rounded-full bg-primary/15 px-xs py-0 font-medium text-primary text-xs";
 
 /**
  * The "Recommended" pill next to an agent-recommended option — a plain label. Its rationale renders

--- a/apps/web/src/chat/tools/visualize/ComparisonCard.tsx
+++ b/apps/web/src/chat/tools/visualize/ComparisonCard.tsx
@@ -30,7 +30,7 @@ export function ComparisonCard({ args }: ToolRenderProps) {
 						<div className="flex items-center gap-xs">
 							<span className="text-sm text-text">{opt.name}</span>
 							{opt.recommended ? (
-								<span className="rounded-[var(--radius-sm)] bg-primary px-1.5 py-0.5 text-[10px] text-on-accent">
+								<span className="rounded-[var(--radius-sm)] bg-primary px-1.5 py-0.5 text-on-accent text-xs">
 									Recommended
 								</span>
 							) : null}

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -51,7 +51,7 @@ function CommandGroup({
 	return (
 		<CommandPrimitive.Group
 			className={cn(
-				"[&_[cmdk-group-heading]]:px-sm [&_[cmdk-group-heading]]:py-xs [&_[cmdk-group-heading]]:text-hint [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider",
+				"[&_[cmdk-group-heading]]:px-sm [&_[cmdk-group-heading]]:py-xs [&_[cmdk-group-heading]]:text-eyebrow [&_[cmdk-group-heading]]:text-hint",
 				className,
 			)}
 			{...props}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -46,7 +46,7 @@ function DropdownMenuLabel({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label>) {
 	return (
 		<DropdownMenuPrimitive.Label
-			className={cn("px-sm py-xs text-xs uppercase tracking-wider text-muted", className)}
+			className={cn("px-sm py-xs text-eyebrow text-muted", className)}
 			{...props}
 		/>
 	);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -107,6 +107,20 @@
 	font-size: var(--font-body);
 }
 
+/*
+ * The eyebrow / section-label role: a small uppercase label above or beside a group (panel labels,
+ * rail group headings, settings sub-groups, menu group headings, plan sections, card tags). Carries
+ * size + weight + tracking + transform — the whole type style — so a call site adds only its colour.
+ * Replaces five near-identical spellings (400/500 × wide/wider × 10px/9px) with one.
+ */
+@utility text-eyebrow {
+	font-size: var(--font-xs);
+	line-height: var(--line-height);
+	font-weight: 400;
+	letter-spacing: var(--tracking-wider);
+	text-transform: uppercase;
+}
+
 /* The canonical ThinkRail brand display style — family/weight/tracking ONLY; each usage sets its own
  * size + line-height (header wordmark: text-lg; welcome hero: text-[44px] leading-tight). */
 @utility text-brand {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -30,13 +30,28 @@
 
 	--font-sans: var(--font);
 
+	/*
+	 * Each tier declares BOTH halves of its type style: the size AND its line-height. Tailwind pairs
+	 * every `--text-*` with a default `--text-*--line-height` (xs 1.333, sm 1.4286, base 1.5, lg 1.5556);
+	 * overriding only the size would leave those defaults governing line-height, i.e. Tailwind
+	 * would own a typography property our design system is supposed to own. Pinning each pair to
+	 * `--line-height` makes the documented global (tokens.css, 1.6) the real value at every tier, and
+	 * keeps every property of a type style declared in one place — the shape a token source (the planned
+	 * typography JSON) can generate. Per-usage exceptions stay where they belong: a `leading-*` utility
+	 * sets `--tw-leading`, which still wins over the pair.
+	 */
 	--text-xs: var(--font-xs);
+	--text-xs--line-height: var(--line-height);
 	--text-sm: var(--font-sm);
+	--text-sm--line-height: var(--line-height);
 	/* Reading tier: chat messages, markdown, page-level supporting copy — never UI controls. Same value
 	   as `text-md` (the heading size) on purpose; the two names carry different semantic roles. */
 	--text-base: var(--font-md);
+	--text-base--line-height: var(--line-height);
 	--text-md: var(--font-md);
+	--text-md--line-height: var(--line-height);
 	--text-lg: var(--font-lg);
+	--text-lg--line-height: var(--line-height);
 
 	--spacing-xs: var(--space-xs);
 	--spacing-sm: var(--space-sm);

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -251,13 +251,13 @@ export function CenterTabs() {
 					data-testid="workspace-ready"
 					className="flex max-w-[440px] flex-col items-center gap-xs"
 				>
-					<span className="font-medium text-hint text-xs uppercase tracking-wider">
+					<span className="text-eyebrow text-hint">
 						{isDefault ? "Default workspace" : "Workspace ready"}
 					</span>
 					<h2 className="max-w-full truncate font-medium text-md text-text">
 						{isDefault ? (contextProject?.name ?? activeWorkspace.name) : activeWorkspace.name}
 					</h2>
-					<p className="flex max-w-full items-center gap-xs font-[var(--font-mono)] text-muted text-xs">
+					<p className="flex max-w-full items-center gap-xs text-muted text-xs">
 						<GitBranch className="size-3.5 shrink-0" />
 						{isDefault ? (
 							<span className="truncate">on {activeWorkspace.branch}</span>

--- a/apps/web/src/panels/DiffPane.tsx
+++ b/apps/web/src/panels/DiffPane.tsx
@@ -83,9 +83,7 @@ export function DiffPane({ tab }: { tab: DiffTab }) {
 				aria-label="Diff view mode"
 				className="flex h-8 shrink-0 items-center gap-xs border-border2 border-b bg-bg-dark px-sm"
 			>
-				<span className="mr-auto truncate font-[var(--font-mono)] text-hint text-xs">
-					{tab.path}
-				</span>
+				<span className="mr-auto truncate text-mono text-hint">{tab.path}</span>
 				{toggles}
 			</div>
 			<div className="min-h-0 flex-1">

--- a/apps/web/src/panels/MarkdownPreview.tsx
+++ b/apps/web/src/panels/MarkdownPreview.tsx
@@ -16,7 +16,9 @@ import { documentComponents, remarkHeadingIds } from "./markdownLinks";
  *    the base font.
  */
 const DOCUMENT_PROSE = [
-	"max-w-none break-words text-[length:var(--font-md)] leading-[1.65] text-pretty text-text",
+	// The reading tier (14px, `--font-md`) rather than the same-valued heading tier: this is a prose
+	// root. The 1.65 leading stays as-is — an untokenised prose line-height (see TYPOGRAPHY-AUDIT.md).
+	"max-w-none break-words text-base leading-[1.65] text-pretty text-text",
 	"[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
 	// Headings — em-relative sizes; fixed margins (bigger top than bottom); h1/h2 get a section rule.
 	"[&_h1]:mt-0 [&_h1]:mb-md [&_h1]:border-border2 [&_h1]:border-b [&_h1]:pb-xs [&_h1]:font-semibold [&_h1]:text-[2em] [&_h1]:leading-tight [&_h1]:text-balance",

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -533,8 +533,8 @@ export function NewWorkspaceDialog({
 						</p>
 					) : (
 						<p className="mt-xs text-hint text-xs">
-							Type <span className="font-[var(--font-mono)]">/</span> for a project skill —
-							previewed from the current checkout; the created workspace's session is authoritative.
+							Type <span className="text-mono">/</span> for a project skill — previewed from the
+							current checkout; the created workspace's session is authoritative.
 						</p>
 					)}
 				</div>
@@ -709,9 +709,9 @@ function BranchPicker({
 				{ref === baseRef ? <Check className="size-3.5 text-primary" /> : null}
 			</span>
 			<GitBranch className="size-3.5 shrink-0 text-hint" />
-			<span className="truncate font-[var(--font-mono)] text-xs">{ref}</span>
+			<span className="truncate text-xs">{ref}</span>
 			{ref === defaultBranch ? (
-				<span className="ml-auto shrink-0 font-[var(--font-mono)] text-hint text-xs">default</span>
+				<span className="ml-auto shrink-0 text-hint text-xs">default</span>
 			) : null}
 		</CommandItem>
 	);
@@ -725,9 +725,7 @@ function BranchPicker({
 			>
 				<GitBranch className="size-3.5 shrink-0 text-muted" />
 				<span className="shrink-0 text-hint text-xs">From</span>
-				<span className="truncate font-[var(--font-mono)] text-muted text-xs">
-					{baseRef || "branch"}
-				</span>
+				<span className="truncate text-muted text-xs">{baseRef || "branch"}</span>
 				<ChevronDown className="size-3 shrink-0 text-hint" />
 			</PopoverTrigger>
 			<PopoverContent align="start" container={container} className="w-[320px] p-0">

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -95,7 +95,7 @@ export function ProjectTree() {
 	return (
 		<nav className="flex flex-col gap-sm">
 			<header className="flex h-7 items-center justify-between pr-xs pl-sm">
-				<span className="text-xs uppercase tracking-wider text-muted">Projects</span>
+				<span className="text-eyebrow text-muted">Projects</span>
 				<AddProjectMenu
 					projects={projects}
 					onOpen={() => void pickAndOpen()}
@@ -271,7 +271,7 @@ function WorkspaceRow({
 					{workspace.branch !== workspace.name && (
 						<span
 							data-testid="workspace-branch"
-							className="truncate font-[var(--font-mono)] text-hint text-xs leading-tight"
+							className="truncate text-hint text-xs leading-tight"
 						>
 							{workspace.branch}
 						</span>

--- a/apps/web/src/panels/ProvidersSettings.tsx
+++ b/apps/web/src/panels/ProvidersSettings.tsx
@@ -251,7 +251,7 @@ export function ProvidersSettings() {
 function Group({ title, children }: { title: string; children: ReactNode }) {
 	return (
 		<section className="flex flex-col gap-sm">
-			<h4 className="text-muted text-xs uppercase tracking-wider">{title}</h4>
+			<h4 className="text-eyebrow text-muted">{title}</h4>
 			<div className="flex flex-col gap-xs">{children}</div>
 		</section>
 	);

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -89,9 +89,7 @@ function TabButton({
 			data-testid={testid}
 			data-active={active}
 			onClick={onClick}
-			className={`text-xs uppercase tracking-wider ${
-				active ? "text-text" : "text-hint hover:text-muted"
-			}`}
+			className={`text-eyebrow ${active ? "text-text" : "text-hint hover:text-muted"}`}
 		>
 			{children}
 		</button>

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -84,7 +84,7 @@ export function SettingsDialog() {
 							>
 								<Icon className="size-4 shrink-0" />
 								{label}
-								<span className="ml-auto rounded-full border border-border2 px-xs py-0.5 text-eyebrow text-hint">
+								<span className="ml-auto rounded-full border border-border2 px-xs py-0.5 text-hint text-xs uppercase tracking-wider">
 									Soon
 								</span>
 							</span>

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -84,7 +84,7 @@ export function SettingsDialog() {
 							>
 								<Icon className="size-4 shrink-0" />
 								{label}
-								<span className="ml-auto rounded-full border border-border2 px-xs py-0.5 text-mono text-hint uppercase">
+								<span className="ml-auto rounded-full border border-border2 px-xs py-0.5 text-eyebrow text-hint">
 									Soon
 								</span>
 							</span>

--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -168,7 +168,7 @@ function SpecNodeRow({
 					<span
 						data-testid="spec-role"
 						className={cn(
-							"max-w-16 shrink-0 truncate text-right text-[9px] uppercase tracking-wider",
+							"max-w-16 shrink-0 truncate text-right text-eyebrow",
 							isMainSpec || isActive ? "text-primary" : "text-hint",
 						)}
 					>

--- a/apps/web/src/panels/TemplatesSettings.tsx
+++ b/apps/web/src/panels/TemplatesSettings.tsx
@@ -288,7 +288,7 @@ function TemplateGroup({
 	return (
 		<section className="flex flex-col gap-sm">
 			<div className="flex items-center justify-between">
-				<h4 className="font-medium text-muted text-xs uppercase tracking-wider">{title}</h4>
+				<h4 className="text-eyebrow text-muted">{title}</h4>
 				<button
 					type="button"
 					data-testid={`template-new-${scope}`}

--- a/apps/web/src/panels/TerminalsPanel.tsx
+++ b/apps/web/src/panels/TerminalsPanel.tsx
@@ -35,7 +35,7 @@ export function TerminalsPanel() {
 	return (
 		<div data-testid="terminal-panel" className="flex h-full min-h-0 flex-col">
 			<div className="flex h-7 shrink-0 items-center gap-xs border-b border-border2 pr-xs pl-sm">
-				<span className="shrink-0 text-xs uppercase tracking-wider text-muted">Terminal</span>
+				<span className="shrink-0 text-eyebrow text-muted">Terminal</span>
 				<div className="flex min-w-0 flex-1 items-center gap-px overflow-x-auto">
 					{tabs.map((tab) => (
 						<TerminalTabButton

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -243,7 +243,7 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			)}
 		>
 			{tag ? (
-				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 font-[var(--font-mono)] text-[10px] text-primary uppercase tracking-wide">
+				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 font-[var(--font-mono)] text-primary text-xs uppercase tracking-wide">
 					{tag}
 				</span>
 			) : null}

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -243,7 +243,7 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			)}
 		>
 			{tag ? (
-				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 text-eyebrow text-primary">
+				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 text-primary text-xs uppercase tracking-wider">
 					{tag}
 				</span>
 			) : null}

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -243,7 +243,7 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			)}
 		>
 			{tag ? (
-				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 font-[var(--font-mono)] text-primary text-xs uppercase tracking-wide">
+				<span className="absolute top-md right-md rounded-full border border-[var(--primary-40)] bg-[var(--primary-10)] px-sm py-0.5 text-eyebrow text-primary">
 					{tag}
 				</span>
 			) : null}

--- a/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
+++ b/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
@@ -55,7 +55,7 @@ Where they disagree, this file names the drift; it does not silently "fix" eithe
   3. Third-party text rendered by Monaco, xterm, mermaid and shiki is configured in JS, not classes;
      it is inventoried separately in §2.9.
 
-**Headline count (after §11):** **32** distinct typographic styles (family × size × weight ×
+**Headline count (after §11):** **33** distinct typographic styles (family × size × weight ×
 line-height × tracking × transform × style, ignoring colour) across 72 of the 159 `.ts(x)` files,
 expressed through 5 size utilities + 4 named role utilities (`text-mono`, `text-base-mono`,
 `text-eyebrow`, `text-brand`) + **14 hardcoded values, all documented exceptions** (hero 44px, OTP
@@ -680,10 +680,10 @@ screenshot/measurement probes above (temporary specs, not committed).
 ## 11. Consolidation pass — the minimal semantic set
 
 Driven by four decisions (recorded in `.thinkrail/context/TASK-typography-consolidation.md`). Net
-effect: **43 → 32** distinct typographic styles, **16 → 14** hardcoded values (all now documented
+effect: **43 → 33** distinct typographic styles, **16 → 14** hardcoded values (all now documented
 exceptions), zero ad-hoc mono outside the exceptions.
 
-### 11.1 One named eyebrow role — 5 variants → 1 (18 usages)
+### 11.1 One named eyebrow role — 5 variants → 1 (16 usages)
 
 `@utility text-eyebrow` = `--font-xs` (10px) / 400 / `tracking-wider` / `uppercase` / `--line-height`.
 Colour stays at the call site. It replaces:
@@ -695,12 +695,16 @@ Colour stays at the call site. It replaces:
 | `text-xs uppercase tracking-wide` | 2 | tracking 0.025em → 0.05em |
 | `text-xs font-medium uppercase tracking-wide` | 2 | 500 → 400 + tracking |
 | `text-[9px] uppercase tracking-wider` | 1 | 9px → 10px |
-| `font-[var(--font-mono)] text-xs uppercase tracking-wide` (Welcome tag) | 1 | mono → proportional + tracking |
-| `text-mono uppercase` ("Soon" pill) | 1 | mono 11px → proportional 10px |
 
 Adopted in: `RightPanel`, `ProjectTree`, `TerminalsPanel`, `SpecsPanel`, `ProvidersSettings`,
-`TemplatesSettings`, `CenterTabs`, `SettingsDialog`, `WelcomePanel`, `SkillsDialog` ×2,
-`HistoryOverlay` ×2, `TodoList` ×2, `ThinkingSelector`, `ui/command`, `ui/dropdown-menu`.
+`TemplatesSettings`, `CenterTabs`, `SkillsDialog` ×2, `HistoryOverlay` ×2, `TodoList` ×2,
+`ThinkingSelector`, `ui/command`, `ui/dropdown-menu`.
+
+**The role is reserved for eyebrow/section-label content.** Two pills that share the same *appearance*
+— the "Soon" pill (`SettingsDialog`) and the Welcome card tag — deliberately spell their own
+`text-xs uppercase tracking-wider` instead: reusing the primitives is fine, borrowing a semantic role
+to shrink the style count is not. That is the one style the consolidation leaves on the table (33, not
+32), by decision.
 
 ### 11.2 Mono is code-only again — identity text is proportional
 
@@ -714,8 +718,8 @@ inline code, shell commands, slash syntax, keycaps. Everything else proportional
 | `CenterTabs:260` workspace-ready branch line | mono 10px | `text-xs` |
 | `SkillsDialog:394` skill name | mono 12px | `text-sm` |
 | `TodoList:207` todo note | mono 10px | `text-xs` |
-| `WelcomePanel:246` card tag | mono 10px uppercase | `text-eyebrow` |
-| `SettingsDialog:87` "Soon" pill | `text-mono` uppercase | `text-eyebrow` |
+| `WelcomePanel:246` card tag | mono 10px uppercase | `text-xs uppercase tracking-wider` (proportional label pill) |
+| `SettingsDialog:87` "Soon" pill | `text-mono` uppercase (11px) | `text-xs uppercase tracking-wider` (proportional label pill) |
 | `NewWorkspaceDialog:536` the `/` syntax glyph | ad-hoc mono, inherited size | `text-mono` (11px) |
 | `DiffPane:86` diff header path | ad-hoc mono 10px | `text-mono` (11px) |
 
@@ -731,6 +735,10 @@ gains 1px of text — no padding compensation was needed (a whole-DOM clipping p
 clipped elements, and no pill sits in a row that requires matching heights).
 
 ### 11.4 Unchanged by design
+
+The diff header's path stays `text-mono` — confirmed as technical content (it labels code and sits
+above a monospaced diff), not metadata.
+
 
 Hero `text-[44px]` + `text-brand`; the OTP code; the markdown skins (`Markdown` fenced `0.85em`,
 `MarkdownPreview`'s em heading scale + `leading-[1.65]`); `text-base` ≡ `text-md` (two roles, one

--- a/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
+++ b/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
@@ -1,0 +1,595 @@
+---
+id: web-typography-audit
+type: submodule-design
+status: active
+title: Typography audit — every text style in apps/web, as implemented
+parent: module-web
+references:
+  - web-typography
+tags:
+  - audit
+  - typography
+---
+
+# Typography audit (as-implemented)
+
+An **audit only** — a full inventory of every text style `apps/web` actually renders, the hardcoded
+values that survive outside the token system and why, and where the system duplicates itself or loses
+hierarchy. **Nothing here changes code, tokens, or branding.** No recommendation in §8 has been
+applied.
+
+Companion documents:
+
+- `TYPOGRAPHY.md` — the *intended* system (scale, weight policy, mono policy). Normative.
+- **This file** — the *observed* system, and every place the two disagree. Descriptive.
+
+Where they disagree, this file names the drift; it does not silently "fix" `TYPOGRAPHY.md`.
+
+## 0. Scope & method
+
+- **Tree audited:** branch `design/typography` @ `bf0ab47` — i.e. **after** the typography sweep of
+  PR #137 and after `main` (`71fcc91`) was merged in. So the findings below are what ships *if #137
+  lands as-is*, not the older `main` state.
+- **Surface:** `apps/web/src` only (frontend). `apps/website` is a separate app with its own type
+  system and is referenced once, in §4, where its brand-font fallback differs from the app's.
+- **Method:** static extraction of every class/style token from every string literal in `**/*.ts(x)`
+  plus the CSS layer (`styles/tokens.css`, `index.css`, `styles/global.css`), then grouping by the
+  distinct *combination* of family + size + weight + tracking + leading + transform + colour.
+  Provenance ("why does this still exist") comes from `git log -L` on each site and from the sweep's
+  own file list (`git diff bb503d0..a9e0a58` — 36 paths under `apps/web/src`, of which 31 are
+  component/TS files and 5 are the CSS/spec layer).
+- **Reproduce:** the two throwaway scripts used are reproduced in Appendix A — the numbers in this
+  document are counted, not estimated.
+- **Known method limits (read before trusting a count):**
+  1. Grouping is per *string literal*. A `className` assembled from several literals (`cn(a, b)`,
+     ternaries) is counted as several partial combos, so a few rows below carry two colour tokens
+     (`text-muted text-text` = the active/inactive pair) or two weights. Such rows are marked
+     *conditional*.
+  2. Styles inherited rather than declared (a `text-xs` container styling its children) are counted
+     at the declaration site, not at each visual occurrence. The real number of *visually distinct*
+     text renderings is therefore higher than 78.
+  3. Third-party text rendered by Monaco, xterm, mermaid and shiki is configured in JS, not classes;
+     it is inventoried separately in §2.9.
+
+**Headline count:** 78 distinct declared typography combinations across 72 of the 159 `.ts(x)` files,
+expressed through 5 size utilities + 3 composite utilities + **12 distinct hardcoded size expressions
+at 25 sites**.
+
+## 1. The token layer
+
+### 1.1 Size tokens (`styles/tokens.css` → `:root`)
+
+| Token | Value | Mapped to a utility? | Used? |
+|---|---|---|---|
+| `--font-xs` | 10px | `text-xs` | ✅ 150 uses |
+| `--font-sm` | 12px | `text-sm` | ✅ 97 uses |
+| `--font-body` | 13px | only inside `text-base-mono` | ⚠️ 1 indirect use |
+| `--font-md` | 14px | `text-base` **and** `text-md` | ✅ 3 + 9 uses |
+| `--font-mono-size` | 11px | inside `text-mono`; read by Monaco + xterm | ✅ |
+| `--font-lg` | 18px | `text-lg` | ✅ 2 uses |
+| `--font-lg2` | 20px | — | ❌ **dead** |
+| `--font-xl` | 25px | — | ❌ **dead** |
+| `--font-xxl` | 40px | — | ❌ **dead** |
+| `--font-base` | 13px (re-written to 13px at runtime by `utils/fontScale.ts`) | — | ⚠️ spacing only (`--space-*` derive from it) + `global.css` body |
+| `--compact-font-base` | 9px (written at runtime, never read) | — | ❌ **dead write** |
+| `--uppercase-size` | 13px | — | ❌ **dead** |
+| `--uppercase-weight` | 500 | — | ❌ **dead** |
+| `--uppercase-spacing` | 0.5px | — | ❌ **dead** |
+| `--line-height` | 1.6 | `global.css` body; read by Monaco | ✅ |
+
+Seven of fifteen size-ish tokens are dead. `TYPOGRAPHY.md` already declares four of them
+("kept untouched deliberately"); `--compact-font-base`, `--uppercase-*` are undeclared dead weight,
+and `--compact-font-base` is actively *written* on every boot by `applyFontScale()` for no reader.
+
+`utils/fontScale.ts` is a parameterised scale (`applyFontScale(base = 13, compactBase = 9)`) with
+exactly one call site (`main.tsx`, no arguments) and no UI — so the app has a font-scale mechanism
+that cannot currently be scaled.
+
+### 1.2 Family tokens
+
+| Token | Declared stack | Intended role |
+|---|---|---|
+| `--font` | `"Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif` | the only proportional face |
+| `--font-mono` | `"JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code", monospace` | technical text |
+| `--font-accent` | `"Cabinet Grotesk", sans-serif` | brand display only |
+
+See §4 — one of these three is never loaded.
+
+### 1.3 The utility layer (`index.css`)
+
+Mapped into Tailwind (`@theme inline`): `text-xs` `text-sm` `text-base` `text-md` `text-lg`,
+`--font-sans → --font`.
+Hand-written (`@utility`): `text-mono` (mono @ 11px), `text-base-mono` (mono @ 13px),
+`text-brand` (accent family + weight 800 + 0.5px tracking, **no size**).
+
+Deliberate collision: `text-base` and `text-md` are the **same 14px value** under two names
+(reading tier vs heading tier). Nothing enforces the distinction — see §6.1.
+
+## 2. Style inventory — every distinct combination
+
+Sizes resolve as: `text-xs` 10px · `text-sm` 12px · `text-base`/`text-md` 14px · `text-lg` 18px ·
+`text-mono` 11px mono · `text-base-mono` 13px mono. Weight is 400 unless stated (`font-medium` 500,
+`font-semibold` 600, `text-brand` 800). Line-height is the global 1.6 unless stated. Tracking is 0
+unless stated. Counts are declaration sites.
+
+The 78 machine-distinct combinations are presented below as **60 numbered rows**: a row folds pure
+colour variants of one identical style (e.g. `text-xs` at `text-red`/`text-green`/`text-gold`) and the
+*conditional* rows where one literal carries an active/inactive colour pair. Nothing is dropped — the
+folded variants are named inside their row, and §9 requires the showcase to render all 78.
+
+### 2.1 Display / brand
+
+| # | Style | Family | Size | Weight | LH | Tracking | Transform | Colour | Sites |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | `text-brand text-[44px] leading-tight text-primary` | accent | **44px (hardcoded)** | 800 | tight | 0.5px | — | `--primary` | `panels/WelcomePanel.tsx:144` (hero) |
+| 2 | `text-brand text-lg text-primary` | accent | 18px | 800 | 1.6 | 0.5px | — | `--primary` | `shell/Shell.tsx:54` (wordmark) |
+
+Only two brand usages exist, both via `text-brand` — the one place the system is fully consolidated.
+
+### 2.2 Titles (dialog / card / section / screen)
+
+| # | Style | Size | Weight | Notes | Sites |
+|---|---|---|---|---|---|
+| 3 | `text-md font-semibold leading-none text-text` | 14px | 600 | the canonical dialog title | `components/ui/dialog.tsx:66` (every dialog) |
+| 4 | `text-md font-semibold text-text` | 14px | 600 | dialog-title analog inside a chat card | `chat/tools/AskUserQuestionCard.tsx:542,803` |
+| 5 | `text-md font-medium text-text` | 14px | 500 | in-page settings/section heading | `panels/{PrivacySettings:24,GithubSettings:43,ProvidersSettings:111,AppearanceSettings:29,TemplatesSettings:221}`, `panels/CenterTabs.tsx:257` |
+| 6 | `text-sm font-medium text-text` | 12px | 500 | compact title | `panels/ConfirmPopover:63`, `panels/WelcomePanel:259` (**card title**), `panels/TemplatesSettings:379`, `panels/PrivacySettings:33`, `panels/ProvidersSettings:157`, `chat/TemplateEditorDialog:197`, `chat/tools/visualize/{DiagramCard:19,ComparisonCard:20}`, `components/ErrorBoundary:85` |
+| 7 | `text-sm font-medium` (colour from context) | 12px | 500 | toast title | `components/ui/toast.tsx:50` |
+| 8 | `font-medium text-text` (size inherited) | — | 500 | inline emphasis / label | `chat/TemplateEditorDialog:295`, `panels/{PrivacySettings:62,68, useOpenProject:98, ProjectTree:311, MarkdownPreview(strong)}` |
+
+`CenterTabs:257` (#5) is the *workspace screen heading* — 14px/500, where `TYPOGRAPHY.md` specifies
+"entity screen heading = `text-md` **400**". `WelcomePanel:259` (#6) is the *welcome card title* —
+12px/500, where `TYPOGRAPHY.md` specifies "card title = **dialog title** = 14px/600". Both are
+spec-vs-code drift, not judgement calls (see §6.2).
+
+### 2.3 Body / reading
+
+| # | Style | Size | Notes | Sites |
+|---|---|---|---|---|
+| 9 | `text-base text-text` | 14px | the reading tier | `chat/turns.tsx:61,103` (chat messages), `panels/ProviderWarningBanner.tsx:42` |
+| 10 | `text-[length:var(--font-md)] leading-[1.65] text-pretty text-text` | 14px | markdown-preview prose root — **token via arbitrary value**, and **1.65 ≠ the global 1.6** | `panels/MarkdownPreview.tsx:19` |
+| 11 | `text-sm` (bare, colour inherited) | 12px | the default UI text | 23 sites across 18 files |
+| 12 | `text-sm text-text` | 12px | UI text, explicit colour | 31 sites across 20 files |
+| 13 | `text-sm text-muted` | 12px | secondary UI text | 9 sites (incl. `ui/dialog.tsx:76` DialogDescription, `ui/toast.tsx:59`) |
+| 14 | `text-sm text-hint` | 12px | tertiary UI text / empty states | 10 sites |
+| 15 | `text-sm leading-tight` | 12px | rail row (2-line) | `panels/ProjectTree.tsx:267` |
+| 16 | `text-sm text-red` / `text-sm text-green` | 12px | inline error / success | `chat/turns:170`, `chat/HistoryOverlay:485`, `auth/LoginDialog:93,88` |
+| 17 | `text-sm capitalize text-text` | 12px | thinking-level value | `chat/ThinkingSelector.tsx:50` |
+| 18 | `text-sm font-medium text-hint` | 12px/500 | todo-plan section | `chat/TodoList.tsx:169` |
+
+The **composer textarea is `text-sm` (12px)** (`chat/Composer.tsx:786`) while the messages it produces
+render at `text-base` (14px) — you type two pixels smaller than you read (§6.3).
+
+### 2.4 Caption / metadata / helper
+
+| # | Style | Size | Notes | Sites |
+|---|---|---|---|---|
+| 19 | `text-xs text-hint` | 10px | **the single most-used style in the app** | 56 sites across 26 files |
+| 20 | `text-xs text-muted` | 10px | secondary metadata | 25 sites across 15 files |
+| 21 | `text-xs` (bare) | 10px | inherited colour | 15 sites |
+| 22 | `text-xs text-text` | 10px | high-contrast metadata + **tooltip body** | `ui/tooltip.tsx:19`, `chat/Composer:655`, `chat/tools/AskUserQuestionCard:573`, `chat/tools/visualize/ComparisonCard:42,52` |
+| 23 | `text-xs italic text-hint` | 10px | "no output"/empty placeholders in tool cards | 8 sites (7 files) |
+| 24 | `text-xs text-red` / `text-green` / `text-gold` / `text-primary` | 10px | status-coloured metadata | 9 / 2 / 1 / 1 sites |
+| 25 | `text-xs leading-snug text-muted` | 10px | card subtitle | `panels/{NewWorkspaceDialog:499, WelcomePanel:260}` |
+| 26 | `text-[10px] text-hint` | **10px hardcoded** | identical to #19 | `chat/HistoryOverlay.tsx:139,151,173` |
+| 27 | `text-[11px] text-hint` / `text-[11px] text-muted` | **11px hardcoded, proportional** | no token exists at 11px proportional | `chat/HistoryOverlay.tsx:284,493,572` |
+| 28 | `text-xs text-muted text-text` *(conditional)* | 10px | active/inactive pair | `chat/SkillsButton:32`, `chat/ChatView`, `panels/TemplatesSettings` |
+
+### 2.5 Eyebrows / section labels (uppercase) — **9 variants**
+
+| # | Style | Size | Weight | Tracking | Colour | Sites |
+|---|---|---|---|---|---|---|
+| 29 | `text-xs uppercase tracking-wider text-muted` | 10px | 400 | wider | muted | `panels/{ProvidersSettings:254,TerminalsPanel:38,ProjectTree:98}`, `ui/dropdown-menu.tsx:49` |
+| 30 | `text-xs uppercase tracking-wider text-hint` | 10px | 400 | wider | hint | `chat/ThinkingSelector.tsx:34` |
+| 31 | `text-xs uppercase tracking-wider` (bare) | 10px | 400 | wider | inherited | `panels/RightPanel.tsx:92` |
+| 32 | `text-xs font-medium uppercase tracking-wider text-hint` | 10px | **500** | wider | hint | `panels/CenterTabs.tsx:254` |
+| 33 | `text-xs font-medium uppercase tracking-wider text-muted` | 10px | **500** | wider | muted | `panels/TemplatesSettings.tsx:291` |
+| 34 | `text-xs uppercase tracking-wide text-hint` | 10px | 400 | **wide** | hint | `chat/HistoryOverlay.tsx:502,525` |
+| 35 | `text-xs font-medium uppercase tracking-wide text-text` | 10px | **500** | **wide** | text | `chat/SkillsDialog.tsx:197,313` |
+| 36 | `text-[10px] uppercase tracking-wider text-hint` | **10px hardcoded** | 400 | wider | hint | `chat/TodoList.tsx:131,172` |
+| 37 | `text-[9px] uppercase tracking-wider` | **9px hardcoded** | 400 | wider | inherited | `panels/SpecsPanel.tsx:171` |
+
+Nine ways to render the same semantic thing ("a small uppercase group label"), differing only in
+weight (400/500), tracking (`wide`/`wider`), colour (hint/muted/text/inherited) and size
+(10px token / 10px literal / 9px literal). `--uppercase-size/-weight/-spacing` — tokens that exist
+precisely for this role — are used by none of them.
+
+### 2.6 Buttons / controls
+
+| # | Style | Size | Weight | Sites |
+|---|---|---|---|---|
+| 38 | `font-medium` + `text-sm` (`h-8 px-md` / `h-7 px-sm`) | 12px | 500 | `components/ui/button.tsx:6,16,17` — the shared primitive (15 importers) |
+| 39 | `text-sm font-medium text-on-accent` (hand-rolled primary button) | 12px | 500 | `chat/tools/AskUserQuestionCard.tsx:348,358`, `panels/NewWorkspaceDialog.tsx:566` |
+| 40 | `font-medium text-primary` (link-ish action) | inherited | 500 | `chat/tools/AskUserQuestionCard:659`, `panels/NewWorkspaceDialog:612` |
+| 41 | `text-sm` nav item (settings sidebar) | 12px | 400 | `panels/SettingsDialog.tsx:69` |
+| 42 | `text-sm` command/menu item | 12px | 400 | `ui/command.tsx:25,66`, `ui/dropdown-menu.tsx:35` |
+
+Three call sites (#39) re-declare the shared Button's exact type treatment instead of using `Button`.
+
+### 2.7 Inputs
+
+| # | Style | Size | Sites |
+|---|---|---|---|
+| 43 | `text-sm` textarea | 12px | `ui/textarea.tsx:9`, `chat/Composer.tsx:786` (+ its mirror div, `:693`) |
+| 44 | `text-sm text-text placeholder:text-hint` `<input>` | 12px | `chat/tools/AskUserQuestionCard:723`, `chat/ExtUiDialog:60`, `chat/HistoryOverlay:559`, `chat/TodoList:81`, `auth/LoginDialog:164`, `chat/TemplateEditorDialog:184,222,235` (via a local `INPUT_CLASS` constant) |
+
+Placeholders are uniformly `placeholder:text-hint` (9 sites) and inherit the field's size.
+
+Inputs are the *most* consistent surface in the app — every one is `text-sm text-text` with a
+`text-hint` placeholder. But there is **no `Input` primitive** in `components/ui/` (unlike `textarea`),
+so that agreement is 5 copies of a literal plus one file-local `INPUT_CLASS` constant, held by
+coincidence rather than by a shared component. There is also no `input` role in the scale — inputs are
+just "default UI text", which is why the composer/message mismatch in §6.3 exists.
+
+### 2.8 Badges / pills / keycaps — **5 variants**
+
+| # | Style | Family | Size | Sites |
+|---|---|---|---|---|
+| 45 | `text-mono uppercase` | mono | 11px | `panels/SettingsDialog.tsx:87` ("Soon") |
+| 46 | `font-[var(--font-mono)] text-[10px] uppercase tracking-wide text-primary` | mono | **10px hardcoded** | `panels/WelcomePanel.tsx:246` (card tag, e.g. "spec-first") |
+| 47 | `text-[10px] text-on-accent` | **proportional** | **10px hardcoded** | `chat/tools/visualize/ComparisonCard.tsx:33` ("Recommended") |
+| 48 | `text-[11px] font-medium text-primary` | proportional | **11px hardcoded** | `chat/tools/AskUserQuestionCard.tsx:730` (pill) |
+| 49 | `text-xs` diff-stat badge | proportional | 10px | `panels/DiffStatBadge.tsx:17` |
+| 50 | `text-mono` keycap (`↵`) | mono | 11px | `panels/NewWorkspaceDialog.tsx:569` |
+| 51 | `text-[10px] text-hint` shortcut hint | proportional | **10px hardcoded** | `chat/HistoryOverlay.tsx:151,173` |
+
+Same UI object (a small pill), five typographic treatments across mono/proportional and 10/11px.
+
+### 2.9 Code / terminal / third-party surfaces
+
+| # | Surface | Configuration | Resolves to |
+|---|---|---|---|
+| 52 | `text-mono` (tool output, code blocks, diffs) | `index.css` utility | JetBrains Mono 11px |
+| 53 | `text-mono text-text` / `text-muted` / `text-hint` | same + colour | 11px mono |
+| 54 | `text-mono leading-relaxed` | `chat/tools/{BashCard:13,EditCard:34}` | 11px mono, 1.625 |
+| 55 | `text-base-mono` | `chat/Markdown.tsx:62` (inline code in prose) | 13px mono |
+| 56 | `font-[var(--font-mono)] text-[0.85em]` | `chat/Markdown.tsx:68,95` (fenced blocks) | ~11.9px mono, **em-relative** |
+| 57 | Monaco (all editors **and** diff panes) | `panels/monacoSetup.ts:76-86` — `fontSize` ← `--font-mono-size`, `fontFamily` ← `--font-mono`, `lineHeight` ← `--line-height` | 11px mono, 1.6 |
+| 58 | xterm terminal | `panels/TerminalInstance.tsx:97-98` — same two tokens | 11px mono |
+| 59 | mermaid diagrams | `chat/tools/visualize/mermaid.ts:39` — `fontFamily` ← `--font-mono`, **no size** | mono at mermaid's default size |
+| 60 | shiki-highlighted code | inherits `text-mono` from its container | 11px mono |
+
+Monaco and xterm are the only third-party surfaces reading the token layer for *both* family and
+size; mermaid takes family only, so diagram label size is outside the system entirely.
+
+### 2.10 Mono outside the mono utilities — **6 different mono sizes**
+
+`font-[var(--font-mono)]` appears 13 times, bypassing `text-mono`/`text-base-mono`:
+
+| Site | Effective size | Sanctioned by `TYPOGRAPHY.md`? |
+|---|---|---|
+| `auth/LoginDialog.tsx:132` (OTP, `text-lg tracking-widest`) | 18px | ✅ explicit exception |
+| `chat/Markdown.tsx:68,95` (fenced code, `text-[0.85em]`) | em-relative | ✅ explicit exception |
+| `panels/ProjectTree.tsx:274` (rail branch sub-line, `text-xs`) | 12px | ✅ named survivor |
+| `panels/NewWorkspaceDialog.tsx:712,714,728` (branch-picker refs, `text-xs`) | 12px | ✅ named survivor |
+| `panels/NewWorkspaceDialog.tsx:536` (the literal `/` in a caption) | 10px (inherits `text-xs`) | ⚠️ undocumented |
+| `panels/CenterTabs.tsx:260` (workspace-ready branch line, `text-xs`) | 12px | ❌ undocumented |
+| `panels/DiffPane.tsx:86` (diff header path, `text-xs`) | 12px | ❌ undocumented |
+| `chat/SkillsDialog.tsx:394` (skill name, `text-sm`) | 12px | ❌ undocumented — and it's an *identity* name, which the mono policy forbids |
+| `chat/TodoList.tsx:207` (todo note, `text-[10px]`) | 10px | ❌ undocumented |
+| `panels/WelcomePanel.tsx:246` (card tag, `text-[10px]`) | 10px | ❌ undocumented |
+
+Counting the utilities, mono renders at **10, 11, 12, 13, 18px and `0.85em`** — six sizes for a
+two-tier policy.
+
+## 3. Remaining hardcoded typography — and why it survives
+
+25 sites carry a hardcoded size (12 distinct values). Grouped by *why*, since the reason determines
+whether it is technical debt or a deliberate exception.
+
+| Value | Sites | Verdict (below) |
+|---|---|---|
+| `text-[10px]` | 8 | drift — token exists (§3.2) |
+| `text-[11px]` | 4 | scale gap (§3.3) |
+| `text-[0.85em]` | 4 | sanctioned / prose (§3.1, §3.4) |
+| `text-[9px]` | 1 | unmapped token (§3.3) |
+| `text-[44px]` | 1 | sanctioned (§3.1) |
+| `text-[2em]` `[1.5em]` `[1.25em]` `[1em]` `[0.875em]` `[0.9em]` | 6 | prose scale (§3.4) |
+| `text-[length:var(--font-md)]` | 1 | duplicate spelling (§3.4) |
+
+### 3.1 Sanctioned by the spec (leave alone)
+
+| Value | Site | Why it exists |
+|---|---|---|
+| `text-[44px]` | `WelcomePanel:144` hero | `text-brand` deliberately carries **no size** — every brand usage sets its own. `TYPOGRAPHY.md` documents this exact value. |
+| `text-[0.85em]` ×3 | `Markdown.tsx:68,95,102` fenced code | Document content must scale *with the prose*, so it is em-relative by design (user-confirmed in `TYPOGRAPHY.md`). |
+
+### 3.2 A token exists with the identical value — pure drift (5 sites)
+
+| Value | Site | Identical token |
+|---|---|---|
+| `text-[10px]` | `HistoryOverlay:139,151,173` | `text-xs` (`--font-xs` = 10px) |
+| `text-[10px]` | `TodoList:131,172,207` | `text-xs` |
+| `text-[10px]` | `ComparisonCard:33` | `text-xs` |
+| `text-[10px]` | `WelcomePanel:246` | `text-xs` |
+
+**Why they survive:** provenance explains it exactly. `HistoryOverlay` (Ctrl+R history search, #109,
+2026‑07‑26), `TodoList` (chat TODO plans, 2026‑07‑21), `SkillsDialog`/`SkillsButton`/
+`ProjectSkillsNotice` (skills manager, #94, 2026‑07‑24), `TemplatesSettings`/`TemplateEditorDialog`
+(prompt templates, #110, 2026‑07‑26), `PrivacySettings` (analytics, 2026‑07‑26) and `DiffPane`
+(2026‑07‑22) all landed on `main` **in parallel with** the typography sweep (2026‑07‑27, branch cut
+from `bb503d0`). The sweep touched **31 component files**; none of those surfaces was among
+them, and merging `main` into the branch resolved *text* conflicts, not *policy*. `ComparisonCard` and `WelcomePanel` *were*
+swept — but the sweep's scope was weights, mono and tiers, explicitly **not** arbitrary px sizes, so
+their literals passed through untouched.
+
+### 3.3 No token exists for the value (4 sites)
+
+| Value | Site | Gap |
+|---|---|---|
+| `text-[11px]` ×3 | `HistoryOverlay:284,493,572` | 11px **proportional** has no token. `--font-mono-size` is 11px but is the *mono* tier, and `text-mono` would change the family too. The proportional scale jumps 10 → 12. |
+| `text-[11px]` | `AskUserQuestionCard:730` | same gap, in a pill |
+| `text-[9px]` | `SpecsPanel:171` | 9px exists as `--compact-font-base` — but it is written by JS and **never mapped to a utility**, so there was nothing to reference. |
+
+### 3.4 Deliberately relative (markdown prose skins)
+
+`MarkdownPreview.tsx:22-42` implements a full em-relative heading scale — `text-[2em]`, `[1.5em]`,
+`[1.25em]`, `[1em]`, `[0.875em]`, `[0.85em]`, plus `text-[0.9em]` for tables — all at
+`font-semibold`, on a root of `text-[length:var(--font-md)] leading-[1.65]`.
+
+**Why:** rendered documents need an internally-proportional scale that tracks the prose root, which
+a fixed-px token scale cannot express. This is legitimate — but it is **entirely undocumented**:
+`TYPOGRAPHY.md` sanctions em-relative sizing only for *fenced code*, and says markdown headings are
+"600" without mentioning that their sizes live outside the scale. Two sub-findings:
+
+- `text-[length:var(--font-md)]` reaches for the token through an arbitrary value where `text-base`
+  is the same 14px — the file predates the `text-base` mapping (added 2026‑07‑10 vs the sweep).
+- `leading-[1.65]` silently disagrees with the global `--line-height: 1.6`, and there is no
+  `--line-height-prose` token to hold the intended difference.
+
+### 3.5 Non-size hardcoding
+
+- **Tracking:** `tracking-wider` (12), `tracking-wide` (5), `tracking-widest` (1) are Tailwind
+  defaults (0.025em / 0.05em / 0.1em) — none flow from `--uppercase-spacing: 0.5px`, the token meant
+  for exactly this.
+- **Line-height:** `leading-tight` (6), `leading-snug` (3), `leading-relaxed` (2), `leading-none` (1),
+  `leading-normal` (1), `leading-[1.65]` (1) — six treatments, all Tailwind constants; only the
+  global 1.6 is tokenised.
+- **Weights:** `font-medium` (36) and `font-semibold` (13) are the only weights in component code —
+  consistent with the 400/500/600 policy. `text-brand`'s 800 is the only weight inside a utility.
+  No `font-bold`/`font-extrabold` survives in components (the sweep's one real consolidation).
+
+## 4. Font-family audit
+
+### 4.1 What is actually loaded
+
+`apps/web/index.html` loads exactly one stylesheet:
+
+```
+fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700
+                          &family=JetBrains+Mono:wght@400;500;600;700&display=swap
+```
+
+There is **no `@font-face` rule and no self-hosted font file anywhere in the repo.**
+
+| Family | Declared in | Loaded? | What actually renders |
+|---|---|---|---|
+| **Geist** | `--font` | ✅ Google Fonts, weights 400/500/600/700 | Geist at 400/500/600 (the app uses only these three) |
+| **JetBrains Mono** | `--font-mono` | ✅ Google Fonts, 400/500/600/700 | JetBrains Mono 400 (the app never sets a mono weight) |
+| **Cabinet Grotesk** | `--font-accent` | ❌ **never loaded** (it is a Fontshare font, absent from the Google Fonts request and from every `@font-face`) | falls through to the stack's next entry: **generic `sans-serif`** |
+
+### 4.2 Findings
+
+1. **The brand face never renders.** `text-brand` (wordmark + hero) resolves to the browser's default
+   `sans-serif` — Helvetica/Arial on macOS, Arial on Windows — at a **synthesised** 800 weight, since
+   the fallback stack ends at `sans-serif` rather than falling back to Geist. `TYPOGRAPHY.md`
+   acknowledges this ("known unloaded fallback, left as-is"), so it is a known, unfixed gap, not a
+   surprise — but it means the two most brand-critical strings in the product are the two least
+   controlled typographically.
+2. **The app and the website disagree on the fallback.** `apps/website/src/styles.css:12` declares
+   `--font-display: "Cabinet Grotesk", var(--font-sans)` — i.e. the site degrades to **Geist**, the
+   app degrades to **generic sans-serif**. Same brand, two different rendered wordmarks.
+3. **Weight 800 is not in the loaded set** even for Geist (400;500;600;700 requested), so any accent
+   fallback is synthetically emboldened.
+4. **Geist 700 is loaded but never used** — the app's heaviest real weight is 600.
+5. **A local-first app fetches its fonts from a CDN.** ThinkRail runs on localhost (and ships as a
+   single binary); with no network, *all three* families fall back to system fonts, so the entire
+   type system silently degrades offline. `display=swap` also means a FOUT on every cold load. This
+   is additionally a third-party request on every app boot, which sits oddly beside the app's own
+   Privacy settings panel.
+6. **No unexpected families otherwise.** Every text surface resolves to one of the three declared
+   stacks; mermaid uses `--font-mono` (§2.9), Monaco/xterm use `--font-mono`, and no component
+   declares a raw family string.
+
+## 5. Duplicate styles (visually identical, separately implemented)
+
+| # | Duplicate | Occurrences | Note |
+|---|---|---|---|
+| D1 | `text-[10px]` ≡ `text-xs` | 8 literal sites vs 150 token sites | Byte-identical rendering; §3.2 |
+| D2 | `text-base` ≡ `text-md` (both 14px) | 3 vs 9 | Deliberate two-name split, unenforced |
+| D3 | `text-[length:var(--font-md)]` ≡ `text-base` | 1 | Same token, longer spelling |
+| D4 | Dialog title vs ask-question title (`text-md font-semibold text-text` ± `leading-none`) | 1 + 2 | Same style, one via the `DialogTitle` primitive, one hand-rolled |
+| D5 | Shared `Button` type treatment vs 3 hand-rolled primary buttons | 1 vs 3 | `text-sm font-medium` + `bg-primary text-on-accent` re-declared |
+| D6 | Eyebrow, 9 near-identical variants | 15 sites | §2.5 — differ only in weight/tracking/colour/size |
+| D7 | Badge/pill, 5 treatments | 7 sites | §2.8 |
+| D8 | `text-xs italic text-hint` empty-state placeholder | 8 sites, copy-pasted | Identical string in 7 tool-card files |
+| D9 | `--font-body` (13px) ≡ `--font-base` (13px) | 2 tokens, 1 value | One feeds `text-base-mono`, the other feeds spacing |
+| D10 | Card subtitle `text-xs leading-snug text-muted` | 2 sites | Same style, two files, no shared primitive |
+| D11 | Mono-at-12px (`font-[var(--font-mono)] text-xs`) | 6 sites | An unnamed *de facto* third mono tier |
+| D12 | `<input>` type treatment | 5 literals + 1 local constant | No `Input` primitive exists to own it (§2.7) |
+
+## 6. Missing hierarchy (should probably share one semantic role)
+
+### 6.1 `text-base` vs `text-md` — same value, opposite meaning, no guard
+
+14px means "reading text" under one name and "heading" under the other. Nothing prevents a heading
+from using `text-base` or body copy from using `text-md`, and `CenterTabs:257` already uses
+`text-md font-medium` as a *screen heading* while `MarkdownPreview:19` uses the same 14px as a
+*prose root*. If the two roles ever need different sizes, every one of the 12 sites must be
+re-classified by hand.
+
+### 6.2 Titles: four weights for one concept
+
+Dialog title 14px/600 · ask-card title 14px/600 (hand-rolled) · in-page section 14px/500 ·
+welcome **card** title 12px/500 · workspace screen heading 14px/500. `TYPOGRAPHY.md` says card title
+= dialog title and screen heading = 14px/**400**; the code says otherwise in both places. So "title"
+is currently 3 sizes × 3 weights with no single owner.
+
+### 6.3 Input vs output: you type at 12px and read at 14px
+
+`Composer` textarea is `text-sm`; the message it produces renders `text-base`. Same content, two
+tiers, and no `input` role in the scale to reconcile them.
+
+### 6.4 Eyebrow/section label has no owner
+
+Nine variants (§2.5) for one semantic role, while the three `--uppercase-*` tokens that describe the
+role exactly are dead. Adding a tenth surface today means picking arbitrarily from nine precedents.
+
+### 6.5 "Small technical pill" has no owner
+
+Badges (§2.8) split across mono/proportional and 10/11px, so `Soon`, `spec-first`, `Recommended` and
+the diff-stat counter read as four different design languages in one product.
+
+### 6.6 Metadata has two indistinguishable colour tiers
+
+`text-xs text-hint` (56) and `text-xs text-muted` (25) are used for the same class of content
+(timestamps, counts, paths, helper text) with no documented rule for choosing. `text-xs text-text`
+(5) is a third, higher-contrast variant of the same role — including the **tooltip body**, which is
+the only text in the app whose entire purpose is a tooltip yet carries no tooltip-specific role.
+
+### 6.7 Empty states disagree with themselves
+
+`text-xs italic text-hint` (8 tool cards) vs `text-sm text-hint` (panels/rails) vs
+`text-sm text-muted` (rail placeholder, deliberately per `TYPOGRAPHY.md`) — three empty-state voices,
+one of which is documented and two of which are not.
+
+### 6.8 Line-height and tracking are outside the system
+
+Six leading values and three tracking values, all Tailwind constants, none tokenised (§3.5). The
+prose root's 1.65 already diverges from the global 1.6 with nothing recording why.
+
+## 7. Component mapping (style → components)
+
+Reverse index of §2. "→" reads *is used by*.
+
+| Style (canonical spelling) | Components |
+|---|---|
+| **Brand display** `text-brand text-[44px]` | Welcome hero |
+| **Brand inline** `text-brand text-lg` | Shell header wordmark |
+| **Dialog title** `text-md font-semibold leading-none` | every `Dialog` (Settings, New Workspace, Skills, Templates, Login, Ext-UI, Template editor) via `ui/dialog` → plus hand-rolled twins in AskUserQuestionCard (question title, "Review your answers") |
+| **Section heading** `text-md font-medium` | PrivacySettings, GithubSettings, ProvidersSettings, AppearanceSettings, TemplatesSettings, CenterTabs (workspace-ready heading) |
+| **Compact title** `text-sm font-medium` | ConfirmPopover, Toast, Welcome cards, TemplatesSettings rows, PrivacySettings rows, ProvidersSettings rows, TemplateEditorDialog, DiagramCard, ComparisonCard, ErrorBoundary |
+| **Reading text** `text-base` | chat user + assistant messages (`turns.tsx`), ProviderWarningBanner |
+| **Prose root** `text-[length:var(--font-md)] leading-[1.65]` | MarkdownPreview (file preview) |
+| **Default UI text** `text-sm` | Button (both sizes), textarea, Composer, command palette, dropdown items, Settings nav, ProjectTree rows, TreeRow, ChangesPanel, TerminalsPanel, SpecsPanel, CenterTabs, HistoryOverlay, SkillsDialog, LoginDialog, ModelSelector, ThinkingSelector, TodoList, ErrorBoundary, ProjectSkillsNotice, JetBrainsAiCard, GithubSettings, ProvidersSettings, NewWorkspaceDialog, ExtUiDialog, AskUserQuestionCard, ComparisonCard |
+| **Metadata / helper** `text-xs text-hint` \| `text-muted` | 26 files — FileTree, ChangesPanel, SpecsPanel, TerminalsPanel, RightPanel, ProjectTree, CenterTabs, DiffPane, ChatHeader, ChatView, ActivityGroup, SessionStatsBar, StreamIndicator, ToolCard, ReadCard, WriteCard, EditCard, WebSearchCard, WebFetchCard, MermaidView, PanZoomView, Collapsible, ChatPlan, ModelSelector, SkillsDialog, SkillsButton, SlashCommandCompletion, HistoryOverlay, TemplateEditorDialog, TemplatesSettings, PrivacySettings, GithubSettings, ProvidersSettings, AppearanceSettings, JetBrainsAiCard, NewWorkspaceDialog, WelcomePanel, ProjectSkillsNotice, LoginDialog, Shell, ErrorBoundary, AskUserQuestionCard |
+| **Tooltip body** `text-xs text-text` | `ui/tooltip` |
+| **Eyebrow** (9 variants) | RightPanel (panel labels), TerminalsPanel, ProvidersSettings, ProjectTree (rail groups), dropdown-menu labels, CenterTabs (workspace-ready eyebrow), TemplatesSettings, SkillsDialog (group headers), HistoryOverlay (section headers), ThinkingSelector, TodoList (plan headers), SpecsPanel (`spec-role` chip, the app's only 9px text) |
+| **Badge / pill** (5 variants) | SettingsDialog "Soon", WelcomePanel card tag, ComparisonCard "Recommended", AskUserQuestionCard pill, DiffStatBadge, NewWorkspaceDialog keycap |
+| **Empty state** | tool cards (`text-xs italic text-hint`), FileTree/ChangesPanel/SpecsPanel/TerminalsPanel (`text-xs text-hint`), ProjectTree rail (`text-sm text-muted`) |
+| **Code / output** `text-mono` | BashCard, CodeBlock, EditCard, toolRegistry (default tool renderer), ExtUiDialog (JSON editor), GithubSettings (`gh` commands), JetBrainsAiCard, SlashCommandCompletion, SettingsDialog badge, NewWorkspaceDialog keycap, TerminalInstance container |
+| **Inline code** `text-base-mono` | `chat/Markdown` (prose inline code) |
+| **Fenced code** `font-mono text-[0.85em]` | `chat/Markdown`, MarkdownPreview |
+| **Mono-at-12px** (undocumented tier) | ProjectTree branch line, NewWorkspaceDialog refs, CenterTabs branch line, DiffPane header path, SkillsDialog skill name |
+| **Monaco** | all file editors + both diff panes (`monacoSetup.sharedEditorOptions`) |
+| **xterm** | TerminalInstance |
+| **mermaid** | DiagramCard / MermaidView |
+
+## 8. Recommendations (not applied)
+
+Ordered by ratio of clarity gained to risk taken. Each is a *proposal*; none is implemented, and
+several need a design decision that is explicitly **not** made here.
+
+**Zero-visual-change consolidation (safe):**
+
+1. Replace the 8 `text-[10px]` literals with `text-xs` — byte-identical output, removes D1.
+2. Replace `text-[length:var(--font-md)]` with `text-base` — identical output, removes D3.
+3. Use the shared `Button` (or its `buttonVariants`) at the 3 hand-rolled primary buttons — removes D5
+   (15 files already import it).
+4. Delete the dead tokens (`--font-lg2/-xl/-xxl`, `--uppercase-*`) **or** give them a role; and either
+   map `--compact-font-base` to a utility (then use it at `SpecsPanel:171`) or stop writing it in
+   `applyFontScale()`. Also decide whether `--font-body` and `--font-base` (both 13px, D9) should be
+   one token.
+
+**Needs a decision, then a small change:**
+
+5. **Close the 11px proportional gap.** Either add one token (`--font-2xs`?) for the 4 `text-[11px]`
+   sites, or rule that 10px/12px are the only small tiers and move those sites onto one. Today the
+   scale has a hole and the code fills it by hand.
+6. **Name the eyebrow role.** One utility (`text-eyebrow`) fixing size + weight + tracking, with
+   colour left to the caller, would collapse 9 variants into 1 — and would finally give the
+   `--uppercase-*` tokens a consumer. Requires choosing 400-vs-500 and `wide`-vs-`wider` (a visible
+   change at some sites).
+7. **Name the badge/pill role** (mono vs proportional, 10 vs 11px) — collapses 5 treatments into 1.
+8. **Resolve `text-base` vs `text-md`.** Either enforce the split (lint rule / distinct values) or
+   merge them into one 14px name. Two names for one value with no guard will keep drifting.
+9. **Decide the composer's tier** (§6.3): either the input joins the reading tier, or the mismatch is
+   recorded as intentional.
+10. **Tokenise prose line-height** (`--line-height-prose: 1.65`) so the markdown root's divergence from
+    1.6 is a decision rather than a literal.
+11. **Document the markdown em-scale** in `TYPOGRAPHY.md` — it is the app's only relative type scale
+    and currently exists only in code.
+
+**Font-layer (highest user-visible impact):**
+
+12. **Self-host the three families** (or bundle them) so a local/offline/binary launch renders the real
+    type system rather than system fallbacks, and the app stops making a Google Fonts request at boot.
+13. **Decide Cabinet Grotesk's fate:** load it (Fontshare/self-host) or make `--font-accent` fall back
+    to Geist as `apps/website` already does. Today the brand renders as generic `sans-serif` in the app
+    and as Geist on the site.
+14. **Align the requested weight set with the used one** — drop the unused 700, add 800 if any accent
+    fallback should legitimately be extra-bold instead of synthesised.
+
+**Spec hygiene:**
+
+15. Reconcile the three `TYPOGRAPHY.md` claims the code contradicts: welcome **card title** (spec
+    14px/600, code 12px/500), **entity screen heading** (spec 400, code 500), and the five
+    *undocumented* mono usages in §2.10 — either sweep the code or amend the spec, but they should not
+    both stand.
+16. Add a "sweep-debt" note naming the surfaces built in parallel with the sweep and therefore never
+    swept (skills manager, prompt templates, history search, TODO plans, diff pane, privacy settings),
+    so the next pass has a checklist instead of re-deriving it.
+
+## 9. Specimen plan for the (deferred) showcase page
+
+The showcase UI is intentionally **not built yet**. When it is, this section is its contract — the page
+is a *view* of this document, and this document stays the source of truth after the page is deleted.
+
+- **Sections, in order:** Display/Brand · Titles · Body/Reading · Caption & Metadata · Eyebrows ·
+  Buttons & Controls · Inputs · Badges/Pills · Navigation & Tabs · Tooltip · Status · Code · Terminal ·
+  Monaco · Chat · Markdown prose · Third-party (mermaid).
+- **One card per numbered style in §2** (78 combinations, not 78 roles), each showing: the exact class
+  string, the *resolved* family/size/weight/line-height/tracking/transform/colour, the site count, and
+  its component list from §7.
+- **Each specimen renders:** `ABCDEFGHIJKLMNOPQRSTUVWXYZ` / `abcdefghijklmnopqrstuvwxyz` /
+  `0123456789` / "The quick brown fox jumps over the lazy dog."
+- **Flags rendered inline:** `hardcoded` (§3), `duplicate-of` (§5), `no-owner` (§6), `unloaded-font`
+  (§4) — so the audit's findings are visible on the specimen, not only in prose.
+- **Constraints:** the page must apply the *live* utilities (no re-declared literals), so it re-themes
+  with the theme engine and cannot drift from what components render; it must not introduce a token; and
+  it must be removable in a single revert.
+
+## Appendix A — reproducing the counts
+
+Both scripts are throwaway (run from the repo root with `bun`), intentionally not committed as tooling.
+
+```ts
+// 1. Frequency of every typography class in component code.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+const files: string[] = [];
+(function walk(d: string) {
+  for (const e of readdirSync(d)) {
+    const p = join(d, e);
+    statSync(p).isDirectory() ? walk(p) : /\.tsx?$/.test(p) && files.push(p);
+  }
+})("apps/web/src");
+const RE =
+  /(?<![-\w])(text-(?:xs|sm|base-mono|base|md|lg|mono|brand)|text-\[[^\]]+\]|font-(?:medium|semibold|bold|extrabold|normal)|font-\[var\(--font[a-z-]*\)\]|uppercase|capitalize|lowercase|italic|leading-[\w[\].\/-]+|tracking-[\w-]+)(?![-\w])/g;
+const n = new Map<string, number>();
+for (const f of files)
+  for (const m of readFileSync(f, "utf8").matchAll(RE)) n.set(m[1], (n.get(m[1]) ?? 0) + 1);
+console.log([...n].sort((a, b) => b[1] - a[1]));
+```
+
+The second script groups the same matches per string literal into the family/size/weight/tracking/
+leading/transform/colour tuples of §2 and prints each tuple with its `file:line` sites; the combination
+count (78) and every site list above come from its output.
+
+Provenance queries used in §3:
+
+```sh
+git log -1 --format='%h %ad %s' --date=short -L '<line>,<line>:apps/web/src/<file>'   # who wrote this line
+git diff --name-only bb503d0..a9e0a58 -- apps/web/src                                  # what the sweep touched
+git log --diff-filter=A --format='%ad %s' --date=short -1 -- apps/web/src/<file>        # when a surface was added
+```

--- a/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
+++ b/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
@@ -147,7 +147,7 @@ spec-vs-code drift, not judgement calls (see §6.2).
 | # | Style | Size | Notes | Sites |
 |---|---|---|---|---|
 | 9 | `text-base text-text` | 14px | the reading tier | `chat/turns.tsx:61,103` (chat messages), `panels/ProviderWarningBanner.tsx:42` |
-| 10 | `text-[length:var(--font-md)] leading-[1.65] text-pretty text-text` | 14px | markdown-preview prose root — **token via arbitrary value**, and **1.65 ≠ the global 1.6** | `panels/MarkdownPreview.tsx:19` |
+| 10 | `text-base leading-[1.65] text-pretty text-text` | 14px | markdown-preview prose root. Was `text-[length:var(--font-md)]` — replaced (§5, D3). `1.65` still ≠ the global `1.6` and is untokenised | `panels/MarkdownPreview.tsx:19` |
 | 11 | `text-sm` (bare, colour inherited) | 12px | the default UI text | 23 sites across 18 files |
 | 12 | `text-sm text-text` | 12px | UI text, explicit colour | 31 sites across 20 files |
 | 13 | `text-sm text-muted` | 12px | secondary UI text | 9 sites (incl. `ui/dialog.tsx:76` DialogDescription, `ui/toast.tsx:59`) |
@@ -274,8 +274,9 @@ two-tier policy.
 
 ## 3. Remaining hardcoded typography — and why it survives
 
-25 sites carry a hardcoded size (12 distinct values). Grouped by *why*, since the reason determines
-whether it is technical debt or a deliberate exception.
+**24 sites carry a hardcoded size (11 distinct values)** after the one unambiguous replacement landed
+(§5, D3). Grouped by *why*, since the reason determines whether it is technical debt or a deliberate
+exception.
 
 | Value | Sites | Verdict (below) |
 |---|---|---|
@@ -285,7 +286,7 @@ whether it is technical debt or a deliberate exception.
 | `text-[9px]` | 1 | unmapped token (§3.3) |
 | `text-[44px]` | 1 | sanctioned (§3.1) |
 | `text-[2em]` `[1.5em]` `[1.25em]` `[1em]` `[0.875em]` `[0.9em]` | 6 | prose scale (§3.4) |
-| `text-[length:var(--font-md)]` | 1 | duplicate spelling (§3.4) |
+| ~~`text-[length:var(--font-md)]`~~ | 0 | **replaced** by `text-base` (§5, D3) |
 
 ### 3.1 Sanctioned by the spec (leave alone)
 
@@ -296,12 +297,15 @@ whether it is technical debt or a deliberate exception.
 
 ### 3.2 A token exists with the identical value — pure drift (5 sites)
 
-| Value | Site | Identical token |
-|---|---|---|
-| `text-[10px]` | `HistoryOverlay:139,151,173` | `text-xs` (`--font-xs` = 10px) |
-| `text-[10px]` | `TodoList:131,172,207` | `text-xs` |
-| `text-[10px]` | `ComparisonCard:33` | `text-xs` |
-| `text-[10px]` | `WelcomePanel:246` | `text-xs` |
+| Value | Site | Same-size token | Appearance-identical? |
+|---|---|---|---|
+| `text-[10px]` | `HistoryOverlay:139,151,173` | `text-xs` (`--font-xs` = 10px) | ✅ pixel-verified |
+| `text-[10px]` | `TodoList:131,172,207` | `text-xs` | ❓ unverified (agent-only surface) |
+| `text-[10px]` | `ComparisonCard:33` | `text-xs` | ❓ unverified (agent-only surface) |
+| `text-[10px]` | `WelcomePanel:246` | `text-xs` | ❌ **no** — pill 23px → 20px (§5.1) |
+
+The font-*size* mapping is unambiguous at all 8 sites; the *line-height* is not (§5.1), which is why
+none of them has been swapped.
 
 **Why they survive:** provenance explains it exactly. `HistoryOverlay` (Ctrl+R history search, #109,
 2026‑07‑26), `TodoList` (chat TODO plans, 2026‑07‑21), `SkillsDialog`/`SkillsButton`/
@@ -332,13 +336,16 @@ a fixed-px token scale cannot express. This is legitimate — but it is **entire
 `TYPOGRAPHY.md` sanctions em-relative sizing only for *fenced code*, and says markdown headings are
 "600" without mentioning that their sizes live outside the scale. Two sub-findings:
 
-- `text-[length:var(--font-md)]` reaches for the token through an arbitrary value where `text-base`
-  is the same 14px — the file predates the `text-base` mapping (added 2026‑07‑10 vs the sweep).
+- ~~`text-[length:var(--font-md)]`~~ reached for the token through an arbitrary value where `text-base`
+  is the same 14px — the file predated the `text-base` mapping (2026‑07‑10 vs the sweep). **Replaced**
+  (§5, D3); the em-relative heading scale below is untouched.
 - `leading-[1.65]` silently disagrees with the global `--line-height: 1.6`, and there is no
   `--line-height-prose` token to hold the intended difference.
 
 ### 3.5 Non-size hardcoding
 
+- **Line-height, the big one:** the size utilities silently carry Tailwind's per-size line-heights, so
+  the documented "global 1.6" governs far less text than the spec implies — see §5.1.
 - **Tracking:** `tracking-wider` (12), `tracking-wide` (5), `tracking-widest` (1) are Tailwind
   defaults (0.025em / 0.05em / 0.1em) — none flow from `--uppercase-spacing: 0.5px`, the token meant
   for exactly this.
@@ -395,9 +402,9 @@ There is **no `@font-face` rule and no self-hosted font file anywhere in the rep
 
 | # | Duplicate | Occurrences | Note |
 |---|---|---|---|
-| D1 | `text-[10px]` ≡ `text-xs` | 8 literal sites vs 150 token sites | Byte-identical rendering; §3.2 |
+| D1 | `text-[10px]` vs `text-xs` | 8 literal sites vs 150 token sites | **NOT equivalent** — same font-size, different line-height. See §5.1. |
 | D2 | `text-base` ≡ `text-md` (both 14px) | 3 vs 9 | Deliberate two-name split, unenforced |
-| D3 | `text-[length:var(--font-md)]` ≡ `text-base` | 1 | Same token, longer spelling |
+| D3 | ~~`text-[length:var(--font-md)]` ≡ `text-base`~~ | 0 (**resolved**) | Was `MarkdownPreview:19`; now `text-base`, pixel-verified identical because the element's own `leading-[1.65]` supplies `--tw-leading` |
 | D4 | Dialog title vs ask-question title (`text-md font-semibold text-text` ± `leading-none`) | 1 + 2 | Same style, one via the `DialogTitle` primitive, one hand-rolled |
 | D5 | Shared `Button` type treatment vs 3 hand-rolled primary buttons | 1 vs 3 | `text-sm font-medium` + `bg-primary text-on-accent` re-declared |
 | D6 | Eyebrow, 9 near-identical variants | 15 sites | §2.5 — differ only in weight/tracking/colour/size |
@@ -407,6 +414,37 @@ There is **no `@font-face` rule and no self-hosted font file anywhere in the rep
 | D10 | Card subtitle `text-xs leading-snug text-muted` | 2 sites | Same style, two files, no shared primitive |
 | D11 | Mono-at-12px (`font-[var(--font-mono)] text-xs`) | 6 sites | An unnamed *de facto* third mono tier |
 | D12 | `<input>` type treatment | 5 literals + 1 local constant | No `Input` primitive exists to own it (§2.7) |
+
+### 5.1 The line-height trap (why D1 is not a duplicate)
+
+The size utilities do **not** carry font-size alone. Tailwind's default theme pairs every size with a
+line-height, and mapping `--text-*` through `@theme inline` overrides the *size* while leaving the
+paired line-height in place. Both halves are visible in the built CSS:
+
+```css
+--text-xs--line-height: calc(1 / .75);      /* 1.3333 */
+--text-sm--line-height: calc(1.25 / .875);  /* 1.4286 */
+--text-base--line-height: calc(1.5 / 1);    /* 1.5    */
+--text-lg--line-height: calc(1.75 / 1.125); /* 1.5556 */
+
+.text-xs       { font-size: var(--font-xs); line-height: var(--tw-leading, var(--text-xs--line-height)) }
+.text-\[10px\] { font-size: 10px }           /* no line-height — inherits the global 1.6 */
+```
+
+So `text-[10px]` inherits 1.6 while `text-xs` applies 1.3333. Measured on the Welcome card tag
+(`WelcomePanel:246`), swapping the literal for the token shrinks the pill from **23px to 20px** tall —
+a real, visible change. The three `HistoryOverlay` sites are pixel-identical either way (their line box
+doesn't drive layout), but the *class* of change is not appearance-neutral, so **all 8 sites were left
+unchanged** pending a decision (§8, item 1).
+
+Two consequences beyond D1:
+
+1. **`TYPOGRAPHY.md`'s "Line-height: Global 1.6" is not what renders.** Every site carrying
+   `text-xs`/`text-sm`/`text-base`/`text-lg` (~253) renders at Tailwind's default ratio for that size
+   (1.333 / 1.4286 / 1.5 / 1.5556) unless a `leading-*` utility overrides it. 1.6 applies only to text
+   with *no* size utility — the body default and inherited text.
+2. The type system therefore has **two** line-height regimes (documented-global vs
+   Tailwind-default-per-size), and the spec describes only the first.
 
 ## 6. Missing hierarchy (should probably share one semantic role)
 
@@ -456,7 +494,10 @@ one of which is documented and two of which are not.
 ### 6.8 Line-height and tracking are outside the system
 
 Six leading values and three tracking values, all Tailwind constants, none tokenised (§3.5). The
-prose root's 1.65 already diverges from the global 1.6 with nothing recording why.
+prose root's 1.65 already diverges from the global 1.6 with nothing recording why — and, more
+fundamentally, **most text never uses the global 1.6 at all**: the size utilities carry Tailwind's
+per-size line-heights (§5.1). So "line-height" currently has three owners — the documented global
+value, Tailwind's implicit per-size defaults, and six ad-hoc `leading-*` overrides.
 
 ## 7. Component mapping (style → components)
 
@@ -470,7 +511,7 @@ Reverse index of §2. "→" reads *is used by*.
 | **Section heading** `text-md font-medium` | PrivacySettings, GithubSettings, ProvidersSettings, AppearanceSettings, TemplatesSettings, CenterTabs (workspace-ready heading) |
 | **Compact title** `text-sm font-medium` | ConfirmPopover, Toast, Welcome cards, TemplatesSettings rows, PrivacySettings rows, ProvidersSettings rows, TemplateEditorDialog, DiagramCard, ComparisonCard, ErrorBoundary |
 | **Reading text** `text-base` | chat user + assistant messages (`turns.tsx`), ProviderWarningBanner |
-| **Prose root** `text-[length:var(--font-md)] leading-[1.65]` | MarkdownPreview (file preview) |
+| **Prose root** `text-base leading-[1.65]` | MarkdownPreview (file preview) |
 | **Default UI text** `text-sm` | Button (both sizes), textarea, Composer, command palette, dropdown items, Settings nav, ProjectTree rows, TreeRow, ChangesPanel, TerminalsPanel, SpecsPanel, CenterTabs, HistoryOverlay, SkillsDialog, LoginDialog, ModelSelector, ThinkingSelector, TodoList, ErrorBoundary, ProjectSkillsNotice, JetBrainsAiCard, GithubSettings, ProvidersSettings, NewWorkspaceDialog, ExtUiDialog, AskUserQuestionCard, ComparisonCard |
 | **Metadata / helper** `text-xs text-hint` \| `text-muted` | 26 files — FileTree, ChangesPanel, SpecsPanel, TerminalsPanel, RightPanel, ProjectTree, CenterTabs, DiffPane, ChatHeader, ChatView, ActivityGroup, SessionStatsBar, StreamIndicator, ToolCard, ReadCard, WriteCard, EditCard, WebSearchCard, WebFetchCard, MermaidView, PanZoomView, Collapsible, ChatPlan, ModelSelector, SkillsDialog, SkillsButton, SlashCommandCompletion, HistoryOverlay, TemplateEditorDialog, TemplatesSettings, PrivacySettings, GithubSettings, ProvidersSettings, AppearanceSettings, JetBrainsAiCard, NewWorkspaceDialog, WelcomePanel, ProjectSkillsNotice, LoginDialog, Shell, ErrorBoundary, AskUserQuestionCard |
 | **Tooltip body** `text-xs text-text` | `ui/tooltip` |
@@ -490,10 +531,14 @@ Reverse index of §2. "→" reads *is used by*.
 Ordered by ratio of clarity gained to risk taken. Each is a *proposal*; none is implemented, and
 several need a design decision that is explicitly **not** made here.
 
-**Zero-visual-change consolidation (safe):**
+**Zero-visual-change consolidation:**
 
-1. Replace the 8 `text-[10px]` literals with `text-xs` — byte-identical output, removes D1.
-2. Replace `text-[length:var(--font-md)]` with `text-base` — identical output, removes D3.
+1. ⚠️ **Not safe after all** — replacing the 8 `text-[10px]` literals with `text-xs` also swaps
+   line-height 1.6 → 1.333 (§5.1), measured at −3px of pill height on the Welcome tag. Needs one of:
+   accept the tightening; pin the current leading at those sites; or rule that the documented global
+   1.6 wins everywhere (which changes ~253 sites, not 8). **Open decision.**
+2. ✅ **Done** — `text-[length:var(--font-md)]` → `text-base` at `MarkdownPreview:19`, pixel-verified
+   identical (its `leading-[1.65]` already supplies `--tw-leading`). D3 resolved.
 3. Use the shared `Button` (or its `buttonVariants`) at the 3 hand-rolled primary buttons — removes D5
    (15 files already import it).
 4. Delete the dead tokens (`--font-lg2/-xl/-xxl`, `--uppercase-*`) **or** give them a role; and either
@@ -517,6 +562,10 @@ several need a design decision that is explicitly **not** made here.
    recorded as intentional.
 10. **Tokenise prose line-height** (`--line-height-prose: 1.65`) so the markdown root's divergence from
     1.6 is a decision rather than a literal.
+10b. **Decide who owns line-height** (§5.1): either accept Tailwind's per-size ratios and amend
+    `TYPOGRAPHY.md` (which says 1.6 globally), or neutralise the paired `--text-*--line-height`
+    values so the documented 1.6 actually governs. This is the prerequisite for item 1 — and it is a
+    ~253-site visual decision, not a cleanup.
 11. **Document the markdown em-scale** in `TYPOGRAPHY.md` — it is the app's only relative type scale
     and currently exists only in code.
 

--- a/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
+++ b/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
@@ -13,17 +13,21 @@ tags:
 
 # Typography audit (as-implemented)
 
-An **audit only** — a full inventory of every text style `apps/web` actually renders, the hardcoded
-values that survive outside the token system and why, and where the system duplicates itself or loses
-hierarchy. **Nothing here changes code, tokens, or branding.** No recommendation in §8 has been
-applied.
+A full inventory of every text style `apps/web` actually renders, the hardcoded values that survive
+outside the token system and why, and where the system duplicates itself or loses hierarchy.
+
+The document is **descriptive** — it reports, it does not decide. Two of its findings have since been
+acted on in a **reconciliation pass** (§10): line-height became a declared property of every size
+tier, and the 9 hardcoded values whose token mapping was unambiguous were replaced. Everything else in
+§8 remains a proposal; nothing else has been changed, and no branding or token was added.
 
 Companion documents:
 
-- `TYPOGRAPHY.md` — the *intended* system (scale, weight policy, mono policy). Normative.
-- **This file** — the *observed* system, and every place the two disagree. Descriptive.
+- `TYPOGRAPHY.md` — the *intended* system (scale, weight policy, mono policy). **Normative** — and the
+  side that wins: where implementation and spec disagreed, the implementation moved (§10).
+- **This file** — the *observed* system, and every place the two still disagree. Descriptive.
 
-Where they disagree, this file names the drift; it does not silently "fix" `TYPOGRAPHY.md`.
+Where they disagree, this file names the drift; it does not silently "fix" either side.
 
 ## 0. Scope & method
 
@@ -51,9 +55,14 @@ Where they disagree, this file names the drift; it does not silently "fix" `TYPO
   3. Third-party text rendered by Monaco, xterm, mermaid and shiki is configured in JS, not classes;
      it is inventoried separately in §2.9.
 
-**Headline count:** 78 distinct declared typography combinations across 72 of the 159 `.ts(x)` files,
-expressed through 5 size utilities + 3 composite utilities + **12 distinct hardcoded size expressions
-at 25 sites**.
+**Headline count:** **75** distinct declared typography combinations across 72 of the 159 `.ts(x)`
+files, expressed through 5 size utilities + 3 composite utilities + **10 distinct hardcoded size
+expressions at 16 sites**.
+
+> **Reconciliation pass applied (see §10).** This document was first written against a tree with 78
+> combinations / 25 hardcoded sites. Two changes have since landed: line-height became a declared
+> property of every size tier, and the 9 hardcoded values whose token mapping was unambiguous were
+> replaced. Every count and table below reflects the *current* tree; §10 records what moved and why.
 
 ## 1. The token layer
 
@@ -164,35 +173,36 @@ render at `text-base` (14px) — you type two pixels smaller than you read (§6.
 
 | # | Style | Size | Notes | Sites |
 |---|---|---|---|---|
-| 19 | `text-xs text-hint` | 10px | **the single most-used style in the app** | 56 sites across 26 files |
+| 19 | `text-xs text-hint` | 10px | **the single most-used style in the app** | 59 sites across 26 files (+3 from §10) |
 | 20 | `text-xs text-muted` | 10px | secondary metadata | 25 sites across 15 files |
 | 21 | `text-xs` (bare) | 10px | inherited colour | 15 sites |
 | 22 | `text-xs text-text` | 10px | high-contrast metadata + **tooltip body** | `ui/tooltip.tsx:19`, `chat/Composer:655`, `chat/tools/AskUserQuestionCard:573`, `chat/tools/visualize/ComparisonCard:42,52` |
 | 23 | `text-xs italic text-hint` | 10px | "no output"/empty placeholders in tool cards | 8 sites (7 files) |
 | 24 | `text-xs text-red` / `text-green` / `text-gold` / `text-primary` | 10px | status-coloured metadata | 9 / 2 / 1 / 1 sites |
 | 25 | `text-xs leading-snug text-muted` | 10px | card subtitle | `panels/{NewWorkspaceDialog:499, WelcomePanel:260}` |
-| 26 | `text-[10px] text-hint` | **10px hardcoded** | identical to #19 | `chat/HistoryOverlay.tsx:139,151,173` |
-| 27 | `text-[11px] text-hint` / `text-[11px] text-muted` | **11px hardcoded, proportional** | no token exists at 11px proportional | `chat/HistoryOverlay.tsx:284,493,572` |
+| 26 | ~~`text-[10px] text-hint`~~ | — | **resolved** — folded into #19 (`text-xs text-hint`) | was `chat/HistoryOverlay.tsx:139,151,173` |
+| 27 | `text-[11px] text-hint` / `text-[11px] text-muted` | **11px hardcoded, proportional** | no token exists at 11px proportional — **the one remaining size gap** (§3.3) | `chat/HistoryOverlay.tsx:284,493,572` |
 | 28 | `text-xs text-muted text-text` *(conditional)* | 10px | active/inactive pair | `chat/SkillsButton:32`, `chat/ChatView`, `panels/TemplatesSettings` |
 
-### 2.5 Eyebrows / section labels (uppercase) — **9 variants**
+### 2.5 Eyebrows / section labels (uppercase) — **8 variants**
 
 | # | Style | Size | Weight | Tracking | Colour | Sites |
 |---|---|---|---|---|---|---|
 | 29 | `text-xs uppercase tracking-wider text-muted` | 10px | 400 | wider | muted | `panels/{ProvidersSettings:254,TerminalsPanel:38,ProjectTree:98}`, `ui/dropdown-menu.tsx:49` |
-| 30 | `text-xs uppercase tracking-wider text-hint` | 10px | 400 | wider | hint | `chat/ThinkingSelector.tsx:34` |
+| 30 | `text-xs uppercase tracking-wider text-hint` | 10px | 400 | wider | hint | `chat/ThinkingSelector.tsx:34`, `chat/TodoList.tsx:131,172` (the latter two via §10) |
 | 31 | `text-xs uppercase tracking-wider` (bare) | 10px | 400 | wider | inherited | `panels/RightPanel.tsx:92` |
 | 32 | `text-xs font-medium uppercase tracking-wider text-hint` | 10px | **500** | wider | hint | `panels/CenterTabs.tsx:254` |
 | 33 | `text-xs font-medium uppercase tracking-wider text-muted` | 10px | **500** | wider | muted | `panels/TemplatesSettings.tsx:291` |
 | 34 | `text-xs uppercase tracking-wide text-hint` | 10px | 400 | **wide** | hint | `chat/HistoryOverlay.tsx:502,525` |
 | 35 | `text-xs font-medium uppercase tracking-wide text-text` | 10px | **500** | **wide** | text | `chat/SkillsDialog.tsx:197,313` |
-| 36 | `text-[10px] uppercase tracking-wider text-hint` | **10px hardcoded** | 400 | wider | hint | `chat/TodoList.tsx:131,172` |
+| 36 | ~~`text-[10px] uppercase tracking-wider text-hint`~~ | — | — | — | — | **resolved** — folded into #30 (`text-xs … text-hint`); was `chat/TodoList.tsx:131,172` |
 | 37 | `text-[9px] uppercase tracking-wider` | **9px hardcoded** | 400 | wider | inherited | `panels/SpecsPanel.tsx:171` |
 
-Nine ways to render the same semantic thing ("a small uppercase group label"), differing only in
-weight (400/500), tracking (`wide`/`wider`), colour (hint/muted/text/inherited) and size
-(10px token / 10px literal / 9px literal). `--uppercase-size/-weight/-spacing` — tokens that exist
-precisely for this role — are used by none of them.
+Eight ways to render the same semantic thing ("a small uppercase group label"), differing in weight
+(400/500), tracking (`wide`/`wider`), colour (hint/muted/text/inherited) and size (10px token vs the
+one 9px literal). Down from nine: §10 folded the `text-[10px]` variant into #30, so size is no longer
+a *third* axis of divergence. `--uppercase-size/-weight/-spacing` — tokens that exist precisely for
+this role — are still used by none of them, so the role remains unowned (§6.4).
 
 ### 2.6 Buttons / controls
 
@@ -221,17 +231,17 @@ so that agreement is 5 copies of a literal plus one file-local `INPUT_CLASS` con
 coincidence rather than by a shared component. There is also no `input` role in the scale — inputs are
 just "default UI text", which is why the composer/message mismatch in §6.3 exists.
 
-### 2.8 Badges / pills / keycaps — **5 variants**
+### 2.8 Badges / pills / keycaps — **5 variants** (all now token-sized except the 11px gap)
 
 | # | Style | Family | Size | Sites |
 |---|---|---|---|---|
 | 45 | `text-mono uppercase` | mono | 11px | `panels/SettingsDialog.tsx:87` ("Soon") |
-| 46 | `font-[var(--font-mono)] text-[10px] uppercase tracking-wide text-primary` | mono | **10px hardcoded** | `panels/WelcomePanel.tsx:246` (card tag, e.g. "spec-first") |
-| 47 | `text-[10px] text-on-accent` | **proportional** | **10px hardcoded** | `chat/tools/visualize/ComparisonCard.tsx:33` ("Recommended") |
+| 46 | `font-[var(--font-mono)] text-xs uppercase tracking-wide text-primary` | mono | 10px (was a literal) | `panels/WelcomePanel.tsx:246` (card tag, e.g. "spec-first") |
+| 47 | `text-xs text-on-accent` | **proportional** | 10px (was a literal) | `chat/tools/visualize/ComparisonCard.tsx:33` ("Recommended") |
 | 48 | `text-[11px] font-medium text-primary` | proportional | **11px hardcoded** | `chat/tools/AskUserQuestionCard.tsx:730` (pill) |
 | 49 | `text-xs` diff-stat badge | proportional | 10px | `panels/DiffStatBadge.tsx:17` |
 | 50 | `text-mono` keycap (`↵`) | mono | 11px | `panels/NewWorkspaceDialog.tsx:569` |
-| 51 | `text-[10px] text-hint` shortcut hint | proportional | **10px hardcoded** | `chat/HistoryOverlay.tsx:151,173` |
+| 51 | `text-xs text-hint` shortcut hint | proportional | 10px (was a literal) | `chat/HistoryOverlay.tsx:151,173` |
 
 Same UI object (a small pill), five typographic treatments across mono/proportional and 10/11px.
 
@@ -266,27 +276,26 @@ size; mermaid takes family only, so diagram label size is outside the system ent
 | `panels/CenterTabs.tsx:260` (workspace-ready branch line, `text-xs`) | 12px | ❌ undocumented |
 | `panels/DiffPane.tsx:86` (diff header path, `text-xs`) | 12px | ❌ undocumented |
 | `chat/SkillsDialog.tsx:394` (skill name, `text-sm`) | 12px | ❌ undocumented — and it's an *identity* name, which the mono policy forbids |
-| `chat/TodoList.tsx:207` (todo note, `text-[10px]`) | 10px | ❌ undocumented |
-| `panels/WelcomePanel.tsx:246` (card tag, `text-[10px]`) | 10px | ❌ undocumented |
+| `chat/TodoList.tsx:207` (todo note, now `text-xs`) | 10px | ❌ undocumented |
+| `panels/WelcomePanel.tsx:246` (card tag, now `text-xs`) | 10px | ❌ undocumented |
 
 Counting the utilities, mono renders at **10, 11, 12, 13, 18px and `0.85em`** — six sizes for a
 two-tier policy.
 
 ## 3. Remaining hardcoded typography — and why it survives
 
-**24 sites carry a hardcoded size (11 distinct values)** after the one unambiguous replacement landed
-(§5, D3). Grouped by *why*, since the reason determines whether it is technical debt or a deliberate
-exception.
+**16 sites carry a hardcoded size (10 distinct values)** after the reconciliation pass (§10). Grouped
+by *why*, since the reason determines whether it is technical debt or a deliberate exception.
 
 | Value | Sites | Verdict (below) |
 |---|---|---|
-| `text-[10px]` | 8 | drift — token exists (§3.2) |
-| `text-[11px]` | 4 | scale gap (§3.3) |
+| `text-[11px]` | 4 | **scale gap — left as-is by decision** (§3.3) |
 | `text-[0.85em]` | 4 | sanctioned / prose (§3.1, §3.4) |
-| `text-[9px]` | 1 | unmapped token (§3.3) |
+| `text-[9px]` | 1 | **scale gap — left as-is by decision** (§3.3) |
 | `text-[44px]` | 1 | sanctioned (§3.1) |
 | `text-[2em]` `[1.5em]` `[1.25em]` `[1em]` `[0.875em]` `[0.9em]` | 6 | prose scale (§3.4) |
-| ~~`text-[length:var(--font-md)]`~~ | 0 | **replaced** by `text-base` (§5, D3) |
+| ~~`text-[10px]`~~ | 0 | **replaced** by `text-xs` (§10) |
+| ~~`text-[length:var(--font-md)]`~~ | 0 | **replaced** by `text-base` (§10) |
 
 ### 3.1 Sanctioned by the spec (leave alone)
 
@@ -295,17 +304,18 @@ exception.
 | `text-[44px]` | `WelcomePanel:144` hero | `text-brand` deliberately carries **no size** — every brand usage sets its own. `TYPOGRAPHY.md` documents this exact value. |
 | `text-[0.85em]` ×3 | `Markdown.tsx:68,95,102` fenced code | Document content must scale *with the prose*, so it is em-relative by design (user-confirmed in `TYPOGRAPHY.md`). |
 
-### 3.2 A token exists with the identical value — pure drift (5 sites)
+### 3.2 A token existed with the identical value — **resolved** (8 sites)
 
-| Value | Site | Same-size token | Appearance-identical? |
-|---|---|---|---|
-| `text-[10px]` | `HistoryOverlay:139,151,173` | `text-xs` (`--font-xs` = 10px) | ✅ pixel-verified |
-| `text-[10px]` | `TodoList:131,172,207` | `text-xs` | ❓ unverified (agent-only surface) |
-| `text-[10px]` | `ComparisonCard:33` | `text-xs` | ❓ unverified (agent-only surface) |
-| `text-[10px]` | `WelcomePanel:246` | `text-xs` | ❌ **no** — pill 23px → 20px (§5.1) |
+All 8 `text-[10px]` literals are now `text-xs` (§10). They are listed here because the *reason they
+survived* is still the useful finding — and because the swap only became appearance-neutral after
+line-height became a declared tier property (§5.1).
 
-The font-*size* mapping is unambiguous at all 8 sites; the *line-height* is not (§5.1), which is why
-none of them has been swapped.
+| Value | Site | Now |
+|---|---|---|
+| `text-[10px]` | `HistoryOverlay:139,151,173` | `text-xs` |
+| `text-[10px]` | `TodoList:131,172,207` | `text-xs` |
+| `text-[10px]` | `ComparisonCard:33` | `text-xs` |
+| `text-[10px]` | `WelcomePanel:246` | `text-xs` |
 
 **Why they survive:** provenance explains it exactly. `HistoryOverlay` (Ctrl+R history search, #109,
 2026‑07‑26), `TodoList` (chat TODO plans, 2026‑07‑21), `SkillsDialog`/`SkillsButton`/
@@ -319,11 +329,14 @@ their literals passed through untouched.
 
 ### 3.3 No token exists for the value (4 sites)
 
+**These 5 sites are deliberately unchanged** — no token was invented for them; they are the audit's
+two standing design decisions.
+
 | Value | Site | Gap |
 |---|---|---|
 | `text-[11px]` ×3 | `HistoryOverlay:284,493,572` | 11px **proportional** has no token. `--font-mono-size` is 11px but is the *mono* tier, and `text-mono` would change the family too. The proportional scale jumps 10 → 12. |
 | `text-[11px]` | `AskUserQuestionCard:730` | same gap, in a pill |
-| `text-[9px]` | `SpecsPanel:171` | 9px exists as `--compact-font-base` — but it is written by JS and **never mapped to a utility**, so there was nothing to reference. |
+| `text-[9px]` | `SpecsPanel:171` | 9px exists as `--compact-font-base` — but it is written by JS and **never mapped to a utility**, so there is nothing to reference. |
 
 ### 3.4 Deliberately relative (markdown prose skins)
 
@@ -344,8 +357,8 @@ a fixed-px token scale cannot express. This is legitimate — but it is **entire
 
 ### 3.5 Non-size hardcoding
 
-- **Line-height, the big one:** the size utilities silently carry Tailwind's per-size line-heights, so
-  the documented "global 1.6" governs far less text than the spec implies — see §5.1.
+- **Line-height, the big one — now closed:** the size utilities used to silently carry Tailwind's
+  per-size line-heights; each tier now declares its own (§5.1, §10).
 - **Tracking:** `tracking-wider` (12), `tracking-wide` (5), `tracking-widest` (1) are Tailwind
   defaults (0.025em / 0.05em / 0.1em) — none flow from `--uppercase-spacing: 0.5px`, the token meant
   for exactly this.
@@ -402,7 +415,7 @@ There is **no `@font-face` rule and no self-hosted font file anywhere in the rep
 
 | # | Duplicate | Occurrences | Note |
 |---|---|---|---|
-| D1 | `text-[10px]` vs `text-xs` | 8 literal sites vs 150 token sites | **NOT equivalent** — same font-size, different line-height. See §5.1. |
+| D1 | ~~`text-[10px]` vs `text-xs`~~ | 0 (**resolved**) | Was *not* equivalent (line-height); made equivalent by §5.1, then swapped — §10 |
 | D2 | `text-base` ≡ `text-md` (both 14px) | 3 vs 9 | Deliberate two-name split, unenforced |
 | D3 | ~~`text-[length:var(--font-md)]` ≡ `text-base`~~ | 0 (**resolved**) | Was `MarkdownPreview:19`; now `text-base`, pixel-verified identical because the element's own `leading-[1.65]` supplies `--tw-leading` |
 | D4 | Dialog title vs ask-question title (`text-md font-semibold text-text` ± `leading-none`) | 1 + 2 | Same style, one via the `DialogTitle` primitive, one hand-rolled |
@@ -415,11 +428,13 @@ There is **no `@font-face` rule and no self-hosted font file anywhere in the rep
 | D11 | Mono-at-12px (`font-[var(--font-mono)] text-xs`) | 6 sites | An unnamed *de facto* third mono tier |
 | D12 | `<input>` type treatment | 5 literals + 1 local constant | No `Input` primitive exists to own it (§2.7) |
 
-### 5.1 The line-height trap (why D1 is not a duplicate)
+### 5.1 The line-height trap — found here, now closed
 
-The size utilities do **not** carry font-size alone. Tailwind's default theme pairs every size with a
-line-height, and mapping `--text-*` through `@theme inline` overrides the *size* while leaving the
-paired line-height in place. Both halves are visible in the built CSS:
+**This was the audit's most consequential finding, and it is the reason §10 exists.**
+
+The size utilities did **not** carry font-size alone. Tailwind's default theme pairs every size with a
+line-height, and mapping `--text-*` through `@theme inline` overrode the *size* while leaving the
+paired line-height in place. The original built CSS:
 
 ```css
 --text-xs--line-height: calc(1 / .75);      /* 1.3333 */
@@ -431,20 +446,22 @@ paired line-height in place. Both halves are visible in the built CSS:
 .text-\[10px\] { font-size: 10px }           /* no line-height — inherits the global 1.6 */
 ```
 
-So `text-[10px]` inherits 1.6 while `text-xs` applies 1.3333. Measured on the Welcome card tag
-(`WelcomePanel:246`), swapping the literal for the token shrinks the pill from **23px to 20px** tall —
-a real, visible change. The three `HistoryOverlay` sites are pixel-identical either way (their line box
-doesn't drive layout), but the *class* of change is not appearance-neutral, so **all 8 sites were left
-unchanged** pending a decision (§8, item 1).
+So `text-[10px]` inherited 1.6 while `text-xs` applied 1.3333. Measured on the Welcome card tag
+(`WelcomePanel:246`), swapping the literal for the token shrank the pill from **23px to 20px** — a real,
+visible change. Two consequences, both larger than D1 itself:
 
-Two consequences beyond D1:
+1. **`TYPOGRAPHY.md`'s "Line-height: 1.6 global" was not what rendered.** Every site carrying
+   `text-xs`/`text-sm`/`text-base`/`text-lg` (~253) used Tailwind's ratio for that size
+   (1.333 / 1.4286 / 1.5 / 1.5556) unless a `leading-*` overrode it. 1.6 governed only text with *no*
+   size utility — the body default and inherited text.
+2. The type system had **two** line-height regimes (documented-global vs Tailwind-default-per-size),
+   and the spec described only the first.
 
-1. **`TYPOGRAPHY.md`'s "Line-height: Global 1.6" is not what renders.** Every site carrying
-   `text-xs`/`text-sm`/`text-base`/`text-lg` (~253) renders at Tailwind's default ratio for that size
-   (1.333 / 1.4286 / 1.5 / 1.5556) unless a `leading-*` utility overrides it. 1.6 applies only to text
-   with *no* size utility — the body default and inherited text.
-2. The type system therefore has **two** line-height regimes (documented-global vs
-   Tailwind-default-per-size), and the spec describes only the first.
+**Resolution (§10):** the spec was *not* amended to match the framework. Instead every tier now
+declares both halves of its style — `--text-<tier>` **and** `--text-<tier>--line-height:
+var(--line-height)` — so the documented 1.6 is what renders, and no typography property is owned by
+Tailwind's defaults. This also made D1's swap a no-op: with the pair pinned, `text-xs` and
+`text-[10px]` compute the same 10px/16px, and the Welcome tag stayed 23px (pixel-verified).
 
 ## 6. Missing hierarchy (should probably share one semantic role)
 
@@ -494,10 +511,10 @@ one of which is documented and two of which are not.
 ### 6.8 Line-height and tracking are outside the system
 
 Six leading values and three tracking values, all Tailwind constants, none tokenised (§3.5). The
-prose root's 1.65 already diverges from the global 1.6 with nothing recording why — and, more
-fundamentally, **most text never uses the global 1.6 at all**: the size utilities carry Tailwind's
-per-size line-heights (§5.1). So "line-height" currently has three owners — the documented global
-value, Tailwind's implicit per-size defaults, and six ad-hoc `leading-*` overrides.
+prose root's 1.65 still diverges from the global 1.6 with nothing recording why. The *systemic* half of
+this finding is closed: line-height now has two owners (the declared tier value and explicit
+`leading-*` overrides) instead of three — Tailwind's implicit defaults no longer participate (§5.1).
+The six `leading-*` constants remain untokenised.
 
 ## 7. Component mapping (style → components)
 
@@ -526,19 +543,17 @@ Reverse index of §2. "→" reads *is used by*.
 | **xterm** | TerminalInstance |
 | **mermaid** | DiagramCard / MermaidView |
 
-## 8. Recommendations (not applied)
+## 8. Recommendations (§10 records the two that have been applied)
 
-Ordered by ratio of clarity gained to risk taken. Each is a *proposal*; none is implemented, and
-several need a design decision that is explicitly **not** made here.
+Ordered by ratio of clarity gained to risk taken. Items 1, 2 and 10b are **done** (§10); the rest are
+*proposals*, several of which need a design decision that is explicitly **not** made here.
 
 **Zero-visual-change consolidation:**
 
-1. ⚠️ **Not safe after all** — replacing the 8 `text-[10px]` literals with `text-xs` also swaps
-   line-height 1.6 → 1.333 (§5.1), measured at −3px of pill height on the Welcome tag. Needs one of:
-   accept the tightening; pin the current leading at those sites; or rule that the documented global
-   1.6 wins everywhere (which changes ~253 sites, not 8). **Open decision.**
-2. ✅ **Done** — `text-[length:var(--font-md)]` → `text-base` at `MarkdownPreview:19`, pixel-verified
-   identical (its `leading-[1.65]` already supplies `--tw-leading`). D3 resolved.
+1. ✅ **Done** (§10) — the 8 `text-[10px]` literals are `text-xs`, after §5.1's line-height ownership
+   change made the swap appearance-neutral. D1 resolved.
+2. ✅ **Done** (§10) — `text-[length:var(--font-md)]` → `text-base` at `MarkdownPreview:19`,
+   pixel-verified identical (its `leading-[1.65]` already supplies `--tw-leading`). D3 resolved.
 3. Use the shared `Button` (or its `buttonVariants`) at the 3 hand-rolled primary buttons — removes D5
    (15 files already import it).
 4. Delete the dead tokens (`--font-lg2/-xl/-xxl`, `--uppercase-*`) **or** give them a role; and either
@@ -562,10 +577,9 @@ several need a design decision that is explicitly **not** made here.
    recorded as intentional.
 10. **Tokenise prose line-height** (`--line-height-prose: 1.65`) so the markdown root's divergence from
     1.6 is a decision rather than a literal.
-10b. **Decide who owns line-height** (§5.1): either accept Tailwind's per-size ratios and amend
-    `TYPOGRAPHY.md` (which says 1.6 globally), or neutralise the paired `--text-*--line-height`
-    values so the documented 1.6 actually governs. This is the prerequisite for item 1 — and it is a
-    ~253-site visual decision, not a cleanup.
+10b. ✅ **Done** (§10) — line-height ownership was decided in favour of the design system: the paired
+    `--text-*--line-height` values are declared in our layer as `var(--line-height)`, so the
+    documented 1.6 governs every tier. The spec was **not** amended to match Tailwind.
 11. **Document the markdown em-scale** in `TYPOGRAPHY.md` — it is the app's only relative type scale
     and currently exists only in code.
 
@@ -607,6 +621,56 @@ is a *view* of this document, and this document stays the source of truth after 
 - **Constraints:** the page must apply the *live* utilities (no re-declared literals), so it re-themes
   with the theme engine and cannot drift from what components render; it must not introduce a token; and
   it must be removable in a single revert.
+
+## 10. Reconciliation pass — what was applied, and what was deliberately not
+
+The audit's first version was descriptive only. One reconciliation pass has since landed, on the
+principle that **the specification leads and the implementation follows** — explicitly *not* the other
+way around.
+
+### 10.1 Line-height became a declared property of every tier
+
+`index.css` now declares both halves of each tier — `--text-<tier>` **and**
+`--text-<tier>--line-height: var(--line-height)` — for `xs`, `sm`, `base`, `md`, `lg`.
+
+- **Why:** Tailwind's per-size defaults were silently owning a typography property this design system
+  owns (§5.1). The alternative — amending `TYPOGRAPHY.md` to describe 1.333/1.4286/1.5/1.5556 — was
+  rejected: the framework should not become the source of truth.
+- **Forward-compatibility:** every property of a tier is now declared in one place, which is the shape
+  a token source (the planned typography JSON: family, size, weight, line-height, tracking, transform
+  per role) can generate. Nothing here depends on Tailwind's defaults any more.
+- **Visual effect — intended, and real:** text at every tier gains its documented 1.6 leading. Measured
+  line boxes: `text-xs` 13.33px → 16px, `text-sm` 17.14px → 19.2px, `text-base` 21px → 22.4px,
+  `text-lg` 28px → 28.8px. Fixed-height rows (`h-7`/`h-8` rails, tree rows) are unchanged; auto-height
+  rows grow ~2–3px (a centre tab 25.2px → 27.2px, a right-panel tab label 13.3px → 16px). A
+  whole-DOM clipping probe (`scrollHeight > clientHeight` on every `overflow-hidden` element) found
+  **0 clipped elements before and after**, so no component needed a padding/min-height fix.
+- Per-usage `leading-*` overrides are untouched: they set `--tw-leading`, which still wins over the pair.
+
+### 10.2 Hardcoded values replaced by their semantic tokens (9 sites)
+
+| Was | Now | Sites | Proof of no visual change |
+|---|---|---|---|
+| `text-[10px]` | `text-xs` | `HistoryOverlay:139,151,173` · `TodoList:131,172,207` · `ComparisonCard:33` · `WelcomePanel:246` | Both compute 10px/16px once §10.1 lands. Welcome tag box **23px before and after** (byte-identical element PNG); the history overlay full-page shot is byte-identical. `TodoList`/`ComparisonCard` are agent-only surfaces — not screenshot-verified, but neither sits under a `leading-*` ancestor, so the computed pair is the same 10px/16px. |
+| `text-[length:var(--font-md)]` | `text-base` | `MarkdownPreview:19` | Byte-identical full-page shot; its own `leading-[1.65]` supplies `--tw-leading` in both spellings. |
+
+No token was invented, no `leading-*` was added to "hold" an old value, and no literal was kept for
+backward compatibility.
+
+### 10.3 Deliberately left alone
+
+| Left as-is | Why |
+|---|---|
+| `text-[11px]` ×4 (`HistoryOverlay`, `AskUserQuestionCard`) | A genuine **scale gap** — 11px proportional has no token, and inventing one was out of scope. Standing design decision. |
+| `text-[9px]` ×1 (`SpecsPanel`) | Same: 9px exists only as the unmapped `--compact-font-base`. Standing design decision. |
+| `text-[44px]` (hero), OTP code, fenced-code + prose em scales | Documented exceptions (§3.1, §3.4). |
+| Mono-at-12px ×6, hand-rolled buttons ×3, the ask-card title twin, `<input>` literals, `--font-body`/`--font-base` | Duplicates that differ in **appearance or box model**, not only implementation (§5) — each needs its own decision, not a mechanical swap. |
+| The 8 eyebrow variants, 5 badge treatments, `text-base`≡`text-md`, dead tokens | Hierarchy/token-layer decisions (§6, §1.1) — out of scope for a reconciliation pass. |
+
+### 10.4 Verification
+
+`check:deps` · `check:seams` · `lint` · `typecheck` 10/10 · unit · **e2e no-agent 115/115**, plus the
+screenshot/measurement probes above (temporary specs, not committed).
 
 ## Appendix A — reproducing the counts
 

--- a/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
+++ b/apps/web/src/styles/TYPOGRAPHY-AUDIT.md
@@ -55,14 +55,19 @@ Where they disagree, this file names the drift; it does not silently "fix" eithe
   3. Third-party text rendered by Monaco, xterm, mermaid and shiki is configured in JS, not classes;
      it is inventoried separately in §2.9.
 
-**Headline count:** **75** distinct declared typography combinations across 72 of the 159 `.ts(x)`
-files, expressed through 5 size utilities + 3 composite utilities + **10 distinct hardcoded size
-expressions at 16 sites**.
+**Headline count (after §11):** **32** distinct typographic styles (family × size × weight ×
+line-height × tracking × transform × style, ignoring colour) across 72 of the 159 `.ts(x)` files,
+expressed through 5 size utilities + 4 named role utilities (`text-mono`, `text-base-mono`,
+`text-eyebrow`, `text-brand`) + **14 hardcoded values, all documented exceptions** (hero 44px, OTP
+mono, and the markdown em scales).
 
-> **Reconciliation pass applied (see §10).** This document was first written against a tree with 78
-> combinations / 25 hardcoded sites. Two changes have since landed: line-height became a declared
-> property of every size tier, and the 9 hardcoded values whose token mapping was unambiguous were
-> replaced. Every count and table below reflects the *current* tree; §10 records what moved and why.
+> **Two passes have been applied since this was written.** §10 (reconciliation): line-height became a
+> declared property of every tier + 9 unambiguous hardcoded values replaced. §11 (consolidation): the
+> eyebrow role got a name, identity text lost its mono, and the last two scale gaps closed.
+>
+> §§1–9 describe the tree **as first audited** and are kept as the record of what was found (the
+> "why it survived" analysis is the durable part). Where a finding has since been resolved the row
+> says so, but **for current counts read §10–§11 and the headline above**, not the per-section tallies.
 
 ## 1. The token layer
 
@@ -671,6 +676,78 @@ backward compatibility.
 
 `check:deps` · `check:seams` · `lint` · `typecheck` 10/10 · unit · **e2e no-agent 115/115**, plus the
 screenshot/measurement probes above (temporary specs, not committed).
+
+## 11. Consolidation pass — the minimal semantic set
+
+Driven by four decisions (recorded in `.thinkrail/context/TASK-typography-consolidation.md`). Net
+effect: **43 → 32** distinct typographic styles, **16 → 14** hardcoded values (all now documented
+exceptions), zero ad-hoc mono outside the exceptions.
+
+### 11.1 One named eyebrow role — 5 variants → 1 (18 usages)
+
+`@utility text-eyebrow` = `--font-xs` (10px) / 400 / `tracking-wider` / `uppercase` / `--line-height`.
+Colour stays at the call site. It replaces:
+
+| Old spelling | Sites | Change |
+|---|---|---|
+| `text-xs uppercase tracking-wider` (400) | 8 | none (canonical) |
+| `text-xs font-medium uppercase tracking-wider` | 2 | 500 → 400 |
+| `text-xs uppercase tracking-wide` | 2 | tracking 0.025em → 0.05em |
+| `text-xs font-medium uppercase tracking-wide` | 2 | 500 → 400 + tracking |
+| `text-[9px] uppercase tracking-wider` | 1 | 9px → 10px |
+| `font-[var(--font-mono)] text-xs uppercase tracking-wide` (Welcome tag) | 1 | mono → proportional + tracking |
+| `text-mono uppercase` ("Soon" pill) | 1 | mono 11px → proportional 10px |
+
+Adopted in: `RightPanel`, `ProjectTree`, `TerminalsPanel`, `SpecsPanel`, `ProvidersSettings`,
+`TemplatesSettings`, `CenterTabs`, `SettingsDialog`, `WelcomePanel`, `SkillsDialog` ×2,
+`HistoryOverlay` ×2, `TodoList` ×2, `ThinkingSelector`, `ui/command`, `ui/dropdown-menu`.
+
+### 11.2 Mono is code-only again — identity text is proportional
+
+The rule applied: mono = terminal, editor, code blocks, tool output, diff code + the diff header path,
+inline code, shell commands, slash syntax, keycaps. Everything else proportional.
+
+| Site | Was | Now |
+|---|---|---|
+| `ProjectTree:274` rail branch sub-line | mono 10px | `text-xs` |
+| `NewWorkspaceDialog:712,714,728` branch refs + picker trigger | mono 10px | `text-xs` |
+| `CenterTabs:260` workspace-ready branch line | mono 10px | `text-xs` |
+| `SkillsDialog:394` skill name | mono 12px | `text-sm` |
+| `TodoList:207` todo note | mono 10px | `text-xs` |
+| `WelcomePanel:246` card tag | mono 10px uppercase | `text-eyebrow` |
+| `SettingsDialog:87` "Soon" pill | `text-mono` uppercase | `text-eyebrow` |
+| `NewWorkspaceDialog:536` the `/` syntax glyph | ad-hoc mono, inherited size | `text-mono` (11px) |
+| `DiffPane:86` diff header path | ad-hoc mono 10px | `text-mono` (11px) |
+
+Mono now renders at exactly **11px** (`text-mono`), **13px** (`text-base-mono`, inline code in prose),
+plus the two documented exceptions (OTP 18px, fenced code `0.85em`) — down from six sizes.
+
+### 11.3 Scale gaps closed — `text-xs` is the only compact proportional size
+
+`text-[11px]` ×4 (`HistoryOverlay:284,493,572` chrome + `AskUserQuestionCard`'s Recommended pill) and
+`text-[9px]` ×1 (`SpecsPanel` role chip) → `text-xs` (10px). No token invented, no 11px/9px tier
+introduced. Layout effect: the history scope chip's pill height 23.6px → 22px and the Specs role chip
+gains 1px of text — no padding compensation was needed (a whole-DOM clipping probe reports **0**
+clipped elements, and no pill sits in a row that requires matching heights).
+
+### 11.4 Unchanged by design
+
+Hero `text-[44px]` + `text-brand`; the OTP code; the markdown skins (`Markdown` fenced `0.85em`,
+`MarkdownPreview`'s em heading scale + `leading-[1.65]`); `text-base` ≡ `text-md` (two roles, one
+value); the remaining `leading-*` overrides; the hand-rolled buttons and the ask-card title twin (they
+differ in box model, not just type); `--font-body`/`--font-base`; the dead tokens.
+
+### 11.5 Verification
+
+`lint` · `typecheck` 10/10 · unit · **e2e no-agent 115/115** · clipping probe 0 · 12-surface before/after
+screenshots (this pass changes appearance **on purpose** at the sites listed above: 03-shell, 06-specs,
+09-new-workspace, 10-history, 11/12-welcome-tag differ; the rest are byte-identical).
+
+### 11.6 Correction to §2.10
+
+§2.10 labelled the ad-hoc mono sites carrying `text-xs` as **12px**. Wrong: `--font-xs` is 10px
+(`--font-sm` is 12px), so those were mono at 10px. The resolved set was 10px ×8, 12px ×1
+(`SkillsDialog`), 18px ×1 (OTP), inherited ×1, `0.85em` ×2.
 
 ## Appendix A — reproducing the counts
 

--- a/apps/web/src/styles/TYPOGRAPHY.md
+++ b/apps/web/src/styles/TYPOGRAPHY.md
@@ -30,7 +30,7 @@ Fixed-px tokens in `styles/tokens.css` `:root` (shared by every theme):
 | `--font-md` | 14px | reading text AND the heading size (two utility names, below) |
 | `--font-mono-size` | 11px | the dense technical (mono) size |
 | `--font-lg` | 18px | large display (wordmark) |
-| `--line-height` | 1.6 | global |
+| `--line-height` | 1.6 | global — and the line-height of **every** size tier (see below) |
 
 (`--font-lg2`/`--font-xl`/`--font-xxl`, `--compact-font-base`, `--uppercase-*` exist but are unused —
 kept untouched deliberately.)
@@ -44,6 +44,15 @@ Tailwind mapping (`src/index.css` `@theme inline`):
   page-level supporting copy. **Never UI controls.**
 - `text-md` → `var(--font-md)` — 14px. The heading size (dialog/panel titles). Same value as
   `text-base`, different semantic role — both names stay.
+
+Each tier declares **both halves** of its style: `--text-<tier>` *and* `--text-<tier>--line-height`
+(pinned to `var(--line-height)`). Tailwind pairs every size with a default line-height (xs 1.333,
+sm 1.4286, base 1.5, lg 1.5556); mapping only the size would leave those defaults owning a typography
+property this design system owns — so the pairs are declared explicitly and the documented 1.6 is what
+actually renders at every tier. A per-usage `leading-*` utility sets `--tw-leading` and still wins.
+This "every property of a tier declared in one place" shape is deliberate: it is what a token source
+(the planned typography JSON — family, size, weight, line-height, tracking, transform per role) can
+generate without the implementation smuggling in framework defaults.
 
 ## Utilities (`@utility` in `index.css`)
 
@@ -79,9 +88,13 @@ Disabled = `opacity-50`, no token.
 
 ## Line-height / tracking
 
-Global 1.6; `leading-none` on dialog/card titles; `leading-tight` on the hero, the header scope
-block, and rail rows; `leading-snug` on card subtitles; `tracking-wider` on uppercase eyebrows; 0.5px
-tracking lives inside `text-brand` only.
+1.6 everywhere by default — both as the `global.css` body value and as each size tier's declared
+line-height (see Tailwind mapping above), so a tier's line-height never comes from the framework.
+Per-usage overrides: `leading-none` on dialog/card titles; `leading-tight` on the hero, the header
+scope block, and rail rows; `leading-snug` on card subtitles; `leading-relaxed` on tool output;
+`leading-[1.65]` on the markdown-preview prose root (the one untokenised value — see
+`TYPOGRAPHY-AUDIT.md` §3.4). `tracking-wider` on uppercase eyebrows; 0.5px tracking lives inside
+`text-brand` only.
 
 ## Rendering
 

--- a/apps/web/src/styles/TYPOGRAPHY.md
+++ b/apps/web/src/styles/TYPOGRAPHY.md
@@ -9,7 +9,9 @@ parent: module-web
 # Typography system
 
 The durable reference for `apps/web`'s typography: the type scale and its semantic tiers, the weight
-policy, and where mono is allowed. Components express all of it through token utilities (see
+policy, and where mono is allowed. (For the *as-implemented* picture — every declared style, the
+hardcoded values that remain and why, duplicates, and where this spec and the code disagree — see the
+companion audit `TYPOGRAPHY-AUDIT.md`. It is descriptive; this file stays normative.) Components express all of it through token utilities (see
 `apps/web/SPEC.md` → Styling & theming); this spec is what keeps those utilities from drifting.
 
 (Two companion efforts are specced/reviewed separately and referenced where they touch type: the

--- a/apps/web/src/styles/TYPOGRAPHY.md
+++ b/apps/web/src/styles/TYPOGRAPHY.md
@@ -29,6 +29,7 @@ Fixed-px tokens in `styles/tokens.css` `:root` (shared by every theme):
 | `--font-body` | 13px | the base body size (`--font-base` alias feeds spacing) |
 | `--font-md` | 14px | reading text AND the heading size (two utility names, below) |
 | `--font-mono-size` | 11px | the dense technical (mono) size |
+| — | — | *(no 11px or 9px proportional tier exists — `text-xs` is the single compact proportional size)* |
 | `--font-lg` | 18px | large display (wordmark) |
 | `--line-height` | 1.6 | global — and the line-height of **every** size tier (see below) |
 
@@ -60,6 +61,11 @@ generate without the implementation smuggling in framework defaults.
   technical badges, keycaps.
 - `text-base-mono` = `--font-mono` @ `--font-body` (13px): ONLY inline code inside `text-base`
   long-form content.
+- `text-eyebrow` = `--font-xs` (10px) @ 400, `tracking-wider`, `uppercase`, line-height `--line-height`:
+  THE eyebrow / section-label role — panel labels, rail group headings, settings sub-group headings,
+  menu group headings, plan sections, the workspace-ready eyebrow, the Specs role chip, card tags, the
+  "Soon" pill. Carries the whole type style; the call site adds only colour (`text-muted` /
+  `text-hint` / `text-text` / conditional). No other uppercase label style may exist.
 - `text-brand` = `--font-accent`, weight 800, 0.5px tracking: the canonical ThinkRail brand display
   style. Carries family/weight/tracking ONLY; each usage sets its own size + line-height — the Shell
   header wordmark (`text-brand text-lg text-primary`) and the Welcome hero (`text-brand text-[44px]
@@ -109,17 +115,21 @@ from `--font-mono`.
 
 ## Mono usage policy
 
-Mono is strictly for code/terminal/output/technical badges/keycaps. Branches, project/workspace
-names, model names/ids are proportional — mono had leaked into identity text. Sanctioned exceptions
-and survivors:
+Mono is strictly for **code and technical content**: terminal, editor, code blocks, tool output, diff
+code and the diff header's path, inline code, shell commands, slash-command syntax, keycaps. Identity
+and label text is **proportional** — branches and refs, project/workspace names, skill names, model
+names/ids, tags, metadata and UI labels. Mono is never used to make a label look technical; the
+survivors that once did are swept (see the note at the end of this section). Sanctioned exceptions:
 
 - Login OTP code: `font-[var(--font-mono)] text-lg tracking-widest` — intentional emphasis.
 - Markdown **fenced** code blocks: `font-[var(--font-mono)] text-[0.85em]` — document content that
   scales with the prose skin, deliberately NOT the fixed `text-mono` tier (user-confirmed).
 - Composer slash-command names and the ExtUiDialog JSON editor: `text-mono` — command syntax and a
   code-editing surface (user-confirmed exceptions to the "no mono for names" rule).
-- Known unswept survivors, do not "fix": the rail workspace-branch sub-line (`ProjectTree`) and the
-  branch-picker refs (`NewWorkspaceDialog`).
+Swept (formerly "known survivors", now proportional — do not reintroduce mono): the rail
+workspace-branch sub-line (`ProjectTree`), the branch-picker refs and its trigger (`NewWorkspaceDialog`),
+the workspace-ready branch line (`CenterTabs`), the skill name (`SkillsDialog`), the todo note
+(`TodoList`), the Welcome card tag and the "Soon" pill (both now `text-eyebrow`).
 
 ## Typographic roles
 
@@ -138,8 +148,8 @@ and survivors:
 | Status label (neutral) | `text-sm text-muted`, sentence case, no tracking | "Workspace ready", connection status |
 | Helper text | `text-xs text-hint` | settings helpers, placeholders (`placeholder:text-hint`) |
 | Empty state | `text-xs text-hint` (panels); rail placeholder deliberately `text-sm text-muted` | trees, changes, specs, terminals |
-| Eyebrow | `text-xs uppercase tracking-wider`, `text-muted` or `text-hint` (both exist; not unified) | section labels, group headings |
-| Technical badge | `text-mono uppercase` pill | SOON, spec-first, keycap |
+| Eyebrow | `text-eyebrow` + a colour | section labels, group headings, plan sections, Specs role chip, card tags, "Soon" |
+| Technical badge | `text-mono` pill | keycap (`↵`) |
 | Inline code | `text-base-mono` (chat/markdown) / `text-mono` (in `text-sm` sentences) — background consolidation proposed in the colour-system PR | shared `Markdown.tsx`, `GithubSettings` |
 | Code block | `text-mono` on `bg-elevated`/`bg-bg-dark` | tool output (markdown fenced blocks: em-based, see Mono policy) |
 

--- a/apps/web/src/styles/TYPOGRAPHY.md
+++ b/apps/web/src/styles/TYPOGRAPHY.md
@@ -63,9 +63,11 @@ generate without the implementation smuggling in framework defaults.
   long-form content.
 - `text-eyebrow` = `--font-xs` (10px) @ 400, `tracking-wider`, `uppercase`, line-height `--line-height`:
   THE eyebrow / section-label role — panel labels, rail group headings, settings sub-group headings,
-  menu group headings, plan sections, the workspace-ready eyebrow, the Specs role chip, card tags, the
-  "Soon" pill. Carries the whole type style; the call site adds only colour (`text-muted` /
-  `text-hint` / `text-text` / conditional). No other uppercase label style may exist.
+  menu group headings, plan sections, the workspace-ready eyebrow, the Specs role chip. Carries the
+  whole type style; the call site adds only colour (`text-muted` / `text-hint` / `text-text` /
+  conditional). **Reserved for eyebrow/section-label content**: a pill or badge that merely looks
+  similar (the "Soon" pill, the Welcome card tag) spells its own
+  `text-xs uppercase tracking-wider` — same primitives, no borrowed semantic role.
 - `text-brand` = `--font-accent`, weight 800, 0.5px tracking: the canonical ThinkRail brand display
   style. Carries family/weight/tracking ONLY; each usage sets its own size + line-height — the Shell
   header wordmark (`text-brand text-lg text-primary`) and the Welcome hero (`text-brand text-[44px]
@@ -129,7 +131,8 @@ survivors that once did are swept (see the note at the end of this section). San
 Swept (formerly "known survivors", now proportional — do not reintroduce mono): the rail
 workspace-branch sub-line (`ProjectTree`), the branch-picker refs and its trigger (`NewWorkspaceDialog`),
 the workspace-ready branch line (`CenterTabs`), the skill name (`SkillsDialog`), the todo note
-(`TodoList`), the Welcome card tag and the "Soon" pill (both now `text-eyebrow`).
+(`TodoList`), the Welcome card tag and the "Soon" pill (both now proportional
+`text-xs uppercase tracking-wider`).
 
 ## Typographic roles
 
@@ -148,7 +151,8 @@ the workspace-ready branch line (`CenterTabs`), the skill name (`SkillsDialog`),
 | Status label (neutral) | `text-sm text-muted`, sentence case, no tracking | "Workspace ready", connection status |
 | Helper text | `text-xs text-hint` | settings helpers, placeholders (`placeholder:text-hint`) |
 | Empty state | `text-xs text-hint` (panels); rail placeholder deliberately `text-sm text-muted` | trees, changes, specs, terminals |
-| Eyebrow | `text-eyebrow` + a colour | section labels, group headings, plan sections, Specs role chip, card tags, "Soon" |
+| Eyebrow | `text-eyebrow` + a colour | section labels, group headings, plan sections, Specs role chip |
+| Label pill | `text-xs uppercase tracking-wider` + a colour | "Soon", the Welcome card tag |
 | Technical badge | `text-mono` pill | keycap (`↵`) |
 | Inline code | `text-base-mono` (chat/markdown) / `text-mono` (in `text-sm` sentences) — background consolidation proposed in the colour-system PR | shared `Markdown.tsx`, `GithubSettings` |
 | Code block | `text-mono` on `bg-elevated`/`bg-bg-dark` | tool output (markdown fenced blocks: em-based, see Mono policy) |


### PR DESCRIPTION
Stacked on #137 (base `design/typography`) — review that one first; this PR's diff is only what's on top of it.

Two things: an **audit** of the typography as-implemented, and the **reconciliation + consolidation** it justified.

## The audit — `apps/web/src/styles/TYPOGRAPHY-AUDIT.md`

A spec node (`web-typography-audit`) that stays useful after any temporary showcase page: every declared text style with its resolved values and component sites, every hardcoded value **with why it survived**, the font-load audit, duplicates, missing hierarchy, the style→component map, and recommendations. §§1–9 are the original as-found record; §10–§11 record what has since been applied.

Notable findings:

- **Cabinet Grotesk is never loaded** (no `@font-face`, absent from the Google Fonts request), so `text-brand` — the wordmark and the hero — renders as generic `sans-serif` at a synthesised 800. `apps/website` falls back to Geist instead, so the app and the site disagree on the wordmark. Not fixed here.
- All three families come from a CDN in a local-first app, so everything degrades to system fonts offline.
- Provenance: the drift clustered in surfaces built *in parallel* with PR #137's sweep (skills manager, prompt templates, history search, TODO plans, diff pane, privacy settings) — the sweep touched 31 files, none of them.
- 7 of 15 size-ish tokens are dead; `--compact-font-base` is written on every boot with no reader.

## What changed in the code

**1. The typography layer owns line-height** (`0127211`). Tailwind pairs each `--text-*` with a default line-height, and mapping only the size left those defaults in force — `text-xs` rendered at 1.333, `text-sm` at 1.4286 — while `TYPOGRAPHY.md` documents 1.6. Each tier now declares both halves (`--text-<tier>` + `--text-<tier>--line-height: var(--line-height)`), so the documented value is what renders and no typography property is owned by the framework. The spec was deliberately **not** amended to match Tailwind. Every property of a tier now lives in one place — the shape a future typography JSON can generate.

*Intended reflow, measured:* `text-xs` 13.33→16px, `text-sm` 17.14→19.2px, `text-base` 21→22.4px, `text-lg` 28→28.8px. Fixed-height rows unchanged; auto-height rows +2–3px. A whole-DOM clipping probe reports **0** clipped elements before and after, so no component needed a padding fix.

**2. Hardcoded values → semantic tokens** (`33c9a09`, `12713fe`). All 8 `text-[10px]` → `text-xs`, and the prose root's `text-[length:var(--font-md)]` → `text-base`. Both were proven pixel-identical (byte-identical screenshots), the first only *after* change 1 — before it, the token would have tightened those pills by ~3px.

**3. Consolidation into a minimal semantic set** (`489b7d1`, `852a536`) — **43 → 33 distinct typographic styles**:

- **`@utility text-eyebrow`** (10px / 400 / `tracking-wider` / `uppercase`; colour at the call site) replaces 5 near-identical spellings across **16 section-label sites**. The role is reserved for eyebrow/section-label content — the "Soon" pill and the Welcome card tag reuse the same primitives but spell their own classes rather than borrow the role.
- **Mono is code-only again.** `text-mono` = terminal, editor, code blocks, tool output, diff code + the diff header path, inline code, shell commands, slash syntax, keycaps. Identity text is proportional, which sweeps the former "known survivors": rail branch sub-line, branch-picker refs, workspace-ready branch line, skill name, todo note, card tag. **Mono now renders at 11px and 13px only**, down from six sizes.
- **The last scale gaps close downward:** `text-[11px]` ×4 and `text-[9px]` ×1 → `text-xs`, the single compact proportional size. No token invented.

Every remaining hardcoded value is a documented exception: the hero's 44px (`text-brand` carries no size), the OTP code, and the markdown skins (fenced `0.85em`, `MarkdownPreview`'s em heading scale + `leading-[1.65]`).

## Still open (recorded, not done)

Dead tokens; `text-base` ≡ `text-md` with no guard; untokenised `leading-*` incl. the prose 1.65; the 3 hand-rolled primary buttons; `--font-body`/`--font-base` duplication; the Cabinet Grotesk loading gap; the deferred typography-showcase page (§9 is its contract) and the typography JSON.

## Verification

`check:deps` · `check:seams` · `lint` · `typecheck` 10/10 · unit · **e2e no-agent 115/115** · clipping probe 0 · no suppressions added.

Changes 1 and 3 alter appearance **on purpose**; change 2 is pixel-identical. 12-surface before/after screenshots captured for both — attaching below.
