### PR TITLE
fix(changes): branch scope measures from the merge-base; a moved prefetch nudges its readers

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -453,7 +453,8 @@ a project picker, the prompt hero, and the reused
   the two-rows-read-as-selected ambiguity the single-selection rule above exists to prevent.
 - **The diff scope is chosen in the Changes header, and enters the tab's identity.** Two header controls say
   what is being diffed: the **`ChangesScopeMenu`** pill — *All
-  changes* (everything vs the target branch, the default) / *Uncommitted changes* / one **commit** from the
+  changes* (the workspace's work since diverging from the target branch — measured from the merge-base,
+  so upstream commits landing on the target are never phantom rows here; the default) / *Uncommitted changes* / one **commit** from the
   branch's list — and the shared **`BranchPicker`** pill for the **target branch** (`workspace.setDiffBase`;
   the panel converges on the broadcast `workspace.updated`, never optimistically). The menu's contents load
   **lazily on each open**, never on panel mount: `git.listCommits` for the commit rows (subject +

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -105,8 +105,8 @@ export function selectCatalogModel(
 }
 
 /**
- * The **default** diff scope: everything on the workspace's branch vs its diff base (the behaviour that
- * predates the scope selector). A shared module constant, not a fresh object per read, so
+ * The **default** diff scope: the workspace's work since diverging from its diff base (the scope that
+ * predates the scope selector; the host measures it from the merge-base). A shared module constant, not a fresh object per read, so
  * {@link selectDiffScope} is referentially stable for a workspace that never picked a scope.
  */
 export const BRANCH_SCOPE: GitDiffScope = { kind: "branch" };

--- a/e2e/changes.spec.ts
+++ b/e2e/changes.spec.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Locator, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
-import { E2E_DATA_DIR } from "./fixtures/paths";
+import { E2E_DATA_DIR, E2E_FIXTURE_REPO } from "./fixtures/paths";
 import { largeRepetitiveMarkdownEdited } from "./fixtures/repo";
 
 test("Changes tab shows the active worktree's diff and swaps per workspace", async ({ page }) => {
@@ -355,6 +355,50 @@ test("The scope menu's target-branch picker re-points what the changes are measu
 	).toHaveAttribute("data-active", "true");
 });
 
+test("A target that advanced past the fork point adds no phantom changes (merge-base semantics)", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	seedCommitAndDirtyEdit();
+
+	// A branch that is main + one commit the workspace never saw ("upstream" work) — built in a throwaway
+	// git worktree so the shared fixture's main checkout is never disturbed. Self-cleaning: resetState
+	// prunes stray worktrees and deletes every non-main branch.
+	const upstreamWt = join(E2E_DATA_DIR, "worktrees", "e2e-upstream");
+	gitIn(E2E_FIXTURE_REPO, "worktree", "add", upstreamWt, "-b", "future-main", "main");
+	writeFileSync(join(upstreamWt, "upstream.txt"), "landed on the base after the fork\n");
+	gitIn(upstreamWt, "add", "upstream.txt");
+	gitIn(
+		upstreamWt,
+		"-c",
+		"user.email=e2e@thinkrail.test",
+		"-c",
+		"user.name=ThinkRail E2E",
+		"commit",
+		"-m",
+		"upstream work",
+	);
+
+	await page.getByTestId("tab-changes").click();
+	await expect(page.getByTestId("change-item")).toHaveCount(2); // committed.txt + README.md
+
+	// Re-point the target at the advanced branch. Tip semantics would now claim upstream.txt as a phantom
+	// deletion — a file this workspace never touched; measuring from the merge-base (the fork point) keeps
+	// the list at exactly the workspace's own work.
+	await page.getByTestId("changes-target-picker").click();
+	await page.locator('[data-testid="branch-option"][data-branch="future-main"]').click();
+	await expect(page.getByTestId("changes-target-picker")).toContainText("future-main");
+
+	// Convergence signal: a fresh own edit must appear via the fs tick — that landed read was taken
+	// against the new target, which makes the phantom's absence a claim about the NEW range, not a stale
+	// list. (Under tip semantics this same read would surface upstream.txt as a fourth, deleted row.)
+	writeFileSync(join(worktreeDir(), "own-file.txt"), "still just my work\n");
+	await expect(page.getByTestId("change-item")).toHaveCount(3);
+	await expect(page.getByTestId("change-item").filter({ hasText: "own-file.txt" })).toHaveCount(1);
+	await expect(page.getByTestId("change-item").filter({ hasText: "upstream.txt" })).toHaveCount(0);
+});
+
 test("A change row's action menu opens from the ⌄ button and from right-click; Copy path writes the relative path", async ({
 	page,
 	context,
@@ -635,11 +679,16 @@ test("Re-pointing the target branch re-reads an open branch-scope diff tab — a
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
 	const worktree = seedCommitAndDirtyEdit();
-	// A second target branch whose copy of the file says something ELSE. That string is the whole point: it can
-	// only appear on screen through a re-read against that target, so the assertions below fail if the tab does
-	// not follow the target. (A previous version edited the worktree file instead — which the fs-tick re-read
-	// would have shown anyway, so it passed with the target dimension removed entirely.)
-	writeFileSync(join(worktree, "committed.txt"), "committed by the target branch\n");
+	// Two targets whose FORK POINTS hold different copies of the file — the observable dimension under
+	// merge-base semantics (the original side always comes from the fork point, an ancestor of the
+	// workspace, never from a target's own tip). A second workspace commit revises the file, and
+	// `e2e-target` parks on the FIRST commit: targeting `main` puts the fork point before the file existed
+	// (add-style original), targeting `e2e-target` puts it at the first commit — whose content
+	// ("committed by e2e") can appear on screen only through a re-read against that target, so the
+	// assertions below fail if the tab does not follow the re-point. (A previous version edited the
+	// worktree file instead — which the fs-tick re-read would have shown anyway, so it passed with the
+	// target dimension removed entirely.)
+	writeFileSync(join(worktree, "committed.txt"), "revised by the workspace\n");
 	gitIn(worktree, "add", "committed.txt");
 	gitIn(
 		worktree,
@@ -649,29 +698,26 @@ test("Re-pointing the target branch re-reads an open branch-scope diff tab — a
 		"user.name=ThinkRail E2E",
 		"commit",
 		"-m",
-		"e2e target commit",
+		"e2e revise commit",
 	);
-	gitIn(worktree, "branch", "e2e-target", "HEAD");
-	gitIn(worktree, "reset", "--hard", "HEAD~1"); // the workspace branch keeps only its own commit
-	// `reset --hard` also wiped the seeded dirty edit — restore it: the second half of this test parks on
-	// README.md's diff tab while the target moves.
-	writeFileSync(join(worktree, "README.md"), "# sample-project\n\ndirty edit by e2e\n");
+	gitIn(worktree, "branch", "e2e-target", "HEAD~1");
 
 	await page.getByTestId("tab-changes").click();
-	// A file changed by the branch's commit — visible in the default (vs base) scope, where the target has no
-	// copy of it at all, so the diff is an add of the worktree content. Double-clicked: the tab must be KEPT,
-	// or the second row below would replace it in the workspace's preview slot.
+	// A file changed by the branch's commits — visible in the default (vs base) scope, where the fork point
+	// has no copy of it at all, so the diff is an add of the worktree content. Double-clicked: the tab must
+	// be KEPT, or the second row below would replace it in the workspace's preview slot.
 	const committedRow = page.getByTestId("change-item").filter({ hasText: "committed.txt" });
 	await committedRow.dblclick();
 	const diffPane = page.getByTestId("diff-pane");
-	await expect(diffPane).toContainText("committed by e2e");
-	await expect(diffPane).not.toContainText("committed by the target branch");
+	await expect(diffPane).toContainText("revised by the workspace");
+	await expect(diffPane).not.toContainText("committed by e2e");
 
 	// (1) The ACTIVE tab follows a re-point immediately — a branch-scope tab means "this file vs the
-	// workspace's current target", it does not wait for the next fs tick.
+	// workspace's current target", it does not wait for the next fs tick. The fork point is now the first
+	// commit, so ITS copy becomes the original side.
 	await page.getByTestId("changes-target-picker").click();
 	await page.locator('[data-testid="branch-option"][data-branch="e2e-target"]').click();
-	await expect(diffPane).toContainText("committed by the target branch");
+	await expect(diffPane).toContainText("committed by e2e");
 
 	// (2) A BACKGROUNDED tab follows it too. Panes mount only while their tab is active, so the drift has to be
 	// detected on activation — which works only because the tab persists the target its content was read
@@ -683,8 +729,8 @@ test("Re-pointing the target branch re-reads an open branch-scope diff tab — a
 	await page.locator('[data-testid="branch-option"][data-branch="main"]').first().click();
 
 	await committedRow.click();
-	await expect(diffPane).toContainText("committed by e2e");
-	await expect(diffPane).not.toContainText("committed by the target branch");
+	await expect(diffPane).toContainText("revised by the workspace");
+	await expect(diffPane).not.toContainText("committed by e2e");
 });
 
 test("A commit scope whose commit is rewritten away falls back to All changes with a toast", async ({

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -108,7 +108,8 @@ of the host.
   non-removable and non-renamable server-side; absent = a normal worktree workspace — an explicit wire
   field, never an id convention), `Session` (chat tab),
   `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types — incl. **`GitDiffScope`** (what the Changes
-  panel is diffing: `branch` → everything vs the workspace's diff base / `uncommitted` → worktree vs `HEAD` /
+  panel is diffing: `branch` → the workspace's work since diverging from its diff base (the range starts at
+  their merge-base, never the base's tip) / `uncommitted` → worktree vs `HEAD` /
   `commit` → one commit, `sha^` vs `sha`; omitted on the wire = `branch`, so an older client is unchanged)
   and **`GitCommit`** (a commit row of the scope menu's list). The two meanings of a workspace's base are
   **two fields**: `Workspace.baseBranch` is *creation provenance* (the ref the worktree was cut from — what
@@ -192,7 +193,10 @@ of the host.
   taking an optional **`scope: GitDiffScope`** (an unresolvable scope — a commit a rebase removed — is
   *rejected*, which the panel reads as "reset the scope" instead of staying wedged on a dead sha) /
   **`git.listCommits`** (the workspace branch's own commits, `<diff base>..HEAD`, newest first, capped
-  host-side — the scope menu's lazily-fetched list) / **`skills.state`** (`SkillCatalogEntry[]` — full catalog +
+  host-side — the scope menu's lazily-fetched list) / **`git.prefetch`** (best-effort background fetch of a
+  remote base — the New-Workspace dialog's freshness warm-up; always acks `{ ok }`, and when the fetch
+  actually moved the local remote-tracking ref the host follows up with pathless `workspace.fsChanged`
+  frames to the workspaces whose diff base that ref is, so their git-derived reads re-converge) / **`skills.state`** (`SkillCatalogEntry[]` — full catalog +
   per-skill `decision` + `group` — for a `workspaceId`) / **`project.skills`** (the same, project-scoped, for
   the pre-session manager) / **`session.reloadResources`** (re-scan skills + rebuild the system prompt for one
   running session; rejected while streaming) /

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -216,7 +216,7 @@ export interface GitFileChange {
 	path: string;
 	status: GitFileStatus;
 	/**
-	 * Lines added / removed vs the base branch (`git diff --numstat`; untracked files count their whole
+	 * Lines added / removed over the scope's range (`git diff --numstat`; untracked files count their whole
 	 * content as added). Omitted when git reports no per-line count — binary files, or a rename whose
 	 * numstat path couldn't be resolved. Used by the Changes tree's per-file / per-folder `+/−` badge.
 	 */
@@ -234,7 +234,9 @@ export interface GitStatus {
  * tab's content must never change meaning because the rail's scope flipped underneath it). Omitted on the
  * wire = `{ kind: "branch" }`, so an older client keeps working unchanged.
  *
- * - `branch` — everything on this workspace's branch vs its diff base (`diffBase ?? baseBranch`).
+ * - `branch` — what this workspace changed since diverging from its diff base (`diffBase ??
+ *   baseBranch`): the range starts at their **merge-base** (the fork point), never at the base's tip —
+ *   upstream work landing on the base is not this workspace's change and never shows up here.
  * - `uncommitted` — the worktree vs `HEAD` (what a commit here would record).
  * - `commit` — one commit alone (`sha^` vs `sha`; a root commit degrades to an add-style diff).
  */

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -22,7 +22,12 @@ ref off the workspace-create critical path.
   args)` (its async twin — `Bun.spawn`, off the event loop, for network-bound ops like `fetch` that must
   not block the host);
   **the scope→range resolver** — `resolveDiffRange(ws, scope?)` → `DiffRange` — **the one definition of what
-  a `GitDiffScope` means** (`branch`: `git diff <base>` + untracked, sides = base ref ↔ worktree;
+  a `GitDiffScope` means** (`branch`: `git diff <merge-base(base, HEAD)>` + untracked, sides = **fork
+  point** ↔ worktree — what the workspace changed *since diverging*, so a base that advanced underneath it
+  (a fetch moving `origin/main`, upstream work landing) never surfaces as phantom changes; while the base
+  hasn't diverged the merge-base *is* its tip, and a failed `merge-base` (missing base, unrelated
+  histories, unborn `HEAD`) falls back to the raw ref, keeping the old error surfaces — and keeping the
+  file list ancestry-consistent with `listCommits`' `base..HEAD`;
   `uncommitted`: `git diff HEAD` + untracked, sides = `HEAD` ↔ worktree; `commit`: `git diff <sha>^ <sha>`, no
   untracked, both sides from history — a **root** commit degrades to `git show --format=` with an empty
   original, the same add-style degradation an absent path already gets). Both reads build their argv from it
@@ -48,8 +53,8 @@ ref off the workspace-create critical path.
   `git branch` porcelain refuses it), `listBranches` reads refs with `for-each-ref`, so an option-shaped
   branch reaches the picker of any repo the user opens — and browsing someone's repo is the product's job;
   **`diffBaseRef(ws)`** — `diffBase ?? baseBranch`, the single collapse of a workspace's two base meanings
-  (creation provenance vs review target), consumed by the resolver, `listCommits`, and the `workspaces`
-  module's `diffStats`;
+  (creation provenance vs review target), consumed by the resolver and `listCommits` (the `workspaces`
+  module's `diffStats` reaches it *through* the resolver — see Get right);
   `gitStatus(workspaceId, scope?)` — changed files over the range plus untracked (only when the range ends at
   the worktree), each carrying per-file `added`/`removed` line counts (`git diff --numstat`, its rename-mangled paths resolved
   via `numstatPath` to match `--name-status`; binary rows dropped; untracked files count their whole
@@ -80,7 +85,15 @@ ref off the workspace-create critical path.
   module for the Default workspace's folder-truth `branch`; `prefetchBranch(projectId, ref)` — best-effort background
   `git fetch` of a remote ref (via `gitAsync`, branch passed after `--` so a `-`-prefixed name can't be
   parsed as a git option), so a later `createWorkspace` branches off a fresh tip without the network
-  round-trip on its critical path (non-`origin/` ref / offline → no-op).
+  round-trip on its critical path (non-`origin/` ref / offline → no-op). Its result also says whether the
+  fetch **`moved`** the local remote-tracking ref (first appearance included; compared on the
+  fully-qualified `refs/remotes/…` — the exact ref a fetch updates — so a local branch literally named
+  `origin/<b>` can't shadow the check via git's DWIM order): a moved ref *may* change what a sibling
+  workspace's branch-scope diff means (its merge-base can move), and it is invisible to the `watch` module
+  (the write lands in the project repo's shared `.git`, outside every watched location) — so the
+  `git.prefetch` handler uses `moved` to fan out the host's pathless `fsChanged` nudge (`host`'s fsNudge
+  seam; an unaffected re-read is an idempotent no-op). `moved` is host-internal; the wire response stays
+  `{ ok }`.
 - **Public surface (barrel):** `git`, `gitAsync`, `gitStatus`, `gitDiffFile`, `listCommits`,
   `resolveDiffRange`, `changedFileArgs`, `diffBaseRef`, `DiffRange`, `isSafeRef`, `assertSafeRef`,
   `listBranches`, `resolveDefaultBranch`, `currentBranch`, `prefetchBranch`.

--- a/packages/server/src/git/diffScope.ts
+++ b/packages/server/src/git/diffScope.ts
@@ -36,7 +36,18 @@ export interface DiffRange {
 const OID = /^[0-9a-f]{4,64}$/;
 
 /**
- * Resolve a scope against a workspace. A `commit` scope is validated twice — shape (`OID`, so a crafted
+ * Resolve a scope against a workspace.
+ *
+ * A `branch` scope measures "what this workspace changed": it spans from the **merge-base** of the diff
+ * base and `HEAD` (the fork point), not from the base's tip — a base that advanced underneath the
+ * workspace (a fetch moving `origin/main`, a commit landing on the local base) must not surface upstream
+ * work as phantom changes (`D` rows for files this worktree never touched). While the base hasn't
+ * diverged, the merge-base *is* its tip, so the range is identical to a plain `git diff <base>`. A failed
+ * `merge-base` (missing/deleted base, unrelated histories, unborn `HEAD`) **falls back to the raw ref**,
+ * preserving the old behavior exactly where it mattered: a missing base still fails the diff loudly
+ * (never reading as "no changes"), unrelated histories still diff against the tip.
+ *
+ * A `commit` scope is validated twice — shape (`OID`, so a crafted
  * `sha` can never reach a git argument as e.g. an option or a path) and existence (`rev-parse --verify`,
  * whose full oid is what we then use) — and **throws** when the commit is gone (a rebase or branch reset):
  * a `CodedError("UNKNOWN_COMMIT")`, so the panel can turn *that* rejection (and only that one — not a
@@ -90,11 +101,15 @@ export function resolveDiffRange(
 		};
 	}
 	const base = diffBaseRef(ws);
+	// The fork point (see the function docstring). No trailing `--` here: `merge-base` takes revs only,
+	// so a ref that also names a path on disk can't be "ambiguous" the way it is for `diff`.
+	const mergeBase = git(ws.worktreePath, ["merge-base", "--end-of-options", base, "HEAD"]);
+	const forkPoint = mergeBase.ok && mergeBase.out ? mergeBase.out : base;
 	return {
 		listPrefix: ["diff"],
-		listRevs: [base],
+		listRevs: [forkPoint],
 		untracked: true,
-		originalRef: base,
+		originalRef: forkPoint,
 		modifiedRef: null,
 	};
 }
@@ -109,6 +124,9 @@ export function resolveDiffRange(
  *   ambiguity fails the whole command — and a failed diff used to read as *no changes*, i.e. a review
  *   surface calling a dirty worktree clean.
  */
-export function changedFileArgs(range: DiffRange, mode: "--name-status" | "--numstat"): string[] {
+export function changedFileArgs(
+	range: DiffRange,
+	mode: "--name-status" | "--numstat" | "--shortstat",
+): string[] {
 	return [...range.listPrefix, mode, "--end-of-options", ...range.listRevs, "--"];
 }

--- a/packages/server/src/git/git.test.ts
+++ b/packages/server/src/git/git.test.ts
@@ -195,12 +195,31 @@ test("prefetchBranch fetches a remote ref and no-ops on a local ref or unknown p
 	const remoteTip = gitOut(remoteRepo, "rev-parse", "main");
 	expect(gitOut(repo, "rev-parse", "origin/main")).not.toBe(remoteTip);
 
-	expect(await prefetchBranch("p1", "origin/main")).toEqual({ ok: true });
+	// The fetch advances the local remote-tracking ref → `moved` (the handler's fanout trigger).
+	expect(await prefetchBranch("p1", "origin/main")).toEqual({ ok: true, moved: true });
 	expect(gitOut(repo, "rev-parse", "origin/main")).toBe(remoteTip);
 
+	// Fetching again with nothing new is ok but NOT a move — no invalidation fans out for a no-op fetch.
+	expect(await prefetchBranch("p1", "origin/main")).toEqual({ ok: true, moved: false });
+
+	// A ref's *first appearance* counts as moved: siblings measuring against it were failing their reads.
+	git(repo, "update-ref", "-d", "refs/remotes/origin/main");
+	expect(await prefetchBranch("p1", "origin/main")).toEqual({ ok: true, moved: true });
+
+	// Move detection reads the FULLY-QUALIFIED remote-tracking ref: a local branch literally named
+	// `origin/main` sits earlier in git's DWIM resolution (`refs/heads/…`) and never moves on a fetch — it
+	// must not shadow the comparison into a missed nudge.
+	git(repo, "update-ref", "refs/heads/origin/main", "HEAD");
+	writeFileSync(join(clone, "remote-only-2.txt"), "more\n");
+	git(clone, "add", "-A");
+	git(clone, "commit", "-m", "remote-only-2");
+	git(clone, "push", "origin", "main");
+	expect(await prefetchBranch("p1", "origin/main")).toEqual({ ok: true, moved: true });
+	git(repo, "update-ref", "-d", "refs/heads/origin/main");
+
 	// A local ref never touches the network; an unknown project can't fetch — both are quiet no-ops.
-	expect(await prefetchBranch("p1", "main")).toEqual({ ok: false });
-	expect(await prefetchBranch("nope", "origin/main")).toEqual({ ok: false });
+	expect(await prefetchBranch("p1", "main")).toEqual({ ok: false, moved: false });
+	expect(await prefetchBranch("nope", "origin/main")).toEqual({ ok: false, moved: false });
 });
 
 test("gitStatus reads the Default workspace's branch live, not the persisted snapshot", () => {
@@ -232,20 +251,26 @@ test("diffBaseRef resolves the re-pointed diff target over the creation base", (
 test("resolveDiffRange: one definition per scope (branch / uncommitted / commit)", () => {
 	const ws = { baseBranch: "main", worktreePath: repo };
 
-	// Default (and explicit `branch`): everything vs the diff base, ending at the worktree.
+	// Default (and explicit `branch`): what the workspace changed since diverging from the diff base —
+	// the range starts at the MERGE-BASE of base and HEAD (here HEAD is on main, so it's main's tip oid),
+	// never at the base ref's own tip.
 	expect(resolveDiffRange(ws)).toEqual(resolveDiffRange(ws, { kind: "branch" }));
 	const branch = resolveDiffRange(ws, { kind: "branch" });
+	const forkPoint = branch.originalRef ?? "";
+	expect(forkPoint).toMatch(/^[0-9a-f]{40,}$/);
 	// `--end-of-options` brackets the revs so a flag-shaped ref can't be parsed as one; the trailing `--`
 	// closes the other side, so a rev that also names a path isn't an "ambiguous argument".
 	expect(changedFileArgs(branch, "--name-status")).toEqual([
 		"diff",
 		"--name-status",
 		"--end-of-options",
-		"main",
+		forkPoint,
 		"--",
 	]);
-	expect(branch).toMatchObject({ untracked: true, originalRef: "main", modifiedRef: null });
-	// The re-pointed target is what a branch range spans.
+	expect(branch).toMatchObject({ untracked: true, listRevs: [forkPoint], modifiedRef: null });
+	// The re-pointed target is what a branch range spans — and a target with no merge-base to resolve
+	// (this ref doesn't exist here) FALLS BACK to the raw ref, preserving the old error surfaces: a
+	// missing base still fails the downstream diff loudly instead of reading as "no changes".
 	expect(resolveDiffRange({ ...ws, diffBase: "origin/release" }, { kind: "branch" })).toMatchObject(
 		{
 			listRevs: ["origin/release"],
@@ -321,6 +346,25 @@ test("gitStatus scopes: branch spans the base range, uncommitted only the dirty 
 
 	const uncommitted = gitStatus("w1", { kind: "uncommitted" }).changes.map((c) => c.path);
 	expect(uncommitted).toEqual(["dirty.txt"]);
+});
+
+test("branch scope measures from the merge-base: upstream commits on the base are never phantom changes", () => {
+	git(repo, "switch", "-c", "feature");
+	commitOnFeature("feature.txt", "feature\n", "feature work");
+	// The base advances AFTER the branch forked — upstream work landing on main (or a fetch moving it).
+	git(repo, "switch", "main");
+	writeFileSync(join(repo, "upstream.txt"), "upstream\n");
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "upstream work");
+	git(repo, "switch", "feature");
+	seedWorkspace({ branch: "feature" });
+
+	// Tip semantics would list upstream.txt as a phantom deletion; the merge-base range shows only the
+	// workspace's own work — agreeing with listCommits' `base..HEAD`, which was always ancestry-based.
+	expect(gitStatus("w1").changes.map((c) => c.path)).toEqual(["feature.txt"]);
+	expect(listCommits("w1").commits.map((c) => c.subject)).toEqual(["feature work"]);
+	// The per-file read agrees: the original side comes from the fork point, where the file didn't exist.
+	expect(gitDiffFile("w1", "feature.txt")).toEqual({ original: "", modified: "feature\n" });
 });
 
 test("gitStatus/gitDiffFile for a commit scope read only that commit, from history", () => {

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -83,10 +83,32 @@ export function currentBranch(repoPath: string): string {
  * overlaps the time the user spends choosing a branch / typing the prompt, so the create itself stays local
  * and instant. Async (`gitAsync`, never `spawnSync`) so the network fetch can't block the host's event
  * loop; a local (non-`origin/`) ref or an offline/failed fetch is a harmless no-op ack.
+ *
+ * `moved` reports whether the fetch changed which commit the local remote-tracking ref names (its first
+ * appearance counts). A moved ref *may* change what a sibling workspace's branch-scope diff means (its
+ * merge-base can move), so the `git.prefetch` handler fans the pathless `fsChanged` invalidation out to
+ * the workspaces reading that ref (see `host`'s fsNudge seam; the re-read is idempotent when the
+ * merge-base stayed put) — `moved` is host-internal and never reaches the wire (the response stays
+ * `{ ok }`).
  */
-export async function prefetchBranch(projectId: string, ref: string): Promise<{ ok: boolean }> {
+export async function prefetchBranch(
+	projectId: string,
+	ref: string,
+): Promise<{ ok: boolean; moved: boolean }> {
 	const project = loadProjects().find((p) => p.id === projectId);
-	if (!project || !ref.startsWith("origin/")) return { ok: false };
+	if (!project || !ref.startsWith("origin/")) return { ok: false, moved: false };
+	// Fully qualified on purpose: the short name resolves by git's DWIM order, where a local branch
+	// literally named `origin/<b>` (`refs/heads/origin/<b>`) would shadow the remote-tracking ref — and the
+	// fetch updates `refs/remotes/…` regardless, so the comparison must read exactly that.
+	const revParse = () =>
+		git(project.path, [
+			"rev-parse",
+			"--verify",
+			"--quiet",
+			"--end-of-options",
+			`refs/remotes/${ref}`,
+		]);
+	const before = revParse();
 	// `--` so a `-`-prefixed branch name can't be parsed by git as an option.
 	const result = await gitAsync(project.path, [
 		"fetch",
@@ -94,7 +116,10 @@ export async function prefetchBranch(projectId: string, ref: string): Promise<{ 
 		"--",
 		ref.slice("origin/".length),
 	]);
-	return { ok: result.ok };
+	if (!result.ok) return { ok: false, moved: false };
+	const after = revParse();
+	const moved = after.ok && after.out !== "" && (!before.ok || before.out !== after.out);
+	return { ok: true, moved };
 }
 
 /** Map a `git diff --name-status` code (`M`, `A`, `D`, `R100`, …) to our status enum. */
@@ -179,7 +204,8 @@ function diffFailure(stderr: string): Error {
 }
 
 /**
- * A worktree's changed files over the given {@link GitDiffScope} (default: everything vs the diff base),
+ * A worktree's changed files over the given {@link GitDiffScope} (default: the branch scope — what the
+ * workspace changed since diverging from its diff base),
  * plus any untracked files when the range ends at the worktree. Each carries `+/−` counts. Throws for a
  * scope naming a commit that no longer exists (see `resolveDiffRange`) — and for a diff that **failed**,
  * which must never be reported as a clean worktree.
@@ -245,8 +271,8 @@ function showBlob(worktreePath: string, ref: string, path: string): string {
 }
 
 /**
- * Both sides of one changed file over the given {@link GitDiffScope} (default: everything vs the diff
- * base), for the center Monaco diff tab: `original` = the file at the range's start (empty when it doesn't
+ * Both sides of one changed file over the given {@link GitDiffScope} (default: the branch scope — since
+ * diverging from the diff base), for the center Monaco diff tab: `original` = the file at the range's start (empty when it doesn't
  * exist there — untracked/added, a renamed file's new path, or a root commit — which degrades to an
  * add-style diff), `modified` = the file at its end: the worktree (empty when deleted) for a range ending
  * there, else the commit's own tree.

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -27,7 +27,13 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `refreshDefaultWorkspace` (**re-sync a Default workspace's folder-truth branch** — host-mediated, since
   `watch` has no `workspaces` edge, and self-publishing through the workspace-lifecycle tee) **and** a
   pathless `fsChanged` frame (`paths: []`, `truncated: false`) so the clients' `HEAD`-relative reads
-  (`git.status`, an `uncommitted`-scope diff tab) re-read when a terminal `commit`/`reset` moves a ref
+  (`git.status`, an `uncommitted`-scope diff tab) re-read when a terminal `commit`/`reset` moves a ref;
+  the same publish also feeds the **fsNudge seam** (`fsNudge.ts`: `setFsNudgePublisher` +
+  `nudgeBaseRefWorkspaces`), the host mediation the `git.prefetch` handler triggers when the app's own
+  background fetch **moved** a remote-tracking ref — a write only the project repo's shared `.git` sees,
+  invisible to every worktree watcher — fanning the pathless frame to each workspace of that project whose
+  diff base is the moved ref (their branch-scope merge-base may have moved — the re-read is idempotent when
+  it hasn't; everyone else stays asleep)
   without touching a worktree file; call
   `ensureWatch(workspaceId)` from the
   workspace-read handlers (`fs.*`, `git.status`/`git.diffFile`, `spec.graph`) — a read is the "a client is

--- a/packages/server/src/host/fsNudge.test.ts
+++ b/packages/server/src/host/fsNudge.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Workspace, WorkspaceFsChangedPayload } from "@thinkrail/contracts";
+import { nudgeBaseRefWorkspaces, setFsNudgePublisher } from "./fsNudge";
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+function ws(id: string, projectId: string, extra: Partial<Workspace>): Workspace {
+	return {
+		id,
+		projectId,
+		name: id,
+		branch: id,
+		worktreePath: `/tmp/${id}`,
+		baseBranch: "main",
+		...extra,
+	};
+}
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-fsnudge-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	writeFileSync(
+		join(dataDir, "workspaces.json"),
+		JSON.stringify([
+			// Measures against the fetched ref via its creation base → nudged.
+			ws("w-base", "p1", { baseBranch: "origin/main" }),
+			// Re-pointed ONTO the fetched ref → nudged (`diffBase` wins over `baseBranch`).
+			ws("w-repointed", "p1", { baseBranch: "main", diffBase: "origin/main" }),
+			// Re-pointed AWAY from it → its diff didn't change meaning → silent.
+			ws("w-away", "p1", { baseBranch: "origin/main", diffBase: "release" }),
+			// Another ref entirely → silent.
+			ws("w-other-ref", "p1", {}),
+			// Same ref, another project → silent (the fetch ran in p1's repo, not this one's).
+			ws("w-other-project", "p2", { baseBranch: "origin/main" }),
+		]),
+	);
+});
+
+afterEach(() => {
+	setFsNudgePublisher(null);
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("nudges exactly the project's workspaces whose diff base is the moved ref, as pathless frames", () => {
+	const frames: WorkspaceFsChangedPayload[] = [];
+	setFsNudgePublisher((payload) => frames.push(payload));
+
+	nudgeBaseRefWorkspaces("p1", "origin/main");
+
+	// Pathless (an invalidation, not data — no `.git` path may reach a client), never truncated.
+	expect(frames).toEqual([
+		{ workspaceId: "w-base", paths: [], truncated: false },
+		{ workspaceId: "w-repointed", paths: [], truncated: false },
+	]);
+});
+
+test("without an installed publisher the nudge is a silent no-op (unit-test / teardown state)", () => {
+	setFsNudgePublisher(null);
+	expect(() => nudgeBaseRefWorkspaces("p1", "origin/main")).not.toThrow();
+});

--- a/packages/server/src/host/fsNudge.ts
+++ b/packages/server/src/host/fsNudge.ts
@@ -1,0 +1,39 @@
+import type { WorkspaceFsChangedPayload } from "@thinkrail/contracts";
+import { diffBaseRef } from "../git";
+import { listWorkspaceRecords } from "../workspaces";
+
+/**
+ * Host-side invalidation for a git ref that moved **without any worktree seeing it**: the app's own
+ * background `git fetch` (`git.prefetch`) writes only to the project repo's shared `.git`
+ * (`refs/remotes/…`), which is outside every linked worktree's watched root *and* outside its
+ * non-recursive `.git/worktrees/<name>` metadata watcher — so no `watch`-module signal can exist. The
+ * `git.prefetch` handler calls this when the fetch actually moved the ref, and it fans the same
+ * **pathless** `fsChanged` frame the repo-metadata seam uses (an invalidation, not data: no `.git` path
+ * ever reaches a client) out to the workspaces whose branch-scope diff is measured against that ref.
+ * Re-reads are idempotent — a workspace whose merge-base didn't move re-reads into identical state.
+ *
+ * Lives in `host` (not `git`/`watch`): it is host mediation between two feature modules, exactly like the
+ * repo-metadata fanout wired next to it in `createServer`.
+ */
+type FsNudgePublisher = (payload: WorkspaceFsChangedPayload) => void;
+
+// Injected by `createServer` (the same publisher inversion the watch/workspaces seams use). `null` in
+// unit tests → the nudge is a silent no-op.
+let publish: FsNudgePublisher | null = null;
+
+/** Install (or clear with `null`) the sink the nudge frames are published through. */
+export function setFsNudgePublisher(publisher: FsNudgePublisher | null): void {
+	publish = publisher;
+}
+
+/**
+ * Nudge every workspace of `projectId` whose diff base is `ref` (the moved remote-tracking ref, e.g.
+ * `origin/main`) to re-read its git-derived views. Workspaces measuring against another ref — or another
+ * project's — are deliberately not woken: their diffs cannot have changed meaning.
+ */
+export function nudgeBaseRefWorkspaces(projectId: string, ref: string): void {
+	if (!publish) return;
+	for (const ws of listWorkspaceRecords(projectId)) {
+		if (diffBaseRef(ws) === ref) publish({ workspaceId: ws.id, paths: [], truncated: false });
+	}
+}

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -98,6 +98,7 @@ import {
 	workspaceDiffStats,
 } from "../workspaces";
 import { ackSend } from "./ackSend";
+import { nudgeBaseRefWorkspaces } from "./fsNudge";
 import { buildHistoryScope } from "./historyScope";
 import { dropLogin, recordLoginStart } from "./loginAnalytics";
 
@@ -175,9 +176,16 @@ const handlers: Record<string, Handler> = {
 	},
 	"workspace.diffStats": (params) => workspaceDiffStats((params as { id: string }).id),
 	"git.listBranches": (params) => listBranches((params as { projectId: string }).projectId),
-	"git.prefetch": (params) => {
+	"git.prefetch": async (params) => {
 		const p = params as { projectId: string; ref: string };
-		return prefetchBranch(p.projectId, p.ref);
+		const { ok, moved } = await prefetchBranch(p.projectId, p.ref);
+		// A fetch that moved the local remote-tracking ref may have changed what a sibling workspace's
+		// branch-scope diff *means* (its merge-base can move) — and it is invisible to the watch module (it
+		// writes only to the shared `.git`, outside every watched location), so this is the one signal those
+		// workspaces get; an unaffected re-read is an idempotent no-op. `moved` itself stays host-internal:
+		// the wire result remains `{ ok }`.
+		if (moved) nudgeBaseRefWorkspaces(p.projectId, p.ref);
+		return { ok };
 	},
 	"github.authStatus": () => githubAuthStatus(),
 	"github.refresh": () => githubRefresh(),

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -28,6 +28,7 @@ import {
 	maybeAutoRenameWorkspace,
 	maybeNaiveNameWorkspace,
 } from "./autoRename";
+import { setFsNudgePublisher } from "./fsNudge";
 import { handleRequest } from "./handlers";
 import { trackLoginOutcome } from "./loginAnalytics";
 
@@ -176,6 +177,10 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		);
 	};
 	setWatchPublisher(publishFsChanged);
+	// The same frame, publishable from the `git.prefetch` handler: the app's own background fetch moves
+	// `refs/remotes/…` in the project repo's shared `.git` — a location no worktree watcher can see — so the
+	// handler nudges the workspaces whose diff base that ref is (see `fsNudge.ts`).
+	setFsNudgePublisher(publishFsChanged);
 
 	// The notifier's second seam, host-mediated (`watch` has no `workspaces` edge): a git-metadata write in
 	// a watched worktree — a `git switch`/`commit`/`reset` in its terminal — converges two things that a

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -72,9 +72,11 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   a name, `symbolic-ref` does not) — both halves of the same door, closed by one check. **The two base meanings are two
   fields on purpose:** `baseBranch` = where the branch came from, `diffBase` = what its review is measured
   against; collapsing them would make a re-pointed target lie about provenance (the `branch · from
-  baseBranch` receipt). Every read of "the base" — including this module's own `diffStats` — resolves it
-  through the `git` module's `diffBaseRef`, never inline (and reaches git bracketed by `--end-of-options` … `--`,
-  like every other rev this app passes). `diffStats` yields **no stats at all** (logged) when git couldn't
+  baseBranch` receipt). Every read of "the base" resolves through the `git` module, never inline —
+  `diffStats` composes the git module's **branch-scope range** (`resolveDiffRange` +
+  `changedFileArgs(…, "--shortstat")`), so the rail badge measures exactly what the Changes panel shows
+  (merge-base semantics included — upstream commits on the base never inflate the badge) and reaches git
+  bracketed by `--end-of-options` … `--` like every other rev this app passes. `diffStats` yields **no stats at all** (logged) when git couldn't
   answer, rather than a fabricated `+0 −0` — a failed read must not paint a dirty worktree as clean; the
   `Workspace.diffStats` field is simply absent, and `workspaceDiffStats` rejects,
   `getWorkspace` (by-id lookup, throws on unknown — anchors a chat session's cwd),

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -426,6 +426,15 @@ test("the Default workspace's branch and base refresh from the folder on each li
 	git(repo, "add", "-A");
 	git(repo, "commit", "-m", "feature work");
 	expect(listWorkspaces("p1")[0]?.diffStats?.added).toBe(2);
+
+	// The badge shares the Changes panel's branch-scope range (the resolver): work landing on the BASE
+	// after the fork must not inflate it — tip semantics would count main's new file as a removal here.
+	git(repo, "switch", "main");
+	writeFileSync(join(repo, "upstream.txt"), "a\nb\nc\n");
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "upstream work");
+	git(repo, "switch", "feature/x");
+	expect(listWorkspaces("p1")[0]?.diffStats).toEqual({ added: 2, removed: 0 });
 });
 
 test("refreshDefaultWorkspace re-syncs and publishes Default drift off the list path", async () => {

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -5,11 +5,12 @@ import type { DiffStats, Project, Workspace } from "@thinkrail/contracts";
 import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
 import {
 	assertSafeRef,
+	changedFileArgs,
 	currentBranch,
-	diffBaseRef,
 	git,
 	gitAsync,
 	resolveDefaultBranch,
+	resolveDiffRange,
 } from "../git";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
 import { getProjects } from "../projects";
@@ -112,22 +113,15 @@ function applyFolderTruth(ws: Workspace, truth: { branch: string; baseBranch: st
 }
 
 /**
- * Working-tree changes of a worktree vs its **diff base** (the re-pointed target, else the creation base).
+ * Working-tree changes of a worktree over its **branch scope** — the same range the Changes panel shows
+ * (the git module's resolver: merge-base of the diff base and `HEAD`, so upstream commits never inflate
+ * the badge), composed through `changedFileArgs` so the counts can't disagree with the file list.
  * `undefined` when git couldn't answer — **not** `{0,0}`: a failed diff read as "clean" is how a dirty
  * worktree ends up wearing no badge, so the unknown is left unknown (the rail then shows no badge, as it does
  * for a genuinely clean worktree, but nothing claims a count it doesn't have) and the reason is logged.
  */
 function diffStats(ws: Workspace): DiffStats | undefined {
-	// The revs are bracketed on both sides: `--end-of-options` so a repo/user-supplied ref can't be re-parsed
-	// as an option, and a trailing `--` so a base that also names a path on disk is read as a rev instead of
-	// making git bail with "ambiguous argument" (the same framing `changedFileArgs` uses).
-	const result = git(ws.worktreePath, [
-		"diff",
-		"--shortstat",
-		"--end-of-options",
-		diffBaseRef(ws),
-		"--",
-	]);
+	const result = git(ws.worktreePath, changedFileArgs(resolveDiffRange(ws), "--shortstat"));
 	if (!result.ok) {
 		console.warn(
 			`git diff --shortstat failed in ${ws.worktreePath}: ${result.err || "unknown error"}`,


### PR DESCRIPTION
> **Stacked on #164** (`conductor-changes-analysis`) — review only the top commit; merge #164 first, this PR then retargets to `main` automatically.

## Problem

Reported in Slack (Olga → Rinat) and confirmed by a live probe: the app's own background fetch (`git.prefetch`, fired whenever the New-Workspace dialog opens) moves `refs/remotes/…` in the project repo's **shared** `.git` — a location no worktree watcher can see (outside every watched root *and* outside the non-recursive `.git/worktrees/<name>` metadata watcher). So sibling workspaces' Changes lists, open diff tabs, and rail ± badges silently kept a stale range, and a read taken *after* the fetch (opening a diff tab) disagreed with the list rendered *before* it.

The deeper defect underneath: the `branch` scope diffed against the base **tip**, so once the base advanced past the fork point, the eventual recompute surfaced upstream commits as **phantom changes** — files the workspace never touched, shown as deleted (probe: `M a.txt` → `M a.txt`, `D b.txt`, `D c.txt` after one fetch). It also contradicted the scope-selector task-spec's own live-refresh contract, and disagreed with the commit menu (`listCommits` is `base..HEAD`, which was always ancestry-based).

## What changed (two halves, one design)

1. **The branch scope measures from the merge-base** (`resolveDiffRange`): the range starts at `merge-base(diffBase ?? baseBranch, HEAD)` — the fork point — never at the base's tip. Byte-identical while the base hasn't diverged; a failed `merge-base` (missing/deleted base, unrelated histories, unborn `HEAD`) falls back to the raw ref, so a missing base still fails loudly instead of reading as "no changes". The rail badge (`diffStats`) now composes the **same resolver range** (`--shortstat` through `changedFileArgs`), so badge and panel can never disagree.
2. **A base-moving prefetch nudges its readers**: `prefetchBranch` reports whether the fetch actually moved the local remote-tracking ref — compared on the fully-qualified `refs/remotes/<ref>`, so a local branch literally named `origin/<b>` can't shadow the check via git's DWIM resolution. On a move, the `git.prefetch` handler fans the existing **pathless `workspace.fsChanged`** frame (the repo-metadata pattern) to that project's workspaces whose diff base is the moved ref (new host seam: `host/fsNudge.ts`). Wire result stays `{ ok }` — **no protocol change**; open tabs re-read because pathless frames deliberately never take `useLiveTabContent`'s path-membership skip.

Deliberately out of scope (recorded in the design): an "N commits behind base" indicator, a shared-refs watcher for *external* fetches (IDE/`gh`), and push-refreshing rail badges (they keep their existing `workspace.list` cadence — same as a terminal commit today).

## Verification

- **Unit (388)** — new pins: resolver fork-point + raw-ref fallback, `prefetchBranch.moved` (no-op fetch, first appearance, the DWIM-shadow case), fanout selection (only same-project workspaces reading the moved ref), badge stats ignoring upstream commits.
- **e2e (149, no-agent)** — new spec: a target that advanced past the fork point adds **no phantom rows** (throwaway worktree + re-pointable target; self-cleaning under `resetState`).
- **Both semantics pins verified to fail** with tip semantics temporarily forced back, then restored green.
- One existing e2e spec (*"Re-pointing the target re-reads an open diff tab"*) was itself pinning tip semantics — its probe string could only render by diffing against a target **ahead of** the workspace, the exact phantom-review this removes. Reshaped to two targets with **different fork points** holding different file copies; the original probe intent ("this string appears only via a re-read against that target") is intact.
- Pre-commit review pass raised 3 findings (DWIM shadow, overstated docstrings, `git.prefetch` missing from the contracts SPEC's method list) — all fixed in this commit.

## Specs (spec leads code)

git SPEC (branch scope = merge-base + fallback; `prefetchBranch.moved` contract), workspaces SPEC (`diffStats` through the resolver), host SPEC (fsNudge seam), contracts SPEC (`GitDiffScope` semantics + `git.prefetch` entry), panels SPEC + docstrings (`domain.ts`, `selectors.ts`).
