### PR TITLE
fix(ci): stop the Windows build failing on CRLF checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# LF working tree everywhere. Git for Windows defaults to core.autocrlf=true (as do GitHub's
+# windows-latest runners), and CRLF checkouts make every generated-file drift gate report false
+# staleness. `text=auto` leaves Git's binary detection alone.
+* text=auto eol=lf

--- a/apps/web/scripts/SPEC.md
+++ b/apps/web/scripts/SPEC.md
@@ -24,8 +24,10 @@ it is a *generator*: it uses `node:fs` and `node:path`, which must never reach b
 | `validate-typography.ts` | CLI. Validates `src/styles/typography.json` and prints a summary. The enforced gate. |
 | `colors.ts` | the library: load → validate → render. The **only** place a colour derivation (a palette alias or an alpha step) is written. |
 | `generate-colors.ts` | CLI. Writes `src/styles/generated/colors.css` — the roles, the appearance-level effects, and the Tailwind map; `--check` fails when it is stale. |
+| `generatedFiles.ts` | what both CLIs do with a rendered file: `--check` reports drift, otherwise write. The **only** definition of "stale", so the two pipelines and the tests cannot disagree. |
+| `generatedFiles.test.ts` | pins that definition — content drift and a missing file are stale, a CRLF working tree is not. |
 
-Public surface: the `typography.ts` and `colors.ts` exports. There is no `index.ts` barrel — the two CLIs are entry points
+Public surface: the `typography.ts`, `colors.ts` and `generatedFiles.ts` exports. There is no `index.ts` barrel — the two CLIs are entry points
 invoked by name from `package.json`, and the one importer outside this directory
 (`src/styles/*.test.ts`) imports the library directly, which keeps the tests and the generator provably
 in agreement about the same functions.
@@ -54,7 +56,9 @@ in agreement about the same functions.
   the naming rule was wrong.
 - **Generation is deterministic and idempotent.** Same input → byte-identical output; no clock, no
   randomness, no environment reads. That is what makes `--check` a usable drift gate in pre-commit,
-  `apps/web build` and CI.
+  `apps/web build` and CI. Line endings are the one exception, because they belong to the checkout
+  rather than the content: `.gitattributes` pins the working tree to LF, and every comparison against
+  a committed file goes through `normalizeEol` so a CRLF clone cannot report drift that is not there.
 - **`validate()` is the gate, not the JSON Schema.** `typography.schema.json` is the editor-facing
   contract (`$schema` in the source gives completion + inline errors); the toolchain has no JSON Schema
   validator. Shape checks, referential integrity and the policies Schema cannot express — mono is

--- a/apps/web/scripts/generate-colors.ts
+++ b/apps/web/scripts/generate-colors.ts
@@ -8,11 +8,9 @@
  * The generated output is committed so every colour change is reviewable as a diff — the same
  * arrangement `generate-typography.ts` uses for type.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, relative } from "node:path";
 import { type Colors, GENERATED_CSS_PATH, loadColors, renderCss, validate } from "./colors";
+import { writeOrCheck } from "./generatedFiles";
 
-const check = process.argv.includes("--check");
 const colors: Colors = loadColors();
 
 const errors = validate(colors);
@@ -22,24 +20,9 @@ if (errors.length > 0) {
 	process.exit(1);
 }
 
-const outputs = [{ path: GENERATED_CSS_PATH, content: renderCss(colors) }];
-
-if (check) {
-	const stale = outputs.filter(
-		({ path, content }) => (existsSync(path) ? readFileSync(path, "utf8") : "") !== content,
-	);
-	if (stale.length > 0) {
-		for (const { path } of stale) {
-			console.error(`colors: ${relative(process.cwd(), path)} is STALE`);
-		}
-		console.error("Run `bun run colors:generate` and commit the result.");
-		process.exit(1);
-	}
-	console.log(`colors: generated output is up to date (v${colors.metadata.version})`);
-} else {
-	for (const { path, content } of outputs) {
-		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, content);
-		console.log(`colors: wrote ${relative(process.cwd(), path)}`);
-	}
-}
+writeOrCheck({
+	label: "colors",
+	version: colors.metadata.version,
+	check: process.argv.includes("--check"),
+	outputs: [{ path: GENERATED_CSS_PATH, content: renderCss(colors) }],
+});

