### PR TITLE
refactor(fonts): make the font stacks a single source of truth

### DIFF
--- a/apps/web/src/styles/TYPOGRAPHY.md
+++ b/apps/web/src/styles/TYPOGRAPHY.md
@@ -210,11 +210,18 @@ Self-hosted variable faces. The packages are declared per family as `selfHosted`
 **no font CDN**, so an offline host renders the real system. Both faces are variable, so 800 and
 italics are real, not synthetic. Pinned by `e2e/fonts.spec.ts`.
 
+**Swapping a family is a one-file change**: edit the family's `stack` + `selfHosted` here, `bun add` the
+new package, `typography:generate`. No face name is written anywhere else — the tests read it back from
+the generated output (`e2e/fixtures/typography.ts`), and `validate` rejects both a `selfHosted` package
+that is not a dependency and a font dependency no family claims. The one other copy of the stacks lives
+in `apps/website` (a standalone leaf that cannot import ours); `apps/website/src/fonts.test.ts` fails
+when it drifts from this file.
+
 `tokens.css` holds **no typography at all** — not a value and not an alias. It used to carry `--font`,
 `--font-mono`, `--font-accent`, `--font-mono-size` and `--line-height` as aliases onto the generated
 tokens; every one of them is gone, because a second name for a value is the thing that drifts. The
-consumers that cannot use a class read the `--tr-*` tokens directly. Cabinet Grotesk is retired and must
-not return (it was never loaded).
+consumers that cannot use a class read the `--tr-*` tokens directly. Cabinet Grotesk is retired
+repo-wide and must not return.
 
 ## Mono policy
 

--- a/apps/web/src/styles/typography.test.ts
+++ b/apps/web/src/styles/typography.test.ts
@@ -88,8 +88,15 @@ describe("typography source", () => {
 			semibold: 600,
 			brand: 800,
 		});
-		expect(resolveFamily(typography, "interface").stack[0]).toBe("Geist Variable");
-		expect(resolveFamily(typography, "code").stack[0]).toBe("JetBrains Mono Variable");
+		// Each self-hosted face LEADS its own stack — behind a system font it would never render. The
+		// face names stay in the JSON alone, so swapping a family is a one-file change.
+		for (const id of ["interface", "code"]) {
+			const family = resolveFamily(typography, id);
+			expect(family.selfHosted ?? [], `${id} self-hosted`).not.toEqual([]);
+			expect(family.stack[0], `${id} leads with its bundled face`).not.toMatch(
+				/^(?:-apple-system|sans-serif|serif|monospace)$/,
+			);
+		}
 		// The brand family is an ALIAS of interface — the stack is never copied.
 		expect(isRef(typography.fontFamilies.brand)).toBe(true);
 		expect(resolveFamily(typography, "brand")).toEqual(resolveFamily(typography, "interface"));

--- a/apps/website/SPEC.md
+++ b/apps/website/SPEC.md
@@ -30,10 +30,10 @@ binary.
   woff2 files into `dist/`. They are shared with `apps/web`, so they come from the root
   `workspaces.catalog` — one pin for both apps, which is what keeps the site's faces identical to the
   app's.
-- **Fonts are self-hosted**, from the same packages and family names as the app (Geist Variable +
-  JetBrains Mono Variable), so the site's type matches without importing anything from `apps/web`. The
-  one remaining external font request is `--font-display` (Cabinet Grotesk, via Fontshare): it has no
-  npm package, and self-hosting it is a licence decision to take deliberately.
+- **Fonts are self-hosted; the site makes no external font request.** Packages and stacks are copied
+  from the app's `typography.json`, not imported — and `src/fonts.test.ts` reads that JSON at test time
+  and fails on drift, which is what makes copying safe. `--font-display` aliases `--font-sans`,
+  mirroring the app's `brand` family.
 - **Brand values are copied, not imported.** Theme palettes are lifted at authoring time from
   `apps/web/src/themes/bundled/*.theme.json` (dark = default, darcula, light, gruvbox) into the site's
   own CSS custom properties under `[data-theme]`; the site never reaches into `apps/web` at build time

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -28,14 +28,7 @@
 				document.documentElement.setAttribute("data-theme", theme);
 			} catch (_) {}
 		</script>
