### PR TITLE
Open workspace actions on right click

### DIFF
--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -13,7 +13,7 @@ import {
 	Trash2,
 	X,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	ContextMenu,
@@ -534,6 +534,10 @@ function WorkspaceRow({
 	const isExternal = isExternalWorkspace(workspace);
 	const Icon = isDefault ? House : isExternal ? FolderOpen : GitBranch;
 	const [menuOpen, setMenuOpen] = useState(false);
+	const openMenuFromContext = (event: MouseEvent) => {
+		event.preventDefault();
+		setMenuOpen(true);
+	};
 	// A centered dialog, not an anchored popover: the trigger is a generic overflow icon, not a dedicated
 	// delete affordance, so anchoring a confirm box to it the way the old dedicated Remove button did would
 	// read oddly. Opened from the menu item's `onSelect`, `preventDefault`ed so Radix's own close-then-
@@ -552,6 +556,7 @@ function WorkspaceRow({
 				<button
 					type="button"
 					onClick={onSelect}
+					onContextMenu={openMenuFromContext}
 					className="flex min-w-0 flex-1 items-center gap-sm text-left"
 				>
 					<Icon className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-text-muted"}`} />
@@ -574,16 +579,17 @@ function WorkspaceRow({
 							</span>
 						)}
 					</span>
+					<DiffStatBadge
+						added={stats?.added ?? 0}
+						removed={stats?.removed ?? 0}
+						className="self-start group-hover:hidden"
+					/>
 				</button>
-				<DiffStatBadge
-					added={stats?.added ?? 0}
-					removed={stats?.removed ?? 0}
-					className="self-start group-hover:hidden"
-				/>
 				<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
 					<DropdownMenuTrigger
 						data-testid="workspace-menu"
 						aria-label={`Actions for ${workspace.name}`}
+						onContextMenu={openMenuFromContext}
 						// This menu is the row's only surface for Open in / Copy path / Reveal / Remove, so it
 						// can't be hover-only-invisible: a touch device has no hover and would never discover
 						// it. `opacity-0` only applies under `(hover: hover)` (a device that actually has a

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -544,19 +544,20 @@ function WorkspaceRow({
 	// return-focus-to-trigger doesn't fight the dialog's focus trap opening right behind it.
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	return (
-		<>
-			<div
+		<li>
+			<fieldset
+				aria-label={workspace.name}
 				data-testid="workspace-item"
 				data-active={isActive}
 				data-kind={workspace.kind ?? "worktree"}
-				className={`group flex min-h-7 items-center gap-sm rounded-[var(--radius-sm)] py-xs pr-xs pl-xl transition-colors ${
+				onContextMenu={openMenuFromContext}
+				className={`group flex min-h-7 min-w-0 items-center gap-sm rounded-[var(--radius-sm)] border-0 py-xs pr-xs pl-xl transition-colors ${
 					isActive || menuOpen ? "bg-control-bg-selected" : "hover:bg-control-bg-hovered"
 				}`}
 			>
 				<button
 					type="button"
 					onClick={onSelect}
-					onContextMenu={openMenuFromContext}
 					className="flex min-w-0 flex-1 items-center gap-sm text-left"
 				>
 					<Icon className={`size-4 shrink-0 ${isActive ? "text-primary" : "text-text-muted"}`} />
@@ -579,17 +580,16 @@ function WorkspaceRow({
 							</span>
 						)}
 					</span>
-					<DiffStatBadge
-						added={stats?.added ?? 0}
-						removed={stats?.removed ?? 0}
-						className="self-start group-hover:hidden"
-					/>
 				</button>
+				<DiffStatBadge
+					added={stats?.added ?? 0}
+					removed={stats?.removed ?? 0}
+					className="self-start group-hover:hidden"
+				/>
 				<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
 					<DropdownMenuTrigger
 						data-testid="workspace-menu"
 						aria-label={`Actions for ${workspace.name}`}
-						onContextMenu={openMenuFromContext}
 						// This menu is the row's only surface for Open in / Copy path / Reveal / Remove, so it
 						// can't be hover-only-invisible: a touch device has no hover and would never discover
 						// it. `opacity-0` only applies under `(hover: hover)` (a device that actually has a
@@ -644,7 +644,7 @@ function WorkspaceRow({
 						)}
 					</DropdownMenuContent>
 				</DropdownMenu>
-			</div>
+			</fieldset>
 			{!isDefault && (
 				<ConfirmDialog
 					open={confirmOpen}
@@ -676,6 +676,6 @@ function WorkspaceRow({
 					onConfirm={onRemove}
 				/>
 			)}
-		</>
+		</li>
 	);
 }

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -36,10 +36,12 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   row disappearing with no toast, while rejection keeps it and raises an error toast. Menu/dialog dismissal
   restores the source project-name focus; successful close focuses the fallback project name or rail Add
   project. `ProjectTree` also owns the `NewWorkspaceDialog` the per-project `+` opens **and** each
-  workspace row's hover-revealed **kebab menu** (`MoreVertical`, `DropdownMenu`) — a `DropdownMenuSub`
-  **"Open in"** (rendered only when at least one editor was detected), **Copy path**, **Reveal in file
-  manager**, and (worktrees only) **Remove workspace** — worded **Remove from ThinkRail** on an external
-  row, whose confirm promises the checkout and its branch stay untouched. "Open in" comes from the
+  workspace row's hover-revealed **kebab menu** (`MoreVertical`, controlled `DropdownMenu`) — right-clicking
+  anywhere on the row opens that exact menu at the kebab without selecting/activating the workspace, while
+  the kebab remains the touch and keyboard-focus path. Its actions are a `DropdownMenuSub` **"Open in"**
+  (rendered only when at least one editor was detected), **Copy path**, **Reveal in file manager**, and
+  (worktrees only) **Remove workspace** — worded **Remove from ThinkRail** on an external row, whose
+  confirm promises the checkout and its branch stay untouched. "Open in" comes from the
   host-wide `editor.list`;
   GUI entries call `workspace.openIn`, while terminal-kind Vim activates the workspace and runs through
   `addTerminal`'s one-shot `initialCommand`. Copy writes `worktreePath`; Reveal calls `workspace.reveal`.

--- a/e2e/workspace-actions.spec.ts
+++ b/e2e/workspace-actions.spec.ts
@@ -79,7 +79,10 @@ test("right-click opens the workspace's kebab menu without activating it", async
 	await expect(activeRow).toHaveAttribute("data-active", "true");
 	await expect(defaultRow).toHaveAttribute("data-active", "false");
 
-	await defaultRow.click({ button: "right" });
+	const rowBox = await defaultRow.boundingBox();
+	if (!rowBox) throw new Error("Workspace row has no geometry");
+	// Exercise the row's left indentation, outside both child buttons: the outer row owns right-click.
+	await page.mouse.click(rowBox.x + 4, rowBox.y + rowBox.height / 2, { button: "right" });
 	const actions = page.getByTestId("workspace-actions");
 	await expect(actions).toBeVisible();
 	const [actionsBox, kebabBox] = await Promise.all([

--- a/e2e/workspace-actions.spec.ts
+++ b/e2e/workspace-actions.spec.ts
@@ -69,6 +69,32 @@ test("the Default workspace's kebab menu offers Open in / Copy path but no Remov
 	await expect(page.getByTestId("workspace-remove")).toHaveCount(0);
 });
 
+test("right-click opens the workspace's kebab menu without activating it", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await settleAfterCreate(page);
+
+	const activeRow = worktreeRows(page).first();
+	const defaultRow = page.locator('[data-testid="workspace-item"][data-kind="default"]');
+	await expect(activeRow).toHaveAttribute("data-active", "true");
+	await expect(defaultRow).toHaveAttribute("data-active", "false");
+
+	await defaultRow.click({ button: "right" });
+	const actions = page.getByTestId("workspace-actions");
+	await expect(actions).toBeVisible();
+	const [actionsBox, kebabBox] = await Promise.all([
+		actions.boundingBox(),
+		defaultRow.getByTestId("workspace-menu").boundingBox(),
+	]);
+	if (!actionsBox || !kebabBox) throw new Error("Workspace menu has no anchor geometry");
+	expect(Math.abs(actionsBox.x + actionsBox.width - (kebabBox.x + kebabBox.width))).toBeLessThan(8);
+	expect(Math.abs(actionsBox.y - (kebabBox.y + kebabBox.height))).toBeLessThan(12);
+	await expect(page.getByTestId("workspace-copy-path")).toBeVisible();
+	await expect(page.getByTestId("workspace-remove")).toHaveCount(0);
+	await expect(activeRow).toHaveAttribute("data-active", "true");
+	await expect(defaultRow).toHaveAttribute("data-active", "false");
+});
+
 test("the kebab is hover-only ONLY on devices that actually have hover — never invisible by default", async ({
 	page,
 }) => {


### PR DESCRIPTION
## Summary
- open the workspace kebab menu on right click
- preserve workspace selection and menu anchoring
- add e2e coverage

## Tests
- `bun run e2e` (190 passed)