### PR TITLE
fix(ci): fail the Pages deploy fast instead of hanging for 10 minutes

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -13,10 +13,11 @@ permissions:
   pages: write
   id-token: write
 
-# One deploy at a time; a newer push supersedes an in-flight one.
+# One deploy at a time; a newer push supersedes a *queued* one. An in-flight deploy is never cancelled —
+# a production publish should finish. (Same setting, same reason, as GitHub's own Pages starter.)
 concurrency:
   group: site-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -38,6 +39,9 @@ jobs:
       - uses: actions/upload-pages-artifact@v4
         with:
           path: apps/website/dist
+          # The action defaults to 1 day; deploy-pages resolves the artifact by name at run time, so 7
+          # (as in ci.yml/_build.yml) keeps "re-run the deploy job" a usable remedy for a week.
+          retention-days: 7
 
   deploy:
     name: Deploy to GitHub Pages
@@ -47,5 +51,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # A healthy deploy reports `succeed` in ~10s. When the Pages backend never dequeues the deployment
+      # it just sits in `deployment_queued` and the action can only keep polling — so cap the wait far
+      # below the 10min default: go red in 3min with the real error, not 10min (run 31107056870).
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+        with:
+          timeout: 180000

--- a/apps/website/SPEC.md
+++ b/apps/website/SPEC.md
@@ -104,6 +104,14 @@ settings: Pages → Source: GitHub Actions, and Pages → Custom domain: `thinkr
 identity. Canonical/OG URLs in `index.html` (and the README website link) point at
 `https://thinkrail.ai/`, never the `jetbrains.github.io/thinkrail` address (which redirects there).
 
+**The deploy fails fast rather than hanging.** `deploy-pages` only creates the Pages deployment and then
+polls it, so a stalled backend hangs the step until timeout — 10min on 2026-08-06 (`31107056870`),
+leaving `main` red and the site stale. Hence `timeout: 180000` (a healthy deploy reports `succeed` in
+~10s), `retention-days: 7` on the artifact so re-running the `deploy` job stays a valid remedy for a
+week, and `cancel-in-progress: false` so an in-flight publish finishes. Don't add an in-job retry: the
+deployment is keyed by `GITHUB_SHA` and the timeout cancels it, so a second attempt moments later only
+reads back `deployment_cancelled`. Re-deploying that SHA *later* is fine — hence the remedy above.
+
 ## Assets
 
 `public/og.png` is a capture of the site's own hero. The transcript in the `features/agent-chat.md`


### PR DESCRIPTION
Run [`31107056870`](https://github.com/JetBrains/thinkrail/actions/runs/31107056870) lost the #174 website build. 