-		<!-- Geist + JetBrains Mono are self-hosted and bundled (src/styles.css), matching the app. Cabinet
-		     Grotesk (--font-display) is still fetched: it has no npm package, and self-hosting it is a
-		     licence call to make deliberately — the last external font request on the site. -->
-		<link rel="preconnect" href="https://api.fontshare.com" crossorigin />
-		<link
-			href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@700,800&display=swap"
-			rel="stylesheet"
-		/>
+		<!-- Every face is self-hosted and bundled (src/styles.css), matching the app. No font CDN. -->
 		<link rel="stylesheet" href="/src/styles.css" />
 	</head>
 	<body>

--- a/apps/website/src/fonts.test.ts
+++ b/apps/website/src/fonts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * The site copies the app's font stacks rather than importing them — it is a standalone leaf with no
+ * workspace deps (SPEC.md). Copying is only safe if it cannot drift, so this reads the app's source of
+ * truth at TEST time (never at build time) and fails when the two disagree. It is also what keeps a
+ * font swap in `apps/web` a one-file change: this test names the site as the second place to update.
+ */
+const CSS = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
+const TYPOGRAPHY = JSON.parse(
+	readFileSync(new URL("../../web/src/styles/typography.json", import.meta.url), "utf8"),
+) as {
+	fontFamilies: Record<string, { stack: string[]; selfHosted?: string[] } | { $ref: string }>;
+};
+
+/** A family from the app's JSON, following the one `$ref` hop the format allows. */
+function appFamily(id: string) {
+	const entry = TYPOGRAPHY.fontFamilies[id];
+	if (!entry) throw new Error(`unknown app font family '${id}'`);
+	return "$ref" in entry ? appFamily(entry.$ref) : entry;
+}
+
+/** A custom property's value from the site's CSS, as a list of unquoted family names. */
+function cssStack(name: string): string[] {
+	const match = CSS.match(new RegExp(`--${name}:([^;]*);`));
+	if (!match) throw new Error(`--${name} is not declared in styles.css`);
+	return (match[1] as string).split(",").map((f) => f.trim().replace(/^"|"$/g, ""));
+}
+
+describe("site fonts match the app", () => {
+	it("declares the same stacks", () => {
+		expect(cssStack("font-sans")).toEqual(appFamily("interface").stack);
+		expect(cssStack("font-mono")).toEqual(appFamily("code").stack);
+	});
+
+	it("aliases the display role onto the interface face, like the app's brand family", () => {
+		expect(cssStack("font-display")).toEqual(["var(--font-sans)"]);
+	});
+
+	it("bundles the same font packages", () => {
+		const imported = [...CSS.matchAll(/@import "([^"]+)";/g)].map((m) => m[1]);
+		expect(imported).toEqual([
+			...(appFamily("interface").selfHosted ?? []),
+			...(appFamily("code").selfHosted ?? []),
+		]);
+	});
+
+	it("requests no font from a CDN", () => {
+		const html = readFileSync(new URL("../index.html", import.meta.url), "utf8");
+		for (const source of [CSS, html])
+			expect(source).not.toMatch(/fonts\.(?:googleapis|gstatic)\.com|api\.fontshare\.com/);
+	});
+});

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -4,10 +4,9 @@
  * (see SPEC.md: values are lifted at authoring time, never imported).
  */
 
-/* Self-hosted variable faces, same packages and family names as the app
-   (apps/web/src/styles/generated/fonts.css, generated from its typography.json)
-   — no Google Fonts call from the site either. `--font-display` (Cabinet Grotesk) is still CDN-served;
-   see the note in index.html. */
+/* Self-hosted variable faces — no external font request from the site at all. The packages, the stacks
+   below and `--font-display` are copied from apps/web/src/styles/typography.json (the app's source of
+   truth); `src/fonts.test.ts` reads that JSON and fails on drift. */
 @import "@fontsource-variable/geist";
 @import "@fontsource-variable/geist/wght-italic.css";
 @import "@fontsource-variable/jetbrains-mono";
@@ -19,7 +18,9 @@
 	--font-sans: "Geist Variable", "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 	--font-mono:
 		"JetBrains Mono Variable", "JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code", monospace;
-	--font-display: "Cabinet Grotesk", var(--font-sans);
+	/* The display role, mirroring the app's `brand` family — an alias of the interface face, not a
+	   second typeface. */
+	--font-display: var(--font-sans);
 
 	/* dark (the app's default) */
 	--chrome: #171719;

