### PR TITLE
fix(terminal): key shells to their tab, with the host owning the mapping

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -78,12 +78,12 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   with no yes/no follow-up. The hook returns a `dialogs` node each consumer renders. **Selecting a
   project** (clicking its row — the chevron expands/collapses separately) **deselects any active
   workspace**, so the shell returns to that project's Welcome — a deliberate "project home" gesture; the
-  workspace's tabs survive in the store, so re-selecting it restores its view. **Terminals need more than the
-  store to survive that round trip**, since the whole workspace surface — `TerminalsPanel` included —
-  unmounts: each instance therefore **detaches** its PTY instead of closing it
-  (`detachedPtyByClientId` in `TerminalInstance`) and the next mount re-adopts the same shell, so a
-  long-running process is never silently killed by a project-home gesture. Only a *closed tab* kills its PTY.
-  The painted scrollback does not survive (a remount is a fresh xterm buffer); the process does. Also
+  workspace's tabs survive in the store, so re-selecting it restores its view. That round trip unmounts the
+  whole workspace surface, `TerminalsPanel` included — but **terminals keep no client-side state to lose**:
+  the host owns the tab list and keys shells by `(workspaceId, tabKey)`, so mounting is one idempotent
+  `terminal.attach` and unmounting does nothing at all. Attach returns the recorded output to repaint, so the
+  screen comes back too. **Only `terminal.close`, from the user closing a tab, kills a PTY** — and it refuses
+  a shell with child processes until a `ConfirmDialog` is accepted. Also
   `FileTree`, `SpecsPanel`, `RightPanel`,
   `ChangesPanel` (the changed files under a header that says **what** is being diffed — the
   **`ChangesScopeMenu`** scope pill + the shared **`BranchPicker`** target-branch pill — plus the

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -81,7 +81,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   workspace's tabs survive in the store, so re-selecting it restores its view. That round trip unmounts the
   whole workspace surface, `TerminalsPanel` included — but **terminals keep no client-side state to lose**:
   the host owns the tab list and keys shells by `(workspaceId, tabKey)`, so mounting is one idempotent
-  `terminal.attach` and unmounting does nothing at all. Attach returns the recorded output to repaint, so the
+  `terminal.attach` and unmounting does nothing at all. **Exactly one `TerminalInstance` is mounted app-wide —
+  the tab on screen.** Mounting *is* attaching and attachment is exclusive, so an instance per tab would claim
+  terminals this client is not showing and take them from the client that opened them; switching tabs
+  re-attaches and repaints from the host's recording. Attach returns the recorded output to repaint, so the
   screen comes back too. **Only `terminal.close`, from the user closing a tab, kills a PTY** — and it refuses
   a shell with child processes until a `ConfirmDialog` is accepted. Also
   `FileTree`, `SpecsPanel`, `RightPanel`,

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -6,6 +6,7 @@ import {
 	Palette,
 	ShieldCheck,
 	SlidersHorizontal,
+	SquareTerminal,
 } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib";
@@ -15,12 +16,14 @@ import { GithubSettings } from "./GithubSettings";
 import { PrivacySettings } from "./PrivacySettings";
 import { ProvidersSettings } from "./ProvidersSettings";
 import { TemplatesSettings } from "./TemplatesSettings";
+import { TerminalSettings } from "./TerminalSettings";
 
 /** The live settings sections, in nav order. */
 const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
 	{ id: SettingsSection.Providers, label: "Providers", icon: KeyRound },
 	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
 	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
+	{ id: SettingsSection.Terminal, label: "Terminal", icon: SquareTerminal },
 	{ id: SettingsSection.Templates, label: "Templates", icon: LayoutTemplate },
 	{ id: SettingsSection.Privacy, label: "Privacy", icon: ShieldCheck },
 ];
@@ -96,6 +99,8 @@ export function SettingsDialog() {
 							<ProvidersSettings />
 						) : section === SettingsSection.Github ? (
 							<GithubSettings />
+						) : section === SettingsSection.Terminal ? (
+							<TerminalSettings />
 						) : section === SettingsSection.Templates ? (
 							<TemplatesSettings />
 						) : section === SettingsSection.Privacy ? (

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -120,7 +120,6 @@ interface Props {
 	/** This tab's durable identity. Half of `(workspaceId, tabKey)`, which is what the host keys shells on. */
 	tabKey: string;
 	workspaceId: string;
-	visible: boolean;
 	/**
 	 * Run once, on the shell this tab was opened for (e.g. "Open in Vim"), then spent.
 	 *
@@ -140,7 +139,7 @@ interface Props {
  * Attach returns the recorded output to repaint, so a remount shows the screen it left behind rather than an
  * empty buffer over a live process.
  */
-export default function TerminalInstance({ tabKey, workspaceId, visible, initialCommand }: Props) {
+export default function TerminalInstance({ tabKey, workspaceId, initialCommand }: Props) {
 	const hostRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<XTerm | null>(null);
 	const serverIdRef = useRef<string | null>(null);
@@ -424,21 +423,17 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 		};
 	}, [tabKey, workspaceId]);
 
-	// Hidden containers report zero size, so fit + focus when this layer becomes visible. `applyFit`
-	// no-ops until the layer has a real size, so a not-yet-laid-out frame can't shrink the buffer; the
-	// ResizeObserver fires the effective fit once layout settles.
+	// This instance is mounted only while it is the tab on screen, so mounting IS becoming visible: fit against
+	// the real layout once it exists, put the viewport on the live prompt, and take focus. `applyFit` no-ops
+	// until the layer has a size, and the ResizeObserver fires the effective fit once layout settles.
 	useEffect(() => {
-		if (!visible) return;
 		const frame = requestAnimationFrame(() => {
 			fitFnRef.current?.();
-			// Snap the viewport back to the live prompt: a resize while hidden can leave it scrolled off the
-			// buffer, so on re-show the rendered rows would otherwise show blank/stale rows instead of the
-			// preserved output.
 			termRef.current?.scrollToBottom();
 			termRef.current?.focus();
 		});
 		return () => cancelAnimationFrame(frame);
-	}, [visible]);
+	}, []);
 
 	const takeBack = useCallback(() => reattachRef.current?.(), []);
 
@@ -450,8 +445,10 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 			data-exited={exited}
 			data-failed={failed}
 			data-detached={detached}
-			data-visible={visible}
-			className={`absolute inset-0 ${visible ? "" : "hidden"}`}
+			// Always true now that only the shown tab is mounted — kept so tests and tooling can address "the
+			// terminal on screen" without knowing that.
+			data-visible="true"
+			className="absolute inset-0"
 		>
 			<div ref={hostRef} className="h-full w-full" />
 			{detached ? (

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -1,11 +1,15 @@
-import type { TerminalDataPush, TerminalExitPush } from "@thinkrail/contracts";
+import type {
+	TerminalDataPush,
+	TerminalDetachedPush,
+	TerminalExitPush,
+} from "@thinkrail/contracts";
 import { WS_CHANNELS } from "@thinkrail/contracts";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebFontsAddon } from "@xterm/addon-web-fonts";
 import { type ITheme, Terminal as XTerm } from "@xterm/xterm";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { cssColorToHex } from "@/lib";
 import { useAppStore } from "../store";
@@ -13,30 +17,6 @@ import { onThemeSwap } from "../themes";
 import { getTransport } from "../transport";
 import { createPtySizeSync } from "./ptySizeSync";
 import { createTerminalPrebindBuffer } from "./terminalPrebindBuffer";
-
-/**
- * PTY ids left behind by unmounted instances, keyed by tab `clientId`.
- *
- * An instance unmounts for two very different reasons. Its **tab was closed** — the PTY should die. Or **the
- * surface it lives on went away while the tab survived**: the shell only mounts `TerminalsPanel` while a
- * workspace is active (`shell/Shell.tsx`), so every visit to Project Home unmounts every terminal of every
- * workspace. Killing the PTY in that second case silently kills whatever was running in it — a dev server, a
- * watch build — with no warning and no visible cause.
- *
- * So unmount hands the id here instead, and the next mount re-adopts it — after one `terminal.alive` round trip
- * to confirm the shell is still there, because a shell that died while detached had no mounted instance to hear
- * its `terminal.exit`. Once bound, output resumes on its own: `terminal.data` is keyed by PTY id. Module scope
- * is the point — the registry has to outlive the component.
- *
- * The registry only ever holds *detached* PTYs: adopting removes the entry, and a genuinely closed tab is
- * reaped rather than registered. A PTY orphaned by a page reload is reaped host-side once that client has been
- * gone for the abandoned-client grace window (a reload arrives under a new client id, so the old one never
- * comes back).
- * One entry can go stale — a workspace removed *while* its terminals are detached has no mounted instance to
- * run the reap — but the host kills those PTYs itself on archive, and `clientId` is a fresh UUID per tab, so a
- * stale entry can never be adopted by a later tab. It costs a dangling string until reload, nothing more.
- */
-const detachedPtyByClientId = new Map<string, string>();
 
 /**
  * Trailing-edge delay before an observed resize reaches the PTY. Long enough that a divider drag collapses into
@@ -137,40 +117,45 @@ function tryLoad(fn: () => void): void {
 }
 
 interface Props {
-	clientId: string;
+	/** This tab's durable identity. Half of `(workspaceId, tabKey)`, which is what the host keys shells on. */
+	tabKey: string;
 	workspaceId: string;
 	visible: boolean;
-	/** Sent once, right after this terminal's PTY is *created* (e.g. "Open in Vim") — never replayed. The
-	 * mount effect can run more than once per tab (see `detachedPtyByClientId`), so this deliberately hangs
-	 * off the create branch only: re-attaching to an existing shell must not re-run the command. */
+	/**
+	 * Run once, on the shell this tab was opened for (e.g. "Open in Vim"), then spent.
+	 *
+	 * The mount effect runs many times per tab — every trip to Project Home unmounts it — so it is gated on the
+	 * host's `created` flag *and* cleared from the store once used. `created` alone is not enough: a tab whose
+	 * shell exited gets a fresh one on the next attach, which is also `created`.
+	 */
 	initialCommand?: string;
 }
 
 /**
- * One xterm terminal bound to a server PTY. Stays mounted while its tab exists (hidden when not the
- * active tab) so its buffer survives workspace/tab switches; re-fits when it becomes visible.
+ * One xterm terminal bound to a server PTY.
  *
- * The PTY outlives the component, not the other way round: an unmount that leaves the tab in place detaches
- * the shell into `detachedPtyByClientId` for the next mount to adopt, so nothing running in it dies. Only a
- * closed tab kills its PTY.
+ * The shell belongs to `(workspaceId, tabKey)`, not to this component — so unmounting does **nothing** to it.
+ * No detach registry, no liveness probe, no "was my tab closed or did the panel go away?" inference: mounting
+ * is a single idempotent `terminal.attach`, and the only thing that kills a shell is the user closing the tab.
+ * Attach returns the recorded output to repaint, so a remount shows the screen it left behind rather than an
+ * empty buffer over a live process.
  */
