### PR TITLE
feat(analytics): message_sent event on every user send

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ stored in `~/.thinkrail/installation.json`; it never leaves the host except as t
 `distinct_id` on events. Events additionally carry only low-cardinality, non-personal metadata: app
 version, release channel (`stable`/`nightly`), OS (`macos`/`linux`/`windows`), architecture
 (`x64`/`arm64`), and — on chat/login events — the model/provider name **only if it is a pi built-in**
-(anything user-configured is reported as `custom`). Events are sent **personless** (no person
+(anything user-configured is reported as `custom`). Message activity is counted as a bare send event
+carrying only *how* it was sent (`prompt`/`steer`/`follow_up`) — never the message itself. Events are sent **personless** (no person
 profiles are ever built) and with **GeoIP lookup disabled**.
 
 **Never collected:** file paths or names, prompts, code, chat transcripts, API keys, token counts,

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -1,5 +1,5 @@
 import type { AskUserAnswersDetails, TranscriptMessage, UserMessage } from "@thinkrail/contracts";
-import { isAskUserAnswersMessage, TODO_NUDGE_PREFIX } from "@thinkrail/contracts";
+import { isAskUserAnswersMessage, isControlMessage } from "@thinkrail/contracts";
 import type { ChatTurn, ToolResultState } from "./types";
 
 /** The leading text of a user message (string or text blocks). */
@@ -48,7 +48,7 @@ export function messagesToRuntime(messages: TranscriptMessage[]): HydratedRuntim
 		if (message.role === "user") {
 			// A pi-todos hidden nudge renders no turn, but still consumes its positional slot below
 			// (turnId stays null) so turnIdByMessageIndex stays aligned with the server's messageIndex.
-			if (!userText(message.content).startsWith(TODO_NUDGE_PREFIX)) {
+			if (!isControlMessage(userText(message.content))) {
 				turnId = crypto.randomUUID();
 				turns.push({ kind: "user", id: turnId, message });
 			}

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -20,7 +20,10 @@ of the host.
 - **Owns:** the wire — entity types, the `pi` event/message types (re-exported), the WS method & channel
   registries, and the protocol version.
 - **Public surface (`index.ts`):** `export type *` of `piProtocol` + `domain`; the value re-exports
-  `DEFAULT_CONFIG` from `domain`; `export *` (value) of `wsProtocol`
+  `DEFAULT_CONFIG`, `MAX_HISTORY_LIMIT`, `MAX_HISTORY_QUERY_LENGTH`, `TODO_NUDGE_PREFIX` +
+  **`isControlMessage(text)`** (the one shared reading of that marker — the client hides such sends on
+  hydrate, the host skips them in the history index and does not count them as `message_sent`; both
+  sides agree here rather than each re-deriving `startsWith`) from `domain`; `export *` (value) of `wsProtocol`
   (`WS_METHODS`, `WS_CHANNELS`, the typed maps, `PROTOCOL_VERSION`).
 - **Allowed deps:** none at runtime. **Type-only** devDeps on `@earendil-works/pi-ai` +
   `@earendil-works/pi-agent-core`, imported **from their package roots** (type-only → erased at build).

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -363,6 +363,15 @@ export const DEFAULT_CONFIG: AppConfig = { theme: "dark", analyticsEnabled: true
  */
 export const TODO_NUDGE_PREFIX = "[thinkrail:todo-nudge] ";
 
+/**
+ * True when a send's text is internal control traffic rather than a user-authored message. The one
+ * shared reading of the marker above — the client hides these on hydrate, the host skips them in the
+ * history index and does not count them as sent messages in analytics.
+ */
+export function isControlMessage(text: string): boolean {
+	return text.startsWith(TODO_NUDGE_PREFIX);
+}
+
 /** History-search scope — the overlay's cycle: this chat → workspace → project → everywhere. */
 export type HistoryScope =
 	| { kind: "chat"; sessionId: string }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,11 +1,13 @@
 // The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol), the
 // app-config default (`DEFAULT_CONFIG`), the history-search caps (`MAX_HISTORY_LIMIT`,
-// `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX`) — small
+// `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX` +
+// its shared `isControlMessage` reading) — small
 // plain constants both sides must agree on. Theme catalogs stay browser-side; the wire carries an opaque id.
 
 export type * from "./domain";
 export {
 	DEFAULT_CONFIG,
+	isControlMessage,
 	MAX_HISTORY_LIMIT,
 	MAX_HISTORY_QUERY_LENGTH,
 	TODO_NUDGE_PREFIX,

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -52,7 +52,9 @@ PostHog won on free tier, EU residency, and a self-host path).
   text, no length, no image count) and no identity params (model preference is `chat_started`'s job).
   New-chat and existing-chat sends are the same event; `chat_started` stays the new-chat signal. Fired
   by `host` from `session.prompt`/`steer`/`followUp` **after the send is accepted** (`ackSend`), so a
-  rejected send never counts.
+  rejected send never counts — and **only for user-authored** sends: the same wire methods also carry
+  internal control traffic (the client's TODO wake-nudge), which `isControlMessage` filters out, so the
+  count stays "messages the user sent" and never inflates with the app's own prompts.
 - **Public surface (barrel):** `initializeAnalytics`, `track`, `setAnalyticsSending`,
   `shutdownAnalytics`, `resetAnalyticsForTests`, the event types + bucket helpers.
 - **Allowed deps:** `persistence` (installation record + data dir), `contracts` (types),

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -22,7 +22,7 @@ PostHog won on free tier, EU residency, and a self-host path).
 
 - **Owns:**
   - `events.ts` — the closed `AnalyticsEvent` union (`app_installed` / `app_started` /
-    `chat_started {provider, model}` / `provider_login {provider, method}`) and
+    `chat_started {provider, model}` / `message_sent {mode}` / `provider_login {provider, method}`) and
     `bucketProvider()` / `bucketProviderModel()`: identity passes raw **only** when it matches pi's
     built-in catalog (`getBuiltinProviders()` / `getBuiltinModels()`); a custom provider — or a custom
     model id on a known provider — becomes `"custom"`. Fails closed. The machine-checked privacy pin is
@@ -47,6 +47,12 @@ PostHog won on free tier, EU residency, and a self-host path).
     sink selection, env stamping, first-run notice + `app_installed` announce, `app_started`),
     `track(event)`, `setAnalyticsSending(enabled)`, `shutdownAnalytics()` (best-effort flush — the
     host's `stop()` fires it without awaiting), `resetAnalyticsForTests()`.
+- **Engagement (`message_sent`):** one event per user-authored send, `mode` from the closed vocabulary
+  `prompt` | `steer` | `follow_up` (pi's three send methods) — never anything about the message (no
+  text, no length, no image count) and no identity params (model preference is `chat_started`'s job).
+  New-chat and existing-chat sends are the same event; `chat_started` stays the new-chat signal. Fired
+  by `host` from `session.prompt`/`steer`/`followUp` **after the send is accepted** (`ackSend`), so a
+  rejected send never counts.
 - **Public surface (barrel):** `initializeAnalytics`, `track`, `setAnalyticsSending`,
   `shutdownAnalytics`, `resetAnalyticsForTests`, the event types + bucket helpers.
 - **Allowed deps:** `persistence` (installation record + data dir), `contracts` (types),

--- a/packages/server/src/analytics/analytics.test.ts
+++ b/packages/server/src/analytics/analytics.test.ts
@@ -101,6 +101,7 @@ const EVENT_SAMPLES = {
 	app_installed: { name: "app_installed" },
 	app_started: { name: "app_started" },
 	chat_started: { name: "chat_started", params: { provider: "anthropic", model: "some-model" } },
+	message_sent: { name: "message_sent", params: { mode: "prompt" } },
 	provider_login: { name: "provider_login", params: { provider: "openai", method: "oauth" } },
 } as const satisfies { [K in AnalyticsEvent["name"]]: Extract<AnalyticsEvent, { name: K }> };
 
@@ -111,6 +112,7 @@ const EXPECTED_KEYS: Record<keyof typeof EVENT_SAMPLES, string[]> = {
 	app_installed: ENV_KEYS,
 	app_started: ENV_KEYS,
 	chat_started: [...ENV_KEYS, "provider", "model"],
+	message_sent: [...ENV_KEYS, "mode"],
 	provider_login: [...ENV_KEYS, "provider", "method"],
 };
 

--- a/packages/server/src/analytics/events.ts
+++ b/packages/server/src/analytics/events.ts
@@ -7,15 +7,20 @@ import { getBuiltinModels, getBuiltinProviders } from "@earendil-works/pi-ai/pro
 /** How a provider credential was configured in-app. A closed vocabulary, never user input. */
 export type LoginMethod = "oauth" | "api-key" | "central";
 
+/** How a user-authored message was sent. A closed vocabulary mirroring pi's three send methods. */
+export type SendMode = "prompt" | "steer" | "follow_up";
+
 /**
  * Every analytics event the host can emit. `app_installed`/`app_started` carry no event params (the
- * env set below rides on every event); the identity params on the other two pass through
- * `bucketProviderModel`/`bucketProvider` first, so a user-configured name never leaves the process.
+ * env set below rides on every event); the identity params on `chat_started`/`provider_login` pass
+ * through `bucketProviderModel`/`bucketProvider` first, so a user-configured name never leaves the
+ * process. `message_sent` carries only its closed-vocabulary `mode` — nothing about the message itself.
  */
 export type AnalyticsEvent =
 	| { name: "app_installed" }
 	| { name: "app_started" }
 	| { name: "chat_started"; params: { provider: string; model: string } }
+	| { name: "message_sent"; params: { mode: SendMode } }
 	| { name: "provider_login"; params: { provider: string; method: LoginMethod } };
 
 /** The bucket a user-configured (non-built-in) provider or model id collapses to. */

--- a/packages/server/src/analytics/index.ts
+++ b/packages/server/src/analytics/index.ts
@@ -7,6 +7,7 @@ export {
 	bucketProvider,
 	bucketProviderModel,
 	type LoginMethod,
+	type SendMode,
 } from "./events";
 export {
 	type AnalyticsOptions,

--- a/packages/server/src/history/extract.ts
+++ b/packages/server/src/history/extract.ts
@@ -4,7 +4,7 @@ import {
 	parseSessionEntries,
 	type SessionEntry,
 } from "@earendil-works/pi-coding-agent";
-import { TODO_NUDGE_PREFIX } from "@thinkrail/contracts";
+import { isControlMessage } from "@thinkrail/contracts";
 
 /** One searchable message from a session transcript (see SPEC.md for the messageIndex invariant). */
 export interface HistoryEntry {
@@ -92,7 +92,7 @@ export function extractSession(jsonl: string): ExtractedSession | null {
 		// Internal control traffic: the pi-todos wake-nudge is hidden from the transcript on hydrate, so it
 		// must not surface as a recallable/insertable prompt. The index was already consumed above, so
 		// skipping only the text keeps every later hit's anchor aligned.
-		if (message.role === "user" && text.startsWith(TODO_NUDGE_PREFIX)) continue;
+		if (message.role === "user" && isControlMessage(text)) continue;
 		out.push({
 			text,
 			role: message.role,

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -34,7 +34,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
   **analytics wiring** (`initializeAnalytics` at boot from the launcher-threaded `analytics` option —
   keys/channel/mute + the initial `getConfig().analyticsEnabled`; a `setAnalyticsSending` sync teed
   off the settings publisher; a fire-and-forget `shutdownAnalytics()` in `stop()` — best-effort queue
-  drain; and every `track()` call site: `chat_started` in `session.create`, `provider_login` from the
+  drain; and every `track()` call site: `chat_started` in `session.create`, `message_sent` (via the
+  local `trackSend(mode)`) after an **accepted** `session.prompt`/`session.steer`/`session.followUp`
+  (`prompt`/`steer`/`follow_up`; `session.answerQuestion` is a tool reply, not a message),
+  `provider_login` from the
   login-publisher tee's terminal `success` frames with the method (`oauth`/`api-key`) looked up from
   `loginAnalytics.ts` — the loginId→method map the `provider.loginStart` handler records (and
   `provider.loginCancel` clears; an unknown loginId tracks nothing, fails closed) — +

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -35,8 +35,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
   keys/channel/mute + the initial `getConfig().analyticsEnabled`; a `setAnalyticsSending` sync teed
   off the settings publisher; a fire-and-forget `shutdownAnalytics()` in `stop()` — best-effort queue
   drain; and every `track()` call site: `chat_started` in `session.create`, `message_sent` (via the
-  local `trackSend(mode)`) after an **accepted** `session.prompt`/`session.steer`/`session.followUp`
-  (`prompt`/`steer`/`follow_up`; `session.answerQuestion` is a tool reply, not a message),
+  local `trackSend(mode, text)`) after an **accepted** `session.prompt`/`session.steer`/`session.followUp`
+  (`prompt`/`steer`/`follow_up`; skipped when contracts' `isControlMessage(text)` — the client's TODO
+  wake-nudge rides the same methods and is not a user message; `session.answerQuestion` is a tool reply,
+  not a message either),
   `provider_login` from the
   login-publisher tee's terminal `success` frames with the method (`oauth`/`api-key`) looked up from
   `loginAnalytics.ts` — the loginId→method map the `provider.loginStart` handler records (and

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -11,6 +11,7 @@ import type {
 	WireModel,
 	Workspace,
 } from "@thinkrail/contracts";
+import { isControlMessage } from "@thinkrail/contracts";
 import {
 	abortSession,
 	answerQuestion,
@@ -118,9 +119,12 @@ async function archiveTeardown(ws: Workspace): Promise<void> {
 
 /**
  * Analytics for a user-authored send, fired only once the send was ACCEPTED (a rejected send throws
- * before this and never counts). Carries just the closed-vocabulary `mode` — nothing about the message.
+ * before this and never counts). Carries just the closed-vocabulary `mode` — nothing about the message,
+ * not even its length. Internal control traffic (the client's TODO wake-nudge, marked on the wire) is
+ * not a message the user sent, so it is skipped: the `session.*` send methods carry both kinds.
  */
-function trackSend(mode: SendMode): void {
+function trackSend(mode: SendMode, text: string): void {
+	if (isControlMessage(text)) return;
 	track({ name: "message_sent", params: { mode } });
 }
 
@@ -339,19 +343,19 @@ const handlers: Record<string, Handler> = {
 	"session.prompt": async (params) => {
 		const p = params as { sessionId: string; text: string; images?: ImageContent[] };
 		await ackSend(promptSession(p.sessionId, p.text, p.images));
-		trackSend("prompt");
+		trackSend("prompt", p.text);
 		return { ok: true } as const;
 	},
 	"session.steer": async (params) => {
 		const p = params as { sessionId: string; text: string; images?: ImageContent[] };
 		await ackSend(steerSession(p.sessionId, p.text, p.images));
-		trackSend("steer");
+		trackSend("steer", p.text);
 		return { ok: true } as const;
 	},
 	"session.followUp": async (params) => {
 		const p = params as { sessionId: string; text: string; images?: ImageContent[] };
 		await ackSend(followUpSession(p.sessionId, p.text, p.images));
-		trackSend("follow_up");
+		trackSend("follow_up", p.text);
 		return { ok: true } as const;
 	},
 	"session.abort": async (params) => {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -38,7 +38,7 @@ import {
 	setSessionThinkingLevel,
 	steerSession,
 } from "../agent";
-import { bucketProviderModel, track } from "../analytics";
+import { bucketProviderModel, type SendMode, track } from "../analytics";
 import {
 	cancelLogin,
 	connectJbcentral,
@@ -114,6 +114,14 @@ async function archiveTeardown(ws: Workspace): Promise<void> {
 	} catch (error) {
 		console.warn(`workspace archive teardown failed for ${ws.id}: ${error}`);
 	}
+}
+
+/**
+ * Analytics for a user-authored send, fired only once the send was ACCEPTED (a rejected send throws
+ * before this and never counts). Carries just the closed-vocabulary `mode` — nothing about the message.
+ */
+function trackSend(mode: SendMode): void {
+	track({ name: "message_sent", params: { mode } });
 }
 
 const handlers: Record<string, Handler> = {
@@ -331,16 +339,19 @@ const handlers: Record<string, Handler> = {
 	"session.prompt": async (params) => {
 		const p = params as { sessionId: string; text: string; images?: ImageContent[] };
 		await ackSend(promptSession(p.sessionId, p.text, p.images));
+		trackSend("prompt");
 		return { ok: true } as const;
 	},
 	"session.steer": async (params) => {
 		const p = params as { sessionId: string; text: string; images?: ImageContent[] };
 		await ackSend(steerSession(p.sessionId, p.text, p.images));
+		trackSend("steer");
 		return { ok: true } as const;
 	},
 	"session.followUp": async (params) => {
 		const p = params as { sessionId: string; text: string; images?: ImageContent[] };
 		await ackSend(followUpSession(p.sessionId, p.text, p.images));
+		trackSend("follow_up");
 		return { ok: true } as const;
 	},
 	"session.abort": async (params) => {


### PR DESCRIPTION
## What

Adds a fifth member to the closed analytics event union: **`message_sent`**, fired once per user-authored send — a new chat's first message and any message in an existing chat alike (`chat_started` remains the new-chat signal).

```ts
| { name: "message_sent"; params: { mode: SendMode } }   // SendMode = "prompt" | "steer" | "follow_up"
```

## Design decisions

- **`mode` only.** Closed vocabulary mirroring pi's three send methods. No text, no length, no image count, and no identity params — model preference is already answered by `chat_started`, which also kept `agent` free of a new session-model accessor.
- **Accepted sends only.** `trackSend(mode)` sits *after* `await ackSend(...)` in `session.prompt` / `session.steer` / `session.followUp`, so a rejected send (bad model, missing key, malformed send) never counts.
- **`session.answerQuestion` untracked** — a tool reply, not a user message.
- **Call site stays in `host`.** Per `submodule-server-analytics`, feature modules remain analytics-free.

## Privacy

The machine-checked pin is `analytics.test.ts`: `EVENT_SAMPLES` is exhaustive over the union (a new variant without a sample is a compile error) and `EXPECTED_KEYS` asserts the exact outgoing property set — here `app_version`, `channel`, `os`, `arch`, `mode`.

## Specs updated

- `packages/server/src/analytics/SPEC.md` — event list + a new "Engagement" bullet (vocabulary, accepted-only firing, why no identity params).
- `packages/server/src/host/SPEC.md` — the new `track()` call site.
- `README.md` — Analytics & Privacy section.

## Verification

`check:deps` · `check:seams` · `lint` · `typecheck` · `bun run test` (365 pass) · `bun run e2e` (124 pass) · `spec_validate` clean. No suppressions added.

Not covered by a test: the accepted-path fire needs a live pi session (`@agent` territory); the negative path holds structurally from `track` sitting after `await ackSend`. Happy to add an `@agent` e2e assertion if you'd like it pinned.