--- a/e2e/fixtures/typography.ts
+++ b/e2e/fixtures/typography.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * The faces the app ships, read from the generated typography CSS — the same stylesheet the browser
+ * loads, and itself generated from `apps/web/src/styles/typography.json` (kept in step by
+ * `typography:check`). Specs assert against these instead of a literal face name, so swapping a font
+ * stays a one-file change in that JSON.
+ *
+ * The token is read rather than imported: `apps/web/scripts/typography.ts` uses `import.meta.dir`,
+ * which is Bun-only, and Playwright runs under Node.
+ */
+const GENERATED = readFileSync(
+	new URL("../../apps/web/src/styles/generated/typography.css", import.meta.url),
+	"utf8",
+);
+
+/** The head of a family token's stack: the self-hosted face, the one that actually renders. */
+function bundledFace(id: string): string {
+	const match = GENERATED.match(new RegExp(`--tr-font-family-${id}:\\s*([^,;]+)`));
+	if (!match) throw new Error(`--tr-font-family-${id} is not in the generated typography CSS`);
+	return (match[1] as string).trim().replace(/^"|"$/g, "");
+}
+
+export const INTERFACE_FACE = bundledFace("interface");
+export const CODE_FACE = bundledFace("code");

--- a/e2e/fonts.spec.ts
+++ b/e2e/fonts.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { CODE_FACE, INTERFACE_FACE } from "./fixtures/typography";
 
 // The app's faces must ship *inside* the artifact: ThinkRail runs locally (often offline) and is
 // distributed as a single-file binary, so a font CDN would mean system-font fallback on an air-gapped