--- a/apps/web/scripts/generate-typography.ts
+++ b/apps/web/scripts/generate-typography.ts
@@ -7,8 +7,7 @@
  *
  * The generated CSS is committed so every typography change is reviewable as a diff.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, relative } from "node:path";
+import { writeOrCheck } from "./generatedFiles";
 import {
 	GENERATED_FONTS_PATH,
 	GENERATED_PATH,
@@ -18,7 +17,6 @@ import {
 	validate,
 } from "./typography";
 
-const check = process.argv.includes("--check");
 const typography = loadTypography();
 
 const errors = validate(typography);
@@ -28,27 +26,12 @@ if (errors.length > 0) {
 	process.exit(1);
 }
 
-const outputs = [
-	{ path: GENERATED_PATH, content: renderCss(typography) },
-	{ path: GENERATED_FONTS_PATH, content: renderFontsCss(typography) },
-];
-
-if (check) {
-	const stale = outputs.filter(
-		({ path, content }) => (existsSync(path) ? readFileSync(path, "utf8") : "") !== content,
-	);
-	if (stale.length > 0) {
-		for (const { path } of stale) {
-			console.error(`typography: ${relative(process.cwd(), path)} is STALE`);
-		}
-		console.error("Run `bun run typography:generate` and commit the result.");
-		process.exit(1);
-	}
-	console.log(`typography: generated output is up to date (v${typography.metadata.version})`);
-} else {
-	for (const { path, content } of outputs) {
-		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, content);
-		console.log(`typography: wrote ${relative(process.cwd(), path)}`);
-	}
-}
+writeOrCheck({
+	label: "typography",
+	version: typography.metadata.version,
+	check: process.argv.includes("--check"),
+	outputs: [
+		{ path: GENERATED_PATH, content: renderCss(typography) },
+		{ path: GENERATED_FONTS_PATH, content: renderFontsCss(typography) },
+	],
+});

--- a/apps/web/scripts/generatedFiles.test.ts
+++ b/apps/web/scripts/generatedFiles.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type GeneratedFile, isStale } from "./generatedFiles";
+
+const committed = (content: string): GeneratedFile => {
+	const path = join(mkdtempSync(join(tmpdir(), "thinkrail-generated-")), "generated.css");
+	writeFileSync(path, content);
+	return { path, content };
+};
+
+const CSS = ":root {\n\t--font-size-body: 14px;\n}\n";
+
+describe("isStale", () => {
+	it("is false when the committed copy matches what the generator renders", () => {
+		expect(isStale(committed(CSS))).toBe(false);
+	});
+
+	// Regression pin: a CRLF checkout made every file read as stale, and the Windows nightly never
+	// got past `typography:check`.
+	it("treats CRLF line endings in the working tree as identical content", () => {
+		const { path } = committed(CSS.replaceAll("\n", "\r\n"));
+		expect(isStale({ path, content: CSS })).toBe(false);
+	});
+
+	it("is true when the content genuinely differs", () => {
+		const { path } = committed(CSS);
+		expect(isStale({ path, content: CSS.replace("14px", "15px") })).toBe(true);
+	});
+
+	it("is true when the file has never been generated", () => {
+		const { path } = committed(CSS);
+		expect(isStale({ path: `${path}.missing`, content: CSS })).toBe(true);
+	});
+});

--- a/apps/web/scripts/generatedFiles.ts
+++ b/apps/web/scripts/generatedFiles.ts
@@ -1,0 +1,48 @@
+/**
+ * `--check` reports drift, otherwise write. Shared by both generator CLIs so they cannot disagree on
+ * what "stale" means.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative } from "node:path";
+
+export type GeneratedFile = { path: string; content: string };
+
+/** Line endings belong to the checkout, not the content — Git rewrites them under `core.autocrlf`. */
+export const normalizeEol = (text: string): string => text.replaceAll("\r\n", "\n");
+
+const onDisk = (path: string): string => (existsSync(path) ? readFileSync(path, "utf8") : "");
+
+export const isStale = ({ path, content }: GeneratedFile): boolean =>
+	normalizeEol(onDisk(path)) !== normalizeEol(content);
+
+/** Exits the process: these are CLI entry points whose status code is the interface. */
+export function writeOrCheck({
+	label,
+	version,
+	outputs,
+	check,
+}: {
+	label: string;
+	version: string;
+	outputs: GeneratedFile[];
+	check: boolean;
+}): void {
+	if (!check) {
+		for (const { path, content } of outputs) {
+			mkdirSync(dirname(path), { recursive: true });
+			writeFileSync(path, content);
+			console.log(`${label}: wrote ${relative(process.cwd(), path)}`);
+		}
+		return;
+	}
+
+	const stale = outputs.filter(isStale);
+	if (stale.length > 0) {
+		for (const { path } of stale) {
+			console.error(`${label}: ${relative(process.cwd(), path)} is STALE`);
+		}
+		console.error(`Run \`bun run ${label}:generate\` and commit the result.`);
+		process.exit(1);
+	}
+	console.log(`${label}: generated output is up to date (v${version})`);
+}

