### PR TITLE
fix(projects): one cwd, one ThinkRail identity

### DIFF
--- a/e2e/workspaces.spec.ts
+++ b/e2e/workspaces.spec.ts
@@ -9,7 +9,7 @@ import {
 	openWorkspaceMenu,
 	worktreeRows,
 } from "./fixtures/app";
-import { E2E_DATA_DIR, E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { E2E_DATA_DIR, E2E_FIXTURE_REPO, E2E_PICK_DIR_POINTER } from "./fixtures/paths";
 
 test("opens and safely forgets an existing user-owned worktree", async ({ page }) => {
 	// Start with a persisted project whose workspace list has never been hydrated. Opening from its context
@@ -131,6 +131,64 @@ test("opens and safely forgets an existing user-owned worktree", async ({ page }
 			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "branch", "-D", "feature/existing"]);
 		} catch {
 			// The per-test reset is the final cleanup backstop if setup failed before the branch existed.
+		}
+		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "prune"]);
+	}
+});
+
+test("an attached worktree cannot also be opened as a project", async ({ page }) => {
+	// pi keys chat transcripts by directory, so one folder must map to exactly one ThinkRail identity:
+	// otherwise the project's Default workspace would serve the attached workspace's chats as its own and
+	// purge them when either side is archived. `openExistingWorktree` guards its door; Add project guards this one.
+	await openFixtureProject(page);
+	const external = join(E2E_DATA_DIR, "claimed-worktree-fixture");
+	rmSync(external, { recursive: true, force: true });
+	execFileSync("git", [
+		"-C",
+		E2E_FIXTURE_REPO,
+		"worktree",
+		"add",
+		external,
+		"-b",
+		"feature/claimed",
+		"main",
+	]);
+
+	try {
+		const projectRow = page.getByTestId("project-item").filter({ hasText: "sample-project" });
+		await projectRow.click({ button: "right" });
+		await page.getByTestId("project-menu-open-existing-worktree").click();
+		const dialog = page.getByTestId("existing-worktree-dialog");
+		await dialog
+			.getByTestId("existing-worktree-candidate")
+			.filter({ hasText: "feature/claimed" })
+			.click();
+		await expect(dialog).toHaveCount(0);
+		await expect(page.locator('[data-testid="workspace-item"][data-kind="external"]')).toHaveCount(
+			1,
+		);
+
+		// Point the stubbed directory picker at the checkout ThinkRail now holds as a workspace.
+		writeFileSync(E2E_PICK_DIR_POINTER, external);
+		await page.getByTestId("add-project-menu").click();
+		await page.getByTestId("menu-open-project").click();
+
+		// Refused with a legible reason, and no second identity is created for the folder.
+		const error = page.getByTestId("open-error-dialog");
+		await expect(error).toBeVisible();
+		await expect(error).toContainText("already open in ThinkRail as a workspace");
+		await expect(page.getByTestId("project-item")).toHaveCount(1);
+	} finally {
+		writeFileSync(E2E_PICK_DIR_POINTER, E2E_FIXTURE_REPO);
+		try {
+			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "remove", "--force", external]);
+		} catch {
+			rmSync(external, { recursive: true, force: true });
+		}
+		try {
+			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "branch", "-D", "feature/claimed"]);
+		} catch {
+			// Setup may have failed before the branch existed; the per-test reset is the backstop.
 		}
 		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "prune"]);
 	}

--- a/packages/server/src/projects/SPEC.md
+++ b/packages/server/src/projects/SPEC.md
@@ -23,7 +23,14 @@ bootstrap it into one so it can be opened.
   records migrate as open. **`openProject`** finds a known root even when closed, clears `closed`, bumps
   `lastOpened`, preserves its id, persists, and publishes the full snapshot; **`closeProject`** marks that
   same record closed and publishes it without deleting the project, repository, workspace records, or