-export default function TerminalInstance({
-	clientId,
-	workspaceId,
-	visible,
-	initialCommand,
-}: Props) {
+export default function TerminalInstance({ tabKey, workspaceId, visible, initialCommand }: Props) {
 	const hostRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<XTerm | null>(null);
 	const serverIdRef = useRef<string | null>(null);
 	const fitFnRef = useRef<(() => void) | null>(null);
+	/** Re-run the attach — how the "take it back" action reclaims a tab another client took over. */
+	const reattachRef = useRef<(() => void) | null>(null);
 	/** Immutable tab creation intent; prop changes must not tear down a live shell. */
 	const initialCommandRef = useRef(initialCommand);
 	const [ready, setReady] = useState(false);
 	/** The shell behind this tab is gone — see the `terminal.exit` subscription below. */
 	const [exited, setExited] = useState(false);
-	/** No PTY was ever obtained, so this pane is inert — see the `terminal.create` rejection below. */
+	/** No PTY could be obtained, so this pane is inert — see the attach rejection below. */
 	const [failed, setFailed] = useState(false);
+	/** Another client attached to this tab, so its output goes there now — see `terminal.detached`. */
+	const [detached, setDetached] = useState(false);
 
 	useEffect(() => {
 		const host = hostRef.current;
@@ -252,8 +237,8 @@ export default function TerminalInstance({
 		applyFit();
 		requestAnimationFrame(applyFit);
 
-		// Pushes can beat `terminal.create`'s response, before this instance knows which page-owned PTY is its
-		// own. The bounded pre-bind buffer filters on adoption and becomes inert on bind/failure.
+		// Pushes can beat the attach response, before this instance knows which PTY is its own. The bounded
+		// pre-bind buffer filters on adoption and becomes inert on bind/failure.
 		const prebind = createTerminalPrebindBuffer();
 		const writeTruncation = (): void => term.write("\r\n[output truncated]\r\n");
 		/** Paint a batch, saying so when the host had to drop output to stay bounded. */
@@ -270,6 +255,8 @@ export default function TerminalInstance({
 			if (ev.id === serverIdRef.current) writeFrame(ev);
 		});
 		const onData = term.onData((data) => {
+			// A null id is also how a taken-over tab stops accepting input: typing into it would run commands
+			// whose output goes to whoever attached last.
 			const id = serverIdRef.current;
 			if (id) sendTerminalWrite(getTransport().request("terminal.write", { id, data }));
 		});
@@ -279,9 +266,9 @@ export default function TerminalInstance({
 		// and silently dropped, with no way to tell.
 		const handleExit = (ev: TerminalExitPush): void => {
 			if (ev.id !== serverIdRef.current) return;
-			// Forget the id: there is nothing left to write to, to detach for a later mount, or to close.
+			// Forget the id: there is nothing left to write to. The TAB stays — the user closes it themselves,
+			// and attaching again would simply give this tab a fresh shell.
 			serverIdRef.current = null;
-			detachedPtyByClientId.delete(clientId);
 			term.write(`\r\n[process exited${ev.exitCode === 0 ? "" : ` with code ${ev.exitCode}`}]\r\n`);
 			setExited(true);
 		};
@@ -290,6 +277,18 @@ export default function TerminalInstance({
 			if (prebind.acceptExit(ev)) return;
 			handleExit(ev);
 		});
+		const unsubscribeDetached = getTransport().subscribe(
+			WS_CHANNELS.terminalDetached,
+			(payload) => {
+				const ev = payload as TerminalDetachedPush;
+				if (ev.workspaceId !== workspaceId || ev.tabKey !== tabKey) return;
+				// A PTY has one size, so only one client can have its layout honoured. Say so rather than going
+				// quietly dead, and offer to take it back.
+				serverIdRef.current = null;
+				setReady(false);
+				setDetached(true);
+			},
+		);
 
 		let disposed = false;
 
@@ -310,115 +309,65 @@ export default function TerminalInstance({
 			});
 
 		/**
-		 * Let go of a PTY: hand it to the registry if this tab outlived the instance, otherwise kill it. The
-		 * store is the authority on "does the tab still exist" — closing a tab removes it *before* React
-		 * unmounts the instance, so a genuine close is already absent here, while an incidental unmount
-		 * (Project Home, a workspace switch) still finds it.
+		 * Ask the host for this tab's shell.
+		 *
+		 * Idempotent get-or-create, so there is exactly one call and no state to hold between steps. Unmounting
+		 * mid-flight needs no cleanup at all: the shell belongs to the tab, and the next mount asks the same
+		 * question and gets the same shell. That is the whole reason this replaced a client-held registry —
+		 * the old path removed its only pointer before a liveness round trip, and a remount inside that window
+		 * spawned a second shell and orphaned the first for the life of the host.
 		 */
-		const releasePty = (id: string): void => {
-			const tabSurvives = useAppStore
-				.getState()
-				.terminalsByWorkspace[workspaceId]?.some((t) => t.clientId === clientId);
-			if (tabSurvives) {
-				detachedPtyByClientId.set(clientId, id);
-				return;
-			}
-			detachedPtyByClientId.delete(clientId);
-			void getTransport()
-				.request("terminal.close", { id })
-				.catch(() => {});
-		};
-
-		/** Bind to a PTY id: route its output here, catch up on ordered pre-bind events, and go ready. */
-		const bindPty = (id: string): void => {
-			serverIdRef.current = id;
-			const buffered = prebind.bind(id);
-			if (buffered.truncated) writeTruncation();
-			for (const ev of buffered.frames) writeFrame(ev);
-			setReady(true);
-			// A very short-lived shell can send its addressed exit before the create response names its id.
-			// Paint buffered data first, then apply that matching exit exactly as a live subscription would.
-			if (buffered.exit) handleExit(buffered.exit);
-		};
-
-		/** Ask the host for a brand-new shell. */
-		const createPty = (): void => {
-			// The size the PTY is actually spawned at, captured NOW. Recording `term.cols` at resolve time instead
-			// would bake in whatever the grid had since become, so a resize that landed while this request was in
+		const attach = (): void => {
+			// The size the PTY is spawned at, captured NOW. Recording `term.cols` at resolve time instead would
+			// bake in whatever the grid had since become, so a resize that landed while this request was in
 			// flight would look already-applied and never be sent — leaving the shell permanently mis-sized.
 			const spawnedAt = { cols: term.cols, rows: term.rows };
 			void getTransport()
-				.request("terminal.create", { workspaceId, ...spawnedAt })
-				.then(({ id }) => {
-					if (disposed) {
-						// Close rather than detach: this shell was never bound, never produced output and holds no
-						// user work, and a concurrent mount (React StrictMode remounts every effect in dev) has
-						// already created its own. Detaching it would leak a second live shell per terminal open.
-						void getTransport()
-							.request("terminal.close", { id })
-							.catch(() => {});
-						return;
-					}
+				.request("terminal.attach", { workspaceId, tabKey, ...spawnedAt })
+				.then(({ id, created, replay }) => {
+					if (disposed) return;
 					sizeSync.acknowledge(spawnedAt);
-					bindPty(id);
+					// Repaint what this shell last showed before live frames resume: a remount is a fresh xterm
+					// buffer, so without this a surviving shell comes back behind a blank screen and looks dead.
+					// After a host restart this is the revived tab's picture, over a genuinely new shell.
+					if (replay) term.write(replay);
+					serverIdRef.current = id;
+					const buffered = prebind.bind(id);
+					if (buffered.truncated) writeTruncation();
+					for (const ev of buffered.frames) writeFrame(ev);
+					setDetached(false);
+					setExited(false);
+					setReady(true);
+					// A very short-lived shell can send its addressed exit before the response names its id.
+					// Paint buffered data first, then apply that matching exit exactly as a live subscription would.
+					if (buffered.exit) handleExit(buffered.exit);
 					// Catch up if the grid moved while we were waiting; a no-op when it didn't.
 					applyFit();
-					if (serverIdRef.current === id && initialCommandRef.current)
+					if (created && serverIdRef.current === id && initialCommandRef.current) {
 						sendTerminalWrite(
 							getTransport().request("terminal.write", {
 								id,
 								data: `${initialCommandRef.current}\r`,
 							}),
 						);
+						// Spend it: `created` is also true when a tab's previous shell exited and this attach spawned
+						// a replacement, so gating on that alone would reopen vim on every revisit.
+						initialCommandRef.current = undefined;
+						useAppStore.getState().consumeTerminalInitialCommand(workspaceId, tabKey);
+					}
 				})
 				.catch(() => {
 					if (disposed) return;
 					// Reconnects replay this request, so this is a real host refusal or deadline rather than an
 					// ambiguous dropped response. Stop pre-bind intake: this failed pane must not retain every other
-					// terminal's page-addressed output for the rest of its life.
+					// terminal's addressed output for the rest of its life.
 					prebind.stop();
 					term.write("\r\n[could not start a shell — close this tab and open a new one]\r\n");
 					setFailed(true);
 				});
 		};
-
-		const detached = detachedPtyByClientId.get(clientId);
-		if (detached === undefined) {
-			createPty();
-		} else {
-			detachedPtyByClientId.delete(clientId);
-			// Re-attaching to a shell this tab detached earlier — but confirm it is still there first.
-			// `terminal.exit` is only heard by a MOUNTED instance, and a detach happens precisely when none is
-			// (Project Home unmounts the whole panel), so a shell that died while detached leaves a dead id here.
-			// Adopting it blindly hands back a tab that looks alive and ready while every keystroke goes nowhere —
-			// exactly the failure the exit event exists to prevent.
-			void getTransport()
-				.request("terminal.alive", { id: detached })
-				.then(({ alive }) => {
-					if (disposed) {
-						// Unmounted mid-check: hand the shell back to the registry (or kill it) rather than leaking.
-						if (alive) releasePty(detached);
-						return;
-					}
-					if (!alive) {
-						createPty();
-						return;
-					}
-					// The shell kept the size it had while detached, which may no longer match this layout. The
-					// scrollback is a fresh xterm buffer — the *process* survived, its painted history did not.
-					bindPty(detached);
-					applyFit();
-				})
-				.catch(() => {
-					// The liveness check genuinely failed or timed out (socket loss itself is replayed). A fresh shell
-					// is safer than presenting one we cannot vouch for. Best-effort kill the id we gave up on so it
-					// is not left running with nothing pointing at it.
-					void getTransport()
-						.request("terminal.close", { id: detached })
-						.catch(() => {});
-					if (!disposed) createPty();
-				});
-		}
+		reattachRef.current = attach;
+		attach();
 
 		const resizeObserver = new ResizeObserver(scheduleFit);
 		resizeObserver.observe(host);
@@ -428,7 +377,10 @@ export default function TerminalInstance({
 		});
 
 		return () => {
+			// Nothing here touches the shell. It belongs to the tab and outlives every view of it — only
+			// `terminal.close`, driven by the user closing the tab, ever kills one.
 			disposed = true;
+			reattachRef.current = null;
 			prebind.stop();
 			sizeSync.dispose();
 			clearTimeout(fitTimer);
@@ -437,11 +389,11 @@ export default function TerminalInstance({
 			onData.dispose();
 			unsubscribe();
 			unsubscribeExit();
-			const id = serverIdRef.current;
-			if (id) releasePty(id);
+			unsubscribeDetached();
+			serverIdRef.current = null;
 			term.dispose();
 		};
-	}, [clientId, workspaceId]);
+	}, [tabKey, workspaceId]);
 
 	// Hidden containers report zero size, so fit + focus when this layer becomes visible. `applyFit`
 	// no-ops until the layer has a real size, so a not-yet-laid-out frame can't shrink the buffer; the
@@ -459,17 +411,33 @@ export default function TerminalInstance({
 		return () => cancelAnimationFrame(frame);
 	}, [visible]);
 
+	const takeBack = useCallback(() => reattachRef.current?.(), []);
+
 	return (
 		<div
 			data-testid="terminal-instance"
-			data-client-id={clientId}
+			data-tab-key={tabKey}
 			data-ready={ready}
 			data-exited={exited}
 			data-failed={failed}
+			data-detached={detached}
 			data-visible={visible}
 			className={`absolute inset-0 ${visible ? "" : "hidden"}`}
 		>
 			<div ref={hostRef} className="h-full w-full" />
+			{detached ? (
+				<div className="absolute inset-0 flex flex-col items-center justify-center gap-sm bg-overlay">
+					<p className="tr-text-metadata text-text-muted">This terminal is open somewhere else.</p>
+					<button
+						type="button"
+						data-testid="terminal-take-back"
+						onClick={takeBack}
+						className="rounded-[var(--radius-sm)] bg-control-bg px-sm py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
+					>
+						Take it back
+					</button>
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -335,6 +335,8 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 					const buffered = prebind.bind(id);
 					if (buffered.truncated) writeTruncation();
 					for (const ev of buffered.frames) writeFrame(ev);
+					// The host now knows this tab, so it is no longer exempt from an authoritative list.
+					useAppStore.getState().settleTerminalAttach(workspaceId, tabKey);
 					setDetached(false);
 					setExited(false);
 					setReady(true);

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -264,6 +264,14 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 		// The shell exited (the user typed `exit`, or it crashed). Until the host said so, the tab went on
 		// looking alive — cursor blinking, keystrokes accepted — while every keystroke was written to a dead id
 		// and silently dropped, with no way to tell.
+		/**
+		 * Bumped whenever this tab is taken over. An attach response is only proof of attachment *as of when the
+		 * host handled it*: a takeover can land in between, and a reconnect even replays the original request and
+		 * gets the cached success back. Comparing generations lets a later detach always win, so the pane can
+		 * never go ready over a PTY that now rejects everything it sends.
+		 */
+		let attachGeneration = 0;
+
 		const handleExit = (ev: TerminalExitPush): void => {
 			if (ev.id !== serverIdRef.current) return;
 			// Forget the id: there is nothing left to write to. The TAB stays — the user closes it themselves,
@@ -285,6 +293,7 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 				// A PTY has one size, so only one client can have its layout honoured. Say so rather than going
 				// quietly dead, and offer to take it back.
 				serverIdRef.current = null;
+				attachGeneration += 1;
 				setReady(false);
 				setDetached(true);
 			},
@@ -322,10 +331,13 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 			// bake in whatever the grid had since become, so a resize that landed while this request was in
 			// flight would look already-applied and never be sent — leaving the shell permanently mis-sized.
 			const spawnedAt = { cols: term.cols, rows: term.rows };
+			const startedAt = attachGeneration;
 			void getTransport()
 				.request("terminal.attach", { workspaceId, tabKey, ...spawnedAt })
 				.then(({ id, created, replay }) => {
 					if (disposed) return;
+					// Someone took the tab over while this was in flight, so this answer is already stale.
+					if (attachGeneration !== startedAt) return;
 					sizeSync.acknowledge(spawnedAt);
 					// Repaint what this shell last showed before live frames resume: a remount is a fresh xterm
 					// buffer, so without this a surviving shell comes back behind a blank screen and looks dead.

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -239,7 +239,13 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 
 		// Pushes can beat the attach response, before this instance knows which PTY is its own. The bounded
 		// pre-bind buffer filters on adoption and becomes inert on bind/failure.
-		const prebind = createTerminalPrebindBuffer();
+		// One buffer PER ATTACH ATTEMPT, not per mount. A buffer is single-use — inert once bound — so reusing it
+		// for a reclaim ("Take it back") would leave the reclaimed attempt unable to correlate anything that
+		// arrives before its response, while `detached` has already cleared the id. A reconnect makes that
+		// concrete: the host resumes a held `terminal.exit` on `open`, before it re-serves the replayed attach
+		// from its cache, so the exit would be dropped by both the inert buffer and the null id — and the pane
+		// would then go ready over a shell that is already dead.
+		let prebind = createTerminalPrebindBuffer();
 		const writeTruncation = (): void => term.write("\r\n[output truncated]\r\n");
 		/** Paint a batch, saying so when the host had to drop output to stay bounded. */
 		const writeFrame = (ev: TerminalDataPush): void => {
@@ -332,19 +338,28 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 			// flight would look already-applied and never be sent — leaving the shell permanently mis-sized.
 			const spawnedAt = { cols: term.cols, rows: term.rows };
 			const startedAt = attachGeneration;
+			// Retire the previous attempt's buffer and take a fresh one for this attempt, so pushes that beat this
+			// response are held for it. The subscriptions read `prebind` at call time, so they follow it.
+			prebind.stop();
+			const attemptPrebind = createTerminalPrebindBuffer();
+			prebind = attemptPrebind;
 			void getTransport()
 				.request("terminal.attach", { workspaceId, tabKey, ...spawnedAt })
 				.then(({ id, created, replay }) => {
 					if (disposed) return;
-					// Someone took the tab over while this was in flight, so this answer is already stale.
-					if (attachGeneration !== startedAt) return;
+					// Someone took the tab over while this was in flight, so this answer is already stale. A newer
+					// attempt owns `prebind` by now; only this attempt's own buffer is ours to retire.
+					if (attachGeneration !== startedAt) {
+						attemptPrebind.stop();
+						return;
+					}
 					sizeSync.acknowledge(spawnedAt);
 					// Repaint what this shell last showed before live frames resume: a remount is a fresh xterm
 					// buffer, so without this a surviving shell comes back behind a blank screen and looks dead.
 					// After a host restart this is the revived tab's picture, over a genuinely new shell.
 					if (replay) term.write(replay);
 					serverIdRef.current = id;
-					const buffered = prebind.bind(id);
+					const buffered = attemptPrebind.bind(id);
 					if (buffered.truncated) writeTruncation();
 					for (const ev of buffered.frames) writeFrame(ev);
 					// The host now knows this tab, so it is no longer exempt from an authoritative list.
@@ -375,7 +390,7 @@ export default function TerminalInstance({ tabKey, workspaceId, visible, initial
 					// Reconnects replay this request, so this is a real host refusal or deadline rather than an
 					// ambiguous dropped response. Stop pre-bind intake: this failed pane must not retain every other
 					// terminal's addressed output for the rest of its life.
-					prebind.stop();
+					attemptPrebind.stop();
 					term.write("\r\n[could not start a shell — close this tab and open a new one]\r\n");
 					setFailed(true);
 				});

--- a/apps/web/src/panels/TerminalSettings.tsx
+++ b/apps/web/src/panels/TerminalSettings.tsx
@@ -1,0 +1,73 @@
+import { TERMINAL_REPLAY_KB } from "@thinkrail/contracts";
+import { Check } from "lucide-react";
+import { cn } from "@/lib";
+import { toast, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+
+/**
+ * Replay budgets offered, in KiB. Presets rather than a free number field: the value sizes a buffer held per
+ * live terminal *and* written to disk, so the useful range is a handful of orders of magnitude, not any
+ * integer — and presets need no validation UI for a setting most people will never open.
+ */
+const REPLAY_CHOICES: { kb: number; label: string; hint: string }[] = [
+	{ kb: 0, label: "Off", hint: "Reattaching shows an empty screen over the live shell" },
+	{ kb: 16, label: "16 KB", hint: "About a screenful" },
+	{ kb: TERMINAL_REPLAY_KB.default, label: "64 KB", hint: "A screenful plus scrollback (default)" },
+	{ kb: 256, label: "256 KB", hint: "Long scrollback; more memory per terminal" },
+	{ kb: TERMINAL_REPLAY_KB.max, label: "1 MB", hint: "Maximum" },
+];
+
+/**
+ * The "Terminal" settings section: how much output the host keeps to repaint a reattaching terminal.
+ *
+ * Server-synced like the theme picker — `settings.update` fires and the UI converges when the host's
+ * `settings.changed` broadcast folds into the store, with no optimistic apply.
+ */
+export function TerminalSettings() {
+	const replayKb = useAppStore((s) => s.terminalReplayKb);
+
+	const select = (kb: number) => {
+		if (kb === replayKb) return;
+		getTransport()
+			.request("settings.update", { config: { terminalReplayKb: kb } })
+			.catch(() => toast.error("Couldn't change the replay size"));
+	};
+
+	return (
+		<section data-testid="settings-terminal" className="flex flex-col gap-sm">
+			<div className="flex flex-col gap-xs">
+				<h3 className="tr-title-section text-text-default">Replayed output</h3>
+				<p className="text-text-muted tr-text-metadata">
+					A terminal keeps running when you leave it, but the view is rebuilt from scratch when you
+					come back. This is how much of its recent output the host keeps so the screen is restored
+					too. Applies to terminals opened from now on.
+				</p>
+			</div>
+			<div className="flex flex-col gap-xs">
+				{REPLAY_CHOICES.map(({ kb, label, hint }) => {
+					const active = kb === replayKb;
+					return (
+						<button
+							key={kb}
+							type="button"
+							aria-pressed={active}
+							data-testid={`terminal-replay-${kb}`}
+							data-active={active}
+							onClick={() => select(kb)}
+							className={cn(
+								"flex items-center gap-sm rounded-[var(--radius-md)] border px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+								active
+									? "border-primary-muted bg-clip-padding bg-primary-subtle text-text-default"
+									: "border-border-default text-text-muted hover:bg-control-bg-hovered hover:text-text-default",
+							)}
+						>
+							<span className="flex-1">{label}</span>
+							<span className="shrink-0 text-text-muted tr-text-metadata">{hint}</span>
+							{active ? <Check className="size-4 shrink-0 text-primary" /> : null}
+						</button>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/panels/TerminalsPanel.tsx
+++ b/apps/web/src/panels/TerminalsPanel.tsx
@@ -3,8 +3,6 @@ import { WS_CHANNELS } from "@thinkrail/contracts";
 import { Plus, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import {
-	allTerminalTabs,
-	isTerminalVisible,
 	selectActiveTerminalId,
 	selectWorkspaceTerminals,
 	type TerminalTab,
@@ -15,10 +13,9 @@ import { ConfirmDialog } from "./ConfirmDialog";
 
 const TerminalInstance = lazy(() => import("./TerminalInstance"));
 
-/** Lower-right terminals for the active worktree. All instances stay mounted; only the active is shown. */
+/** Lower-right terminals for the active worktree. Only the shown tab is mounted — see `shown` below. */
 export function TerminalsPanel() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
-	const terminalsByWorkspace = useAppStore((s) => s.terminalsByWorkspace);
 	const tabs = useAppStore(selectWorkspaceTerminals);
 	const activeTerminalId = useAppStore(selectActiveTerminalId);
 	const addTerminal = useAppStore((s) => s.addTerminal);
@@ -87,7 +84,14 @@ export function TerminalsPanel() {
 			});
 	}, []);
 
-	const allTerminals = allTerminalTabs(terminalsByWorkspace);
+	// EXACTLY ONE instance is mounted, app-wide: the tab this client is actually looking at.
+	//
+	// Mounting is attaching, and attachment is exclusive — so rendering every tab would have this client claim
+	// terminals it is not showing. With a shared tab list that is actively harmful: the moment another browser
+	// opened a terminal, our hidden instance for it would attach and snatch it out from under the person who
+	// just opened it. Switching tabs re-attaches and repaints from the host's recording, which is exactly what
+	// that recording is for; a background shell keeps running and keeps being recorded regardless.
+	const shown = tabs.find((tab) => tab.tabKey === activeTerminalId) ?? null;
 
 	return (
 		<div data-testid="terminal-panel" className="flex h-full min-h-0 flex-col">
@@ -123,16 +127,15 @@ export function TerminalsPanel() {
 						No terminals yet — press + to open one.
 					</p>
 				) : null}
-				{allTerminals.map((tab) => (
-					<Suspense key={tab.tabKey} fallback={null}>
+				{shown ? (
+					<Suspense key={shown.tabKey} fallback={null}>
 						<TerminalInstance
-							tabKey={tab.tabKey}
-							workspaceId={tab.workspaceId}
-							visible={isTerminalVisible(tab, activeWorkspaceId, activeTerminalId)}
-							{...(tab.initialCommand ? { initialCommand: tab.initialCommand } : {})}
+							tabKey={shown.tabKey}
+							workspaceId={shown.workspaceId}
+							{...(shown.initialCommand ? { initialCommand: shown.initialCommand } : {})}
 						/>
 					</Suspense>
-				))}
+				) : null}
 			</div>
 			<ConfirmDialog
 				open={confirmBusy !== null}

--- a/apps/web/src/panels/TerminalsPanel.tsx
+++ b/apps/web/src/panels/TerminalsPanel.tsx
@@ -1,3 +1,5 @@
+import type { TerminalTabsPush } from "@thinkrail/contracts";
+import { WS_CHANNELS } from "@thinkrail/contracts";
 import { Plus, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import {
@@ -50,6 +52,15 @@ export function TerminalsPanel() {
 		};
 	}, [activeWorkspaceId]);
 
+	// Which terminals exist is shared state, so the host announces every change. Without folding it, a tab
+	// closed in another browser would leave a dead instance mounted here, still accepting input.
+	useEffect(() => {
+		return getTransport().subscribe(WS_CHANNELS.terminalTabs, (payload) => {
+			const ev = payload as TerminalTabsPush;
+			useAppStore.getState().setWorkspaceTerminals(ev.workspaceId, ev.tabs);
+		});
+	}, []);
+
 	/**
 	 * Close a tab and kill its shell — the only gesture that ever does.
 	 *
@@ -60,13 +71,16 @@ export function TerminalsPanel() {
 	const closeTab = useCallback((tab: TerminalTab, force: boolean) => {
 		void getTransport()
 			.request("terminal.close", { workspaceId: tab.workspaceId, tabKey: tab.tabKey, force })
-			.then(({ closed, busy }) => {
-				if (closed) {
-					useAppStore.getState().closeTerminalTab(tab.workspaceId, tab.tabKey);
-					setConfirmBusy(null);
+			.then(({ busy }) => {
+				if (busy) {
+					setConfirmBusy(tab);
 					return;
 				}
-				if (busy) setConfirmBusy(tab);
+				// Anything not busy means the tab is gone host-side — either this call killed it, or there was no
+				// such tab (an attach that never landed, or one another client already closed). Both leave the row
+				// stale, and only dropping it on `closed` would make those two undismissable.
+				useAppStore.getState().closeTerminalTab(tab.workspaceId, tab.tabKey);
+				setConfirmBusy(null);
 			})
 			.catch(() => {
 				// Nothing was closed, so the tab stays exactly as it is.

--- a/apps/web/src/panels/TerminalsPanel.tsx
+++ b/apps/web/src/panels/TerminalsPanel.tsx
@@ -1,5 +1,5 @@
 import { Plus, X } from "lucide-react";
-import { lazy, Suspense, useEffect } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import {
 	allTerminalTabs,
 	isTerminalVisible,
@@ -8,6 +8,8 @@ import {
 	type TerminalTab,
 	useAppStore,
 } from "../store";
+import { getTransport } from "../transport";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 const TerminalInstance = lazy(() => import("./TerminalInstance"));
 
@@ -18,17 +20,58 @@ export function TerminalsPanel() {
 	const tabs = useAppStore(selectWorkspaceTerminals);
 	const activeTerminalId = useAppStore(selectActiveTerminalId);
 	const addTerminal = useAppStore((s) => s.addTerminal);
-	const closeTerminalTab = useAppStore((s) => s.closeTerminalTab);
 	const setActiveTerminalTab = useAppStore((s) => s.setActiveTerminalTab);
+	/** The tab whose shell is running something, held while we ask whether to kill it anyway. */
+	const [confirmBusy, setConfirmBusy] = useState<TerminalTab | null>(null);
 
-	// Landing on a workspace with no terminals opens one — every worktree gets a shell ready to go.
+	// Adopt the host's tab list for this workspace, then open one if it has none. The host owns the list, so a
+	// reload — or a different browser — finds the shells that are still running rather than starting new ones.
 	useEffect(() => {
 		if (!activeWorkspaceId) return;
-		const store = useAppStore.getState();
-		if ((store.terminalsByWorkspace[activeWorkspaceId]?.length ?? 0) === 0) {
-			store.addTerminal(activeWorkspaceId);
-		}
+		let current = true;
+		void getTransport()
+			.request("terminal.list", { workspaceId: activeWorkspaceId })
+			.then(({ tabs: hostTabs }) => {
+				if (!current) return;
+				useAppStore.getState().setWorkspaceTerminals(activeWorkspaceId, hostTabs);
+				// Re-read AFTER the write: `getState()` hands back a snapshot, so the pre-write one would still
+				// show no tabs and we would open a second terminal beside the shells already running here.
+				const after = useAppStore.getState();
+				// Every worktree gets a shell ready to go — but only once we know the host has none.
+				if ((after.terminalsByWorkspace[activeWorkspaceId]?.length ?? 0) === 0) {
+					after.addTerminal(activeWorkspaceId);
+				}
+			})
+			.catch(() => {
+				// The host is unreachable; the transport reconnects and this re-runs on the next workspace entry.
+			});
+		return () => {
+			current = false;
+		};
 	}, [activeWorkspaceId]);
+
+	/**
+	 * Close a tab and kill its shell — the only gesture that ever does.
+	 *
+	 * The host refuses while the shell has child processes and says so, and we ask before retrying with
+	 * `force`. Deliberately not a flag read from the tab list: something started after the rail loaded would
+	 * make a cached answer wrong in exactly the direction that loses work.
+	 */
+	const closeTab = useCallback((tab: TerminalTab, force: boolean) => {
+		void getTransport()
+			.request("terminal.close", { workspaceId: tab.workspaceId, tabKey: tab.tabKey, force })
+			.then(({ closed, busy }) => {
+				if (closed) {
+					useAppStore.getState().closeTerminalTab(tab.workspaceId, tab.tabKey);
+					setConfirmBusy(null);
+					return;
+				}
+				if (busy) setConfirmBusy(tab);
+			})
+			.catch(() => {
+				// Nothing was closed, so the tab stays exactly as it is.
+			});
+	}, []);
 
 	const allTerminals = allTerminalTabs(terminalsByWorkspace);
 
@@ -39,11 +82,11 @@ export function TerminalsPanel() {
 				<div className="flex min-w-0 flex-1 items-center gap-px overflow-x-auto">
 					{tabs.map((tab) => (
 						<TerminalTabButton
-							key={tab.clientId}
+							key={tab.tabKey}
 							tab={tab}
-							active={tab.clientId === activeTerminalId}
-							onSelect={() => setActiveTerminalTab(tab.workspaceId, tab.clientId)}
-							onClose={() => closeTerminalTab(tab.workspaceId, tab.clientId)}
+							active={tab.tabKey === activeTerminalId}
+							onSelect={() => setActiveTerminalTab(tab.workspaceId, tab.tabKey)}
+							onClose={() => closeTab(tab, false)}
 						/>
 					))}
 				</div>
@@ -67,9 +110,9 @@ export function TerminalsPanel() {
 					</p>
 				) : null}
 				{allTerminals.map((tab) => (
-					<Suspense key={tab.clientId} fallback={null}>
+					<Suspense key={tab.tabKey} fallback={null}>
 						<TerminalInstance
-							clientId={tab.clientId}
+							tabKey={tab.tabKey}
 							workspaceId={tab.workspaceId}
 							visible={isTerminalVisible(tab, activeWorkspaceId, activeTerminalId)}
 							{...(tab.initialCommand ? { initialCommand: tab.initialCommand } : {})}
@@ -77,6 +120,20 @@ export function TerminalsPanel() {
 					</Suspense>
 				))}
 			</div>
+			<ConfirmDialog
+				open={confirmBusy !== null}
+				onOpenChange={(open) => {
+					if (!open) setConfirmBusy(null);
+				}}
+				title="Something is running"
+				description={`“${confirmBusy?.title ?? "This terminal"}” has a running process. Closing the tab ends it.`}
+				confirmLabel="Close anyway"
+				confirmTestId="terminal-close-busy-confirm"
+				destructive
+				onConfirm={() => {
+					if (confirmBusy) closeTab(confirmBusy, true);
+				}}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/panels/terminalPrebindBuffer.ts
+++ b/apps/web/src/panels/terminalPrebindBuffer.ts
@@ -4,7 +4,7 @@ export interface TerminalPrebindResult {
 	frames: TerminalDataPush[];
 	/** This PTY lost oldest pre-bind bytes to the browser-side cap. */
 	truncated: boolean;
-	/** A very short-lived shell can exit before `terminal.create` returns its id. */
+	/** A very short-lived shell can exit before `terminal.attach` returns its id. */
 	exit?: TerminalExitPush;
 }
 
@@ -24,7 +24,7 @@ const DEFAULT_MAX_FRAMES = 256;
 const DEFAULT_MAX_EXITS = 128;
 
 /**
- * A bounded pre-correlation buffer for terminal pushes that race `terminal.create`'s response.
+ * A bounded pre-correlation buffer for terminal pushes that race `terminal.attach`'s response.
  *
  * Terminal pushes are addressed to the page, so before the response names this instance's PTY it sees frames
  * for every terminal. The buffer is deliberately global-capped, records which PTY lost bytes while evicting,

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -87,10 +87,12 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `DocTab`'s content exists only in the store (no file backs it), so a silent replace would destroy it
   with nothing to reopen. There is deliberately **no keyboard shortcut**: gestures only.
   `terminalsByWorkspace`
-  / `activeTerminalByWorkspace` (`addTerminal`/`closeTerminalTab`/`setActiveTerminalTab` — `addTerminal`
-  takes an optional `initialCommand`, carried on the new tab's `TerminalTab.initialCommand` and consumed
-  exactly once by `TerminalInstance` right after its own PTY comes up, e.g. the workspace row's "Open in
-  Vim"); the
+  / `activeTerminalByWorkspace` — a **mirror of host state, never the authority**: the host owns the tab list
+  and keys shells by `(workspaceId, tabKey)`, so this store can never hold the only record of a running shell.
+  `setWorkspaceTerminals` adopts a `terminal.list` result (keeping a locally-added tab whose attach is still in
+  flight); `addTerminal` only mints a `tabKey` — the instance's attach is what registers it host-side — and
+  takes an optional `initialCommand` consumed once, only when attach reports it `created` the shell (the
+  workspace row's "Open in Vim"); `closeTerminalTab` drops the row after `terminal.close` confirms. The
   **per-session chat state** — `sessions: Record<sessionId, SessionRuntime>`, where a `SessionRuntime` holds
   one chat's `turns` (pi-canonical) / `toolResults` / `askAnswers` (the `ask-user-answers` replies keyed
   by tool call id — indexed by the reducer and hydration, never turned into bubbles) /

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -89,8 +89,10 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `terminalsByWorkspace`
   / `activeTerminalByWorkspace` — a **mirror of host state, never the authority**: the host owns the tab list
   and keys shells by `(workspaceId, tabKey)`, so this store can never hold the only record of a running shell.
-  `setWorkspaceTerminals` adopts a `terminal.list` result (keeping a locally-added tab whose attach is still in
-  flight); `addTerminal` only mints a `tabKey` — the instance's attach is what registers it host-side — and
+  `setWorkspaceTerminals` adopts a `terminal.list` result or a `terminal.tabs` broadcast, keeping a local tab the
+  host omits **only while its own attach is genuinely in flight** (`TerminalTab.attachPending`, cleared by
+  `settleTerminalAttach`) — any other omitted tab has really gone, and preserving it would let its instance
+  re-attach and resurrect both the tab and a shell; `addTerminal` only mints a `tabKey` — the instance's attach is what registers it host-side — and
   takes an optional `initialCommand` consumed once, only when attach reports it `created` the shell (the
   workspace row's "Open in Vim"); `closeTerminalTab` drops the row after `terminal.close` confirms. The
   **per-session chat state** — `sessions: Record<sessionId, SessionRuntime>`, where a `SessionRuntime` holds

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -281,10 +281,8 @@ branch's review — a commit sha means nothing in another worktree — and dropp
   one lookup for "the workspace with this id" — `selectActiveWorkspace` is it applied to the active id, and
   `openFileInTab`/`ChatView` read the worktree root through it),
   `selectWorkspaceTerminals` / `selectActiveTerminalId` (the active workspace's terminal tabs and which one is
-  showing) plus the pure helpers `allTerminalTabs` / `isTerminalVisible` — helpers rather than store selectors
-  because each derives a fresh value per call, and subscribing to that would re-render on every unrelated store
-  change; visibility is two conditions (right workspace **and** right tab) because every workspace's terminals
-  stay mounted,
+  showing — the panel mounts an instance for **that one only**, since mounting attaches and attachment is
+  exclusive; the flatten/visibility helpers a mount-everything panel needed are gone),
   `selectActiveWorkspaceProjectId`, `selectHistoryTarget` + `HistoryTarget` (the shell's `Ctrl+R` routing
   target: the active chat tab, or the workspace's newest chat when a file/diff/doc tab is active),
   `selectContextProject`, `selectSkillsStale`, **`selectDiffScope` + `BRANCH_SCOPE`** (what a workspace's

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -122,6 +122,7 @@ export const SettingsSection = {
 	Providers: "providers",
 	Github: "github",
 	Appearance: "appearance",
+	Terminal: "terminal",
 	Templates: "templates",
 	Privacy: "privacy",
 } as const;
@@ -626,6 +627,8 @@ interface AppState {
 	/** Anonymous-usage-analytics switch (host-owned, same `applyConfig` fold as `theme`). Only this boolean
 	 * ever reaches a client — events are emitted host-side and the install id never crosses the wire. */
 	analyticsEnabled: boolean;
+	/** How much terminal output the host keeps for replay, in KiB (host-owned; same `applyConfig` fold). */
+	terminalReplayKb: number;
 	/** Transient notifications, oldest-first (the Toaster renders + times them out). At-most a handful live
 	 * at once; a failed wire call that has no better home (no chat tab to host an error turn) lands here. */
 	toasts: Toast[];
@@ -1059,6 +1062,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	settingsSection: SettingsSection.Providers,
 	theme: DEFAULT_CONFIG.theme,
 	analyticsEnabled: DEFAULT_CONFIG.analyticsEnabled,
+	terminalReplayKb: DEFAULT_CONFIG.terminalReplayKb,
 	toasts: [],
 	setStatus: (status) => set({ status }),
 	setWelcome: (protocolVersion) => set({ protocolVersion }),
@@ -1705,7 +1709,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 		set({ settingsOpen: true, settingsSection: section }),
 	closeSettings: () => set({ settingsOpen: false }),
 	setSettingsSection: (section) => set({ settingsSection: section }),
-	applyConfig: (config) => set({ theme: config.theme, analyticsEnabled: config.analyticsEnabled }),
+	applyConfig: (config) =>
+		set({
+			theme: config.theme,
+			analyticsEnabled: config.analyticsEnabled,
+			terminalReplayKb: config.terminalReplayKb,
+		}),
 	requestRightTab: (workspaceId, tab) => set({ rightTabRequest: { workspaceId, tab } }),
 	// The path intent and the flip always travel together — one action, so no call site can send half of it.
 	// The nav count is stamped here, at the click, because that is when the user navigated — the panel only

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -161,6 +161,13 @@ export interface TerminalTab {
 	title: string;
 	/** A command to run once, only if the attach actually created this shell (e.g. "Open in Vim"). */
 	initialCommand?: string;
+	/**
+	 * This client minted the tab and its `terminal.attach` has not landed yet, so the host does not know about
+	 * it. Only such a tab may survive an authoritative list that omits it — anything else missing from the
+	 * host's list is a tab that genuinely no longer exists (another client closed it), and keeping it would let
+	 * its instance re-attach and resurrect both the tab and a shell.
+	 */
+	attachPending?: true;
 }
 
 /** A chat tab the user closed — reopenable from history; its session + runtime stay alive in `sessions`. */
@@ -731,6 +738,7 @@ interface AppState {
 	clearWorkspaceTabs: (workspaceId: string) => void;
 	addTerminal: (workspaceId: string, initialCommand?: string) => void;
 	setWorkspaceTerminals: (workspaceId: string, tabs: TerminalTabInfo[]) => void;
+	settleTerminalAttach: (workspaceId: string, tabKey: string) => void;
 	consumeTerminalInitialCommand: (workspaceId: string, tabKey: string) => void;
 	closeTerminalTab: (workspaceId: string, tabKey: string) => void;
 	setActiveTerminalTab: (workspaceId: string, tabKey: string) => void;
@@ -1355,6 +1363,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				tabKey,
 				workspaceId,
 				title: nextTerminalTitle(list),
+				attachPending: true,
 				...(initialCommand ? { initialCommand } : {}),
 			};
 			// No create call: mounting the instance attaches, and attach is what registers the tab host-side.
@@ -1366,18 +1375,20 @@ export const useAppStore = create<AppState>((set, get) => ({
 	/**
 	 * Adopt the host's tab list for a workspace.
 	 *
-	 * Host order and titles win, but a tab this client has just opened and not yet attached is kept: the
-	 * request that registers it may still be in flight, and dropping it here would unmount the very instance
-	 * about to make that call.
+	 * Host order and titles win. A tab is kept despite being absent from that list ONLY while its own attach is
+	 * still in flight — that request is what registers it, so dropping it would unmount the very instance about
+	 * to make the call. Any other local tab the host does not list has genuinely gone (another client closed
+	 * it), and preserving it would let its instance re-attach and bring back both the tab and a shell.
 	 */
 	setWorkspaceTerminals: (workspaceId, tabs) =>
 		set((s) => {
 			const local = s.terminalsByWorkspace[workspaceId] ?? [];
 			const known = new Set(tabs.map((tab) => tab.tabKey));
-			const pending = local.filter((tab) => !known.has(tab.tabKey));
+			const pending = local.filter((tab) => !known.has(tab.tabKey) && tab.attachPending);
 			const merged: TerminalTab[] = [
 				...tabs.map((tab) => {
 					const existing = local.find((candidate) => candidate.tabKey === tab.tabKey);
+					// Confirmed by the host, so no longer pending whatever this client thought.
 					return {
 						tabKey: tab.tabKey,
 						workspaceId,
@@ -1394,6 +1405,22 @@ export const useAppStore = create<AppState>((set, get) => ({
 				activeTerminalByWorkspace: {
 					...s.activeTerminalByWorkspace,
 					[workspaceId]: activeSurvives ? active : (merged.at(-1)?.tabKey ?? null),
+				},
+			};
+		}),
+	/** The tab's attach landed: the host knows about it, so it is no longer exempt from an authoritative list. */
+	settleTerminalAttach: (workspaceId, tabKey) =>
+		set((s) => {
+			const list = s.terminalsByWorkspace[workspaceId] ?? [];
+			if (!list.some((t) => t.tabKey === tabKey && t.attachPending)) return s;
+			return {
+				terminalsByWorkspace: {
+					...s.terminalsByWorkspace,
+					[workspaceId]: list.map(({ attachPending, ...rest }) =>
+						rest.tabKey === tabKey
+							? rest
+							: { ...rest, ...(attachPending ? { attachPending } : {}) },
+					),
 				},
 			};
 		}),

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -12,6 +12,7 @@ import type {
 	SessionSummary,
 	SlashCommandInfo,
 	SpecGraphNode,
+	TerminalTabInfo,
 	ThemeId,
 	ThinkingLevel,
 	WireModel,
@@ -145,12 +146,19 @@ export interface Toast {
  * the newest visible. */
 const MAX_TOASTS = 5;
 
-/** A terminal tab. `clientId` is the stable UI key; the server PTY id is owned by its `TerminalInstance`. */
+/**
+ * A terminal tab — a local mirror of host state, not the authority.
+ *
+ * The host owns the tab list (`terminal.list`); `tabKey` is the durable identity it keys shells on, so this
+ * store never holds the only record of a running shell. That inversion is deliberate: when the browser was the
+ * sole keeper of the tab→shell mapping, losing it mid-round-trip spawned a duplicate shell and orphaned the
+ * original for the life of the host.
+ */
 export interface TerminalTab {
-	clientId: string;
+	tabKey: string;
 	workspaceId: string;
 	title: string;
-	/** A command to run once, right after this tab's PTY is ready (e.g. "Open in Vim") — never replayed. */
+	/** A command to run once, only if the attach actually created this shell (e.g. "Open in Vim"). */
 	initialCommand?: string;
 }
 
@@ -719,8 +727,10 @@ interface AppState {
 	) => void;
 	clearWorkspaceTabs: (workspaceId: string) => void;
 	addTerminal: (workspaceId: string, initialCommand?: string) => void;
-	closeTerminalTab: (workspaceId: string, clientId: string) => void;
-	setActiveTerminalTab: (workspaceId: string, clientId: string) => void;
+	setWorkspaceTerminals: (workspaceId: string, tabs: TerminalTabInfo[]) => void;
+	consumeTerminalInitialCommand: (workspaceId: string, tabKey: string) => void;
+	closeTerminalTab: (workspaceId: string, tabKey: string) => void;
+	setActiveTerminalTab: (workspaceId: string, tabKey: string) => void;
 	openChatSession: (
 		workspaceId: string,
 		sessionId: string,
@@ -1336,37 +1346,92 @@ export const useAppStore = create<AppState>((set, get) => ({
 	addTerminal: (workspaceId, initialCommand) =>
 		set((s) => {
 			const list = s.terminalsByWorkspace[workspaceId] ?? [];
-			const clientId = crypto.randomUUID();
+			const tabKey = crypto.randomUUID();
 			const tab: TerminalTab = {
-				clientId,
+				tabKey,
 				workspaceId,
 				title: nextTerminalTitle(list),
 				...(initialCommand ? { initialCommand } : {}),
 			};
+			// No create call: mounting the instance attaches, and attach is what registers the tab host-side.
 			return {
 				terminalsByWorkspace: { ...s.terminalsByWorkspace, [workspaceId]: [...list, tab] },
-				activeTerminalByWorkspace: { ...s.activeTerminalByWorkspace, [workspaceId]: clientId },
+				activeTerminalByWorkspace: { ...s.activeTerminalByWorkspace, [workspaceId]: tabKey },
 			};
 		}),
-	closeTerminalTab: (workspaceId, clientId) =>
+	/**
+	 * Adopt the host's tab list for a workspace.
+	 *
+	 * Host order and titles win, but a tab this client has just opened and not yet attached is kept: the
+	 * request that registers it may still be in flight, and dropping it here would unmount the very instance
+	 * about to make that call.
+	 */
+	setWorkspaceTerminals: (workspaceId, tabs) =>
 		set((s) => {
-			const list = (s.terminalsByWorkspace[workspaceId] ?? []).filter(
-				(t) => t.clientId !== clientId,
-			);
-			const wasActive = s.activeTerminalByWorkspace[workspaceId] === clientId;
+			const local = s.terminalsByWorkspace[workspaceId] ?? [];
+			const known = new Set(tabs.map((tab) => tab.tabKey));
+			const pending = local.filter((tab) => !known.has(tab.tabKey));
+			const merged: TerminalTab[] = [
+				...tabs.map((tab) => {
+					const existing = local.find((candidate) => candidate.tabKey === tab.tabKey);
+					return {
+						tabKey: tab.tabKey,
+						workspaceId,
+						title: tab.title,
+						...(existing?.initialCommand ? { initialCommand: existing.initialCommand } : {}),
+					};
+				}),
+				...pending,
+			];
+			const active = s.activeTerminalByWorkspace[workspaceId] ?? null;
+			const activeSurvives = merged.some((tab) => tab.tabKey === active);
+			return {
+				terminalsByWorkspace: { ...s.terminalsByWorkspace, [workspaceId]: merged },
+				activeTerminalByWorkspace: {
+					...s.activeTerminalByWorkspace,
+					[workspaceId]: activeSurvives ? active : (merged.at(-1)?.tabKey ?? null),
+				},
+			};
+		}),
+	/**
+	 * Spend a tab's one-shot `initialCommand`, so it can never run a second time.
+	 *
+	 * `created` alone is not enough to gate on: a tab whose shell exited gets a *fresh* one on the next attach,
+	 * which is also `created` — so an "Open in Vim" tab would reopen vim every time the workspace was revisited.
+	 * The intent belongs to the tab's creation, not to any shell behind it.
+	 */
+	consumeTerminalInitialCommand: (workspaceId, tabKey) =>
+		set((s) => {
+			const list = s.terminalsByWorkspace[workspaceId] ?? [];
+			if (!list.some((t) => t.tabKey === tabKey && t.initialCommand)) return s;
+			return {
+				terminalsByWorkspace: {
+					...s.terminalsByWorkspace,
+					[workspaceId]: list.map(({ initialCommand, ...rest }) =>
+						rest.tabKey === tabKey
+							? rest
+							: { ...rest, ...(initialCommand ? { initialCommand } : {}) },
+					),
+				},
+			};
+		}),
+	closeTerminalTab: (workspaceId, tabKey) =>
+		set((s) => {
+			const list = (s.terminalsByWorkspace[workspaceId] ?? []).filter((t) => t.tabKey !== tabKey);
+			const wasActive = s.activeTerminalByWorkspace[workspaceId] === tabKey;
 			return {
 				terminalsByWorkspace: { ...s.terminalsByWorkspace, [workspaceId]: list },
 				activeTerminalByWorkspace: {
 					...s.activeTerminalByWorkspace,
 					[workspaceId]: wasActive
-						? (list.at(-1)?.clientId ?? null)
+						? (list.at(-1)?.tabKey ?? null)
 						: (s.activeTerminalByWorkspace[workspaceId] ?? null),
 				},
 			};
 		}),
-	setActiveTerminalTab: (workspaceId, clientId) =>
+	setActiveTerminalTab: (workspaceId, tabKey) =>
 		set((s) => ({
-			activeTerminalByWorkspace: { ...s.activeTerminalByWorkspace, [workspaceId]: clientId },
+			activeTerminalByWorkspace: { ...s.activeTerminalByWorkspace, [workspaceId]: tabKey },
 		})),
 	openChatSession: (workspaceId, sessionId, model, thinkingLevel, syncedTick) =>
 		set((s) => {

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -292,5 +292,5 @@ export function isTerminalVisible(
 	activeWorkspaceId: string | null,
 	activeTerminalId: string | null,
 ): boolean {
-	return tab.workspaceId === activeWorkspaceId && tab.clientId === activeTerminalId;
+	return tab.workspaceId === activeWorkspaceId && tab.tabKey === activeTerminalId;
 }

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -266,31 +266,3 @@ export function selectActiveTerminalId(state: TerminalState): string | null {
 	if (!state.activeWorkspaceId) return null;
 	return state.activeTerminalByWorkspace[state.activeWorkspaceId] ?? null;
 }
-
-/**
- * Every workspace's terminal tabs, flattened. All of them stay mounted — that is what keeps their buffers and
- * their shells alive across a workspace switch — so the panel renders this list, not just the active
- * workspace's. A pure helper over the already-subscribed record rather than a store selector, because it builds
- * a fresh array on every call and subscribing to that would re-render on every unrelated store change.
- */
-export function allTerminalTabs(
-	terminalsByWorkspace: Record<string, TerminalTab[]>,
-): TerminalTab[] {
-	return Object.values(terminalsByWorkspace).flat();
-}
-
-/**
- * Whether a terminal tab is the one on screen — exactly one is, app-wide.
- *
- * Two conditions, not one: every workspace's terminals stay mounted so their buffers and shells survive a
- * workspace switch, so "is my tab the active tab" is not enough — it must also belong to the workspace in view.
- * A pure helper over the two already-subscribed values rather than a store selector, so a component can't
- * accidentally subscribe to a freshly built closure on every render.
- */
-export function isTerminalVisible(
-	tab: TerminalTab,
-	activeWorkspaceId: string | null,
-	activeTerminalId: string | null,
-): boolean {
-	return tab.workspaceId === activeWorkspaceId && tab.tabKey === activeTerminalId;
-}

--- a/architecture.md
+++ b/architecture.md
@@ -109,6 +109,17 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
     tags `libghostty-vt` with an official WASM/npm distribution, and (b) `ghostty-web` ships past 0.4.0 with
     mouse reporting and OSC 8 working.
 
+12. **A shell belongs to a tab, and the host owns the mapping.** Terminals are keyed by
+    `(workspaceId, tabKey)` and reached through one idempotent `terminal.attach`; the client keeps no
+    tab→shell pointer of its own. Shells are **owner-scoped**, matching `history`/`todos`/`templates`, so
+    they survive a reload, a closed browser and a different browser — attach is exclusive, and taking a tab
+    over notifies the displaced client. Lifetime is bounded by reference (no tab → no shell) plus the host
+    process, **not** by timers: no idle culling, no abandoned-client reap. A host restart cannot preserve
+    shells (in-process `pi`, PTY hangup), so tabs are revived with fresh shells showing recorded output.
+    **tmux was rejected** as the persistence layer: an unassumable dependency on Windows, a competing tab
+    model, env-propagation breakage, and polling-based capture — for restart survival we have already
+    decided not to hold. Detail: [[submodule-server-terminal]].
+
 ## Invariants
 
 - Never **value**-import `pi` in browser-bundled code; import types only, from the `pi-ai` /

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -109,7 +109,7 @@ test("the terminal's shell counts characters, not bytes", async ({ page }) => {
 // project row — the deliberate "project home" gesture, which clears the active workspace — unmounted every
 // terminal of *every* workspace, and each unmount closed its PTY. Anything running in one (a dev server, a
 // watch build) was silently killed by a single click, with the tabs reappearing afterwards backed by new,
-// empty shells, so nothing looked wrong. Instances now detach their PTY and the next mount re-adopts it.
+// empty shells, so nothing looked wrong. A shell now belongs to its tab and the remount just re-attaches.
 test("a shell survives a trip to Project Home and back", async ({ page }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
@@ -125,14 +125,99 @@ test("a shell survives a trip to Project Home and back", async ({ page }) => {
 	await page.getByTestId("project-item").first().click();
 	await expect(page.getByTestId("terminal-panel")).toHaveCount(0);
 
-	// Back into the workspace. The remount is a fresh xterm buffer, so the old output is genuinely gone and
-	// the assertion below can only pass on newly painted output from the re-adopted shell.
 	await worktreeRows(page).nth(0).getByRole("button").first().click();
 	await waitTerminalReady(page);
-	await expect(visibleTerminalScreen(page)).not.toContainText("CHECK=alive");
+	// The screen comes back too: the remount is a fresh xterm buffer, and attach replays the host's recording
+	// into it. Without that a live shell would sit behind a blank pane and look dead.
+	await expect(visibleTerminalScreen(page)).toContainText("CHECK=alive");
 
+	// And it is genuinely the same process, not a repainted picture of a dead one.
+	await runInTerminal(page, 'echo "AGAIN=$TR_SURVIVOR"');
+	await expect(visibleTerminalScreen(page)).toContainText("AGAIN=alive");
+});
+
+// The race the attach redesign exists for. Leaving and re-entering faster than one round trip used to find an
+// empty client-side registry — the old code took the tab's pty id OUT of it before asking the host whether that
+// shell was still alive — so the remount spawned a SECOND shell and the first was left running with nothing
+// pointing at it, for the life of the host. Reproduced by holding the response and re-entering inside it.
+test("rapid re-entry never spawns a second shell", async ({ page }) => {
+	const ptyIds = new Set<string>();
+	let delayAttachMs = 0;
+
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		const attachIds = new Set<string>();
+		ws.onMessage((message) => {
+			try {
+				const frame = JSON.parse(message.toString()) as { id?: string; method?: string };
+				if (frame.method === "terminal.attach" && frame.id) attachIds.add(frame.id);
+			} catch {
+				// Not a JSON request frame.
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => {
+			const text = message.toString();
+			let frame: { id?: string; channel?: string; data?: { id?: string } } = {};
+			try {
+				frame = JSON.parse(text) as typeof frame;
+			} catch {
+				// Relayed verbatim below.
+			}
+			if (frame.channel === "terminal.data" && frame.data?.id) ptyIds.add(frame.data.id);
+			if (frame.id && attachIds.has(frame.id) && delayAttachMs > 0) {
+				setTimeout(() => ws.send(text), delayAttachMs);
+				return;
+			}
+			ws.send(message);
+		});
+	});
+
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+	await runInTerminal(page, "TR_SURVIVOR=alive");
 	await runInTerminal(page, 'echo "CHECK=$TR_SURVIVOR"');
 	await expect(visibleTerminalScreen(page)).toContainText("CHECK=alive");
+
+	// Hold every attach answer long enough to leave and come back twice inside one round trip.
+	delayAttachMs = 3000;
+	for (let round = 0; round < 2; round++) {
+		await page.getByTestId("project-item").first().click();
+		await expect(page.getByTestId("terminal-panel")).toHaveCount(0);
+		await worktreeRows(page).nth(0).getByRole("button").first().click();
+		await expect(visibleTerminal(page)).toHaveCount(1);
+	}
+	delayAttachMs = 0;
+	await waitTerminalReady(page);
+
+	// Same shell throughout: its state is intact, and only ever one PTY produced output for this tab.
+	await runInTerminal(page, 'echo "AFTER=$TR_SURVIVOR"');
+	await expect(visibleTerminalScreen(page)).toContainText("AFTER=alive");
+	expect(ptyIds.size, "exactly one shell should ever have existed for this tab").toBe(1);
+});
+
+// Shells are keyed to the tab and owned by the host, not by the page — so a reload finds the ones still
+// running instead of starting new ones (and leaving the old set alive with nothing pointing at them).
+test("a shell survives a page reload", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+	await runInTerminal(page, "TR_RELOAD=survived");
+	await runInTerminal(page, 'echo "BEFORE=$TR_RELOAD"');
+	await expect(visibleTerminalScreen(page)).toContainText("BEFORE=survived");
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	// A reload keeps no client state, so the rail comes back collapsed with nothing selected.
+	await page.getByTestId("project-expand").first().click();
+	await worktreeRows(page).nth(0).click();
+	await waitTerminalReady(page);
+
+	// One tab, not a second one beside a now-invisible shell.
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
+	await runInTerminal(page, 'echo "AFTER=$TR_RELOAD"');
+	await expect(visibleTerminalScreen(page)).toContainText("AFTER=survived");
 });
 
 // Regression: the host used to publish every PTY's bytes to one `terminal.data` topic that *every* socket
@@ -142,10 +227,15 @@ test("a shell survives a trip to Project Home and back", async ({ page }) => {
 // to the one client that owns the PTY.
 test("a terminal's output never reaches another client", async ({ page, context }) => {
 	await openFixtureProject(page);
-	await createWorkspaceViaDialog(page);
+	await createWorkspaceViaDialog(page); // workspace 1 — A's
+	await createWorkspaceViaDialog(page); // workspace 2 — B's
+	await waitTerminalReady(page);
+	// Back to workspace 1, so A and B are looking at DIFFERENT terminals. Same-tab attach is a deliberate
+	// takeover now (shells are owner-scoped), so the addressing guarantee is about tabs nobody attached to.
+	await worktreeRows(page).nth(0).click();
 	await waitTerminalReady(page);
 
-	// A second tab on the same host, in the same workspace, with a terminal of its own.
+	// A second tab on the same host, in the other workspace, with a terminal of its own.
 	const page2 = await context.newPage();
 
 	// Record every frame B's socket RECEIVES. The assertion has to be about the wire, not the screen: the
@@ -160,7 +250,7 @@ test("a terminal's output never reaches another client", async ({ page, context 
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page2.getByTestId("project-expand").first().click();
-	await worktreeRows(page2).first().click();
+	await worktreeRows(page2).nth(1).click();
 	await waitTerminalReady(page2);
 
 	// Each prints a marker only its own terminal should ever show.
@@ -231,11 +321,9 @@ test("Ctrl+C still interrupts while an input method is active", async ({ page })
 	await expect(term).toContainText("TR_INTERRUPTED_42");
 });
 
-// The gap the detach registry opens: an instance hands its PTY to `detachedPtyByClientId` on an incidental
-// unmount, but `terminal.exit` is only listened for by a *mounted* instance. At Project Home none are mounted,
-// so a shell that dies while detached leaves a dead id in the registry — and the next mount adopts it, giving
-// back a tab that looks perfectly alive but whose keystrokes go nowhere. That is exactly the symptom the
-// exit event exists to prevent, so re-attaching has to confirm the shell is still there.
+// `terminal.exit` is only heard by a *mounted* instance, and at Project Home none are — so a shell that dies
+// while nobody is looking is a state the client can never be told about. `terminal.attach` closes that gap by
+// construction (a tab whose shell is gone gets a fresh one), which is why no liveness probe exists to go stale.
 test("a shell that dies while detached is not re-attached as if alive", async ({ page }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
@@ -304,10 +392,10 @@ test("a shell survives losing the connection and reconnecting", async ({ page })
 });
 
 // A response can die after the host committed a mutation. The client must replay that unresolved frame under
-// the same request id, and the host must return the cached result rather than running the handler twice. A
-// terminal create makes both failures observable: rejecting would leave the tab failed, while rerunning would
-// return a second PTY id and orphan the first shell.
-test("a terminal create response lost with its socket is replayed exactly once", async ({
+// the same request id, and the host must return the cached result rather than running the handler twice. An
+// attach makes both failures observable: rejecting would leave the tab failed, while rerunning would return a
+// second PTY id and orphan the first shell.
+test("a terminal attach response lost with its socket is replayed exactly once", async ({
 	page,
 }) => {
 	let createRequestId: string | undefined;
@@ -321,7 +409,7 @@ test("a terminal create response lost with its socket is replayed exactly once",
 			const text = message.toString();
 			try {
 				const frame = JSON.parse(text) as { id?: string; method?: string };
-				if (frame.method === "terminal.create" && frame.id) {
+				if (frame.method === "terminal.attach" && frame.id) {
 					createRequestId ??= frame.id;
 					createRequestIds.push(frame.id);
 				}
@@ -411,79 +499,72 @@ test("final shell output is delivered before exit after reconnect", async ({ pag
 	expect(outputIndex).toBeGreaterThanOrEqual(0);
 	expect(exitIndex).toBeGreaterThan(outputIndex);
 });
-
-// The ownership half of the isolation fix: not just "output goes only to the owner" but "another client cannot
-// write to, resize or kill a terminal it does not own". Nothing pinned that, so every ownership guard in
-// `terminalManager` was freely deletable. An id the caller does not own must behave exactly like one that never
-// existed — same answer, so probing ids reveals nothing about which exist.
-test("another client cannot drive a terminal it does not own", async ({ page, context }) => {
-	// Sniff A's own PTY id off its socket, so the probe below uses a REAL id rather than a made-up one (a
-	// made-up id would pass against no ownership checks at all).
-	const ptyIds: string[] = [];
-	page.on("websocket", (ws) => {
-		ws.on("framereceived", (frame) => {
-			try {
-				const msg = JSON.parse(frame.payload.toString()) as {
-					channel?: string;
-					data?: { id?: string };
-				};
-				if (msg.channel === "terminal.data" && msg.data?.id) ptyIds.push(msg.data.id);
-			} catch {
-				// Not a JSON push frame — irrelevant here.
-			}
-		});
-	});
-
+// Shells are owner-scoped, not page-scoped: a second browser reaches the SAME shells rather than starting a
+// parallel set that leaves the first invisible and unreachable. Attach is exclusive though — a PTY has one
+// size — so taking a tab over tells the displaced client instead of silently reflowing it.
+test("a second client takes a terminal over and the first is told", async ({ page, context }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
 	await waitTerminalReady(page);
-	await runInTerminal(page, "echo TR_OWNER_READY");
-	await expect(visibleTerminalScreen(page)).toContainText("TR_OWNER_READY");
+	await runInTerminal(page, "TR_SHARED=yes");
+	await runInTerminal(page, 'echo "FIRST=$TR_SHARED"');
+	await expect(visibleTerminalScreen(page)).toContainText("FIRST=yes");
 
-	const victimId = ptyIds[0];
-	expect(victimId, "should have observed A's PTY id on its own socket").toBeTruthy();
-
-	// A second client, with its own identity, tries to use A's terminal.
+	// A second browser page: its own client identity, the same host and the same workspace.
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page2.getByTestId("project-expand").first().click();
+	await worktreeRows(page2).nth(0).click();
+	await waitTerminalReady(page2);
 
-	const probe = await page2.evaluate(async (id) => {
-		const socket = new WebSocket(`ws://${location.host}/ws?client=probe-client`);
-		await new Promise((resolve) => socket.addEventListener("open", resolve, { once: true }));
-		const ask = (method: string, params: unknown) =>
-			new Promise<{ ok?: boolean; result?: unknown }>((resolve) => {
-				const frameId = `probe_${method}`;
-				const onMessage = (event: MessageEvent) => {
-					const frame = JSON.parse(String(event.data)) as { id?: string };
-					if (frame.id !== frameId) return;
-					socket.removeEventListener("message", onMessage);
-					resolve(frame as { ok?: boolean; result?: unknown });
-				};
-				socket.addEventListener("message", onMessage);
-				socket.send(JSON.stringify({ id: frameId, method, params }));
-			});
+	// It finds the running shell, not a fresh one — same tab, same process state.
+	await expect(page2.getByTestId("terminal-tab")).toHaveCount(1);
+	await runInTerminal(page2, 'echo "SECOND=$TR_SHARED"');
+	await expect(visibleTerminalScreen(page2)).toContainText("SECOND=yes");
 
-		const alive = await ask("terminal.alive", { id });
-		// Try to inject a command into someone else's shell, and to resize and kill it.
-		const write = await ask("terminal.write", { id, data: "echo TR_INJECTED_BY_B\r" });
-		const resize = await ask("terminal.resize", { id, cols: 5, rows: 2 });
-		const close = await ask("terminal.close", { id });
-		socket.close();
-		return { alive, write, resize, close };
-	}, victimId);
+	// And the first page says so rather than sitting there looking live while its output goes elsewhere.
+	await expect(visibleTerminal(page)).toHaveAttribute("data-detached", "true");
 
-	// The host answers as if the id simply does not exist — no error that would confirm it does.
-	expect(probe.alive.ok).toBe(true);
-	expect((probe.alive.result as { alive: boolean }).alive).toBe(false);
-	expect(probe.write.ok).toBe(true);
-	expect(probe.resize.ok).toBe(true);
-	expect(probe.close.ok).toBe(true);
-
-	// And none of it touched A: no injected command ran, and the shell is alive and correctly sized.
-	await expect(visibleTerminalScreen(page)).not.toContainText("TR_INJECTED_BY_B");
-	await runInTerminal(page, "echo TR_STILL_MINE_$((3 * 3))");
-	await expect(visibleTerminalScreen(page)).toContainText("TR_STILL_MINE_9");
+	// Taking it back reverses the handover.
+	await page.getByTestId("terminal-take-back").click();
+	await waitTerminalReady(page);
+	await runInTerminal(page, 'echo "BACK=$TR_SHARED"');
+	await expect(visibleTerminalScreen(page)).toContainText("BACK=yes");
 
 	await page2.close();
+});
+
+// Closing a tab is now the only client-driven way to kill a shell, and shells outlive reloads — so the host
+// refuses while something is running and the UI confirms first. The check and the kill are one synchronous
+// host pass, so nothing started in between can die unannounced.
+test("closing a tab with a running process asks first", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+
+	await runInTerminal(page, "sleep 45");
+	// Give the shell time to fork the job before we ask to close it.
+	await page.waitForTimeout(1500);
+
+	await page.getByTestId("terminal-tab-close").first().click();
+	// Refused, and still there.
+	await expect(page.getByTestId("confirm-dialog")).toBeVisible();
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
+
+	await page.getByTestId("terminal-close-busy-confirm").click();
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(0);
+});
+
+// An idle prompt has nothing to lose, so it must not train people to click through the dialog above.
+test("closing an idle tab does not ask", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+	await openTerminal(page);
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(2);
+
+	await page.getByTestId("terminal-tab-close").nth(1).click();
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
+	await expect(page.getByTestId("confirm-dialog")).toHaveCount(0);
 });

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -568,3 +568,33 @@ test("closing an idle tab does not ask", async ({ page }) => {
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
 	await expect(page.getByTestId("confirm-dialog")).toHaveCount(0);
 });
+
+// Which terminals exist is shared state: the host owns the tab list, so a change in one browser has to reach
+// the others. Without the broadcast, a tab closed in B left A with a dead instance mounted and still taking
+// keystrokes, and a tab B opened stayed invisible to A until some later remount happened to re-read the list.
+test("a tab opened or closed in one browser reaches the other", async ({ page, context }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
+
+	const page2 = await context.newPage();
+	await page2.goto("/");
+	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page2.getByTestId("project-expand").first().click();
+	await worktreeRows(page2).nth(0).click();
+	await waitTerminalReady(page2);
+	await expect(page2.getByTestId("terminal-tab")).toHaveCount(1);
+
+	// B opens a second terminal — A must see it without touching anything.
+	await page2.getByTestId("terminal-add").click();
+	await expect(page2.getByTestId("terminal-tab")).toHaveCount(2);
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(2);
+
+	// B closes it again — A converges back rather than keeping a tab whose shell is gone.
+	await page2.getByTestId("terminal-tab-close").nth(1).click();
+	await expect(page2.getByTestId("terminal-tab")).toHaveCount(1);
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
+
+	await page2.close();
+});

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -591,6 +591,15 @@ test("a tab opened or closed in one browser reaches the other", async ({ page, c
 	await expect(page2.getByTestId("terminal-tab")).toHaveCount(2);
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(2);
 
+	// ...and seeing it must not mean CLAIMING it. Only the tab a client is actually looking at is attached, so
+	// A's row for B's new terminal is just a row. Rendering an instance per shared tab would have A's hidden
+	// one attach and snatch the terminal out from under the person who just opened it.
+	// (A being detached on the *first* terminal is separate and correct: B entered the workspace looking at it,
+	// which is what exclusive attach means.)
+	await expect(visibleTerminal(page2)).toHaveAttribute("data-detached", "false");
+	await runInTerminal(page2, "echo TR_STILL_B");
+	await expect(visibleTerminalScreen(page2)).toContainText("TR_STILL_B");
+
 	// B closes it again — A converges back rather than keeping a tab whose shell is gone.
 	await page2.getByTestId("terminal-tab-close").nth(1).click();
 	await expect(page2.getByTestId("terminal-tab")).toHaveCount(1);

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -598,3 +598,60 @@ test("a tab opened or closed in one browser reaches the other", async ({ page, c
 
 	await page2.close();
 });
+
+// The prebind buffer is single-use, so reclaiming a tab has to start a fresh one: otherwise anything that
+// arrives before the reclaim's response is dropped by both the inert buffer and the id that detaching cleared.
+// A shell dying in that window is the case that matters — the pane would go ready over a dead PTY and accept
+// keystrokes forever.
+test("a shell that dies during a reclaim is not presented as alive", async ({ page, context }) => {
+	let delayAttachMs = 0;
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		const attachIds = new Set<string>();
+		ws.onMessage((message) => {
+			try {
+				const frame = JSON.parse(message.toString()) as { id?: string; method?: string };
+				if (frame.method === "terminal.attach" && frame.id) attachIds.add(frame.id);
+			} catch {
+				// Not a JSON request frame.
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => {
+			const text = message.toString();
+			let frame: { id?: string } = {};
+			try {
+				frame = JSON.parse(text) as typeof frame;
+			} catch {
+				// Relayed verbatim below.
+			}
+			if (frame.id && attachIds.has(frame.id) && delayAttachMs > 0) {
+				setTimeout(() => ws.send(text), delayAttachMs);
+				return;
+			}
+			ws.send(message);
+		});
+	});
+
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+
+	// B takes the tab over, then arms the shell to die — only the attached client may drive it.
+	const page2 = await context.newPage();
+	await page2.goto("/");
+	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page2.getByTestId("project-expand").first().click();
+	await worktreeRows(page2).nth(0).click();
+	await waitTerminalReady(page2);
+	await expect(visibleTerminal(page)).toHaveAttribute("data-detached", "true");
+	await runInTerminal(page2, "(sleep 5; kill -9 $$) &");
+
+	// A reclaims, but its answer is held long enough for the shell to die first — so the exit reaches A before
+	// the attach response it belongs to.
+	delayAttachMs = 9000;
+	await page.getByTestId("terminal-take-back").click();
+	await expect(visibleTerminal(page)).toHaveAttribute("data-exited", "true", { timeout: 20_000 });
+
+	await page2.close();
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -174,7 +174,10 @@ of the host.
   never eagerly for every project) / `workspace.*` / `fs.*` / `git.*` / **`spec.graph`**
   (the Specs-viewer whole-graph read, per workspace) / **`todo.*`** — **`list`**/**`add`**/**`update`**/
   **`remove`**, the chat's per-session TODO plan (keyed by `workspaceId` + `sessionId`; `add` tags the
-  item `origin:"user"`) / `terminal.*` / `model.list` + **`model.refresh`** (awaits the host's
+  item `origin:"user"`) / **`terminal.*`** — **`attach`** (idempotent get-or-create keyed by
+  `(workspaceId, tabKey)`, returning `created` + the `replay` to repaint; the only way a PTY is born, and it
+  replaced `create`+`alive`) / **`list`** (the host owns the tab list) / `write` / `resize` /
+  **`close`** (by `tabKey`, refusing a busy shell unless `force`) / `model.list` + **`model.refresh`** (awaits the host's
   single-flighted catalog refresh and returns **`RefreshedModels`** — the post-refresh list plus
   **`complete`**, whether that pass settled inside the host's capped wait, since only a settled list is
   authoritative; `force` bypasses pi's 4h freshness throttle, so a user-initiated refresh actually fetches) / **`model.clampThinking`** (pi's
@@ -228,9 +231,10 @@ of the host.
   **`settings.changed`** (the full `AppConfig`, broadcast so every client
   converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`
   per frame, keyed by `loginId`; the sibling of `pi.extensionUi`, since a login runs on the Welcome screen
-  before any session exists) / `terminal.data` + **`terminal.exit`** (the only **addressed** channels — sent to
-  the single client that owns the PTY rather than broadcast, so a shell's bytes never reach another browser;
-  `terminal.data` may carry `truncated` when the host had to drop held output) / the **workspace lifecycle
+  before any session exists) / `terminal.data` + **`terminal.exit`** + **`terminal.detached`** (the only
+  **addressed** channels — sent to the single *attached* client rather than broadcast, so a shell's bytes never
+  reach another browser; `terminal.data` may carry `truncated` when the host had to drop held output,
+  `terminal.detached` says another client took the tab over) / the **workspace lifecycle
   trio** — **`workspace.created`**
   / **`workspace.updated`** / **`workspace.removed`** — registry membership changes fanned out to every
   client so it stays shared domain state (architecture #9), all emitted by the server's `workspaces`

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -422,10 +422,25 @@ export interface AppConfig {
 	 * `installation.json`, deliberately not in this broadcast bag).
 	 */
 	analyticsEnabled: boolean;
+	/**
+	 * How much of each terminal's recent output the host keeps to repaint a reattaching client, in KiB.
+	 *
+	 * A remount builds a fresh xterm buffer, so this is what stands between a surviving shell and a blank pane.
+	 * Costs memory per live terminal and disk in `terminals.json`, so it is bounded and adjustable rather than
+	 * generous by fiat. `0` disables replay entirely.
+	 */
+	terminalReplayKb: number;
 }
 
+/** Bounds for `AppConfig.terminalReplayKb`, enforced host-side so a hand-edited config cannot exhaust memory. */
+export const TERMINAL_REPLAY_KB = { min: 0, max: 1024, default: 64 } as const;
+
 /** The config a fresh host (no `config.json` yet) falls back to. */
-export const DEFAULT_CONFIG: AppConfig = { theme: "dark", analyticsEnabled: true };
+export const DEFAULT_CONFIG: AppConfig = {
+	theme: "dark",
+	analyticsEnabled: true,
+	terminalReplayKb: TERMINAL_REPLAY_KB.default,
+};
 
 /**
  * Prefix on the internal "wake the agent" nudge the client sends when a TODO is added. It is control

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,6 +10,7 @@ export {
 	isControlMessage,
 	MAX_HISTORY_LIMIT,
 	MAX_HISTORY_QUERY_LENGTH,
+	TERMINAL_REPLAY_KB,
 	TODO_NUDGE_PREFIX,
 } from "./domain";
 export type * from "./piProtocol";

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -62,6 +62,31 @@ export interface TerminalExitPush {
 	exitCode: number;
 }
 
+/**
+ * Another client took this tab over, so we are no longer the one receiving its output.
+ *
+ * Addressed by `tabKey` rather than PTY id because the displaced client may never have learned the id — and
+ * `tabKey` is what its tab is keyed on regardless.
+ */
+export interface TerminalDetachedPush {
+	workspaceId: string;
+	tabKey: string;
+}
+
+/**
+ * One terminal tab, as the host reports it. The tab list is host state — the rail renders this rather than
+ * keeping a list of its own, so the two can never disagree about which shells exist.
+ *
+ * Deliberately carries no "is something running" flag. That question is only ever asked to decide whether
+ * closing needs confirmation, and any answer cached from list time is exactly wrong by then: start a dev server
+ * after the rail loaded and a stale `busy: false` would wave the close through silently. `terminal.close`
+ * answers it atomically instead.
+ */
+export interface TerminalTabInfo {
+	tabKey: string;
+	title: string;
+}
+
 /** Bumped on any breaking wire change; sent in `server.welcome` so a stale UI can detect host drift. */
 // v4: model.* / session.create / session.setModel / SessionSummary now carry `WireModel` (pi's `Model`
 // minus the secret-bearing `baseUrl`/`headers`); the host re-resolves the real model by `{provider,id}`.
@@ -138,7 +163,14 @@ export interface TerminalExitPush {
 // the host free the retained copy — an *un*acknowledged one may have died with its socket and stays replayable.
 // The version prevents a replaying UI from connecting to a pre-dedup host and executing a mutation twice after
 // a lost response.
-export const PROTOCOL_VERSION = 27;
+// v28: a terminal is identified by `(workspaceId, tabKey)` — a pair the client can always re-derive — and the
+// HOST owns the tab list. `terminal.attach` is idempotent get-or-create and replaces `terminal.create` +
+// `terminal.alive` (both gone): one call answers "give me this tab's shell", so there is no window in which a
+// client holds the only pointer to a running shell. Shells are owner-scoped rather than per-page, so they now
+// survive a reload, a closed browser and a different browser; attach is exclusive, and taking one over tells
+// the previous client via `terminal.detached`. Attach also returns the recorded output to repaint (`replay`),
+// which is what a revived tab shows after a host restart.
+export const PROTOCOL_VERSION = 28;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -229,11 +261,11 @@ export const WS_METHODS = {
 	// The workspace branch's own commits (`<diff base>..HEAD`, newest first) — the scope menu's commit list,
 	// fetched lazily when that menu first opens.
 	gitListCommits: "git.listCommits",
-	terminalCreate: "terminal.create",
+	terminalAttach: "terminal.attach",
+	terminalList: "terminal.list",
 	terminalWrite: "terminal.write",
 	terminalResize: "terminal.resize",
 	terminalClose: "terminal.close",
-	terminalAlive: "terminal.alive",
 	dialogSelectDirectory: "dialog.selectDirectory",
 	// Skill-only command preview for New Workspace, before a worktree/session exists.
 	skillList: "skill.list",
@@ -310,13 +342,20 @@ export const WS_CHANNELS = {
 	// In-app login flow updates (a `LoginPush` per frame), keyed by loginId. Session-less — a login runs on
 	// the Welcome screen before any session exists, so this is the sibling of pi.extensionUi, not scoped to one.
 	providerLogin: "provider.login",
-	// Both terminal channels are addressed to the ONE client that owns the PTY, not broadcast: a shell's bytes
-	// are that client's alone (tokens, keys, private paths), and a second browser filtering them out
-	// client-side is not isolation. Ownership is keyed to a client id that survives reconnects — see
-	// `terminalManager.closeClientTerminals`.
+	// Every terminal channel is addressed to the ONE client currently attached to that PTY, never broadcast: a
+	// shell's bytes are tokens, keys and private paths, and a second browser filtering them out client-side is
+	// not isolation. Which client that is can change (attach is exclusive with takeover) — what never happens
+	// is a frame going to a socket that did not attach.
 	terminalData: "terminal.data",
 	/** `{ id, exitCode }` — the shell behind a terminal exited, so its tab is now dead and must say so. */
 	terminalExit: "terminal.exit",
+	/**
+	 * `{ workspaceId, tabKey }` — another client attached to this tab, so this one is no longer the recipient.
+	 * A PTY has one size, so only one client can have its layout honoured; rather than silently reflowing
+	 * whoever else is looking (tmux's smallest-client rule, its most complained-about behaviour), the displaced
+	 * client is told and offers to take the tab back.
+	 */
+	terminalDetached: "terminal.detached",
 	// The workspace-registry lifecycle trio, broadcast to every client so registry membership is shared
 	// domain state (architecture #9), not per-client. All three are emitted by the `workspaces` module's
 	// injected publisher (host maps kind → channel); every client reacts identically (no per-client
@@ -492,20 +531,46 @@ export interface WsMethodMap {
 	// Commits on the workspace's branch that its diff base doesn't have (`git log <base>..HEAD`), newest
 	// first and capped host-side — the scope menu's commit rows.
 	"git.listCommits": { params: { workspaceId: string }; result: { commits: GitCommit[] } };
-	// `cols`/`rows` are the client's already-measured grid. Optional so an older client still works, but
-	// sending them matters: a PTY spawned at a default 80×24 renders its first prompt at the wrong size and
-	// then reflows when the real size arrives, which can visibly garble it.
-	"terminal.create": {
-		params: { workspaceId: string; cols?: number; rows?: number };
-		result: { id: string };
+	/**
+	 * Give me this tab's shell — idempotent get-or-create, and the only way a PTY is ever born.
+	 *
+	 * Calling it twice for the same `(workspaceId, tabKey)` returns the same shell, so a client never has to
+	 * remember an id, ask whether one is still alive, or decide whether to make another. That is the whole
+	 * point: the previous protocol made the client hold the only pointer to a running shell between a "does
+	 * this still exist?" question and its answer, and losing it there orphaned the shell for the life of the
+	 * host. `created` distinguishes a fresh shell from an adopted one — a one-shot `initialCommand` may only
+	 * run on the former.
+	 *
+	 * `cols`/`rows` are the client's already-measured grid; a PTY spawned at a default 80×24 renders its first
+	 * prompt at the wrong size and then reflows, which can visibly garble it. `replay` is the shell's recorded
+	 * recent output, to repaint before live frames resume — a remount is a fresh xterm buffer, so without it a
+	 * surviving shell comes back behind a blank screen. After a host restart it is what a revived tab shows.
+	 */
+	"terminal.attach": {
+		params: { workspaceId: string; tabKey: string; title?: string; cols?: number; rows?: number };
+		result: { id: string; created: boolean; replay?: string };
+	};
+	/** This workspace's tab list, host-owned: the rail renders it rather than remembering one of its own. */
+	"terminal.list": {
+		params: { workspaceId: string };
+		result: { tabs: TerminalTabInfo[] };
 	};
 	"terminal.write": { params: { id: string; data: string }; result: Ack };
 	"terminal.resize": { params: { id: string; cols: number; rows: number }; result: Ack };
-	"terminal.close": { params: { id: string }; result: Ack };
-	// Is this id still a live PTY the caller owns? A tab re-attaching to a shell it detached earlier has to
-	// ask, because `terminal.exit` is only heard by a MOUNTED terminal and a detach happens exactly when none
-	// is mounted — so the shell may have died unobserved.
-	"terminal.alive": { params: { id: string }; result: { alive: boolean } };
+	/**
+	 * Close a tab and kill its shell — the one client-driven kill, and an explicit user gesture by definition.
+	 * Keyed by `tabKey`, not by PTY id: the tab is what the user closed, and the shell behind it may since have
+	 * been replaced. Unmounting a view never routes here.
+	 *
+	 * Refuses and reports `busy` when the shell has child processes, unless `force` says the user confirmed.
+	 * The check and the kill happen in the same synchronous handler, so nothing can start between them — which
+	 * is why this is one call rather than a "is it busy?" question the client answers separately and stalely.
+	 * `closed: false, busy: false` means there was no such tab.
+	 */
+	"terminal.close": {
+		params: { workspaceId: string; tabKey: string; force?: boolean };
+		result: { closed: boolean; busy: boolean };
+	};
 	"dialog.selectDirectory": { params: Record<string, never>; result: { path: string | null } };
 	// Preview from the selected project's current checkout; the eventual worktree session is authoritative.
 	"skill.list": { params: { projectId: string }; result: SlashCommandInfo[] };

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -87,6 +87,15 @@ export interface TerminalTabInfo {
 	title: string;
 }
 
+/**
+ * The host's tab list for one workspace — an idempotent snapshot, never a delta, so folding it twice is
+ * harmless and a late subscriber can be caught up with the newest one.
+ */
+export interface TerminalTabsPush {
+	workspaceId: string;
+	tabs: TerminalTabInfo[];
+}
+
 /** Bumped on any breaking wire change; sent in `server.welcome` so a stale UI can detect host drift. */
 // v4: model.* / session.create / session.setModel / SessionSummary now carry `WireModel` (pi's `Model`
 // minus the secret-bearing `baseUrl`/`headers`); the host re-resolves the real model by `{provider,id}`.
@@ -356,6 +365,15 @@ export const WS_CHANNELS = {
 	 * client is told and offers to take the tab back.
 	 */
 	terminalDetached: "terminal.detached",
+	/**
+	 * `{ workspaceId, tabs }` — the host's tab list for a workspace changed (a tab was opened or closed).
+	 *
+	 * BROADCAST, unlike the three channels above: which terminals exist is shared domain state (architecture
+	 * #9), the same as the workspace lifecycle trio, so every client converges. Only the *contents* of a shell
+	 * are addressed to one client. Without this, a tab closed in one browser leaves another with a dead
+	 * instance mounted and accepting input.
+	 */
+	terminalTabs: "terminal.tabs",
 	// The workspace-registry lifecycle trio, broadcast to every client so registry membership is shared
 	// domain state (architecture #9), not per-client. All three are emitted by the `workspaces` module's
 	// injected publisher (host maps kind → channel); every client reacts identically (no per-client

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -20,8 +20,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `resolveWorktreeFile` — path-contained; bad id/escape/miss → 404; Bun infers the content-type) so the
   markdown viewer's relative `<img>`s resolve, static serving with
   `index.html` fallback, the `server.welcome` push, the **`?client=` page identity** read off the socket URL at
-  upgrade (threaded to every handler as `RequestContext` and used to own that client's PTYs) plus the
-  `clientKey → socket` registry and the **abandoned-client reap timer** that outlives a reconnect; the
+  upgrade (threaded to every handler as `RequestContext`; it addresses terminal output but no longer *owns*
+  PTYs — see [[submodule-server-terminal]]) plus the `clientKey → socket` registry and the **replay-namespace
+  retention timer** that outlives a reconnect (terminals are deliberately untouched by it); the
   **request replay cache** keyed by `(clientKey, requestId)` (the first frame
   owns one handler promise + its
   serialized response, a reconnect replay awaits/returns that same result, a mismatched duplicate is rejected,
@@ -79,7 +80,8 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `provider.loginCancel` clears; an unknown loginId tracks nothing, fails closed) — +
   `provider.jbcentralConnect`→connected (central) — per `submodule-server-analytics`,
   feature modules never track), and
-  `stop()` → agent-session + terminal cleanup then socket close); `boot.ts` (`bootHost` → resolve the
+  `stop()` → agent-session cleanup, then `persistTerminalSessions()` **before** `closeAllTerminals()`, then
+  socket close); `boot.ts` (`bootHost` → resolve the
   login-shell PATH, pick the port per `portMode` (`"exact"` vs `"free"`), start `createServer`, and
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort
   streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
@@ -173,9 +175,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
   (`workspace.created`/`updated`/`removed`, published from the `workspaces` module's injected publisher)
   use push channels. Every **broadcast** push channel a client should hear must be `ws.subscribe`d in the WS
   `open` handler — a publish on an unsubscribed topic reaches nobody, silently. Two channels are deliberately
-  **not** subscribed and not broadcast: `terminal.data` and `terminal.exit` are sent to the single owning client
-  with `ws.send`, because a PTY's bytes belong to one client (see [[submodule-server-terminal]]). Adding a
-  terminal-style addressed channel means wiring a publisher, not a subscription.
+  **not** subscribed and not broadcast: `terminal.data`, `terminal.exit` and `terminal.detached` are sent with
+  `ws.send` to the single *attached* client (see [[submodule-server-terminal]]). Adding a terminal-style
+  addressed channel means wiring a publisher, not a subscription.
 - The host is the single place features are wired together — features never reach back into it.
 - **A send (prompt/steer/followUp/answerQuestion) is acked when ACCEPTED, not when the turn ends**
   (`ackSend`): pi's send methods resolve only at turn end, and a turn can outlive the client's request

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -109,13 +109,11 @@ import { dropLogin, recordLoginStart } from "./loginAnalytics";
 /**
  * Who a request came from. Threaded to every handler so one can scope a resource to its caller; most ignore
  * it, since almost everything the host owns is shared domain state that every client sees identically
- * (architecture #9). Terminals are the exception — a PTY belongs to one client.
+ * (architecture #9). Terminals use it for *attachment*, not ownership — a shell belongs to its tab, but only
+ * the client currently attached may receive its output or drive it.
  */
 export interface RequestContext {
-	/**
-	 * The calling client's id (`?client=` on its socket URL). Stable across that client's reconnects and new
-	 * on every reload, which is what lets a PTY outlive a dropped connection without outliving the page.
-	 */
+	/** The calling client's id (`?client=` on its socket URL), stable across that client's reconnects. */
 	clientKey: string;
 }
 
@@ -291,14 +289,17 @@ const handlers: Record<string, Handler> = {
 	"terminal.list": (params) => ({
 		tabs: listTerminals((params as { workspaceId: string }).workspaceId),
 	}),
-	"terminal.write": (params) => {
+	// Both carry the caller: only the client currently ATTACHED to a terminal may drive it. A displaced client
+	// can still hold a valid PTY id, and a reconnect replays its queued frames — without this its keystrokes
+	// would land in whoever took the tab over.
+	"terminal.write": (params, ctx) => {
 		const p = params as { id: string; data: string };
-		writeTerminal(p.id, p.data);
+		writeTerminal(p.id, p.data, ctx.clientKey);
 		return { ok: true } as const;
 	},
-	"terminal.resize": (params) => {
+	"terminal.resize": (params, ctx) => {
 		const p = params as { id: string; cols: number; rows: number };
-		resizeTerminal(p.id, p.cols, p.rows);
+		resizeTerminal(p.id, p.cols, p.rows, ctx.clientKey);
 		return { ok: true } as const;
 	},
 	"terminal.close": (params) => {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -78,10 +78,10 @@ import {
 	templateDirs,
 } from "../templates";
 import {
-	closeTerminal,
+	attachTerminal,
+	closeTerminalTab,
 	closeWorkspaceTerminals,
-	createTerminal,
-	isTerminalAlive,
+	listTerminals,
 	resizeTerminal,
 	writeTerminal,
 } from "../terminal";
@@ -273,29 +273,38 @@ const handlers: Record<string, Handler> = {
 	// Every terminal op is scoped to `ctx.clientKey`: a PTY belongs to the client that created it, so another
 	// connection can neither read its output nor write to or kill it. An id the caller doesn't own is treated
 	// exactly like one that doesn't exist.
-	"terminal.create": (params, ctx) => {
+	// SYNCHRONOUS ON PURPOSE — see `attachTerminal`. Lookup and insert in one tick is what makes attach atomic
+	// on Bun's single event loop, so two concurrent attaches for the same tab cannot both spawn a shell. An
+	// `await` anywhere in this path silently reintroduces double-spawn.
+	"terminal.attach": (params, ctx) => {
 		// Forwarded whole rather than rebuilt: under `exactOptionalPropertyTypes`, an absent `cols` and an
 		// explicit `cols: undefined` are different types, and only the former means "use the default".
-		const p = params as { workspaceId: string; cols?: number; rows?: number };
-		return createTerminal(p.workspaceId, ctx.clientKey, p);
+		const p = params as {
+			workspaceId: string;
+			tabKey: string;
+			title?: string;
+			cols?: number;
+			rows?: number;
+		};
+		return attachTerminal(p.workspaceId, p.tabKey, ctx.clientKey, p);
 	},
-	"terminal.write": (params, ctx) => {
-		const p = params as { id: string; data: string };
-		writeTerminal(p.id, p.data, ctx.clientKey);
-		return { ok: true } as const;
-	},
-	"terminal.resize": (params, ctx) => {
-		const p = params as { id: string; cols: number; rows: number };
-		resizeTerminal(p.id, p.cols, p.rows, ctx.clientKey);
-		return { ok: true } as const;
-	},
-	"terminal.close": (params, ctx) => {
-		closeTerminal((params as { id: string }).id, ctx.clientKey);
-		return { ok: true } as const;
-	},
-	"terminal.alive": (params, ctx) => ({
-		alive: isTerminalAlive((params as { id: string }).id, ctx.clientKey),
+	"terminal.list": (params) => ({
+		tabs: listTerminals((params as { workspaceId: string }).workspaceId),
 	}),
+	"terminal.write": (params) => {
+		const p = params as { id: string; data: string };
+		writeTerminal(p.id, p.data);
+		return { ok: true } as const;
+	},
+	"terminal.resize": (params) => {
+		const p = params as { id: string; cols: number; rows: number };
+		resizeTerminal(p.id, p.cols, p.rows);
+		return { ok: true } as const;
+	},
+	"terminal.close": (params) => {
+		const p = params as { workspaceId: string; tabKey: string; force?: boolean };
+		return closeTerminalTab(p.workspaceId, p.tabKey, p.force ?? false);
+	},
 	"skill.list": (params) => {
 		const { projectId } = params as { projectId: string };
 		const project = listProjects().find((candidate) => candidate.id === projectId);

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -28,8 +28,9 @@ import {
 import { getConfig, setSettingsPublisher } from "../settings";
 import {
 	closeAllTerminals,
-	closeClientTerminals,
+	persistTerminalSessions,
 	resumeClientTerminals,
+	reviveTerminalSessions,
 	setTerminalPublisher,
 } from "../terminal";
 import { setRepoMetaPublisher, setWatchPublisher, stopAllWatches } from "../watch";
@@ -78,15 +79,18 @@ interface SocketData {
 }
 
 /**
- * How long a vanished client's PTYs are kept before being killed.
+ * How long a vanished client's retained request results are kept before its namespace is retired.
  *
- * The client reconnects on its own with backoff, so a dropped socket usually means a hiccup, not a departure —
- * and a shell can be holding real work (a dev server, a watch build). Waiting is therefore the safe default and
- * killing is the exception: this only has to be longer than a realistic reconnect, not short. A genuinely gone
- * client (closed tab, closed laptop, reload — a reload arrives under a *new* client id) then loses its shells
- * one window later instead of leaving them running until the host restarts.
+ * This no longer touches terminals. Shells are owner-scoped and reference-counted by the host-owned tab list
+ * (see `submodule-server-terminal`): a shell dies when its tab is closed, its workspace is archived, it exits,
+ * or the host stops — never because a browser went away. Killing on client disappearance was what made a
+ * reload destroy your work, and reference-based GC makes it redundant besides.
+ *
+ * What still needs retiring is the exactly-once replay cache, which is per client and would otherwise retain a
+ * page's responses forever. The client reconnects on its own with backoff, so this only has to outlast a
+ * realistic reconnect.
  */
-const ABANDONED_CLIENT_GRACE_MS = 60_000;
+const CLIENT_REPLAY_RETENTION_MS = 60_000;
 
 /** Ids arrive from the wire, so an `ack`/`resume` list is filtered rather than trusted to hold strings. */
 const isRequestId = (id: unknown): id is string => typeof id === "string";
@@ -104,7 +108,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 
 	/** The live socket per client id. One entry per connected page; a reconnect replaces its own entry. */
 	const sockets = new Map<string, Bun.ServerWebSocket<SocketData>>();
-	/** Pending "this client looks gone, reap its resources" timers, cancelled if it reconnects in time. */
+	/** Pending "this client looks gone, retire its replay namespace" timers, cancelled if it reconnects. */
 	const reapTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	/** Exactly-once handler results for unresolved requests replayed by a reconnecting page. */
 	const requestReplays = new RequestReplayCache<string>();
@@ -118,13 +122,12 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	let stopping = false;
 
 	/**
-	 * Arm the grace window after which a client with no socket counts as gone, and its host resources are freed.
+	 * Arm the window after which a client with no socket counts as gone and its replay namespace is retired.
 	 *
 	 * Re-arms itself while `clearClient` declines — a request still in flight means the page can come back and
 	 * replay exactly that id, and forgetting the entry would run its handler a second time (see
-	 * `requestReplayCache`). The shells are gone either way on the first pass; `closeClientTerminals` is
-	 * idempotent, so a retry only retries the retirement. It ends when that last handler settles, on a
-	 * reconnect (`open` cancels the timer and the namespace stands), or at `stop()`, which clears them all.
+	 * `requestReplayCache`). It ends when that last handler settles, on a reconnect (`open` cancels the timer
+	 * and the namespace stands), or at `stop()`, which clears them all.
 	 */
 	const armClientReap = (clientKey: string): void => {
 		reapTimers.set(
@@ -132,9 +135,8 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 			setTimeout(() => {
 				reapTimers.delete(clientKey);
 				if (sockets.has(clientKey)) return;
-				closeClientTerminals(clientKey);
 				if (!requestReplays.clearClient(clientKey)) armClientReap(clientKey);
-			}, ABANDONED_CLIENT_GRACE_MS),
+			}, CLIENT_REPLAY_RETENTION_MS),
 		);
 	};
 
@@ -295,7 +297,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				resumeClientTerminals(ws.data.clientKey);
 			},
 			close(ws) {
-				if (stopping) return; // shutting down: closeAllTerminals covers every PTY, no reaping needed
+				if (stopping) return; // shutting down: stop() clears every namespace, no retiring needed
 				const { clientKey } = ws.data;
 				// Only forget the socket if it is still the current one: a fast reconnect can register the new
 				// socket before the old one's close fires, and clearing then would orphan a live connection.
@@ -303,9 +305,9 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 					sockets.delete(clientKey);
 					terminalBackpressured.delete(clientKey);
 				}
+				// Terminals are deliberately untouched. A shell belongs to its tab, not to whoever was looking at
+				// it, so a closed browser leaves every shell running — that is what makes a reload non-destructive.
 				if (sockets.has(clientKey) || reapTimers.has(clientKey)) return;
-				// Don't kill this client's shells yet — it reconnects on its own, and a hiccup must not cost the
-				// user a running dev server. Only if nothing comes back within the grace window is it gone.
 				armClientReap(clientKey);
 			},
 		},
@@ -468,6 +470,10 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		enabled: getConfig().analyticsEnabled,
 	});
 
+	// Give back the terminal tabs the last run ended with. The shells themselves are gone — a host restart hangs
+	// up every PTY — so each tab gets a fresh one on first attach, showing its predecessor's recorded output.
+	reviveTerminalSessions();
+
 	// Open a project on boot if the launcher passed one (e.g. `thinkrail /path/to/repo`). Best-effort:
 	// a non-repo / missing dir is a warning, not a boot failure — the UI's Open-Project flow still works.
 	if (projectPath) {
@@ -501,6 +507,9 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 			sockets.clear();
 			terminalBackpressured.clear();
 			requestReplays.clear();
+			// Write the tabs and their recorded output down BEFORE killing the shells — this is the only moment
+			// the picture still exists, and a restart restores tabs from it (see `persistTerminalSessions`).
+			persistTerminalSessions();
 			closeAllTerminals();
 			server.stop(true);
 		},

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -1,6 +1,10 @@
 import { createHash, randomUUID } from "node:crypto";
 import { join, normalize } from "node:path";
-import type { ServerWelcome, WorkspaceFsChangedPayload } from "@thinkrail/contracts";
+import type {
+	ServerWelcome,
+	TerminalTabsPush,
+	WorkspaceFsChangedPayload,
+} from "@thinkrail/contracts";
 import { PROTOCOL_VERSION, WS_CHANNELS } from "@thinkrail/contracts";
 import { errorCodeOf } from "@thinkrail/shared/codedError";
 import {
@@ -32,6 +36,7 @@ import {
 	resumeClientTerminals,
 	reviveTerminalSessions,
 	setTerminalPublisher,
+	setTerminalTabsPublisher,
 } from "../terminal";
 import { setRepoMetaPublisher, setWatchPublisher, stopAllWatches } from "../watch";
 import { getWorkspace, refreshUserOwnedWorkspace, setWorkspacePublisher } from "../workspaces";
@@ -187,6 +192,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				ws.subscribe(WS_CHANNELS.piExtensionUi);
 				ws.subscribe(WS_CHANNELS.providerLogin);
 				ws.subscribe(WS_CHANNELS.projectUpdated);
+				ws.subscribe(WS_CHANNELS.terminalTabs);
 				ws.subscribe(WS_CHANNELS.workspaceCreated);
 				ws.subscribe(WS_CHANNELS.workspaceUpdated);
 				ws.subscribe(WS_CHANNELS.workspaceRemoved);
@@ -364,6 +370,17 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	// full record snapshot (idempotent under the store's fold-by-id, so the auto-rename's naive-then-agentic
 	// pair is two updates, last wins); `removed` sends the `{ projectId, id }` pair. Every client — including
 	// the initiator — converges by reacting to these, never a per-client optimistic mutation.
+	// Which terminals exist is shared domain state, so tab-list changes are BROADCAST (the workspace-trio
+	// pattern) even though a shell's contents are addressed to the one attached client. An idempotent snapshot
+	// per workspace: folding it twice is harmless, and a client that missed one converges on the next.
+	setTerminalTabsPublisher((workspaceId, tabs) => {
+		const data: TerminalTabsPush = { workspaceId, tabs };
+		server.publish(
+			WS_CHANNELS.terminalTabs,
+			JSON.stringify({ channel: WS_CHANNELS.terminalTabs, data }),
+		);
+	});
+
 	setWorkspacePublisher((event) => {
 		const channel =
 			event.kind === "created"

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -39,6 +39,31 @@ export function saveWorkspaces(workspaces: Workspace[]): void {
 	writeJson("workspaces.json", workspaces);
 }
 
+/**
+ * One terminal tab as written to disk, so a host restart gives its tabs back.
+ *
+ * `recorded` is the shell's last output window, restored as the revived tab's replay — the process is gone
+ * either way (see `submodule-server-terminal`), so this is the picture, not the shell. A **PTY id is
+ * deliberately never persisted**: attaching to an id that outlived its process is exactly the `Couldn't attach
+ * - can't find terminal with id` failure Theia ships. Only `tabKey` is durable.
+ */
+export interface PersistedTerminalTab {
+	tabKey: string;
+	title: string;
+	recorded?: string;
+}
+
+/** Terminal tabs per workspace id. */
+export type PersistedTerminalSessions = Record<string, PersistedTerminalTab[]>;
+
+export function loadTerminalSessions(): PersistedTerminalSessions {
+	return readJson<PersistedTerminalSessions>("terminals.json", {});
+}
+
+export function saveTerminalSessions(sessions: PersistedTerminalSessions): void {
+	writeJson("terminals.json", sessions);
+}
+
 /** OUR server-synced app settings. Missing/corrupt file, or missing keys, fall back to `DEFAULT_CONFIG`. */
 export function loadConfig(): AppConfig {
 	return { ...DEFAULT_CONFIG, ...readJson<Partial<AppConfig>>("config.json", {}) };

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -10,10 +10,14 @@ tags: [v1]
 
 ## Responsibility
 
-The server-synced app config — OUR settings (an opaque theme selection today), an extensible `AppConfig`
-bag. Reads/merges/persists it and fans changes out to every client, so a preference set on one client
-follows the user to the others (architecture #9: shared domain state). The web client owns the available
-theme manifests; settings stores only the selected string id.
+The server-synced app config — OUR settings (an opaque theme selection, the analytics switch, the terminal
+replay budget), an extensible `AppConfig` bag. Reads/merges/persists it and fans changes out to every client,
+so a preference set on one client follows the user to the others (architecture #9: shared domain state). The
+web client owns the available theme manifests; settings stores only the selected string id.
+
+**A numeric setting is clamped by its consumer, not here** — `terminalReplayKb` sizes a per-terminal buffer, so
+`terminal` bounds it against `TERMINAL_REPLAY_KB` on read. This bag persists what it is given; a hand-edited
+`config.json` must not be able to exhaust memory.
 
 ## Boundary
 

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -41,7 +41,11 @@ tabs**. A tab's shell outlives every client that looks at it.
   previous client gets `terminal.detached`. Mirroring is additive if ever wanted.
 - **Only the attached client may drive a terminal.** `writeTerminal`/`resizeTerminal` take the caller and
   no-op otherwise: a displaced client keeps a valid PTY id and a reconnect replays its queued frames, which
-  would land in whoever holds the tab now. Reclaiming is an explicit gesture, as in `tmux attach -d`.
+  would land in whoever holds the tab now. Reclaiming is an explicit gesture, as in `tmux attach -d`. Such a
+  caller is **re-told it is detached** — the original notice is fire-and-forget and can be lost (a client
+  mid-reconnect during the takeover replays its attach and gets the cached success back), so learning on the
+  first keystroke is what stops a tab looking live while nothing happens. The client also guards the reverse
+  order with an attach generation, so a stale attach response can never clear a newer detach.
 - **Output stays addressed**, never broadcast — a frame only ever reaches a client that attached. The tab
   *list* is the exception: which terminals exist is shared domain state (architecture #9), so every change
   fans out on `terminal.tabs` as an idempotent per-workspace snapshot.

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -53,9 +53,12 @@ tabs**. A tab's shell outlives every client that looks at it.
   sweep on attach. Unmounting a view kills nothing.
 - **No idle culling.** Terminal "activity" can only mean last PTY I/O, so a quiet long-running command would be
   culled mid-flight (Jupyter's `cull_inactive_timeout` does exactly this). **No abandoned-client reap** either.
-- **Revive, not reconnect, across a host restart.** Shells cannot survive it; `persistTerminalSessions()`
-  writes tabs + recordings from `stop()` **before** `closeAllTerminals()`, and `reviveTerminalSessions()`
-  restores tabs whose first attach spawns a fresh shell showing the old picture. Unclean exit → empty shells.
+- **Revive, not reconnect, across a host restart.** Shells cannot survive it. **Membership is persisted on
+  every change** (open / close / archive), not only at `stop()` — the host has no crash isolation, so an
+  ungraceful exit is an ordinary path and a shutdown-only file would resurrect a closed tab and spawn a shell
+  for it. `stop()` additionally captures a full set of recordings before `closeAllTerminals()`;
+  `reviveTerminalSessions()` restores tabs whose first attach spawns a fresh shell showing the old picture.
+  Recordings are best-effort, so an unclean exit gives back the right tabs with blank screens.
 - **Not tmux.** Would buy restart survival at the cost of a dep we can't assume on Windows, a competing tab
   model, env-propagation breakage, and `capture-pane` polling. We already accept no crash isolation.
 

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -10,63 +10,58 @@ tags: [v1]
 
 ## Responsibility
 
-Workspace-scoped `bun-pty` terminals, each rooted in the worktree cwd; their output streams to the one client
-that owns them.
+Workspace-scoped `bun-pty` terminals rooted in the worktree cwd, **and the per-workspace list of terminal
+tabs**. A tab's shell outlives every client that looks at it.
 
 ## Boundary
 
-- **Owns:** PTYs keyed by id, each tagged with its `workspaceId` **and its owning `clientKey`**; output batched
-  and pushed on the `terminal.data` channel plus a `terminal.exit` announcement, both via an injected
-  publisher; `createTerminal`/`writeTerminal`/`resizeTerminal`/`closeTerminal`,
-  `resumeClientTerminals(clientKey)`, `closeClientTerminals(clientKey)`,
-  `closeWorkspaceTerminals(workspaceId)` (kill the workspace's PTYs when it's **archived**, so no shell orphans
-  on a now-deleted worktree dir — the host calls it before removing the worktree), `closeAllTerminals()` on
-  shutdown, `setTerminalPublisher`.
-- **Public surface (barrel):** the four terminal operations + `isTerminalAlive` (serves `terminal.alive`, the
-  liveness check a re-attaching tab must pass — see below) + `resumeClientTerminals` + `closeClientTerminals` +
-  `closeWorkspaceTerminals` + `closeAllTerminals` + `setTerminalPublisher`; the `TerminalDeliveryResult` type
-  shared with the host publisher adapter (no WebSocket type crosses this boundary).
-- **Allowed deps:** `persistence` (worktree cwd lookup); `contracts` (`WS_CHANNELS`); `bun-pty`; `process.env`.
-- **Forbidden:** `host`; sibling features. The module never learns what a WebSocket is — it addresses a client
-  by opaque key through the injected publisher.
+- **Owns:** the ordered per-workspace tab list (persisted) and the PTY behind each tab, keyed by
+  `(workspaceId, tabKey)`; batched output on `terminal.data` plus `terminal.exit` / `terminal.detached`, via an
+  injected publisher; the bounded per-terminal output recorder replayed on attach.
+- **Public surface (barrel):** `attachTerminal`, `listTerminals`, `writeTerminal`, `resizeTerminal`,
+  `closeTerminalTab`, `resumeClientTerminals`, `closeWorkspaceTerminals`, `persistTerminalSessions`,
+  `reviveTerminalSessions`, `closeAllTerminals`, `resetTerminalState` (test seam), `setTerminalPublisher`;
+  the `TerminalDeliveryResult` type shared with the host publisher adapter.
+- **Allowed deps:** `persistence`, `contracts` (`WS_CHANNELS`), `bun-pty`, `process.env`.
+- **Forbidden:** `host`; sibling features. No WebSocket type crosses this boundary — clients are opaque keys.
 
-## A terminal belongs to one client
+## Decisions
 
-Every operation is checked against the caller's `clientKey`, and output is **addressed**, never broadcast.
-Previously each PTY's bytes went to a single topic every socket subscribed to, leaving each browser to discard
-the frames that weren't its own — so every connected client received everything typed or printed in every
-terminal of every workspace. An id the caller doesn't own is treated exactly like one that doesn't exist, so
-probing ids reveals nothing about which exist.
+- **A shell is keyed by `(workspaceId, tabKey)`**, never by a socket, a client, or a component. `tabKey` is
+  durable and client-supplied; PTY ids are per-run and **never persisted** (attaching to an id that outlived
+  its process is Theia's `Couldn't attach - can't find terminal with id`).
+- **`attachTerminal` is idempotent get-or-create** — the only way a PTY is born. No separate liveness call, so
+  there is no window in which a client holds the only pointer to a running shell.
+- **Ownership is the host's owner, not the browser page.** Any client may attach; consistent with `history`,
+  `todos` and `templates`, which already assume a single-owner host. Consequence: shells survive a reload, a
+  closed browser and a different browser.
+- **Attach is exclusive with takeover.** A PTY has one size, so a new attach becomes the recipient and the
+  previous client gets `terminal.detached`. Mirroring is additive if ever wanted.
+- **Output stays addressed**, never broadcast — a frame only ever reaches a client that attached.
+- **A shell dies from exactly five causes:** tab closed, workspace archived, natural exit, host stop, orphan
+  sweep on attach. Unmounting a view kills nothing.
+- **No idle culling.** Terminal "activity" can only mean last PTY I/O, so a quiet long-running command would be
+  culled mid-flight (Jupyter's `cull_inactive_timeout` does exactly this). **No abandoned-client reap** either.
+- **Revive, not reconnect, across a host restart.** Shells cannot survive it; `persistTerminalSessions()`
+  writes tabs + recordings from `stop()` **before** `closeAllTerminals()`, and `reviveTerminalSessions()`
+  restores tabs whose first attach spawns a fresh shell showing the old picture. Unclean exit → empty shells.
+- **Not tmux.** Would buy restart survival at the cost of a dep we can't assume on Windows, a competing tab
+  model, env-propagation breakage, and `capture-pane` polling. We already accept no crash isolation.
 
-Ownership is keyed to a **client id that survives reconnects** (`?client=` on the socket URL), not to the
-socket. This is load-bearing in both directions: the client reconnects on its own, so socket-keyed ownership
-would silently orphan a shell on any network hiccup, while an id that also survived a reload could never be
-reaped. `closeClientTerminals` therefore runs on a **grace timer** (`host/server.ts`), not on socket close.
+## Restrictions
 
-## Output is batched, and cannot be pushed back on
+- **`attachTerminal` and its handler must stay synchronous.** Lookup and insert in one tick is what makes
+  attach atomic on Bun's single event loop; an `await` between them reintroduces double-spawn.
+- **`closeTerminalTab` checks `busy` and kills in the same synchronous pass.** A separately-asked question
+  lets a process started in between die unannounced.
+- Recorder rules: raw bytes (not a serialized grid); never replay resize events; re-emit observed private
+  modes; **never record the alt screen**; applied in one write on bind.
+- Attach hands back the recording and then **discards** held batcher output — the replay already contains it.
 
-`bun-pty` exposes no `pause()`/`resume()` and starts its read loop at spawn, so the host **cannot slow a shell
-down** — `yes` or a huge `cat` will be read as fast as it is produced. Two consequences, both handled in
-`outputBatcher.ts` (timer-only and transport-free, so it is unit-tested directly):
+## Validation
 
-- Reads are grouped into whole frames instead of one frame per read.
-- Delivery has three explicit outcomes: **delivered**, **backpressured** (this frame was accepted, but no more
-  may be sent), and **unavailable** (this frame was not accepted). The host maps Bun's `send()` statuses
-  correctly (`>0`, `-1`, `0`) and latches per-client backpressure until `drain`/reconnect; a batcher likewise
-  stops retrying while blocked. A batch the owner cannot take is **kept and retried**
-  (`resumeClientTerminals`), so a brief disconnect no longer leaves a silent hole in the scrollback. Held
-  output is capped; past the cap the **oldest** is dropped and the next batch is flagged `truncated` so the
-  client can say so rather than appearing to have simply printed less.
-
-A natural PTY exit moves its final pending output plus `terminal.exit` into one per-client completion queue.
-The data must be accepted before the exit can be accepted, including across reconnect/backpressure, so a
-command cannot return with only its death notice and no final result. Intentional close/archive/shutdown instead
-discards pending output. A client reaped as abandoned drops its completions — there is nobody to tell.
-
-`terminal.alive` closes the matching gap on the client's side: `terminal.exit` is only heard by a *mounted*
-terminal, and a tab detaches its PTY precisely when none is mounted, so a shell that died while detached must be
-detected by asking rather than by having been told.
-
-Every intentional path that kills a PTY disposes its batcher, so held output is dropped rather than delivered
-against a terminal that no longer exists. Natural exit is the one exception: `finish()` transfers the pending
-batch into the ordered completion above before the batcher is retired.
+- `outputRecorder.test.ts` — bounds, line/escape-safe trimming, alt-screen exclusion, mode restoration.
+- `outputBatcher.test.ts` — batching, backpressure, truncation, `reset`.
+- `shellBusy.test.ts` — child detection, including that an unanswerable platform reports *not* busy.
+- `terminalManager.test.ts` — attach idempotency (incl. concurrent), takeover, close/busy, revive.
+- `e2e/terminals.spec.ts` — the rapid re-entry regression, reload survival, second-client takeover.

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -16,11 +16,13 @@ tabs**. A tab's shell outlives every client that looks at it.
 ## Boundary
 
 - **Owns:** the ordered per-workspace tab list (persisted) and the PTY behind each tab, keyed by
-  `(workspaceId, tabKey)`; batched output on `terminal.data` plus `terminal.exit` / `terminal.detached`, via an
-  injected publisher; the bounded per-terminal output recorder replayed on attach.
+  `(workspaceId, tabKey)`; batched output on `terminal.data` plus `terminal.exit` / `terminal.detached`
+  (addressed) and `terminal.tabs` (broadcast), via injected publishers; the bounded per-terminal output
+  recorder replayed on attach.
 - **Public surface (barrel):** `attachTerminal`, `listTerminals`, `writeTerminal`, `resizeTerminal`,
   `closeTerminalTab`, `resumeClientTerminals`, `closeWorkspaceTerminals`, `persistTerminalSessions`,
-  `reviveTerminalSessions`, `closeAllTerminals`, `resetTerminalState` (test seam), `setTerminalPublisher`;
+  `reviveTerminalSessions`, `closeAllTerminals`, `resetTerminalState` (test seam), `setTerminalPublisher`,
+  `setTerminalTabsPublisher`;
   the `TerminalDeliveryResult` type shared with the host publisher adapter.
 - **Allowed deps:** `persistence`, `contracts` (`WS_CHANNELS`), `bun-pty`, `process.env`.
 - **Forbidden:** `host`; sibling features. No WebSocket type crosses this boundary — clients are opaque keys.
@@ -37,7 +39,12 @@ tabs**. A tab's shell outlives every client that looks at it.
   closed browser and a different browser.
 - **Attach is exclusive with takeover.** A PTY has one size, so a new attach becomes the recipient and the
   previous client gets `terminal.detached`. Mirroring is additive if ever wanted.
-- **Output stays addressed**, never broadcast — a frame only ever reaches a client that attached.
+- **Only the attached client may drive a terminal.** `writeTerminal`/`resizeTerminal` take the caller and
+  no-op otherwise: a displaced client keeps a valid PTY id and a reconnect replays its queued frames, which
+  would land in whoever holds the tab now. Reclaiming is an explicit gesture, as in `tmux attach -d`.
+- **Output stays addressed**, never broadcast — a frame only ever reaches a client that attached. The tab
+  *list* is the exception: which terminals exist is shared domain state (architecture #9), so every change
+  fans out on `terminal.tabs` as an idempotent per-workspace snapshot.
 - **A shell dies from exactly five causes:** tab closed, workspace archived, natural exit, host stop, orphan
   sweep on attach. Unmounting a view kills nothing.
 - **No idle culling.** Terminal "activity" can only mean last PTY I/O, so a quiet long-running command would be
@@ -55,13 +62,18 @@ tabs**. A tab's shell outlives every client that looks at it.
 - **`closeTerminalTab` checks `busy` and kills in the same synchronous pass.** A separately-asked question
   lets a process started in between die unannounced.
 - Recorder rules: raw bytes (not a serialized grid); never replay resize events; re-emit observed private
-  modes; **never record the alt screen**; applied in one write on bind.
+  modes; **never record the alt screen**, tracking it as a *stream* since a switch can split across PTY reads
+  and both screens can appear in one; **never record a mode sequence itself** (replaying `?1049h` would flip
+  the fresh terminal to the alt screen); applied in one write on bind.
 - Attach hands back the recording and then **discards** held batcher output — the replay already contains it.
 
 ## Validation
 
-- `outputRecorder.test.ts` — bounds, line/escape-safe trimming, alt-screen exclusion, mode restoration.
+- `outputRecorder.test.ts` — bounds, line/escape-safe trimming, alt-screen exclusion (incl. a switch split
+  across reads and enter+exit in one read), mode restoration.
 - `outputBatcher.test.ts` — batching, backpressure, truncation, `reset`.
 - `shellBusy.test.ts` — child detection, including that an unanswerable platform reports *not* busy.
-- `terminalManager.test.ts` — attach idempotency (incl. concurrent), takeover, close/busy, revive.
-- `e2e/terminals.spec.ts` — the rapid re-entry regression, reload survival, second-client takeover.
+- `terminalManager.test.ts` — attach idempotency (incl. concurrent), takeover, displaced-client rejection,
+  tab-list broadcast, close/busy, revive.
+- `e2e/terminals.spec.ts` — the rapid re-entry regression, reload survival, second-client takeover,
+  cross-client tab convergence.

--- a/packages/server/src/terminal/outputBatcher.ts
+++ b/packages/server/src/terminal/outputBatcher.ts
@@ -35,6 +35,14 @@ export interface OutputBatcher {
 	push(chunk: string): void;
 	/** Retry held output after the receiver becomes writable (drain/reconnect). */
 	resume(): void;
+	/**
+	 * Drop held output and unblock — for a client that has just been handed the recorded window on attach.
+	 *
+	 * That replay already shows everything held here, so flushing it afterwards would paint the same bytes a
+	 * second time. Discarding is also what keeps a reattach bounded: the recorder is the definition of "what the
+	 * screen should show", and it is a far smaller window than the flood a batcher may be holding.
+	 */
+	reset(): void;
 	/** Retire the batcher and transfer its final pending output to the exit-completion queue. */
 	finish(): OutputBatch | undefined;
 	/** Retire the batcher and drop pending output (an intentional PTY teardown). */
@@ -104,6 +112,13 @@ export function createOutputBatcher(options: OutputBatcherOptions): OutputBatche
 			if (disposed) return;
 			blocked = false;
 			flush();
+		},
+		reset() {
+			if (disposed) return;
+			clearTimer();
+			pending = "";
+			truncated = false;
+			blocked = false;
 		},
 		finish,
 		dispose() {

--- a/packages/server/src/terminal/outputRecorder.test.ts
+++ b/packages/server/src/terminal/outputRecorder.test.ts
@@ -96,6 +96,51 @@ describe("outputRecorder", () => {
 			expect(body(recorder.snapshot())).not.toContain("htop-row-");
 		});
 
+		test("a switch split across two reads is still seen", () => {
+			// PTY reads are byte boundaries, not message boundaries. Matching per-read missed this entirely and
+			// recorded the full-screen bytes the recorder promises to exclude.
+			const recorder = createOutputRecorder();
+			recorder.push("before\r\n");
+			recorder.push(`${ESC}[?10`);
+			recorder.push("49h");
+			recorder.push("VIM SCREEN\r\n");
+			recorder.push(ALT_OFF);
+			recorder.push("after\r\n");
+
+			const text = body(recorder.snapshot());
+			expect(text).toContain("before");
+			expect(text).toContain("after");
+			expect(text).not.toContain("VIM SCREEN");
+		});
+
+		test("enter and exit inside one read keep both sides of it", () => {
+			const recorder = createOutputRecorder();
+			recorder.push(`head ${ALT_ON}HIDDEN${ALT_OFF} tail\r\n`);
+
+			const text = body(recorder.snapshot());
+			expect(text).toContain("head ");
+			expect(text).toContain(" tail");
+			expect(text).not.toContain("HIDDEN");
+		});
+
+		test("the switch sequence itself is never replayed", () => {
+			// Replaying `?1049h` would flip the fresh terminal to the alt screen and show nothing at all.
+			const recorder = createOutputRecorder();
+			recorder.push("visible\r\n");
+			recorder.push(ALT_ON);
+			recorder.push("hidden");
+			recorder.push(ALT_OFF);
+			expect(recorder.snapshot()).not.toContain("[?1049");
+		});
+
+		test("a lone escape byte in ordinary output does not stall recording", () => {
+			const recorder = createOutputRecorder();
+			recorder.push("start\r\n");
+			recorder.push(`${ESC}`);
+			recorder.push("(B plain text\r\n");
+			expect(body(recorder.snapshot())).toContain("plain text");
+		});
+
 		test("the legacy 47 / 1047 switches count too", () => {
 			const recorder = createOutputRecorder();
 			recorder.push("normal\r\n");

--- a/packages/server/src/terminal/outputRecorder.test.ts
+++ b/packages/server/src/terminal/outputRecorder.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+import { createOutputRecorder } from "./outputRecorder";
+
+/** The escape byte, named so no test writes a bare control character into a pattern or literal. */
+const ESC = "\u001b";
+
+const ALT_ON = `${ESC}[?1049h`;
+const ALT_OFF = `${ESC}[?1049l`;
+
+/** Everything after the mode-restoring preamble — the recorded output itself. */
+function body(snapshot: string): string {
+	const lastEscape = snapshot.lastIndexOf(`${ESC}[?`);
+	if (lastEscape === -1) return snapshot.replace(`${ESC}[0m`, "");
+	return snapshot.slice(
+		snapshot.indexOf("h", lastEscape) + 1 || snapshot.indexOf("l", lastEscape) + 1,
+	);
+}
+
+describe("outputRecorder", () => {
+	test("replays what the shell printed", () => {
+		const recorder = createOutputRecorder();
+		recorder.push("$ echo hi\r\n");
+		recorder.push("hi\r\n");
+		expect(recorder.snapshot()).toContain("$ echo hi\r\nhi\r\n");
+	});
+
+	test("nothing recorded replays nothing — not a bare preamble", () => {
+		expect(createOutputRecorder().snapshot()).toBe("");
+	});
+
+	test("normalizes the pen so a trimmed colour run cannot bleed into a fresh terminal", () => {
+		const recorder = createOutputRecorder();
+		recorder.push("plain\r\n");
+		expect(recorder.snapshot().startsWith(`${ESC}[0m`)).toBe(true);
+	});
+
+	describe("bounded window", () => {
+		test("drops the oldest output and keeps the newest", () => {
+			const recorder = createOutputRecorder({ maxChars: 64 });
+			for (let i = 0; i < 40; i++) recorder.push(`line-${i}\n`);
+			const text = body(recorder.snapshot());
+			expect(text.length).toBeLessThanOrEqual(64);
+			expect(text).toContain("line-39");
+			expect(text).not.toContain("line-0\n");
+		});
+
+		test("trims at a line boundary, never mid-line", () => {
+			const recorder = createOutputRecorder({ maxChars: 20 });
+			for (let i = 0; i < 10; i++) recorder.push(`abcdefgh-${i}\n`);
+			// A trim that cut anywhere else would leave a leading fragment of the line it sliced.
+			for (const line of body(recorder.snapshot()).split("\n")) {
+				if (line !== "") expect(line).toMatch(/^abcdefgh-\d$/);
+			}
+		});
+
+		test("never opens mid escape sequence", () => {
+			const recorder = createOutputRecorder({ maxChars: 24 });
+			// Colour codes packed against the boundary: a naive slice lands inside one and xterm would print the
+			// remainder as literal text.
+			for (let i = 0; i < 12; i++) recorder.push(`${ESC}[31mred-${i}${ESC}[0m\n`);
+			const text = body(recorder.snapshot());
+			const sgr = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
+			expect(text.match(sgr)?.every((code) => code.startsWith(`${ESC}[`)) ?? true).toBe(true);
+			// A slice inside `ESC [ 3 1 m` would leave the tail of that sequence as literal text at the front.
+			expect(/^[0-9;]*m/.test(text)).toBe(false);
+		});
+
+		test("drops everything rather than emitting a fragment when no line boundary survives", () => {
+			const recorder = createOutputRecorder({ maxChars: 4 });
+			recorder.push("no-newlines-at-all-anywhere");
+			expect(body(recorder.snapshot())).toBe("");
+		});
+	});
+
+	describe("alt screen", () => {
+		test("a full-screen app is not recorded, and the normal buffer survives it", () => {
+			const recorder = createOutputRecorder();
+			recorder.push("before vim\r\n");
+			recorder.push(ALT_ON);
+			recorder.push("~\r\n~\r\n~\r\nVIM - Vi IMproved\r\n");
+			recorder.push(ALT_OFF);
+			recorder.push("after vim\r\n");
+
+			const text = body(recorder.snapshot());
+			expect(text).toContain("before vim");
+			expect(text).toContain("after vim");
+			// Replaying a torn-off slice of a full-screen app paints garbage no live process will correct.
+			expect(text).not.toContain("VIM - Vi IMproved");
+		});
+
+		test("output while the alt screen is open stays out even across many reads", () => {
+			const recorder = createOutputRecorder();
+			recorder.push("prompt\r\n");
+			recorder.push(ALT_ON);
+			for (let i = 0; i < 20; i++) recorder.push(`htop-row-${i}\r\n`);
+			expect(body(recorder.snapshot())).not.toContain("htop-row-");
+		});
+
+		test("the legacy 47 / 1047 switches count too", () => {
+			const recorder = createOutputRecorder();
+			recorder.push("normal\r\n");
+			recorder.push(`${ESC}[?47h`);
+			recorder.push("hidden\r\n");
+			recorder.push(`${ESC}[?47l`);
+			expect(body(recorder.snapshot())).not.toContain("hidden");
+		});
+	});
+
+	describe("mode restoration", () => {
+		test("re-emits observed modes so a fresh terminal agrees with the live shell", () => {
+			const recorder = createOutputRecorder();
+			recorder.push(`${ESC}[?2004h${ESC}[?1h$ `);
+			const snapshot = recorder.snapshot();
+			expect(snapshot).toContain(`${ESC}[?2004h`);
+			expect(snapshot).toContain(`${ESC}[?1h`);
+		});
+
+		test("re-emits the LAST value, not merely the fact it was seen", () => {
+			const recorder = createOutputRecorder();
+			recorder.push(`${ESC}[?25h visible `);
+			recorder.push(`${ESC}[?25l hidden `);
+			// Asserted on the preamble, not the whole snapshot: the recorded body still contains both original
+			// sequences, and replaying them in order is exactly what leaves the cursor hidden either way.
+			expect(recorder.snapshot().startsWith(`${ESC}[0m${ESC}[?25l`)).toBe(true);
+		});
+
+		test("handles several modes set in one sequence", () => {
+			const recorder = createOutputRecorder();
+			recorder.push(`${ESC}[?1000;1006h x`);
+			const snapshot = recorder.snapshot();
+			expect(snapshot).toContain(`${ESC}[?1000h`);
+			expect(snapshot).toContain(`${ESC}[?1006h`);
+		});
+
+		test("leaves untouched modes alone rather than asserting xterm's defaults", () => {
+			const recorder = createOutputRecorder();
+			recorder.push("plain output\r\n");
+			expect(recorder.snapshot()).not.toContain(`${ESC}[?7`);
+			expect(recorder.snapshot()).not.toContain(`${ESC}[?25`);
+		});
+
+		test("survives the window trimming away the sequence that set them", () => {
+			const recorder = createOutputRecorder({ maxChars: 16 });
+			recorder.push(`${ESC}[?2004h`);
+			for (let i = 0; i < 20; i++) recorder.push(`filler-${i}\n`);
+			// The bytes that enabled bracketed paste are long gone from the window; the mode is not.
+			expect(recorder.snapshot()).toContain(`${ESC}[?2004h`);
+		});
+	});
+
+	describe("restore", () => {
+		test("seeds a revived terminal with its predecessor's output", () => {
+			const recorder = createOutputRecorder();
+			recorder.restore("from the previous run\r\n");
+			expect(recorder.snapshot()).toContain("from the previous run");
+		});
+
+		test("bounds what it is handed", () => {
+			const recorder = createOutputRecorder({ maxChars: 32 });
+			recorder.restore(Array.from({ length: 50 }, (_, i) => `old-${i}\n`).join(""));
+			expect(body(recorder.snapshot()).length).toBeLessThanOrEqual(32);
+		});
+
+		test("live output appends after restored output", () => {
+			const recorder = createOutputRecorder();
+			recorder.restore("previous run\r\n");
+			recorder.push("this run\r\n");
+			const text = body(recorder.snapshot());
+			expect(text.indexOf("previous run")).toBeLessThan(text.indexOf("this run"));
+		});
+	});
+
+	test("dispose stops recording and forgets what it held", () => {
+		const recorder = createOutputRecorder();
+		recorder.push("secret\r\n");
+		recorder.dispose();
+		recorder.push("more\r\n");
+		expect(recorder.snapshot()).toBe("");
+	});
+});

--- a/packages/server/src/terminal/outputRecorder.test.ts
+++ b/packages/server/src/terminal/outputRecorder.test.ts
@@ -178,3 +178,17 @@ describe("outputRecorder", () => {
 		expect(recorder.snapshot()).toBe("");
 	});
 });
+
+describe("replay disabled", () => {
+	test("a zero budget records nothing", () => {
+		const recorder = createOutputRecorder({ maxChars: 0 });
+		recorder.push("$ echo hi\r\nhi\r\n");
+		expect(recorder.snapshot()).toBe("");
+	});
+
+	test("a zero budget also refuses a restored recording", () => {
+		const recorder = createOutputRecorder({ maxChars: 0 });
+		recorder.restore("from the previous run\r\n");
+		expect(recorder.snapshot()).toBe("");
+	});
+});

--- a/packages/server/src/terminal/outputRecorder.ts
+++ b/packages/server/src/terminal/outputRecorder.ts
@@ -1,0 +1,139 @@
+/**
+ * A bounded rolling record of one PTY's output, replayed into a fresh xterm when a client attaches.
+ *
+ * A shell survives every remount, but the painted screen does not — a remount builds a new xterm with an empty
+ * buffer, so without this a surviving shell comes back behind a blank terminal and looks dead. Every comparable
+ * implementation replays: VS Code's pty host records raw bytes (`persistentSessionScrollback`), Zed's daemon
+ * snapshots the grid, the tmux-backed brokers keep a ring buffer for reconnecting clients.
+ *
+ * Raw bytes rather than a serialized grid, deliberately: xterm's own parser re-derives the screen, so we never
+ * have to model modes we don't yet support.
+ */
+
+/** Recording bounds — enough to repaint a screen plus useful scrollback, per terminal, held in memory. */
+export const DEFAULT_RECORDER_MAX_CHARS = 64 * 1024;
+
+/**
+ * DEC private modes worth restoring explicitly.
+ *
+ * The window is a *tail*: whatever set these may have scrolled out of it, and applying a replay without them
+ * leaves the fresh xterm disagreeing with the live shell — arrow keys emitting the wrong bytes, a cursor drawn
+ * that the program thinks it hid, paste arriving unbracketed. Only modes actually observed are re-emitted, so
+ * a terminal that never touched one keeps xterm's default for it.
+ */
+const TRACKED_MODES: ReadonlySet<number> = new Set([
+	1, // application cursor keys — arrows send SS3 instead of CSI
+	7, // autowrap
+	25, // cursor visibility
+	1000, // mouse: button events
+	1002, // mouse: drag tracking
+	1003, // mouse: any-motion tracking
+	1006, // mouse: SGR coordinate encoding
+	2004, // bracketed paste
+]);
+
+/** Alt-screen switches. Entering suspends recording; the replay is what the *normal* buffer last held. */
+const ALT_BUFFER_MODES: ReadonlySet<number> = new Set([47, 1047, 1049]);
+
+/** The escape byte, named rather than written into the patterns below — a bare control character in a regex
+ * literal is indistinguishable from a typo, which is exactly what the lint rule against them is for. */
+const ESC = "\u001b";
+
+/** `CSI ? <params> h|l` — the only form that carries the private modes above. */
+const PRIVATE_MODE_RE = new RegExp(`${ESC}\\[\\?([0-9;]+)([hl])`, "g");
+
+export interface OutputRecorder {
+	/** Feed one raw read from the PTY. */
+	push(chunk: string): void;
+	/** Bytes to write into a fresh xterm so it shows what this shell last painted; empty when nothing to show. */
+	snapshot(): string;
+	/** Seed a revived terminal with the output its predecessor left behind (see `reviveTerminalSessions`). */
+	restore(recorded: string): void;
+	dispose(): void;
+}
+
+export interface OutputRecorderOptions {
+	maxChars?: number;
+}
+
+/**
+ * Trim to a line boundary so a replay never opens mid-line — and, more importantly, never mid-escape-sequence.
+ * A sequence cut in half is parsed as literal garbage by the receiving terminal. Escape sequences never contain
+ * a newline, so the first byte after one is always a safe place to start.
+ */
+function trimToLineStart(text: string, overBy: number): string {
+	const boundary = text.indexOf("\n", overBy - 1);
+	// No newline left to cut at: drop the whole thing rather than emit a fragment of a sequence.
+	return boundary === -1 ? "" : text.slice(boundary + 1);
+}
+
+export function createOutputRecorder(options: OutputRecorderOptions = {}): OutputRecorder {
+	const maxChars = options.maxChars ?? DEFAULT_RECORDER_MAX_CHARS;
+	let recorded = "";
+	/** Explicitly observed private modes and their last value; unobserved modes keep xterm's default. */
+	const modes = new Map<number, boolean>();
+	let inAltBuffer = false;
+	let disposed = false;
+
+	/** Track mode + alt-screen transitions, and report where the alt-screen state flips within this chunk. */
+	const scan = (chunk: string): void => {
+		PRIVATE_MODE_RE.lastIndex = 0;
+		let match = PRIVATE_MODE_RE.exec(chunk);
+		while (match !== null) {
+			const enabled = match[2] === "h";
+			// `CSI ? 1000 ; 1006 h` sets several at once.
+			for (const raw of (match[1] ?? "").split(";")) {
+				const mode = Number.parseInt(raw, 10);
+				if (Number.isNaN(mode)) continue;
+				if (ALT_BUFFER_MODES.has(mode)) inAltBuffer = enabled;
+				else if (TRACKED_MODES.has(mode)) modes.set(mode, enabled);
+			}
+			match = PRIVATE_MODE_RE.exec(chunk);
+		}
+	};
+
+	const append = (text: string): void => {
+		if (text === "") return;
+		recorded += text;
+		if (recorded.length > maxChars) {
+			recorded = trimToLineStart(recorded, recorded.length - maxChars);
+		}
+	};
+
+	return {
+		push(chunk) {
+			if (disposed || chunk === "") return;
+			const wasInAltBuffer = inAltBuffer;
+			scan(chunk);
+			// A full-screen app (vim, htop, lazygit) owns the alt screen, and replaying a torn-off slice of one
+			// paints garbage that no live process will ever correct. So the alt screen is never recorded, and the
+			// window keeps what the normal buffer last showed — which is what the user sees again on `:q` anyway.
+			// A chunk that *enters* the alt screen still carries normal-buffer output before the switch; letting
+			// that through would need sub-chunk splitting for no visible gain, so entering discards the chunk and
+			// leaving resumes with the next one.
+			if (wasInAltBuffer || inAltBuffer) return;
+			append(chunk);
+		},
+		snapshot() {
+			if (recorded === "") return "";
+			const prefix: string[] = [];
+			// Normalize the pen first: the tail may begin inside a colour run whose SGR scrolled out, which would
+			// otherwise inherit whatever the fresh xterm happened to have.
+			prefix.push("\x1b[0m");
+			for (const [mode, enabled] of modes) prefix.push(`\x1b[?${mode}${enabled ? "h" : "l"}`);
+			return `${prefix.join("")}${recorded}`;
+		},
+		restore(previous) {
+			if (disposed) return;
+			recorded =
+				previous.length > maxChars
+					? trimToLineStart(previous, previous.length - maxChars)
+					: previous;
+		},
+		dispose() {
+			disposed = true;
+			recorded = "";
+			modes.clear();
+		},
+	};
+}

--- a/packages/server/src/terminal/outputRecorder.ts
+++ b/packages/server/src/terminal/outputRecorder.ts
@@ -42,6 +42,16 @@ const ESC = "\u001b";
 /** `CSI ? <params> h|l` — the only form that carries the private modes above. */
 const PRIVATE_MODE_RE = new RegExp(`${ESC}\\[\\?([0-9;]+)([hl])`, "g");
 
+/**
+ * A trailing fragment that could still become a private-mode sequence once the next read arrives.
+ *
+ * PTY reads are arbitrary byte boundaries, not message boundaries: `ESC [ ? 1 0 4 9 h` can be split across two
+ * of them. Matching per-read would miss the switch and record a full-screen app's bytes — the one thing the
+ * recorder promises to exclude. Anything longer than a plausible sequence is not held back, so a lone `ESC` in
+ * ordinary output cannot stall the recorder.
+ */
+const PARTIAL_MODE_RE = new RegExp(`${ESC}(?:\\[\\??[0-9;]{0,16})?$`);
+
 export interface OutputRecorder {
 	/** Feed one raw read from the PTY. */
 	push(chunk: string): void;
@@ -74,21 +84,17 @@ export function createOutputRecorder(options: OutputRecorderOptions = {}): Outpu
 	const modes = new Map<number, boolean>();
 	let inAltBuffer = false;
 	let disposed = false;
+	/** A trailing byte run that may still complete into a mode sequence on the next read. */
+	let carry = "";
 
-	/** Track mode + alt-screen transitions, and report where the alt-screen state flips within this chunk. */
-	const scan = (chunk: string): void => {
-		PRIVATE_MODE_RE.lastIndex = 0;
-		let match = PRIVATE_MODE_RE.exec(chunk);
-		while (match !== null) {
-			const enabled = match[2] === "h";
-			// `CSI ? 1000 ; 1006 h` sets several at once.
-			for (const raw of (match[1] ?? "").split(";")) {
-				const mode = Number.parseInt(raw, 10);
-				if (Number.isNaN(mode)) continue;
-				if (ALT_BUFFER_MODES.has(mode)) inAltBuffer = enabled;
-				else if (TRACKED_MODES.has(mode)) modes.set(mode, enabled);
-			}
-			match = PRIVATE_MODE_RE.exec(chunk);
+	/** Apply one private-mode sequence's parameters, reporting whether it switched the alt screen. */
+	const applyModes = (params: string, enabled: boolean): void => {
+		// `CSI ? 1000 ; 1006 h` sets several at once.
+		for (const raw of params.split(";")) {
+			const mode = Number.parseInt(raw, 10);
+			if (Number.isNaN(mode)) continue;
+			if (ALT_BUFFER_MODES.has(mode)) inAltBuffer = enabled;
+			else if (TRACKED_MODES.has(mode)) modes.set(mode, enabled);
 		}
 	};
 
@@ -100,21 +106,52 @@ export function createOutputRecorder(options: OutputRecorderOptions = {}): Outpu
 		}
 	};
 
+	/**
+	 * Walk the stream, appending only the segments written while the normal screen was showing.
+	 *
+	 * Split at each alt-screen transition rather than judging a whole read at once: an enter and an exit can
+	 * share one read (a short `vim` session), and output either side of a switch belongs to different screens.
+	 */
+	const consume = (text: string): void => {
+		let cursor = 0;
+		PRIVATE_MODE_RE.lastIndex = 0;
+		let match = PRIVATE_MODE_RE.exec(text);
+		while (match !== null) {
+			const before = inAltBuffer;
+			// The bytes up to this sequence belong to whichever screen was showing before it. The sequence
+			// itself is never recorded: replaying `?1049h` would flip the fresh terminal to the alt screen and
+			// show nothing at all, and the modes worth restoring are re-emitted by `snapshot`'s preamble.
+			if (!before) append(text.slice(cursor, match.index));
+			applyModes(match[1] ?? "", match[2] === "h");
+			cursor = match.index + match[0].length;
+			match = PRIVATE_MODE_RE.exec(text);
+		}
+		if (!inAltBuffer) append(text.slice(cursor));
+	};
+
 	return {
 		push(chunk) {
 			// A zero budget is "replay off" (AppConfig.terminalReplayKb = 0): record nothing at all rather than
 			// keep a window that trimToLineStart would empty anyway.
 			if (disposed || maxChars <= 0 || chunk === "") return;
-			const wasInAltBuffer = inAltBuffer;
-			scan(chunk);
 			// A full-screen app (vim, htop, lazygit) owns the alt screen, and replaying a torn-off slice of one
-			// paints garbage that no live process will ever correct. So the alt screen is never recorded, and the
-			// window keeps what the normal buffer last showed — which is what the user sees again on `:q` anyway.
-			// A chunk that *enters* the alt screen still carries normal-buffer output before the switch; letting
-			// that through would need sub-chunk splitting for no visible gain, so entering discards the chunk and
-			// leaving resumes with the next one.
-			if (wasInAltBuffer || inAltBuffer) return;
-			append(chunk);
+			// paints garbage no live process will correct — so the alt screen is never recorded and the window
+			// keeps what the normal buffer last showed, which is what the user sees again on `:q` anyway.
+			const text = carry + chunk;
+			carry = "";
+			// Hold back a trailing fragment that may still become a mode sequence, so a switch split across two
+			// reads is still seen.
+			const partial = PARTIAL_MODE_RE.exec(text);
+			if (partial && partial.index > 0) {
+				carry = text.slice(partial.index);
+				consume(text.slice(0, partial.index));
+				return;
+			}
+			if (partial && partial.index === 0) {
+				carry = text;
+				return;
+			}
+			consume(text);
 		},
 		snapshot() {
 			if (recorded === "") return "";
@@ -135,6 +172,7 @@ export function createOutputRecorder(options: OutputRecorderOptions = {}): Outpu
 		dispose() {
 			disposed = true;
 			recorded = "";
+			carry = "";
 			modes.clear();
 		},
 	};

--- a/packages/server/src/terminal/outputRecorder.ts
+++ b/packages/server/src/terminal/outputRecorder.ts
@@ -10,7 +10,7 @@
  * have to model modes we don't yet support.
  */
 
-/** Recording bounds — enough to repaint a screen plus useful scrollback, per terminal, held in memory. */
+/** Fallback window when no size is supplied — `AppConfig.terminalReplayKb` is the real source. */
 export const DEFAULT_RECORDER_MAX_CHARS = 64 * 1024;
 
 /**
@@ -102,7 +102,9 @@ export function createOutputRecorder(options: OutputRecorderOptions = {}): Outpu
 
 	return {
 		push(chunk) {
-			if (disposed || chunk === "") return;
+			// A zero budget is "replay off" (AppConfig.terminalReplayKb = 0): record nothing at all rather than
+			// keep a window that trimToLineStart would empty anyway.
+			if (disposed || maxChars <= 0 || chunk === "") return;
 			const wasInAltBuffer = inAltBuffer;
 			scan(chunk);
 			// A full-screen app (vim, htop, lazygit) owns the alt screen, and replaying a torn-off slice of one
@@ -124,7 +126,7 @@ export function createOutputRecorder(options: OutputRecorderOptions = {}): Outpu
 			return `${prefix.join("")}${recorded}`;
 		},
 		restore(previous) {
-			if (disposed) return;
+			if (disposed || maxChars <= 0) return;
 			recorded =
 				previous.length > maxChars
 					? trimToLineStart(previous, previous.length - maxChars)

--- a/packages/server/src/terminal/shellBusy.test.ts
+++ b/packages/server/src/terminal/shellBusy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { hasChildProcesses, parseProcChildren } from "./shellBusy";
+
+describe("parseProcChildren", () => {
+	test("reads the pid list", () => {
+		expect(parseProcChildren("1234 5678 91011\n")).toEqual([1234, 5678, 91011]);
+	});
+
+	test("no children is an empty file, not an absent one", () => {
+		expect(parseProcChildren("")).toEqual([]);
+		expect(parseProcChildren("\n")).toEqual([]);
+	});
+
+	test("ignores anything that is not a pid", () => {
+		expect(parseProcChildren("12 junk -3 0 34")).toEqual([12, 34]);
+	});
+});
+
+describe("hasChildProcesses", () => {
+	test("a shell running something reports busy; a bare process does not", async () => {
+		// Stands in for a terminal with a job in it: the shell is the pid we ask about and the sleep is its child.
+		// The trailing `:` matters — given a single final command a shell `exec`s it and *becomes* the process
+		// rather than forking, so there would be no child to find. The bare `sleep` is the idle-prompt case: a
+		// live process with nothing under it.
+		const withChild = Bun.spawn(["sh", "-c", "sleep 30; :"], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const withoutChild = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+		try {
+			// The shell has to reach its fork before the answer means anything.
+			await Bun.sleep(300);
+			expect(hasChildProcesses(withChild.pid)).toBe(true);
+			expect(hasChildProcesses(withoutChild.pid)).toBe(false);
+		} finally {
+			withChild.kill();
+			withoutChild.kill();
+		}
+	});
+
+	test("an implausible pid is not busy rather than throwing", () => {
+		expect(hasChildProcesses(0)).toBe(false);
+		expect(hasChildProcesses(-1)).toBe(false);
+		expect(hasChildProcesses(Number.NaN)).toBe(false);
+	});
+
+	test("a pid that no longer exists is not busy", () => {
+		const gone = Bun.spawn(["true"], { stdout: "ignore", stderr: "ignore" });
+		gone.kill();
+		expect(hasChildProcesses(gone.pid)).toBe(false);
+	});
+});

--- a/packages/server/src/terminal/shellBusy.test.ts
+++ b/packages/server/src/terminal/shellBusy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { hasChildProcesses, parseProcChildren } from "./shellBusy";
+import { hasChildProcesses, parseProcChildren, WINDOWS_CHILD_COUNT } from "./shellBusy";
 
 describe("parseProcChildren", () => {
 	test("reads the pid list", () => {
@@ -48,5 +48,22 @@ describe("hasChildProcesses", () => {
 		const gone = Bun.spawn(["true"], { stdout: "ignore", stderr: "ignore" });
 		gone.kill();
 		expect(hasChildProcesses(gone.pid)).toBe(false);
+	});
+});
+
+describe("the Windows probe", () => {
+	// Cannot be executed from CI on Linux, so what is pinned here is the property that does not need Windows:
+	// the pid never reaches PowerShell's parser as text. Interpolating it would be the injection minefield
+	// `apps/cli/src/powershell.ts` exists to avoid.
+	test("passes the pid by environment, never by string interpolation", () => {
+		expect(WINDOWS_CHILD_COUNT).toContain("$env:TR_PARENT_PID");
+		expect(WINDOWS_CHILD_COUNT).not.toMatch(/ParentProcessId=\d/);
+	});
+
+	test("prints a count rather than relying on the exit code", () => {
+		// PowerShell exits 0 whether or not the query matched, so an exit-code answer could not tell "no
+		// children" from "the query failed" — and we would report not-busy on a host where it actually works.
+		expect(WINDOWS_CHILD_COUNT).toContain("Write-Output");
+		expect(WINDOWS_CHILD_COUNT).toContain("$ErrorActionPreference = 'Stop'");
 	});
 });

--- a/packages/server/src/terminal/shellBusy.ts
+++ b/packages/server/src/terminal/shellBusy.ts
@@ -1,0 +1,56 @@
+/**
+ * Does this shell have anything running in it?
+ *
+ * Asked at exactly one moment: the user clicked × on a terminal tab. Closing a tab is now the only client-driven
+ * way to kill a shell, and shells outlive reloads and browsers — so an unguarded × can silently take down a dev
+ * server that has been running for hours. VS Code guards the same gesture the same way (`confirmOnKill`).
+ *
+ * The shell itself is the PTY's process; anything it spawned is a child of it. So "busy" is "the shell has
+ * children" — which is why an idle prompt closes in one click and a running `npm run dev` asks first.
+ */
+
+import { readFileSync } from "node:fs";
+
+/** `/proc/<pid>/task/<pid>/children` — whitespace-separated pids, empty when the process has none. */
+export function parseProcChildren(contents: string): number[] {
+	return contents
+		.split(/\s+/)
+		.map((entry) => Number.parseInt(entry, 10))
+		.filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+/** Linux's cheap path: one small synchronous read, no process spawn. Null when the kernel doesn't expose it. */
+function childrenViaProc(pid: number): boolean | null {
+	try {
+		return parseProcChildren(readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8")).length > 0;
+	} catch {
+		// Not Linux, CONFIG_PROC_CHILDREN off, or the process is already gone — the caller falls back.
+		return null;
+	}
+}
+
+/** POSIX fallback (macOS has no `/proc`): `pgrep -P` exits 0 only when the pid has at least one child. */
+function childrenViaPgrep(pid: number): boolean | null {
+	try {
+		const run = Bun.spawnSync(["pgrep", "-P", String(pid)], { stdout: "pipe", stderr: "ignore" });
+		// 0 = matched, 1 = no match, anything else (missing binary, error) is not an answer.
+		if (run.exitCode === 0) return true;
+		if (run.exitCode === 1) return false;
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Whether `pid` has at least one child process.
+ *
+ * Returns **false when it cannot tell** — notably on Windows, where neither probe applies. That is the
+ * deliberate direction to fail: an unanswerable check must not make every tab close a confirmation prompt, which
+ * would train people to click through the one that mattered. The cost is that on such a platform the guard is
+ * simply absent, exactly as it is today.
+ */
+export function hasChildProcesses(pid: number): boolean {
+	if (!Number.isInteger(pid) || pid <= 0) return false;
+	return childrenViaProc(pid) ?? childrenViaPgrep(pid) ?? false;
+}

--- a/packages/server/src/terminal/shellBusy.ts
+++ b/packages/server/src/terminal/shellBusy.ts
@@ -43,14 +43,49 @@ function childrenViaPgrep(pid: number): boolean | null {
 }
 
 /**
+ * Windows: count processes whose parent is `pid` via CIM.
+ *
+ * Printed as a count rather than signalled by exit code — PowerShell exits 0 whether or not the query
+ * matched, so "no children" and "the query failed" would otherwise be indistinguishable and we would guess
+ * *not busy* on a host where the check actually works. `$ErrorActionPreference = 'Stop'` turns a blocked
+ * cmdlet (ConstrainedLanguage mode) into a non-zero exit instead of silent empty output.
+ */
+export const WINDOWS_CHILD_COUNT = [
+	"$ErrorActionPreference = 'Stop'",
+	'$kids = @(Get-CimInstance Win32_Process -Filter "ParentProcessId=$env:TR_PARENT_PID")',
+	"Write-Output $kids.Count",
+].join("; ");
+
+function childrenViaCim(pid: number): boolean | null {
+	// The same two hosts (and order) the directory picker and `apps/cli/src/powershell.ts` use.
+	for (const shell of ["powershell.exe", "pwsh.exe"]) {
+		try {
+			// The pid rides an env var, never the command string: interpolating into PowerShell's own parser is
+			// the injection minefield `apps/cli/src/powershell.ts` exists to sidestep.
+			const run = Bun.spawnSync([shell, "-NoProfile", "-Command", WINDOWS_CHILD_COUNT], {
+				stdout: "pipe",
+				stderr: "ignore",
+				env: { ...process.env, TR_PARENT_PID: String(pid) },
+			});
+			if (run.exitCode !== 0) continue;
+			const count = Number.parseInt(run.stdout.toString().trim(), 10);
+			if (Number.isInteger(count)) return count > 0;
+		} catch {
+			// Host missing or not spawnable — try the next one.
+		}
+	}
+	return null;
+}
+
+/**
  * Whether `pid` has at least one child process.
  *
- * Returns **false when it cannot tell** — notably on Windows, where neither probe applies. That is the
- * deliberate direction to fail: an unanswerable check must not make every tab close a confirmation prompt, which
- * would train people to click through the one that mattered. The cost is that on such a platform the guard is
- * simply absent, exactly as it is today.
+ * Probes in cost order — a `/proc` read, then `pgrep`, then CIM on Windows — and returns **false when none of
+ * them can answer**. That is the deliberate direction to fail: an unanswerable check must not make every tab
+ * close a confirmation prompt, which would train people to click through the one that mattered.
  */
 export function hasChildProcesses(pid: number): boolean {
 	if (!Number.isInteger(pid) || pid <= 0) return false;
+	if (process.platform === "win32") return childrenViaCim(pid) ?? false;
 	return childrenViaProc(pid) ?? childrenViaPgrep(pid) ?? false;
 }

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Workspace } from "@thinkrail/contracts";
+import { saveWorkspaces } from "../persistence";
+import {
+	attachTerminal,
+	closeTerminalTab,
+	listTerminals,
+	persistTerminalSessions,
+	resetTerminalState,
+	reviveTerminalSessions,
+	setTerminalPublisher,
+	writeTerminal,
+} from "./terminalManager";
+
+const WS = "ws-1";
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+
+/** Frames the publisher was handed, so takeover and addressing are observable without a WebSocket. */
+let pushed: { clientKey: string; channel: string; data: unknown }[] = [];
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-terminal-test-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	const worktreePath = join(dataDir, "worktree");
+	mkdirSync(worktreePath);
+	saveWorkspaces([{ id: WS, worktreePath } as Workspace]);
+	pushed = [];
+	setTerminalPublisher((clientKey, channel, data) => {
+		pushed.push({ clientKey, channel, data });
+		return "delivered";
+	});
+});
+
+afterEach(() => {
+	resetTerminalState();
+	setTerminalPublisher(() => "unavailable");
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("attaching twice to a tab returns the SAME shell", () => {
+	const first = attachTerminal(WS, "tab-a", "client-1");
+	const second = attachTerminal(WS, "tab-a", "client-1");
+
+	expect(first.created).toBe(true);
+	expect(second.created).toBe(false);
+	expect(second.id).toBe(first.id);
+});
+
+test("re-entering after the view went away adopts the shell instead of spawning a second one", () => {
+	// The regression this design exists for: a client used to hold the only pointer to a running shell between
+	// asking "is it still alive?" and hearing back, so re-entering inside that window spawned a duplicate and
+	// orphaned the first for the life of the host. There is no such window — the host holds the mapping.
+	const original = attachTerminal(WS, "tab-a", "client-1");
+	const afterLeaving = attachTerminal(WS, "tab-a", "client-1");
+	const afterLeavingAgain = attachTerminal(WS, "tab-a", "client-1");
+
+	expect(afterLeaving.id).toBe(original.id);
+	expect(afterLeavingAgain.id).toBe(original.id);
+	expect(listTerminals(WS)).toHaveLength(1);
+});
+
+test("concurrent attaches on one tab cannot both spawn", () => {
+	// Atomicity comes from attach being synchronous on Bun's single event loop, so this is what an `await`
+	// slipped between the lookup and the insert would break.
+	const results = [1, 2, 3, 4].map(() => attachTerminal(WS, "tab-a", "client-1"));
+
+	expect(new Set(results.map((r) => r.id)).size).toBe(1);
+	expect(results.filter((r) => r.created)).toHaveLength(1);
+});
+
+test("different tabs get different shells", () => {
+	const a = attachTerminal(WS, "tab-a", "client-1");
+	const b = attachTerminal(WS, "tab-b", "client-1");
+
+	expect(b.id).not.toBe(a.id);
+	expect(listTerminals(WS).map((t) => t.tabKey)).toEqual(["tab-a", "tab-b"]);
+});
+
+test("a second client takes the tab over and the first is told", () => {
+	attachTerminal(WS, "tab-a", "client-1");
+	pushed = [];
+
+	const taken = attachTerminal(WS, "tab-a", "client-2");
+
+	expect(taken.created).toBe(false);
+	const detached = pushed.filter((frame) => frame.channel === "terminal.detached");
+	expect(detached).toHaveLength(1);
+	expect(detached[0]?.clientKey).toBe("client-1");
+	expect(detached[0]?.data).toEqual({ workspaceId: WS, tabKey: "tab-a" });
+});
+
+test("re-attaching as the same client does not announce a takeover", () => {
+	attachTerminal(WS, "tab-a", "client-1");
+	pushed = [];
+
+	attachTerminal(WS, "tab-a", "client-1");
+
+	expect(pushed.filter((frame) => frame.channel === "terminal.detached")).toHaveLength(0);
+});
+
+test("the tab list is the host's, in creation order", () => {
+	attachTerminal(WS, "tab-a", "client-1", { title: "One" });
+	attachTerminal(WS, "tab-b", "client-1", { title: "Two" });
+
+	expect(listTerminals(WS)).toEqual([
+		{ tabKey: "tab-a", title: "One" },
+		{ tabKey: "tab-b", title: "Two" },
+	]);
+});
+
+test("closing a tab removes it and reports closed", () => {
+	attachTerminal(WS, "tab-a", "client-1");
+
+	expect(closeTerminalTab(WS, "tab-a")).toEqual({ closed: true, busy: false });
+	expect(listTerminals(WS)).toHaveLength(0);
+});
+
+test("closing an unknown tab is not an error and not busy", () => {
+	expect(closeTerminalTab(WS, "never-existed")).toEqual({ closed: false, busy: false });
+});
+
+test("a shell with something running refuses to close until forced", async () => {
+	const attached = attachTerminal(WS, "tab-a", "client-1");
+	expect(attached.created).toBe(true);
+	// Give the shell its prompt, then start a job so it has a child process.
+	await Bun.sleep(600);
+	writeTerminal(attached.id, "sleep 30\r");
+	await Bun.sleep(800);
+
+	const refused = closeTerminalTab(WS, "tab-a");
+	expect(refused).toEqual({ closed: false, busy: true });
+	expect(listTerminals(WS)).toHaveLength(1);
+
+	expect(closeTerminalTab(WS, "tab-a", true)).toEqual({ closed: true, busy: false });
+	expect(listTerminals(WS)).toHaveLength(0);
+});
+
+test("a host restart gives the tabs back with fresh shells showing the old output", async () => {
+	const first = attachTerminal(WS, "tab-a", "client-1", { title: "Kept" });
+	await Bun.sleep(500);
+	persistTerminalSessions();
+	resetTerminalState();
+
+	expect(listTerminals(WS)).toHaveLength(0);
+	reviveTerminalSessions();
+	expect(listTerminals(WS)).toEqual([{ tabKey: "tab-a", title: "Kept" }]);
+
+	const revived = attachTerminal(WS, "tab-a", "client-1");
+	// A new shell — the old one died with the host — but carrying the picture it left behind.
+	expect(revived.created).toBe(true);
+	expect(revived.id).not.toBe(first.id);
+	expect(revived.replay ?? "").not.toBe("");
+});
+
+test("a revived recording is served once, not to every later attach", async () => {
+	attachTerminal(WS, "tab-a", "client-1");
+	await Bun.sleep(500);
+	persistTerminalSessions();
+	resetTerminalState();
+	reviveTerminalSessions();
+
+	const revived = attachTerminal(WS, "tab-a", "client-1");
+	closeTerminalTab(WS, "tab-a", true);
+	const fresh = attachTerminal(WS, "tab-a", "client-1");
+
+	expect(revived.replay ?? "").not.toBe("");
+	// The closed tab took its recording with it; a tab reopened under the same key starts blank.
+	expect(fresh.replay ?? "").toBe("");
+});
+
+test("persisting writes nothing for a workspace whose tabs were all closed", () => {
+	attachTerminal(WS, "tab-a", "client-1");
+	closeTerminalTab(WS, "tab-a", true);
+	persistTerminalSessions();
+	resetTerminalState();
+	reviveTerminalSessions();
+
+	expect(listTerminals(WS)).toHaveLength(0);
+});

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -10,8 +10,10 @@ import {
 	listTerminals,
 	persistTerminalSessions,
 	resetTerminalState,
+	resizeTerminal,
 	reviveTerminalSessions,
 	setTerminalPublisher,
+	setTerminalTabsPublisher,
 	writeTerminal,
 } from "./terminalManager";
 
@@ -38,6 +40,7 @@ beforeEach(() => {
 afterEach(() => {
 	resetTerminalState();
 	setTerminalPublisher(() => "unavailable");
+	setTerminalTabsPublisher(() => {});
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
@@ -130,7 +133,7 @@ test("a shell with something running refuses to close until forced", async () =>
 	expect(attached.created).toBe(true);
 	// Give the shell its prompt, then start a job so it has a child process.
 	await Bun.sleep(600);
-	writeTerminal(attached.id, "sleep 30\r");
+	writeTerminal(attached.id, "sleep 30\r", "client-1");
 	await Bun.sleep(800);
 
 	const refused = closeTerminalTab(WS, "tab-a");
@@ -182,4 +185,45 @@ test("persisting writes nothing for a workspace whose tabs were all closed", () 
 	reviveTerminalSessions();
 
 	expect(listTerminals(WS)).toHaveLength(0);
+});
+
+test("only the attached client may drive a terminal", async () => {
+	const attached = attachTerminal(WS, "tab-a", "client-1");
+	await Bun.sleep(500);
+
+	// Client B takes the tab over; A keeps a perfectly valid pty id, and a reconnect would replay its queued
+	// frames. Accepting them would run A's keystrokes in B's shell.
+	attachTerminal(WS, "tab-a", "client-2");
+	writeTerminal(attached.id, "echo TR_FROM_DISPLACED\r", "client-1");
+	resizeTerminal(attached.id, 5, 2, "client-1");
+	await Bun.sleep(500);
+
+	const seen = pushed
+		.filter((frame) => frame.channel === "terminal.data")
+		.map((frame) => (frame.data as { data: string }).data)
+		.join("");
+	expect(seen).not.toContain("TR_FROM_DISPLACED");
+
+	// Reclaiming is an explicit gesture, and then input works again.
+	attachTerminal(WS, "tab-a", "client-1");
+	writeTerminal(attached.id, "echo TR_RECLAIMED\r", "client-1");
+	await Bun.sleep(800);
+	const afterReclaim = pushed
+		.filter((frame) => frame.channel === "terminal.data")
+		.map((frame) => (frame.data as { data: string }).data)
+		.join("");
+	expect(afterReclaim).toContain("TR_RECLAIMED");
+});
+
+test("opening and closing a tab broadcasts the new list", () => {
+	const seen: unknown[] = [];
+	setTerminalTabsPublisher((workspaceId, tabs) => seen.push({ workspaceId, tabs }));
+
+	attachTerminal(WS, "tab-a", "client-1", { title: "One" });
+	// Re-attaching changes no membership, so it must not fan out a snapshot per remount.
+	attachTerminal(WS, "tab-a", "client-1");
+	expect(seen).toEqual([{ workspaceId: WS, tabs: [{ tabKey: "tab-a", title: "One" }] }]);
+
+	closeTerminalTab(WS, "tab-a", true);
+	expect(seen.at(-1)).toEqual({ workspaceId: WS, tabs: [] });
 });

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +7,7 @@ import { saveWorkspaces } from "../persistence";
 import {
 	attachTerminal,
 	closeTerminalTab,
+	closeWorkspaceTerminals,
 	listTerminals,
 	persistTerminalSessions,
 	resetTerminalState,
@@ -284,4 +285,38 @@ test("a dead tab's last screen survives a host restart", async () => {
 	reviveTerminalSessions();
 
 	expect(attachTerminal(WS, "tab-a", "client-1").replay ?? "").toContain("TR_LAST_WORDS");
+});
+
+describe("membership survives an ungraceful exit", () => {
+	// The host has no crash isolation by design, so an exit without `stop()` is an ordinary path. Everything
+	// below therefore skips `persistTerminalSessions()` entirely — that is the whole point.
+	test("a tab closed before a crash does not come back", () => {
+		attachTerminal(WS, "tab-a", "client-1");
+		closeTerminalTab(WS, "tab-a", true);
+
+		resetTerminalState();
+		reviveTerminalSessions();
+
+		// Resurrecting it would spawn a shell for a tab the user closed — the no-tab/no-shell rule.
+		expect(listTerminals(WS)).toHaveLength(0);
+	});
+
+	test("a tab opened before a crash is still there", () => {
+		attachTerminal(WS, "tab-a", "client-1", { title: "Survivor" });
+
+		resetTerminalState();
+		reviveTerminalSessions();
+
+		expect(listTerminals(WS)).toEqual([{ tabKey: "tab-a", title: "Survivor" }]);
+	});
+
+	test("archiving a workspace before a crash takes its tabs with it", () => {
+		attachTerminal(WS, "tab-a", "client-1");
+		closeWorkspaceTerminals(WS);
+
+		resetTerminalState();
+		reviveTerminalSessions();
+
+		expect(listTerminals(WS)).toHaveLength(0);
+	});
 });

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -227,3 +227,61 @@ test("opening and closing a tab broadcasts the new list", () => {
 	closeTerminalTab(WS, "tab-a", true);
 	expect(seen.at(-1)).toEqual({ workspaceId: WS, tabs: [] });
 });
+
+test("a displaced client that tries to type is told it is displaced", async () => {
+	const attached = attachTerminal(WS, "tab-a", "client-1");
+	await Bun.sleep(400);
+	attachTerminal(WS, "tab-a", "client-2");
+	pushed = [];
+
+	// The original notice is fire-and-forget and can be lost — most plainly when the displaced client was
+	// mid-reconnect during the takeover, since its replayed attach then gets the cached success back. Learning
+	// on the first keystroke is what stops the tab looking live forever while nothing happens.
+	writeTerminal(attached.id, "echo TR_LOST_NOTICE\r", "client-1");
+
+	const told = pushed.filter((frame) => frame.channel === "terminal.detached");
+	expect(told).toHaveLength(1);
+	expect(told[0]?.clientKey).toBe("client-1");
+	expect(told[0]?.data).toEqual({ workspaceId: WS, tabKey: "tab-a" });
+});
+
+test("the attached client is not told it is displaced", async () => {
+	const attached = attachTerminal(WS, "tab-a", "client-1");
+	await Bun.sleep(400);
+	pushed = [];
+
+	writeTerminal(attached.id, "echo TR_FINE\r", "client-1");
+	resizeTerminal(attached.id, 100, 30, "client-1");
+
+	expect(pushed.filter((frame) => frame.channel === "terminal.detached")).toHaveLength(0);
+});
+
+test("a tab keeps its last screen when its shell exits on its own", async () => {
+	const first = attachTerminal(WS, "tab-a", "client-1");
+	await Bun.sleep(400);
+	writeTerminal(first.id, "echo TR_BEFORE_CRASH\r", "client-1");
+	await Bun.sleep(600);
+	writeTerminal(first.id, "exit\r", "client-1");
+	await Bun.sleep(800);
+
+	// The tab outlives its shell, so the output that would say what happened must outlive it too.
+	expect(listTerminals(WS)).toHaveLength(1);
+	const next = attachTerminal(WS, "tab-a", "client-1");
+	expect(next.created).toBe(true);
+	expect(next.replay ?? "").toContain("TR_BEFORE_CRASH");
+});
+
+test("a dead tab's last screen survives a host restart", async () => {
+	const first = attachTerminal(WS, "tab-a", "client-1");
+	await Bun.sleep(400);
+	writeTerminal(first.id, "echo TR_LAST_WORDS\r", "client-1");
+	await Bun.sleep(600);
+	writeTerminal(first.id, "exit\r", "client-1");
+	await Bun.sleep(800);
+
+	persistTerminalSessions();
+	resetTerminalState();
+	reviveTerminalSessions();
+
+	expect(attachTerminal(WS, "tab-a", "client-1").replay ?? "").toContain("TR_LAST_WORDS");
+});

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -110,9 +110,19 @@ export function setTerminalTabsPublisher(
 	broadcastTabs = fn;
 }
 
-/** Announce this workspace's tab list. Called only where the list actually changed. */
-function publishTabs(workspaceId: string): void {
+/**
+ * React to a change in which tabs exist: tell every client, and write the new membership down.
+ *
+ * Persisting here rather than only at `stop()` is what makes the on-disk list authoritative *during* the run.
+ * The host has no crash isolation by design (a fatal agent or provider fault takes it down, see
+ * `architecture.md`), so an ungraceful exit is an ordinary path — and a file only written on graceful shutdown
+ * would resurrect a tab the user had closed, spawning a shell for it and breaking the no-tab/no-shell rule.
+ * Output snapshots stay best-effort: they ride along when they happen to exist, and `stop()` is still where a
+ * full set is captured.
+ */
+function membershipChanged(workspaceId: string): void {
 	broadcastTabs(workspaceId, listTerminals(workspaceId));
+	persistTerminalSessions();
 }
 
 /** Natural exits retain final output and their death notice as one ordered, reconnect-safe unit. */
@@ -298,7 +308,7 @@ export function attachTerminal(
 	const { id, entry } = spawnForTab(workspaceId, tabKey, clientKey, options, revived);
 	// Only a membership change is worth announcing — re-attaching to an existing tab leaves the list identical,
 	// and broadcasting on every mount would fan out a snapshot per Project Home round trip.
-	if (isNewTab) publishTabs(workspaceId);
+	if (isNewTab) membershipChanged(workspaceId);
 	const replay = entry.recorder.snapshot();
 	return { id, created: true, ...(replay ? { replay } : {}) };
 }
@@ -395,7 +405,7 @@ export function closeTerminalTab(
 	tabs.splice(position, 1);
 	pendingReplay.delete(index);
 	if (entry && id) disposeTerminalEntry(id, entry);
-	publishTabs(workspaceId);
+	membershipChanged(workspaceId);
 	return { closed: true, busy: false };
 }
 
@@ -424,7 +434,7 @@ export function closeWorkspaceTerminals(workspaceId: string): void {
 	for (const key of pendingReplay.keys()) {
 		if (key.startsWith(`${workspaceId}${TAB_INDEX_SEP}`)) pendingReplay.delete(key);
 	}
-	publishTabs(workspaceId);
+	membershipChanged(workspaceId);
 }
 
 /** Kill every live PTY — called on host shutdown so no shell processes orphan. */

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -65,10 +65,13 @@ const ptyByTab = new Map<string, string>();
 /** The ordered tab list per workspace — host-owned state, and the authority on which terminals exist. */
 const tabsByWorkspace = new Map<string, TabRecord[]>();
 /**
- * Recorded output restored from disk, waiting for the tab's first attach (see `reviveTerminalSessions`).
- * Served once and dropped, so a revived picture can never outlive the run it describes.
+ * The picture a tab is holding for its next shell, keyed like `ptyByTab`.
+ *
+ * Filled from disk at boot (`reviveTerminalSessions`) and when a shell exits naturally while its tab lives on —
+ * both are cases where the tab outlives the process that painted it. Served once and dropped, so it can never
+ * outlive the run it describes.
  */
-const revivedOutput = new Map<string, string>();
+const pendingReplay = new Map<string, string>();
 
 /** Separator for the composite tab key. A NUL cannot occur in a workspace id or a tabKey, so the pair can
  * never collide — written as an escape rather than a literal so this file stays text to git and to tooling. */
@@ -220,9 +223,15 @@ function spawnForTab(
 		// An intentional teardown deletes the entry before kill(), so its eventual exit callback is silent.
 		if (terminals.get(id) !== entry) return;
 		terminals.delete(id);
-		ptyByTab.delete(tabIndex(entry.workspaceId, entry.tabKey));
-		// The TAB survives its shell: the user still has to see it died and close it themselves. A later attach
-		// on the same tab gets a fresh shell, which is the same thing the old client-side path did.
+		const index = tabIndex(entry.workspaceId, entry.tabKey);
+		ptyByTab.delete(index);
+		// The TAB survives its shell: the user still has to see it died and close it themselves. Hand its last
+		// screen to the tab before the recorder goes with the entry — otherwise leaving the workspace (or a host
+		// restart) after a crash loses exactly the output that would say what happened, and the next attach
+		// opens a blank pane. A later attach on the same tab gets a fresh shell showing this.
+		const finalScreen = recorder.snapshot();
+		if (finalScreen) pendingReplay.set(index, finalScreen);
+		recorder.dispose();
 		const finalBatch = output.finish();
 		const data: TerminalDataPush | undefined = finalBatch
 			? { id, data: finalBatch.data, truncated: finalBatch.truncated }
@@ -284,8 +293,8 @@ export function attachTerminal(
 	}
 
 	// A revived tab paints what its predecessor left behind; the shell underneath is genuinely new.
-	const revived = revivedOutput.get(index);
-	revivedOutput.delete(index);
+	const revived = pendingReplay.get(index);
+	pendingReplay.delete(index);
 	const { id, entry } = spawnForTab(workspaceId, tabKey, clientKey, options, revived);
 	// Only a membership change is worth announcing — re-attaching to an existing tab leaves the list identical,
 	// and broadcasting on every mount would fan out a snapshot per Project Home round trip.
@@ -313,12 +322,37 @@ function attachedEntry(id: string, caller: string): TerminalEntry | undefined {
 	return entry?.attachedClient === caller ? entry : undefined;
 }
 
+/**
+ * Tell a caller that tried to drive a terminal it is not attached to.
+ *
+ * `terminal.detached` is fire-and-forget, so the original notice can simply be lost — most plainly when the
+ * displaced client was mid-reconnect during the takeover, since a reconnect then replays its attach and the
+ * host's replay cache hands back the *cached* success. Without this the tab looks live forever while every
+ * keystroke silently goes nowhere. Re-announcing on the first thing it tries makes that self-healing.
+ */
+function announceDisplaced(id: string, caller: string): void {
+	const entry = terminals.get(id);
+	if (!entry || entry.attachedClient === caller) return;
+	const push: TerminalDetachedPush = { workspaceId: entry.workspaceId, tabKey: entry.tabKey };
+	pushToClient(caller, WS_CHANNELS.terminalDetached, push);
+}
+
 export function writeTerminal(id: string, data: string, caller: string): void {
-	attachedEntry(id, caller)?.pty.write(data);
+	const entry = attachedEntry(id, caller);
+	if (!entry) {
+		announceDisplaced(id, caller);
+		return;
+	}
+	entry.pty.write(data);
 }
 
 export function resizeTerminal(id: string, cols: number, rows: number, caller: string): void {
-	attachedEntry(id, caller)?.pty.resize(cols, rows);
+	const entry = attachedEntry(id, caller);
+	if (!entry) {
+		announceDisplaced(id, caller);
+		return;
+	}
+	entry.pty.resize(cols, rows);
 }
 
 function disposeTerminalEntry(id: string, entry: TerminalEntry): void {
@@ -359,7 +393,7 @@ export function closeTerminalTab(
 	if (entry && !force && hasChildProcesses(entry.pty.pid)) return { closed: false, busy: true };
 
 	tabs.splice(position, 1);
-	revivedOutput.delete(index);
+	pendingReplay.delete(index);
 	if (entry && id) disposeTerminalEntry(id, entry);
 	publishTabs(workspaceId);
 	return { closed: true, busy: false };
@@ -387,8 +421,8 @@ export function closeWorkspaceTerminals(workspaceId: string): void {
 		if (entry.workspaceId === workspaceId) disposeTerminalEntry(id, entry);
 	}
 	tabsByWorkspace.delete(workspaceId);
-	for (const key of revivedOutput.keys()) {
-		if (key.startsWith(`${workspaceId}${TAB_INDEX_SEP}`)) revivedOutput.delete(key);
+	for (const key of pendingReplay.keys()) {
+		if (key.startsWith(`${workspaceId}${TAB_INDEX_SEP}`)) pendingReplay.delete(key);
 	}
 	publishTabs(workspaceId);
 }
@@ -417,7 +451,7 @@ export function persistTerminalSessions(): void {
 			const entry = id === undefined ? undefined : terminals.get(id);
 			// A tab whose shell already exited keeps whatever it was revived with, so a restart does not blank a
 			// terminal the user had not got round to closing.
-			const recorded = entry ? entry.recorder.snapshot() : revivedOutput.get(index);
+			const recorded = entry ? entry.recorder.snapshot() : pendingReplay.get(index);
 			return { tabKey, title, ...(recorded ? { recorded } : {}) };
 		});
 	}
@@ -439,7 +473,7 @@ export function reviveTerminalSessions(): void {
 			if (typeof tab?.tabKey !== "string" || tab.tabKey === "") continue;
 			restored.push({ tabKey: tab.tabKey, title: tab.title ?? "Terminal" });
 			if (typeof tab.recorded === "string" && tab.recorded !== "") {
-				revivedOutput.set(tabIndex(workspaceId, tab.tabKey), tab.recorded);
+				pendingReplay.set(tabIndex(workspaceId, tab.tabKey), tab.recorded);
 			}
 		}
 		if (restored.length > 0) tabsByWorkspace.set(workspaceId, restored);
@@ -452,5 +486,5 @@ export function resetTerminalState(): void {
 	terminals.clear();
 	ptyByTab.clear();
 	tabsByWorkspace.clear();
-	revivedOutput.clear();
+	pendingReplay.clear();
 }

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -94,6 +94,24 @@ export function setTerminalPublisher(fn: PushToClient): void {
 	pushToClient = fn;
 }
 
+/**
+ * Fan a tab-list snapshot out to every client. Set by `createServer`.
+ *
+ * Which terminals exist is shared domain state (architecture #9), unlike their contents: without this, a tab
+ * closed in one browser leaves another with a dead instance mounted and still accepting input.
+ */
+let broadcastTabs: (workspaceId: string, tabs: TerminalTabInfo[]) => void = () => {};
+export function setTerminalTabsPublisher(
+	fn: (workspaceId: string, tabs: TerminalTabInfo[]) => void,
+): void {
+	broadcastTabs = fn;
+}
+
+/** Announce this workspace's tab list. Called only where the list actually changed. */
+function publishTabs(workspaceId: string): void {
+	broadcastTabs(workspaceId, listTerminals(workspaceId));
+}
+
 /** Natural exits retain final output and their death notice as one ordered, reconnect-safe unit. */
 const completions = createTerminalCompletionQueue((clientKey, channel, data) =>
 	pushToClient(clientKey, channel, data),
@@ -238,7 +256,8 @@ export function attachTerminal(
 	options: { title?: string; cols?: number; rows?: number } = {},
 ): AttachResult {
 	const tabs = tabsFor(workspaceId);
-	if (!tabs.some((tab) => tab.tabKey === tabKey)) {
+	const isNewTab = !tabs.some((tab) => tab.tabKey === tabKey);
+	if (isNewTab) {
 		tabs.push({ tabKey, title: options.title ?? `Terminal ${tabs.length + 1}` });
 	}
 
@@ -268,6 +287,9 @@ export function attachTerminal(
 	const revived = revivedOutput.get(index);
 	revivedOutput.delete(index);
 	const { id, entry } = spawnForTab(workspaceId, tabKey, clientKey, options, revived);
+	// Only a membership change is worth announcing — re-attaching to an existing tab leaves the list identical,
+	// and broadcasting on every mount would fan out a snapshot per Project Home round trip.
+	if (isNewTab) publishTabs(workspaceId);
 	const replay = entry.recorder.snapshot();
 	return { id, created: true, ...(replay ? { replay } : {}) };
 }
@@ -277,12 +299,26 @@ export function listTerminals(workspaceId: string): TerminalTabInfo[] {
 	return tabsFor(workspaceId).map(({ tabKey, title }) => ({ tabKey, title }));
 }
 
-export function writeTerminal(id: string, data: string): void {
-	terminals.get(id)?.pty.write(data);
+/**
+ * The entry for `id`, but only if `caller` is the client currently attached to it.
+ *
+ * Attach is exclusive, so a client that has been taken over must not go on driving the shell — and it can try
+ * to: the transport replays unresolved requests across a reconnect, so a keystroke queued before the takeover
+ * can arrive after it and would otherwise execute in whoever holds the tab now. Reclaiming is an explicit
+ * gesture ("Take it back" → a fresh attach), exactly as `tmux attach -d` and VS Code's window handoff work;
+ * typing into a stale tab must never silently steal it back.
+ */
+function attachedEntry(id: string, caller: string): TerminalEntry | undefined {
+	const entry = terminals.get(id);
+	return entry?.attachedClient === caller ? entry : undefined;
 }
 
-export function resizeTerminal(id: string, cols: number, rows: number): void {
-	terminals.get(id)?.pty.resize(cols, rows);
+export function writeTerminal(id: string, data: string, caller: string): void {
+	attachedEntry(id, caller)?.pty.write(data);
+}
+
+export function resizeTerminal(id: string, cols: number, rows: number, caller: string): void {
+	attachedEntry(id, caller)?.pty.resize(cols, rows);
 }
 
 function disposeTerminalEntry(id: string, entry: TerminalEntry): void {
@@ -325,6 +361,7 @@ export function closeTerminalTab(
 	tabs.splice(position, 1);
 	revivedOutput.delete(index);
 	if (entry && id) disposeTerminalEntry(id, entry);
+	publishTabs(workspaceId);
 	return { closed: true, busy: false };
 }
 
@@ -353,6 +390,7 @@ export function closeWorkspaceTerminals(workspaceId: string): void {
 	for (const key of revivedOutput.keys()) {
 		if (key.startsWith(`${workspaceId}${TAB_INDEX_SEP}`)) revivedOutput.delete(key);
 	}
+	publishTabs(workspaceId);
 }
 
 /** Kill every live PTY — called on host shutdown so no shell processes orphan. */

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -5,9 +5,10 @@ import type {
 	TerminalExitPush,
 	TerminalTabInfo,
 } from "@thinkrail/contracts";
-import { WS_CHANNELS } from "@thinkrail/contracts";
+import { TERMINAL_REPLAY_KB, WS_CHANNELS } from "@thinkrail/contracts";
 import { type IPty, spawn } from "bun-pty";
 import {
+	loadConfig,
 	loadTerminalSessions,
 	loadWorkspaces,
 	type PersistedTerminalSessions,
@@ -112,6 +113,21 @@ function ptyEnv(): Record<string, string> {
 /** The size a PTY starts at when the client didn't measure one — a plain terminal's conventional default. */
 const DEFAULT_PTY_SIZE = { cols: 80, rows: 24 } as const;
 
+/**
+ * How many characters of output to keep per terminal for replay, from `AppConfig.terminalReplayKb`.
+ *
+ * Clamped here rather than trusted: the value is persisted JSON a user can hand-edit, and it sizes a buffer
+ * held per live terminal *and* written to disk. Read per spawn, so changing the setting applies to new shells
+ * without disturbing running ones.
+ */
+function replayBudgetChars(): number {
+	const configured = loadConfig().terminalReplayKb;
+	const kb = Number.isFinite(configured)
+		? Math.min(Math.max(Math.trunc(configured), TERMINAL_REPLAY_KB.min), TERMINAL_REPLAY_KB.max)
+		: TERMINAL_REPLAY_KB.default;
+	return kb * 1024;
+}
+
 function tabsFor(workspaceId: string): TabRecord[] {
 	let tabs = tabsByWorkspace.get(workspaceId);
 	if (!tabs) {
@@ -148,7 +164,7 @@ function spawnForTab(
 	});
 
 	const id = randomUUID();
-	const recorder = createOutputRecorder();
+	const recorder = createOutputRecorder({ maxChars: replayBudgetChars() });
 	// Seed BEFORE the read loop is wired: the shell prints its prompt immediately, and restoring afterwards
 	// would overwrite whatever had already arrived.
 	if (revived !== undefined) recorder.restore(revived);

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -1,14 +1,26 @@
 import { randomUUID } from "node:crypto";
-import type { TerminalDataPush, TerminalExitPush } from "@thinkrail/contracts";
+import type {
+	TerminalDataPush,
+	TerminalDetachedPush,
+	TerminalExitPush,
+	TerminalTabInfo,
+} from "@thinkrail/contracts";
 import { WS_CHANNELS } from "@thinkrail/contracts";
 import { type IPty, spawn } from "bun-pty";
-import { loadWorkspaces } from "../persistence";
+import {
+	loadTerminalSessions,
+	loadWorkspaces,
+	type PersistedTerminalSessions,
+	saveTerminalSessions,
+} from "../persistence";
 import { createTerminalCompletionQueue } from "./completionQueue";
 import {
 	createOutputBatcher,
 	type OutputBatcher,
 	type TerminalDeliveryResult,
 } from "./outputBatcher";
+import { createOutputRecorder, type OutputRecorder } from "./outputRecorder";
+import { hasChildProcesses } from "./shellBusy";
 
 /** Push one addressed frame and report whether it was accepted and whether another may follow. */
 type PushToClient = (clientKey: string, channel: string, data: unknown) => TerminalDeliveryResult;
@@ -16,10 +28,19 @@ type PushToClient = (clientKey: string, channel: string, data: unknown) => Termi
 interface TerminalEntry {
 	pty: IPty;
 	workspaceId: string;
-	/** The client that owns this PTY — see `ownedEntry` for why a terminal is not shared. */
-	clientKey: string;
+	tabKey: string;
+	/** The client currently receiving this terminal's output; null when nobody is looking. */
+	attachedClient: string | null;
 	/** Groups this PTY's reads into whole frames instead of one frame per read. */
 	output: OutputBatcher;
+	/** The rolling window replayed into a fresh xterm on attach. */
+	recorder: OutputRecorder;
+}
+
+/** A tab, which exists whether or not a shell is currently running behind it. */
+interface TabRecord {
+	tabKey: string;
+	title: string;
 }
 
 /**
@@ -32,19 +53,40 @@ const OUTPUT_BATCH = {
 	flushMs: 8,
 	/** Flush early past this, so a flood streams steadily instead of in visible lumps. */
 	maxBatchChars: 32_768,
-	/** Held only while the owner is away (mid-reconnect); past it the oldest output goes. */
+	/** Held only while the attached client is away (mid-reconnect); past it the oldest output goes. */
 	maxPendingChars: 1_048_576,
 } as const;
 
+/** Live PTYs by their per-run id. */
 const terminals = new Map<string, TerminalEntry>();
+/** `(workspaceId, tabKey)` → the PTY id currently behind that tab. */
+const ptyByTab = new Map<string, string>();
+/** The ordered tab list per workspace — host-owned state, and the authority on which terminals exist. */
+const tabsByWorkspace = new Map<string, TabRecord[]>();
+/**
+ * Recorded output restored from disk, waiting for the tab's first attach (see `reviveTerminalSessions`).
+ * Served once and dropped, so a revived picture can never outlive the run it describes.
+ */
+const revivedOutput = new Map<string, string>();
+
+/** Separator for the composite tab key. A NUL cannot occur in a workspace id or a tabKey, so the pair can
+ * never collide — written as an escape rather than a literal so this file stays text to git and to tooling. */
+const TAB_INDEX_SEP = "\u0000";
+
+/** A tab's index key: the `(workspaceId, tabKey)` pair a shell is owned by. */
+function tabIndex(workspaceId: string, tabKey: string): string {
+	return `${workspaceId}${TAB_INDEX_SEP}${tabKey}`;
+}
 
 /**
- * Push terminal output to its owning client. Set by `createServer` once the WS server exists.
+ * Push terminal output to the client attached to it. Set by `createServer` once the WS server exists.
  *
  * Addressed rather than broadcast, deliberately: the host previously published every PTY's bytes to a single
  * topic that *every* socket subscribed to, leaving each browser to discard the ones that weren't its own. That
  * handed every connected client everything typed or printed in every terminal of every workspace — tokens,
  * keys, private paths — which matters all the more once the host is reachable from a phone over Tailscale.
+ * Which client is attached can change (attach is exclusive with takeover); that a frame only ever goes to a
+ * client that attached cannot.
  */
 let pushToClient: PushToClient = () => "unavailable";
 export function setTerminalPublisher(fn: PushToClient): void {
@@ -55,18 +97,6 @@ export function setTerminalPublisher(fn: PushToClient): void {
 const completions = createTerminalCompletionQueue((clientKey, channel, data) =>
 	pushToClient(clientKey, channel, data),
 );
-
-/**
- * The entry for `id`, but only if `owner` may touch it. A PTY belongs to the client that created it: it holds
- * that client's shell, history and output, so another connection must not read it, write to it or kill it.
- *
- * An unknown id and someone else's id are deliberately indistinguishable, so a caller probing ids learns
- * nothing about which exist.
- */
-function ownedEntry(id: string, owner: string): TerminalEntry | undefined {
-	const entry = terminals.get(id);
-	return entry?.clientKey === owner ? entry : undefined;
-}
 
 /** The host's full env (login PATH already resolved at boot) plus terminal-friendly vars. */
 function ptyEnv(): Record<string, string> {
@@ -82,18 +112,29 @@ function ptyEnv(): Record<string, string> {
 /** The size a PTY starts at when the client didn't measure one — a plain terminal's conventional default. */
 const DEFAULT_PTY_SIZE = { cols: 80, rows: 24 } as const;
 
+function tabsFor(workspaceId: string): TabRecord[] {
+	let tabs = tabsByWorkspace.get(workspaceId);
+	if (!tabs) {
+		tabs = [];
+		tabsByWorkspace.set(workspaceId, tabs);
+	}
+	return tabs;
+}
+
 /**
- * Spawn a PTY rooted in the workspace's worktree; its output streams on the `terminal.data` channel.
+ * Spawn a PTY for a tab, rooted in the workspace's worktree.
  *
  * `size` is the client's measured grid. Honouring it at spawn time matters because the shell prints its first
  * prompt immediately: born at the wrong size, that prompt is laid out for the wrong width and then reflowed
  * when the real size arrives a round trip later, which can visibly garble it.
  */
-export function createTerminal(
+function spawnForTab(
 	workspaceId: string,
+	tabKey: string,
 	clientKey: string,
-	size: { cols?: number; rows?: number } = {},
-): { id: string } {
+	size: { cols?: number; rows?: number },
+	revived: string | undefined,
+): { id: string; entry: TerminalEntry } {
 	const ws = loadWorkspaces().find((w) => w.id === workspaceId);
 	if (!ws) throw new Error(`Unknown workspace: ${workspaceId}`);
 
@@ -107,70 +148,177 @@ export function createTerminal(
 	});
 
 	const id = randomUUID();
-	// One frame per batch rather than per read, and output survives a brief reconnect: a batch the owner can't
-	// take is kept and retried (see `resumeClientTerminals`) instead of vanishing.
+	const recorder = createOutputRecorder();
+	// Seed BEFORE the read loop is wired: the shell prints its prompt immediately, and restoring afterwards
+	// would overwrite whatever had already arrived.
+	if (revived !== undefined) recorder.restore(revived);
+	// One frame per batch rather than per read, and output survives a brief reconnect: a batch the attached
+	// client can't take is kept and retried (see `resumeClientTerminals`) instead of vanishing.
 	const output = createOutputBatcher({
 		...OUTPUT_BATCH,
 		onFlush: ({ data, truncated }) => {
+			const entry = terminals.get(id);
+			if (!entry?.attachedClient) return "unavailable";
 			const push: TerminalDataPush = { id, data, truncated };
-			return pushToClient(clientKey, WS_CHANNELS.terminalData, push);
+			return pushToClient(entry.attachedClient, WS_CHANNELS.terminalData, push);
 		},
 	});
-	const entry: TerminalEntry = { pty, workspaceId, clientKey, output };
+	const entry: TerminalEntry = {
+		pty,
+		workspaceId,
+		tabKey,
+		attachedClient: clientKey,
+		output,
+		recorder,
+	};
 	terminals.set(id, entry);
-	pty.onData((data) => output.push(data));
-	// Tell the owner the shell is gone. Without this the tab stays looking alive — cursor blinking, keystrokes
-	// accepted — while every one of them is written to a dead id and silently dropped.
+	ptyByTab.set(tabIndex(workspaceId, tabKey), id);
+
+	pty.onData((data) => {
+		// Record before batching: the recording must survive delivery being dropped or truncated, since its whole
+		// job is to repaint a client that was not there.
+		recorder.push(data);
+		output.push(data);
+	});
+	// Tell the attached client the shell is gone. Without this the tab stays looking alive — cursor blinking,
+	// keystrokes accepted — while every one of them is written to a dead id and silently dropped.
 	pty.onExit(({ exitCode }) => {
 		// An intentional teardown deletes the entry before kill(), so its eventual exit callback is silent.
 		if (terminals.get(id) !== entry) return;
 		terminals.delete(id);
+		ptyByTab.delete(tabIndex(entry.workspaceId, entry.tabKey));
+		// The TAB survives its shell: the user still has to see it died and close it themselves. A later attach
+		// on the same tab gets a fresh shell, which is the same thing the old client-side path did.
 		const finalBatch = output.finish();
 		const data: TerminalDataPush | undefined = finalBatch
 			? { id, data: finalBatch.data, truncated: finalBatch.truncated }
 			: undefined;
 		const exit: TerminalExitPush = { id, exitCode };
-		completions.enqueue(clientKey, { ...(data ? { data } : {}), exit });
+		if (entry.attachedClient) {
+			completions.enqueue(entry.attachedClient, { ...(data ? { data } : {}), exit });
+		}
 	});
-	return { id };
+	return { id, entry };
 }
 
-export function writeTerminal(id: string, data: string, owner: string): void {
-	ownedEntry(id, owner)?.pty.write(data);
-}
-
-export function resizeTerminal(id: string, cols: number, rows: number, owner: string): void {
-	ownedEntry(id, owner)?.pty.resize(cols, rows);
+export interface AttachResult {
+	id: string;
+	created: boolean;
+	replay?: string;
 }
 
 /**
- * Whether `id` is a live PTY this client owns — what a re-attaching tab asks before presenting a detached shell
- * as still working. An id that died, or was never the caller's, answers the same: false.
+ * Give me this tab's shell — idempotent get-or-create, and the only way a PTY is ever born.
+ *
+ * **This function must stay synchronous.** Lookup and insert happen in one tick, which on Bun's single event
+ * loop makes it atomic: two concurrent attaches for the same tab cannot both spawn. That is the per-session
+ * mutex an idempotent attach needs, and it holds only while there is no `await` between the lookup and the
+ * `terminals.set` inside `spawnForTab`. Pinned by `terminalManager.test.ts`.
  */
-export function isTerminalAlive(id: string, owner: string): boolean {
-	return ownedEntry(id, owner) !== undefined;
+export function attachTerminal(
+	workspaceId: string,
+	tabKey: string,
+	clientKey: string,
+	options: { title?: string; cols?: number; rows?: number } = {},
+): AttachResult {
+	const tabs = tabsFor(workspaceId);
+	if (!tabs.some((tab) => tab.tabKey === tabKey)) {
+		tabs.push({ tabKey, title: options.title ?? `Terminal ${tabs.length + 1}` });
+	}
+
+	const index = tabIndex(workspaceId, tabKey);
+	const existingId = ptyByTab.get(index);
+	const existing = existingId === undefined ? undefined : terminals.get(existingId);
+
+	if (existing && existingId) {
+		// Exclusive attach: a PTY has one size, so the newcomer becomes the recipient and whoever held it is told
+		// rather than silently reflowed out from under (tmux's smallest-client rule, its worst-liked behaviour).
+		if (existing.attachedClient && existing.attachedClient !== clientKey) {
+			const push: TerminalDetachedPush = { workspaceId, tabKey };
+			pushToClient(existing.attachedClient, WS_CHANNELS.terminalDetached, push);
+		}
+		existing.attachedClient = clientKey;
+		if (options.cols !== undefined && options.rows !== undefined) {
+			existing.pty.resize(options.cols, options.rows);
+		}
+		const replay = existing.recorder.snapshot();
+		// The replay already shows everything the batcher is holding, so delivering that afterwards would paint
+		// the same bytes twice. Discard rather than resume.
+		existing.output.reset();
+		return { id: existingId, created: false, ...(replay ? { replay } : {}) };
+	}
+
+	// A revived tab paints what its predecessor left behind; the shell underneath is genuinely new.
+	const revived = revivedOutput.get(index);
+	revivedOutput.delete(index);
+	const { id, entry } = spawnForTab(workspaceId, tabKey, clientKey, options, revived);
+	const replay = entry.recorder.snapshot();
+	return { id, created: true, ...(replay ? { replay } : {}) };
+}
+
+/** This workspace's tabs, in order — what the rail renders instead of keeping a list of its own. */
+export function listTerminals(workspaceId: string): TerminalTabInfo[] {
+	return tabsFor(workspaceId).map(({ tabKey, title }) => ({ tabKey, title }));
+}
+
+export function writeTerminal(id: string, data: string): void {
+	terminals.get(id)?.pty.write(data);
+}
+
+export function resizeTerminal(id: string, cols: number, rows: number): void {
+	terminals.get(id)?.pty.resize(cols, rows);
 }
 
 function disposeTerminalEntry(id: string, entry: TerminalEntry): void {
 	// Delete first: bun-pty may report exit synchronously or later, and either way the callback sees this was an
 	// intentional teardown rather than manufacturing a natural-exit completion for a tab we deliberately shut.
 	terminals.delete(id);
+	ptyByTab.delete(tabIndex(entry.workspaceId, entry.tabKey));
 	entry.output.dispose();
+	entry.recorder.dispose();
 	entry.pty.kill();
 }
 
-export function closeTerminal(id: string, owner: string): void {
-	const entry = ownedEntry(id, owner);
-	if (entry) disposeTerminalEntry(id, entry);
+export interface CloseTabResult {
+	closed: boolean;
+	/** The shell had child processes and `force` was not set, so nothing was killed. */
+	busy: boolean;
 }
 
 /**
- * Try again to deliver output held back while a client was unreachable — called when it reconnects, so the gap
- * in its scrollback closes instead of being lost for good.
+ * Close a tab and kill its shell — the only client-driven kill there is.
+ *
+ * Refuses a shell with child processes unless the user has confirmed, and does the check and the kill in the
+ * same synchronous pass so nothing can start in between. Asking separately would let a `npm run dev` launched
+ * between question and answer die unannounced, which is the whole harm being guarded against.
+ */
+export function closeTerminalTab(
+	workspaceId: string,
+	tabKey: string,
+	force = false,
+): CloseTabResult {
+	const tabs = tabsFor(workspaceId);
+	const position = tabs.findIndex((tab) => tab.tabKey === tabKey);
+	if (position === -1) return { closed: false, busy: false };
+
+	const index = tabIndex(workspaceId, tabKey);
+	const id = ptyByTab.get(index);
+	const entry = id === undefined ? undefined : terminals.get(id);
+	if (entry && !force && hasChildProcesses(entry.pty.pid)) return { closed: false, busy: true };
+
+	tabs.splice(position, 1);
+	revivedOutput.delete(index);
+	if (entry && id) disposeTerminalEntry(id, entry);
+	return { closed: true, busy: false };
+}
+
+/**
+ * Try again to deliver output held back while the attached client was unreachable — called when it reconnects,
+ * so the gap in its scrollback closes instead of being lost for good.
  */
 export function resumeClientTerminals(clientKey: string): void {
 	for (const entry of terminals.values()) {
-		if (entry.clientKey === clientKey) entry.output.resume();
+		if (entry.attachedClient === clientKey) entry.output.resume();
 	}
 	// Then ordered natural completions. If live output consumed the socket's remaining capacity, the publisher
 	// reports unavailable and this queue simply waits for the next drain.
@@ -178,18 +326,16 @@ export function resumeClientTerminals(clientKey: string): void {
 }
 
 /**
- * Kill every PTY owned by a client — called once its connection has been gone long enough to count as
- * abandoned (see `server.ts`), so a closed laptop or a killed tab doesn't leave shells running forever.
- *
- * Deliberately *not* called the moment a socket drops: the client reconnects on its own, and a shell holding
- * real work must survive a network hiccup. That is the whole reason ownership is keyed to a client id rather
- * than to a socket.
+ * Kill every PTY rooted in a workspace and forget its tabs — called when the workspace is archived so no shell
+ * process orphans on a now-deleted worktree dir.
  */
-export function closeClientTerminals(clientKey: string): void {
-	// The client is gone for good, so there is nobody left to receive live output or natural completions.
-	completions.clearClient(clientKey);
+export function closeWorkspaceTerminals(workspaceId: string): void {
 	for (const [id, entry] of terminals) {
-		if (entry.clientKey === clientKey) disposeTerminalEntry(id, entry);
+		if (entry.workspaceId === workspaceId) disposeTerminalEntry(id, entry);
+	}
+	tabsByWorkspace.delete(workspaceId);
+	for (const key of revivedOutput.keys()) {
+		if (key.startsWith(`${workspaceId}${TAB_INDEX_SEP}`)) revivedOutput.delete(key);
 	}
 }
 
@@ -200,11 +346,57 @@ export function closeAllTerminals(): void {
 }
 
 /**
- * Kill every PTY rooted in a workspace — called when the workspace is archived so no shell process
- * orphans on a now-deleted worktree dir.
+ * Write every workspace's tabs and their recorded output to disk, so a host restart can give the tabs back.
+ *
+ * Only the picture is saved. A host restart kills every shell — `pi` runs in-process and the kernel hangs up
+ * each PTY regardless — so there is nothing to reattach to, and persisting a PTY id would invite attaching to
+ * one that outlived its process (Theia's `Couldn't attach - can't find terminal with id`). This is VS Code's
+ * *process revive*, not *process reconnection*.
  */
-export function closeWorkspaceTerminals(workspaceId: string): void {
-	for (const [id, entry] of terminals) {
-		if (entry.workspaceId === workspaceId) disposeTerminalEntry(id, entry);
+export function persistTerminalSessions(): void {
+	const sessions: PersistedTerminalSessions = {};
+	for (const [workspaceId, tabs] of tabsByWorkspace) {
+		if (tabs.length === 0) continue;
+		sessions[workspaceId] = tabs.map(({ tabKey, title }) => {
+			const index = tabIndex(workspaceId, tabKey);
+			const id = ptyByTab.get(index);
+			const entry = id === undefined ? undefined : terminals.get(id);
+			// A tab whose shell already exited keeps whatever it was revived with, so a restart does not blank a
+			// terminal the user had not got round to closing.
+			const recorded = entry ? entry.recorder.snapshot() : revivedOutput.get(index);
+			return { tabKey, title, ...(recorded ? { recorded } : {}) };
+		});
 	}
+	saveTerminalSessions(sessions);
+}
+
+/**
+ * Restore the tab lists from disk at boot. Shells are not restored — each tab gets a fresh one on first attach,
+ * showing its predecessor's recorded output so the screen is not simply blank.
+ *
+ * An unclean exit has nothing to read and restores nothing, which is the honest degradation rather than a
+ * special case.
+ */
+export function reviveTerminalSessions(): void {
+	for (const [workspaceId, tabs] of Object.entries(loadTerminalSessions())) {
+		if (!Array.isArray(tabs)) continue;
+		const restored: TabRecord[] = [];
+		for (const tab of tabs) {
+			if (typeof tab?.tabKey !== "string" || tab.tabKey === "") continue;
+			restored.push({ tabKey: tab.tabKey, title: tab.title ?? "Terminal" });
+			if (typeof tab.recorded === "string" && tab.recorded !== "") {
+				revivedOutput.set(tabIndex(workspaceId, tab.tabKey), tab.recorded);
+			}
+		}
+		if (restored.length > 0) tabsByWorkspace.set(workspaceId, restored);
+	}
+}
+
+/** Drop all in-memory terminal state. Test seam — production tears down through `closeAllTerminals`. */
+export function resetTerminalState(): void {
+	closeAllTerminals();
+	terminals.clear();
+	ptyByTab.clear();
+	tabsByWorkspace.clear();
+	revivedOutput.clear();
 }


### PR DESCRIPTION
Stacked on #181 — review that first.

## The bug

Leaving and re-entering a workspace faster than one round trip spawned a **second shell** and left the first running with nothing pointing at it, for the life of the host.

The client held the only copy of the tab→shell mapping and removed the entry *before* asking the host whether that shell was still alive. A remount inside that window found nothing and created another.

Reproduced by holding `terminal.alive` for 3s and re-entering twice:

```
distinct pty ids:   [ '9899f3dd-…', 'f7c7740f-…' ]   ← two shells, one tab
original id frames: 105 → 109 → 112                   ← orphan still running
CHECK=$TR_SURVIVOR → "CHECK="                         ← shell state gone
```

The deeper cause is that the client inferred user intent at unmount time — *"was my tab closed, or did the panel go away?"* — from a store read. That guess is the root of the whole bug family, not just the race.

## The fix

Rather than guard the window, remove the state that can go stale.

| | |
|---|---|
| **`terminal.attach`** | Idempotent get-or-create keyed by `(workspaceId, tabKey)`. Replaces `terminal.create` + `terminal.alive`. Mount is one call; unmount does nothing. |
| **Host owns the tab list** | `terminal.list`. The client can never hold the only record of a running shell. |
| **Owner-scoped shells** | Not per-page — matching `history`/`todos`/`templates`, which already assume a single-owner host. Shells survive a reload, a closed browser, a different browser. |
| **Exclusive attach** | A PTY has one size, so a takeover notifies the displaced client (`terminal.detached`) rather than silently reflowing it. Mirroring stays additive. |
| **Replay on attach** | A bounded server-side recorder repaints the screen, so a surviving shell no longer comes back behind a blank pane. |
| **Revive** | A host restart cannot preserve shells; tabs come back with fresh ones showing the recording. |
| **Reference-based GC** | No tab → no shell, plus host lifetime. The abandoned-client reap is **gone** — it was what made a reload destructive. |
| **Confirm on close** | Closing a tab is the only client-driven kill and refuses a busy shell until confirmed — checked and killed in one synchronous pass, so nothing started in between dies unannounced. |

Atomicity comes from the attach handler being **synchronous** on Bun's single event loop — the per-session mutex for free. Pinned by test and SPEC, because an `await` added later would silently reintroduce double-spawn.

**Deleted:** `detachedPtyByClientId`, `terminal.alive`, `isTerminalAlive`, `closeClientTerminals`, the `tabSurvives` inference, and both stale-closure branches.

## Design check

Cross-checked against VS Code (`attachToProcess`, keyed `(workspaceId, instanceId)`; recorder replay via `persistentSessionScrollback`; reconnection vs revive), tmux (`new -A -s`), Jupyter/terminado (`GET/POST /api/terminals`), and Zed's daemon RFC. Theia is the cautionary case — frontend-held id against an in-memory backend registry produces `Couldn't attach - can't find terminal with id`, which our server-side get-or-create makes unrepresentable.

tmux as the persistence layer was considered and **rejected** (recorded in `architecture.md` #12): unassumable on Windows, competing tab model, env-propagation breakage, polling-based capture — and we have already accepted no crash isolation.

No idle culling, deliberately: Jupyter's `cull_inactive_timeout` measures last PTY I/O, not whether a process runs, and kills quiet long-running commands.

## Verification

- `bun run e2e` — **170 passed**, including new specs for the rapid re-entry race, reload survival, second-client takeover, and both close-confirm paths.
- `bun run test` — 473 unit tests; new: `outputRecorder`, `shellBusy`, `terminalManager` (attach idempotency incl. concurrent, takeover, busy-close, revive).
- `check:deps`, `check:seams`, `lint`, `typecheck` green. No suppressions added.

Protocol v27.

<img width="1280" height="720" alt="settings-terminal-dark" src="https://github.com/user-attachments/assets/c365d3d5-3dfd-46d2-8a87-1cbf560dfe79" />
<img width="1280" height="720" alt="busy-close-dark" src="https://github.com/user-attachments/assets/c8024791-447a-4d66-9454-57a43e9b024c" />
<img width="1280" height="720" alt="detached-light" src="https://github.com/user-attachments/assets/b1c6e8fd-64fd-451a-9fd7-cffdbdb90a1f" />
<img width="1280" height="720" alt="detached-dark" src="https://github.com/user-attachments/assets/29ce9dbd-e25f-4c80-a64a-86734a78aaea" />
<img width="1280" height="720" alt="after-replay-dark" src="https://github.com/user-attachments/assets/915f3354-53d4-4c44-b70f-ad51858da274" />
