### PR TITLE
Open existing Git worktrees as workspaces

### DIFF
--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -22,6 +22,7 @@ import {
 	type DocTab,
 	type EditorTab,
 	isDefaultWorkspace,
+	isExternalWorkspace,
 	selectActiveWorkspace,
 	selectContextProject,
 	selectWorkspaceTick,
@@ -298,9 +299,10 @@ export function CenterTabs() {
 		else closeTab(tab.id);
 	};
 
-	// The Default workspace is the project folder itself — its receipt must tell the truth ("runs
-	// directly in your project folder") instead of promising worktree isolation.
+	// User-owned workspaces never claim ThinkRail-created provenance. Default runs in the project folder;
+	// external is an existing checkout but keeps the normal workspace-scoped tools.
 	const isDefault = activeWorkspace != null && isDefaultWorkspace(activeWorkspace);
+	const isExternal = activeWorkspace != null && isExternalWorkspace(activeWorkspace);
 	const placeholder = (
 		<div className="flex h-full flex-col items-center justify-center gap-md px-lg text-center text-text-muted">
 			{activeWorkspace ? (
@@ -309,14 +311,14 @@ export function CenterTabs() {
 					className="flex max-w-[440px] flex-col items-center gap-xs"
 				>
 					<span className="tr-text-eyebrow text-text-muted">
-						{isDefault ? "Default workspace" : "Workspace ready"}
+						{isDefault ? "Default workspace" : isExternal ? "Existing worktree" : "Workspace ready"}
 					</span>
 					<h2 className="max-w-full truncate tr-title-entity text-text-default">
 						{isDefault ? (contextProject?.name ?? activeWorkspace.name) : activeWorkspace.name}
 					</h2>
 					<p className="flex max-w-full items-center gap-xs text-text-muted tr-text-metadata">
 						<GitBranch className="size-3.5 shrink-0" />
-						{isDefault ? (
+						{isDefault || isExternal ? (
 							<span className="truncate">on {activeWorkspace.branch}</span>
 						) : (
 							<>

--- a/apps/web/src/panels/ExistingWorktreeDialog.tsx
+++ b/apps/web/src/panels/ExistingWorktreeDialog.tsx
@@ -1,0 +1,208 @@
+import type { ExistingWorktreeCandidate, Workspace } from "@thinkrail/contracts";
+import { FolderOpen, GitBranch, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { errorText, getTransport } from "../transport";
+
+/** Choose one checkout from Git's registry and attach it without mutating or taking ownership of it. */
+export function ExistingWorktreeDialog({
+	open,
+	projectId,
+	onOpenChange,
+	onOpened,
+}: {
+	open: boolean;
+	projectId: string;
+	onOpenChange: (open: boolean) => void;
+	onOpened: (workspace: Workspace) => Promise<void>;
+}) {
+	const [candidates, setCandidates] = useState<ExistingWorktreeCandidate[] | null>(null);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [openError, setOpenError] = useState<string | null>(null);
+	const [openingPath, setOpeningPath] = useState<string | null>(null);
+	const requestRef = useRef(0);
+	const firstAvailableRef = useRef<HTMLButtonElement>(null);
+
+	const loadCandidates = useCallback(() => {
+		const request = requestRef.current + 1;
+		requestRef.current = request;
+		setCandidates(null);
+		setLoadError(null);
+		setOpenError(null);
+		void getTransport()
+			.request("workspace.listExisting", { projectId })
+			.then((rows) => {
+				if (requestRef.current === request) setCandidates(rows);
+			})
+			.catch((error) => {
+				if (requestRef.current === request) {
+					setLoadError(errorText(error, "Couldn't list existing worktrees"));
+				}
+			});
+	}, [projectId]);
+
+	useEffect(() => {
+		if (!open) return;
+		loadCandidates();
+		return () => {
+			requestRef.current += 1;
+		};
+	}, [loadCandidates, open]);
+
+	useEffect(() => {
+		if (candidates?.some((candidate) => candidate.status === "available")) {
+			firstAvailableRef.current?.focus();
+		}
+	}, [candidates]);
+
+	const firstAvailablePath = candidates?.find(
+		(candidate) => candidate.status === "available",
+	)?.path;
+
+	const openCandidate = async (candidate: ExistingWorktreeCandidate) => {
+		if (candidate.status !== "available" || openingPath) return;
+		setOpeningPath(candidate.path);
+		setOpenError(null);
+		try {
+			const workspace = await getTransport().request("workspace.openExisting", {
+				projectId,
+				path: candidate.path,
+			});
+			await onOpened(workspace);
+			onOpenChange(false);
+		} catch (error) {
+			setOpenError(errorText(error, "Couldn't finish opening the existing worktree"));
+			setOpeningPath(null);
+		}
+	};
+
+	// Selecting a row commits a server mutation that cannot be rolled back safely. Keep the modal in place
+	// until that request settles rather than accepting a dismissal that a late success would contradict.
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (!nextOpen && openingPath !== null) return;
+		onOpenChange(nextOpen);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="max-w-[36rem]" data-testid="existing-worktree-dialog">
+				<DialogHeader>
+					<div className="flex items-center gap-sm">
+						<FolderOpen className="size-4 shrink-0 text-primary" />
+						<DialogTitle>Open existing worktree</DialogTitle>
+					</div>
+					<DialogDescription>
+						Choose a checkout already registered with this Git repository. ThinkRail will use it in
+						place without moving, renaming, or taking ownership of it.
+					</DialogDescription>
+				</DialogHeader>
+
+				{candidates === null && loadError === null ? (
+					<div
+						className="flex min-h-28 items-center justify-center gap-sm text-text-muted tr-text-ui"
+						data-testid="existing-worktree-loading"
+					>
+						<Loader2 className="size-4 animate-spin" />
+						Reading Git worktrees…
+					</div>
+				) : null}
+
+				{loadError ? (
+					<div className="flex flex-col items-start gap-sm rounded-[var(--radius-md)] bg-feedback-error-subtle p-md text-feedback-error tr-text-ui">
+						<p>{loadError}</p>
+						<Button
+							variant="outline"
+							size="sm"
+							data-testid="existing-worktree-retry"
+							onClick={loadCandidates}
+						>
+							<RefreshCw className="size-3.5" />
+							Retry
+						</Button>
+					</div>
+				) : null}
+
+				{candidates?.length === 0 ? (
+					<div
+						className="rounded-[var(--radius-md)] border border-border-default bg-control-bg p-md text-text-muted tr-text-ui"
+						data-testid="existing-worktree-empty"
+					>
+						No unattached worktrees found. Create one with Git, then reopen this chooser.
+					</div>
+				) : null}
+
+				{candidates && candidates.length > 0 ? (
+					<div
+						className="flex max-h-[min(50vh,24rem)] flex-col gap-xs overflow-y-auto pr-xs"
+						data-testid="existing-worktree-list"
+					>
+						{candidates.map((candidate) => {
+							const available = candidate.status === "available";
+							const opening = openingPath === candidate.path;
+							return (
+								<button
+									key={candidate.path}
+									ref={candidate.path === firstAvailablePath ? firstAvailableRef : undefined}
+									type="button"
+									disabled={!available || openingPath !== null}
+									data-testid="existing-worktree-candidate"
+									data-status={candidate.status}
+									onClick={() => void openCandidate(candidate)}
+									className="flex w-full items-start gap-md rounded-[var(--radius-md)] border border-border-default bg-control-bg p-md text-left outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+								>
+									<div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-container-elevated-bg text-text-muted">
+										{opening ? (
+											<Loader2 className="size-4 animate-spin" />
+										) : (
+											<GitBranch className="size-4" />
+										)}
+									</div>
+									<span className="flex min-w-0 flex-1 flex-col gap-0.5">
+										<span className="truncate text-text-default tr-text-ui">
+											{available ? candidate.branch : "Detached HEAD"}
+										</span>
+										<span className="truncate text-text-subtle tr-text-metadata">
+											{candidate.path}
+										</span>
+										{available ? null : (
+											<span className="text-feedback-warning tr-text-metadata">
+												Create a branch in this worktree before opening it.
+											</span>
+										)}
+									</span>
+								</button>
+							);
+						})}
+					</div>
+				) : null}
+
+				{openError ? (
+					<p
+						className="rounded-[var(--radius-md)] bg-feedback-error-subtle px-md py-sm text-feedback-error tr-text-ui"
+						data-testid="existing-worktree-error"
+					>
+						{openError}
+					</p>
+				) : null}
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						disabled={openingPath !== null}
+						onClick={() => handleOpenChange(false)}
+					>
+						Cancel
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -33,11 +33,18 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { copyText } from "@/lib";
-import { isDefaultWorkspace, selectActiveWorkspaceProjectId, toast, useAppStore } from "../store";
+import {
+	isDefaultWorkspace,
+	isExternalWorkspace,
+	selectActiveWorkspaceProjectId,
+	toast,
+	useAppStore,
+} from "../store";
 import { errorText, getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { DiffStatBadge } from "./DiffStatBadge";
+import { ExistingWorktreeDialog } from "./ExistingWorktreeDialog";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { useOpenProject } from "./useOpenProject";
 
@@ -64,10 +71,12 @@ export function ProjectTree() {
 	// The project a New-Workspace dialog is open for (null = closed). The "+" opens it instead of
 	// creating a workspace directly.
 	const [dialogProjectId, setDialogProjectId] = useState<string | null>(null);
+	const [existingDialogProjectId, setExistingDialogProjectId] = useState<string | null>(null);
 	const addProjectButtonRef = useRef<HTMLButtonElement>(null);
 	const projectNameButtonsRef = useRef(new Map<string, HTMLButtonElement>());
 	const pendingCloseFocusProjectIdRef = useRef<string | null>(null);
 	const workspaceDialogReturnFocusIdRef = useRef<string | null>(null);
+	const existingDialogReturnFocusIdRef = useRef<string | null>(null);
 
 	const registerProjectNameButton = useCallback(
 		(projectId: string, element: HTMLButtonElement | null) => {
@@ -156,6 +165,20 @@ export function ProjectTree() {
 		await loadWorkspaces(workspace.projectId);
 	};
 
+	// The response is authoritative, but the project may never have been expanded: `addWorkspace` rightly
+	// refuses to seed a partial list. Re-list first, install the complete snapshot, then activate the row.
+	const onExistingWorktreeOpened = async (workspace: Workspace) => {
+		const rows = await getTransport().request("workspace.list", {
+			projectId: workspace.projectId,
+		});
+		const attached = rows.find((candidate) => candidate.id === workspace.id);
+		if (!attached) throw new Error("The attached worktree is missing from the workspace list");
+		setExpanded((prev) => new Set(prev).add(workspace.projectId));
+		const store = useAppStore.getState();
+		store.setWorkspaces(workspace.projectId, rows);
+		store.activateWorkspace(attached);
+	};
+
 	// Event-driven removal: just fire the request — no per-client optimism. The host tears the worktree
 	// down and broadcasts `workspace.removed`, which every client (including this one) reacts to via
 	// `applyWorkspaceRemoved`. A rejected request means no event will come, so surface it as an error toast
@@ -207,6 +230,11 @@ export function ProjectTree() {
 		setDialogProjectId(projectId);
 	};
 
+	const openExistingWorktreeDialog = (projectId: string) => {
+		existingDialogReturnFocusIdRef.current = projectId;
+		setExistingDialogProjectId(projectId);
+	};
+
 	return (
 		<nav className="flex flex-col gap-sm">
 			<header className="flex h-7 items-center justify-between pr-xs pl-sm">
@@ -248,6 +276,7 @@ export function ProjectTree() {
 								onClose={() => closeProject(project)}
 								onAddWorkspace={() => openWorkspaceDialog(project.id, false)}
 								onAddWorkspaceFromMenu={() => openWorkspaceDialog(project.id, true)}
+								onOpenExistingWorktree={() => openExistingWorktreeDialog(project.id)}
 								onRegisterNameButton={(element) => registerProjectNameButton(project.id, element)}
 								onRestoreFocus={() => focusProjectNameOrAdd(project.id)}
 							/>
@@ -288,6 +317,21 @@ export function ProjectTree() {
 				/>
 			) : null}
 
+			{existingDialogProjectId !== null ? (
+				<ExistingWorktreeDialog
+					open
+					projectId={existingDialogProjectId}
+					onOpenChange={(isOpen) => {
+						if (isOpen) return;
+						setExistingDialogProjectId(null);
+						const returnFocusId = existingDialogReturnFocusIdRef.current;
+						existingDialogReturnFocusIdRef.current = null;
+						if (returnFocusId) focusProjectNameOrAdd(returnFocusId);
+					}}
+					onOpened={onExistingWorktreeOpened}
+				/>
+			) : null}
+
 			{dialogs}
 		</nav>
 	);
@@ -303,6 +347,7 @@ function ProjectRow({
 	onClose,
 	onAddWorkspace,
 	onAddWorkspaceFromMenu,
+	onOpenExistingWorktree,
 	onRegisterNameButton,
 	onRestoreFocus,
 }: {
@@ -315,6 +360,7 @@ function ProjectRow({
 	onClose: () => void;
 	onAddWorkspace: () => void;
 	onAddWorkspaceFromMenu: () => void;
+	onOpenExistingWorktree: () => void;
 	onRegisterNameButton: (element: HTMLButtonElement | null) => void;
 	onRestoreFocus: () => void;
 }) {
@@ -419,6 +465,16 @@ function ProjectRow({
 						<Plus />
 						Create workspace
 					</ContextMenuItem>
+					<ContextMenuItem
+						data-testid="project-menu-open-existing-worktree"
+						onSelect={(event) => {
+							event.preventDefault();
+							openDialogAfterMenu(onOpenExistingWorktree);
+						}}
+					>
+						<FolderOpen />
+						Open existing worktree…
+					</ContextMenuItem>
 					<ContextMenuSeparator />
 					<ContextMenuItem
 						data-testid="project-menu-close"
@@ -472,11 +528,11 @@ function WorkspaceRow({
 	onRemove: () => void;
 }) {
 	const stats = workspace.diffStats;
-	// The built-in Default workspace (the project folder itself) is non-removable — the server enforces
-	// it; the UI simply offers nothing (no Remove item, no confirm dialog). It wears a House icon in place
-	// of the branch glyph, but otherwise gets the same "Open in" / Copy path / Reveal menu as any worktree.
+	// Default is non-removable; external is removable from ThinkRail but its user-owned checkout is not.
+	// Icons make the three ownership modes legible without adding another text badge to the compact row.
 	const isDefault = isDefaultWorkspace(workspace);
-	const Icon = isDefault ? House : GitBranch;
+	const isExternal = isExternalWorkspace(workspace);
+	const Icon = isDefault ? House : isExternal ? FolderOpen : GitBranch;
 	const [menuOpen, setMenuOpen] = useState(false);
 	// A centered dialog, not an anchored popover: the trigger is a generic overflow icon, not a dedicated
 	// delete affordance, so anchoring a confirm box to it the way the old dedicated Remove button did would
@@ -576,7 +632,7 @@ function WorkspaceRow({
 									}}
 								>
 									<Trash2 />
-									Remove workspace
+									{isExternal ? "Remove from ThinkRail" : "Remove workspace"}
 								</DropdownMenuItem>
 							</>
 						)}
@@ -587,15 +643,28 @@ function WorkspaceRow({
 				<ConfirmDialog
 					open={confirmOpen}
 					onOpenChange={setConfirmOpen}
-					title={`Remove ${workspace.name} workspace`}
-					description={
-						<>
-							Deletes this workspace's chats, terminals, and its worktree. The git branch{" "}
-							<span className="tr-text-emphasis text-text-default">{workspace.branch}</span> is
-							kept.
-						</>
+					title={
+						isExternal
+							? `Remove ${workspace.name} from ThinkRail?`
+							: `Remove ${workspace.name} workspace`
 					}
-					confirmLabel="Remove"
+					description={
+						isExternal ? (
+							<>
+								Removes this workspace's ThinkRail chats and terminals. The existing checkout,
+								files, and branch{" "}
+								<span className="tr-text-emphasis text-text-default">{workspace.branch}</span> stay
+								untouched.
+							</>
+						) : (
+							<>
+								Deletes this workspace's chats, terminals, and its worktree. The git branch{" "}
+								<span className="tr-text-emphasis text-text-default">{workspace.branch}</span> is
+								kept.
+							</>
+						)
+					}
+					confirmLabel={isExternal ? "Remove from ThinkRail" : "Remove"}
 					destructive
 					confirmTestId="confirm-remove"
 					onConfirm={onRemove}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -23,8 +23,11 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   Right-click opens that PR-#167-styled menu at the pointer without selecting/navigating; a scroll-cancelled
   ~700ms long press is its touch equivalent. With a project-name button focused, the standard Context Menu
   key or Shift+F10 opens the same menu for keyboard-only use; arrow/activate/Escape keys work normally.
-  The menu is neutral
-  **Plus Create workspace**, separator, **X Close project**; Create is exactly the direct `+` flow. Close
+  The menu is neutral: **Plus Create workspace**, **FolderOpen Open existing worktree…**, separator,
+  **X Close project**. Create is exactly the direct `+` flow. Open existing worktree opens the
+  `ExistingWorktreeDialog` chooser fed by `workspace.listExisting` (branch + absolute path per row;
+  detached-HEAD rows stay visible but disabled); choosing one calls `workspace.openExisting`, then expands
+  the project and activates the attached row without starting a chat. Close
   opens a centered, neutral `ConfirmDialog` titled **“Close {name}?”**, description **“Removes this project
   from the open projects list. Its repository, workspaces, chats, and running activity are kept. Reopen it
   from Add project → Recents.”**, Cancel initially focused, and **Close project**; Cancel, backdrop, and
@@ -35,7 +38,9 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   project. `ProjectTree` also owns the `NewWorkspaceDialog` the per-project `+` opens **and** each
   workspace row's hover-revealed **kebab menu** (`MoreVertical`, `DropdownMenu`) — a `DropdownMenuSub`
   **"Open in"** (rendered only when at least one editor was detected), **Copy path**, **Reveal in file
-  manager**, and (worktrees only) **Remove workspace**. "Open in" comes from the host-wide `editor.list`;
+  manager**, and (worktrees only) **Remove workspace** — worded **Remove from ThinkRail** on an external
+  row, whose confirm promises the checkout and its branch stay untouched. "Open in" comes from the
+  host-wide `editor.list`;
   GUI entries call `workspace.openIn`, while terminal-kind Vim activates the workspace and runs through
   `addTerminal`'s one-shot `initialCommand`. Copy writes `worktreePath`; Reveal calls `workspace.reveal`.
   Remove is styled destructive and opens a centered `ConfirmDialog`; confirming fires
@@ -301,7 +306,9 @@ a project picker, the prompt hero, and the reused
   `branch · from baseBranch`, and **“Files, chats, changes, and terminals are scoped to this workspace,”**
   followed by the existing **New chat** action. For the **Default workspace** the receipt tells the truth
   instead of promising isolation: **“Default workspace”**, the project name, `on <branch>`, and “Chats,
-  changes, and terminals run directly in your project folder.” It is neither one-time nor dismissible, so it also helps
+  changes, and terminals run directly in your project folder.” An **external workspace** reads
+  **“Existing worktree”** with `on <branch>` for the same reason — ThinkRail did not cut it, so there is no
+  `from <base>` to claim. It is neither one-time nor dismissible, so it also helps
   after the last tab closes without introducing onboarding state. `CenterTabs` also renders ephemeral
   **`doc`** tabs (`DocTab` — inline rendered markdown, no file on disk) via its own
   `DocPane`→`MarkdownPreview`; used for the plan-as-markdown snapshot (see the `chat` module). `CenterTabs`

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -11,7 +11,7 @@ import { TerminalsPanel } from "../panels/TerminalsPanel";
 import { Toaster } from "../panels/Toaster";
 import { WelcomePanel } from "../panels/WelcomePanel";
 import {
-	isDefaultWorkspace,
+	isUserOwnedWorkspace,
 	selectActiveWorkspace,
 	selectContextProject,
 	useAppStore,
@@ -78,10 +78,9 @@ export function Shell() {
 									<span data-testid="scope-branch" className="truncate">
 										{activeWorkspace.branch}
 									</span>
-									{/* The Default workspace has no isolation base — "from <base>" would promise one
-									    (and read "main · from main" on the default branch), so the spine shows only the
-									    live branch, matching the CenterTabs receipt. */}
-									{isDefaultWorkspace(activeWorkspace) ? null : (
+									{/* User-owned Default/external workspaces have no ThinkRail creation provenance,
+									    so "from <base>" would make a promise the app cannot support. */}
+									{isUserOwnedWorkspace(activeWorkspace) ? null : (
 										<span data-testid="scope-base" className="hidden shrink-0 md:inline">
 											· from {activeWorkspace.baseBranch}
 										</span>

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from "bun:test";
 import type { Project, WireModel, Workspace } from "@thinkrail/contracts";
 import type { EditorTab } from "./appStore";
 import {
+	isDefaultWorkspace,
+	isExternalWorkspace,
 	isSkillPath,
+	isUserOwnedWorkspace,
 	matchesWorktreePath,
 	selectActiveWorkspace,
 	selectActiveWorkspaceProjectId,
@@ -26,6 +29,18 @@ const workspace: Workspace = {
 	baseBranch: "main",
 };
 const workspaces = { p1: [], p2: [workspace] };
+
+test("workspace kind predicates distinguish managed and user-owned checkouts", () => {
+	const managed = {};
+	const external = { kind: "external" as const };
+	const defaultWorkspace = { kind: "default" as const };
+
+	expect(isDefaultWorkspace(defaultWorkspace)).toBe(true);
+	expect(isExternalWorkspace(external)).toBe(true);
+	expect(isUserOwnedWorkspace(managed)).toBe(false);
+	expect(isUserOwnedWorkspace(defaultWorkspace)).toBe(true);
+	expect(isUserOwnedWorkspace(external)).toBe(true);
+});
 
 test("active workspace selectors resolve the workspace and its owning project", () => {
 	const state = { activeWorkspaceId: "w2", workspaces };

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -26,6 +26,16 @@ export function isDefaultWorkspace(workspace: Pick<Workspace, "kind">): boolean 
 	return workspace.kind === "default";
 }
 
+/** An explicitly attached existing worktree whose checkout stays user-owned. */
+export function isExternalWorkspace(workspace: Pick<Workspace, "kind">): boolean {
+	return workspace.kind === "external";
+}
+
+/** User-owned checkouts never carry ThinkRail-created-worktree provenance or reclaim semantics. */
+export function isUserOwnedWorkspace(workspace: Pick<Workspace, "kind">): boolean {
+	return isDefaultWorkspace(workspace) || isExternalWorkspace(workspace);
+}
+
 /** Resolve the active workspace from the project-grouped collection without duplicating it in state. */
 export function selectActiveWorkspace(state: ActiveWorkspaceState): Workspace | null {
 	return state.activeWorkspaceId ? selectWorkspaceById(state, state.activeWorkspaceId) : null;

--- a/architecture.md
+++ b/architecture.md
@@ -57,12 +57,15 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    tabs + chat tabs**. The shell arranges panels by layout mode: desktop multi-pane /
    mobile single-view-with-switcher. Both modes share the same panels and store.
 6. **Workspaces are git worktrees (V1).** project (git repo) → workspace (`git worktree` on its own
-   branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. **One deliberate
-   exception:** every project carries exactly one built-in **Default workspace** (`kind: "default"`)
+   branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. **Two deliberate
+   exceptions, both `kind`-marked on the wire and both *user-owned* — never renamed or reclaimed by
+   ThinkRail:** every project carries exactly one built-in **Default workspace** (`kind: "default"`)
    whose cwd is the project folder itself (git's *main working tree*) — non-removable, non-renamable,
    and entered explicitly from the project's Welcome fork ("Work in project folder"), never
    auto-entered — the "just work in my project folder" anchor for users lost in the
-   worktree model (see [[submodule-server-workspaces]]). The shell is built first,
+   worktree model; and an **existing worktree** the user explicitly attaches in place
+   (`kind: "external"`), which ThinkRail may forget but never mutates (see
+   [[submodule-server-workspaces]]). The shell is built first,
    `pi` connected last. Real PR / Checks / Review stay V2.
 7. **Auth is external.** Tailscale ACLs / device identity are the auth; the app carries an `owner` field,
    not a login UI.

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -18,6 +18,9 @@ export default function globalSetup(): void {
 	rmSync(E2E_DATA_DIR, { recursive: true, force: true });
 	mkdirSync(E2E_DATA_DIR, { recursive: true });
 	mkdirSync(E2E_HOME_DIR, { recursive: true });
+	// An empty HOME makes zsh launch its interactive first-run wizard, which consumes the terminal test's
+	// first keystrokes instead of running them. A real (minimal) rc file keeps the isolated shell inert.
+	writeFileSync(join(E2E_HOME_DIR, ".zshrc"), "# ThinkRail e2e isolated shell\n");
 
 	// Isolated pi agent dir: copy the user's provider/auth config so a real provider works (the `@agent`
 	// suite needs it — auth lives across BOTH `auth.json` (OAuth providers) and `models.json` (providers

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -132,16 +132,21 @@ test("project context actions stay compact and close/reopen is lossless across c
 	expect(Math.abs(menuBox.y - pointer.y)).toBeLessThan(8);
 
 	const createFromMenu = page.getByTestId("project-menu-create-workspace");
+	const openExistingFromMenu = page.getByTestId("project-menu-open-existing-worktree");
 	const closeFromMenu = page.getByTestId("project-menu-close");
 	const menuParts = projectActions.locator('[role="menuitem"], [role="separator"]');
-	await expect(menuParts).toHaveCount(3);
+	await expect(menuParts).toHaveCount(4);
 	await expect(menuParts.nth(0)).toHaveText("Create workspace");
-	await expect(menuParts.nth(1)).toHaveAttribute("role", "separator");
-	await expect(menuParts.nth(2)).toHaveText("Close project");
+	await expect(menuParts.nth(1)).toHaveText("Open existing worktree…");
+	await expect(menuParts.nth(2)).toHaveAttribute("role", "separator");
+	await expect(menuParts.nth(3)).toHaveText("Close project");
 	await expect(createFromMenu.locator("svg.lucide-plus")).toHaveCount(1);
+	await expect(openExistingFromMenu.locator("svg.lucide-folder-open")).toHaveCount(1);
 	await expect(closeFromMenu.locator("svg.lucide-x")).toHaveCount(1);
 	await page.keyboard.press("ArrowDown");
 	await expect(createFromMenu).toBeFocused();
+	await page.keyboard.press("ArrowDown");
+	await expect(openExistingFromMenu).toBeFocused();
 	await page.keyboard.press("ArrowDown");
 	await expect(closeFromMenu).toBeFocused();
 	await page.keyboard.press("Escape");

--- a/e2e/workspaces.spec.ts
+++ b/e2e/workspaces.spec.ts
@@ -1,12 +1,140 @@
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
+	openAppFresh,
 	openFixtureProject,
 	openWorkspaceMenu,
 	worktreeRows,
 } from "./fixtures/app";
-import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { E2E_DATA_DIR, E2E_FIXTURE_REPO } from "./fixtures/paths";
+
+test("opens and safely forgets an existing user-owned worktree", async ({ page }) => {
+	// Start with a persisted project whose workspace list has never been hydrated. Opening from its context
+	// menu must still install the complete list before activation (Default + the attached row).
+	await openAppFresh(page);
+	const external = join(E2E_DATA_DIR, "existing-worktree-fixture");
+	const detached = join(E2E_DATA_DIR, "detached-worktree-fixture");
+	rmSync(external, { recursive: true, force: true });
+	rmSync(detached, { recursive: true, force: true });
+	execFileSync("git", [
+		"-C",
+		E2E_FIXTURE_REPO,
+		"worktree",
+		"add",
+		external,
+		"-b",
+		"feature/existing",
+		"main",
+	]);
+	execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "add", "--detach", detached, "main"]);
+	writeFileSync(join(external, "staged.txt"), "preserve this staged addition\n");
+	execFileSync("git", ["-C", external, "add", "staged.txt"]);
+	writeFileSync(
+		join(external, "README.md"),
+		`${readFileSync(join(external, "README.md"), "utf8")}preserve this unstaged edit\n`,
+	);
+	writeFileSync(join(external, "uncommitted.txt"), "preserve this untracked file\n");
+
+	const gitText = (cwd: string, ...args: string[]) =>
+		execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+	const before = {
+		status: gitText(external, "status", "--porcelain=v1", "-z"),
+		branch: gitText(external, "symbolic-ref", "--short", "HEAD"),
+		head: gitText(external, "rev-parse", "HEAD"),
+		registry: gitText(E2E_FIXTURE_REPO, "worktree", "list", "--porcelain", "-z"),
+	};
+	const expectCheckoutUnchanged = () => {
+		expect(gitText(external, "status", "--porcelain=v1", "-z")).toBe(before.status);
+		expect(gitText(external, "symbolic-ref", "--short", "HEAD")).toBe(before.branch);
+		expect(gitText(external, "rev-parse", "HEAD")).toBe(before.head);
+		expect(gitText(E2E_FIXTURE_REPO, "worktree", "list", "--porcelain", "-z")).toBe(
+			before.registry,
+		);
+	};
+
+	writeFileSync(
+		join(E2E_DATA_DIR, "projects.json"),
+		JSON.stringify([
+			{
+				id: "fixture-project",
+				name: "sample-project",
+				path: E2E_FIXTURE_REPO,
+				slug: "sample-project",
+				lastOpened: Date.now(),
+			},
+		]),
+	);
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+
+	try {
+		const projectRow = page.getByTestId("project-item").filter({ hasText: "sample-project" });
+		await expect(projectRow).toBeVisible();
+		await projectRow.click({ button: "right" });
+		await page.getByTestId("project-menu-open-existing-worktree").click();
+
+		const dialog = page.getByTestId("existing-worktree-dialog");
+		await expect(dialog).toBeVisible();
+		const available = dialog
+			.getByTestId("existing-worktree-candidate")
+			.filter({ hasText: "feature/existing" });
+		await expect(available).toContainText(external);
+		await expect(available).toBeFocused();
+		const detachedRow = dialog.locator(
+			'[data-testid="existing-worktree-candidate"][data-status="detached"]',
+		);
+		await expect(detachedRow).toContainText("Detached HEAD");
+		await expect(detachedRow).toContainText("Create a branch");
+		await expect(detachedRow).toBeDisabled();
+
+		await available.click();
+		await expect(dialog).toHaveCount(0);
+		const row = page.locator(
+			'[data-testid="workspace-item"][data-kind="external"][data-active="true"]',
+		);
+		await expect(row).toContainText("existing-worktree-fixture");
+		await expect(row).toContainText("feature/existing");
+		const receipt = page.getByTestId("workspace-ready");
+		await expect(receipt).toContainText("Existing worktree");
+		await expect(receipt).toContainText("on feature/existing");
+		expectCheckoutUnchanged();
+
+		await openWorkspaceMenu(row);
+		await expect(page.getByTestId("workspace-remove")).toHaveText("Remove from ThinkRail");
+		await page.getByTestId("workspace-remove").click();
+		const confirm = page.getByRole("alertdialog", {
+			name: "Remove existing-worktree-fixture from ThinkRail?",
+		});
+		await expect(confirm).toContainText("existing checkout, files, and branch");
+		await expect(confirm).toContainText("stay untouched");
+		await page.getByTestId("confirm-remove").click();
+		await expect(row).toHaveCount(0);
+
+		// The ThinkRail identity is gone, but every externally-owned byte and Git registration survives.
+		expect(existsSync(external)).toBe(true);
+		expect(readFileSync(join(external, "uncommitted.txt"), "utf8")).toBe(
+			"preserve this untracked file\n",
+		);
+		expectCheckoutUnchanged();
+	} finally {
+		for (const path of [external, detached]) {
+			try {
+				execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "remove", "--force", path]);
+			} catch {
+				rmSync(path, { recursive: true, force: true });
+			}
+		}
+		try {
+			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "branch", "-D", "feature/existing"]);
+		} catch {
+			// The per-test reset is the final cleanup backstop if setup failed before the branch existed.
+		}
+		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "prune"]);
+	}
+});
 
 test("creates, removes, and re-creates worktree workspaces (no branch collision)", async ({
 	page,

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -27,7 +27,8 @@ The shell is built first, `pi` connected last:
 - **Projects → workspaces**: open a git repo as a project; a workspace is a `git worktree` (own branch +
   cwd) under `~/.thinkrail/worktrees` — plus one built-in, non-removable **Default workspace** per
   project (the project folder itself), offered as an explicit choice on the project's Welcome so
-  newcomers aren't lost in the worktree model.
+  newcomers aren't lost in the worktree model, and any **existing worktree** the user attaches in place
+  from the project menu (ThinkRail uses its cwd, never touches its checkout).
 - **Center**: a tabbed area — Monaco file tabs + (once `pi` lands) chat tabs.
 - **Right**: an All-files tree of the active worktree + a Changes (git diff) tab; terminals below,
   scoped to the worktree.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -107,15 +107,20 @@ of the host.
   eligible for the agentic auto-rename; `true` = deliberately named (agentic or user), never auto-touched
   again; its optional **`kind: "default"`** marks the built-in per-project **Default workspace** — the
   project folder itself as a workspace, exactly one per project, pinned first in `workspace.list`,
-  non-removable and non-renamable server-side; absent = a normal worktree workspace — an explicit wire
-  field, never an id convention), `Session` (chat tab),
+  non-removable and non-renamable server-side; **`kind: "external"`** marks an explicitly attached,
+  user-owned worktree ThinkRail may forget but must never rename or reclaim; absent = a ThinkRail-managed
+  worktree workspace — an explicit wire field, never an id convention),
+  **`ExistingWorktreeCandidate`** (a `workspace.listExisting` row: absolute `path` + `branch`, or a
+  `detached` row the chooser disables), `Session` (chat tab),
   `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types — incl. **`GitDiffScope`** (what the Changes
   panel is diffing: `branch` → the workspace's work since diverging from its diff base (the range starts at
   their merge-base, never the base's tip) / `uncommitted` → worktree vs `HEAD` /
   `commit` → one commit, `sha^` vs `sha`; omitted on the wire = `branch`, so an older client is unchanged)
   and **`GitCommit`** (a commit row of the scope menu's list). The two meanings of a workspace's base are
   **two fields**: `Workspace.baseBranch` is *creation provenance* (the ref the worktree was cut from — what
-  the receipt's `branch · from baseBranch` shows) and the optional **`Workspace.diffBase`** is the *review
+  the receipt's `branch · from baseBranch` shows; for a **user-owned** workspace, whose provenance isn't
+  ThinkRail's to claim, it is the repo default as the *initial* review target and the UI shows no `from`)
+  and the optional **`Workspace.diffBase`** is the *review
   target* (`workspace.setDiffBase`); every read resolves `diffBase ?? baseBranch` **server-side, in one
   place** — collapsing them into one field would make a re-pointed target lie about where the branch came
   from; **`ProviderStatus`/`ProviderStatusReport`**
@@ -182,6 +187,9 @@ of the host.
   correlated by `loginId` / **`loginCancel`** / **`logout`** /
   the **JetBrains AI** trio **`jbcentralConnect`** (wire Claude+GPT via the jbcentral proxy → a
   `JbcentralConnectResult`) / **`jbcentralDisconnect`** / **`jbcentralLogin`** (launch `central login`)) /
+  **`workspace.listExisting`** (the selected project's unattached Git worktrees, with detached rows
+  disabled by status) / **`workspace.openExisting`** (revalidate + register one branch-backed checkout as
+  `kind: "external"`, emitting the ordinary `workspace.created`, without mutating Git or disk) /
   **`project.setTrust`** (persist a project's trust grant → the updated `Project`; gates its committed
   cross-agent skill aliases) /
   **`skill.list`** (a pre-session, skill-only `SlashCommandInfo[]` preview for a `projectId`, resolved from

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -58,10 +58,12 @@ export interface Workspace {
 	/**
 	 * `"default"` marks the built-in per-project **Default workspace** — the project folder itself
 	 * (git's main working tree) surfaced as a workspace. Exactly one per project, pinned first in
-	 * `workspace.list`, non-removable and non-renamable (enforced server-side). Absent = a normal
-	 * worktree workspace. An explicit wire field — clients must never detect it by id convention.
+	 * `workspace.list`, non-removable and non-renamable (enforced server-side). `"external"` marks an
+	 * explicitly attached, user-owned worktree: ThinkRail may forget its app state but must never rename
+	 * its branch or reclaim its checkout. Absent = a ThinkRail-managed worktree. An explicit wire field —
+	 * clients must never infer ownership from ids or paths.
 	 */
-	kind?: "default";
+	kind?: "default" | "external";
 	/**
 	 * Human-readable display label shown in the UI (Title Case, spaces) — decoupled from `branch`. May
 	 * repeat across workspaces; the branch is what's uniqued. Equals `branch` only for the auto
@@ -73,9 +75,10 @@ export interface Workspace {
 	/** Absolute path to the worktree (the cwd everything downstream uses). */
 	worktreePath: string;
 	/**
-	 * **Creation provenance** — the ref this worktree was cut from (`git worktree add … <baseBranch>`), or
-	 * for the Default workspace the repo's default branch. Shown in the UI as `branch · from baseBranch`.
-	 * It is *not* necessarily what the diff is measured against: see `diffBase`.
+	 * **Creation provenance** for a managed worktree — the ref it was cut from (`git worktree add …
+	 * <baseBranch>`). For user-owned Default/external workspaces, whose creation provenance is not ours to
+	 * claim, this is the repository-default initial review target and the UI shows only `on <branch>`.
+	 * It is *not* necessarily what the diff is measured against after re-pointing: see `diffBase`.
 	 */
 	baseBranch: string;
 	/**
@@ -101,6 +104,11 @@ export interface Workspace {
 	 */
 	skillOverrides?: Record<string, "on" | "off">;
 }
+
+/** One unattached checkout from `git worktree list`, shown in the existing-worktree chooser. */
+export type ExistingWorktreeCandidate =
+	| { path: string; branch: string; status: "available" }
+	| { path: string; status: "detached" };
 
 /**
  * A host-installed editor/IDE the "Open in" menu can offer, from `editor.list` — never a fixed client

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -5,6 +5,7 @@ import type {
 	BranchList,
 	DiffStats,
 	EditorInfo,
+	ExistingWorktreeCandidate,
 	FileNode,
 	GitCommit,
 	GitDiffScope,
@@ -106,7 +107,9 @@ import type {
 // workspace's `worktreePath`, `workspace.reveal` opens the host's file manager there.
 // v24: lossless project close/reopen — Project.closed marks rail membership, server.welcome carries open
 // + recent project views, and project.updated streams full snapshots so every client converges.
-export const PROTOCOL_VERSION = 24;
+// v25: existing-worktree adoption — `Workspace.kind: "external"` marks user-owned checkouts;
+// `workspace.listExisting` discovers candidates and `workspace.openExisting` registers one in place.
+export const PROTOCOL_VERSION = 25;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -161,6 +164,8 @@ export const WS_METHODS = {
 	projectSetGroupEnabled: "project.setGroupEnabled",
 	projectSkills: "project.skills",
 	workspaceCreate: "workspace.create",
+	workspaceListExisting: "workspace.listExisting",
+	workspaceOpenExisting: "workspace.openExisting",
 	workspaceList: "workspace.list",
 	workspaceRemove: "workspace.remove",
 	workspaceDiffStats: "workspace.diffStats",
@@ -376,6 +381,14 @@ export interface WsMethodMap {
 	// omitted, the worktree branches off the repo's current HEAD (the default behavior).
 	"workspace.create": {
 		params: { projectId: string; name?: string; baseRef?: string };
+		result: Workspace;
+	};
+	"workspace.listExisting": {
+		params: { projectId: string };
+		result: ExistingWorktreeCandidate[];
+	};
+	"workspace.openExisting": {
+		params: { projectId: string; path: string };
 		result: Workspace;
 	};
 	"workspace.list": { params: { projectId: string }; result: Workspace[] };

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -82,7 +82,11 @@ ref off the workspace-create critical path.
   resolves to the branch name it will become, never the literal `"HEAD"` (which would persist into a
   user-visible `baseBranch`); **`currentBranch(repoPath)`** — the branch a checkout currently has out
   (`symbolic-ref --short HEAD`, unborn-safe; detached → literal `HEAD`), consumed by the `workspaces`
-  module for the Default workspace's folder-truth `branch`; `prefetchBranch(projectId, ref)` — best-effort background
+  module for a user-owned workspace's folder-truth `branch`, with **`tryCurrentBranch`** its fallible form
+  (`null` when the path is not a readable worktree root, so a refresh never persists an I/O failure as a
+  detach); **`canonicalPath(path)`** — the symlink-resolved form any path compared against git output must
+  take (git resolves symlinks, a caller's path does not), shared with `workspaces`' worktree-identity
+  checks; `prefetchBranch(projectId, ref)` — best-effort background
   `git fetch` of a remote ref (via `gitAsync`, branch passed after `--` so a `-`-prefixed name can't be
   parsed as a git option), so a later `createWorkspace` branches off a fresh tip without the network
   round-trip on its critical path (non-`origin/` ref / offline → no-op). Its result also says whether the
@@ -96,7 +100,8 @@ ref off the workspace-create critical path.
   `{ ok }`.
 - **Public surface (barrel):** `git`, `gitAsync`, `gitStatus`, `gitDiffFile`, `listCommits`,
   `resolveDiffRange`, `changedFileArgs`, `diffBaseRef`, `DiffRange`, `isSafeRef`, `assertSafeRef`,
-  `listBranches`, `resolveDefaultBranch`, `currentBranch`, `prefetchBranch`.
+  `listBranches`, `resolveDefaultBranch`, `tryCurrentBranch`, `currentBranch`, `canonicalPath`,
+  `prefetchBranch`.
 - **Allowed deps:** `persistence` (workspace + project lookup); `contracts` (`Git*`/`BranchList` types);
   `@thinkrail/shared/codedError` (naming a failure for the wire); Bun (spawn).
 - **Forbidden:** `host`; sibling features.
@@ -115,6 +120,6 @@ ref off the workspace-create critical path.
   instead of rendering an empty change set. The `workspaces` module's `diffStats` follows the same rule from
   the other end — it returns *no* stats (and logs why) rather than a fabricated `+0 −0`. A review surface that
   calls a dirty worktree clean is the worst failure this product can have.
-- `gitStatus` reports the **live** current branch for a `kind: "default"` workspace (the project
-  folder's branch moves out-of-band — a terminal `git checkout` — and the persisted snapshot self-heals
-  only at list time; the Changes header must not lag).
+- `gitStatus` reports the **live** current branch for a user-owned (`kind: "default" | "external"`)
+  workspace (its branch moves out-of-band — a terminal `git checkout` — and the persisted snapshot
+  self-heals only at list time; the Changes header must not lag).

--- a/packages/server/src/git/git.test.ts
+++ b/packages/server/src/git/git.test.ts
@@ -11,6 +11,7 @@ import {
 	listCommits,
 	numstatPath,
 	prefetchBranch,
+	tryCurrentBranch,
 } from "./git";
 import { isSafeRef } from "./refs";
 
@@ -147,6 +148,16 @@ test("listBranches with no remote returns local branches and falls back to the r
 	expect(defaultBranch).toBe("main");
 });
 
+test("tryCurrentBranch distinguishes a detached checkout from an invalid workspace root", () => {
+	expect(tryCurrentBranch(repo)).toBe("main");
+	git(repo, "switch", "--detach");
+	expect(tryCurrentBranch(repo)).toBe("HEAD");
+	const nested = join(repo, "nested");
+	mkdirSync(nested);
+	expect(tryCurrentBranch(nested)).toBeNull();
+	expect(tryCurrentBranch(join(dataDir, "missing"))).toBeNull();
+});
+
 test("listBranches surfaces origin branches and the origin default", () => {
 	const remoteRepo = join(dataDir, "remote.git");
 	git(repo, "init", "--bare", remoteRepo); // `git -C repo init --bare <path>` inits at <path>
@@ -241,6 +252,26 @@ test("gitStatus reads the Default workspace's branch live, not the persisted sna
 	);
 	git(repo, "switch", "-c", "feature/live");
 	expect(gitStatus("w-default").branch).toBe("feature/live");
+});
+
+test("gitStatus reads an external workspace's branch live, not the persisted snapshot", () => {
+	writeFileSync(
+		join(dataDir, "workspaces.json"),
+		JSON.stringify([
+			{
+				id: "w-external",
+				projectId: "p1",
+				kind: "external",
+				name: "existing checkout",
+				branch: "main",
+				worktreePath: repo,
+				baseBranch: "main",
+				renamed: true,
+			},
+		]),
+	);
+	git(repo, "switch", "-c", "feature/external-live");
+	expect(gitStatus("w-external").branch).toBe("feature/external-live");
 });
 
 test("diffBaseRef resolves the re-pointed diff target over the creation base", () => {

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { readFileSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
 import type {
 	BranchList,
@@ -66,14 +66,37 @@ export function resolveDefaultBranch(repoPath: string): string {
 }
 
 /**
- * The branch a checkout currently has out — `symbolic-ref --short HEAD`, which (unlike `rev-parse
- * --abbrev-ref`) also answers on an unborn HEAD (a repo with no commits yet). Detached HEAD → the
- * literal `"HEAD"`. Used for the Default workspace, whose branch is whatever the project folder has
- * checked out (it moves out-of-band — a terminal `git checkout` — unlike a worktree's pinned branch).
+ * The comparable form of a path. **Git reports symlink-resolved paths** (`--show-toplevel`, `worktree
+ * list`) while a path we were handed keeps whatever symlinks the caller wrote (macOS's `/var` →
+ * `private/var`), so comparing either side raw mismatches silently. An unreadable path degrades to
+ * `resolve` — a missing dir still compares by name instead of throwing.
+ */
+export function canonicalPath(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return resolve(path);
+	}
+}
+
+/**
+ * Fallibly read the branch a checkout currently has out. A valid detached checkout is the literal
+ * `"HEAD"`; an unreadable/non-worktree root is `null`, so callers that persist folder truth never turn an
+ * I/O failure into a fake detach. `symbolic-ref` also answers on an unborn branch.
+ */
+export function tryCurrentBranch(repoPath: string): string | null {
+	const head = git(repoPath, ["symbolic-ref", "--short", "HEAD"]);
+	if (head.ok && head.out) return head.out;
+	const topLevel = git(repoPath, ["rev-parse", "--show-toplevel"]);
+	return topLevel.ok && canonicalPath(topLevel.out) === canonicalPath(repoPath) ? "HEAD" : null;
+}
+
+/**
+ * Compatibility read for callers that already established a valid checkout. Detached (or unreadable)
+ * paths degrade to `"HEAD"`; persistence refreshes use `tryCurrentBranch` instead.
  */
 export function currentBranch(repoPath: string): string {
-	const head = git(repoPath, ["symbolic-ref", "--short", "HEAD"]);
-	return head.ok && head.out ? head.out : "HEAD";
+	return tryCurrentBranch(repoPath) ?? "HEAD";
 }
 
 /**
@@ -248,9 +271,11 @@ export function gitStatus(workspaceId: string, scope?: GitDiffScope): GitStatus 
 	}
 
 	changes.sort((a, b) => a.path.localeCompare(b.path));
-	// The Default workspace's branch is folder-truth that moves out-of-band (a terminal `git checkout`);
-	// the persisted snapshot self-heals only at list time, so the Changes header reads it live.
-	return { branch: ws.kind === "default" ? currentBranch(ws.worktreePath) : ws.branch, changes };
+	// User-owned workspaces can switch branches out-of-band; the Changes header reads folder truth live
+	// while their persisted snapshot converges through the metadata nudge/list path.
+	const branch =
+		ws.kind === "default" || ws.kind === "external" ? currentBranch(ws.worktreePath) : ws.branch;
+	return { branch, changes };
 }
 
 /**

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -24,8 +24,8 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `pi.extensionUi`) and the `provider.*` login handlers, the **`watch` wiring** (inject the
   `workspace.fsChanged` publish callback into `watch`, plus its **repo-metadata** callback
   (`setRepoMetaPublisher`) fanned out to **two** convergences for a git-metadata write in a watched worktree:
-  `refreshDefaultWorkspace` (**re-sync a Default workspace's folder-truth branch** — host-mediated, since
-  `watch` has no `workspaces` edge, and self-publishing through the workspace-lifecycle tee) **and** a
+  `refreshUserOwnedWorkspace` (**re-sync a user-owned workspace's folder-truth branch** — host-mediated,
+  since `watch` has no `workspaces` edge, and self-publishing through the workspace-lifecycle tee) **and** a
   pathless `fsChanged` frame (`paths: []`, `truncated: false`) so the clients' `HEAD`-relative reads
   (`git.status`, an `uncommitted`-scope diff tab) re-read when a terminal `commit`/`reset` moves a ref;
   the same publish also feeds the **fsNudge seam** (`fsNudge.ts`: `setFsNudgePublisher` +
@@ -105,12 +105,14 @@ channel fan-out, and the process-boot wrapper both launchers share.
     the host may make. `workspace.remove` **rejects a `kind: "default"` workspace loudly, before any
     side-effect** (the record's `worktreePath` is the project folder — the reclaim's `rm -rf` fallback
     must never see it; the UI hides Remove, this guard is for buggy/rogue clients). Otherwise it
-    reaps *everything* rooted in the worktree but is **non-blocking**:
+    reaps *everything* rooted in the worktree (for a user-owned `kind: "external"` one, everything except
+    the checkout itself) but is **non-blocking**:
     it does the fast part synchronously — `forgetWorkspace` (drop the record → gone from `workspace.list`
     immediately) → `evictSpecIndex` (drop the spec cache) → `closeWorkspaceTerminals` (kill its PTYs) —
     **acks**, then runs the slow reclamation in the **background** (`archiveTeardown`, fire-and-forget):
     `removeWorkspaceSessions` (abort a streaming turn, dispose the live sessions, **and** purge pi's
-    on-disk transcripts for the cwd) → `reclaimWorktree` (`git worktree remove`). So the user never waits
+    on-disk transcripts for the cwd) → `reclaimWorktree` (`git worktree remove`; a hard no-op for an
+    external one). So the user never waits
     for the git subprocess + session abort. **Ordering holds:** terminals (sync) and sessions (bg, before
     the reclaim) are down before the dir is deleted, since they hold it as cwd. Best-effort by contract —
     a failed background teardown is `console.warn`ed, never thrown into the void (nothing awaits it), like

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -91,8 +91,10 @@ import {
 	ensureWorkspaceScratchDir,
 	forgetWorkspace,
 	getWorkspace,
+	listExistingWorktrees,
 	listWorkspaceRecords,
 	listWorkspaces,
+	openExistingWorktree,
 	reclaimWorktree,
 	setWorkspaceDiffBase,
 	setWorkspaceSkillOverride,
@@ -161,6 +163,12 @@ const handlers: Record<string, Handler> = {
 	"workspace.create": (params) => {
 		const p = params as { projectId: string; name?: string; baseRef?: string };
 		return createWorkspace(p.projectId, p.name, p.baseRef);
+	},
+	"workspace.listExisting": (params) =>
+		listExistingWorktrees((params as { projectId: string }).projectId),
+	"workspace.openExisting": (params) => {
+		const p = params as { projectId: string; path: string };
+		return openExistingWorktree(p.projectId, p.path);
 	},
 	"workspace.list": (params) => listWorkspaces((params as { projectId: string }).projectId),
 	"workspace.remove": (params) => {

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -27,7 +27,7 @@ import {
 import { getConfig, setSettingsPublisher } from "../settings";
 import { closeAllTerminals, setTerminalPublisher } from "../terminal";
 import { setRepoMetaPublisher, setWatchPublisher, stopAllWatches } from "../watch";
-import { getWorkspace, refreshDefaultWorkspace, setWorkspacePublisher } from "../workspaces";
+import { getWorkspace, refreshUserOwnedWorkspace, setWorkspacePublisher } from "../workspaces";
 import {
 	isPromptCommitted,
 	isSettledTurn,
@@ -208,9 +208,9 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	// a watched worktree — a `git switch`/`commit`/`reset` in its terminal — converges two things that a
 	// file watcher alone cannot see, because such a change can leave the working tree byte-identical and
 	// produce no `fsChanged` batch at all:
-	//   1. a **Default** workspace's folder-truth branch (rail, top bar, receipt) instead of only at the next
-	//      `workspace.list`; self-publishing (`refreshDefaultWorkspace` emits `workspace.updated` through the
-	//      lifecycle tee above), and a no-op for worktree workspaces (pinned branch);
+	//   1. a user-owned **Default/external** workspace's folder-truth branch (rail, top bar, receipt)
+	//      instead of only at the next `workspace.list`; self-publishing (`refreshUserOwnedWorkspace` emits
+	//      `workspace.updated` through the lifecycle tee above), and a no-op for managed worktrees;
 	//   2. every **git-derived read** on the clients — `git.status` and an open `uncommitted`-scope diff tab
 	//      are relative to `HEAD`, so a commit made in a terminal would otherwise keep being reported as
 	//      uncommitted until some later file edit. Emitted as a **pathless** `fsChanged` nudge (no paths, not
@@ -218,7 +218,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	//      naming any file — so no `.git` path leaks to a client, and path-driven consumers (the Skills-reload
 	//      badge) correctly see nothing of interest.
 	setRepoMetaPublisher((workspaceId) => {
-		refreshDefaultWorkspace(workspaceId);
+		refreshUserOwnedWorkspace(workspaceId);
 		publishFsChanged({ workspaceId, paths: [], truncated: false });
 	});
 

--- a/packages/server/src/watch/SPEC.md
+++ b/packages/server/src/watch/SPEC.md
@@ -51,7 +51,7 @@ truth) and visible-panel polling (laggy, wasteful over Tailscale).
     dir's top level holds the refs that move (`HEAD`, `index`, `ORIG_HEAD`) while `objects/`/`logs/` are
     pure storms; a missing/unreadable git dir (non-git folder) or a failed start degrades silently.
 
-  `host` fans the nudge out to two convergences: `refreshDefaultWorkspace` (a **Default** workspace's
+  `host` fans the nudge out to two convergences: `refreshUserOwnedWorkspace` (a user-owned workspace's
   folder-truth branch labels) **and** a pathless `fsChanged` frame (`paths: []`, `truncated: false`) so the
   clients' git-derived reads re-read — `git.status` and an open `uncommitted`-scope diff tab are relative to
   `HEAD`, and would otherwise keep reporting a committed change as uncommitted until the next file edit.

--- a/packages/server/src/watch/watch.ts
+++ b/packages/server/src/watch/watch.ts
@@ -53,8 +53,8 @@ export function setWatchPublisher(publisher: WatchPublisher | null): void {
  * events inside the recursive root watcher (a repo root), and the non-recursive watcher on the **resolved**
  * git dir (a linked worktree's metadata lives in the parent repo, outside the root — see `resolveGitDir`).
  *
- * The host turns it into two convergences: a **Default** workspace's folder-truth branch label
- * (`refreshDefaultWorkspace`) and a pathless client invalidation, so git-derived reads (`git.status`, an
+ * The host turns it into two convergences: a user-owned **Default/external** workspace's folder-truth
+ * branch label (`refreshUserOwnedWorkspace`) and a pathless client invalidation, so git-derived reads (`git.status`, an
  * `uncommitted`-scope diff tab) re-read when a ref moves. This sink stays **pathless** on purpose: `.git`
  * internals are not worktree content, so no `.git` path ever reaches a client.
  */

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -15,13 +15,21 @@ chats. Its **display `name` is decoupled from its git `branch`**: `name` is a hu
 (Title Case, spaces) and `branch` is a kebab slug derived from it — they were once held equal, and still
 coincide for the auto `workspace-N` placeholder, but a named workspace carries both distinctly.
 
-Every project also carries **exactly one built-in Default workspace** (`kind: "default"`) whose
-`worktreePath` is the project folder itself (git's *main working tree*) — the "just work in my project
-folder" anchor, ensured lazily, **non-removable and non-renamable**.
+Two kinds are **user-owned** — ThinkRail uses their cwd but never renames or reclaims them. Every project
+carries **exactly one built-in Default workspace** (`kind: "default"`) whose `worktreePath` is the project
+folder itself (git's *main working tree*) — the "just work in my project folder" anchor, ensured lazily,
+**non-removable and non-renamable**. Any **existing worktree** the user explicitly attaches is recorded in
+place as `kind: "external"` — outside the data dir, never created or mutated here.
 
 ## Boundary
 
-- **Owns:** `createWorkspace` (**async**; off `baseRef` when given — branched with `worktree add -b`, never a detached
+- **Owns:** `listExistingWorktrees(projectId)` (parse `git worktree list --porcelain -z`; drop the project
+  folder, prunable registrations, and every path already represented in ThinkRail; branch-backed rows are
+  `available`, detached-HEAD ones `detached`), `openExistingWorktree(projectId, path)` (revalidate against
+  the Git registry at the mutation door, comparing canonicalized paths; same-project retries are
+  idempotent, cross-project cwd reuse is rejected; persist + emit `created` with `kind: "external"`, a
+  directory-basename display name, `renamed: true`, and the repo default as its initial review target —
+  **no Git or checkout mutation**), `createWorkspace` (**async**; off `baseRef` when given — branched with `worktree add -b`, never a detached
   remote checkout; off the repo `HEAD` otherwise; **remote-ref freshness is prefetched off this critical
   path** — the New-Workspace dialog `git.prefetch`es the base in the background, so create only `git
   fetch`es as a cheap fallback when the local remote-tracking ref is missing entirely — that fallback runs
@@ -70,7 +78,9 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   client-supplied one: with no base picked it comes from `rev-parse --abbrev-ref HEAD`, i.e. from the
   repository, and an untrusted checkout can have an option-shaped branch checked out (`git branch` refuses such
   a name, `symbolic-ref` does not) — both halves of the same door, closed by one check. **The two base meanings are two
-  fields on purpose:** `baseBranch` = where the branch came from, `diffBase` = what its review is measured
+  fields on purpose:** `baseBranch` = where the branch came from (for a user-owned workspace, whose
+  provenance isn't ours to claim: the repo default as its *initial* review target, never labelled `from`),
+  `diffBase` = what its review is measured
   against; collapsing them would make a re-pointed target lie about provenance (the `branch · from
   baseBranch` receipt). Every read of "the base" resolves through the `git` module, never inline —
   `diffStats` composes the git module's **branch-scope range** (`resolveDiffRange` +
@@ -84,10 +94,11 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   and the slow git reclaim are separable (the host archives off the request's critical path):
   `forgetWorkspace(id)` (drop the persistence record, return the removed record or `null` — gone from
   `listWorkspaces` immediately), `reclaimWorktree(ws)` (the slow half — `git worktree remove --force`,
-  keeps the branch; hardened: rm + `prune` if git fails; **refuses the Default and, defense-in-depth,
-  any record whose `worktreePath` resolves to the project folder** — the rm-fallback must never see the
-  user's repo, however a corrupt/hand-edited record got there), and `removeWorkspace(id)` (the synchronous
-  composition of the two, kept for callers/tests that want the whole archive in one call).
+  keeps the branch; hardened: rm + `prune` if git fails; **refuses both user-owned kinds and,
+  defense-in-depth, any record whose `worktreePath` resolves to the project folder** — the rm-fallback must
+  never see the user's repo or an attached checkout, however a corrupt/hand-edited record got there), and
+  `removeWorkspace(id)` (the synchronous composition of the two, kept for callers/tests that want the whole
+  archive in one call).
 - **Default workspace (`kind: "default"`):** exactly one per project. `listWorkspaces` **ensures** it
   — find-or-create by `projectId`+`kind` (id a plain `randomUUID`; the `kind` field is the marker,
   never an id convention), **collapsing duplicates** defensively if out-of-band state churn ever
@@ -105,8 +116,9 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   = the repo's default branch via `git`'s `resolveDefaultBranch` (unborn-safe — its last fallback is
   `currentBranch`, so the literal `"HEAD"` never persists) — so Default's Changes measure like
   any workspace, degenerating to uncommitted work when the folder sits on the default branch itself.
-  Drift is **not** only a list-time discovery: `refreshDefaultWorkspace(workspaceId)` is the same
-  re-sync **without** the diff-stat listing (two cheap git reads; unknown id / a worktree workspace /
+  Drift is **not** only a list-time discovery: `refreshUserOwnedWorkspace(workspaceId)` is the same
+  re-sync **without** the diff-stat listing (an external workspace re-syncs only its `branch`, and an
+  unreadable checkout is never persisted as a fake detached `HEAD`; unknown id / a managed workspace /
   no drift → no save, no emit), which the host wires to `watch`'s **repo-metadata nudge** (host-mediated,
   `watch` has no `workspaces` edge — see [[submodule-server-watch]]). So a `git switch` in the Default
   workspace's terminal converges the rail, the top bar and the empty receipt live, instead of leaving
@@ -140,10 +152,10 @@ folder" anchor, ensured lazily, **non-removable and non-renamable**.
   `removed` carries `{ projectId, id }`) and the host maps `kind` → `workspace.*` channel. This makes the
   module the **single source of workspace lifecycle pushes** (the auto-rename tee no longer pushes — rename
   self-publishes), so registry membership stays shared domain state across every client (architecture #9).
-- **Public surface (barrel):** `createWorkspace`, `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`,
-  `reclaimWorktree`, `removeWorkspace`, `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`,
-  `refreshDefaultWorkspace`, `ensureWorkspaceScratchDir`,
-  `setWorkspacePublisher`, `WorkspaceLifecycleEvent`.
+- **Public surface (barrel):** `createWorkspace`, `listExistingWorktrees`, `openExistingWorktree`,
+  `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`, `reclaimWorktree`, `removeWorkspace`,
+  `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`, `refreshUserOwnedWorkspace`,
+  `ensureWorkspaceScratchDir`, `setWorkspacePublisher`, `WorkspaceLifecycleEvent`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/index.ts
+++ b/packages/server/src/workspaces/index.ts
@@ -1,2 +1,2 @@
-/** Workspaces = git worktrees on their own branch under the data dir. */
+/** Managed and explicitly attached Git worktree workspaces. */
 export * from "./workspaces";

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -4,6 +4,7 @@ import {
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
+	realpathSync,
 	rmSync,
 	symlinkSync,
 	writeFileSync,
@@ -14,10 +15,12 @@ import {
 	createWorkspace,
 	ensureWorkspaceScratchDir,
 	forgetWorkspace,
+	listExistingWorktrees,
 	listWorkspaceRecords,
 	listWorkspaces,
+	openExistingWorktree,
 	reclaimWorktree,
-	refreshDefaultWorkspace,
+	refreshUserOwnedWorkspace,
 	removeWorkspace,
 	renameWorkspace,
 	setWorkspaceDiffBase,
@@ -45,7 +48,9 @@ function worktrees(projectId = "p1") {
 }
 
 beforeEach(() => {
-	dataDir = mkdtempSync(join(tmpdir(), "trpi-ws-test-"));
+	// Resolved: the fixtures compare paths against git's output, and git resolves symlinks (macOS's
+	// tmpdir sits under `/var` → `private/var`).
+	dataDir = realpathSync(mkdtempSync(join(tmpdir(), "trpi-ws-test-")));
 	process.env.THINKRAIL_DATA_DIR = dataDir;
 	repo = join(dataDir, "repo");
 	mkdirSync(repo);
@@ -101,6 +106,142 @@ test("createWorkspace branches off a locally-present remote ref without a networ
 	expect(ws.baseBranch).toBe("origin/main");
 	expect(gitOut(ws.worktreePath, "rev-parse", "HEAD")).toBe(originSha);
 	expect(gitOut(ws.worktreePath, "rev-parse", "--abbrev-ref", "HEAD")).toBe(ws.branch);
+});
+
+test("listExistingWorktrees shows unattached branch and detached checkouts only", async () => {
+	const external = join(dataDir, "existing auth checkout");
+	git(repo, "worktree", "add", external, "-b", "feature/auth", "main");
+	const detached = join(dataDir, "detached checkout");
+	git(repo, "worktree", "add", "--detach", detached, "main");
+	const managed = await createWorkspace("p1");
+
+	const candidates = listExistingWorktrees("p1");
+	expect(candidates).toContainEqual({
+		path: external,
+		branch: "feature/auth",
+		status: "available",
+	});
+	expect(candidates).toContainEqual({ path: detached, status: "detached" });
+	expect(candidates.some((candidate) => candidate.path === repo)).toBe(false);
+	expect(candidates.some((candidate) => candidate.path === managed.worktreePath)).toBe(false);
+});
+
+test("openExistingWorktree adopts idempotently and removal never reclaims the checkout", () => {
+	const external = join(dataDir, "existing auth checkout");
+	git(repo, "worktree", "add", external, "-b", "feature/auth", "main");
+	writeFileSync(join(external, "staged.txt"), "keep staged\n");
+	git(external, "add", "staged.txt");
+	writeFileSync(join(external, "README.md"), "# repo\nkeep unstaged\n");
+	writeFileSync(join(external, "uncommitted.txt"), "keep untracked\n");
+	const before = {
+		status: gitOut(external, "status", "--porcelain=v1", "-z"),
+		branch: gitOut(external, "symbolic-ref", "--short", "HEAD"),
+		head: gitOut(external, "rev-parse", "HEAD"),
+		registry: gitOut(repo, "worktree", "list", "--porcelain", "-z"),
+	};
+	const expectCheckoutUnchanged = () => {
+		expect(gitOut(external, "status", "--porcelain=v1", "-z")).toBe(before.status);
+		expect(gitOut(external, "symbolic-ref", "--short", "HEAD")).toBe(before.branch);
+		expect(gitOut(external, "rev-parse", "HEAD")).toBe(before.head);
+		expect(gitOut(repo, "worktree", "list", "--porcelain", "-z")).toBe(before.registry);
+	};
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((event) => events.push(event));
+
+	const workspace = openExistingWorktree("p1", external);
+	expect(workspace).toMatchObject({
+		projectId: "p1",
+		kind: "external",
+		name: "existing auth checkout",
+		branch: "feature/auth",
+		worktreePath: external,
+		baseBranch: "main",
+		renamed: true,
+	});
+	expect(events).toEqual([{ kind: "created", workspace }]);
+	expect(listExistingWorktrees("p1")).toHaveLength(0);
+	expectCheckoutUnchanged();
+
+	// A stale double-submit returns the one identity and emits no duplicate lifecycle event.
+	expect(openExistingWorktree("p1", external).id).toBe(workspace.id);
+	expect(events).toHaveLength(1);
+	expect(() => renameWorkspace(workspace.id, "hands off")).toThrow(
+		"An existing worktree cannot be renamed by ThinkRail",
+	);
+
+	removeWorkspace(workspace.id);
+	expect(listWorkspaceRecords("p1").some((candidate) => candidate.id === workspace.id)).toBe(false);
+	expect(readFileSync(join(external, "uncommitted.txt"), "utf8")).toBe("keep untracked\n");
+	expectCheckoutUnchanged();
+	expect(gitOut(repo, "show-ref", "--verify", "refs/heads/feature/auth")).not.toBe("");
+});
+
+test("openExistingWorktree rejects detached and unrelated paths", () => {
+	const detached = join(dataDir, "detached checkout");
+	git(repo, "worktree", "add", "--detach", detached, "main");
+	expect(() => openExistingWorktree("p1", detached)).toThrow(
+		"Detached HEAD worktrees cannot be opened; create a branch first",
+	);
+
+	const unrelated = join(dataDir, "unrelated");
+	mkdirSync(unrelated);
+	expect(() => openExistingWorktree("p1", unrelated)).toThrow(
+		"The selected path is not a registered worktree of this project",
+	);
+});
+
+test("existing worktrees represented by another project are rejected before its Default exists", () => {
+	const external = join(dataDir, "existing auth checkout");
+	git(repo, "worktree", "add", external, "-b", "feature/auth", "main");
+	writeFileSync(
+		join(dataDir, "projects.json"),
+		JSON.stringify([
+			{ id: "p1", name: "repo", path: repo, slug: "repo", lastOpened: 1 },
+			{ id: "p2", name: "external", path: external, slug: "external", lastOpened: 2 },
+		]),
+	);
+	// No workspace.list for p2: a project path owns its cwd before the lazy Default is materialized.
+	expect(listWorkspaceRecords("p2")).toHaveLength(0);
+	expect(listExistingWorktrees("p1").some((candidate) => candidate.path === external)).toBe(false);
+	expect(() => openExistingWorktree("p1", external)).toThrow(
+		"This worktree is already open under another ThinkRail project",
+	);
+});
+
+test("external workspace branch metadata converges on refresh and list", () => {
+	const external = join(dataDir, "existing auth checkout");
+	git(repo, "worktree", "add", external, "-b", "feature/auth", "main");
+	const workspace = openExistingWorktree("p1", external);
+	listWorkspaces("p1"); // ensure Default before this test starts observing lifecycle events
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((event) => events.push(event));
+
+	git(external, "switch", "-c", "feature/live");
+	refreshUserOwnedWorkspace(workspace.id);
+	expect(events).toEqual([
+		{
+			kind: "updated",
+			workspace: { ...workspace, branch: "feature/live" },
+		},
+	]);
+
+	events.length = 0;
+	git(external, "switch", "-c", "feature/list-refresh");
+	const listed = listWorkspaces("p1").find((candidate) => candidate.id === workspace.id);
+	expect(listed?.branch).toBe("feature/list-refresh");
+	expect(listed?.name).toBe("existing auth checkout");
+	expect(listed?.baseBranch).toBe("main");
+	expect(events).toHaveLength(1);
+
+	// A missing user-owned checkout is an I/O failure, not a detached checkout. Keep its last-known branch
+	// and stay quiet until the path is readable again.
+	events.length = 0;
+	rmSync(external, { recursive: true, force: true });
+	refreshUserOwnedWorkspace(workspace.id);
+	expect(events).toHaveLength(0);
+	expect(
+		listWorkspaceRecords("p1").find((candidate) => candidate.id === workspace.id)?.branch,
+	).toBe("feature/list-refresh");
 });
 
 test("createWorkspace seeds a self-ignoring .thinkrail/context scratch dir kept out of git", async () => {
@@ -447,7 +588,7 @@ test("the Default workspace's branch and base refresh from the folder on each li
 	expect(listWorkspaces("p1")[0]?.diffStats).toEqual({ added: 2, removed: 0 });
 });
 
-test("refreshDefaultWorkspace re-syncs and publishes Default drift off the list path", async () => {
+test("refreshUserOwnedWorkspace re-syncs and publishes Default drift off the list path", async () => {
 	listWorkspaces("p1"); // ensures the Default
 	const def = listWorkspaceRecords("p1").find((w) => w.kind === "default");
 	if (!def) throw new Error("expected the ensured Default workspace");
@@ -457,20 +598,20 @@ test("refreshDefaultWorkspace re-syncs and publishes Default drift off the list 
 	setWorkspacePublisher((e) => events.push(e));
 
 	// No drift → no save, no emit (the live path runs on every worktree-change batch: it must be quiet).
-	refreshDefaultWorkspace(def.id);
+	refreshUserOwnedWorkspace(def.id);
 	expect(events).toHaveLength(0);
 
 	// A terminal `git checkout` in the project folder converges without any `workspace.list`.
 	git(repo, "switch", "-c", "feature/live");
-	refreshDefaultWorkspace(def.id);
+	refreshUserOwnedWorkspace(def.id);
 	expect(events).toEqual([
 		{ kind: "updated", workspace: { ...def, branch: "feature/live", baseBranch: "feature/live" } },
 	]);
 	expect(listWorkspaceRecords("p1").find((w) => w.id === def.id)?.branch).toBe("feature/live");
 
-	// A worktree workspace's branch is pinned — and an unknown id is a no-op, never a throw.
-	refreshDefaultWorkspace(worktree.id);
-	refreshDefaultWorkspace("nope");
+	// A managed worktree's branch is pinned — and an unknown id is a no-op, never a throw.
+	refreshUserOwnedWorkspace(worktree.id);
+	refreshUserOwnedWorkspace("nope");
 	expect(events).toHaveLength(1);
 });
 

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -1,16 +1,23 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, lstatSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import type { DiffStats, Project, Workspace } from "@thinkrail/contracts";
+import { basename, dirname, join, resolve } from "node:path";
+import type {
+	DiffStats,
+	ExistingWorktreeCandidate,
+	Project,
+	Workspace,
+} from "@thinkrail/contracts";
 import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
 import {
 	assertSafeRef,
+	canonicalPath,
 	changedFileArgs,
 	currentBranch,
 	git,
 	gitAsync,
 	resolveDefaultBranch,
 	resolveDiffRange,
+	tryCurrentBranch,
 } from "../git";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
 import { getProjects, listProjects } from "../projects";
@@ -94,6 +101,116 @@ function nextAutoBranch(project: Project): string {
 	return `workspace-${n}`;
 }
 
+function openProjectById(projectId: string): Project {
+	// Open projects only — stale/rogue clients cannot create or attach work behind a closed rail row.
+	const project = listProjects().find((candidate) => candidate.id === projectId);
+	if (!project) throw new Error(`Unknown project: ${projectId}`);
+	return project;
+}
+
+interface GitWorktreeEntry {
+	path: string;
+	branch?: string;
+	prunable: boolean;
+}
+
+/** Parse Git's NUL-delimited porcelain so spaces/newlines in a worktree path remain data, not syntax. */
+function gitWorktreeEntries(repoPath: string): GitWorktreeEntry[] {
+	const listed = git(repoPath, ["worktree", "list", "--porcelain", "-z"], { raw: true });
+	if (!listed.ok) throw new Error(`git worktree list failed: ${listed.err}`);
+	const entries: GitWorktreeEntry[] = [];
+	for (const record of listed.out.split("\0\0")) {
+		if (!record) continue;
+		let path: string | undefined;
+		let branch: string | undefined;
+		let prunable = false;
+		for (const field of record.split("\0")) {
+			if (field.startsWith("worktree ")) path = field.slice("worktree ".length);
+			else if (field.startsWith("branch refs/heads/")) {
+				branch = field.slice("branch refs/heads/".length);
+			} else if (field === "prunable" || field.startsWith("prunable ")) prunable = true;
+		}
+		if (path) entries.push({ path, prunable, ...(branch ? { branch } : {}) });
+	}
+	return entries;
+}
+
+/**
+ * Git-registered worktrees that are not the selected project's folder and not represented anywhere in
+ * ThinkRail. Detached rows remain visible but disabled; stale/prunable registrations are not checkouts.
+ */
+export function listExistingWorktrees(projectId: string): ExistingWorktreeCandidate[] {
+	const project = openProjectById(projectId);
+	const entries = gitWorktreeEntries(project.path);
+	const projectPath = canonicalPath(project.path);
+	// A cwd already represented by either domain identity is not attachable. Project paths matter even
+	// before their lazily-created Default workspace exists.
+	const representedPaths = new Set([
+		...loadProjects().map((knownProject) => canonicalPath(knownProject.path)),
+		...loadWorkspaces().map((workspace) => canonicalPath(workspace.worktreePath)),
+	]);
+	return entries.flatMap((entry): ExistingWorktreeCandidate[] => {
+		const path = canonicalPath(entry.path);
+		if (entry.prunable || path === projectPath || representedPaths.has(path)) return [];
+		return entry.branch
+			? [{ path: entry.path, branch: entry.branch, status: "available" }]
+			: [{ path: entry.path, status: "detached" }];
+	});
+}
+
+/**
+ * Register one existing branch-backed checkout as a user-owned workspace. Revalidates against Git's
+ * registry at the mutation door and never runs a Git mutation or writes into the checkout.
+ */
+export function openExistingWorktree(projectId: string, requestedPath: string): Workspace {
+	const project = openProjectById(projectId);
+	if (!requestedPath) throw new Error("An existing worktree path is required");
+	const wantedPath = canonicalPath(requestedPath);
+	const projectPath = canonicalPath(project.path);
+	if (wantedPath === projectPath) return ensureDefaultWorkspace(project);
+
+	const entry = gitWorktreeEntries(project.path).find(
+		(candidate) => !candidate.prunable && canonicalPath(candidate.path) === wantedPath,
+	);
+	if (!entry) throw new Error("The selected path is not a registered worktree of this project");
+	if (!entry.branch)
+		throw new Error("Detached HEAD worktrees cannot be opened; create a branch first");
+	const baseBranch = resolveDefaultBranch(project.path);
+
+	// Load only after every git subprocess: another process can update the registries while this thread is
+	// blocked. A project path owns its cwd before its lazy Default workspace has ever been materialized.
+	const projectOwner = loadProjects().find(
+		(candidate) => candidate.id !== projectId && canonicalPath(candidate.path) === wantedPath,
+	);
+	if (projectOwner)
+		throw new Error("This worktree is already open under another ThinkRail project");
+
+	// Same-project retries are idempotent; sharing one cwd across project identities is rejected.
+	const all = loadWorkspaces();
+	const existing = all.find((workspace) => canonicalPath(workspace.worktreePath) === wantedPath);
+	if (existing) {
+		if (existing.projectId === projectId) return existing;
+		throw new Error("This worktree is already open under another ThinkRail project");
+	}
+
+	const displayName =
+		toDisplayName(basename(entry.path)) ?? toDisplayName(entry.branch) ?? "Existing worktree";
+	const workspace: Workspace = {
+		id: randomUUID(),
+		projectId,
+		kind: "external",
+		name: displayName,
+		branch: entry.branch,
+		worktreePath: entry.path,
+		baseBranch,
+		renamed: true,
+	};
+	all.push(workspace);
+	saveWorkspaces(all);
+	emit({ kind: "created", workspace });
+	return workspace;
+}
+
 /**
  * The **Default workspace's** folder-truth fields, read from the project folder itself: `branch` = what it
  * has checked out, `baseBranch` = the repo's default branch. Both move out-of-band (a terminal `git
@@ -150,10 +267,7 @@ export async function createWorkspace(
 	name?: string,
 	baseRef?: string,
 ): Promise<Workspace> {
-	// `listProjects` (open only) — a closed project must reject creation even from a stale or rogue client
-	// that still names it (the rail can't offer the "+" once closed, but the request can still arrive).
-	const project = listProjects().find((p) => p.id === projectId);
-	if (!project) throw new Error(`Unknown project: ${projectId}`);
+	const project = openProjectById(projectId);
 
 	// A user-supplied name is the display name (casing/punctuation preserved); the branch is derived from
 	// it. Omitted (or unusable) → the auto `workspace-N` placeholder, where name === branch.
@@ -227,11 +341,10 @@ export async function createWorkspace(
  * (task-specs / working files). Its `.gitignore` is a lone `*` — which matches the `.gitignore`
  * itself — so the whole dir has zero git footprint yet stays scannable by the spec tools (they ignore
  * only node_modules/.git/dist/build, not .gitignore). Worktree creation seeds eagerly; the host also
- * calls this on session create, which is what seeds the **Default** workspace — merely listing or
- * entering it must never write into the user's repo, starting a chat there may.
+ * calls this on session create, which is what seeds user-owned **Default/external** workspaces — merely
+ * listing or entering one must never write into the user's checkout, starting a chat there may.
  *
- * Hardened — in the Default workspace this runs against **repository-controlled content** inside the
- * user's own repo:
+ * Hardened — in a user-owned workspace this runs against **repository-controlled content**:
  * - The workspace root must already exist: an externally-deleted worktree must fail the session loudly,
  *   not be silently resurrected as an empty non-git directory.
  * - Owned path components are walked with `lstat` (never followed) — a malicious checkout can't symlink
@@ -317,27 +430,36 @@ function ensureDefaultWorkspace(project: Project): Workspace {
 }
 
 /**
- * Re-sync one **Default workspace** record against folder-truth and publish it when it drifted — the
- * *live* half of the ensure above, off the `workspace.list` path: cheap (two `symbolic-ref`-class git
- * reads, **no** diff-stat listing) so the host can call it on `watch`'s debounced **repo-metadata nudge**
- * (a `.git` write in the worktree). A `git switch` in the Default terminal therefore converges the rail,
- * the top bar and the empty receipt in every client — including a switch that leaves the working tree
- * byte-identical — instead of leaving them on the old branch until a manual project reload.
- * Unknown id / a worktree workspace (its branch is pinned) / no drift → a no-op, no save, no emit.
+ * Re-sync one user-owned workspace from its folder truth and publish drift. Default owns both its live
+ * branch + repository-default base; external owns only its live branch (its initial review target stays
+ * stable). Cheap enough for `watch`'s debounced repo-metadata nudge and list-time convergence.
+ * Unknown id / managed workspace / unreadable external checkout / no drift → no save and no emit.
  */
-export function refreshDefaultWorkspace(workspaceId: string): void {
-	// A peek decides whether this id is even a Default (only those drift) — nothing is mutated from it.
-	const peek = loadWorkspaces().find((w) => w.id === workspaceId);
-	if (peek?.kind !== "default") return;
-	// Folder-truth, THEN the snapshot we mutate: the git reads block the JS thread and another process can
-	// rewrite workspaces.json meanwhile, so load→mutate→save stays one uninterrupted block (as above).
-	const truth = folderTruth(peek.worktreePath);
+export function refreshUserOwnedWorkspace(workspaceId: string): void {
+	const peek = loadWorkspaces().find((workspace) => workspace.id === workspaceId);
+	if (peek?.kind !== "default" && peek?.kind !== "external") return;
+	// Read folder truth before the snapshot we mutate: git blocks while another process may rewrite state.
+	// External checkout failures stay unknown — never persist them as a fake detached `HEAD`.
+	const truth =
+		peek.kind === "default"
+			? { kind: "default" as const, ...folderTruth(peek.worktreePath) }
+			: (() => {
+					const branch = tryCurrentBranch(peek.worktreePath);
+					return branch === null ? null : { kind: "external" as const, branch };
+				})();
+	if (!truth) return;
+
 	const all = loadWorkspaces();
-	const ws = all.find((w) => w.id === workspaceId);
-	if (ws?.kind !== "default") return;
-	if (!applyFolderTruth(ws, truth)) return;
+	const workspace = all.find((candidate) => candidate.id === workspaceId);
+	if (workspace?.kind !== truth.kind) return;
+	if (truth.kind === "default") {
+		if (!applyFolderTruth(workspace, truth)) return;
+	} else {
+		if (workspace.branch === truth.branch) return;
+		workspace.branch = truth.branch;
+	}
 	saveWorkspaces(all);
-	emit({ kind: "updated", workspace: ws });
+	emit({ kind: "updated", workspace });
 }
 
 /**
@@ -367,8 +489,10 @@ export function renameWorkspace(
 	const project = getProjects().find((p) => p.id === ws.projectId);
 	if (!project) throw new Error(`Unknown project: ${ws.projectId}`);
 
-	// The Default workspace's branch is the user's real branch — renaming would `git branch -m` it.
+	// User-owned branches are never ours to rename.
 	if (ws.kind === "default") throw new Error("The Default workspace cannot be renamed");
+	if (ws.kind === "external")
+		throw new Error("An existing worktree cannot be renamed by ThinkRail");
 	const displayName = toDisplayName(requestedName);
 	if (!displayName) throw new Error(`Invalid workspace name: ${requestedName}`);
 	const wanted = toBranch(displayName);
@@ -459,6 +583,13 @@ export function listWorkspaces(projectId: string): Workspace[] {
 	// rewrites workspaces.json mid-run). Unknown project → no ensure, the filter returns [] as before.
 	const project = getProjects().find((p) => p.id === projectId);
 	if (project) ensureDefaultWorkspace(project);
+	// External checkouts are user-controlled and may switch branches outside ThinkRail. Converge their
+	// persisted snapshots before calculating branch-scoped stats or returning rows.
+	for (const workspace of loadWorkspaces()) {
+		if (workspace.projectId === projectId && workspace.kind === "external") {
+			refreshUserOwnedWorkspace(workspace.id);
+		}
+	}
 	const rows = loadWorkspaces().filter((w) => w.projectId === projectId);
 	// Pin the Default workspace first (creation order would put a backfilled one last).
 	rows.sort((a, b) => (a.kind === "default" ? -1 : 0) - (b.kind === "default" ? -1 : 0));
@@ -502,9 +633,8 @@ export function forgetWorkspace(id: string): Workspace | null {
  * dir if it lingers then `prune` the stale registration so `git worktree list` never orphans it.
  */
 export function reclaimWorktree(ws: Workspace): void {
-	// Defense in depth: never reclaim the project folder itself (`git worktree remove` would refuse the
-	// main working tree, but the hardened rm-fallback below would not).
-	if (ws.kind === "default") return;
+	// User-owned checkouts are never ours to reclaim. This guard is before every Git/disk side effect.
+	if (ws.kind === "default" || ws.kind === "external") return;
 	const project = loadProjects().find((p) => p.id === ws.projectId);
 	if (!project) return;
 	// Defense in depth: never reclaim the repo's main working tree, however the record got here (a


### PR DESCRIPTION
## Summary

Add an **Open existing worktree…** action to the project menu. It attaches a branch-backed Git worktree in place, opens it immediately, and keeps the checkout user-owned so ThinkRail never renames or deletes it.

Detached worktrees are shown but disabled. Removing an attached worktree only removes its ThinkRail state; its files, index, branch, and Git registration stay untouched.

## Related issues

None.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
