### PR TITLE
fix(jbcentral): put /v1 on the openai proxy baseUrl

### DIFF
--- a/packages/shared/src/jbcentral.test.ts
+++ b/packages/shared/src/jbcentral.test.ts
@@ -19,7 +19,7 @@ describe("isJbcentralProxyUrl", () => {
 		expect(isJbcentralProxyUrl("http://127.0.0.1:19516/wire/s3cr3t/claude-code/anthropic")).toBe(
 			true,
 		);
-		expect(isJbcentralProxyUrl("http://127.0.0.1:4242/wire/abc/codex/openai")).toBe(true);
+		expect(isJbcentralProxyUrl("http://127.0.0.1:4242/wire/abc/pi/openai/v1")).toBe(true);
 		expect(isJbcentralProxyUrl("http://localhost:19516/wire/s3cr3t/claude-code/anthropic")).toBe(
 			true,
 		);
@@ -61,10 +61,12 @@ describe("resolveProxyPort", () => {
 });
 
 describe("buildProxyUrls", () => {
-	test("composes the per-provider proxy URLs (no /v1)", () => {
+	// The `/v1` asymmetry is load-bearing, not cosmetic: the anthropic SDK appends `/v1/messages` to the
+	// baseUrl while the openai SDK appends a bare `/responses`, and the proxy injects neither.
+	test("composes the per-provider proxy URLs (/v1 on openai only)", () => {
 		expect(buildProxyUrls(19516, "sEcReT")).toEqual({
-			anthropicUrl: "http://127.0.0.1:19516/wire/sEcReT/claude-code/anthropic",
-			openaiUrl: "http://127.0.0.1:19516/wire/sEcReT/codex/openai",
+			anthropicUrl: "http://127.0.0.1:19516/wire/sEcReT/pi/anthropic",
+			openaiUrl: "http://127.0.0.1:19516/wire/sEcReT/pi/openai/v1",
 		});
 	});
 

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -62,13 +62,17 @@ export function resolveProxyPort(env: ParseEnv, wireConfig: { proxy_port?: numbe
 }
 
 /**
- * Build the per-provider proxy base URLs. pi passes `model.baseUrl` straight to the official SDK, which
- * appends `/v1/messages` (anthropic) or `/responses` (openai); the proxy's per-provider PathSuffix injects
- * the backend `/v1/`. So no `/v1` here. The **shape here is what `isJbcentralProxyUrl` reads** — keep in sync.
+ * Build the per-provider proxy base URLs, under pi's **own** `/pi/` wire route (not Codex's or Claude
+ * Code's) — the shape `central add pi` writes.
+ *
+ * pi passes `model.baseUrl` straight to the official SDK, which appends `/v1/messages` (anthropic) but a
+ * bare `/responses` (openai). The proxy does **not** inject the backend `/v1/`, so openai's baseUrl must
+ * carry it and anthropic's must not: `/pi/openai/responses` 404s, `/pi/openai/v1/responses` does not.
+ * The **shape here is what `isJbcentralProxyUrl` reads** — keep in sync.
  */
 export function buildProxyUrls(port: number, secret: string): ProxyUrls {
 	const base = `http://127.0.0.1:${port}/wire/${secret}`;
-	return { anthropicUrl: `${base}/claude-code/anthropic`, openaiUrl: `${base}/codex/openai` };
+	return { anthropicUrl: `${base}/pi/anthropic`, openaiUrl: `${base}/pi/openai/v1` };
 }
 
 /** Wire the anthropic + openai providers' baseUrl/apiKey to the proxy, preserving their other fields. Mutates + returns `config`. */


### PR DESCRIPTION
Related to #190 — likely the same area; more fixes expected there later.

## The bug

`buildProxyUrls` assumed the JetBrains Central proxy injects the backend `/v1/`. It does not. pi hands `baseUrl` straight to the official SDK, which appends `/v1/messages` for anthropic but a **bare `/responses`** for openai.

So every openai turn posted to `/llm/openai/responses` → 404, surfacing in chat as:

```
OpenAI API error (404): 404 status code (no body)
```

Anthropic worked by accident — its SDK supplies the `/v1` itself. Anyone who used the in-app **Connect JetBrains AI** button got an openai provider that 404s on every send.

## The fix

Carry `/v1` on openai only, and move both providers onto pi's own `/pi/` wire route rather than borrowing Codex's and Claude Code's — the shape `central add pi` writes into its own extension.

## Verification

Probed against a live proxy (`400` = route exists, body rejected):

| route | status |
|---|---|
| `/wire/<s>/codex/openai/responses` (old) | **404** |
| `/wire/<s>/pi/openai/responses` | **404** |
| `/wire/<s>/pi/openai/v1/responses` | 400 → **200** with a real body |
| `/wire/<s>/pi/anthropic/v1/messages` | 400 → **200** with a real body |

End to end after wiring: `pi -p "say hi"` returns normally and the proxy log shows `POST 200 /llm/openai/v1/responses`.

Gates: `check:deps`, `check:seams`, `lint`, `typecheck`, `test` (509 server + 26 shared) all green. The one biome warning is pre-existing on main (`apps/website/src/styles.css`).

## Note on the detection tests

`isJbcentralProxyUrl` matches loopback + `/wire/`, so it is unaffected by the path change. Its tests deliberately **keep** the legacy `claude-code/anthropic` shapes — an existing `models.json` written by the old code must still read as jbcentral-wired rather than silently reporting "API key".

No e2e run: this path needs a live authenticated proxy, and `e2e:agent` pins `anthropic/claude-opus-4-8`, which never exercised the broken openai URL.