### PR TITLE
chore: gitignore local tool/design scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ e2e/.workflow-runs.jsonl
 docs/*
 .playwright-mcp/
 .claude/
+.mockups/
+.superpowers/
+.gsd/
 
 # Build-only manifests written transiently by apps/cli/scripts/build-binary.ts
 apps/cli/src/*.generated.ts


### PR DESCRIPTION
## Summary
- Ignore `.superpowers/` (skill runtime state: ports, session tokens, pids, logs) which was showing up as untracked and included a local session token.
- Ignore `.mockups/` and `.gsd/` alongside the existing `.claude/` entry for the same class of local-only tool/scratch content.

## Test plan
- [x] `bun run check:deps`, `check:seams`, `lint`, `typecheck` (via pre-commit hook) — all passed
- [x] `git status` confirms no more stray untracked files from these dirs