### PR TITLE
fix(web): improve dark theme text selection visibility

### DIFF
--- a/apps/web/src/themes/bundled/dark.theme.json
+++ b/apps/web/src/themes/bundled/dark.theme.json
@@ -21,7 +21,7 @@
 		"text": "#dfe1e5",
 		"muted": "#a8adb5",
 		"hint": "#71757c",
-		"selection": "#2c2947",
+		"selection": "#2d4f67",
 		"selectionForeground": null,
 		"editorSelection": "#2d4f67",
 		"editorSelectionForeground": null,


### PR DESCRIPTION
## Summary

- Increase the default Dark theme's text-selection background contrast.
- Match browser selection visibility to the existing editor/terminal selection color.
- Keep selected-text foreground behavior unchanged.

Before
<img width="982" height="220" alt="before" src="https://github.com/user-attachments/assets/c51022f4-53be-476c-96d7-5b55ee545b03" />

After
<img width="1008" height="214" alt="after" src="https://github.com/user-attachments/assets/e606e24c-11ef-4cd1-b9df-2cdf38cead5f" />


## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run check:deps`
- `bun run check:seams`
- `bun run e2e` — 124/124 passed.

## Why

The default Dark theme's browser selection was too close to the page background. This small palette-only
change makes the selection band easier to see without changing text colors or other themes.