--- a/apps/web/src/styles/colorUsage.test.ts
+++ b/apps/web/src/styles/colorUsage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { loadColors, paletteVar, renderCss, themeColorKeys, validate } from "../../scripts/colors";
+import { normalizeEol } from "../../scripts/generatedFiles";
 
 /**
  * The colour adoption guard, the sibling of `typographyUsage.test.ts`. Three failure modes shaped it,
@@ -19,7 +20,7 @@ import { loadColors, paletteVar, renderCss, themeColorKeys, validate } from "../
  */
 
 const SRC = new URL("..", import.meta.url).pathname;
-const read = (path: string) => readFileSync(path, "utf8");
+const read = (path: string) => normalizeEol(readFileSync(path, "utf8"));
 const rel = (path: string) => path.slice(SRC.length);
 /** Comments name classes and variables in order to explain them, which is not a usage. */
 const code = (path: string) =>

--- a/apps/web/src/styles/typography.test.ts
+++ b/apps/web/src/styles/typography.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { normalizeEol } from "../../scripts/generatedFiles";
 import type { Style, StyleRef, Typography } from "../../scripts/typography";
 import {
 	allStyles,
@@ -27,7 +28,7 @@ import {
 
 const typography = loadTypography();
 const SRC = new URL("..", import.meta.url).pathname;
-const GENERATED = readFileSync(GENERATED_PATH, "utf8");
+const GENERATED = normalizeEol(readFileSync(GENERATED_PATH, "utf8"));
 
 const read = (p: string) => readFileSync(p, "utf8");
 const px = (id: string) => typography.fontSizes[resolveStyle(typography, id).fontSize];

--- a/apps/web/src/styles/typographyUsage.test.ts
+++ b/apps/web/src/styles/typographyUsage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { normalizeEol } from "../../scripts/generatedFiles";
 import {
 	allStyles,
 	loadTypography,
@@ -40,7 +41,7 @@ function sourceFiles(dir = SRC): string[] {
 	return out;
 }
 const FILES = sourceFiles();
-const read = (p: string) => readFileSync(p, "utf8");
+const read = (p: string) => normalizeEol(readFileSync(p, "utf8"));
 /** Source with comments removed — explanations that name classes are not consumers. */
 const code = (p: string) =>
 	read(p)


### PR DESCRIPTION
The Windows nightly has failed since b665d5b (2026-07-30) and never reached the binary compile — it dies in `typography:check`:

```
typography: src\styles\generated\typography.css is STALE
```

A false positive. `windows-latest` defaults to `core.autocrlf=true`, so checkout writes the LF-committed generated CSS as CRLF, and the gate compares raw bytes against a generator that emits `\n`.

**Fix, two layers:**
- `.gitattributes` — `* text=auto eol=lf` pins the working tree to LF. `text=auto` keeps Git's binary detection intact.
- `scripts/generatedFiles.ts` — the five byte-compares (both generator CLIs + three test read-boundaries) now share one definition of "stale" that ignores line endings. Also removes the ~27-line check/write block duplicated verbatim in both CLIs.

**Verified:** `bun run build:web` — the exact failing CI command — passes against a CRLF tree; both gates pass on a fully-CRLF tree including inputs; regeneration is byte-identical; `check:deps` · `check:seams` · `lint` · `typecheck` · `test` (412) green; zero renormalization churn.

**Note:** this unblocks the Windows job but doesn't validate it — compilation and `smoke:binary` have never run there, so the next nightly may surface a second, genuine failure.