-  live runtimes. `setProjectPublisher` is the host-injected push seam; this module never imports `host`.
+  live runtimes. **One cwd, one ThinkRail identity:** `openProject` rejects a root already held as some
+  workspace's `worktreePath` — pi keys chat transcripts by *directory*, so a second identity on an owned
+  folder would serve that workspace's chats as its own and have them purged when either side is archived.
+  Compared **canonically** (a managed worktree's stored path is composed, `--show-toplevel` answers
+  symlink-resolved) and only **after** the reopen above, whose own Default workspace legitimately holds the
+  project folder. The workspace-side half of the same door is `openExistingWorktree`
+  ([[submodule-server-workspaces]]); reading the workspace records for it stays within the `persistence`
+  dep — this module still never imports its sibling. `setProjectPublisher` is the host-injected push seam; this module never imports `host`.
   It also owns **`inspectProjectPath`** (classify a path — `repo` / `initable` / `missing` /
   `notDirectory` — so the UI picks between opening, an init offer, or an error) and **`initProject`**
   (bootstrap a plain directory: `git init` + `git add -A` + an **allow-empty** initial commit — committing

--- a/packages/server/src/projects/projects.test.ts
+++ b/packages/server/src/projects/projects.test.ts
@@ -60,6 +60,66 @@ afterEach(() => {
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
 });
 
+/**
+ * Seed a persisted workspace record whose cwd is `worktreePath`. Written straight to `workspaces.json`
+ * (never through the `workspaces` module — `projects` must not depend on its sibling, tests included).
+ */
+function seedWorkspace(worktreePath: string, kind?: "default" | "external"): void {
+	writeFileSync(
+		join(dataDir, "workspaces.json"),
+		JSON.stringify([
+			{
+				id: "ws-1",
+				projectId: "p-other",
+				name: "seeded",
+				branch: "feature/seeded",
+				worktreePath,
+				baseBranch: "main",
+				renamed: true,
+				...(kind ? { kind } : {}),
+			},
+		]),
+	);
+}
+
+test("openProject refuses a checkout already attached as an external workspace", () => {
+	// Chat transcripts are keyed by cwd, not by workspace, so two identities on one folder would share
+	// history — and archiving either would purge the other's. One cwd, one ThinkRail identity.
+	const attached = join(dataDir, "auth checkout");
+	makeRepo(attached);
+	seedWorkspace(attached, "external");
+
+	expect(() => openProject(attached)).toThrow("already open in ThinkRail");
+	expect(listProjects()).toHaveLength(0);
+});
+
+test("openProject refuses a ThinkRail-managed worktree dir, whatever symlinks the path carries", () => {
+	// The worktree lives under the data dir, so its record's path is built by `join` (unresolved) while git
+	// answers with the resolved one — the guard must compare canonically or miss the collision entirely.
+	const repo = join(dataDir, "repo");
+	makeRepo(repo);
+	const managed = join(dataDir, "worktrees", "repo", "workspace-1");
+	git(repo, "worktree", "add", "-b", "workspace-1", managed);
+	seedWorkspace(managed);
+
+	expect(() => openProject(managed)).toThrow("already open in ThinkRail");
+	// The project folder itself is still openable — only the worktree's own cwd is taken.
+	expect(openProject(repo).path).toBe(realpathSync(repo));
+});
+
+test("openProject still reopens a closed project whose own Default workspace holds its cwd", () => {
+	// The Default workspace's cwd *is* the project folder, so a naive uniqueness check would lock the
+	// user out of reopening their own project.
+	const repo = join(dataDir, "repo");
+	makeRepo(repo);
+	const project = openProject(repo);
+	seedWorkspace(project.path, "default");
+	closeProject(project.id);
+
+	expect(openProject(repo).id).toBe(project.id);
+	expect(listProjects().map((p) => p.id)).toEqual([project.id]);
+});
+
 test("inspectProjectPath: a path that doesn't exist is `missing`", () => {
 	expect(inspectProjectPath(join(dataDir, "nope"))).toEqual({ kind: "missing" });
 });

--- a/packages/server/src/projects/projects.ts
+++ b/packages/server/src/projects/projects.ts
@@ -2,8 +2,8 @@ import { randomUUID } from "node:crypto";
 import { rmSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { Project, ProjectPathStatus } from "@thinkrail/contracts";
-import { git as runGit } from "../git";
-import { loadProjects, saveProjects } from "../persistence";
+import { canonicalPath, git as runGit } from "../git";
+import { loadProjects, loadWorkspaces, saveProjects } from "../persistence";
 
 type ProjectPublisher = (project: Project) => void;
 
@@ -83,6 +83,16 @@ export function openProject(path: string): Project {
 		emit(existing);
 		return existing;
 	}
+
+	// One cwd, one ThinkRail identity — checked *after* the reopen above, whose own Default workspace
+	// legitimately holds the project folder. pi keys chat transcripts by directory, so a second identity on
+	// a folder some workspace already owns would show that workspace's chats as its own and have them
+	// purged out from under it when either side is archived. `openExistingWorktree` closes the same door
+	// from the workspace side. Canonical: a managed worktree's stored path is composed, never resolved,
+	// while `gitToplevel` answers resolved — a raw compare would miss the collision under any symlink.
+	const wanted = canonicalPath(root);
+	if (loadWorkspaces().some((ws) => canonicalPath(ws.worktreePath) === wanted))
+		throw new Error(`This folder is already open in ThinkRail as a workspace: ${root}`);
 
 	const taken = new Set(projects.map((p) => p.slug));
 	const project: Project = {


### PR DESCRIPTION
Stacked on #178 (base is `git-worktree-conflict`), addressing the blocking review finding there.

## The bug

pi keys chat transcripts by **directory**, not by workspace. `listSessions` picks up disk transcripts whose recorded `cwd` matches and stamps them with the *requesting* `workspaceId`; `purgeDiskSessions` deletes by `cwd`. So ThinkRail depends on each folder mapping to exactly one identity.

`openExistingWorktree` (#178) enforces that at its door. `openProject` did not — it deduped only project-against-project:

```ts
const existing = projects.find((p) => p.path === root);   // never consults workspaces
```

Two identities on one folder go wrong twice:

1. **Immediately** — both list the same transcripts, so one conversation appears twice under two names, each claiming it.
2. **On removal** — archiving either purges that cwd's transcripts, deleting chat history belonging to the other. Removing an external workspace promises to leave the checkout and its history alone.

## Not introduced by #178

Reachable on `main` today: Add project on any folder under `~/.thinkrail/worktrees/<slug>/<branch>`. Inside a linked worktree, `git rev-parse --show-toplevel` answers with *that worktree's* root, so it is accepted as a project whose Default workspace then shares a cwd with the managed workspace:

```
$ git -C "$t/wt" rev-parse --show-toplevel
/private/var/.../tmp.K0c5i8UC9f/wt      # the linked worktree, not $t/r
```

What #178 changes is reachability — attached worktrees live in ordinary code folders, exactly the ones a user would also Add project on — and that it asserts the uniqueness rule on one of the two doors. This PR closes the other, and fixes the old route for free.

## The fix

`openProject` rejects a root already held as some workspace's `worktreePath`:

- **After** the reopen branch, whose own Default workspace legitimately holds the project folder — otherwise reopening a closed project would lock the user out (covered by a test).
- **Canonically** — a managed worktree's stored path is composed by `join(dataDir(), …)` while `--show-toplevel` answers symlink-resolved, so a raw compare misses the collision under any symlink.
- Through `persistence`, an already-allowed dep, so `projects` still never imports `workspaces` (that edge is forbidden — workspaces depends on projects).

`initProject` short-circuits to `openProject` for an already-a-repo path, so it inherits the guard. The boot-time `openProject` is already wrapped in try/catch, so `thinkrail <attached-worktree>` warns instead of silently creating the collision.

No UI change needed: `project.open` throws → `project.inspect` returns `repo` → `useOpenProject` falls through to `setOpenError(errorText(err, …))` and shows the message in the existing `open-error-dialog`.

## Verification

- `bun run test` — 422 pass, 0 fail (3 new unit tests, each watched fail first)
- `bun run e2e` — 157 passed, 0 failed (1 new spec)
- `check:deps`, `check:seams`, `lint`, `typecheck` green

## Known follow-ups (not here)

- Launching `thinkrail <attached-worktree>` now warns and opens nothing; activating the existing workspace instead would be friendlier, but "activate" is a client concept and needs host composition.
- Installs that already created a collision on `main` are not retro-repaired. A defense-in-depth guard skipping the cwd purge when another record still claims that folder would cover them.
- `e2e/fixtures/app.ts:31` — `resetState`'s `rmSync(pi-agent/sessions)` races the agent writing a session file (`ENOTEMPTY`), causing unrelated flakes.