### PR TITLE
fix(chat): clarify usage stats

### DIFF
--- a/apps/web/src/chat/ChatHeader.tsx
+++ b/apps/web/src/chat/ChatHeader.tsx
@@ -23,7 +23,7 @@ export function ChatHeader({
 	return (
 		<div className="flex min-h-9 shrink-0 items-center gap-md border-border-muted border-b bg-container-workspace-bg px-sm py-xs">
 			<div className="flex min-w-0 flex-1 items-center">{left}</div>
-			<div className="flex shrink-0 flex-wrap items-center justify-end gap-md">
+			<div className="flex min-w-0 flex-wrap items-center justify-end gap-md">
 				{statusEntries.map(([key, text]) => (
 					<span key={key} className="text-text-muted tr-text-metadata">
 						{text}

--- a/apps/web/src/chat/SessionStatsBar.test.ts
+++ b/apps/web/src/chat/SessionStatsBar.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import type { SessionStats } from "@thinkrail/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { contextPart, formatTokens, SessionStatsBar, usageParts } from "./SessionStatsBar";
+
+function stats(overrides: Partial<SessionStats> = {}): SessionStats {
+	return {
+		sessionId: "session-1",
+		totalMessages: 1,
+		tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		cost: 0,
+		...overrides,
+	};
+}
+
+describe("SessionStatsBar pi-style formatting", () => {
+	it("matches pi's compact token thresholds", () => {
+		expect([999, 1_200, 12_345, 1_200_000, 10_400_000].map(formatTokens)).toEqual([
+			"999",
+			"1.2k",
+			"12k",
+			"1.2M",
+			"10M",
+		]);
+	});
+
+	it("orders the available pi fields and omits zero values", () => {
+		expect(
+			usageParts(
+				stats({
+					tokens: {
+						input: 12_345,
+						output: 342,
+						cacheRead: 10_400_000,
+						cacheWrite: 83_000,
+						total: 10_495_687,
+					},
+					cost: 6.85,
+				}),
+			),
+		).toEqual(["↑12k", "↓342", "R10M", "W83k", "$6.850"]);
+		expect(usageParts(stats())).toEqual([]);
+	});
+
+	it("renders the approved five-cell context bar and pi-style context label", () => {
+		expect(contextPart({ tokens: 120_000, contextWindow: 200_000, percent: 60 })).toEqual({
+			bar: "▰▰▰▱▱",
+			text: "60.0%/200k",
+		});
+		expect(contextPart({ tokens: null, contextWindow: 200_000, percent: null })).toEqual({
+			bar: "▱▱▱▱▱",
+			text: "?/200k",
+		});
+	});
+
+	it("separates every visible field with a middle dot", () => {
+		const value = stats({
+			tokens: { input: 12_345, output: 342, cacheRead: 0, cacheWrite: 0, total: 12_687 },
+			cost: 0.125,
+			contextUsage: { tokens: 120_000, contextWindow: 200_000, percent: 60 },
+		});
+		const text = renderToStaticMarkup(SessionStatsBar({ stats: value })).replace(/<[^>]+>/g, "");
+		expect(text).toBe("↑12k · ↓342 · $0.125·▰▰▰▱▱60.0%/200k");
+	});
+});

--- a/apps/web/src/chat/SessionStatsBar.test.ts
+++ b/apps/web/src/chat/SessionStatsBar.test.ts
@@ -53,13 +53,15 @@ describe("SessionStatsBar pi-style formatting", () => {
 		});
 	});
 
-	it("separates every visible field with a middle dot", () => {
+	it("separates fields with middle dots and lets the line wrap only between fields", () => {
 		const value = stats({
 			tokens: { input: 12_345, output: 342, cacheRead: 0, cacheWrite: 0, total: 12_687 },
 			cost: 0.125,
 			contextUsage: { tokens: 120_000, contextWindow: 200_000, percent: 60 },
 		});
-		const text = renderToStaticMarkup(SessionStatsBar({ stats: value })).replace(/<[^>]+>/g, "");
-		expect(text).toBe("↑12k · ↓342 · $0.125·▰▰▰▱▱60.0%/200k");
+		const markup = renderToStaticMarkup(SessionStatsBar({ stats: value }));
+		expect(markup.replace(/<[^>]+>/g, "")).toBe("↑12k·↓342·$0.125·▰▰▰▱▱60.0%/200k");
+		expect(markup).toContain("flex-wrap");
+		expect(markup.match(/whitespace-nowrap/g)).toHaveLength(4);
 	});
 });

--- a/apps/web/src/chat/SessionStatsBar.tsx
+++ b/apps/web/src/chat/SessionStatsBar.tsx
@@ -43,26 +43,23 @@ export function SessionStatsBar({ stats }: { stats: SessionStats | null }) {
 	return (
 		<div
 			data-testid="session-stats"
-			className="flex items-center gap-xs text-text-muted tr-text-metadata"
+			className="flex min-w-0 flex-wrap items-center justify-end gap-x-xs gap-y-0 text-text-muted tr-text-metadata"
+			title="Cumulative usage: ↑ input · ↓ output · R cache read · W cache write"
 		>
-			{parts.length > 0 ? (
-				<span
-					className="whitespace-nowrap"
-					title="Cumulative usage: ↑ input · ↓ output · R cache read · W cache write"
-				>
-					{parts.join(" · ")}
+			{parts.map((part, index) => (
+				<span key={part} className="flex items-center gap-xs whitespace-nowrap">
+					{index > 0 ? <span aria-hidden="true">·</span> : null}
+					{part}
 				</span>
-			) : null}
+			))}
 			{context ? (
-				<>
+				<span className="flex items-center gap-xs whitespace-nowrap" title="Context window used">
 					{parts.length > 0 ? <span aria-hidden="true">·</span> : null}
-					<span className="flex items-center gap-xs" title="Context window used">
-						<span aria-hidden="true" className="text-primary">
-							{context.bar}
-						</span>
-						{context.text}
+					<span aria-hidden="true" className="text-primary">
+						{context.bar}
 					</span>
-				</>
+					{context.text}
+				</span>
 			) : null}
 		</div>
 	);

--- a/apps/web/src/chat/SessionStatsBar.tsx
+++ b/apps/web/src/chat/SessionStatsBar.tsx
@@ -1,51 +1,68 @@
-import type { SessionStats } from "@thinkrail/contracts";
-import { cn } from "@/lib";
+import type { ContextUsage, SessionStats } from "@thinkrail/contracts";
 
-function formatTokens(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-	return String(n);
+/** Match pi's compact footer formatting. */
+export function formatTokens(count: number): string {
+	if (count < 1_000) return count.toString();
+	if (count < 10_000) return `${(count / 1_000).toFixed(1)}k`;
+	if (count < 1_000_000) return `${Math.round(count / 1_000)}k`;
+	if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+	return `${Math.round(count / 1_000_000)}M`;
 }
 
-function formatCost(n: number): string {
-	return n >= 0.01 ? `$${n.toFixed(2)}` : `$${n.toFixed(4)}`;
+/** Pi omits zero-valued cumulative fields from its footer. */
+export function usageParts(stats: SessionStats): string[] {
+	const parts: string[] = [];
+	if (stats.tokens.input) parts.push(`↑${formatTokens(stats.tokens.input)}`);
+	if (stats.tokens.output) parts.push(`↓${formatTokens(stats.tokens.output)}`);
+	if (stats.tokens.cacheRead) parts.push(`R${formatTokens(stats.tokens.cacheRead)}`);
+	if (stats.tokens.cacheWrite) parts.push(`W${formatTokens(stats.tokens.cacheWrite)}`);
+	if (stats.cost) parts.push(`$${stats.cost.toFixed(3)}`);
+	return parts;
 }
 
-// Context-bar fill in 10% steps — utility classes (no inline style) so the bar stays themeable.
-const FILL = [
-	"w-0",
-	"w-[10%]",
-	"w-[20%]",
-	"w-[30%]",
-	"w-[40%]",
-	"w-1/2",
-	"w-[60%]",
-	"w-[70%]",
-	"w-[80%]",
-	"w-[90%]",
-	"w-full",
-] as const;
+export function contextPart(usage: ContextUsage): { bar: string; text: string } {
+	const filled =
+		usage.percent === null ? 0 : Math.round(Math.min(100, Math.max(0, usage.percent)) / 20);
+	const contextWindow = formatTokens(usage.contextWindow);
+	return {
+		bar: `${"▰".repeat(filled)}${"▱".repeat(5 - filled)}`,
+		text:
+			usage.percent === null
+				? `?/${contextWindow}`
+				: `${usage.percent.toFixed(1)}%/${contextWindow}`,
+	};
+}
 
-/** Token/cost + context-window usage (cheap win #3). Display only — `pi` owns the numbers. Props-driven. */
+/** Pi-style cumulative usage + current context-window usage. Display only — `pi` owns the numbers. */
 export function SessionStatsBar({ stats }: { stats: SessionStats | null }) {
 	if (!stats) return null;
-	const percent = stats.contextUsage?.percent ?? null;
-	const bucket = percent === null ? null : Math.round(Math.min(100, Math.max(0, percent)) / 10);
+	const parts = usageParts(stats);
+	const context = stats.contextUsage ? contextPart(stats.contextUsage) : null;
+	if (parts.length === 0 && !context) return null;
 
 	return (
 		<div
 			data-testid="session-stats"
-			className="flex items-center gap-sm text-text-muted tr-text-metadata"
+			className="flex items-center gap-xs text-text-muted tr-text-metadata"
 		>
-			<span title="Total tokens">{formatTokens(stats.tokens.total)} tok</span>
-			<span title="Session cost">{formatCost(stats.cost)}</span>
-			{percent !== null && bucket !== null ? (
-				<span className="flex items-center gap-xs" title="Context window used">
-					<span className="block h-1.5 w-16 overflow-hidden rounded-full bg-sunken">
-						<span className={cn("block h-full rounded-full bg-primary", FILL[bucket])} />
-					</span>
-					{Math.round(percent)}%
+			{parts.length > 0 ? (
+				<span
+					className="whitespace-nowrap"
+					title="Cumulative usage: ↑ input · ↓ output · R cache read · W cache write"
+				>
+					{parts.join(" · ")}
 				</span>
+			) : null}
+			{context ? (
+				<>
+					{parts.length > 0 ? <span aria-hidden="true">·</span> : null}
+					<span className="flex items-center gap-xs" title="Context window used">
+						<span aria-hidden="true" className="text-primary">
+							{context.bar}
+						</span>
+						{context.text}
+					</span>
+				</>
 			) : null}
 		</div>
 	);

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -72,9 +72,9 @@ test("model picker plus file and portable-skill completion use the live session 
 	// The thinking-level picker is the honest effort knob.
 	await expect(page.getByTestId("thinking-selector")).toBeVisible();
 
-	// Cheap win #3 — the stats bar renders (token/cost) as soon as the session reports stats.
+	// Cheap win #3 — the stats bar renders current context as soon as the session reports stats.
 	await expect(page.getByTestId("session-stats")).toBeVisible();
-	await expect(page.getByTestId("session-stats")).toContainText(/tok/);
+	await expect(page.getByTestId("session-stats")).toContainText(/[?%]\/\d/);
 
 	// The worktree session is authoritative and discovers the fixture's Claude-compatible project alias.
 	const input = page.getByTestId("chat-input");
@@ -107,10 +107,10 @@ test("stats refresh after a turn completes (cheap win #3)", { tag: "@agent" }, a
 	await page.getByTestId("chat-send").click();
 
 	// Key off turn *completion* (the agent_end notice), not model output — the stats refresh hangs off
-	// `agent_end`, and the env's default model may vary. The stats bar stays mounted with token/cost.
+	// `agent_end`, and the env's default model may vary. The stats bar then shows cumulative usage.
 	await expect(
 		page.locator('[data-testid="chat-message"][data-role="system"]').filter({ hasText: "Done" }),
 	).toBeVisible({ timeout: 80_000 });
 	await expect(page.getByTestId("session-stats")).toBeVisible();
-	await expect(page.getByTestId("session-stats")).toContainText(/tok/);
+	await expect(page.getByTestId("session-stats")).toContainText(/[↑↓RW]/);
 });

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -111,6 +111,19 @@ test("stats refresh after a turn completes (cheap win #3)", { tag: "@agent" }, a
 	await expect(
 		page.locator('[data-testid="chat-message"][data-role="system"]').filter({ hasText: "Done" }),
 	).toBeVisible({ timeout: 80_000 });
-	await expect(page.getByTestId("session-stats")).toBeVisible();
-	await expect(page.getByTestId("session-stats")).toContainText(/[↑↓RW]/);
+	const stats = page.getByTestId("session-stats");
+	await expect(stats).toBeVisible();
+	await expect(stats).toContainText(/[↑↓RW]/);
+
+	// Populated usage wraps at field boundaries on a phone instead of pushing the context or Skills out.
+	await page.setViewportSize({ width: 320, height: 720 });
+	const skills = page.getByTestId("open-skills");
+	await expect(skills).toBeVisible();
+	const statsBox = await stats.boundingBox();
+	const skillsBox = await skills.boundingBox();
+	if (!statsBox || !skillsBox) throw new Error("chat header item has no bounding box");
+	for (const box of [statsBox, skillsBox]) {
+		expect(box.x).toBeGreaterThanOrEqual(0);
+		expect(box.x + box.width).toBeLessThanOrEqual(320);
+	}
 });


### PR DESCRIPTION
## Summary
- show pi-style input/output/cache/cost usage
- keep the five-cell context bar with `%/window`

## Tests
- `bun run test`
- `bun run e2e` (190 passed)
- lint, typecheck, dependency and seam checks