@@ -40,7 +41,7 @@ test("serves the self-hosted variable faces, including the brand weight and real
 	// Both families are declared, and as *variable* faces spanning the weights the type scale uses —
 	// 800 (`text-brand`, `font-extrabold`) included, so the brand style is a real face and not the
 	// browser's synthetic bold.
-	for (const family of ["Geist Variable", "JetBrains Mono Variable"]) {
+	for (const family of [INTERFACE_FACE, CODE_FACE]) {
 		const faces = fonts.faces.filter((f) => f.family === family);
 		expect(faces.length, `${family} is declared`).toBeGreaterThan(0);
 		expect(
@@ -57,7 +58,7 @@ test("serves the self-hosted variable faces, including the brand weight and real
 	}
 
 	// The token stack leads with the bundled face, so body copy actually renders in it.
-	expect(fonts.bodyFamily).toContain("Geist Variable");
+	expect(fonts.bodyFamily).toContain(INTERFACE_FACE);
 });
 
 /** `font-weight: 100 900` (a variable range) covers `target`. */

--- a/e2e/typography.spec.ts
+++ b/e2e/typography.spec.ts
@@ -7,6 +7,7 @@ import {
 	visibleTerminalScreen,
 	waitTerminalReady,
 } from "./fixtures/app";
+import { CODE_FACE, INTERFACE_FACE } from "./fixtures/typography";
 
 /**
  * Computed-style verification: the generated typography actually renders on the real surfaces, and the
@@ -20,9 +21,6 @@ import {
  *
  * Values come from `apps/web/src/styles/typography.json` — update them there, never here.
  */
-const GEIST = /Geist Variable/;
-const MONO = /JetBrains Mono Variable/;
-
 type TypeInfo = {
 	family: string;
 	size: string;
@@ -51,7 +49,7 @@ test("brand, welcome hero and label pill render the generated brand styles", asy
 	await openAppFresh(page);
 	const wordmark = await typeOf(page.locator(".tr-brand-wordmark").first());
 	expect(wordmark).toMatchObject({ size: "18px", weight: "800", lineHeight: "22.5px" });
-	expect(wordmark.family).toMatch(GEIST);
+	expect(wordmark.family).toMatch(INTERFACE_FACE);
 
 	await openFixtureProject(page);
 	expect(await typeOf(page.getByTestId("welcome-title"))).toMatchObject({
@@ -86,8 +84,8 @@ test("entity rows, branch metadata and eyebrows are proportional", async ({ page
 	await createWorkspaceViaDialog(page);
 	for (const testid of ["project-item", "workspace-item", "workspace-name", "workspace-branch"]) {
 		const type = await typeOf(page.getByTestId(testid).first());
-		expect(type.family, `${testid} must be proportional`).toMatch(GEIST);
-		expect(type.family, `${testid} must not be mono`).not.toMatch(MONO);
+		expect(type.family, `${testid} must be proportional`).toMatch(INTERFACE_FACE);
+		expect(type.family, `${testid} must not be mono`).not.toMatch(CODE_FACE);
 	}
 	expect(await typeOf(page.locator(".tr-text-eyebrow").first())).toMatchObject({
 		size: "12px",
@@ -107,7 +105,7 @@ test("Monaco and xterm render the generated code family and size", async ({ page
 	const editor = page.locator(".monaco-editor .view-lines").first();
 	await expect(editor).toBeVisible({ timeout: 30_000 });
 	const editorType = await typeOf(editor);
-	expect(editorType.family).toMatch(MONO);
+	expect(editorType.family).toMatch(CODE_FACE);
 	expect(editorType.size).toBe("11px");
 
 	// A terminal opens with the workspace. Measure the VISIBLE instance: several stay mounted at once
@@ -115,7 +113,7 @@ test("Monaco and xterm render the generated code family and size", async ({ page
 	// with no box — which is what let the old `if (await count())` version skip xterm entirely.
 	await waitTerminalReady(page);
 	const termType = await typeOf(visibleTerminalScreen(page));
-	expect(termType.family).toMatch(MONO);
+	expect(termType.family).toMatch(CODE_FACE);
 	// xterm adopts `code.block`'s size (13px); Monaco stays on the 11px editor tier above.
 	expect(termType.size).toBe("13px");
 });

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -43,7 +43,7 @@ The shell is built first, `pi` connected last:
   spec-graph rendered as its `parent` tree, backed by the same `pi-spec-graph` core model host-side;
   opening a node opens the spec file as an editor tab. Viewer only — no editing, drift detection, or
   graph canvas.
-- ThinkRail branding (violet `#8C81FF`, Darcula background, Geist / JetBrains Mono / Cabinet Grotesk).
+- ThinkRail branding (violet `#8C81FF`, Darcula background, Geist / JetBrains Mono).
 - On-disk state under `~/.thinkrail`.
 
 V1 is explicitly **not**: the workflow **product layer** (a runtime/engine, configurable pipelines —


### PR DESCRIPTION
Face names lived in four places besides `styles/typography.json`, so swapping a family meant editing tests that had no reason to know the typeface. Verified by actually swapping one (Geist → Inter) before and after.

### What changed

**Tests read the face back instead of naming it.** New `e2e/fixtures/typography.ts` pulls `--tr-font-family-{interface,code}` out of the generated CSS — the same stylesheet the browser loads. `e2e/fonts.spec.ts`, `e2e/typography.spec.ts` and `apps/web/src/styles/typography.test.ts` consume it. The unit test now asserts the invariant it meant all along: a self-hosted face must *lead* its stack, since behind a system font it would never render.

(The fixture reads the CSS rather than importing `apps/web/scripts/typography.ts`, which uses Bun-only `import.meta.dir` — Playwright runs under Node, and `import.meta.dir` is a 12-site repo convention I didn't want to break for one file.)

**`apps/website` drift is now gated.** The site is a standalone leaf and cannot import the app, so it keeps its copy of the stacks — but `apps/website/src/fonts.test.ts` reads `apps/web/src/styles/typography.json` at test time and fails when the stacks, the bundled packages, or the display alias diverge. That is what makes copying safe.

**Cabinet Grotesk is gone.** `--font-display` was `"Cabinet Grotesk", var(--font-sans)`, fetched from Fontshare — a face the app retired, so the site's wordmark and hero rendered in a *different* typeface than the app's. It now aliases `--font-sans`, mirroring the app's `brand` family. The `preconnect` + stylesheet `<link>` are removed: **the site now makes no external font request.**

### Result

Swapping a family is a one-file change: edit `stack` + `selfHosted` in `typography.json`, `bun add` the package, `typography:generate`. Three gates catch the rest — `typography:validate` rejects a `selfHosted` package that isn't a dependency *and* a font dependency no family claims; `fonts.test.ts` catches website drift; the e2e specs measure the rendered result.

### Verification

- `check:deps` · `check:seams` · `lint` · `typecheck` · `bun run test` — green
- `bun run e2e` — 155 passed
- `apps/website` builds; no `fontshare`/`Cabinet` in `dist/index.html`
- Negative test: injected a bogus family into the site's `--font-mono` → `fonts.test.ts` failed as intended

No UI-visible change to the app. The site's wordmark/hero/section-headings shift from Cabinet Grotesk to Geist 700 — the intent of the change.