### PR TITLE
Chat: image attachments that can't brick a session, file-chip rendering, and a retry that doesn't duplicate the reply

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -660,7 +660,8 @@ export default function ChatView({
 							context={listContext}
 							components={CHAT_LIST_COMPONENTS}
 							// `overflow-x-hidden` on the scroller: the chat only ever scrolls vertically — wide
-							// content (code, diffs) scrolls inside its own block, never the whole transcript.
+							// content (code, diffs, GFM tables — see Markdown's `Table` wrapper) scrolls inside its
+							// own block, never the whole transcript.
 							className="min-h-0 flex-1 overflow-x-hidden"
 							// Any chat opens at the latest message (a fresh mount would otherwise land mid-transcript);
 							// the jump-to-message deep link overrides post-mount with its centered scrollToIndex.

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -1,6 +1,5 @@
 import type {
 	AskUserQuestionResult,
-	ImageContent,
 	PromptHit,
 	SlashCommandInfo,
 	TemplateInfo,
@@ -45,7 +44,7 @@ import { stripFrontmatter } from "./templateText";
 import { useModelCatalog } from "./useModelCatalog";
 import "./tools/register"; // side-effect: register the built-in pi tool renderers (bash/read/edit/write)
 import { ChatTurnView } from "./turns";
-import type { ChatTurn } from "./types";
+import type { ChatAttachment, ChatTurn } from "./types";
 import { useChatScroll } from "./useChatScroll";
 import { useChatTodos } from "./useChatTodos";
 import { useHistorySearch } from "./useHistorySearch";
@@ -362,9 +361,10 @@ export default function ChatView({
 			.catch(() => {});
 	};
 
-	const onSubmit = (text: string, images: ImageContent[], behavior: SubmitBehavior) => {
-		if (text || images.length > 0)
-			useAppStore.getState().appendUserMessage(sessionId, text, images);
+	const onSubmit = (text: string, attachments: ChatAttachment[], behavior: SubmitBehavior) => {
+		if (text || attachments.length > 0)
+			useAppStore.getState().appendUserMessage(sessionId, text, attachments);
+		const images = attachments.map((a) => a.content);
 		const params = { sessionId, text, ...(images.length > 0 ? { images } : {}) };
 		const method =
 			behavior === "steer"

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -659,7 +659,9 @@ export default function ChatView({
 							data={rows}
 							context={listContext}
 							components={CHAT_LIST_COMPONENTS}
-							className="min-h-0 flex-1"
+							// `overflow-x-hidden` on the scroller: the chat only ever scrolls vertically — wide
+							// content (code, diffs) scrolls inside its own block, never the whole transcript.
+							className="min-h-0 flex-1 overflow-x-hidden"
 							// Any chat opens at the latest message (a fresh mount would otherwise land mid-transcript);
 							// the jump-to-message deep link overrides post-mount with its centered scrollToIndex.
 							initialTopMostItemIndex={{ index: Math.max(rows.length - 1, 0), align: "end" }}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -363,7 +363,8 @@ export default function ChatView({
 	};
 
 	const onSubmit = (text: string, images: ImageContent[], behavior: SubmitBehavior) => {
-		if (text) useAppStore.getState().appendUserMessage(sessionId, text);
+		if (text || images.length > 0)
+			useAppStore.getState().appendUserMessage(sessionId, text, images);
 		const params = { sessionId, text, ...(images.length > 0 ? { images } : {}) };
 		const method =
 			behavior === "steer"

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -53,6 +53,13 @@ interface PendingImage extends AttachedImage {
 	name: string;
 }
 
+/** A refused pick, rendered as a dismissible error chip: the file's name plus why it couldn't attach. */
+interface AttachError {
+	id: string;
+	name: string;
+	reason: string;
+}
+
 /** The token (non-whitespace run) ending at the caret — drives `@`-mention completion. */
 function activeToken(value: string, caret: number): { token: string; start: number } {
 	const match = /(\S+)$/.exec(value.slice(0, caret));
@@ -248,8 +255,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const [pendingImages, setPendingImages] = useState(0);
 	// Files that could NOT be attached (undecodable + provider-unsupported type, or over the request-wide
 	// image budget) — surfaced as dismissible error chips in the attachment strip; silently dropping a
-	// pick would read as a successful attach.
-	const [attachErrors, setAttachErrors] = useState<{ id: string; text: string }[]>([]);
+	// pick would read as a successful attach. Name and reason stay separate so the chip can truncate the
+	// (user-controlled) filename while keeping the reason visible.
+	const [attachErrors, setAttachErrors] = useState<AttachError[]>([]);
 	const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
 	const [mentionDismissed, setMentionDismissed] = useState(false);
 	// The plain `↑`-recall session: `null` when inactive; otherwise an index into `recentPrompts` (0 =
@@ -462,22 +470,16 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			// over-budget turn is rejected forever (the host guard heals history, but never sending is cheaper).
 			let used = imagesRef.current.reduce((sum, p) => sum + p.content.data.length, 0);
 			const additions: PendingImage[] = [];
-			const errors: { id: string; text: string }[] = [];
+			const errors: AttachError[] = [];
 			settled.forEach((result, i) => {
 				const name = picked[i]?.name || "image";
 				if (result.status !== "fulfilled" || result.value === null) {
-					errors.push({
-						id: crypto.randomUUID(),
-						text: `Couldn't attach ${name} — unsupported image format`,
-					});
+					errors.push({ id: crypto.randomUUID(), name, reason: "unsupported image format" });
 					return;
 				}
 				const size = result.value.content.data.length;
 				if (used + size > REQUEST_IMAGE_BASE64_BUDGET) {
-					errors.push({
-						id: crypto.randomUUID(),
-						text: `Couldn't attach ${name} — message image limit reached`,
-					});
+					errors.push({ id: crypto.randomUUID(), name, reason: "message image limit reached" });
 					return;
 				}
 				used += size;
@@ -725,7 +727,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							data-testid="composer-image-error"
 							tone="error"
 							icon={false}
-							label={err.text}
+							// The filename truncates, the reason never does — the reason is the only thing the
+							// user can act on, and a phone has no tooltip to fall back to.
+							title={`Couldn't attach ${err.name} — ${err.reason}`}
+							label={`Couldn't attach ${err.name}`}
+							meta={`— ${err.reason}`}
 							trailing={
 								<button
 									type="button"
@@ -745,12 +751,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							data-width={img.width}
 							data-height={img.height}
 							data-mime={img.content.mimeType}
-							label={
-								<>
-									{img.name}
-									{img.width && img.height ? ` · ${img.width}×${img.height}` : null}
-								</>
-							}
+							title={img.name}
+							label={img.name}
+							meta={img.width && img.height ? ` · ${img.width}×${img.height}` : undefined}
 							trailing={
 								<button
 									type="button"

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -12,6 +12,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { FileChip } from "./FileChip";
 import { type AttachedImage, fileToAttachedImage } from "./imageAttachment";
 import { ModelSelector } from "./ModelSelector";
 import {
@@ -226,6 +227,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const ref = useRef<HTMLTextAreaElement>(null);
 	const [caret, setCaret] = useState(0);
 	const [images, setImages] = useState<PendingImage[]>([]);
+	// How many picked files are still decoding/downscaling in `addFiles` — the attach pipeline is async
+	// (30–140ms measured, wider on mobile), and a send landing inside that window would go WITHOUT the
+	// image (which would then attach itself to the NEXT message). While non-zero: placeholder chips render
+	// below, the send button disables, and `submitText` refuses to fire.
+	const [pendingImages, setPendingImages] = useState(0);
 	const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
 	const [mentionDismissed, setMentionDismissed] = useState(false);
 	// The plain `↑`-recall session: `null` when inactive; otherwise an index into `recentPrompts` (0 =
@@ -331,6 +337,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// with the text and are cleared with the draft in the same step (and any recall or template slot
 	// session ends with the send). No-op when both the (trimmed) text and the image list are empty.
 	const submitText = (raw: string, behavior: SubmitBehavior) => {
+		// Never send while an attachment is still decoding — it would silently miss this message and
+		// stray onto the next one. The draft stays put; the user re-sends once the chip appears.
+		if (pendingImages > 0) return;
 		const text = raw.trim();
 		if (!text && images.length === 0) return;
 		onSubmit(
@@ -417,18 +426,31 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const addFiles = async (files: File[]) => {
 		const picked = files.filter((f) => f.type.startsWith("image/"));
 		if (picked.length === 0) return;
-		// Downscaled at attach time (≤1568px long edge) — an oversized image in history 400s every
-		// subsequent turn once the provider's many-image cap kicks in. See imageAttachment.ts.
-		const attached = await Promise.all(picked.map(fileToAttachedImage));
-		setImages((prev) => [
-			...prev,
-			...attached.map((a, i) => ({
-				id: crypto.randomUUID(),
-				// A clipboard paste often arrives as a generic "image.png" — still better than a mime type.
-				name: picked[i]?.name || "image",
-				...a,
-			})),
-		]);
+		setPendingImages((n) => n + picked.length);
+		try {
+			// Downscaled/re-encoded at attach time (≤1568px long edge, provider-accepted type, ≤5MB) — an
+			// oversized image in history 400s every subsequent turn. See imageAttachment.ts. `allSettled`,
+			// not `all`: a single unreadable file must not discard siblings that decoded fine (and the
+			// callers invoke this as `void addFiles(...)` — a rejection here would be unhandled).
+			const settled = await Promise.allSettled(picked.map(fileToAttachedImage));
+			setImages((prev) => [
+				...prev,
+				...settled.flatMap((result, i) =>
+					result.status === "fulfilled"
+						? [
+								{
+									id: crypto.randomUUID(),
+									// A clipboard paste often arrives as a generic "image.png" — still better than a mime type.
+									name: picked[i]?.name || "image",
+									...result.value,
+								},
+							]
+						: [],
+				),
+			]);
+		} finally {
+			setPendingImages((n) => n - picked.length);
+		}
 	};
 
 	const submit = (behavior: SubmitBehavior) => {
@@ -653,28 +675,43 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				</button>
 			) : null}
 
-			{images.length > 0 ? (
+			{images.length > 0 || pendingImages > 0 ? (
 				<div className="flex flex-wrap gap-xs px-sm pt-sm" data-testid="composer-images">
 					{images.map((img) => (
-						<span
+						<FileChip
 							key={img.id}
 							data-testid="composer-image"
 							data-width={img.width}
 							data-height={img.height}
-							className="flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-default tr-text-metadata"
-						>
-							<FileIcon className="size-3" /> {img.name}
-							{img.width && img.height ? ` · ${img.width}×${img.height}` : null}
-							<button
-								type="button"
-								aria-label="Remove image"
-								onClick={() => setImages((prev) => prev.filter((p) => p.id !== img.id))}
-								className="text-text-muted hover:text-text-default"
-							>
-								<X className="size-3" />
-							</button>
-						</span>
+							data-mime={img.content.mimeType}
+							label={
+								<>
+									{img.name}
+									{img.width && img.height ? ` · ${img.width}×${img.height}` : null}
+								</>
+							}
+							trailing={
+								<button
+									type="button"
+									aria-label="Remove image"
+									onClick={() => setImages((prev) => prev.filter((p) => p.id !== img.id))}
+									className="text-text-muted hover:text-text-default"
+								>
+									<X className="size-3" />
+								</button>
+							}
+						/>
 					))}
+					{pendingImages > 0 ? (
+						<FileChip
+							data-testid="composer-image-pending"
+							label={
+								<span className="text-text-muted">
+									{pendingImages === 1 ? "Attaching…" : `Attaching ${pendingImages}…`}
+								</span>
+							}
+						/>
+					) : null}
 				</div>
 			) : null}
 
@@ -849,7 +886,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							data-testid="chat-send"
 							aria-label={isStreaming ? "Steer" : "Send"}
 							onClick={() => submit(isStreaming ? "steer" : "send")}
-							disabled={!value.trim() && images.length === 0}
+							disabled={pendingImages > 0 || (!value.trim() && images.length === 0)}
 							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-control-primary-bg text-control-primary-text hover:bg-control-primary-bg-hovered disabled:pointer-events-none disabled:bg-control-primary-disabled-bg disabled:text-control-primary-disabled-text"
 						>
 							<ArrowUp className="size-4" />

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -183,7 +183,8 @@ export interface ComposerHandle {
 	/** Replace the draft and send it through the composer's own submit seam — pending image attachments
 	 * travel with the text and are cleared with the draft, exactly like a keyboard send. This is the
 	 * history overlay's ⌘/Ctrl+Enter path; a caller-side `onSubmit` would strand the composer-private
-	 * `images` state (sent without them, stale thumbnails left attached to the next message). */
+	 * `images` state (sent without them, stale thumbnails left attached to the next message). When the
+	 * send is refused (an attachment still decoding), the text lands in the draft rather than nowhere. */
 	insertAndSubmit: (text: string, behavior: SubmitBehavior) => void;
 	/** Replace the draft with a parsed template's expansion; if it produced any slots, start a slot
 	 * session selecting slot 0 (else behaves like `insertText`: caret at the end, no session). */
@@ -424,7 +425,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// after `openHistory`/`slashCompletion` so nothing here forward-references a later binding.
 	useImperativeHandle(handleRef, () => ({
 		insertText: (text: string) => replaceDraft(text),
-		insertAndSubmit: (text: string, behavior: SubmitBehavior) => submitText(text, behavior),
+		// A send refused mid-decode (`canSubmit`) leaves the composer's OWN gestures holding the draft, but
+		// this text lives in the caller's overlay — parking it in the draft is what keeps a recalled prompt
+		// from vanishing when the user happens to send while an attachment is still decoding.
+		insertAndSubmit: (text: string, behavior: SubmitBehavior) =>
+			canSubmit(text) ? submitText(text, behavior) : replaceDraft(text),
 		insertTemplate: (parsed: ParsedTemplate) => {
 			const first = parsed.slots[0];
 			if (!first) {

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -428,7 +428,8 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		if (picked.length === 0) return;
 		setPendingImages((n) => n + picked.length);
 		try {
-			// Downscaled/re-encoded at attach time (≤1568px long edge, provider-accepted type, ≤5MB) — an
+			// Downscaled/re-encoded at attach time (≤1568px long edge, provider-accepted type, ≤4.5MB of
+			// base64) — an
 			// oversized image in history 400s every subsequent turn. See imageAttachment.ts. `allSettled`,
 			// not `all`: a single unreadable file must not discard siblings that decoded fine (and the
 			// callers invoke this as `void addFiles(...)` — a rejection here would be unhandled).

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -1,4 +1,9 @@
-import type { SlashCommandInfo, ThinkingLevel, WireModel } from "@thinkrail/contracts";
+import {
+	REQUEST_IMAGE_BASE64_BUDGET,
+	type SlashCommandInfo,
+	type ThinkingLevel,
+	type WireModel,
+} from "@thinkrail/contracts";
 import { ArrowUp, FileIcon, FolderIcon, History, Sparkles, Square, X } from "lucide-react";
 import {
 	type ClipboardEvent,
@@ -232,6 +237,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// image (which would then attach itself to the NEXT message). While non-zero: placeholder chips render
 	// below, the send button disables, and `submitText` refuses to fire.
 	const [pendingImages, setPendingImages] = useState(0);
+	// Files that could NOT be attached (undecodable + provider-unsupported type, or over the request-wide
+	// image budget) — surfaced as dismissible error chips in the attachment strip; silently dropping a
+	// pick would read as a successful attach.
+	const [attachErrors, setAttachErrors] = useState<{ id: string; text: string }[]>([]);
 	const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
 	const [mentionDismissed, setMentionDismissed] = useState(false);
 	// The plain `↑`-recall session: `null` when inactive; otherwise an index into `recentPrompts` (0 =
@@ -349,6 +358,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		);
 		onChange("");
 		setImages([]);
+		setAttachErrors([]);
 		recallIdxRef.current = null;
 		setSlots(null);
 	};
@@ -434,21 +444,41 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			// not `all`: a single unreadable file must not discard siblings that decoded fine (and the
 			// callers invoke this as `void addFiles(...)` — a rejection here would be unhandled).
 			const settled = await Promise.allSettled(picked.map(fileToAttachedImage));
-			setImages((prev) => [
-				...prev,
-				...settled.flatMap((result, i) =>
-					result.status === "fulfilled"
-						? [
-								{
-									id: crypto.randomUUID(),
-									// A clipboard paste often arrives as a generic "image.png" — still better than a mime type.
-									name: picked[i]?.name || "image",
-									...result.value,
-								},
-							]
-						: [],
-				),
-			]);
+			// Accept/refuse decisions happen HERE, not inside a state updater (updaters must stay pure and
+			// run deferred). The budget baseline is the batch state at call time — a chip removed during
+			// the decode window only makes the check conservative, never over-budget. One message's image
+			// batch must fit the request-wide budget: the provider caps the WHOLE request, and a persisted
+			// over-budget turn is rejected forever (the host guard heals history, but never sending is cheaper).
+			let used = images.reduce((sum, p) => sum + p.content.data.length, 0);
+			const additions: PendingImage[] = [];
+			const errors: { id: string; text: string }[] = [];
+			settled.forEach((result, i) => {
+				const name = picked[i]?.name || "image";
+				if (result.status !== "fulfilled" || result.value === null) {
+					errors.push({
+						id: crypto.randomUUID(),
+						text: `Couldn't attach ${name} — unsupported image format`,
+					});
+					return;
+				}
+				const size = result.value.content.data.length;
+				if (used + size > REQUEST_IMAGE_BASE64_BUDGET) {
+					errors.push({
+						id: crypto.randomUUID(),
+						text: `Couldn't attach ${name} — message image limit reached`,
+					});
+					return;
+				}
+				used += size;
+				additions.push({
+					id: crypto.randomUUID(),
+					// A clipboard paste often arrives as a generic "image.png" — still better than a mime type.
+					name,
+					...result.value,
+				});
+			});
+			if (additions.length > 0) setImages((prev) => [...prev, ...additions]);
+			if (errors.length > 0) setAttachErrors((prev) => [...prev, ...errors]);
 		} finally {
 			setPendingImages((n) => n - picked.length);
 		}
@@ -676,8 +706,25 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				</button>
 			) : null}
 
-			{images.length > 0 || pendingImages > 0 ? (
+			{images.length > 0 || pendingImages > 0 || attachErrors.length > 0 ? (
 				<div className="flex flex-wrap gap-xs px-sm pt-sm" data-testid="composer-images">
+					{attachErrors.map((err) => (
+						<span
+							key={err.id}
+							data-testid="composer-image-error"
+							className="flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border border-feedback-error-muted bg-clip-padding bg-feedback-error-subtle px-sm py-xs text-feedback-error tr-text-metadata"
+						>
+							{err.text}
+							<button
+								type="button"
+								aria-label="Dismiss"
+								onClick={() => setAttachErrors((prev) => prev.filter((p) => p.id !== err.id))}
+								className="hover:opacity-80"
+							>
+								<X className="size-3" />
+							</button>
+						</span>
+					))}
 					{images.map((img) => (
 						<FileChip
 							key={img.id}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -17,6 +17,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { type AttachedImage, fileToAttachedImage } from "./imageAttachment";
 import { ModelSelector } from "./ModelSelector";
 import {
 	SlashCommandMenu,
@@ -44,26 +45,8 @@ export interface MentionCandidate {
 	kind: "file" | "dir";
 }
 
-interface PendingImage {
+interface PendingImage extends AttachedImage {
 	id: string;
-	content: ImageContent;
-}
-
-function fileToImageContent(file: File): Promise<ImageContent> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onerror = () => reject(reader.error ?? new Error("failed to read image"));
-		reader.onload = () => {
-			const result = String(reader.result);
-			const comma = result.indexOf(",");
-			resolve({
-				type: "image",
-				data: comma >= 0 ? result.slice(comma + 1) : result,
-				mimeType: file.type || "image/png",
-			});
-		};
-		reader.readAsDataURL(file);
-	});
 }
 
 /** The token (non-whitespace run) ending at the caret — drives `@`-mention completion. */
@@ -436,11 +419,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const addFiles = async (files: File[]) => {
 		const picked = files.filter((f) => f.type.startsWith("image/"));
 		if (picked.length === 0) return;
-		const contents = await Promise.all(picked.map(fileToImageContent));
-		setImages((prev) => [
-			...prev,
-			...contents.map((content) => ({ id: crypto.randomUUID(), content })),
-		]);
+		// Downscaled at attach time (≤1568px long edge) — an oversized image in history 400s every
+		// subsequent turn once the provider's many-image cap kicks in. See imageAttachment.ts.
+		const attached = await Promise.all(picked.map(fileToAttachedImage));
+		setImages((prev) => [...prev, ...attached.map((a) => ({ id: crypto.randomUUID(), ...a }))]);
 	};
 
 	const submit = (behavior: SubmitBehavior) => {
@@ -670,9 +652,13 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 					{images.map((img) => (
 						<span
 							key={img.id}
+							data-testid="composer-image"
+							data-width={img.width}
+							data-height={img.height}
 							className="flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-default tr-text-metadata"
 						>
 							<FileIcon className="size-3" /> {img.content.mimeType}
+							{img.width && img.height ? ` · ${img.width}×${img.height}` : null}
 							<button
 								type="button"
 								aria-label="Remove image"

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -354,12 +354,14 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	// `insertAndSubmit` both land here, so whatever initiated the send, pending images always travel
 	// with the text and are cleared with the draft in the same step (and any recall or template slot
 	// session ends with the send). No-op when both the (trimmed) text and the image list are empty.
+	// The one send-permission reading, shared by `submitText` and the send button's `disabled`: never
+	// send while an attachment is still decoding (it would silently miss this message and stray onto the
+	// next one — the draft stays put, the user re-sends once the chip appears), and never send empty.
+	const canSubmit = (raw: string) => pendingImages === 0 && (!!raw.trim() || images.length > 0);
+
 	const submitText = (raw: string, behavior: SubmitBehavior) => {
-		// Never send while an attachment is still decoding — it would silently miss this message and
-		// stray onto the next one. The draft stays put; the user re-sends once the chip appears.
-		if (pendingImages > 0) return;
+		if (!canSubmit(raw)) return;
 		const text = raw.trim();
-		if (!text && images.length === 0) return;
 		onSubmit(
 			text,
 			images.map(({ name, content }) => ({ name, content })),
@@ -718,21 +720,23 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			{images.length > 0 || pendingImages > 0 || attachErrors.length > 0 ? (
 				<div className="flex flex-wrap gap-xs px-sm pt-sm" data-testid="composer-images">
 					{attachErrors.map((err) => (
-						<span
+						<FileChip
 							key={err.id}
 							data-testid="composer-image-error"
-							className="flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border border-feedback-error-muted bg-clip-padding bg-feedback-error-subtle px-sm py-xs text-feedback-error tr-text-metadata"
-						>
-							{err.text}
-							<button
-								type="button"
-								aria-label="Dismiss"
-								onClick={() => setAttachErrors((prev) => prev.filter((p) => p.id !== err.id))}
-								className="hover:opacity-80"
-							>
-								<X className="size-3" />
-							</button>
-						</span>
+							tone="error"
+							icon={false}
+							label={err.text}
+							trailing={
+								<button
+									type="button"
+									aria-label="Dismiss"
+									onClick={() => setAttachErrors((prev) => prev.filter((p) => p.id !== err.id))}
+									className="hover:opacity-80"
+								>
+									<X className="size-3" />
+								</button>
+							}
+						/>
 					))}
 					{images.map((img) => (
 						<FileChip
@@ -943,7 +947,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							data-testid="chat-send"
 							aria-label={isStreaming ? "Steer" : "Send"}
 							onClick={() => submit(isStreaming ? "steer" : "send")}
-							disabled={pendingImages > 0 || (!value.trim() && images.length === 0)}
+							disabled={!canSubmit(value)}
 							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-control-primary-bg text-control-primary-text hover:bg-control-primary-bg-hovered disabled:pointer-events-none disabled:bg-control-primary-disabled-bg disabled:text-control-primary-disabled-text"
 						>
 							<ArrowUp className="size-4" />

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -232,6 +232,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const ref = useRef<HTMLTextAreaElement>(null);
 	const [caret, setCaret] = useState(0);
 	const [images, setImages] = useState<PendingImage[]>([]);
+	// The synchronous source of truth for the attachment list — every write goes through `commitImages`,
+	// so an async `addFiles` batch always budgets against the LATEST list, not its render's snapshot
+	// (two overlapping pastes must not each admit a full budget; decision blocks are synchronous JS, so
+	// reads of this ref cannot interleave mid-decision).
+	const imagesRef = useRef<PendingImage[]>([]);
+	const commitImages = (next: PendingImage[]) => {
+		imagesRef.current = next;
+		setImages(next);
+	};
 	// How many picked files are still decoding/downscaling in `addFiles` — the attach pipeline is async
 	// (30–140ms measured, wider on mobile), and a send landing inside that window would go WITHOUT the
 	// image (which would then attach itself to the NEXT message). While non-zero: placeholder chips render
@@ -357,7 +366,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			behavior,
 		);
 		onChange("");
-		setImages([]);
+		commitImages([]);
 		setAttachErrors([]);
 		recallIdxRef.current = null;
 		setSlots(null);
@@ -445,11 +454,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			// callers invoke this as `void addFiles(...)` — a rejection here would be unhandled).
 			const settled = await Promise.allSettled(picked.map(fileToAttachedImage));
 			// Accept/refuse decisions happen HERE, not inside a state updater (updaters must stay pure and
-			// run deferred). The budget baseline is the batch state at call time — a chip removed during
-			// the decode window only makes the check conservative, never over-budget. One message's image
+			// run deferred) — against `imagesRef`, the always-current list, so overlapping batches see each
+			// other's admissions. One message's image
 			// batch must fit the request-wide budget: the provider caps the WHOLE request, and a persisted
 			// over-budget turn is rejected forever (the host guard heals history, but never sending is cheaper).
-			let used = images.reduce((sum, p) => sum + p.content.data.length, 0);
+			let used = imagesRef.current.reduce((sum, p) => sum + p.content.data.length, 0);
 			const additions: PendingImage[] = [];
 			const errors: { id: string; text: string }[] = [];
 			settled.forEach((result, i) => {
@@ -477,7 +486,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 					...result.value,
 				});
 			});
-			if (additions.length > 0) setImages((prev) => [...prev, ...additions]);
+			if (additions.length > 0) commitImages([...imagesRef.current, ...additions]);
 			if (errors.length > 0) setAttachErrors((prev) => [...prev, ...errors]);
 		} finally {
 			setPendingImages((n) => n - picked.length);
@@ -742,7 +751,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 								<button
 									type="button"
 									aria-label="Remove image"
-									onClick={() => setImages((prev) => prev.filter((p) => p.id !== img.id))}
+									onClick={() => commitImages(imagesRef.current.filter((p) => p.id !== img.id))}
 									className="text-text-muted hover:text-text-default"
 								>
 									<X className="size-3" />

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -1,9 +1,4 @@
-import type {
-	ImageContent,
-	SlashCommandInfo,
-	ThinkingLevel,
-	WireModel,
-} from "@thinkrail/contracts";
+import type { SlashCommandInfo, ThinkingLevel, WireModel } from "@thinkrail/contracts";
 import { ArrowUp, FileIcon, FolderIcon, History, Sparkles, Square, X } from "lucide-react";
 import {
 	type ClipboardEvent,
@@ -34,6 +29,7 @@ import {
 	stripUntouchedSlots,
 } from "./slotSession";
 import { ThinkingSelector } from "./ThinkingSelector";
+import type { ChatAttachment } from "./types";
 
 /** How a submit is delivered: a fresh turn, an interrupt, or a queued message after the current turn. */
 export type SubmitBehavior = "send" | "steer" | "followUp";
@@ -47,6 +43,8 @@ export interface MentionCandidate {
 
 interface PendingImage extends AttachedImage {
 	id: string;
+	/** The picked file's name — the chip label (pi's `ImageContent` itself carries no filename). */
+	name: string;
 }
 
 /** The token (non-whitespace run) ending at the caret — drives `@`-mention completion. */
@@ -144,7 +142,7 @@ interface ComposerProps {
 	onSlashActive: (active: boolean) => void;
 	onSelectModel: (model: WireModel) => void;
 	onSelectThinking: (level: ThinkingLevel) => void;
-	onSubmit: (text: string, images: ImageContent[], behavior: SubmitBehavior) => void;
+	onSubmit: (text: string, attachments: ChatAttachment[], behavior: SubmitBehavior) => void;
 	onAbort: () => void;
 	/** Opens the history-recall overlay (`ChatView` seeds it with the current draft) — the history button
 	 * and the shell's global `Ctrl+R`, via the `openHistory` handle. Optional so a standalone/storybook-style
@@ -337,7 +335,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		if (!text && images.length === 0) return;
 		onSubmit(
 			text,
-			images.map((i) => i.content),
+			images.map(({ name, content }) => ({ name, content })),
 			behavior,
 		);
 		onChange("");
@@ -422,7 +420,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		// Downscaled at attach time (≤1568px long edge) — an oversized image in history 400s every
 		// subsequent turn once the provider's many-image cap kicks in. See imageAttachment.ts.
 		const attached = await Promise.all(picked.map(fileToAttachedImage));
-		setImages((prev) => [...prev, ...attached.map((a) => ({ id: crypto.randomUUID(), ...a }))]);
+		setImages((prev) => [
+			...prev,
+			...attached.map((a, i) => ({
+				id: crypto.randomUUID(),
+				// A clipboard paste often arrives as a generic "image.png" — still better than a mime type.
+				name: picked[i]?.name || "image",
+				...a,
+			})),
+		]);
 	};
 
 	const submit = (behavior: SubmitBehavior) => {
@@ -657,7 +663,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							data-height={img.height}
 							className="flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-default tr-text-metadata"
 						>
-							<FileIcon className="size-3" /> {img.content.mimeType}
+							<FileIcon className="size-3" /> {img.name}
 							{img.width && img.height ? ` · ${img.width}×${img.height}` : null}
 							<button
 								type="button"

--- a/apps/web/src/chat/FileChip.tsx
+++ b/apps/web/src/chat/FileChip.tsx
@@ -3,16 +3,26 @@ import type { ReactNode } from "react";
 
 /** The one chip skin shared by the composer's pending-attachment chips, its attach-error chips, and
  * the transcript's `AttachmentChip` (turns.tsx) — a single source so they can't drift apart. Only the
- * colour tokens vary by tone. */
+ * colour tokens vary by tone.
+ *
+ * `max-w-full` is load-bearing: labels are user-controlled filenames, and the chip lives in a
+ * flex-wrap strip inside the composer or a transcript bubble whose scroller is `overflow-x-hidden`.
+ * Unbounded, one long name pushes the chip past the viewport — its remove button off-screen in the
+ * composer, its text clipped and unreachable in the transcript. The label truncates instead (see
+ * `content` below); the icon, the `meta` suffix, and the trailing action never shrink. */
 const CHIP_BASE =
-	"flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border bg-clip-padding px-sm py-xs tr-text-metadata";
+	"flex max-w-full items-center gap-xs rounded-[var(--radius-sm)] border bg-clip-padding px-sm py-xs tr-text-metadata";
 const CHIP_TONE = {
 	default: "border-border-default bg-container-elevated-bg text-text-default",
 	error: "border-feedback-error-muted bg-feedback-error-subtle text-feedback-error",
 } as const;
 
 interface FileChipProps {
+	/** The truncating part — a user-controlled filename or message; anything that must stay readable
+	 * on a narrow viewport belongs in `meta` instead. */
 	label: ReactNode;
+	/** Short suffix kept fully visible while `label` truncates — the `· W×H` size, an error's reason. */
+	meta?: ReactNode;
 	/** Optional trailing slot — e.g. the composer chip's remove button. */
 	trailing?: ReactNode;
 	/** When set, the chip renders as a button with interaction states; a static span otherwise. */
@@ -33,6 +43,7 @@ interface FileChipProps {
 /** A compact "attached file" chip: file icon + label (+ trailing slot). */
 export function FileChip({
 	label,
+	meta,
 	trailing,
 	onClick,
 	tone = "default",
@@ -42,8 +53,10 @@ export function FileChip({
 	const chip = `${CHIP_BASE} ${CHIP_TONE[tone]}`;
 	const content = (
 		<>
-			{icon ? <FileIcon className="size-3" /> : null} {label}
-			{trailing}
+			{icon ? <FileIcon className="size-3 shrink-0" /> : null}
+			<span className="min-w-0 truncate">{label}</span>
+			{meta ? <span className="shrink-0">{meta}</span> : null}
+			{trailing ? <span className="flex shrink-0 items-center">{trailing}</span> : null}
 		</>
 	);
 	if (onClick) {

--- a/apps/web/src/chat/FileChip.tsx
+++ b/apps/web/src/chat/FileChip.tsx
@@ -1,10 +1,15 @@
 import { FileIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
-/** The one chip skin shared by the composer's pending-attachment chips and the transcript's
- * `AttachmentChip` (turns.tsx) — a single source so the two can't drift apart. */
-const CHIP =
-	"flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-default tr-text-metadata";
+/** The one chip skin shared by the composer's pending-attachment chips, its attach-error chips, and
+ * the transcript's `AttachmentChip` (turns.tsx) — a single source so they can't drift apart. Only the
+ * colour tokens vary by tone. */
+const CHIP_BASE =
+	"flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border bg-clip-padding px-sm py-xs tr-text-metadata";
+const CHIP_TONE = {
+	default: "border-border-default bg-container-elevated-bg text-text-default",
+	error: "border-feedback-error-muted bg-feedback-error-subtle text-feedback-error",
+} as const;
 
 interface FileChipProps {
 	label: ReactNode;
@@ -12,6 +17,10 @@ interface FileChipProps {
 	trailing?: ReactNode;
 	/** When set, the chip renders as a button with interaction states; a static span otherwise. */
 	onClick?: () => void;
+	/** Colour tone — `error` renders the feedback-error tokens (attach failures); default otherwise. */
+	tone?: keyof typeof CHIP_TONE;
+	/** The file icon is the norm; an error chip carries its message instead. */
+	icon?: boolean;
 	title?: string;
 	"aria-label"?: string;
 	"data-testid"?: string;
@@ -22,10 +31,18 @@ interface FileChipProps {
 }
 
 /** A compact "attached file" chip: file icon + label (+ trailing slot). */
-export function FileChip({ label, trailing, onClick, ...rest }: FileChipProps) {
+export function FileChip({
+	label,
+	trailing,
+	onClick,
+	tone = "default",
+	icon = true,
+	...rest
+}: FileChipProps) {
+	const chip = `${CHIP_BASE} ${CHIP_TONE[tone]}`;
 	const content = (
 		<>
-			<FileIcon className="size-3" /> {label}
+			{icon ? <FileIcon className="size-3" /> : null} {label}
 			{trailing}
 		</>
 	);
@@ -34,7 +51,7 @@ export function FileChip({ label, trailing, onClick, ...rest }: FileChipProps) {
 			<button
 				type="button"
 				onClick={onClick}
-				className={`${CHIP} transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary`}
+				className={`${chip} transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary`}
 				{...rest}
 			>
 				{content}
@@ -42,7 +59,7 @@ export function FileChip({ label, trailing, onClick, ...rest }: FileChipProps) {
 		);
 	}
 	return (
-		<span className={CHIP} {...rest}>
+		<span className={chip} {...rest}>
 			{content}
 		</span>
 	);

--- a/apps/web/src/chat/FileChip.tsx
+++ b/apps/web/src/chat/FileChip.tsx
@@ -1,0 +1,49 @@
+import { FileIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+/** The one chip skin shared by the composer's pending-attachment chips and the transcript's
+ * `AttachmentChip` (turns.tsx) — a single source so the two can't drift apart. */
+const CHIP =
+	"flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-default tr-text-metadata";
+
+interface FileChipProps {
+	label: ReactNode;
+	/** Optional trailing slot — e.g. the composer chip's remove button. */
+	trailing?: ReactNode;
+	/** When set, the chip renders as a button with interaction states; a static span otherwise. */
+	onClick?: () => void;
+	title?: string;
+	"aria-label"?: string;
+	"data-testid"?: string;
+	"data-width"?: number | undefined;
+	"data-height"?: number | undefined;
+	/** The wire media type actually being sent — the e2e hook pinning the re-encode rule. */
+	"data-mime"?: string | undefined;
+}
+
+/** A compact "attached file" chip: file icon + label (+ trailing slot). */
+export function FileChip({ label, trailing, onClick, ...rest }: FileChipProps) {
+	const content = (
+		<>
+			<FileIcon className="size-3" /> {label}
+			{trailing}
+		</>
+	);
+	if (onClick) {
+		return (
+			<button
+				type="button"
+				onClick={onClick}
+				className={`${CHIP} transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary`}
+				{...rest}
+			>
+				{content}
+			</button>
+		);
+	}
+	return (
+		<span className={CHIP} {...rest}>
+			{content}
+		</span>
+	);
+}

--- a/apps/web/src/chat/Markdown.tsx
+++ b/apps/web/src/chat/Markdown.tsx
@@ -45,10 +45,22 @@ export function Markdown({
 			<ReactMarkdown
 				remarkPlugins={remarkPlugins ? [remarkGfm, ...remarkPlugins] : [remarkGfm]}
 				rehypePlugins={rehypePlugins}
-				components={{ code: CodeBlock, a: Anchor, ...components }}
+				components={{ code: CodeBlock, a: Anchor, table: Table, ...components }}
 			>
 				{text}
 			</ReactMarkdown>
+		</div>
+	);
+}
+
+/** A GFM table in its own horizontal scroller: the chat transcript scrolls only vertically (the
+ * Virtuoso scroller is `overflow-x-hidden`), so like code blocks and tool cards, a table wider than
+ * the bubble must scroll inside its own block — without the wrapper the overflow would simply be
+ * clipped and unreachable. The `[&_table]` skin selectors still apply (descendant selectors). */
+function Table({ children }: { children?: ReactNode }) {
+	return (
+		<div className="overflow-x-auto">
+			<table>{children}</table>
 		</div>
 	);
 }

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -206,7 +206,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   edge — an oversized image in history 400s every later turn once the provider's >20-image 2000px cap
   kicks in, and pi's own resizer is deliberately off server-side), within-bounds images pass through
   byte-identical, undecodable files fall back to raw (the server's `imageGuard` extension is the second
-  line of defense), and the pending chip shows `mime · W×H` (`composer-image` testid +
+  line of defense), and the pending chip shows `filename · W×H` (the picked file's name; mime text appears only in the
+  hydrated-turn fallback when no name survived) (`composer-image` testid +
   `data-width`/`data-height` — the `e2e/composer-images.spec.ts` hooks) — and `openHistory` on its
   imperative handle → `onHistoryOpen`) plus its props-driven **slash-completion
   primitive** (filter/menu/caret + Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -212,8 +212,14 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   ceiling is measured on `data.length`, with `base64EncodedLength` sizing a raw File before encoding);
   anything else re-encodes through canvas, walking a **JPEG quality ladder** while the encoding
   exceeds the ceiling (a within-bounds multi-MB GIF or a small BMP would 400 the request just like an
-  oversized side). Undecodable files fall back to raw (the server's `imageGuard` extension is the
-  second line of defense). While files are still decoding, a placeholder chip renders
+  oversized side). An undecodable file falls back to raw **only when its media type is
+  provider-accepted** (`ACCEPTED_IMAGE_TYPES`, shared via `contracts`); undecodable + unsupported
+  (HEIC…) is **refused** (`fileToAttachedImage` → `null`) — raw pass-through would 400 every later
+  turn — and surfaced as a dismissible error chip (`composer-image-error` testid) in the attachment
+  strip, cleared on send. One message's batch is also bounded by the request-wide
+  **`REQUEST_IMAGE_BASE64_BUDGET`** (24MB of base64, headroom under Anthropic's 32MB per-request cap):
+  files that would push the batch over it are refused with the same error-chip surface. The server's
+  `imageGuard` extension is the second line of defense for history. While files are still decoding, a placeholder chip renders
   (`composer-image-pending` testid) and sends are held (`submitText` refuses, the send button
   disables) — a send mid-decode would otherwise go without the image and strand it on the next
   message. The pending chip shows `filename · W×H` (the picked file's name; mime text appears only in the

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -339,7 +339,10 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   text. The one nuance: the web client's own immediate bubble is an **optimistic echo**
   (`ChatView.onSubmit` → `appendUserMessage`, store-only, appended *before* the transport call resolves;
 attached images ride along as content blocks so the bubble shows them — `UserTurn` renders image blocks
-as inline thumbnails above the text, for the echo and hydrated messages alike) —
+as compact "attached file" chips above the text (no inline preview; click opens the image in a dialog,
+the diagram-fullscreen pattern). The chip label is the picked file's name, carried on the echo turn as
+`attachmentNames` (UI-side only — pi's `ImageContent` has no filename), index-aligned with the image
+blocks; a hydrated turn has no names and falls back to mime-type labels) —
   it shows exactly what was typed (the raw command) until a re-fetch replaces it with pi's real persisted
   record. **The `/` menu merge**
   (`ChatView`): pi's `commands` snapshot (`session.getCommands`, frozen at session-create time) minus its

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -220,9 +220,11 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   **`REQUEST_IMAGE_BASE64_BUDGET`** (24MB of base64, headroom under Anthropic's 32MB per-request cap):
   files that would push the batch over it are refused with the same error-chip surface. The server's
   `imageGuard` extension is the second line of defense for history. While files are still decoding, a placeholder chip renders
-  (`composer-image-pending` testid) and sends are held (`submitText` refuses, the send button
-  disables) — a send mid-decode would otherwise go without the image and strand it on the next
-  message. The pending chip shows `filename · W×H` (the picked file's name; mime text appears only in the
+  (`composer-image-pending` testid) and sends are held (`canSubmit` is the one reading — `submitText`
+  refuses, the send button disables) — a send mid-decode would otherwise go without the image and strand
+  it on the next message. A held send keeps its text: the composer's own gestures leave the draft in
+  place, and `insertAndSubmit` (the overlay's ⌘/Ctrl+Enter, whose text is not in the draft yet) parks it
+  there instead of dropping it. The pending chip shows `filename · W×H` (the picked file's name; mime text appears only in the
   hydrated-turn fallback when no name survived) (`composer-image` testid +
   `data-width`/`data-height`/`data-mime` — the `e2e/composer-images.spec.ts` hooks; both chip skins
   share `FileChip.tsx`). **Chips are bounded, and the label is the only part that gives way**: a chip is

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -207,7 +207,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   edge — an oversized image in history 400s every later turn once the provider's >20-image 2000px cap
   kicks in, and pi's own resizer is deliberately off server-side). An image passes through
   byte-identical only when within pixel bounds **and** a provider-accepted type (png/jpeg/gif/webp)
-  **and** under the provider's **5MB byte ceiling** (`IMAGE_MAX_BYTES`, shared via `contracts`);
+  **and** under the provider's **4.5MB encoded-base64 ceiling** (`IMAGE_MAX_BASE64_BYTES`, shared via
+  `contracts` — pi's own headroom under Anthropic's 5MB API limit; the wire carries base64, so the
+  ceiling is measured on `data.length`, with `base64EncodedLength` sizing a raw File before encoding);
   anything else re-encodes through canvas, walking a **JPEG quality ladder** while the encoding
   exceeds the ceiling (a within-bounds multi-MB GIF or a small BMP would 400 the request just like an
   oversized side). Undecodable files fall back to raw (the server's `imageGuard` extension is the

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -330,7 +330,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `AgentSession.prompt()` substitutes args into `expandedText` before persisting the `role: "user"`
   message, so a `session.getMessages` re-fetch (a reload, or reopening from history) shows the expanded
   text. The one nuance: the web client's own immediate bubble is an **optimistic echo**
-  (`ChatView.onSubmit` → `appendUserMessage`, store-only, appended *before* the transport call resolves) —
+  (`ChatView.onSubmit` → `appendUserMessage`, store-only, appended *before* the transport call resolves;
+attached images ride along as content blocks so the bubble shows them — `UserTurn` renders image blocks
+as inline thumbnails above the text, for the echo and hydrated messages alike) —
   it shows exactly what was typed (the raw command) until a re-fetch replaces it with pi's real persisted
   record. **The `/` menu merge**
   (`ChatView`): pi's `commands` snapshot (`session.getCommands`, frozen at session-create time) minus its

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -225,7 +225,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   message. The pending chip shows `filename · W×H` (the picked file's name; mime text appears only in the
   hydrated-turn fallback when no name survived) (`composer-image` testid +
   `data-width`/`data-height`/`data-mime` — the `e2e/composer-images.spec.ts` hooks; both chip skins
-  share `FileChip.tsx`) — and `openHistory` on its
+  share `FileChip.tsx`). **Chips are bounded, and the label is the only part that gives way**: a chip is
+  `max-w-full` and truncates its `label`, while the icon, the `meta` suffix and the trailing action are
+  shrink-free — filenames are user-controlled, and an unbounded chip would push its own Remove button
+  off a phone viewport (and be clipped by the transcript scroller's `overflow-x-hidden`). So whatever
+  must stay readable at any width goes in `meta`, not `label`: the `· W×H` size, and an attach error's
+  reason (its filename truncates — the reason is what the user can act on, and a phone has no tooltip
+  to fall back to) — and `openHistory` on its
   imperative handle → `onHistoryOpen`) plus its props-driven **slash-completion
   primitive** (filter/menu/caret + Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so
   the two inputs cannot drift; `HistoryOverlay` (the history-recall/search overlay `Composer` opens —

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -165,8 +165,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   final conversational assistant can synthesize an error/length turn. Compacted historical length attempts
   followed by later messages remain history, not a stale current warning. One retry-presentation rule on
   both paths: pi persists a superseded auto-retry attempt ("keep in session for history") that the live
-  reducer dropped on `auto_retry_start`, so hydration hides an errored assistant message followed by
-  another assistant message before any user message (`isRetriedAttempt`); a terminal failure — errored
+  reducer dropped on `auto_retry_start`, so hydration hides an errored assistant message immediately
+  followed by another assistant message — exactly the adjacent shape `_prepareRetry` produces
+  (`isRetriedAttempt`); a terminal failure — errored
   assistant followed by a user message or nothing — stays visible, its failure reported by the trailing
   settlement-derived error turn. It also
   returns `turnIdByMessageIndex` (message-position → minted turn id) — the jump anchor map a
@@ -204,11 +205,19 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   below), image paste/drop — routed through **`imageAttachment.ts`**: `fileToAttachedImage` decodes in
   the browser and downscales anything over a **1568px long edge** (`fitWithin`; Claude's standard-tier
   edge — an oversized image in history 400s every later turn once the provider's >20-image 2000px cap
-  kicks in, and pi's own resizer is deliberately off server-side), within-bounds images pass through
-  byte-identical, undecodable files fall back to raw (the server's `imageGuard` extension is the second
-  line of defense), and the pending chip shows `filename · W×H` (the picked file's name; mime text appears only in the
+  kicks in, and pi's own resizer is deliberately off server-side). An image passes through
+  byte-identical only when within pixel bounds **and** a provider-accepted type (png/jpeg/gif/webp)
+  **and** under the provider's **5MB byte ceiling** (`IMAGE_MAX_BYTES`, shared via `contracts`);
+  anything else re-encodes through canvas, walking a **JPEG quality ladder** while the encoding
+  exceeds the ceiling (a within-bounds multi-MB GIF or a small BMP would 400 the request just like an
+  oversized side). Undecodable files fall back to raw (the server's `imageGuard` extension is the
+  second line of defense). While files are still decoding, a placeholder chip renders
+  (`composer-image-pending` testid) and sends are held (`submitText` refuses, the send button
+  disables) — a send mid-decode would otherwise go without the image and strand it on the next
+  message. The pending chip shows `filename · W×H` (the picked file's name; mime text appears only in the
   hydrated-turn fallback when no name survived) (`composer-image` testid +
-  `data-width`/`data-height` — the `e2e/composer-images.spec.ts` hooks) — and `openHistory` on its
+  `data-width`/`data-height`/`data-mime` — the `e2e/composer-images.spec.ts` hooks; both chip skins
+  share `FileChip.tsx`) — and `openHistory` on its
   imperative handle → `onHistoryOpen`) plus its props-driven **slash-completion
   primitive** (filter/menu/caret + Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so
   the two inputs cannot drift; `HistoryOverlay` (the history-recall/search overlay `Composer` opens —
@@ -344,11 +353,11 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   message, so a `session.getMessages` re-fetch (a reload, or reopening from history) shows the expanded
   text. The one nuance: the web client's own immediate bubble is an **optimistic echo**
   (`ChatView.onSubmit` → `appendUserMessage`, store-only, appended *before* the transport call resolves;
-attached images ride along as content blocks so the bubble shows them — `UserTurn` renders image blocks
-as compact "attached file" chips above the text (no inline preview; click opens the image in a dialog,
-the diagram-fullscreen pattern). The chip label is the picked file's name, carried on the echo turn as
-`attachmentNames` (UI-side only — pi's `ImageContent` has no filename), index-aligned with the image
-blocks; a hydrated turn has no names and falls back to mime-type labels) —
+  attached images ride along as content blocks so the bubble shows them — `UserTurn` renders image blocks
+  as compact "attached file" chips above the text (no inline preview; click opens the image in a dialog,
+  the diagram-fullscreen pattern). The chip label is the picked file's name, carried on the echo turn as
+  `attachmentNames` (UI-side only — pi's `ImageContent` has no filename), index-aligned with the image
+  blocks; a hydrated turn has no names and falls back to mime-type labels) —
   it shows exactly what was typed (the raw command) until a re-fetch replaces it with pi's real persisted
   record. **The `/` menu merge**
   (`ChatView`): pi's `commands` snapshot (`session.getCommands`, frozen at session-create time) minus its

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -163,7 +163,12 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   persisted transcript so a reconnecting/second client renders identically to the live path (same `raw`
   result shape). When supplied, the live summary's `lastSettlement` is authoritative; otherwise only the
   final conversational assistant can synthesize an error/length turn. Compacted historical length attempts
-  followed by later messages remain history, not a stale current warning. It also
+  followed by later messages remain history, not a stale current warning. One retry-presentation rule on
+  both paths: pi persists a superseded auto-retry attempt ("keep in session for history") that the live
+  reducer dropped on `auto_retry_start`, so hydration hides an errored assistant message followed by
+  another assistant message before any user message (`isRetriedAttempt`); a terminal failure — errored
+  assistant followed by a user message or nothing — stays visible, its failure reported by the trailing
+  settlement-derived error turn. It also
   returns `turnIdByMessageIndex` (message-position → minted turn id) — the jump anchor map a
   history-search "jump to message" deep link (`chatLocationRequest`, see `store/SPEC.md`) resolves
   against; entries are `null` for a `toolResult`/`custom` message (never its own turn) and for a

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -196,7 +196,14 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   transcript's last message is in view without scrolling.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
   commands + template **slot sessions** (Tab-through placeholders — see the Template slots bullet
-  below), image paste/drop, `openHistory` on its imperative handle → `onHistoryOpen`) plus its props-driven **slash-completion
+  below), image paste/drop — routed through **`imageAttachment.ts`**: `fileToAttachedImage` decodes in
+  the browser and downscales anything over a **1568px long edge** (`fitWithin`; Claude's standard-tier
+  edge — an oversized image in history 400s every later turn once the provider's >20-image 2000px cap
+  kicks in, and pi's own resizer is deliberately off server-side), within-bounds images pass through
+  byte-identical, undecodable files fall back to raw (the server's `imageGuard` extension is the second
+  line of defense), and the pending chip shows `mime · W×H` (`composer-image` testid +
+  `data-width`/`data-height` — the `e2e/composer-images.spec.ts` hooks) — and `openHistory` on its
+  imperative handle → `onHistoryOpen`) plus its props-driven **slash-completion
   primitive** (filter/menu/caret + Up/Down, Enter/Tab, Escape), reused by `panels/NewWorkspaceDialog` so
   the two inputs cannot drift; `HistoryOverlay` (the history-recall/search overlay `Composer` opens —
   presentational, driven entirely by `useHistorySearch.ts`'s state + callbacks, plus **Save as template**

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -116,6 +116,38 @@ test("an explicit live null suppresses a stale persisted failure while a resumed
 	expect(turns.map((turn) => turn.kind)).toEqual(["assistant"]);
 });
 
+test("a persisted failed attempt superseded by a successful retry hydrates as one assistant turn", () => {
+	// pi's `_prepareRetry` keeps the failed attempt in the session file ("keep in session for history")
+	// while trimming it from the live context; the live reducer drops its turn on `auto_retry_start`.
+	// Hydration must agree, or a reload resurrects the failed partial + a bogus error turn.
+	const { turns, turnIdByMessageIndex } = messagesToRuntime([
+		{ role: "user", content: "hi", timestamp: 1 },
+		{
+			role: "assistant",
+			content: [{ type: "text", text: "partial…" }],
+			stopReason: "error",
+			errorMessage: "fetch failed",
+		},
+		{ role: "assistant", content: [{ type: "text", text: "the real reply" }], stopReason: "stop" },
+	] as unknown as Message[]);
+	expect(turns.map((t) => t.kind)).toEqual(["user", "assistant"]);
+	expect(turnIdByMessageIndex).toEqual([turns[0]?.id ?? null, null, turns[1]?.id ?? null]);
+});
+
+test("exhausted retries hydrate as the final attempt + its error turn; earlier attempts stay hidden", () => {
+	// Attempts 1..N-1 are each followed by another assistant message (the next attempt) ⇒ superseded.
+	// The final attempt is followed by nothing (or a user message) ⇒ terminal — visible, and the
+	// trailing settlement-derived error turn reports its failure, matching the live reducer.
+	const { turns } = messagesToRuntime([
+		{ role: "user", content: "hi", timestamp: 1 },
+		{ role: "assistant", content: [], stopReason: "error", errorMessage: "attempt 1" },
+		{ role: "assistant", content: [], stopReason: "error", errorMessage: "attempt 2" },
+	] as unknown as Message[]);
+	expect(turns.map((t) => t.kind)).toEqual(["user", "assistant", "error"]);
+	const err = turns.find((t) => t.kind === "error");
+	expect(err?.kind === "error" && err.text).toContain("attempt 2");
+});
+
 test("turnIdByMessageIndex maps each message's position to its own turn id, null for non-turn messages, and the assistant's id (not the injected error turn's) when the message ended in an error", () => {
 	const { turns, turnIdByMessageIndex } = messagesToRuntime([
 		{ role: "user", content: "hi", timestamp: 1 },

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -20,7 +20,8 @@ export interface HydratedRuntime {
 	 * which becomes a visible turn but is never a search hit) — the jump anchor map a
 	 * history-search "jump to message" deep link (`chatLocationRequest`) resolves against. A message that
 	 * ended in `stopReason: "error"` maps to its own assistant turn's id, never the synthesized error
-	 * turn's (the error turn has no message index of its own).
+	 * turn's (the error turn has no message index of its own). A retried (superseded) failed attempt
+	 * renders no turn at all, so its slot is `null` like a control message's.
 	 */
 	turnIdByMessageIndex: (string | null)[];
 }
@@ -41,7 +42,7 @@ export function messagesToRuntime(
 	const toolResults: Record<string, ToolResultState> = {};
 	const askAnswers: HydratedRuntime["askAnswers"] = {};
 	const turnIdByMessageIndex: HydratedRuntime["turnIdByMessageIndex"] = [];
-	for (const message of messages) {
+	for (const [index, message] of messages.entries()) {
 		// Exactly one push per message, in order — keeps the map aligned to `messages` regardless of which
 		// branch below fires (a user/assistant message sets it to its own turn's id; every other message
 		// leaves it `null`).
@@ -54,8 +55,16 @@ export function messagesToRuntime(
 				turns.push({ kind: "user", id: turnId, message });
 			}
 		} else if (message.role === "assistant") {
-			turnId = crypto.randomUUID();
-			turns.push({ kind: "assistant", id: turnId, message, streaming: false });
+			if (message.stopReason === "error" && isRetriedAttempt(messages, index)) {
+				// A superseded auto-retry attempt: pi keeps it in the session file for history but removed it
+				// from the live context (`_prepareRetry`), and the live reducer drops its turn on
+				// `auto_retry_start`. Hide it here too — same presentation rule on both paths — or a reload
+				// would resurrect the failed partial next to the retried reply (turnId stays null). Its
+				// failure text never surfaces either: only the trailing terminal below reports a failure.
+			} else {
+				turnId = crypto.randomUUID();
+				turns.push({ kind: "assistant", id: turnId, message, streaming: false });
+			}
 		} else if (message.role === "compactionSummary") {
 			// Only successful compactions persist an entry. It becomes a visible done record, but no jump
 			// anchor: history search indexes user/assistant text only, so this slot remains `null`.
@@ -95,4 +104,23 @@ export function messagesToRuntime(
 	if (failure) turns.push({ kind: "error", id: crypto.randomUUID(), text: failure });
 
 	return { turns, toolResults, askAnswers, turnIdByMessageIndex };
+}
+
+/**
+ * Was the errored assistant message at `index` superseded by an auto-retry? pi's `_prepareRetry`
+ * persists the failed attempt ("keep in session for history") but trims it from the live context and
+ * re-streams the reply as a new assistant message — with no user input in between. So a failed attempt
+ * followed by another assistant message before any user message was retried; a failed attempt followed
+ * by a user message (or nothing) is the run's terminal failure and stays visible (the trailing
+ * settlement-derived error turn reports it) — exactly what the live reducer leaves on screen
+ * (`auto_retry_start` drops the attempt, settlement keeps the last one). Ambiguity resolves toward
+ * showing, never hiding.
+ */
+function isRetriedAttempt(messages: TranscriptMessage[], index: number): boolean {
+	for (let i = index + 1; i < messages.length; i++) {
+		const role = messages[i]?.role;
+		if (role === "assistant") return true;
+		if (role === "user") return false;
+	}
+	return false;
 }

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -3,7 +3,7 @@ import type {
 	AskUserAnswersDetails,
 	TranscriptMessage,
 } from "@thinkrail/contracts";
-import { isAskUserAnswersMessage, isControlMessage } from "@thinkrail/contracts";
+import { isAskUserAnswersMessage, isControlMessage, isRetriedAttempt } from "@thinkrail/contracts";
 import { userText } from "../lib";
 import { assistantFailureText } from "./assistantFailure";
 import type { ChatTurn, ToolResultState } from "./types";
@@ -55,7 +55,7 @@ export function messagesToRuntime(
 				turns.push({ kind: "user", id: turnId, message });
 			}
 		} else if (message.role === "assistant") {
-			if (message.stopReason === "error" && isRetriedAttempt(messages, index)) {
+			if (isRetriedAttempt(messages, index)) {
 				// A superseded auto-retry attempt: pi keeps it in the session file for history but removed it
 				// from the live context (`_prepareRetry`), and the live reducer drops its turn on
 				// `auto_retry_start`. Hide it here too — same presentation rule on both paths — or a reload
@@ -104,23 +104,4 @@ export function messagesToRuntime(
 	if (failure) turns.push({ kind: "error", id: crypto.randomUUID(), text: failure });
 
 	return { turns, toolResults, askAnswers, turnIdByMessageIndex };
-}
-
-/**
- * Was the errored assistant message at `index` superseded by an auto-retry? pi's `_prepareRetry`
- * persists the failed attempt ("keep in session for history") but trims it from the live context and
- * re-streams the reply as a new assistant message — with no user input in between. So a failed attempt
- * followed by another assistant message before any user message was retried; a failed attempt followed
- * by a user message (or nothing) is the run's terminal failure and stays visible (the trailing
- * settlement-derived error turn reports it) — exactly what the live reducer leaves on screen
- * (`auto_retry_start` drops the attempt, settlement keeps the last one). Ambiguity resolves toward
- * showing, never hiding.
- */
-function isRetriedAttempt(messages: TranscriptMessage[], index: number): boolean {
-	for (let i = index + 1; i < messages.length; i++) {
-		const role = messages[i]?.role;
-		if (role === "assistant") return true;
-		if (role === "user") return false;
-	}
-	return false;
 }

--- a/apps/web/src/chat/imageAttachment.test.ts
+++ b/apps/web/src/chat/imageAttachment.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { fitWithin, MAX_ATTACHMENT_EDGE } from "./imageAttachment";
+
+// The pure dimension math behind the composer's attach-time downscale (TASK-image-attachment-downscale):
+// images are capped at MAX_ATTACHMENT_EDGE (1568px — Claude's own standard-tier long edge; anything
+// larger is downsampled provider-side anyway and only risks the 2000px many-image 400). The browser
+// decode/re-encode half lives in `fileToAttachedImage` and is exercised end-to-end by
+// `e2e/composer-images.spec.ts` (bun's DOM has no real image codec).
+
+describe("fitWithin", () => {
+	test("returns the input unchanged when both edges are within the limit", () => {
+		expect(fitWithin(800, 600, 1568)).toEqual({ width: 800, height: 600 });
+		expect(fitWithin(1568, 1568, 1568)).toEqual({ width: 1568, height: 1568 });
+	});
+
+	test("scales a landscape image down to the long edge, preserving aspect", () => {
+		expect(fitWithin(3136, 1568, 1568)).toEqual({ width: 1568, height: 784 });
+		expect(fitWithin(4000, 3000, 1568)).toEqual({ width: 1568, height: 1176 });
+	});
+
+	test("scales a portrait image down to the long edge, preserving aspect", () => {
+		expect(fitWithin(1568, 3136, 1568)).toEqual({ width: 784, height: 1568 });
+		expect(fitWithin(3000, 4000, 1568)).toEqual({ width: 1176, height: 1568 });
+	});
+
+	test("rounds fractional results to whole pixels", () => {
+		const { width, height } = fitWithin(3023, 1701, 1568);
+		expect(width).toBe(1568);
+		expect(height).toBe(882); // 1701 * (1568 / 3023) = 882.16…
+	});
+
+	test("never collapses an extreme aspect ratio to zero", () => {
+		const { width, height } = fitWithin(100_000, 10, 1568);
+		expect(width).toBe(1568);
+		expect(height).toBeGreaterThanOrEqual(1);
+	});
+
+	test("the exported default edge is Claude's 1568px standard-tier long edge", () => {
+		expect(MAX_ATTACHMENT_EDGE).toBe(1568);
+	});
+});

--- a/apps/web/src/chat/imageAttachment.ts
+++ b/apps/web/src/chat/imageAttachment.ts
@@ -5,13 +5,28 @@
 // 8000px — and over 2000px once a request carries more than 20 images — and because history is re-sent
 // every turn, ONE oversized attachment bricks the whole chat. Capping at 1568px (Claude's standard-tier
 // long edge, beyond which it downsamples anyway) stays under every limit while losing nothing the model
-// would actually see. The server-side `imageGuard` extension is the second line of defense for images
-// that predate this or arrive by other routes.
+// would actually see. Two more attach-time rules ride along: a media type outside png/jpeg/gif/webp
+// (BMP, AVIF, HEIC…) is re-encoded even when within pixel bounds (the provider rejects the raw type),
+// and anything over the provider's 5MB per-image byte ceiling (IMAGE_MAX_BYTES — e.g. a multi-MB
+// animated GIF that is dimensionally tiny) is re-encoded down a JPEG quality ladder. The server-side
+// `imageGuard` extension is the second line of defense for images that predate this or arrive by
+// other routes.
 
-import type { ImageContent } from "@thinkrail/contracts";
+import { base64ByteLength, IMAGE_MAX_BYTES, type ImageContent } from "@thinkrail/contracts";
 
 /** Claude's standard-tier long-edge; larger images are downsampled provider-side anyway. */
 export const MAX_ATTACHMENT_EDGE = 1568;
+
+/** The media types the provider accepts as-is; anything else (BMP, AVIF, HEIC…) must be re-encoded
+ * even when its pixel size is already within bounds — pi sends the attachment verbatim, so a raw
+ * `image/bmp` would 400 the request outright. */
+const PROVIDER_ACCEPTED = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+
+/** The JPEG quality ladder for images whose encoding lands over IMAGE_MAX_BYTES: tried top-down, the
+ * first rung under the ceiling wins. At ≤1568px even the bottom rung is far below 5MB in practice; if
+ * an adversarial image still exceeds it, the bottom rung is sent and the server-side `imageGuard`
+ * remains the last line of defense. */
+const JPEG_QUALITY_LADDER = [0.9, 0.8, 0.7, 0.6, 0.5];
 
 /** A composer attachment: the wire content plus the pixel size of what will actually be sent.
  * `width`/`height` are undefined only when the browser couldn't decode the file (sent raw as-is). */
@@ -65,10 +80,13 @@ function dataUrlToContent(dataUrl: string): ImageContent {
 
 /**
  * Turn a picked/pasted/dropped file into a composer attachment, downscaled to MAX_ATTACHMENT_EDGE when
- * its long edge exceeds it. Within-bounds images pass through byte-identical (no re-encode, no quality
- * loss); a resized one re-encodes in its own format when canvas supports it, else PNG. A file the
- * browser can't decode falls back to the raw bytes — attaching must never fail here; the server-side
- * guard still protects the session.
+ * its long edge exceeds it. An image passes through byte-identical (no re-encode, no quality loss)
+ * only when ALL of: within pixel bounds, a provider-accepted media type (png/jpeg/gif/webp), and under
+ * the provider's IMAGE_MAX_BYTES ceiling — a within-bounds 12MB GIF or a small BMP is every bit as
+ * session-poisoning as an 8000px side. Anything else goes through canvas: re-encoded in its own format
+ * when canvas supports it (else PNG), then walked down the JPEG quality ladder while the encoding
+ * exceeds the byte ceiling. A file the browser can't decode falls back to the raw bytes — attaching
+ * must never fail here; the server-side guard still protects the session.
  */
 export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
 	let bitmap: ImageBitmap;
@@ -79,7 +97,8 @@ export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
 	}
 	try {
 		const { width, height } = fitWithin(bitmap.width, bitmap.height, MAX_ATTACHMENT_EDGE);
-		if (width === bitmap.width && height === bitmap.height) {
+		const withinPixels = width === bitmap.width && height === bitmap.height;
+		if (withinPixels && PROVIDER_ACCEPTED.has(file.type) && file.size <= IMAGE_MAX_BYTES) {
 			return { content: await fileToRawContent(file), width, height };
 		}
 		const canvas = document.createElement("canvas");
@@ -89,7 +108,12 @@ export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
 		if (!ctx) return { content: await fileToRawContent(file) };
 		ctx.drawImage(bitmap, 0, 0, width, height);
 		const mimeType = CANVAS_ENCODABLE.has(file.type) ? file.type : "image/png";
-		return { content: dataUrlToContent(canvas.toDataURL(mimeType)), width, height };
+		let content = dataUrlToContent(canvas.toDataURL(mimeType));
+		for (const quality of JPEG_QUALITY_LADDER) {
+			if (base64ByteLength(content.data) <= IMAGE_MAX_BYTES) break;
+			content = dataUrlToContent(canvas.toDataURL("image/jpeg", quality));
+		}
+		return { content, width, height };
 	} finally {
 		bitmap.close();
 	}

--- a/apps/web/src/chat/imageAttachment.ts
+++ b/apps/web/src/chat/imageAttachment.ts
@@ -7,12 +7,16 @@
 // long edge, beyond which it downsamples anyway) stays under every limit while losing nothing the model
 // would actually see. Two more attach-time rules ride along: a media type outside png/jpeg/gif/webp
 // (BMP, AVIF, HEIC…) is re-encoded even when within pixel bounds (the provider rejects the raw type),
-// and anything over the provider's 5MB per-image byte ceiling (IMAGE_MAX_BYTES — e.g. a multi-MB
+// and anything over the provider's 4.5MB encoded-base64 ceiling (IMAGE_MAX_BASE64_BYTES — e.g. a multi-MB
 // animated GIF that is dimensionally tiny) is re-encoded down a JPEG quality ladder. The server-side
 // `imageGuard` extension is the second line of defense for images that predate this or arrive by
 // other routes.
 
-import { base64ByteLength, IMAGE_MAX_BYTES, type ImageContent } from "@thinkrail/contracts";
+import {
+	base64EncodedLength,
+	IMAGE_MAX_BASE64_BYTES,
+	type ImageContent,
+} from "@thinkrail/contracts";
 
 /** Claude's standard-tier long-edge; larger images are downsampled provider-side anyway. */
 export const MAX_ATTACHMENT_EDGE = 1568;
@@ -22,8 +26,9 @@ export const MAX_ATTACHMENT_EDGE = 1568;
  * `image/bmp` would 400 the request outright. */
 const PROVIDER_ACCEPTED = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
 
-/** The JPEG quality ladder for images whose encoding lands over IMAGE_MAX_BYTES: tried top-down, the
- * first rung under the ceiling wins. At ≤1568px even the bottom rung is far below 5MB in practice; if
+/** The JPEG quality ladder for images whose encoding lands over IMAGE_MAX_BASE64_BYTES: tried
+ * top-down, the first rung under the ceiling wins. At ≤1568px even the bottom rung is far below the
+ * ceiling in practice; if
  * an adversarial image still exceeds it, the bottom rung is sent and the server-side `imageGuard`
  * remains the last line of defense. */
 const JPEG_QUALITY_LADDER = [0.9, 0.8, 0.7, 0.6, 0.5];
@@ -82,7 +87,8 @@ function dataUrlToContent(dataUrl: string): ImageContent {
  * Turn a picked/pasted/dropped file into a composer attachment, downscaled to MAX_ATTACHMENT_EDGE when
  * its long edge exceeds it. An image passes through byte-identical (no re-encode, no quality loss)
  * only when ALL of: within pixel bounds, a provider-accepted media type (png/jpeg/gif/webp), and under
- * the provider's IMAGE_MAX_BYTES ceiling — a within-bounds 12MB GIF or a small BMP is every bit as
+ * the provider's IMAGE_MAX_BASE64_BYTES ceiling (measured on the ENCODED base64 the wire actually
+ * carries — pi caps it at 4.5MB, headroom under Anthropic's 5MB) — a within-bounds 12MB GIF or a small BMP is every bit as
  * session-poisoning as an 8000px side. Anything else goes through canvas: re-encoded in its own format
  * when canvas supports it (else PNG), then walked down the JPEG quality ladder while the encoding
  * exceeds the byte ceiling. A file the browser can't decode falls back to the raw bytes — attaching
@@ -98,7 +104,11 @@ export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
 	try {
 		const { width, height } = fitWithin(bitmap.width, bitmap.height, MAX_ATTACHMENT_EDGE);
 		const withinPixels = width === bitmap.width && height === bitmap.height;
-		if (withinPixels && PROVIDER_ACCEPTED.has(file.type) && file.size <= IMAGE_MAX_BYTES) {
+		if (
+			withinPixels &&
+			PROVIDER_ACCEPTED.has(file.type) &&
+			base64EncodedLength(file.size) <= IMAGE_MAX_BASE64_BYTES
+		) {
 			return { content: await fileToRawContent(file), width, height };
 		}
 		const canvas = document.createElement("canvas");
@@ -110,7 +120,7 @@ export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
 		const mimeType = CANVAS_ENCODABLE.has(file.type) ? file.type : "image/png";
 		let content = dataUrlToContent(canvas.toDataURL(mimeType));
 		for (const quality of JPEG_QUALITY_LADDER) {
-			if (base64ByteLength(content.data) <= IMAGE_MAX_BYTES) break;
+			if (content.data.length <= IMAGE_MAX_BASE64_BYTES) break;
 			content = dataUrlToContent(canvas.toDataURL("image/jpeg", quality));
 		}
 		return { content, width, height };

--- a/apps/web/src/chat/imageAttachment.ts
+++ b/apps/web/src/chat/imageAttachment.ts
@@ -1,0 +1,96 @@
+// Attach-time image downscale (TASK-image-attachment-downscale). Pasted/dropped images are decoded and
+// resized in the browser BEFORE they become ImageContent: pi's own resizer is deliberately disabled
+// server-side (`images.autoResize:false` — its photon/WASM codec can't ship in the single-file binary),
+// so anything the composer lets through goes to the provider verbatim. Anthropic rejects a side over
+// 8000px — and over 2000px once a request carries more than 20 images — and because history is re-sent
+// every turn, ONE oversized attachment bricks the whole chat. Capping at 1568px (Claude's standard-tier
+// long edge, beyond which it downsamples anyway) stays under every limit while losing nothing the model
+// would actually see. The server-side `imageGuard` extension is the second line of defense for images
+// that predate this or arrive by other routes.
+
+import type { ImageContent } from "@thinkrail/contracts";
+
+/** Claude's standard-tier long-edge; larger images are downsampled provider-side anyway. */
+export const MAX_ATTACHMENT_EDGE = 1568;
+
+/** A composer attachment: the wire content plus the pixel size of what will actually be sent.
+ * `width`/`height` are undefined only when the browser couldn't decode the file (sent raw as-is). */
+export interface AttachedImage {
+	content: ImageContent;
+	width?: number;
+	height?: number;
+}
+
+/** Aspect-preserving fit of `width`×`height` into a `maxEdge` square: unchanged when already within,
+ * else scaled so the long edge equals `maxEdge` (rounded, floored at 1px). */
+export function fitWithin(
+	width: number,
+	height: number,
+	maxEdge: number,
+): { width: number; height: number } {
+	const longEdge = Math.max(width, height);
+	if (longEdge <= maxEdge) return { width, height };
+	const scale = maxEdge / longEdge;
+	return {
+		width: Math.max(1, Math.round(width * scale)),
+		height: Math.max(1, Math.round(height * scale)),
+	};
+}
+
+/** Mime types canvas.toDataURL can (re-)encode; anything else re-encodes as PNG when resized. */
+const CANVAS_ENCODABLE = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+function fileToRawContent(file: File): Promise<ImageContent> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onerror = () => reject(reader.error ?? new Error("failed to read image"));
+		reader.onload = () => {
+			const result = String(reader.result);
+			const comma = result.indexOf(",");
+			resolve({
+				type: "image",
+				data: comma >= 0 ? result.slice(comma + 1) : result,
+				mimeType: file.type || "image/png",
+			});
+		};
+		reader.readAsDataURL(file);
+	});
+}
+
+function dataUrlToContent(dataUrl: string): ImageContent {
+	const comma = dataUrl.indexOf(",");
+	const mimeType = /^data:([^;,]+)/.exec(dataUrl)?.[1] ?? "image/png";
+	return { type: "image", data: comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl, mimeType };
+}
+
+/**
+ * Turn a picked/pasted/dropped file into a composer attachment, downscaled to MAX_ATTACHMENT_EDGE when
+ * its long edge exceeds it. Within-bounds images pass through byte-identical (no re-encode, no quality
+ * loss); a resized one re-encodes in its own format when canvas supports it, else PNG. A file the
+ * browser can't decode falls back to the raw bytes — attaching must never fail here; the server-side
+ * guard still protects the session.
+ */
+export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
+	let bitmap: ImageBitmap;
+	try {
+		bitmap = await createImageBitmap(file);
+	} catch {
+		return { content: await fileToRawContent(file) };
+	}
+	try {
+		const { width, height } = fitWithin(bitmap.width, bitmap.height, MAX_ATTACHMENT_EDGE);
+		if (width === bitmap.width && height === bitmap.height) {
+			return { content: await fileToRawContent(file), width, height };
+		}
+		const canvas = document.createElement("canvas");
+		canvas.width = width;
+		canvas.height = height;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return { content: await fileToRawContent(file) };
+		ctx.drawImage(bitmap, 0, 0, width, height);
+		const mimeType = CANVAS_ENCODABLE.has(file.type) ? file.type : "image/png";
+		return { content: dataUrlToContent(canvas.toDataURL(mimeType)), width, height };
+	} finally {
+		bitmap.close();
+	}
+}

--- a/apps/web/src/chat/imageAttachment.ts
+++ b/apps/web/src/chat/imageAttachment.ts
@@ -62,27 +62,22 @@ export function fitWithin(
 /** Mime types canvas.toDataURL can (re-)encode; anything else re-encodes as PNG when resized. */
 const CANVAS_ENCODABLE = new Set(["image/png", "image/jpeg", "image/webp"]);
 
-function fileToRawContent(file: File): Promise<ImageContent> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onerror = () => reject(reader.error ?? new Error("failed to read image"));
-		reader.onload = () => {
-			const result = String(reader.result);
-			const comma = result.indexOf(",");
-			resolve({
-				type: "image",
-				data: comma >= 0 ? result.slice(comma + 1) : result,
-				mimeType: file.type || "image/png",
-			});
-		};
-		reader.readAsDataURL(file);
-	});
-}
-
 function dataUrlToContent(dataUrl: string): ImageContent {
 	const comma = dataUrl.indexOf(",");
 	const mimeType = /^data:([^;,]+)/.exec(dataUrl)?.[1] ?? "image/png";
 	return { type: "image", data: comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl, mimeType };
+}
+
+function fileToRawContent(file: File): Promise<ImageContent> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onerror = () => reject(reader.error ?? new Error("failed to read image"));
+		// readAsDataURL yields `data:<type>;base64,…`, but `file.type` is the trusted source (a File's
+		// data URL always carries its own type) — keep it authoritative and fall back like the parser.
+		reader.onload = () =>
+			resolve({ ...dataUrlToContent(String(reader.result)), mimeType: file.type || "image/png" });
+		reader.readAsDataURL(file);
+	});
 }
 
 /**

--- a/apps/web/src/chat/imageAttachment.ts
+++ b/apps/web/src/chat/imageAttachment.ts
@@ -8,11 +8,13 @@
 // would actually see. Two more attach-time rules ride along: a media type outside png/jpeg/gif/webp
 // (BMP, AVIF, HEIC…) is re-encoded even when within pixel bounds (the provider rejects the raw type),
 // and anything over the provider's 4.5MB encoded-base64 ceiling (IMAGE_MAX_BASE64_BYTES — e.g. a multi-MB
-// animated GIF that is dimensionally tiny) is re-encoded down a JPEG quality ladder. The server-side
-// `imageGuard` extension is the second line of defense for images that predate this or arrive by
-// other routes.
+// animated GIF that is dimensionally tiny) is re-encoded down a JPEG quality ladder. An undecodable
+// file with a provider-unsupported type is refused outright (null) — raw pass-through would poison the
+// session. The server-side `imageGuard` extension is the second line of defense for images that
+// predate these rules or arrive by other routes.
 
 import {
+	ACCEPTED_IMAGE_TYPES,
 	base64EncodedLength,
 	IMAGE_MAX_BASE64_BYTES,
 	type ImageContent,
@@ -21,10 +23,10 @@ import {
 /** Claude's standard-tier long-edge; larger images are downsampled provider-side anyway. */
 export const MAX_ATTACHMENT_EDGE = 1568;
 
-/** The media types the provider accepts as-is; anything else (BMP, AVIF, HEIC…) must be re-encoded
- * even when its pixel size is already within bounds — pi sends the attachment verbatim, so a raw
- * `image/bmp` would 400 the request outright. */
-const PROVIDER_ACCEPTED = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+/** The media types the provider accepts as-is (shared with the host's `imageGuard` via contracts);
+ * anything else (BMP, AVIF, HEIC…) must be re-encoded even when its pixel size is already within
+ * bounds — pi sends the attachment verbatim, so a raw `image/bmp` would 400 the request outright. */
+const PROVIDER_ACCEPTED = new Set(ACCEPTED_IMAGE_TYPES);
 
 /** The JPEG quality ladder for images whose encoding lands over IMAGE_MAX_BASE64_BYTES: tried
  * top-down, the first rung under the ceiling wins. At ≤1568px even the bottom rung is far below the
@@ -91,14 +93,20 @@ function dataUrlToContent(dataUrl: string): ImageContent {
  * carries — pi caps it at 4.5MB, headroom under Anthropic's 5MB) — a within-bounds 12MB GIF or a small BMP is every bit as
  * session-poisoning as an 8000px side. Anything else goes through canvas: re-encoded in its own format
  * when canvas supports it (else PNG), then walked down the JPEG quality ladder while the encoding
- * exceeds the byte ceiling. A file the browser can't decode falls back to the raw bytes — attaching
- * must never fail here; the server-side guard still protects the session.
+ * exceeds the byte ceiling.
+ *
+ * Returns `null` when the file cannot be attached safely: the browser can't decode it AND its media
+ * type is provider-unsupported — there is nothing to re-encode from, and sending the raw bytes (the
+ * old fallback) would 400 the request and, once persisted, every later turn. A decode failure on an
+ * ACCEPTED type still falls back to the raw bytes (the provider may well decode what the browser
+ * can't; the server-side guard still bounds its size).
  */
-export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
+export async function fileToAttachedImage(file: File): Promise<AttachedImage | null> {
 	let bitmap: ImageBitmap;
 	try {
 		bitmap = await createImageBitmap(file);
 	} catch {
+		if (!PROVIDER_ACCEPTED.has(file.type)) return null;
 		return { content: await fileToRawContent(file) };
 	}
 	try {
@@ -115,7 +123,9 @@ export async function fileToAttachedImage(file: File): Promise<AttachedImage> {
 		canvas.width = width;
 		canvas.height = height;
 		const ctx = canvas.getContext("2d");
-		if (!ctx) return { content: await fileToRawContent(file) };
+		// No 2d context (headless/limits): raw is safe only for a type the provider accepts.
+		if (!ctx)
+			return PROVIDER_ACCEPTED.has(file.type) ? { content: await fileToRawContent(file) } : null;
 		ctx.drawImage(bitmap, 0, 0, width, height);
 		const mimeType = CANVAS_ENCODABLE.has(file.type) ? file.type : "image/png";
 		let content = dataUrlToContent(canvas.toDataURL(mimeType));

--- a/apps/web/src/chat/rows.test.ts
+++ b/apps/web/src/chat/rows.test.ts
@@ -19,6 +19,22 @@ function user(id: string, timestamp = 0): ChatTurn {
 	return { kind: "user", id, message: { role: "user", content: "hi", timestamp } } as ChatTurn;
 }
 
+function userWithAttachment(id: string, names: string[]): ChatTurn {
+	return {
+		kind: "user",
+		id,
+		message: {
+			role: "user",
+			content: [
+				{ type: "text", text: "hi" },
+				...names.map(() => ({ type: "image" as const, data: "AA==", mimeType: "image/png" })),
+			],
+			timestamp: 0,
+		},
+		attachmentNames: names,
+	} as ChatTurn;
+}
+
 function assistant(
 	id: string,
 	blocks: Block[],
@@ -114,6 +130,12 @@ describe("deriveRows grouping", () => {
 		if (primary?.kind !== "tool") throw new Error("expected tool row");
 		expect(primary.toolCallId).toBe("v1");
 		expect(rows[4]?.id).toBe("q1");
+	});
+
+	test("a user turn's attachmentNames pass through to its row (echo-only; hydrated turns carry none)", () => {
+		const rows = deriveRows([userWithAttachment("u1", ["shot.png"]), user("u2")], {}, false);
+		expect(rows[0]?.kind === "user" ? rows[0].attachmentNames : null).toEqual(["shot.png"]);
+		expect(rows[1]?.kind === "user" ? "attachmentNames" in rows[1] : null).toBe(false);
 	});
 
 	test("non-assistant turns (user/system/error/retry) break runs and map 1:1", () => {

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -36,7 +36,7 @@ export type ActivityStep =
  * so they double as Virtuoso item keys and fold-state cache keys.
  */
 export type ChatRow =
-	| { kind: "user"; id: string; message: UserMessage }
+	| { kind: "user"; id: string; message: UserMessage; attachmentNames?: string[] }
 	| { kind: "system"; id: string; text: string }
 	| { kind: "error"; id: string; text: string }
 	| ({ kind: "compaction"; id: string } & CompactionState)
@@ -129,7 +129,12 @@ export function deriveRows(
 			flushRun();
 			switch (turn.kind) {
 				case "user":
-					rows.push({ kind: "user", id: turn.id, message: turn.message });
+					rows.push({
+						kind: "user",
+						id: turn.id,
+						message: turn.message,
+						...(turn.attachmentNames ? { attachmentNames: turn.attachmentNames } : {}),
+					});
 					break;
 				case "system":
 					rows.push({ kind: "system", id: turn.id, text: turn.text });

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -1,10 +1,11 @@
-import type { UserMessage } from "@thinkrail/contracts";
+import type { ImageContent, UserMessage } from "@thinkrail/contracts";
 import {
 	BookOpen,
 	ChevronDown,
 	ChevronRight,
 	Clock,
 	FileDiff,
+	FileIcon,
 	FileText,
 	FoldVertical,
 	RotateCw,
@@ -12,6 +13,7 @@ import {
 	Wrench,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
 	cn,
 	parseSkillInvocation,
@@ -53,7 +55,7 @@ export function ChatTurnView({
 }) {
 	switch (row.kind) {
 		case "user":
-			return <UserTurn id={row.id} message={row.message} />;
+			return <UserTurn id={row.id} message={row.message} attachmentNames={row.attachmentNames} />;
 		case "system":
 			return <SystemTurn text={row.text} />;
 		case "error":
@@ -110,22 +112,61 @@ export function ChatTurnView({
 	}
 }
 
-/** Image blocks keyed for React — content tail + a duplicate counter (blocks carry no ids). */
-function userImages(content: UserMessage["content"]) {
+/** Image blocks keyed for React — content tail + a duplicate counter (blocks carry no ids). The chip
+ * label is the picked file's name when the echo turn carries it (`attachmentNames`, index-aligned with
+ * the image blocks); a hydrated turn has no names — pi's `ImageContent` carries none — so it falls
+ * back to the mime type. */
+function userAttachments(content: UserMessage["content"], names?: string[]) {
 	if (typeof content === "string") return [];
 	const seen = new Map<string, number>();
 	return content
 		.filter((c) => c.type === "image")
-		.map((img) => {
+		.map((img, i) => {
 			const tail = img.data.slice(-24);
 			const n = seen.get(tail) ?? 0;
 			seen.set(tail, n + 1);
-			return { key: `${tail}-${n}`, img };
+			return { key: `${tail}-${n}`, label: names?.[i] ?? img.mimeType, img };
 		});
 }
 
 const USER_BUBBLE =
 	"max-w-[85%] whitespace-pre-wrap break-words rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-md py-sm tr-text-reading text-text-muted";
+
+/** An attachment chip: filename (or mime type) that opens the image full-size in a dialog on click —
+ * the same popup pattern as the diagram full-screen view (Esc / overlay / close button to dismiss). */
+function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
+	const [open, setOpen] = useState(false);
+	return (
+		<>
+			<button
+				type="button"
+				data-testid="chat-attachment-chip"
+				title="View image"
+				onClick={() => setOpen(true)}
+				className="flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-default tr-text-metadata transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary"
+			>
+				<FileIcon className="size-3" /> {label}
+			</button>
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent
+					data-testid="chat-attachment-dialog"
+					className="flex max-h-[90vh] w-auto max-w-[95vw] flex-col gap-sm"
+				>
+					<DialogHeader>
+						<DialogTitle>{label}</DialogTitle>
+					</DialogHeader>
+					<div className="min-h-0 flex-1 overflow-auto">
+						<img
+							src={`data:${img.mimeType};base64,${img.data}`}
+							alt={label}
+							className="max-h-[80vh] max-w-full rounded-[var(--radius-sm)]"
+						/>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}
 
 /** The user bubble. Pi's canonical expanded skill block renders as a compact, collapsed invocation with
  * any user-supplied request kept visible beneath it. A review send's context package renders as a compact
@@ -134,9 +175,17 @@ const USER_BUBBLE =
  * file); each comment unfolds to its full text + the quoted fragment — instead of the structured XML the
  * agent needs. Everything is parsed from the message itself (the transcript IS the history), so any old
  * chat unfolds the same way; the folds survive virtualization via the shared cache. */
-function UserTurn({ id, message }: { id: string; message: UserMessage }) {
+function UserTurn({
+	id,
+	message,
+	attachmentNames,
+}: {
+	id: string;
+	message: UserMessage;
+	attachmentNames?: string[] | undefined;
+}) {
 	const text = userText(message.content);
-	const images = userImages(message.content);
+	const attachments = userAttachments(message.content, attachmentNames);
 	const skill = parseSkillInvocation(text);
 	if (skill) {
 		return (
@@ -157,15 +206,10 @@ function UserTurn({ id, message }: { id: string; message: UserMessage }) {
 	return (
 		<div data-testid="chat-message" data-role="user" className="flex justify-end">
 			<div className={USER_BUBBLE}>
-				{images.length > 0 ? (
+				{attachments.length > 0 ? (
 					<div className="flex flex-wrap gap-xs pb-xs" data-testid="chat-message-images">
-						{images.map(({ key, img }) => (
-							<img
-								key={key}
-								src={`data:${img.mimeType};base64,${img.data}`}
-								alt="attached"
-								className="max-h-40 max-w-full rounded-[var(--radius-sm)] border border-border-default"
-							/>
+						{attachments.map(({ key, label, img }) => (
+							<AttachmentChip key={key} label={label} img={img} />
 						))}
 					</div>
 				) : null}

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -110,6 +110,20 @@ export function ChatTurnView({
 	}
 }
 
+/** Image blocks keyed for React — content tail + a duplicate counter (blocks carry no ids). */
+function userImages(content: UserMessage["content"]) {
+	if (typeof content === "string") return [];
+	const seen = new Map<string, number>();
+	return content
+		.filter((c) => c.type === "image")
+		.map((img) => {
+			const tail = img.data.slice(-24);
+			const n = seen.get(tail) ?? 0;
+			seen.set(tail, n + 1);
+			return { key: `${tail}-${n}`, img };
+		});
+}
+
 const USER_BUBBLE =
 	"max-w-[85%] whitespace-pre-wrap rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-md py-sm tr-text-reading text-text-muted";
 
@@ -122,6 +136,7 @@ const USER_BUBBLE =
  * chat unfolds the same way; the folds survive virtualization via the shared cache. */
 function UserTurn({ id, message }: { id: string; message: UserMessage }) {
 	const text = userText(message.content);
+	const images = userImages(message.content);
 	const skill = parseSkillInvocation(text);
 	if (skill) {
 		return (
@@ -142,6 +157,18 @@ function UserTurn({ id, message }: { id: string; message: UserMessage }) {
 	return (
 		<div data-testid="chat-message" data-role="user" className="flex justify-end">
 			<div className={USER_BUBBLE}>
+				{images.length > 0 ? (
+					<div className="flex flex-wrap gap-xs pb-xs" data-testid="chat-message-images">
+						{images.map(({ key, img }) => (
+							<img
+								key={key}
+								src={`data:${img.mimeType};base64,${img.data}`}
+								alt="attached"
+								className="max-h-40 max-w-full rounded-[var(--radius-sm)] border border-border-default"
+							/>
+						))}
+					</div>
+				) : null}
 				{review ? (
 					<div data-testid="review-package-card" className="whitespace-normal">
 						<span data-testid="review-package-summary" className="block text-text-default">

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -140,7 +140,9 @@ function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
 		<>
 			<FileChip
 				data-testid="chat-attachment-chip"
-				title="View image"
+				// The full label as the tooltip, not the action ("View image"): the chip truncates a long
+				// filename, and the aria-label below already carries the action for a screen reader.
+				title={label}
 				// The chip text is the accessible name's base; the aria-label adds the action so a screen
 				// reader hears "View attachment image.png", not a bare mime type on the hydrated fallback.
 				aria-label={`View attachment ${label}`}

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -125,7 +125,7 @@ function userImages(content: UserMessage["content"]) {
 }
 
 const USER_BUBBLE =
-	"max-w-[85%] whitespace-pre-wrap rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-md py-sm tr-text-reading text-text-muted";
+	"max-w-[85%] whitespace-pre-wrap break-words rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-md py-sm tr-text-reading text-text-muted";
 
 /** The user bubble. Pi's canonical expanded skill block renders as a compact, collapsed invocation with
  * any user-supplied request kept visible beneath it. A review send's context package renders as a compact

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -5,7 +5,6 @@ import {
 	ChevronRight,
 	Clock,
 	FileDiff,
-	FileIcon,
 	FileText,
 	FoldVertical,
 	RotateCw,
@@ -22,6 +21,7 @@ import {
 	userText,
 } from "@/lib";
 import { ActivityGroup } from "./ActivityGroup";
+import { FileChip } from "./FileChip";
 import { useFold, useSelection } from "./foldState";
 import { Markdown } from "./Markdown";
 import { parseReviewPackage, type ReviewPackageItem, reviewPackageLabel } from "./reviewPackage";
@@ -138,15 +138,15 @@ function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
 	const [open, setOpen] = useState(false);
 	return (
 		<>
-			<button
-				type="button"
+			<FileChip
 				data-testid="chat-attachment-chip"
 				title="View image"
+				// The chip text is the accessible name's base; the aria-label adds the action so a screen
+				// reader hears "View attachment image.png", not a bare mime type on the hydrated fallback.
+				aria-label={`View attachment ${label}`}
 				onClick={() => setOpen(true)}
-				className="flex items-center gap-xs whitespace-nowrap rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-default tr-text-metadata transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary"
-			>
-				<FileIcon className="size-3" /> {label}
-			</button>
+				label={label}
+			/>
 			<Dialog open={open} onOpenChange={setOpen}>
 				<DialogContent
 					data-testid="chat-attachment-dialog"
@@ -156,9 +156,11 @@ function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
 						<DialogTitle>{label}</DialogTitle>
 					</DialogHeader>
 					<div className="min-h-0 flex-1 overflow-auto">
+						{/* alt="" on purpose: the dialog title already announces the label (which can be a bare
+						 mime type on hydrated turns) — repeating it as alt text reads out "image/png" twice. */}
 						<img
 							src={`data:${img.mimeType};base64,${img.data}`}
-							alt={label}
+							alt=""
 							className="max-h-[80vh] max-w-full rounded-[var(--radius-sm)]"
 						/>
 					</div>

--- a/apps/web/src/chat/types.ts
+++ b/apps/web/src/chat/types.ts
@@ -1,4 +1,16 @@
-import type { AssistantMessage, ExtUiRequest, UserMessage } from "@thinkrail/contracts";
+import type {
+	AssistantMessage,
+	ExtUiRequest,
+	ImageContent,
+	UserMessage,
+} from "@thinkrail/contracts";
+
+/** An image attachment travelling with a send: pi's `ImageContent` (no filename on the wire — pi's
+ * model carries none) plus the picked file's name, which the optimistic echo shows on its chip. */
+export interface ChatAttachment {
+	name: string;
+	content: ImageContent;
+}
 
 /** The extension-UI frames that await a browser reply (the ones `ExtUiDialog` renders). */
 export type ExtUiDialogRequest = Extract<
@@ -15,7 +27,7 @@ export type ExtUiDialogRequest = Extract<
  * `toolCallId` and rendered inline with their call (see `ToolResultState`).
  */
 export type ChatTurn =
-	| { kind: "user"; id: string; message: UserMessage }
+	| { kind: "user"; id: string; message: UserMessage; attachmentNames?: string[] }
 	| { kind: "assistant"; id: string; message: AssistantMessage; streaming: boolean }
 	| { kind: "system"; id: string; text: string; endedAt?: number }
 	/** The live or hydrated compaction record (see SPEC §Rendering model). */

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -175,7 +175,10 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   attempt's assistant message from the live context before re-running the turn (the retry re-streams it
   as a new message) while *keeping it in the session file*, so the reducer drops the superseded failed
   assistant turn (`removeSupersededAssistant`, the same rule as the overflow-compaction path) —
-  otherwise the client renders the reply twice (frozen failed partial + retried copy). Closed
+  otherwise the client renders the reply twice (frozen failed partial + retried copy). Hydration applies
+  the same presentation rule to the persisted copy (`chat/hydrate.ts` hides retried attempts — an
+  errored assistant followed by another assistant before any user message), so live and reloaded clients
+  agree. Closed
   chats are reopenable: the workbench close command first publishes the shared placement removal and only
   after host acceptance invokes **`closeChatToHistory`**, which **keeps the runtime + session alive** and
   records it in **`closedChatsByWorkspace`** (`ClosedChat[]`, per workspace, most-recent-first) and clears

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -171,7 +171,12 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   settled transcript never claims ongoing work) and still removes the superseded assistant attempt. The
   reducer relies on pi's guarantee that every emitted `compaction_start` is paired with a
   `compaction_end` (both success and failure paths emit it), the same trust every other event pair gets.
-  Closed chats are reopenable: the workbench close command first publishes the shared placement removal and only
+  **`auto_retry_start` mirrors pi's live-context surgery**: pi's `_prepareRetry` trims the failed
+  attempt's assistant message from the live context before re-running the turn (the retry re-streams it
+  as a new message) while *keeping it in the session file*, so the reducer drops the superseded failed
+  assistant turn (`removeSupersededAssistant`, the same rule as the overflow-compaction path) —
+  otherwise the client renders the reply twice (frozen failed partial + retried copy). Closed
+  chats are reopenable: the workbench close command first publishes the shared placement removal and only
   after host acceptance invokes **`closeChatToHistory`**, which **keeps the runtime + session alive** and
   records it in **`closedChatsByWorkspace`** (`ClosedChat[]`, per workspace, most-recent-first) and clears
   any pending jump/history-open request for that session. File, diff, and registered-document render caches

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -459,6 +459,85 @@ test("a lingering retry countdown is swept up only when the run settles", () => 
 	expect(rt("a").turns.some((t) => t.kind === "system" && t.text === "✓ Done")).toBe(true);
 });
 
+test("auto-retry drops the failed attempt's turn — the retried message must not render twice", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+
+	// Attempt 1: the provider stream dies mid-message (e.g. "fetch failed"). pi commits the partial
+	// assistant message with stopReason "error", ends the run with willRetry: true, then — in
+	// `_prepareRetry` — REMOVES that failed message from the transcript before re-running the turn.
+	// The reducer must mirror that removal, or the client renders the reply twice (the frozen failed
+	// partial + the retried message) while the transcript — and any reloaded client — holds one.
+	store.handlePiEvent(agentStart, "a");
+	store.handlePiEvent(assistantStart, "a");
+	store.handlePiEvent(assistantText("The answer is"), "a");
+	store.handlePiEvent(
+		{
+			type: "message_end",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "The answer is" }],
+				stopReason: "error",
+				errorMessage: "fetch failed",
+			},
+		} as unknown as PiEvent,
+		"a",
+	);
+	store.handlePiEvent(
+		{ type: "agent_end", willRetry: true, messages: [] } as unknown as PiEvent,
+		"a",
+	);
+	store.handlePiEvent(retryStart(1, 3, 2_000), "a");
+	expect(rt("a").turns.some((t) => t.kind === "retry")).toBe(true); // countdown shows
+
+	// Attempt 2: pi continues the run and streams the SAME reply from scratch as a new message.
+	store.handlePiEvent(agentStart, "a");
+	store.handlePiEvent(assistantStart, "a");
+	store.handlePiEvent(assistantText("The answer is 4"), "a");
+	store.handlePiEvent(
+		{
+			type: "message_end",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "The answer is 4" }],
+				stopReason: "stop",
+			},
+		} as unknown as PiEvent,
+		"a",
+	);
+	store.handlePiEvent(agentEnd, "a");
+	store.handlePiEvent(agentSettled(), "a"); // settlement, not agent_end, concludes the run on main's model
+
+	const after = rt("a");
+	// Exactly ONE assistant turn — the retried message; the failed attempt's copy is gone, matching
+	// what pi's transcript (and therefore a reloaded/hydrated client) shows.
+	const assistants = after.turns.filter((t) => t.kind === "assistant");
+	expect(assistants).toHaveLength(1);
+	expect(
+		assistants[0]?.kind === "assistant" &&
+			assistants[0].message.content.some((c) => c.type === "text" && c.text === "The answer is 4"),
+	).toBe(true);
+	expect(after.turns.some((t) => t.kind === "retry")).toBe(false);
+	expect(after.turns.some((t) => t.kind === "system" && t.text === "✓ Done")).toBe(true);
+});
+
+test("auto-retry with no assistant message yet (error before message_start) drops nothing", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+	store.appendUserMessage("a", "hi");
+
+	// The request failed before any assistant tokens arrived — pi's `_prepareRetry` only slices when
+	// the transcript's last message is an assistant message; the user turn must survive untouched.
+	store.handlePiEvent(agentStart, "a");
+	store.handlePiEvent(
+		{ type: "agent_end", willRetry: true, messages: [] } as unknown as PiEvent,
+		"a",
+	);
+	store.handlePiEvent(retryStart(1, 3, 2_000), "a");
+	expect(rt("a").turns.filter((t) => t.kind === "user")).toHaveLength(1);
+	expect(rt("a").turns.some((t) => t.kind === "retry")).toBe(true);
+});
+
 test("a turn that ends in a provider error surfaces the error (not a false ✓ Done)", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -3,6 +3,7 @@ import type {
 	AskUserQuestionResult,
 	ExtUiRequest,
 	GitDiffScope,
+	ImageContent,
 	LayoutChangedPayload,
 	LayoutSettings,
 	LayoutToolId,
@@ -1124,7 +1125,7 @@ interface AppState {
 		syncedTick?: number,
 		options?: LayoutOpenOptions,
 	) => void;
-	appendUserMessage: (sessionId: string, text: string) => void;
+	appendUserMessage: (sessionId: string, text: string, images?: ImageContent[]) => void;
 	/**
 	 * Surface a failed send as a visible error turn. The turn-driving wire calls (`session.prompt`/`steer`/
 	 * `followUp`/`create`) can reject before any pi event streams — e.g. `prompt()` throws "no API key" /
@@ -2908,7 +2909,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 					: s.closedChatsByWorkspace,
 			};
 		}),
-	appendUserMessage: (sessionId, text) =>
+	appendUserMessage: (sessionId, text, images) =>
 		set((s) =>
 			withRuntime(s, sessionId, (rt) => ({
 				...rt,
@@ -2917,7 +2918,16 @@ export const useAppStore = create<AppState>((set, get) => ({
 					{
 						kind: "user",
 						id: crypto.randomUUID(),
-						message: { role: "user", content: text, timestamp: Date.now() },
+						message: {
+							role: "user",
+							// Mirror pi's own persisted shape: plain string when text-only, content blocks
+							// when images ride along — so the optimistic echo renders like a re-fetch would.
+							content:
+								images && images.length > 0
+									? [...(text ? [{ type: "text" as const, text }] : []), ...images]
+									: text,
+							timestamp: Date.now(),
+						},
 					},
 				],
 			})),

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -3,7 +3,6 @@ import type {
 	AskUserQuestionResult,
 	ExtUiRequest,
 	GitDiffScope,
-	ImageContent,
 	LayoutChangedPayload,
 	LayoutSettings,
 	LayoutToolId,
@@ -33,7 +32,13 @@ import { create } from "zustand";
 import type { LoginState } from "../auth";
 import { assistantFailureText } from "../chat/assistantFailure";
 import type { HydratedRuntime } from "../chat/hydrate";
-import type { ChatTurn, CompactionState, ExtUiDialogRequest, ToolResultState } from "../chat/types";
+import type {
+	ChatAttachment,
+	ChatTurn,
+	CompactionState,
+	ExtUiDialogRequest,
+	ToolResultState,
+} from "../chat/types";
 import {
 	type LayoutAttention,
 	layoutResourceIdentity,
@@ -1125,7 +1130,7 @@ interface AppState {
 		syncedTick?: number,
 		options?: LayoutOpenOptions,
 	) => void;
-	appendUserMessage: (sessionId: string, text: string, images?: ImageContent[]) => void;
+	appendUserMessage: (sessionId: string, text: string, attachments?: ChatAttachment[]) => void;
 	/**
 	 * Surface a failed send as a visible error turn. The turn-driving wire calls (`session.prompt`/`steer`/
 	 * `followUp`/`create`) can reject before any pi event streams — e.g. `prompt()` throws "no API key" /
@@ -2909,7 +2914,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 					: s.closedChatsByWorkspace,
 			};
 		}),
-	appendUserMessage: (sessionId, text, images) =>
+	appendUserMessage: (sessionId, text, attachments) =>
 		set((s) =>
 			withRuntime(s, sessionId, (rt) => ({
 				...rt,
@@ -2923,11 +2928,19 @@ export const useAppStore = create<AppState>((set, get) => ({
 							// Mirror pi's own persisted shape: plain string when text-only, content blocks
 							// when images ride along — so the optimistic echo renders like a re-fetch would.
 							content:
-								images && images.length > 0
-									? [...(text ? [{ type: "text" as const, text }] : []), ...images]
+								attachments && attachments.length > 0
+									? [
+											...(text ? [{ type: "text" as const, text }] : []),
+											...attachments.map((a) => a.content),
+										]
 									: text,
 							timestamp: Date.now(),
 						},
+						// pi's ImageContent has no filename, so the picked names live on the echo turn only —
+						// a hydrated (re-fetched) turn falls back to mime-type chips.
+						...(attachments && attachments.length > 0
+							? { attachmentNames: attachments.map((a) => a.name) }
+							: {}),
 					},
 				],
 			})),

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -670,10 +670,23 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 				: { ...rt, turns: settled };
 		}
 		case "auto_retry_start":
+			// pi's `_prepareRetry` trims the failed attempt's assistant message from the LIVE context before
+			// re-running the turn (the retry re-streams it as a brand-new message) — while KEEPING it in the
+			// session file for history. Mirror the trim (same superseded-attempt rule as the overflow-
+			// compaction path above), or the client renders the reply twice: the frozen failed partial plus
+			// the retried copy.
 			// Show a live countdown over the back-off; cleared on auto_retry_end (or final settlement).
 			// Replace-or-append per source: the event fires once per attempt, and the two retry flows
 			// (turn vs summarization) may overlap — each keeps exactly one indicator.
-			return appendRetryTurn(rt, "turn", event);
+			return appendRetryTurn(
+				{
+					...rt,
+					turns: removeSupersededAssistant(rt.turns, rt.attemptAssistantId),
+					attemptAssistantId: null,
+				},
+				"turn",
+				event,
+			);
 		case "auto_retry_end":
 			// The retry resolved → normal streaming/answer rendering replaces the indicator.
 			return clearRetryTurns(rt, "turn");

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -674,7 +674,8 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 			// re-running the turn (the retry re-streams it as a brand-new message) — while KEEPING it in the
 			// session file for history. Mirror the trim (same superseded-attempt rule as the overflow-
 			// compaction path above), or the client renders the reply twice: the frozen failed partial plus
-			// the retried copy.
+			// the retried copy. Hydration applies the same presentation rule to the persisted copy
+			// (`chat/hydrate.ts` `isRetriedAttempt`), so live and reloaded clients agree.
 			// Show a live countdown over the back-off; cleared on auto_retry_end (or final settlement).
 			// Replace-or-append per source: the event fires once per attempt, and the two retry flows
 			// (turn vs summarization) may overlap — each keeps exactly one indicator.

--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,7 @@
       "devDependencies": {
         "@earendil-works/pi-agent-core": "catalog:",
         "@earendil-works/pi-ai": "catalog:",
+        "@types/bun": "catalog:",
         "typescript": "catalog:",
       },
     },

--- a/e2e/composer-images.spec.ts
+++ b/e2e/composer-images.spec.ts
@@ -66,3 +66,38 @@ test("pasting a small image leaves its dimensions untouched", async ({ page }) =
 	await expect(chip).toHaveAttribute("data-width", "640");
 	await expect(chip).toHaveAttribute("data-height", "480");
 });
+
+test("pasting a within-bounds BMP re-encodes it to a provider-accepted type", async ({ page }) => {
+	await openChatComposer(page);
+
+	// A hand-built 24bpp BMP, 64×48 — within every pixel bound, but `image/bmp` is not a type the
+	// provider accepts, so the attach pipeline must re-encode it (as PNG) instead of passing it raw.
+	await page.getByTestId("chat-input").evaluate(async (el) => {
+		const w = 64;
+		const h = 48;
+		const rowSize = Math.ceil((w * 3) / 4) * 4;
+		const size = 54 + rowSize * h;
+		const view = new DataView(new ArrayBuffer(size));
+		view.setUint8(0, 0x42); // 'B'
+		view.setUint8(1, 0x4d); // 'M'
+		view.setUint32(2, size, true);
+		view.setUint32(10, 54, true); // pixel data offset
+		view.setUint32(14, 40, true); // BITMAPINFOHEADER
+		view.setInt32(18, w, true);
+		view.setInt32(22, h, true);
+		view.setUint16(26, 1, true); // planes
+		view.setUint16(28, 24, true); // bpp
+		view.setUint32(34, rowSize * h, true);
+		const file = new File([view.buffer], "shot.bmp", { type: "image/bmp" });
+		const dt = new DataTransfer();
+		dt.items.add(file);
+		el.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true }));
+	});
+
+	const chip = page.getByTestId("composer-image");
+	await expect(chip).toHaveCount(1);
+	await expect(chip).toHaveAttribute("data-width", "64");
+	await expect(chip).toHaveAttribute("data-height", "48");
+	await expect(chip).toHaveAttribute("data-mime", "image/png");
+	await expect(chip).toContainText("shot.bmp");
+});

--- a/e2e/composer-images.spec.ts
+++ b/e2e/composer-images.spec.ts
@@ -101,3 +101,30 @@ test("pasting a within-bounds BMP re-encodes it to a provider-accepted type", as
 	await expect(chip).toHaveAttribute("data-mime", "image/png");
 	await expect(chip).toContainText("shot.bmp");
 });
+
+test("an undecodable provider-unsupported file is refused with an error chip, never attached raw", async ({
+	page,
+}) => {
+	await openChatComposer(page);
+
+	// Garbage bytes labeled image/heic: Chromium can't decode it, and the provider rejects the media
+	// type outright — the old raw fallback would poison the session, so the composer must refuse it
+	// and say so (silently dropping the pick would read as a successful attach).
+	await page.getByTestId("chat-input").evaluate(async (el) => {
+		const file = new File([new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04])], "photo.heic", {
+			type: "image/heic",
+		});
+		const dt = new DataTransfer();
+		dt.items.add(file);
+		el.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true }));
+	});
+
+	const error = page.getByTestId("composer-image-error");
+	await expect(error).toHaveCount(1);
+	await expect(error).toContainText("photo.heic");
+	await expect(page.getByTestId("composer-image")).toHaveCount(0);
+
+	// Dismissible — the strip returns to empty.
+	await error.getByRole("button", { name: "Dismiss" }).click();
+	await expect(error).toHaveCount(0);
+});

--- a/e2e/composer-images.spec.ts
+++ b/e2e/composer-images.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+
+// Attach-time image downscale (TASK-image-attachment-downscale): a pasted/dropped image larger than
+// 1568px on its long edge is downscaled in the browser BEFORE it becomes an ImageContent — otherwise it
+// enters the session history raw and, once the request carries >20 images, Anthropic's 2000px per-side
+// cap 400s every subsequent turn (the "bricked chat"). The composer chip surfaces the final W×H
+// (`composer-image` testid, data-width/data-height), which is what these specs assert against. No agent
+// needed: the composer is interactive as soon as the chat tab mounts, and nothing here sends a prompt.
+
+/** Open the fixture project and land in a workspace with a mounted chat composer. */
+async function openChatComposer(page: import("@playwright/test").Page): Promise<void> {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+}
+
+/** Paste a generated PNG of the given size into the composer via a synthetic ClipboardEvent. */
+async function pastePng(
+	page: import("@playwright/test").Page,
+	width: number,
+	height: number,
+): Promise<void> {
+	await page.getByTestId("chat-input").evaluate(
+		async (el, size) => {
+			const canvas = document.createElement("canvas");
+			canvas.width = size.width;
+			canvas.height = size.height;
+			const ctx = canvas.getContext("2d");
+			if (!ctx) throw new Error("no 2d context");
+			ctx.fillStyle = "#3366aa";
+			ctx.fillRect(0, 0, size.width, size.height);
+			const blob = await new Promise<Blob | null>((r) => canvas.toBlob(r, "image/png"));
+			if (!blob) throw new Error("toBlob failed");
+			const file = new File([blob], "pasted.png", { type: "image/png" });
+			const dt = new DataTransfer();
+			dt.items.add(file);
+			el.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true }));
+		},
+		{ width, height },
+	);
+}
+
+test("pasting an oversized image downscales it to the 1568px long edge before it can be sent", async ({
+	page,
+}) => {
+	await openChatComposer(page);
+
+	// 2400×1600 would trip Anthropic's 2000px many-image cap if sent raw.
+	await pastePng(page, 2400, 1600);
+
+	const chip = page.getByTestId("composer-image");
+	await expect(chip).toHaveCount(1);
+	await expect(chip).toHaveAttribute("data-width", "1568");
+	await expect(chip).toHaveAttribute("data-height", "1045"); // 1600 * (1568 / 2400), rounded
+	await expect(chip).toContainText("1568×1045");
+});
+
+test("pasting a small image leaves its dimensions untouched", async ({ page }) => {
+	await openChatComposer(page);
+
+	await pastePng(page, 640, 480);
+
+	const chip = page.getByTestId("composer-image");
+	await expect(chip).toHaveCount(1);
+	await expect(chip).toHaveAttribute("data-width", "640");
+	await expect(chip).toHaveAttribute("data-height", "480");
+});

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -217,7 +217,8 @@ test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the r
 		);
 	});
 	await expect(thumbnails).toBeVisible();
-	await expect(thumbnails).toContainText("image/png");
+	// The attachment chip shows the file's NAME (file-chip rendering; the mime type is no longer shown).
+	await expect(thumbnails).toContainText("pixel.png");
 
 	// Recall a prompt (same navigation as above: query "fix", cycle scope to `all`) and insert-and-send.
 	await input.press("Control+r");

--- a/e2e/hydrate-midstream.live.spec.ts
+++ b/e2e/hydrate-midstream.live.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+
+// Tagged @agent (see agent.live.spec.ts): a REAL pi agent. Pins the mid-stream hydration invariant:
+// a client that hydrates while a turn streams (reload, second tab, workspace switch) must end up with
+// exactly ONE copy of the streaming assistant message. This holds by construction today —
+// `session.getMessages` returns only COMMITTED messages (pi keeps the in-flight partial in
+// `streamingMessage`, pushing it to the transcript at message_end), and the reducer's adopt-by-mint
+// path builds the live turn once — but a pi bump or a hydration change could silently break either
+// half, and the symptom (a duplicated reply) is exactly the class of bug users report as "дубляж".
+test("a reload mid-stream does not duplicate the streaming assistant message", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(180_000);
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+
+	// A deliberately long plain-text answer keeps the assistant message streaming for several
+	// seconds — the window in which the reload's hydration snapshot contains the partial message.
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			"Write the numbers 1 to 1000 separated by spaces, as plain text on one line. " +
+				"No code blocks, no tools, no commentary — only the numbers.",
+		);
+	await page.getByTestId("chat-send").click();
+
+	// Reload at the FIRST sign the assistant message is forming (message_start landed) — the earlier
+	// the reload, the more stream is left to land after hydration.
+	const assistant = page.locator('[data-testid="chat-message"][data-role="assistant"]');
+	await expect(assistant.first()).toBeVisible({ timeout: 60_000 });
+
+	// Reload mid-stream. The session keeps streaming host-side; the fresh page re-hydrates the
+	// transcript (which includes the in-flight partial) and then receives the live updates.
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	// A fresh load renders the project collapsed — re-activate the workspace to trigger hydration.
+	await page.getByTestId("project-item").first().click();
+	await expect(worktreeRows(page).first()).toBeVisible({ timeout: 15_000 });
+	await worktreeRows(page).first().click();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1, {
+		timeout: 30_000,
+	});
+	// Guard: the turn must still be streaming when the hydrated chat lands, or this test exercised
+	// nothing (the 1000-number answer keeps the window comfortably open past a reload + two clicks).
+	await expect(page.getByTestId("stream-indicator")).toBeVisible({ timeout: 10_000 });
+
+	// Let the turn finish: the live agent_end lands as the web-local "Done" notice.
+	await expect(
+		page.locator('[data-testid="chat-message"][data-role="system"]').filter({ hasText: "Done" }),
+	).toBeVisible({ timeout: 120_000 });
+
+	// Exactly ONE assistant message: the hydrated turn was adopted by the live stream, not doubled.
+	await expect(assistant).toHaveCount(1);
+});

--- a/e2e/hydrate-midstream.live.spec.ts
+++ b/e2e/hydrate-midstream.live.spec.ts
@@ -7,7 +7,7 @@ import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fi
 // `session.getMessages` returns only COMMITTED messages (pi keeps the in-flight partial in
 // `streamingMessage`, pushing it to the transcript at message_end), and the reducer's adopt-by-mint
 // path builds the live turn once — but a pi bump or a hydration change could silently break either
-// half, and the symptom (a duplicated reply) is exactly the class of bug users report as "дубляж".
+// half, and the symptom (a duplicated reply) is exactly the class of bug users report as duplication.
 test("a reload mid-stream does not duplicate the streaming assistant message", {
 	tag: "@agent",
 }, async ({ page }) => {

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -27,7 +27,10 @@ of the host.
   `DEFAULT_CONFIG`, `MAX_HISTORY_LIMIT`, `MAX_HISTORY_QUERY_LENGTH`, `TODO_NUDGE_PREFIX` +
   **`isControlMessage(text)`** (the one shared reading of that marker — the client hides such sends on
   hydrate, the host skips them in the history index and does not count them as `message_sent`; both
-  sides agree here rather than each re-deriving `startsWith`) from `domain`; **`isTranscriptMessageRole(role)`**
+  sides agree here rather than each re-deriving `startsWith`) + **`isRetriedAttempt(messages, index)`**
+  (the one shared reading of pi's persisted-but-superseded auto-retry attempts — the client's hydration
+  hides their turns, the host's history indexer skips their text; both consume the index slot so jump
+  anchors stay aligned) from `domain`; **`isTranscriptMessageRole(role)`**
   from `piProtocol` (the one definition of which roles a transcript carries: the host filters
   `session.getMessages` by it *and* `history` counts `messageIndex` by it, so two copies differing by a role
   would silently shift every later jump anchor); `export *` (value) of `wsProtocol`

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,10 +7,12 @@
 		".": "./src/index.ts"
 	},
 	"scripts": {
+		"test": "bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
 		"@earendil-works/pi-agent-core": "catalog:",
+		"@types/bun": "catalog:",
 		"@earendil-works/pi-ai": "catalog:",
 		"typescript": "catalog:"
 	}

--- a/packages/contracts/src/domain.test.ts
+++ b/packages/contracts/src/domain.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { base64ByteLength, IMAGE_MAX_BYTES, isRetriedAttempt } from "./domain";
+
+// The shared presentation/measurement contracts live here (next to isControlMessage), used by both the
+// web client and the host — so their behavior is pinned where it's defined, not only transitively
+// through each consumer's suites.
+
+describe("isRetriedAttempt", () => {
+	const failed = { role: "assistant", stopReason: "error" };
+	const ok = { role: "assistant", stopReason: "stop" };
+	const userMsg = { role: "user" };
+
+	test("a failed assistant immediately followed by the retried assistant is superseded", () => {
+		expect(isRetriedAttempt([userMsg, failed, ok], 1)).toBe(true);
+	});
+
+	test("a failed assistant followed by a user message is the run's terminal failure — visible", () => {
+		expect(isRetriedAttempt([userMsg, failed, userMsg, ok], 1)).toBe(false);
+	});
+
+	test("a trailing failed assistant (nothing after it) stays visible", () => {
+		expect(isRetriedAttempt([userMsg, failed], 1)).toBe(false);
+	});
+
+	test("a non-error assistant is never a retried attempt, even when another assistant follows", () => {
+		expect(isRetriedAttempt([userMsg, ok, ok], 1)).toBe(false);
+	});
+
+	test("non-assistant roles and out-of-range indices are never retried attempts", () => {
+		expect(isRetriedAttempt([userMsg, failed, ok], 0)).toBe(false);
+		expect(isRetriedAttempt([userMsg, failed, ok], 7)).toBe(false);
+	});
+
+	test("an intervening toolResult breaks adjacency — pi's _prepareRetry re-runs the turn directly, so anything between the two means this was not a retry", () => {
+		const toolResult = { role: "toolResult" };
+		expect(isRetriedAttempt([userMsg, failed, toolResult, ok], 1)).toBe(false);
+	});
+});
+
+describe("base64ByteLength", () => {
+	test("counts decoded bytes across padding variants without decoding", () => {
+		for (const text of ["", "a", "ab", "abc", "abcd", "hello world!", "\x00\x01\x02\xff"]) {
+			const bytes = Buffer.from(text, "binary");
+			expect(base64ByteLength(bytes.toString("base64"))).toBe(bytes.length);
+		}
+	});
+
+	test("the shared provider ceiling is Anthropic's 5MB per-image limit", () => {
+		expect(IMAGE_MAX_BYTES).toBe(5 * 1024 * 1024);
+	});
+});

--- a/packages/contracts/src/domain.test.ts
+++ b/packages/contracts/src/domain.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { base64EncodedLength, IMAGE_MAX_BASE64_BYTES, isRetriedAttempt } from "./domain";
+import {
+	ACCEPTED_IMAGE_TYPES,
+	base64EncodedLength,
+	IMAGE_MAX_BASE64_BYTES,
+	isRetriedAttempt,
+	REQUEST_IMAGE_BASE64_BUDGET,
+} from "./domain";
 
 // The shared presentation/measurement contracts live here (next to isControlMessage), used by both the
 // web client and the host — so their behavior is pinned where it's defined, not only transitively
@@ -46,5 +52,21 @@ describe("image payload ceiling", () => {
 
 	test("the shared ceiling is pi's 4.5MB encoded-base64 cap (headroom under Anthropic's 5MB API limit)", () => {
 		expect(IMAGE_MAX_BASE64_BYTES).toBe(4.5 * 1024 * 1024);
+	});
+
+	test("the request-wide image budget leaves headroom under Anthropic's 32MB per-request cap", () => {
+		expect(REQUEST_IMAGE_BASE64_BUDGET).toBe(24 * 1024 * 1024);
+		expect(REQUEST_IMAGE_BASE64_BUDGET).toBeLessThan(32 * 1024 * 1024);
+		// The budget must admit at least a few ceiling-sized images — otherwise the per-image ceiling is dead.
+		expect(REQUEST_IMAGE_BASE64_BUDGET).toBeGreaterThan(IMAGE_MAX_BASE64_BYTES * 4);
+	});
+
+	test("the provider-accepted media types are exactly png/jpeg/gif/webp", () => {
+		expect([...ACCEPTED_IMAGE_TYPES].sort()).toEqual([
+			"image/gif",
+			"image/jpeg",
+			"image/png",
+			"image/webp",
+		]);
 	});
 });

--- a/packages/contracts/src/domain.test.ts
+++ b/packages/contracts/src/domain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { base64ByteLength, IMAGE_MAX_BYTES, isRetriedAttempt } from "./domain";
+import { base64EncodedLength, IMAGE_MAX_BASE64_BYTES, isRetriedAttempt } from "./domain";
 
 // The shared presentation/measurement contracts live here (next to isControlMessage), used by both the
 // web client and the host — so their behavior is pinned where it's defined, not only transitively
@@ -37,15 +37,14 @@ describe("isRetriedAttempt", () => {
 	});
 });
 
-describe("base64ByteLength", () => {
-	test("counts decoded bytes across padding variants without decoding", () => {
-		for (const text of ["", "a", "ab", "abc", "abcd", "hello world!", "\x00\x01\x02\xff"]) {
-			const bytes = Buffer.from(text, "binary");
-			expect(base64ByteLength(bytes.toString("base64"))).toBe(bytes.length);
+describe("image payload ceiling", () => {
+	test("base64EncodedLength matches the real encoded length across quantum boundaries", () => {
+		for (const n of [0, 1, 2, 3, 4, 5, 100, 3 * 1024]) {
+			expect(base64EncodedLength(n)).toBe(Buffer.alloc(n).toString("base64").length);
 		}
 	});
 
-	test("the shared provider ceiling is Anthropic's 5MB per-image limit", () => {
-		expect(IMAGE_MAX_BYTES).toBe(5 * 1024 * 1024);
+	test("the shared ceiling is pi's 4.5MB encoded-base64 cap (headroom under Anthropic's 5MB API limit)", () => {
+		expect(IMAGE_MAX_BASE64_BYTES).toBe(4.5 * 1024 * 1024);
 	});
 });

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -745,8 +745,28 @@ export function isControlMessage(text: string): boolean {
 }
 
 /**
+ * The provider's per-image byte ceiling (Anthropic's 5MB API limit — pi's own resizer names the same
+ * number). Shared contract: the web composer re-encodes an attachment down under it at attach time,
+ * and the host's `imageGuard` strips any historical image block still over it (self-healing a session
+ * poisoned before the composer-side fix, or via another route).
+ */
+export const IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Decoded byte length of a base64 string without decoding it: 3 bytes per 4-char quantum, minus
+ * padding. Both image-size guards (composer + host) measure wire payloads with this same reading.
+ */
+export function base64ByteLength(base64: string): number {
+	if (base64.length === 0) return 0;
+	const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+	return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+/**
  * True when the message at `index` is a superseded auto-retry attempt: an assistant message that ended
- * in `stopReason: "error"` with another assistant message following before any user message. pi's
+ * in `stopReason: "error"` with the retried assistant message *immediately* following — exactly the
+ * shape pi's `_prepareRetry` produces (it trims the failed attempt from the live context and re-runs
+ * the turn straight away, so nothing can land between the two). pi's
  * `_prepareRetry` persists the failed attempt ("keep in session for history") while trimming it from
  * the live context, so every presenter of the persisted transcript needs the same reading — the
  * client's hydration hides its turn, and the host's history indexer must not surface its text as a
@@ -759,12 +779,7 @@ export function isRetriedAttempt(
 ): boolean {
 	const message = messages[index];
 	if (message?.role !== "assistant" || message.stopReason !== "error") return false;
-	for (let i = index + 1; i < messages.length; i++) {
-		const role = messages[i]?.role;
-		if (role === "assistant") return true;
-		if (role === "user") return false;
-	}
-	return false;
+	return messages[index + 1]?.role === "assistant";
 }
 
 /** History-search scope — the overlay's cycle: this chat → workspace → project → everywhere. */

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -765,6 +765,28 @@ export function base64EncodedLength(byteLength: number): number {
 }
 
 /**
+ * The image media types the provider accepts verbatim. pi forwards an attachment's media type as-is,
+ * so anything else (BMP, AVIF, HEIC…) 400s the request outright — and once persisted, every later
+ * turn. Shared contract: the composer re-encodes (or refuses) anything outside this set at attach
+ * time, and the host's `imageGuard` strips legacy blocks that predate that rule.
+ */
+export const ACCEPTED_IMAGE_TYPES: readonly string[] = [
+	"image/png",
+	"image/jpeg",
+	"image/gif",
+	"image/webp",
+];
+
+/**
+ * The request-wide budget for encoded image payload, in base64 bytes. Anthropic caps a whole Messages
+ * request at 32MB, and history is re-sent every turn — several images each under the per-image ceiling
+ * can still push the request past the limit *permanently*. 24MB keeps ~25% headroom for text, tool
+ * results, and JSON framing. Shared contract: the composer bounds one message's batch at attach time,
+ * and the host's `imageGuard` strips history largest-first until the whole request fits.
+ */
+export const REQUEST_IMAGE_BASE64_BUDGET = 24 * 1024 * 1024;
+
+/**
  * True when the message at `index` is a superseded auto-retry attempt: an assistant message that ended
  * in `stopReason: "error"` with the retried assistant message *immediately* following — exactly the
  * shape pi's `_prepareRetry` produces (it trims the failed attempt from the live context and re-runs

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -745,21 +745,23 @@ export function isControlMessage(text: string): boolean {
 }
 
 /**
- * The provider's per-image byte ceiling (Anthropic's 5MB API limit — pi's own resizer names the same
- * number). Shared contract: the web composer re-encodes an attachment down under it at attach time,
- * and the host's `imageGuard` strips any historical image block still over it (self-healing a session
- * poisoned before the composer-side fix, or via another route).
+ * The provider's per-image payload ceiling, measured in ENCODED base64 bytes: pi's own resizer caps
+ * `Buffer.byteLength(base64)` at 4.5MB as headroom below Anthropic's 5MB API limit — the wire carries
+ * base64, which inflates raw bytes by 4/3, so an image whose *decoded* size looks fine can still
+ * overflow the request. Shared contract: the web composer re-encodes an attachment down under it at
+ * attach time, and the host's `imageGuard` strips any historical image block still over it
+ * (self-healing a session poisoned before the composer-side fix, or via another route). Both layers
+ * compare `data.length` directly — base64 is ASCII, so string length IS the encoded byte length.
  */
-export const IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const IMAGE_MAX_BASE64_BYTES = 4.5 * 1024 * 1024;
 
 /**
- * Decoded byte length of a base64 string without decoding it: 3 bytes per 4-char quantum, minus
- * padding. Both image-size guards (composer + host) measure wire payloads with this same reading.
+ * Encoded base64 length of a payload of `byteLength` raw bytes (4 chars per 3-byte quantum, padded):
+ * the composer's raw pass-through path sizes a File against IMAGE_MAX_BASE64_BYTES with this same
+ * reading before it ever encodes.
  */
-export function base64ByteLength(base64: string): number {
-	if (base64.length === 0) return 0;
-	const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
-	return Math.floor((base64.length * 3) / 4) - padding;
+export function base64EncodedLength(byteLength: number): number {
+	return Math.ceil(byteLength / 3) * 4;
 }
 
 /**

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -744,6 +744,29 @@ export function isControlMessage(text: string): boolean {
 	return text.startsWith(TODO_NUDGE_PREFIX);
 }
 
+/**
+ * True when the message at `index` is a superseded auto-retry attempt: an assistant message that ended
+ * in `stopReason: "error"` with another assistant message following before any user message. pi's
+ * `_prepareRetry` persists the failed attempt ("keep in session for history") while trimming it from
+ * the live context, so every presenter of the persisted transcript needs the same reading — the
+ * client's hydration hides its turn, and the host's history indexer must not surface its text as a
+ * searchable/jumpable hit (its jump anchor is null). A failed attempt followed by a user message (or
+ * nothing) is the run's terminal failure and stays visible. Ambiguity resolves toward showing.
+ */
+export function isRetriedAttempt(
+	messages: readonly { role: string; stopReason?: string }[],
+	index: number,
+): boolean {
+	const message = messages[index];
+	if (message?.role !== "assistant" || message.stopReason !== "error") return false;
+	for (let i = index + 1; i < messages.length; i++) {
+		const role = messages[i]?.role;
+		if (role === "assistant") return true;
+		if (role === "user") return false;
+	}
+	return false;
+}
+
 /** History-search scope — the overlay's cycle: this chat → workspace → project → everywhere. */
 export type HistoryScope =
 	| { kind: "chat"; sessionId: string }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,14 +1,17 @@
 // The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol), the
 // app-config default (`DEFAULT_CONFIG`), the history-search caps (`MAX_HISTORY_LIMIT`,
 // `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX` +
-// its shared `isControlMessage` reading, plus the shared `isRetriedAttempt` transcript reading), and
-// the transcript-role policy (`isTranscriptMessageRole`, the one set the host's transcript filter and
+// its shared `isControlMessage` reading, plus the shared `isRetriedAttempt` transcript reading and the
+// shared image byte ceiling `IMAGE_MAX_BYTES` + `base64ByteLength` measurement), and the
+// transcript-role policy (`isTranscriptMessageRole`, the one set the host's transcript filter and
 // its search index must share) — small
 // plain constants both sides must agree on. Theme catalogs stay browser-side; the wire carries an opaque id.
 
 export type * from "./domain";
 export {
+	base64ByteLength,
 	DEFAULT_CONFIG,
+	IMAGE_MAX_BYTES,
 	isControlMessage,
 	isRetriedAttempt,
 	MAX_HISTORY_LIMIT,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,14 +1,16 @@
 // The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol), the
 // app-config default (`DEFAULT_CONFIG`), the history-search caps (`MAX_HISTORY_LIMIT`,
 // `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX` +
-// its shared `isControlMessage` reading), and the transcript-role policy (`isTranscriptMessageRole`, the
-// one set the host's transcript filter and its search index must share) — small
+// its shared `isControlMessage` reading, plus the shared `isRetriedAttempt` transcript reading), and
+// the transcript-role policy (`isTranscriptMessageRole`, the one set the host's transcript filter and
+// its search index must share) — small
 // plain constants both sides must agree on. Theme catalogs stay browser-side; the wire carries an opaque id.
 
 export type * from "./domain";
 export {
 	DEFAULT_CONFIG,
 	isControlMessage,
+	isRetriedAttempt,
 	MAX_HISTORY_LIMIT,
 	MAX_HISTORY_QUERY_LENGTH,
 	TERMINAL_REPLAY_KB,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@
 
 export type * from "./domain";
 export {
+	ACCEPTED_IMAGE_TYPES,
 	base64EncodedLength,
 	DEFAULT_CONFIG,
 	IMAGE_MAX_BASE64_BYTES,
@@ -16,6 +17,7 @@ export {
 	isRetriedAttempt,
 	MAX_HISTORY_LIMIT,
 	MAX_HISTORY_QUERY_LENGTH,
+	REQUEST_IMAGE_BASE64_BUDGET,
 	TERMINAL_REPLAY_KB,
 	TODO_NUDGE_PREFIX,
 } from "./domain";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,16 +2,16 @@
 // app-config default (`DEFAULT_CONFIG`), the history-search caps (`MAX_HISTORY_LIMIT`,
 // `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX` +
 // its shared `isControlMessage` reading, plus the shared `isRetriedAttempt` transcript reading and the
-// shared image byte ceiling `IMAGE_MAX_BYTES` + `base64ByteLength` measurement), and the
+// shared image payload ceiling `IMAGE_MAX_BASE64_BYTES` + `base64EncodedLength` measurement), and the
 // transcript-role policy (`isTranscriptMessageRole`, the one set the host's transcript filter and
 // its search index must share) — small
 // plain constants both sides must agree on. Theme catalogs stay browser-side; the wire carries an opaque id.
 
 export type * from "./domain";
 export {
-	base64ByteLength,
+	base64EncodedLength,
 	DEFAULT_CONFIG,
-	IMAGE_MAX_BYTES,
+	IMAGE_MAX_BASE64_BYTES,
 	isControlMessage,
 	isRetriedAttempt,
 	MAX_HISTORY_LIMIT,

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -5,7 +5,8 @@
 		"declaration": true,
 		"declarationMap": true,
 		"outDir": "./dist",
-		"rootDir": "./src"
+		"rootDir": "./src",
+		"types": ["bun"]
 	},
 	"include": ["src"]
 }

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -94,7 +94,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     with a per-session `SessionManager` **and a `buildSessionSettings(cwd)` settings manager** (the user's
     real settings + an in-memory `images.autoResize:false` override — never persisted — so the `read` tool
     sends image files **raw**, bypassing pi's photon/WASM resizer that the single-file binary can't bundle;
-    the web UI downsizes user-attached images itself); a shared `registerSession` publishes each event
+    the web UI downsizes user-attached images itself at attach time — `apps/web`'s `chat/imageAttachment`
+    caps the long edge at 1568px — and the `imageGuard` extension below is the in-context second line of
+    defense); a shared `registerSession` publishes each event
     tagged with its id + `bindExtensions({ mode:'rpc', uiContext })`. The event projection retains the
     final `agent_end` assistant's reported terminal metadata and attaches it to `agent_settled`, so the
     wire has one authoritative automatic-work terminal even when compaction/retry happens between those
@@ -241,6 +243,19 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     the manager bullet above). Pure over pi's `SessionManager` (compaction-aware via
     `buildSessionContext`; idempotent; appends at the leaf, where orphans sit by construction) —
     unit-tested against `SessionManager.inMemory`.
+  - `imageGuard` — the oversized-image guard: an inline extension (`oversizedImageGuard`, one of
+    `buildResourceLoader`'s shared factories) hooked on pi's **`context` event** (fired before every LLM
+    call, live sessions included). It sniffs each image block's pixel dimensions straight from the base64
+    header bytes (PNG/JPEG/GIF/WebP — no codec, never strips what it can't sniff) and replaces any block
+    exceeding the provider cap — **8000px per side, dropping to 2000px once the whole context carries more
+    than 20 images** (Anthropic's rules; generous enough to be harmless elsewhere) — with a text note
+    carrying the W×H and a re-attach hint. This is what un-bricks a session poisoned by an oversized image
+    (history is re-sent every turn, so one bad image 400s forever): sessions are append-only and the host
+    has no image codec (the autoResize tradeoff above), so the guard transforms the **outgoing context
+    only** — session file and transcript stay untouched, and a stuck chat recovers on its very next
+    message. The count-aware cap also degrades a raw >2000px `read`-tool image to a note instead of a
+    brick once a session crosses 21 images. Pure core (`guardOversizedImages`, `imageDimensions`)
+    unit-tested with hand-built header bytes.
   - `extensions` — Pi resource wiring. Candidate generation loads the reviewed external Central path once
     through a headless `DefaultResourceLoader` to apply provider registrations, without inspecting it.
     `buildResourceLoader(cwd, settingsManager, excludedPaths)` then resolves Pi's normal settings/package +
@@ -327,7 +342,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     binary-capable Jiti seam; it is never bundled, staged, or copied into ThinkRail. Both modes append
     `extensionFactories`: a **headless-search policy** (a `tool_call` hook defaulting
     `web_search`'s `workflow` to `"none"`, since pi-web-access would otherwise open a browser curator our
-    `rpc` host can't render) **and** `askUserQuestionExtension` (registers the `ask_user_question` tool).
+    `rpc` host can't render), `askUserQuestionExtension` (registers the `ask_user_question` tool), **and**
+    `oversizedImageGuard` (the context-level image-size guard, see the `imageGuard` bullet).
     Both session paths pass it as `resourceLoader`. `buildResourceLoader` stays internal; the seam +
     its types are on the barrel.
 - **Public surface (barrel):** the manager operations (incl. `answerQuestion` +

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -252,13 +252,19 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     header bytes (PNG/JPEG/GIF/WebP — no codec, never strips what it can't sniff; **bounded work per
     pass**: only a 256KiB decoded prefix is ever materialized — a JPEG whose SOF lies beyond it sniffs as
     unknown, not stripped — and each block is sniffed exactly once per pass) and replaces any block
-    violating a provider rule with a text note naming the violated rule plus a re-attach hint. Three
-    rules, in order: the **4.5MB encoded-base64 payload ceiling** (`IMAGE_MAX_BASE64_BYTES`, shared
+    violating a provider rule with a text note naming the violated rule plus a re-attach hint. Five
+    rules, in order: the **provider-accepted media types** (`ACCEPTED_IMAGE_TYPES`, shared with the
+    composer via `contracts` — pi forwards an image's media type verbatim, so a legacy `image/heic`
+    block 400s the whole request; stripping it heals sessions poisoned before the composer refused such
+    files); the **4.5MB encoded-base64 payload ceiling** (`IMAGE_MAX_BASE64_BYTES`, shared
     with the composer via `contracts` — pi's own headroom under Anthropic's 5MB API limit, compared
-    against `data.length` since the wire carries base64, so it applies even to unsniffable formats); the **8000px per-side hard cap**; and the **count-aware 2000px cap** once the
+    against `data.length` since the wire carries base64, so it applies even to unsniffable formats); the **8000px per-side hard cap**; the **count-aware 2000px cap** once the
     whole context carries more than 20 images — stripping changes the very count that selects that cap,
     so 2000px violators are stripped **largest-first only until the survivors fit back under the
-    threshold** (18 small + 3 at 2500px ⇒ one stripped, the other two stay legal under 8000px). This is what un-bricks a session poisoned by an oversized image
+    threshold** (18 small + 3 at 2500px ⇒ one stripped, the other two stay legal under 8000px); and the
+    **request-wide `REQUEST_IMAGE_BASE64_BUDGET`** (24MB of base64, headroom under Anthropic's 32MB
+    per-request cap — several per-image-legal blocks can still overflow the whole request), enforced by
+    stripping survivors **largest-first until the aggregate fits**. This is what un-bricks a session poisoned by an oversized image
     (history is re-sent every turn, so one bad image 400s forever): sessions are append-only and the host
     has no image codec (the autoResize tradeoff above), so the guard transforms the **outgoing context
     only** — session file and transcript stay untouched, and a stuck chat recovers on its very next

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -252,9 +252,13 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     header bytes (PNG/JPEG/GIF/WebP — no codec, never strips what it can't sniff; **bounded work per
     pass**: only a 256KiB decoded prefix is ever materialized — a JPEG whose SOF lies beyond it sniffs as
     unknown, not stripped — and each block is sniffed exactly once per pass) and replaces any block
-    exceeding the provider cap — **8000px per side, dropping to 2000px once the whole context carries more
-    than 20 images** (Anthropic's rules; generous enough to be harmless elsewhere) — with a text note
-    carrying the W×H and a re-attach hint. This is what un-bricks a session poisoned by an oversized image
+    violating a provider rule with a text note naming the violated rule plus a re-attach hint. Three
+    rules, in order: the **5MB per-image byte ceiling** (`IMAGE_MAX_BYTES` + `base64ByteLength`, shared
+    with the composer via `contracts` — measured from the base64 length, so it applies even to
+    unsniffable formats); the **8000px per-side hard cap**; and the **count-aware 2000px cap** once the
+    whole context carries more than 20 images — stripping changes the very count that selects that cap,
+    so 2000px violators are stripped **largest-first only until the survivors fit back under the
+    threshold** (18 small + 3 at 2500px ⇒ one stripped, the other two stay legal under 8000px). This is what un-bricks a session poisoned by an oversized image
     (history is re-sent every turn, so one bad image 400s forever): sessions are append-only and the host
     has no image codec (the autoResize tradeoff above), so the guard transforms the **outgoing context
     only** — session file and transcript stay untouched, and a stuck chat recovers on its very next

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -245,7 +245,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     unit-tested against `SessionManager.inMemory`.
   - `imageGuard` — the oversized-image guard: an inline extension (`oversizedImageGuard`, one of
     `buildResourceLoader`'s shared factories) hooked on pi's **`context` event** (fired before every LLM
-    call, live sessions included). It sniffs each image block's pixel dimensions straight from the base64
+    call, live sessions included). **Anthropic-family only**: the caps are Anthropic's model-level rules,
+    so the handler gates on the context's active model (`isAnthropicFamilyModel` — native
+    `anthropic`/`anthropic-messages`, or a Claude model id through Bedrock/Vertex/aggregators; unknown
+    model ⇒ no-op) and every other provider's image context passes through untouched. It sniffs each image block's pixel dimensions straight from the base64
     header bytes (PNG/JPEG/GIF/WebP — no codec, never strips what it can't sniff; **bounded work per
     pass**: only a 256KiB decoded prefix is ever materialized — a JPEG whose SOF lies beyond it sniffs as
     unknown, not stripped — and each block is sniffed exactly once per pass) and replaces any block

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -246,7 +246,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   - `imageGuard` — the oversized-image guard: an inline extension (`oversizedImageGuard`, one of
     `buildResourceLoader`'s shared factories) hooked on pi's **`context` event** (fired before every LLM
     call, live sessions included). It sniffs each image block's pixel dimensions straight from the base64
-    header bytes (PNG/JPEG/GIF/WebP — no codec, never strips what it can't sniff) and replaces any block
+    header bytes (PNG/JPEG/GIF/WebP — no codec, never strips what it can't sniff; **bounded work per
+    pass**: only a 256KiB decoded prefix is ever materialized — a JPEG whose SOF lies beyond it sniffs as
+    unknown, not stripped — and each block is sniffed exactly once per pass) and replaces any block
     exceeding the provider cap — **8000px per side, dropping to 2000px once the whole context carries more
     than 20 images** (Anthropic's rules; generous enough to be harmless elsewhere) — with a text note
     carrying the W×H and a re-attach hint. This is what un-bricks a session poisoned by an oversized image

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -253,9 +253,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     pass**: only a 256KiB decoded prefix is ever materialized — a JPEG whose SOF lies beyond it sniffs as
     unknown, not stripped — and each block is sniffed exactly once per pass) and replaces any block
     violating a provider rule with a text note naming the violated rule plus a re-attach hint. Three
-    rules, in order: the **5MB per-image byte ceiling** (`IMAGE_MAX_BYTES` + `base64ByteLength`, shared
-    with the composer via `contracts` — measured from the base64 length, so it applies even to
-    unsniffable formats); the **8000px per-side hard cap**; and the **count-aware 2000px cap** once the
+    rules, in order: the **4.5MB encoded-base64 payload ceiling** (`IMAGE_MAX_BASE64_BYTES`, shared
+    with the composer via `contracts` — pi's own headroom under Anthropic's 5MB API limit, compared
+    against `data.length` since the wire carries base64, so it applies even to unsniffable formats); the **8000px per-side hard cap**; and the **count-aware 2000px cap** once the
     whole context carries more than 20 images — stripping changes the very count that selects that cap,
     so 2000px violators are stripped **largest-first only until the survivors fit back under the
     threshold** (18 small + 3 at 2500px ⇒ one stripped, the other two stay legal under 8000px). This is what un-bricks a session poisoned by an oversized image

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -32,6 +32,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { SkillCatalogEntry, SlashCommandInfo } from "@thinkrail/contracts";
 import { askUserQuestionExtension } from "./askUserQuestion";
+import { oversizedImageGuard } from "./imageGuard";
 import { reviewToolExtension } from "./reviewTool";
 import { decideSkill, type SkillAdmissionContext } from "./skillAdmission";
 import {
@@ -250,7 +251,12 @@ export async function buildResourceLoader(
 	getAdmission: () => SkillAdmissionContext,
 	excludedExtensionPaths: readonly string[] = [],
 ): Promise<ResourceLoader> {
-	const sharedFactories = [headlessSearchPolicy, askUserQuestionExtension, reviewToolExtension];
+	const sharedFactories = [
+		headlessSearchPolicy,
+		askUserQuestionExtension,
+		reviewToolExtension,
+		oversizedImageGuard,
+	];
 	const skillInputs = resolveSkillInputs(cwd, getAdmission);
 	const agentDir = getAgentDir();
 	const common = {

--- a/packages/server/src/agent/imageGuard.test.ts
+++ b/packages/server/src/agent/imageGuard.test.ts
@@ -51,6 +51,35 @@ function gifBytes(width: number, height: number): Buffer {
 	return b;
 }
 
+function webpRiff(chunk: string): Buffer {
+	const b = Buffer.alloc(30);
+	b.write("RIFF", 0, "ascii");
+	b.writeUInt32LE(22, 4);
+	b.write("WEBP", 8, "ascii");
+	b.write(chunk, 12, "ascii");
+	b.writeUInt32LE(10, 16);
+	return b;
+}
+
+function webpVp8Bytes(width: number, height: number): Buffer {
+	// Lossy: 3-byte frame tag at 20, sync code 0x9D 0x01 0x2A, then 14-bit LE width / height.
+	const b = webpRiff("VP8 ");
+	b[23] = 0x9d;
+	b[24] = 0x01;
+	b[25] = 0x2a;
+	b.writeUInt16LE(width, 26);
+	b.writeUInt16LE(height, 28);
+	return b;
+}
+
+function webpVp8lBytes(width: number, height: number): Buffer {
+	// Lossless: signature 0x2F at 20, then 14-bit width-1 / height-1 packed little-endian.
+	const b = webpRiff("VP8L");
+	b[20] = 0x2f;
+	b.writeUInt32LE((width - 1) | ((height - 1) << 14), 21);
+	return b;
+}
+
 function webpBytes(width: number, height: number): Buffer {
 	const b = Buffer.alloc(30);
 	b.write("RIFF", 0, "ascii");
@@ -111,6 +140,33 @@ describe("imageDimensions", () => {
 			width: 2600,
 			height: 2200,
 		});
+	});
+
+	test("reads lossy WebP (VP8) frame dimensions", () => {
+		expect(imageDimensions(webpVp8Bytes(3200, 1400).toString("base64"))).toEqual({
+			width: 3200,
+			height: 1400,
+		});
+		// A missing sync code reads as undefined — never a bogus size.
+		const noSync = webpVp8Bytes(3200, 1400);
+		noSync[23] = 0x00;
+		expect(imageDimensions(noSync.toString("base64"))).toBeUndefined();
+	});
+
+	test("reads lossless WebP (VP8L) packed dimensions", () => {
+		expect(imageDimensions(webpVp8lBytes(9000, 123).toString("base64"))).toEqual({
+			width: 9000,
+			height: 123,
+		});
+		// 14-bit boundary values survive the bit packing.
+		expect(imageDimensions(webpVp8lBytes(16384, 1).toString("base64"))).toEqual({
+			width: 16384,
+			height: 1,
+		});
+		// A wrong signature byte reads as undefined.
+		const badSig = webpVp8lBytes(9000, 123);
+		badSig[20] = 0x30;
+		expect(imageDimensions(badSig.toString("base64"))).toBeUndefined();
 	});
 
 	test("sniffs from a bounded prefix — a multi-MB payload after the header is never a problem", () => {
@@ -216,6 +272,49 @@ describe("guardOversizedImages", () => {
 	test("leaves an image with unsniffable bytes untouched (never strips blind)", () => {
 		const messages = [user([image(Buffer.from("mystery-format"))])];
 		expect(guardOversizedImages(messages)).toBeUndefined();
+	});
+
+	test("strips an image over the 5MB byte ceiling — dimensions within bounds, even unsniffable", () => {
+		// A dimensionally-tiny image whose payload is huge (the 12MB-GIF class), and an unsniffable
+		// format over the ceiling — the byte rule needs no dimensions, so both are stripped.
+		const hugeGif = Buffer.concat([gifBytes(1280, 960), Buffer.alloc(6 * 1024 * 1024, 0xab)]);
+		const hugeMystery = Buffer.concat([
+			Buffer.from("mystery-format"),
+			Buffer.alloc(6 * 1024 * 1024, 0xcd),
+		]);
+		const guarded = guardOversizedImages([user([image(hugeGif, "image/gif"), image(hugeMystery)])]);
+		expect(guarded).toBeDefined();
+		const content = (guarded?.[0] as { content: { type: string; text?: string }[] }).content;
+		expect(content.every((b) => b.type === "text")).toBe(true);
+		expect(content[0]?.text).toContain("5MB image size limit");
+		expect(content[1]?.text).toContain("5MB image size limit");
+	});
+
+	test("keeps an image at the byte ceiling boundary", () => {
+		const atLimit = Buffer.concat([
+			gifBytes(100, 100),
+			Buffer.alloc(5 * 1024 * 1024 - gifBytes(100, 100).length, 0xab),
+		]);
+		expect(guardOversizedImages([user([image(atLimit, "image/gif")])])).toBeUndefined();
+	});
+
+	test("re-evaluates the count-aware cap as it strips: largest-first, only down to the threshold", () => {
+		// 18 small + 3 over 2000px ⇒ 21 images select the strict cap, but stripping ONE (the largest)
+		// brings the request to 20, where the 8000px cap applies — the other two are legal and stay.
+		const small = image(pngBytes(500, 500));
+		const messages: AgentMessage[] = [
+			toolResult(Array.from({ length: 18 }, () => small)),
+			user([image(pngBytes(2600, 100)), image(pngBytes(2500, 100)), image(pngBytes(2400, 100))]),
+		];
+		const guarded = guardOversizedImages(messages);
+		expect(guarded).toBeDefined();
+		const tr = (guarded?.[0] as { content: { type: string }[] }).content;
+		expect(tr.every((b) => b.type === "image")).toBe(true);
+		const u = (guarded?.[1] as { content: { type: string; text?: string }[] }).content;
+		expect(u[0]?.type).toBe("text"); // the largest (2600px) goes…
+		expect(u[0]?.text).toContain("2600×100");
+		expect(u[1]?.type).toBe("image"); // …the other two survive under the now-lifted cap
+		expect(u[2]?.type).toBe("image");
 	});
 
 	test("does not mutate the input messages", () => {

--- a/packages/server/src/agent/imageGuard.test.ts
+++ b/packages/server/src/agent/imageGuard.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage, ImageContent } from "@thinkrail/contracts";
 import {
 	guardOversizedImages,
 	imageDimensions,
+	isAnthropicFamilyModel,
 	MANY_IMAGE_EDGE_LIMIT,
 	MANY_IMAGE_THRESHOLD,
 	oversizedImageGuard,
@@ -225,24 +226,65 @@ describe("guardOversizedImages", () => {
 	});
 });
 
+// ---- the provider gate ----
+
+describe("isAnthropicFamilyModel", () => {
+	test("matches native Anthropic and Claude-through-a-front, and nothing else", () => {
+		expect(isAnthropicFamilyModel({ provider: "anthropic", api: "anthropic-messages" })).toBe(true);
+		expect(
+			isAnthropicFamilyModel({ provider: "amazon-bedrock", id: "anthropic.claude-sonnet" }),
+		).toBe(true);
+		expect(
+			isAnthropicFamilyModel({ provider: "openai", api: "openai-responses", id: "gpt-5" }),
+		).toBe(false);
+		expect(isAnthropicFamilyModel({ provider: "google", id: "gemini-3-pro" })).toBe(false);
+		// No model ⇒ no known policy ⇒ never strip.
+		expect(isAnthropicFamilyModel(undefined)).toBe(false);
+	});
+});
+
 // ---- the extension wiring ----
 
-test("oversizedImageGuard registers a context handler that returns replaced messages", async () => {
-	let handler: ((event: { type: "context"; messages: AgentMessage[] }) => unknown) | undefined;
+type ContextHandler = (
+	event: { type: "context"; messages: AgentMessage[] },
+	ctx: { model: { api?: string; provider?: string; id?: string } | undefined },
+) => unknown;
+
+function registeredHandler(): ContextHandler {
+	let handler: ContextHandler | undefined;
 	const pi = {
-		on: (event: string, h: typeof handler) => {
+		on: (event: string, h: ContextHandler) => {
 			if (event === "context") handler = h;
 		},
 	};
 	oversizedImageGuard(pi as never);
-	expect(handler).toBeDefined();
+	if (!handler) throw new Error("no context handler registered");
+	return handler;
+}
 
-	const clean = await handler?.({ type: "context", messages: [user("hello")] });
+const anthropicCtx = { model: { provider: "anthropic", api: "anthropic-messages", id: "claude" } };
+
+test("oversizedImageGuard registers a context handler that returns replaced messages", async () => {
+	const handler = registeredHandler();
+
+	const clean = await handler({ type: "context", messages: [user("hello")] }, anthropicCtx);
 	expect(clean).toBeUndefined();
 
-	const dirty = (await handler?.({
-		type: "context",
-		messages: [user([image(pngBytes(9000, 100))])],
-	})) as { messages: AgentMessage[] };
+	const dirty = (await handler(
+		{ type: "context", messages: [user([image(pngBytes(9000, 100))])] },
+		anthropicCtx,
+	)) as { messages: AgentMessage[] };
 	expect(dirty?.messages).toBeDefined();
+});
+
+test("the guard is a no-op for a non-Anthropic model — the caps are Anthropic's, not the provider's", async () => {
+	const handler = registeredHandler();
+	const oversized = { type: "context" as const, messages: [user([image(pngBytes(9000, 100))])] };
+
+	expect(
+		await handler(oversized, {
+			model: { provider: "openai", api: "openai-responses", id: "gpt-5" },
+		}),
+	).toBeUndefined();
+	expect(await handler(oversized, { model: undefined })).toBeUndefined();
 });

--- a/packages/server/src/agent/imageGuard.test.ts
+++ b/packages/server/src/agent/imageGuard.test.ts
@@ -304,6 +304,58 @@ describe("guardOversizedImages", () => {
 		expect(content[0]?.text).toContain("4.5MB image payload limit");
 	});
 
+	test("strips a provider-unsupported media type even when small and within bounds — legacy HEIC/BMP heals", () => {
+		// The composer refuses these now, but sessions poisoned before that rule (or fed by another
+		// client) re-send the block every turn — the guard is what un-bricks them.
+		const guarded = guardOversizedImages([
+			user([
+				image(Buffer.from("tiny-heic-payload"), "image/heic"),
+				image(gifBytes(100, 100), "image/gif"),
+			]),
+		]);
+		expect(guarded).toBeDefined();
+		const content = (guarded?.[0] as { content: { type: string; text?: string }[] }).content;
+		expect(content[0]?.type).toBe("text");
+		expect(content[0]?.text).toContain("media type image/heic is not supported");
+		expect(content[1]?.type).toBe("image");
+	});
+
+	test("strips largest-first down to the request-wide 24MB image budget — each image alone is legal", () => {
+		// Seven ~4.2MiB-of-base64 images: every one passes the 4.5MiB per-image ceiling, but the sum
+		// (~29.4MiB) exceeds the 24MiB aggregate budget — the largest two go, five stay (~21MiB).
+		const mib = 1024 * 1024;
+		const gif = (decodedBytes: number) =>
+			image(
+				Buffer.concat([
+					gifBytes(100, 100),
+					Buffer.alloc(decodedBytes - gifBytes(100, 100).length, 0xab),
+				]),
+				"image/gif",
+			);
+		const blocks = [3.1, 3.1, 3.1, 3.1, 3.1, 3.2, 3.3].map((m) => gif(Math.round(m * mib)));
+		const guarded = guardOversizedImages([user(blocks)]);
+		expect(guarded).toBeDefined();
+		const content = (guarded?.[0] as { content: { type: string; text?: string }[] }).content;
+		const stripped = content.filter((b) => b.type === "text");
+		const kept = content.filter((b) => b.type === "image");
+		expect(stripped.length).toBe(2);
+		expect(kept.length).toBe(5);
+		for (const note of stripped) expect(note.text).toContain("over the 24MB budget");
+		// Largest-first: the 3.3MiB and 3.2MiB blocks are the ones stripped — all five 3.1MiB stay.
+		const keptSizes = kept.map((b) => (b as { data?: string }).data?.length ?? 0);
+		for (const size of keptSizes)
+			expect(size).toBeLessThanOrEqual(Math.ceil((3.1 * mib) / 3) * 4 + 8);
+	});
+
+	test("keeps a request whose aggregate image payload is under the budget", () => {
+		const mib = 1024 * 1024;
+		const small = image(
+			Buffer.concat([gifBytes(100, 100), Buffer.alloc(3 * mib, 0xab)]),
+			"image/gif",
+		);
+		expect(guardOversizedImages([user([small, small, small])])).toBeUndefined();
+	});
+
 	test("keeps an image exactly at the encoded-base64 ceiling boundary", () => {
 		// 3.375MiB decoded is divisible by 3 → exactly 4.5MiB of base64, the last legal size.
 		const atLimit = Buffer.concat([

--- a/packages/server/src/agent/imageGuard.test.ts
+++ b/packages/server/src/agent/imageGuard.test.ts
@@ -112,6 +112,33 @@ describe("imageDimensions", () => {
 		});
 	});
 
+	test("sniffs from a bounded prefix — a multi-MB payload after the header is never a problem", () => {
+		// The guard runs on every LLM call; only the header region is decoded, so trailing image data
+		// (the actual pixels) beyond the 256KiB sniff bound must not affect the result.
+		const big = Buffer.concat([pngBytes(3024, 1964), Buffer.alloc(4 * 1024 * 1024, 0xab)]);
+		expect(imageDimensions(big.toString("base64"))).toEqual({ width: 3024, height: 1964 });
+	});
+
+	test("a JPEG whose SOF lies beyond the sniff bound reads as undefined — never stripped blind", () => {
+		// SOI + a chain of max-size APP1 segments pushing the SOF past 256KiB of decoded bytes.
+		const filler = Buffer.alloc(0xffff + 2);
+		filler[0] = 0xff;
+		filler[1] = 0xe1; // APP1
+		filler.writeUInt16BE(0xffff, 2);
+		const sof = Buffer.alloc(9);
+		sof[0] = 0xff;
+		sof[1] = 0xc0;
+		sof.writeUInt16BE(7, 2);
+		sof.writeUInt16BE(100, 5);
+		sof.writeUInt16BE(200, 7);
+		const jpeg = Buffer.concat([
+			Buffer.from([0xff, 0xd8]),
+			...Array.from({ length: 5 }, () => filler), // ~320KiB of metadata before the SOF
+			sof,
+		]);
+		expect(imageDimensions(jpeg.toString("base64"))).toBeUndefined();
+	});
+
 	test("returns undefined for unrecognized bytes and invalid base64", () => {
 		expect(imageDimensions(Buffer.from("not an image at all").toString("base64"))).toBeUndefined();
 		expect(imageDimensions("!!!not-base64!!!")).toBeUndefined();

--- a/packages/server/src/agent/imageGuard.test.ts
+++ b/packages/server/src/agent/imageGuard.test.ts
@@ -274,7 +274,7 @@ describe("guardOversizedImages", () => {
 		expect(guardOversizedImages(messages)).toBeUndefined();
 	});
 
-	test("strips an image over the 5MB byte ceiling — dimensions within bounds, even unsniffable", () => {
+	test("strips an image over the 4.5MB encoded-base64 ceiling — dimensions within bounds, even unsniffable", () => {
 		// A dimensionally-tiny image whose payload is huge (the 12MB-GIF class), and an unsniffable
 		// format over the ceiling — the byte rule needs no dimensions, so both are stripped.
 		const hugeGif = Buffer.concat([gifBytes(1280, 960), Buffer.alloc(6 * 1024 * 1024, 0xab)]);
@@ -286,15 +286,31 @@ describe("guardOversizedImages", () => {
 		expect(guarded).toBeDefined();
 		const content = (guarded?.[0] as { content: { type: string; text?: string }[] }).content;
 		expect(content.every((b) => b.type === "text")).toBe(true);
-		expect(content[0]?.text).toContain("5MB image size limit");
-		expect(content[1]?.text).toContain("5MB image size limit");
+		expect(content[0]?.text).toContain("4.5MB image payload limit");
+		expect(content[1]?.text).toContain("4.5MB image payload limit");
 	});
 
-	test("keeps an image at the byte ceiling boundary", () => {
+	test("strips an image whose DECODED size is under Anthropic's 5MB but whose base64 exceeds pi's 4.5MB cap", () => {
+		// 3.6MiB decoded → 4.8MiB of base64: the wire carries base64, so this payload is rejected by the
+		// provider even though its raw byte size looks legal — the ceiling must be measured encoded.
+		const decoded = Buffer.concat([
+			gifBytes(100, 100),
+			Buffer.alloc(Math.round(3.6 * 1024 * 1024) - gifBytes(100, 100).length, 0xab),
+		]);
+		expect(decoded.length).toBeLessThan(5 * 1024 * 1024);
+		expect(decoded.toString("base64").length).toBeGreaterThan(4.5 * 1024 * 1024);
+		const guarded = guardOversizedImages([user([image(decoded, "image/gif")])]);
+		const content = (guarded?.[0] as { content: { type: string; text?: string }[] }).content;
+		expect(content[0]?.text).toContain("4.5MB image payload limit");
+	});
+
+	test("keeps an image exactly at the encoded-base64 ceiling boundary", () => {
+		// 3.375MiB decoded is divisible by 3 → exactly 4.5MiB of base64, the last legal size.
 		const atLimit = Buffer.concat([
 			gifBytes(100, 100),
-			Buffer.alloc(5 * 1024 * 1024 - gifBytes(100, 100).length, 0xab),
+			Buffer.alloc(3.375 * 1024 * 1024 - gifBytes(100, 100).length, 0xab),
 		]);
+		expect(atLimit.toString("base64").length).toBe(4.5 * 1024 * 1024);
 		expect(guardOversizedImages([user([image(atLimit, "image/gif")])])).toBeUndefined();
 	});
 

--- a/packages/server/src/agent/imageGuard.test.ts
+++ b/packages/server/src/agent/imageGuard.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage, ImageContent } from "@thinkrail/contracts";
+import {
+	guardOversizedImages,
+	imageDimensions,
+	MANY_IMAGE_EDGE_LIMIT,
+	MANY_IMAGE_THRESHOLD,
+	oversizedImageGuard,
+	SINGLE_IMAGE_EDGE_LIMIT,
+} from "./imageGuard";
+
+// The un-bricking half of TASK-image-attachment-downscale: an oversized image anywhere in a session's
+// history re-fails EVERY turn (Anthropic caps a side at 8000px, dropping to 2000px once a request
+// carries more than 20 images). Sessions are append-only and the host has no image codec, so the guard
+// transforms the OUTGOING context (pi's `context` extension event) — sniffing dimensions straight from
+// the base64 header bytes and replacing violating image blocks with a text note — while the session
+// file and transcript stay untouched.
+
+// ---- tiny hand-built image headers (only the bytes the sniffer reads) ----
+
+function pngBytes(width: number, height: number): Buffer {
+	const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const ihdr = Buffer.alloc(21);
+	ihdr.writeUInt32BE(13, 0);
+	ihdr.write("IHDR", 4);
+	ihdr.writeUInt32BE(width, 8);
+	ihdr.writeUInt32BE(height, 12);
+	return Buffer.concat([sig, ihdr]);
+}
+
+function jpegBytes(width: number, height: number): Buffer {
+	const soi = Buffer.from([0xff, 0xd8]);
+	// An APP0 segment before the SOF, so the sniffer must actually walk segments.
+	const app0 = Buffer.from([0xff, 0xe0, 0x00, 0x04, 0x00, 0x00]);
+	const sof = Buffer.alloc(9);
+	sof[0] = 0xff;
+	sof[1] = 0xc0; // SOF0
+	sof.writeUInt16BE(7, 2);
+	sof[4] = 8; // bit depth
+	sof.writeUInt16BE(height, 5);
+	sof.writeUInt16BE(width, 7);
+	return Buffer.concat([soi, app0, sof]);
+}
+
+function gifBytes(width: number, height: number): Buffer {
+	const b = Buffer.alloc(10);
+	b.write("GIF89a", 0, "ascii");
+	b.writeUInt16LE(width, 6);
+	b.writeUInt16LE(height, 8);
+	return b;
+}
+
+function webpBytes(width: number, height: number): Buffer {
+	const b = Buffer.alloc(30);
+	b.write("RIFF", 0, "ascii");
+	b.writeUInt32LE(22, 4);
+	b.write("WEBP", 8, "ascii");
+	b.write("VP8X", 12, "ascii");
+	b.writeUInt32LE(10, 16);
+	b.writeUIntLE(width - 1, 24, 3);
+	b.writeUIntLE(height - 1, 27, 3);
+	return b;
+}
+
+const image = (bytes: Buffer, mimeType = "image/png"): ImageContent => ({
+	type: "image",
+	data: bytes.toString("base64"),
+	mimeType,
+});
+
+const user = (content: string | (ImageContent | { type: "text"; text: string })[]): AgentMessage =>
+	({ role: "user", content, timestamp: 1 }) as AgentMessage;
+
+const toolResult = (content: (ImageContent | { type: "text"; text: string })[]) =>
+	({
+		role: "toolResult",
+		toolCallId: "tc1",
+		toolName: "read",
+		content,
+		isError: false,
+		timestamp: 1,
+	}) as AgentMessage;
+
+// ---- imageDimensions: header sniffing, no codec ----
+
+describe("imageDimensions", () => {
+	test("reads PNG IHDR dimensions", () => {
+		expect(imageDimensions(pngBytes(3024, 1964).toString("base64"))).toEqual({
+			width: 3024,
+			height: 1964,
+		});
+	});
+
+	test("walks JPEG segments to the SOF frame header", () => {
+		expect(imageDimensions(jpegBytes(4032, 3024).toString("base64"))).toEqual({
+			width: 4032,
+			height: 3024,
+		});
+	});
+
+	test("reads GIF logical screen dimensions", () => {
+		expect(imageDimensions(gifBytes(2500, 900).toString("base64"))).toEqual({
+			width: 2500,
+			height: 900,
+		});
+	});
+
+	test("reads WebP VP8X canvas dimensions", () => {
+		expect(imageDimensions(webpBytes(2600, 2200).toString("base64"))).toEqual({
+			width: 2600,
+			height: 2200,
+		});
+	});
+
+	test("returns undefined for unrecognized bytes and invalid base64", () => {
+		expect(imageDimensions(Buffer.from("not an image at all").toString("base64"))).toBeUndefined();
+		expect(imageDimensions("!!!not-base64!!!")).toBeUndefined();
+		expect(imageDimensions("")).toBeUndefined();
+	});
+});
+
+// ---- guardOversizedImages: the context transform ----
+
+describe("guardOversizedImages", () => {
+	test("keeps a 2000–8000px image while the context holds few images", () => {
+		const messages = [user([{ type: "text", text: "look" }, image(pngBytes(3000, 2000))])];
+		expect(guardOversizedImages(messages)).toBeUndefined();
+	});
+
+	test("always strips an image over the 8000px hard cap", () => {
+		const messages = [user([image(pngBytes(9000, 100))])];
+		const guarded = guardOversizedImages(messages);
+		expect(guarded).toBeDefined();
+		const content = (guarded?.[0] as { content: { type: string; text?: string }[] }).content;
+		expect(content).toHaveLength(1);
+		expect(content[0]?.type).toBe("text");
+		expect(content[0]?.text).toContain("9000×100");
+		expect(content[0]?.text).toContain(`${SINGLE_IMAGE_EDGE_LIMIT}px`);
+	});
+
+	test("applies the stricter 2000px cap once the context carries more than 20 images", () => {
+		const small = image(pngBytes(100, 100));
+		const big = image(pngBytes(2100, 1000)); // legal alone, illegal in a many-image request
+		const messages: AgentMessage[] = [
+			toolResult(Array.from({ length: MANY_IMAGE_THRESHOLD }, () => small)),
+			user([big]),
+		];
+		const guarded = guardOversizedImages(messages);
+		expect(guarded).toBeDefined();
+		// The 20 small images survive untouched…
+		const tr = (guarded?.[0] as { content: { type: string }[] }).content;
+		expect(tr.every((b) => b.type === "image")).toBe(true);
+		// …the 21st, oversized one becomes a text note naming the stricter cap.
+		const u = (guarded?.[1] as { content: { type: string; text?: string }[] }).content;
+		expect(u[0]?.type).toBe("text");
+		expect(u[0]?.text).toContain(`${MANY_IMAGE_EDGE_LIMIT}px`);
+	});
+
+	test("the same 2100px image is kept while the context holds 20 images or fewer", () => {
+		const small = image(pngBytes(100, 100));
+		const messages: AgentMessage[] = [
+			toolResult(Array.from({ length: MANY_IMAGE_THRESHOLD - 1 }, () => small)),
+			user([image(pngBytes(2100, 1000))]),
+		];
+		expect(guardOversizedImages(messages)).toBeUndefined();
+	});
+
+	test("strips oversized images inside tool results too", () => {
+		const messages = [
+			toolResult([{ type: "text", text: "read it" }, image(jpegBytes(9500, 200), "image/jpeg")]),
+		];
+		const guarded = guardOversizedImages(messages);
+		const content = (guarded?.[0] as { content: { type: string; text?: string }[] }).content;
+		expect(content[0]).toEqual({ type: "text", text: "read it" });
+		expect(content[1]?.type).toBe("text");
+		expect(content[1]?.text).toContain("9500×200");
+	});
+
+	test("no-ops (returns undefined) when nothing is oversized", () => {
+		const messages: AgentMessage[] = [
+			user("plain string content"),
+			user([{ type: "text", text: "hi" }, image(pngBytes(1568, 882))]),
+			toolResult([{ type: "text", text: "ok" }]),
+		];
+		expect(guardOversizedImages(messages)).toBeUndefined();
+	});
+
+	test("leaves an image with unsniffable bytes untouched (never strips blind)", () => {
+		const messages = [user([image(Buffer.from("mystery-format"))])];
+		expect(guardOversizedImages(messages)).toBeUndefined();
+	});
+
+	test("does not mutate the input messages", () => {
+		const original = user([image(pngBytes(9000, 9000))]);
+		const snapshot = JSON.parse(JSON.stringify(original));
+		guardOversizedImages([original]);
+		expect(original).toEqual(snapshot);
+	});
+});
+
+// ---- the extension wiring ----
+
+test("oversizedImageGuard registers a context handler that returns replaced messages", async () => {
+	let handler: ((event: { type: "context"; messages: AgentMessage[] }) => unknown) | undefined;
+	const pi = {
+		on: (event: string, h: typeof handler) => {
+			if (event === "context") handler = h;
+		},
+	};
+	oversizedImageGuard(pi as never);
+	expect(handler).toBeDefined();
+
+	const clean = await handler?.({ type: "context", messages: [user("hello")] });
+	expect(clean).toBeUndefined();
+
+	const dirty = (await handler?.({
+		type: "context",
+		messages: [user([image(pngBytes(9000, 100))])],
+	})) as { messages: AgentMessage[] };
+	expect(dirty?.messages).toBeDefined();
+});

--- a/packages/server/src/agent/imageGuard.ts
+++ b/packages/server/src/agent/imageGuard.ts
@@ -6,7 +6,9 @@
 // no image codec (the same photon/WASM bundling problem that disabled autoResize), so the guard
 // transforms the OUTGOING context instead: on pi's `context` event (fired before every LLM call, live
 // sessions included — a stuck chat unsticks on its very next message) it sniffs each image's dimensions
-// straight from the base64 header bytes and replaces violating image blocks with a text note. The
+// straight from the base64 header bytes, measures its byte size from the base64 length (the provider
+// also caps an image at 5MB — IMAGE_MAX_BYTES, shared with the composer's attach-time ladder), and
+// replaces violating image blocks with a text note. The
 // session file and the visible transcript stay untouched. The caps are Anthropic's model-level rules,
 // so the guard fires ONLY for the Anthropic model family (the `context` handler's ctx.model — native
 // `anthropic-messages` api / `anthropic` provider, or a Claude model served through Bedrock/Vertex);
@@ -15,7 +17,7 @@
 // a note (not a brick) once the same session crosses 21.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { AgentMessage } from "@thinkrail/contracts";
+import { type AgentMessage, base64ByteLength, IMAGE_MAX_BYTES } from "@thinkrail/contracts";
 
 /** Anthropic's per-side cap for requests carrying 20 images or fewer. */
 export const SINGLE_IMAGE_EDGE_LIMIT = 8000;
@@ -123,10 +125,18 @@ type ContentBlock = { type: string } & Record<string, unknown>;
 const isImageBlock = (block: ContentBlock): block is ContentBlock & { data: string } =>
 	block.type === "image" && typeof block.data === "string";
 
+const REMOVAL_HINT = "ask the user to re-attach a smaller version if it is still needed";
+
 /**
- * Replace every image block that exceeds the provider's per-side cap with a text note carrying its
- * dimensions (copy-on-write — the input is never mutated). The cap is count-aware: 8000px normally,
- * 2000px when the whole context carries more than 20 images. Returns undefined when nothing changed.
+ * Replace every image block that violates a provider limit with a text note naming the violated rule
+ * (copy-on-write — the input is never mutated). Three rules, applied in order:
+ * 1. bytes — anything over IMAGE_MAX_BYTES (5MB) is stripped, sniffable or not;
+ * 2. the 8000px hard per-side cap;
+ * 3. the count-aware 2000px cap — and because stripping changes the very count that selects the cap,
+ *    2000px violators are stripped LARGEST-FIRST only until the surviving image count is back at the
+ *    20-image threshold; the rest are then legal under the 8000px cap and stay (18 small + 3 at
+ *    2500px ⇒ one stripped, not three).
+ * Returns undefined when nothing changed.
  */
 export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] | undefined {
 	const blocksOf = (m: AgentMessage): ContentBlock[] | undefined => {
@@ -137,41 +147,74 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 	// One bounded sniff per image block per pass, cached by block identity — the hook fires on every LLM
 	// call, so re-decoding per predicate (count / detect / note text) would multiply the work.
 	const sniffed = new Map<ContentBlock, Dimensions | undefined>();
-	let imageCount = 0;
+	const imageBlocks: (ContentBlock & { data: string })[] = [];
 	for (const message of messages) {
 		for (const block of blocksOf(message) ?? []) {
 			if (isImageBlock(block)) {
-				imageCount++;
+				imageBlocks.push(block);
 				sniffed.set(block, imageDimensions(block.data));
 			}
 		}
 	}
-	if (imageCount === 0) return undefined;
-	const cap = imageCount > MANY_IMAGE_THRESHOLD ? MANY_IMAGE_EDGE_LIMIT : SINGLE_IMAGE_EDGE_LIMIT;
+	if (imageBlocks.length === 0) return undefined;
 
-	const exceeds = (block: ContentBlock): boolean => {
+	// The removal note per stripped block — membership doubles as the strip decision.
+	const notes = new Map<ContentBlock, string>();
+	for (const block of imageBlocks) {
+		const bytes = base64ByteLength(block.data);
+		if (bytes > IMAGE_MAX_BYTES) {
+			const mb = (bytes / (1024 * 1024)).toFixed(1);
+			notes.set(
+				block,
+				`[image removed: ${mb}MB exceeds the provider's ${IMAGE_MAX_BYTES / (1024 * 1024)}MB image size limit — ${REMOVAL_HINT}]`,
+			);
+			continue;
+		}
 		const d = sniffed.get(block);
-		return d !== undefined && (d.width > cap || d.height > cap);
-	};
+		if (d && (d.width > SINGLE_IMAGE_EDGE_LIMIT || d.height > SINGLE_IMAGE_EDGE_LIMIT)) {
+			notes.set(
+				block,
+				`[image removed: ${d.width}×${d.height} exceeds the provider's ${SINGLE_IMAGE_EDGE_LIMIT}px image-dimension limit — ${REMOVAL_HINT}]`,
+			);
+		}
+	}
 
-	let changed = false;
+	// The stricter cap only applies while the request still carries more than the threshold — each strip
+	// lowers the count, so strip largest-first and stop the moment the survivors fit under the threshold
+	// (the rest become legal under the 8000px cap already enforced above).
+	let surviving = imageBlocks.length - notes.size;
+	if (surviving > MANY_IMAGE_THRESHOLD) {
+		const longEdge = (b: ContentBlock) => {
+			const d = sniffed.get(b);
+			return d ? Math.max(d.width, d.height) : 0;
+		};
+		const strictViolators = imageBlocks
+			.filter((b) => !notes.has(b) && longEdge(b) > MANY_IMAGE_EDGE_LIMIT)
+			.sort((a, b) => longEdge(b) - longEdge(a));
+		for (const block of strictViolators) {
+			if (surviving <= MANY_IMAGE_THRESHOLD) break;
+			const d = sniffed.get(block);
+			notes.set(
+				block,
+				`[image removed: ${d?.width}×${d?.height} exceeds the provider's ${MANY_IMAGE_EDGE_LIMIT}px image-dimension limit for requests carrying more than ${MANY_IMAGE_THRESHOLD} images — ${REMOVAL_HINT}]`,
+			);
+			surviving--;
+		}
+	}
+	if (notes.size === 0) return undefined;
+
 	const guarded = messages.map((message) => {
 		const blocks = blocksOf(message);
-		if (!blocks?.some(exceeds)) return message;
-		changed = true;
+		if (!blocks?.some((b) => notes.has(b))) return message;
 		const content = blocks.map((block) => {
-			if (!exceeds(block)) return block;
-			const d = sniffed.get(block);
-			return {
-				type: "text",
-				text: `[image removed: ${d ? `${d.width}×${d.height}` : "unknown size"} exceeds the provider's ${cap}px image-dimension limit — ask the user to re-attach a smaller version if it is still needed]`,
-			};
+			const note = notes.get(block);
+			return note ? { type: "text", text: note } : block;
 		});
 		// Object.assign keeps the concrete message variant (its type is `message & {content}`), which
 		// widens back to AgentMessage without a lossy double-cast.
 		return Object.assign({}, message, { content }) as AgentMessage;
 	});
-	return changed ? guarded : undefined;
+	return guarded;
 }
 
 /** Does this model enforce Anthropic's image-dimension rules? Native Anthropic (api/provider), plus

--- a/packages/server/src/agent/imageGuard.ts
+++ b/packages/server/src/agent/imageGuard.ts
@@ -85,13 +85,24 @@ function webpDimensions(b: Buffer): Dimensions | undefined {
 	return undefined;
 }
 
+/** How many decoded bytes the sniffer may look at. PNG/GIF/WebP dimensions sit at fixed offsets in the
+ * first ~30 bytes; only JPEG walks marker segments, and its metadata segments (EXIF, thumbnails) cap at
+ * 64KiB each — 256KiB of prefix covers real-world files with several of them. The bound is the point:
+ * the guard runs on pi's `context` hook before EVERY LLM call in the in-process host, so decoding whole
+ * multi-MB images there would be an unbounded allocation per turn. A JPEG whose SOF lies beyond the
+ * bound sniffs as undefined — "couldn't sniff", never stripped blind. */
+const MAX_SNIFF_BYTES = 256 * 1024;
+// base64 quantum is 4 chars → 3 bytes; keep the prefix on a 4-char boundary so the slice decodes clean.
+const MAX_SNIFF_BASE64_CHARS = Math.ceil(MAX_SNIFF_BYTES / 3) * 4;
+
 /** Sniff an image's pixel dimensions from its base64 data (PNG / JPEG / GIF / WebP header bytes — no
- * codec, no decode). Undefined for unrecognized or malformed data: the guard never strips blind. */
+ * codec, and only a bounded prefix is ever decoded). Undefined for unrecognized or malformed data: the
+ * guard never strips blind. */
 export function imageDimensions(base64: string): Dimensions | undefined {
 	if (!base64) return undefined;
 	let bytes: Buffer;
 	try {
-		bytes = Buffer.from(base64, "base64");
+		bytes = Buffer.from(base64.slice(0, MAX_SNIFF_BASE64_CHARS), "base64");
 	} catch {
 		return undefined;
 	}
@@ -121,42 +132,45 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 		return Array.isArray(content) ? (content as ContentBlock[]) : undefined;
 	};
 
+	// One bounded sniff per image block per pass, cached by block identity — the hook fires on every LLM
+	// call, so re-decoding per predicate (count / detect / note text) would multiply the work.
+	const sniffed = new Map<ContentBlock, Dimensions | undefined>();
 	let imageCount = 0;
 	for (const message of messages) {
-		for (const block of blocksOf(message) ?? []) if (isImageBlock(block)) imageCount++;
+		for (const block of blocksOf(message) ?? []) {
+			if (isImageBlock(block)) {
+				imageCount++;
+				sniffed.set(block, imageDimensions(block.data));
+			}
+		}
 	}
 	if (imageCount === 0) return undefined;
 	const cap = imageCount > MANY_IMAGE_THRESHOLD ? MANY_IMAGE_EDGE_LIMIT : SINGLE_IMAGE_EDGE_LIMIT;
 
+	const exceeds = (block: ContentBlock): boolean => {
+		const d = sniffed.get(block);
+		return d !== undefined && (d.width > cap || d.height > cap);
+	};
+
 	let changed = false;
 	const guarded = messages.map((message) => {
 		const blocks = blocksOf(message);
-		if (!blocks?.some((b) => isImageBlock(b) && exceeds(b.data, cap))) return message;
+		if (!blocks?.some(exceeds)) return message;
 		changed = true;
-		const content = blocks.map((block) =>
-			isImageBlock(block) && exceeds(block.data, cap)
-				? {
-						type: "text",
-						text: `[image removed: ${dims(block.data)} exceeds the provider's ${cap}px image-dimension limit — ask the user to re-attach a smaller version if it is still needed]`,
-					}
-				: block,
-		);
+		const content = blocks.map((block) => {
+			if (!exceeds(block)) return block;
+			const d = sniffed.get(block);
+			return {
+				type: "text",
+				text: `[image removed: ${d ? `${d.width}×${d.height}` : "unknown size"} exceeds the provider's ${cap}px image-dimension limit — ask the user to re-attach a smaller version if it is still needed]`,
+			};
+		});
 		// Object.assign keeps the concrete message variant (its type is `message & {content}`), which
 		// widens back to AgentMessage without a lossy double-cast.
 		return Object.assign({}, message, { content }) as AgentMessage;
 	});
 	return changed ? guarded : undefined;
 }
-
-const exceeds = (base64: string, cap: number): boolean => {
-	const d = imageDimensions(base64);
-	return d !== undefined && (d.width > cap || d.height > cap);
-};
-
-const dims = (base64: string): string => {
-	const d = imageDimensions(base64);
-	return d ? `${d.width}×${d.height}` : "unknown size";
-};
 
 /** The inline pi extension: registered in `buildResourceLoader`'s shared factories, so every session —
  * live or reopened — gets its outgoing context guarded on each LLM call. */

--- a/packages/server/src/agent/imageGuard.ts
+++ b/packages/server/src/agent/imageGuard.ts
@@ -7,7 +7,9 @@
 // transforms the OUTGOING context instead: on pi's `context` event (fired before every LLM call, live
 // sessions included — a stuck chat unsticks on its very next message) it sniffs each image's dimensions
 // straight from the base64 header bytes, measures its byte size from the base64 length (the provider
-// also caps an image at 4.5MB of base64 — IMAGE_MAX_BASE64_BYTES, shared with the composer's attach-time ladder), and
+// also caps an image at 4.5MB of base64 — IMAGE_MAX_BASE64_BYTES, shared with the composer's attach-time
+// ladder — the whole request at 32MB — REQUEST_IMAGE_BASE64_BUDGET keeps 24MB of it for images — and
+// rejects media types outside png/jpeg/gif/webp — ACCEPTED_IMAGE_TYPES), and
 // replaces violating image blocks with a text note. The
 // session file and the visible transcript stay untouched. The caps are Anthropic's model-level rules,
 // so the guard fires ONLY for the Anthropic model family (the `context` handler's ctx.model — native
@@ -17,7 +19,12 @@
 // a note (not a brick) once the same session crosses 21.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { type AgentMessage, IMAGE_MAX_BASE64_BYTES } from "@thinkrail/contracts";
+import {
+	ACCEPTED_IMAGE_TYPES,
+	type AgentMessage,
+	IMAGE_MAX_BASE64_BYTES,
+	REQUEST_IMAGE_BASE64_BUDGET,
+} from "@thinkrail/contracts";
 
 /** Anthropic's per-side cap for requests carrying 20 images or fewer. */
 export const SINGLE_IMAGE_EDGE_LIMIT = 8000;
@@ -129,14 +136,20 @@ const REMOVAL_HINT = "ask the user to re-attach a smaller version if it is still
 
 /**
  * Replace every image block that violates a provider limit with a text note naming the violated rule
- * (copy-on-write — the input is never mutated). Three rules, applied in order:
- * 1. bytes — anything whose base64 payload (`data.length` — what the wire actually carries) exceeds
+ * (copy-on-write — the input is never mutated). Five rules, applied in order:
+ * 1. media type — anything outside ACCEPTED_IMAGE_TYPES (BMP, AVIF, HEIC…) is stripped: pi forwards
+ *    the type verbatim and the provider rejects the whole request (heals sessions poisoned before the
+ *    composer refused such files);
+ * 2. bytes — anything whose base64 payload (`data.length` — what the wire actually carries) exceeds
  *    IMAGE_MAX_BASE64_BYTES (4.5MB, pi's own headroom under Anthropic's 5MB) is stripped, sniffable or not;
- * 2. the 8000px hard per-side cap;
- * 3. the count-aware 2000px cap — and because stripping changes the very count that selects the cap,
+ * 3. the 8000px hard per-side cap;
+ * 4. the count-aware 2000px cap — and because stripping changes the very count that selects the cap,
  *    2000px violators are stripped LARGEST-FIRST only until the surviving image count is back at the
  *    20-image threshold; the rest are then legal under the 8000px cap and stay (18 small + 3 at
- *    2500px ⇒ one stripped, not three).
+ *    2500px ⇒ one stripped, not three);
+ * 5. the request-wide REQUEST_IMAGE_BASE64_BUDGET (24MB, headroom under Anthropic's 32MB per-request
+ *    cap) — several images each under the per-image ceiling can still overflow the whole request, so
+ *    survivors are stripped LARGEST-FIRST until the aggregate encoded payload fits.
  * Returns undefined when nothing changed.
  */
 export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] | undefined {
@@ -162,6 +175,14 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 	// The removal note per stripped block — membership doubles as the strip decision.
 	const notes = new Map<ContentBlock, string>();
 	for (const block of imageBlocks) {
+		const mimeType = (block as { mimeType?: unknown }).mimeType;
+		if (typeof mimeType === "string" && !ACCEPTED_IMAGE_TYPES.includes(mimeType)) {
+			notes.set(
+				block,
+				`[image removed: media type ${mimeType} is not supported by the provider (accepted: ${ACCEPTED_IMAGE_TYPES.join(", ")}) — ${REMOVAL_HINT}]`,
+			);
+			continue;
+		}
 		// base64 is ASCII: string length IS the encoded byte length — the size the provider sees.
 		if (block.data.length > IMAGE_MAX_BASE64_BYTES) {
 			const mb = (block.data.length / (1024 * 1024)).toFixed(1);
@@ -200,6 +221,24 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 				`[image removed: ${d?.width}×${d?.height} exceeds the provider's ${MANY_IMAGE_EDGE_LIMIT}px image-dimension limit for requests carrying more than ${MANY_IMAGE_THRESHOLD} images — ${REMOVAL_HINT}]`,
 			);
 			surviving--;
+		}
+	}
+
+	// Rule 5: the whole request must fit — per-image-legal blocks can still sum past the provider's
+	// request cap, and a persisted overflow rejects every later turn. Largest-first keeps the most
+	// images for the budget spent.
+	const survivors = imageBlocks.filter((b) => !notes.has(b));
+	let totalBytes = survivors.reduce((sum, b) => sum + b.data.length, 0);
+	if (totalBytes > REQUEST_IMAGE_BASE64_BUDGET) {
+		const bySize = [...survivors].sort((a, b) => b.data.length - a.data.length);
+		for (const block of bySize) {
+			if (totalBytes <= REQUEST_IMAGE_BASE64_BUDGET) break;
+			const mb = (block.data.length / (1024 * 1024)).toFixed(1);
+			notes.set(
+				block,
+				`[image removed: ${mb}MB of base64 pushed the request's total image payload over the ${REQUEST_IMAGE_BASE64_BUDGET / (1024 * 1024)}MB budget (the provider caps the whole request) — ${REMOVAL_HINT}]`,
+			);
+			totalBytes -= block.data.length;
 		}
 	}
 	if (notes.size === 0) return undefined;

--- a/packages/server/src/agent/imageGuard.ts
+++ b/packages/server/src/agent/imageGuard.ts
@@ -134,6 +134,10 @@ const isImageBlock = (block: ContentBlock): block is ContentBlock & { data: stri
 
 const REMOVAL_HINT = "ask the user to re-attach a smaller version if it is still needed";
 
+/** Byte count → the "NMB" text the removal notes carry (one decimal for measurements, exact for limits). */
+const mb = (bytes: number) => `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+const mbLimit = (bytes: number) => `${bytes / (1024 * 1024)}MB`;
+
 /**
  * Replace every image block that violates a provider limit with a text note naming the violated rule
  * (copy-on-write — the input is never mutated). Five rules, applied in order:
@@ -185,10 +189,9 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 		}
 		// base64 is ASCII: string length IS the encoded byte length — the size the provider sees.
 		if (block.data.length > IMAGE_MAX_BASE64_BYTES) {
-			const mb = (block.data.length / (1024 * 1024)).toFixed(1);
 			notes.set(
 				block,
-				`[image removed: ${mb}MB of base64 exceeds the provider's ${IMAGE_MAX_BASE64_BYTES / (1024 * 1024)}MB image payload limit — ${REMOVAL_HINT}]`,
+				`[image removed: ${mb(block.data.length)} of base64 exceeds the provider's ${mbLimit(IMAGE_MAX_BASE64_BYTES)} image payload limit — ${REMOVAL_HINT}]`,
 			);
 			continue;
 		}
@@ -233,10 +236,9 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 		const bySize = [...survivors].sort((a, b) => b.data.length - a.data.length);
 		for (const block of bySize) {
 			if (totalBytes <= REQUEST_IMAGE_BASE64_BUDGET) break;
-			const mb = (block.data.length / (1024 * 1024)).toFixed(1);
 			notes.set(
 				block,
-				`[image removed: ${mb}MB of base64 pushed the request's total image payload over the ${REQUEST_IMAGE_BASE64_BUDGET / (1024 * 1024)}MB budget (the provider caps the whole request) — ${REMOVAL_HINT}]`,
+				`[image removed: ${mb(block.data.length)} of base64 pushed the request's total image payload over the ${mbLimit(REQUEST_IMAGE_BASE64_BUDGET)} budget (the provider caps the whole request) — ${REMOVAL_HINT}]`,
 			);
 			totalBytes -= block.data.length;
 		}

--- a/packages/server/src/agent/imageGuard.ts
+++ b/packages/server/src/agent/imageGuard.ts
@@ -1,0 +1,168 @@
+// Oversized-image guard (TASK-image-attachment-downscale): the un-bricking half of the image-size fix.
+// Anthropic caps an image side at 8000px — dropping to 2000px once a single request carries more than
+// 20 images — and pi re-sends the whole history every turn, so ONE oversized image (a pre-fix
+// attachment, or a raw `read` of a huge file — `images.autoResize:false` sends read-tool images
+// verbatim) permanently 400s the session. Sessions are append-only ("pi owns state") and the host has
+// no image codec (the same photon/WASM bundling problem that disabled autoResize), so the guard
+// transforms the OUTGOING context instead: on pi's `context` event (fired before every LLM call, live
+// sessions included — a stuck chat unsticks on its very next message) it sniffs each image's dimensions
+// straight from the base64 header bytes and replaces violating image blocks with a text note. The
+// session file and the visible transcript stay untouched. The caps are Anthropic's, but generous enough
+// to be harmless for every other provider; the count-aware cap also self-heals the read-tool case — a
+// raw 3000px file read is legal while the context holds ≤20 images and degrades to a note (not a brick)
+// once the same session crosses 21.
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AgentMessage } from "@thinkrail/contracts";
+
+/** Anthropic's per-side cap for requests carrying 20 images or fewer. */
+export const SINGLE_IMAGE_EDGE_LIMIT = 8000;
+/** Anthropic's stricter per-side cap once a request carries more than MANY_IMAGE_THRESHOLD images. */
+export const MANY_IMAGE_EDGE_LIMIT = 2000;
+/** Image count above which the stricter cap applies. */
+export const MANY_IMAGE_THRESHOLD = 20;
+
+interface Dimensions {
+	width: number;
+	height: number;
+}
+
+function pngDimensions(b: Buffer): Dimensions | undefined {
+	// 8-byte signature, 4-byte length, "IHDR", then 4-byte width + height (big-endian).
+	if (b.length < 24) return undefined;
+	if (b.readUInt32BE(0) !== 0x89504e47 || b.toString("ascii", 12, 16) !== "IHDR") return undefined;
+	return { width: b.readUInt32BE(16), height: b.readUInt32BE(20) };
+}
+
+function jpegDimensions(b: Buffer): Dimensions | undefined {
+	// SOI, then walk marker segments to the first SOFn frame header (0xC0–0xCF minus C4/C8/CC).
+	if (b.length < 4 || b[0] !== 0xff || b[1] !== 0xd8) return undefined;
+	let off = 2;
+	while (off + 9 <= b.length) {
+		if (b[off] !== 0xff) return undefined;
+		const marker = b[off + 1] ?? 0;
+		if (marker === 0xff) {
+			off++; // fill byte
+			continue;
+		}
+		const isSof = marker >= 0xc0 && marker <= 0xcf && ![0xc4, 0xc8, 0xcc].includes(marker);
+		if (isSof) return { width: b.readUInt16BE(off + 7), height: b.readUInt16BE(off + 5) };
+		if (marker === 0xd9 || marker === 0xda) return undefined; // EOI / entropy-coded data — no SOF seen
+		off += 2 + b.readUInt16BE(off + 2);
+	}
+	return undefined;
+}
+
+function gifDimensions(b: Buffer): Dimensions | undefined {
+	// "GIF87a"/"GIF89a", then logical screen width + height (little-endian).
+	if (b.length < 10 || b.toString("ascii", 0, 3) !== "GIF") return undefined;
+	return { width: b.readUInt16LE(6), height: b.readUInt16LE(8) };
+}
+
+function webpDimensions(b: Buffer): Dimensions | undefined {
+	if (
+		b.length < 30 ||
+		b.toString("ascii", 0, 4) !== "RIFF" ||
+		b.toString("ascii", 8, 12) !== "WEBP"
+	)
+		return undefined;
+	const chunk = b.toString("ascii", 12, 16);
+	if (chunk === "VP8X") {
+		// Canvas size: 24-bit little-endian width-1 / height-1 after the 4-byte flags field.
+		return { width: b.readUIntLE(24, 3) + 1, height: b.readUIntLE(27, 3) + 1 };
+	}
+	if (chunk === "VP8 ") {
+		// Lossy: frame tag, then 0x9D 0x01 0x2A, then 14-bit little-endian width / height.
+		if (b[23] !== 0x9d || b[24] !== 0x01 || b[25] !== 0x2a) return undefined;
+		return { width: b.readUInt16LE(26) & 0x3fff, height: b.readUInt16LE(28) & 0x3fff };
+	}
+	if (chunk === "VP8L") {
+		// Lossless: signature 0x2F, then 14-bit width-1 / height-1 packed little-endian.
+		if (b[20] !== 0x2f) return undefined;
+		const bits = b.readUInt32LE(21);
+		return { width: (bits & 0x3fff) + 1, height: ((bits >> 14) & 0x3fff) + 1 };
+	}
+	return undefined;
+}
+
+/** Sniff an image's pixel dimensions from its base64 data (PNG / JPEG / GIF / WebP header bytes — no
+ * codec, no decode). Undefined for unrecognized or malformed data: the guard never strips blind. */
+export function imageDimensions(base64: string): Dimensions | undefined {
+	if (!base64) return undefined;
+	let bytes: Buffer;
+	try {
+		bytes = Buffer.from(base64, "base64");
+	} catch {
+		return undefined;
+	}
+	if (bytes.length < 10) return undefined;
+	try {
+		return (
+			pngDimensions(bytes) ?? jpegDimensions(bytes) ?? gifDimensions(bytes) ?? webpDimensions(bytes)
+		);
+	} catch {
+		return undefined; // truncated header — a read past the buffer is "couldn't sniff", not a crash
+	}
+}
+
+type ContentBlock = { type: string } & Record<string, unknown>;
+
+const isImageBlock = (block: ContentBlock): block is ContentBlock & { data: string } =>
+	block.type === "image" && typeof block.data === "string";
+
+/**
+ * Replace every image block that exceeds the provider's per-side cap with a text note carrying its
+ * dimensions (copy-on-write — the input is never mutated). The cap is count-aware: 8000px normally,
+ * 2000px when the whole context carries more than 20 images. Returns undefined when nothing changed.
+ */
+export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] | undefined {
+	const blocksOf = (m: AgentMessage): ContentBlock[] | undefined => {
+		const content = (m as { content?: unknown }).content;
+		return Array.isArray(content) ? (content as ContentBlock[]) : undefined;
+	};
+
+	let imageCount = 0;
+	for (const message of messages) {
+		for (const block of blocksOf(message) ?? []) if (isImageBlock(block)) imageCount++;
+	}
+	if (imageCount === 0) return undefined;
+	const cap = imageCount > MANY_IMAGE_THRESHOLD ? MANY_IMAGE_EDGE_LIMIT : SINGLE_IMAGE_EDGE_LIMIT;
+
+	let changed = false;
+	const guarded = messages.map((message) => {
+		const blocks = blocksOf(message);
+		if (!blocks?.some((b) => isImageBlock(b) && exceeds(b.data, cap))) return message;
+		changed = true;
+		const content = blocks.map((block) =>
+			isImageBlock(block) && exceeds(block.data, cap)
+				? {
+						type: "text",
+						text: `[image removed: ${dims(block.data)} exceeds the provider's ${cap}px image-dimension limit — ask the user to re-attach a smaller version if it is still needed]`,
+					}
+				: block,
+		);
+		// Object.assign keeps the concrete message variant (its type is `message & {content}`), which
+		// widens back to AgentMessage without a lossy double-cast.
+		return Object.assign({}, message, { content }) as AgentMessage;
+	});
+	return changed ? guarded : undefined;
+}
+
+const exceeds = (base64: string, cap: number): boolean => {
+	const d = imageDimensions(base64);
+	return d !== undefined && (d.width > cap || d.height > cap);
+};
+
+const dims = (base64: string): string => {
+	const d = imageDimensions(base64);
+	return d ? `${d.width}×${d.height}` : "unknown size";
+};
+
+/** The inline pi extension: registered in `buildResourceLoader`'s shared factories, so every session —
+ * live or reopened — gets its outgoing context guarded on each LLM call. */
+export function oversizedImageGuard(pi: ExtensionAPI): void {
+	pi.on("context", (event) => {
+		const messages = guardOversizedImages(event.messages);
+		return messages ? { messages } : undefined;
+	});
+}

--- a/packages/server/src/agent/imageGuard.ts
+++ b/packages/server/src/agent/imageGuard.ts
@@ -7,10 +7,12 @@
 // transforms the OUTGOING context instead: on pi's `context` event (fired before every LLM call, live
 // sessions included — a stuck chat unsticks on its very next message) it sniffs each image's dimensions
 // straight from the base64 header bytes and replaces violating image blocks with a text note. The
-// session file and the visible transcript stay untouched. The caps are Anthropic's, but generous enough
-// to be harmless for every other provider; the count-aware cap also self-heals the read-tool case — a
-// raw 3000px file read is legal while the context holds ≤20 images and degrades to a note (not a brick)
-// once the same session crosses 21.
+// session file and the visible transcript stay untouched. The caps are Anthropic's model-level rules,
+// so the guard fires ONLY for the Anthropic model family (the `context` handler's ctx.model — native
+// `anthropic-messages` api / `anthropic` provider, or a Claude model served through Bedrock/Vertex);
+// other providers keep their full image context untouched. The count-aware cap also self-heals the
+// read-tool case — a raw 3000px file read is legal while the context holds ≤20 images and degrades to
+// a note (not a brick) once the same session crosses 21.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentMessage } from "@thinkrail/contracts";
@@ -172,10 +174,24 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 	return changed ? guarded : undefined;
 }
 
+/** Does this model enforce Anthropic's image-dimension rules? Native Anthropic (api/provider), plus
+ * Claude models reached through an aggregator or cloud front (Bedrock/Vertex/OpenRouter expose them
+ * under their own provider ids — the model id still names claude). Undefined model ⇒ false: without a
+ * known policy the guard must not strip anything. */
+export function isAnthropicFamilyModel(
+	model: { api?: string; provider?: string; id?: string } | undefined,
+): boolean {
+	if (!model) return false;
+	if (model.provider === "anthropic" || model.api === "anthropic-messages") return true;
+	return /claude/i.test(model.id ?? "");
+}
+
 /** The inline pi extension: registered in `buildResourceLoader`'s shared factories, so every session —
- * live or reopened — gets its outgoing context guarded on each LLM call. */
+ * live or reopened — gets its outgoing context guarded on each LLM call. The dimension caps are
+ * Anthropic's, so the guard is a no-op for every other model family. */
 export function oversizedImageGuard(pi: ExtensionAPI): void {
-	pi.on("context", (event) => {
+	pi.on("context", (event, ctx) => {
+		if (!isAnthropicFamilyModel(ctx.model)) return undefined;
 		const messages = guardOversizedImages(event.messages);
 		return messages ? { messages } : undefined;
 	});

--- a/packages/server/src/agent/imageGuard.ts
+++ b/packages/server/src/agent/imageGuard.ts
@@ -7,7 +7,7 @@
 // transforms the OUTGOING context instead: on pi's `context` event (fired before every LLM call, live
 // sessions included — a stuck chat unsticks on its very next message) it sniffs each image's dimensions
 // straight from the base64 header bytes, measures its byte size from the base64 length (the provider
-// also caps an image at 5MB — IMAGE_MAX_BYTES, shared with the composer's attach-time ladder), and
+// also caps an image at 4.5MB of base64 — IMAGE_MAX_BASE64_BYTES, shared with the composer's attach-time ladder), and
 // replaces violating image blocks with a text note. The
 // session file and the visible transcript stay untouched. The caps are Anthropic's model-level rules,
 // so the guard fires ONLY for the Anthropic model family (the `context` handler's ctx.model — native
@@ -17,7 +17,7 @@
 // a note (not a brick) once the same session crosses 21.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { type AgentMessage, base64ByteLength, IMAGE_MAX_BYTES } from "@thinkrail/contracts";
+import { type AgentMessage, IMAGE_MAX_BASE64_BYTES } from "@thinkrail/contracts";
 
 /** Anthropic's per-side cap for requests carrying 20 images or fewer. */
 export const SINGLE_IMAGE_EDGE_LIMIT = 8000;
@@ -130,7 +130,8 @@ const REMOVAL_HINT = "ask the user to re-attach a smaller version if it is still
 /**
  * Replace every image block that violates a provider limit with a text note naming the violated rule
  * (copy-on-write — the input is never mutated). Three rules, applied in order:
- * 1. bytes — anything over IMAGE_MAX_BYTES (5MB) is stripped, sniffable or not;
+ * 1. bytes — anything whose base64 payload (`data.length` — what the wire actually carries) exceeds
+ *    IMAGE_MAX_BASE64_BYTES (4.5MB, pi's own headroom under Anthropic's 5MB) is stripped, sniffable or not;
  * 2. the 8000px hard per-side cap;
  * 3. the count-aware 2000px cap — and because stripping changes the very count that selects the cap,
  *    2000px violators are stripped LARGEST-FIRST only until the surviving image count is back at the
@@ -161,12 +162,12 @@ export function guardOversizedImages(messages: AgentMessage[]): AgentMessage[] |
 	// The removal note per stripped block — membership doubles as the strip decision.
 	const notes = new Map<ContentBlock, string>();
 	for (const block of imageBlocks) {
-		const bytes = base64ByteLength(block.data);
-		if (bytes > IMAGE_MAX_BYTES) {
-			const mb = (bytes / (1024 * 1024)).toFixed(1);
+		// base64 is ASCII: string length IS the encoded byte length — the size the provider sees.
+		if (block.data.length > IMAGE_MAX_BASE64_BYTES) {
+			const mb = (block.data.length / (1024 * 1024)).toFixed(1);
 			notes.set(
 				block,
-				`[image removed: ${mb}MB exceeds the provider's ${IMAGE_MAX_BYTES / (1024 * 1024)}MB image size limit — ${REMOVAL_HINT}]`,
+				`[image removed: ${mb}MB of base64 exceeds the provider's ${IMAGE_MAX_BASE64_BYTES / (1024 * 1024)}MB image payload limit — ${REMOVAL_HINT}]`,
 			);
 			continue;
 		}

--- a/packages/server/src/history/SPEC.md
+++ b/packages/server/src/history/SPEC.md
@@ -38,8 +38,9 @@ to preserve).
   The internal
   `TODO_NUDGE_PREFIX` control message (hidden from the transcript on hydrate) is skipped after its index
   slot is consumed, so alignment holds; a **superseded auto-retry attempt** (the shared
-  `isRetriedAttempt` reading from contracts — an errored assistant followed by another assistant before
-  any user message, which hydration renders as no turn / null anchor) is skipped the same way, so a
+  `isRetriedAttempt` reading from contracts — an errored assistant immediately followed by another
+  assistant, the adjacent shape pi's `_prepareRetry` produces,
+  which hydration renders as no turn / null anchor) is skipped the same way, so a
   failed partial's text never becomes a hit that could only resolve to "couldn't locate the message". Entry text is **full, never truncated** — a hit's `text` is what
   recall inserts and what the overlay's preview presents as the whole prompt, so a cap would silently
   corrupt recall of long pasted-log prompts and make terms past the cutoff unsearchable (the memory

--- a/packages/server/src/history/SPEC.md
+++ b/packages/server/src/history/SPEC.md
@@ -37,7 +37,10 @@ to preserve).
   sent (it renders the client's compaction marker), so it consumes an index slot without being searchable.
   The internal
   `TODO_NUDGE_PREFIX` control message (hidden from the transcript on hydrate) is skipped after its index
-  slot is consumed, so alignment holds. Entry text is **full, never truncated** — a hit's `text` is what
+  slot is consumed, so alignment holds; a **superseded auto-retry attempt** (the shared
+  `isRetriedAttempt` reading from contracts — an errored assistant followed by another assistant before
+  any user message, which hydration renders as no turn / null anchor) is skipped the same way, so a
+  failed partial's text never becomes a hit that could only resolve to "couldn't locate the message". Entry text is **full, never truncated** — a hit's `text` is what
   recall inserts and what the overlay's preview presents as the whole prompt, so a cap would silently
   corrupt recall of long pasted-log prompts and make terms past the cutoff unsearchable (the memory
   precedent is pi itself: `SessionInfo.allMessagesText` holds every session's full text in memory). Tool

--- a/packages/server/src/history/extract.test.ts
+++ b/packages/server/src/history/extract.test.ts
@@ -364,4 +364,78 @@ describe("extractSession", () => {
 			{ text: "next prompt", role: "user", timestamp: 300, messageIndex: 2 },
 		]);
 	});
+
+	test("excludes a superseded auto-retry attempt but still consumes its index slot", () => {
+		// pi persists the failed attempt (`_prepareRetry` keeps it "in session for history") but the client
+		// hydrates no turn for it (its jump anchor is null) — so its text must not become a searchable,
+		// jumpable hit that could only ever resolve to "couldn't locate the message". Same shared
+		// `isRetriedAttempt` reading as the client's hydration.
+		const jsonl = [
+			header(),
+			line({
+				type: "message",
+				id: "u0",
+				parentId: null,
+				message: { role: "user", content: "what is 2+2", timestamp: 100 },
+			}),
+			line({
+				type: "message",
+				id: "a0",
+				parentId: "u0",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "unique failed partial" }],
+					stopReason: "error",
+					errorMessage: "fetch failed",
+					timestamp: 200,
+				},
+			}),
+			line({
+				type: "message",
+				id: "a1",
+				parentId: "a0",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "the answer is 4" }],
+					stopReason: "stop",
+					timestamp: 300,
+				},
+			}),
+		].join("\n");
+		// The failed attempt (index 1) is hidden; the retried reply keeps its real position (index 2).
+		expect(entriesOf(jsonl)).toEqual([
+			{ text: "what is 2+2", role: "user", timestamp: 100, messageIndex: 0 },
+			{ text: "the answer is 4", role: "assistant", timestamp: 300, messageIndex: 2 },
+		]);
+	});
+
+	test("a terminal failed attempt (no retry after it) stays searchable", () => {
+		// Followed by a user message (or nothing) ⇒ not superseded — the turn is rendered on hydrate, so
+		// the hit stays jumpable.
+		const jsonl = [
+			header(),
+			line({
+				type: "message",
+				id: "a0",
+				parentId: null,
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "terminal failure partial" }],
+					stopReason: "error",
+					errorMessage: "retries exhausted",
+					timestamp: 100,
+				},
+			}),
+			line({
+				type: "message",
+				id: "u0",
+				parentId: "a0",
+				message: { role: "user", content: "try again", timestamp: 200 },
+			}),
+		].join("\n");
+		expect(entriesOf(jsonl)).toEqual([
+			{ text: "terminal failure partial", role: "assistant", timestamp: 100, messageIndex: 0 },
+			{ text: "try again", role: "user", timestamp: 200, messageIndex: 1 },
+		]);
+	});
 });

--- a/packages/server/src/history/extract.ts
+++ b/packages/server/src/history/extract.ts
@@ -4,7 +4,7 @@ import {
 	parseSessionEntries,
 	type SessionEntry,
 } from "@earendil-works/pi-coding-agent";
-import { isControlMessage, isTranscriptMessageRole } from "@thinkrail/contracts";
+import { isControlMessage, isRetriedAttempt, isTranscriptMessageRole } from "@thinkrail/contracts";
 
 /** One searchable message from a session transcript (see SPEC.md for the messageIndex invariant). */
 export interface HistoryEntry {
@@ -74,22 +74,24 @@ export function extractSession(jsonl: string): ExtractedSession | null {
 	}
 	const { messages } = buildSessionContext(entries);
 
+	// Indexing against the wire's own role policy is what keeps a hit's `messageIndex` aligned with the
+	// client's `turnIdByMessageIndex`: a role the host strips (branch summaries) must not consume a slot
+	// here, and one it sends must — a `compactionSummary` does, without ever becoming a searchable entry
+	// (the role check below). Filtering FIRST (not a running counter) so `isRetriedAttempt` sees the
+	// same adjacency the client renders on hydrate.
+	const renderable = messages.filter((message) => isTranscriptMessageRole(message.role));
 	const out: HistoryEntry[] = [];
-	let messageIndex = 0;
-	for (const message of messages) {
-		// Indexing against the wire's own role policy is what keeps a hit's `messageIndex` aligned with the
-		// client's `turnIdByMessageIndex`: a role the host strips (branch summaries) must not consume a slot
-		// here, and one it sends must — a `compactionSummary` does, without ever becoming a searchable entry
-		// (the role check below).
-		if (!isTranscriptMessageRole(message.role)) continue;
-		const index = messageIndex++;
+	for (const [index, message] of renderable.entries()) {
 		if (message.role !== "user" && message.role !== "assistant") continue;
 		const text = textOf(message.content);
 		if (!text.trim()) continue;
 		// Internal control traffic: the pi-todos wake-nudge is hidden from the transcript on hydrate, so it
-		// must not surface as a recallable/insertable prompt. The index was already consumed above, so
-		// skipping only the text keeps every later hit's anchor aligned.
+		// must not surface as a recallable/insertable prompt. The index slot is still consumed (it is the
+		// loop position), so every later hit's anchor stays aligned.
 		if (message.role === "user" && isControlMessage(text)) continue;
+		// A superseded auto-retry attempt renders no turn on hydrate (its jump anchor is null), so its text
+		// must not surface as a searchable/jumpable hit either — same shared reading as the client's.
+		if (isRetriedAttempt(renderable, index)) continue;
 		out.push({
 			text,
 			role: message.role,


### PR DESCRIPTION
Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  Four independent fixes to the chat surface, all in apps/web/src/chat plus one server-side guard. The headline is the image-attachment fix: a single oversized pasted image used to permanently break a chat —  
  pi re-sends the whole history every turn, so once Anthropic's cap rejected that image, every subsequent turn 400'd and the conversation was unrecoverable.                                                     
                                                                                                                                                                                                                 
  Oversized images — two lines of defense                                                                                                                                                                        
                                                                                                                                                                                                                 
  Anthropic caps an image side at 8000px, dropping to 2000px once a single request carries more than 20 images. The composer was sending pasted images raw, and pi's own resizer is deliberately off server-side 
  (images.autoResize:false — the photon/WASM bundling problem).                                                                                                                                                  
                                                                                                                                                                                                                 
  Client — apps/web/src/chat/imageAttachment.ts (new). Pasted and dropped images are decoded in the browser and downscaled to a 1568px long edge (Claude's own standard-tier edge) before becoming ImageContent. 
  Within-bounds images pass through byte-identical; an undecodable file falls back to raw. The pending chip shows mime · W×H.                                                                                    
                                                                                                                                                                                                                 
  Server — packages/server/src/agent/imageGuard.ts (new). An inline pi extension on the context event (fired before every LLM call, live sessions included) sniffs each image block's dimensions straight from   
  the base64 header bytes — PNG/JPEG/GIF/WebP, no codec, never strips what it can't sniff — and replaces any block over the cap with a text note carrying the W×H and a re-attach hint.                          
                                                                                                                                                                                                                 
  Sessions are append-only ("pi owns state") and the host has no image codec, so the guard transforms the outgoing context only — the session file and the visible transcript stay untouched. That's what        
  un-bricks the already-poisoned chats: they recover on their very next message. The count-aware cap also self-heals the read-tool case — a raw 3000px read is legal while the context holds ≤20 images and      
  degrades to a note (not a brick) once the session crosses 21.   
  
  Attachments render as file chips                                                                                                                                                                               
                                                                                                                                                                                                                 
  UserTurn shows image blocks as compact "attached file" chips above the text rather than inline previews; clicking opens the image in a dialog (the diagram-fullscreen pattern). The chip label is the picked   
  file's name, carried on the echo turn as attachmentNames — UI-side only, since pi's ImageContent has no filename field — index-aligned with the image blocks. A hydrated turn has no names and falls back to   
  mime-type labels.                                                                                                                                                                                              
                                                                                                                                                                                                                 
  New ChatAttachment type (name + content) threads the filename from composer to echo turn without touching the wire.                                                                                            
                                                                                                                                                                                                                 
  No horizontal scroll in the transcript                                                                                                                                                                         
                                                                                                                                                                                                                 
  Long unbroken tokens in the user bubble (URLs, pasted paths) pushed it wider than the container. break-words on the bubble and overflow-x-hidden on the Virtuoso scroller — wide content scrolls inside its own
  code/diff block, never the whole chat.                                                                                                                                                                         
                                                                                                                                                                                                                 
  Auto-retry no longer duplicates the reply                                                                                                                                                                      
                                                                                                                                                                                                                 
  pi's _prepareRetry removes the failed attempt's assistant message from the transcript before re-running the turn, and the retried run re-streams the reply as a brand-new message. The reducer only showed a   
  countdown on auto_retry_start and kept the failed attempt's turn, so the client rendered the reply twice (frozen failed partial + retried copy) while pi's transcript — and any reloaded client hydrating it — 
  held one. The reducer now mirrors pi's slice: drop the trailing assistant turn on auto_retry_start, skipping client-only retry-countdown turns, conservative like pi's own last-message guard.                 
                                                                                                                                                                                                                 
  Testing                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  - Unit: imageAttachment.test.ts (downscale math, passthrough, fallback), imageGuard.test.ts (hand-built header bytes per format, both caps, the count threshold), rows.test.ts (attachment names on derived    
  rows), appStore.test.ts — including a red-first reducer test replaying pi's exact retry event sequence (message_end error → agent_end willRetry → auto_retry_start → retried stream ⇒ exactly one assistant    
  turn) plus the error-before-message_start edge.                                                                                                                                                                
  - E2E: e2e/composer-images.spec.ts (no-agent — attach, chip metadata, downscale assertions). A true e2e repro of the retry bug needs a mid-turn provider network failure the real-provider-only agent suite    
  can't induce; instead e2e/hydrate-midstream.live.spec.ts (@agent) pins the neighbouring invariant that falsified the first hypothesis — reloading mid-stream hydrates exactly one copy of the streaming        
  message.                                                                                                                                                                                                       
  - Gates (all green on the rebased branch): check:deps, check:seams, lint, typecheck, test (570 pass / 0 fail).                                                                                                 
                                                                                                                                                                                                                 
  Specs updated: apps/web/src/chat/SPEC.md, apps/web/src/store/SPEC.md, packages/server/src/agent/SPEC.md.       