### PR TITLE
Fix false skill reload warnings from large filesystem batches

### DIFF
--- a/apps/web/src/panels/openTabs.test.ts
+++ b/apps/web/src/panels/openTabs.test.ts
@@ -70,9 +70,12 @@ test("a diff tab is stamped with the target and tick captured BEFORE its read, n
 	// Mid-read: the review target is re-pointed (a `workspace.setDiffBase` broadcast) and the worktree
 	// changes (an `fsChanged` push). Neither is reflected in the response now on its way back.
 	useAppStore.getState().updateWorkspace(workspace({ diffBase: "develop" }));
-	useAppStore
-		.getState()
-		.noteFsChanged({ workspaceId: "w1", paths: ["README.md"], truncated: false });
+	useAppStore.getState().noteFsChanged({
+		workspaceId: "w1",
+		paths: ["README.md"],
+		truncated: false,
+		skillChange: "none",
+	});
 
 	pending?.resolve({ original: "old", modified: "new" });
 	await open;
@@ -83,9 +86,12 @@ test("a diff tab is stamped with the target and tick captured BEFORE its read, n
 });
 
 test("an undisturbed open stamps the state it actually read against", async () => {
-	useAppStore
-		.getState()
-		.noteFsChanged({ workspaceId: "w1", paths: ["other.ts"], truncated: false });
+	useAppStore.getState().noteFsChanged({
+		workspaceId: "w1",
+		paths: ["other.ts"],
+		truncated: false,
+		skillChange: "none",
+	});
 	const open = openDiffInTab("w1", { kind: "branch" }, "README.md", "preview");
 	pending?.resolve({ original: "old", modified: "new" });
 	await open;

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -187,13 +187,15 @@ including a mutation's initiator, converges here — no optimism); `applyWorkspa
 entry; the pending-draft count is a selector (`selectReviewDraftCount`), never duplicated in
 components. The **Skills-reload badge** rides the same tick without a separate signal:
   `noteFsChanged` also folds **`skillChangeTickByWorkspace: Record<workspaceId, tick>`** — the tick of the
-  most recent *skill-relevant* batch (a `.claude|.github|.gemini|.pi|.agents/skills` path, via
-  `isSkillPath`, or a truncated watcher batch), *accumulated* so a later non-skill batch never clears it.
-  A fresh watcher's synthetic startup nudge remains a conservative truncated wildcard. Transport's
-  centralized skill-load preparation awaits `workspace.watchReady`, folds a duplicate wildcard fallback
-  unless the watcher was already known ready (the event push may have died during reconnect), then
-  captures the load's baseline tick. The newly loaded session stays clean; a real skill frame after readiness
-  remains newer than the baseline. Each chat records
+  most recent *skill-relevant* batch, from the host-authored `payload.skillChange` semantic (`detected` for
+  a concrete project-skill path, `unknown` for a genuinely pathless uncertainty, `none` for concrete
+  non-skill churn). It is independent of the capped generic `paths`/`truncated` pair, so a large build cannot
+  masquerade as a skill change and a skill event after the path cap is not lost; it stays *accumulated* so a
+  later non-skill batch never clears it. A fresh watcher's synthetic startup nudge remains conservative
+  `unknown`. Transport's centralized skill-load preparation awaits `workspace.watchReady`, folds a duplicate
+  unknown fallback unless the watcher was already known ready (the event push may have died during
+  reconnect), then captures the load's baseline tick. The newly loaded session stays clean; a real skill
+  frame after readiness remains newer than the baseline. Each chat records
   **`skillsSyncedTickBySession: Record<sessionId, tick>`** = the tick it loaded skills at.
   It advances **only when resources are actually (re)loaded against current disk**: a fresh
   `openChatSession`, a disk-only `hydrateSession` attach, and **`markSkillsSynced(sessionId, syncedTick)`** on
@@ -305,8 +307,8 @@ branch's review — a commit sha means nothing in another worktree — and dropp
   Changes panel is diffing, defaulting to the shared branch-scope constant), **`selectDiffBaseRef`** (the ref
   it is measured against — the client-side mirror of the host's one resolution), **`selectDiffTabTargetRef`**
   (that ref *as an open diff tab's live dimension*: the target for a branch-scope tab, `""` for a
-  commit/uncommitted one whose sides can't move — derived here, never re-assembled in a panel), `selectWorkspaceTick` (the
-  sync-baseline snapshot; + the `isSkillPath` path predicate it shares with `noteFsChanged`);
+  commit/uncommitted one whose sides can't move — derived here, never re-assembled in a panel),
+  `selectWorkspaceTick` (the sync-baseline snapshot);
   `matchesWorktreePath` (line an agent-reported path — relative or absolute — up against a worktree-relative
   one; shared by the Changes deep link and the spec classifier. The suffix rule is for **absolute reports
   only** and is anchored at a separator: unanchored, `/wt/src/a-foo.ts` would match `src/foo.ts`; applied to

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -7,6 +7,8 @@ import type {
 	SpecGraphNode,
 	WireModel,
 	Workspace,
+	WorkspaceFsChangedPayload,
+	WorkspaceSkillChange,
 } from "@thinkrail/contracts";
 import { type FileTab, type SessionRuntime, toast, useAppStore } from "./appStore";
 import {
@@ -1510,11 +1512,12 @@ test("the diff scope is per workspace, defaults to the branch, and is dropped wi
 
 // The Skills-reload badge (selectSkillsStale) is store-derived, so it must not depend on the ChatView
 // mount that reads it. These drive the real store actions end-to-end.
-const skillFs = (workspaceId: string, paths: string[], truncated = false) => ({
-	workspaceId,
-	paths,
-	truncated,
-});
+const skillFs = (
+	workspaceId: string,
+	paths: string[],
+	skillChange: WorkspaceSkillChange = "detected",
+	truncated = false,
+): WorkspaceFsChangedPayload => ({ workspaceId, paths, truncated, skillChange });
 const isStale = (workspaceId: string, sessionId: string) =>
 	selectSkillsStale(useAppStore.getState(), workspaceId, sessionId);
 
@@ -1536,8 +1539,8 @@ test("skills badge: a skill-dir change flags the loaded session; reload clears i
 	expect(isStale("ws1", "a")).toBe(false);
 
 	// Later unrelated (non-skill) fs churn must not re-raise the badge — the core regression.
-	s().noteFsChanged(skillFs("ws1", ["src/app.ts"]));
-	s().noteFsChanged(skillFs("ws1", ["README.md"]));
+	s().noteFsChanged(skillFs("ws1", ["src/app.ts"], "none"));
+	s().noteFsChanged(skillFs("ws1", ["README.md"], "none"));
 	expect(isStale("ws1", "a")).toBe(false);
 });
 
@@ -1546,24 +1549,48 @@ test("skills badge: the skill-change tick is accumulated, so a later non-skill b
 	s().openChatSession("ws1", "a", null, "medium");
 
 	s().noteFsChanged(skillFs("ws1", [".claude/skills/foo/SKILL.md"])); // skill change
-	s().noteFsChanged(skillFs("ws1", ["src/app.ts"])); // later non-skill batch replaces `paths`
+	s().noteFsChanged(skillFs("ws1", ["src/app.ts"], "none")); // later non-skill batch replaces `paths`
 	// Before the fix this false-negatived (the last batch wasn't a skill path); now it stays stale.
 	expect(isStale("ws1", "a")).toBe(true);
 });
 
-test("skills badge: a pathless non-truncated repo-metadata nudge refreshes without staling", () => {
+test("skills badge: a pathless skill-neutral repo-metadata nudge refreshes without staling", () => {
 	const s = () => useAppStore.getState();
 	s().openChatSession("ws1", "a", null, "medium");
-	s().noteFsChanged(skillFs("ws1", []));
+	s().noteFsChanged(skillFs("ws1", [], "none"));
 	expect(selectWorkspaceTick(s(), "ws1")).toBe(1); // live readers still re-read
 	expect(isStale("ws1", "a")).toBe(false);
 });
 
-test("skills badge: a truncated wildcard batch flags stale even with no skill path", () => {
+test("skills badge: generic path overflow is neutral, but detected and unknown skill impact flags", () => {
 	const s = () => useAppStore.getState();
 	s().openChatSession("ws1", "a", null, "medium");
-	s().noteFsChanged(skillFs("ws1", [], true));
+
+	// The live false positive: a build exceeded the generic path cap, but every observed path was
+	// concretely non-skill. `truncated` still refreshes broad readers; it is not skill evidence.
+	s().noteFsChanged(skillFs("ws1", ["dist/chunk.js"], "none", true));
+	expect(selectWorkspaceTick(s(), "ws1")).toBe(1);
+	expect(isStale("ws1", "a")).toBe(false);
+
+	// A skill event survives even when its own path was beyond the retained generic list.
+	s().noteFsChanged(skillFs("ws1", ["dist/chunk.js"], "detected", true));
 	expect(isStale("ws1", "a")).toBe(true);
+	s().markSkillsSynced("a", selectWorkspaceTick(s(), "ws1"));
+
+	// A platform event with no classifiable path remains conservative.
+	s().noteFsChanged(skillFs("ws1", [], "unknown", true));
+	expect(isStale("ws1", "a")).toBe(true);
+});
+
+test("skills badge: non-skill overflow during session creation does not open the new chat stale", () => {
+	const s = () => useAppStore.getState();
+	// Startup uncertainty is folded before the load baseline (the workspace.watchReady contract).
+	s().noteFsChanged(skillFs("ws1", [], "unknown", true));
+	const baseline = selectWorkspaceTick(s(), "ws1");
+	// The reproduced event: >100 generated build outputs land while session.create is in flight.
+	s().noteFsChanged(skillFs("ws1", ["dist/chunk.js"], "none", true));
+	s().openChatSession("ws1", "new", null, "medium", baseline);
+	expect(isStale("ws1", "new")).toBe(false);
 });
 
 test("skills badge: per session — a chat opened after the change isn't flagged; reload clears only its own", () => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -32,7 +32,6 @@ import { shallowEqualArrays, userText } from "../lib";
 import type { ConnectionStatus } from "../transport";
 import {
 	type HistoryTarget,
-	isSkillPath,
 	selectActiveWorkspaceProjectId,
 	selectWorkspaceNavTick,
 	selectWorkspaceTick,
@@ -661,9 +660,10 @@ interface AppState {
 	 */
 	fsChangesByWorkspace: Record<string, { tick: number; paths: string[]; truncated: boolean }>;
 	/**
-	 * Per workspace, the `fsChangesByWorkspace` tick of the most recent *skill-relevant* batch — a change
-	 * under a `.claude|.github|.gemini|.pi|.agents/skills` dir, or a truncated wildcard we can't inspect.
-	 * Folded alongside the fs signal in `noteFsChanged`; compared against a session's
+	 * Per workspace, the `fsChangesByWorkspace` tick of the most recent *skill-relevant* batch — host
+	 * evidence is `detected` for a concrete project-skill path or `unknown` for a truly pathless event;
+	 * generic path-list truncation with `skillChange: "none"` is deliberately irrelevant. Folded alongside
+	 * the fs signal in `noteFsChanged`; compared against a session's
 	 * `skillsSyncedTickBySession` to derive the Skills-reload badge (`selectSkillsStale`). Accumulated (not
 	 * overwritten by a later non-skill batch), so a genuine pending skill change is never lost.
 	 */
@@ -1341,9 +1341,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 		set((s) => {
 			const prev = s.fsChangesByWorkspace[payload.workspaceId];
 			const tick = (prev?.tick ?? 0) + 1;
-			// A skill-dir change (or a truncated wildcard we can't inspect) advances the workspace's
-			// skill-change tick, flagging every session that loaded skills before it (selectSkillsStale).
-			const skillChanged = payload.truncated || payload.paths.some(isSkillPath);
+			// The host classifies skill evidence before its generic path cap, so a large concrete non-skill
+			// batch cannot masquerade as a resource change and an over-cap skill path is not lost.
+			const skillChanged = payload.skillChange !== "none";
 			return {
 				fsChangesByWorkspace: {
 					...s.fsChangesByWorkspace,

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -4,7 +4,6 @@ import type { EditorTab } from "./appStore";
 import {
 	isDefaultWorkspace,
 	isExternalWorkspace,
-	isSkillPath,
 	isUserOwnedWorkspace,
 	matchesWorktreePath,
 	selectActiveWorkspace,
@@ -76,27 +75,6 @@ test("context project falls back to the selected Project Home", () => {
 			workspaces,
 		}),
 	).toBe(projects[0]);
-});
-
-test("isSkillPath matches every alias' skills dir, and only a real skills dir", () => {
-	for (const yes of [
-		".claude/skills/foo/SKILL.md",
-		".github/skills/x.md",
-		".gemini/skills",
-		".agents/skills/z",
-		"nested/dir/.pi/skills/y.md",
-	]) {
-		expect(isSkillPath(yes)).toBe(true);
-	}
-	for (const no of [
-		"README.md",
-		".claude/settings.json", // an alias dir, but not its skills
-		".claudeskills/x", // no `/skills` segment
-		"src/claude/skills/x", // "claude" without the leading dot
-		"skills/x", // bare skills, no alias parent
-	]) {
-		expect(isSkillPath(no)).toBe(false);
-	}
 });
 
 test("selectSkillsStale is a strict tick comparison, defaulting missing ticks to 0", () => {

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -162,11 +162,6 @@ export function selectDiffTabTargetRef(
 	return tab.scope.kind === "branch" ? selectDiffBaseRef(state, tab.workspaceId) : "";
 }
 
-/** Whether a worktree-relative path is inside a skill directory — the auto-detect trigger for a reload. */
-export function isSkillPath(path: string): boolean {
-	return /(^|\/)\.(claude|github|gemini|pi|agents)\/skills(\/|$)/.test(path);
-}
-
 /**
  * Whether a path **as pi reported it** (worktree-relative or absolute — a tool call's `path` argument is
  * whichever the agent passed) designates the worktree-relative `rel`. Shared by every consumer that has to

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -48,7 +48,8 @@ The single WebSocket client to the host, and its app-wide singleton.
   host error) with a plain `Error`, so *having* a code is exactly how a caller tells "this
   specific failure" from "the read failed"); `skillLoad.ts` (the one app-integration coordinator for session
   resource loads: single-flight `workspace.watchReady` per workspace; unless the watcher was already known
-  ready, fold the conservative wildcard locally as a replay-safe fallback; capture the store tick only
+  ready, fold the conservative `skillChange: "unknown"` wildcard locally as a replay-safe fallback; capture
+  the store tick only
   afterward; then wrappers issue `session.create` / `session.getMessages` / `session.reloadResources`, so no
   call site can accidentally reverse readiness and baseline ordering).
 - **Public surface (barrel):** `initTransport`, `getTransport`, the three skill-load-safe session request

--- a/apps/web/src/transport/skillLoad.test.ts
+++ b/apps/web/src/transport/skillLoad.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { WorkspaceWatchReadyResult } from "@thinkrail/contracts";
+import type { WorkspaceFsChangedPayload, WorkspaceWatchReadyResult } from "@thinkrail/contracts";
 import { createSkillLoadRequests } from "./skillLoad";
 
 test("skill-load requests share startup, fold the replay fallback before the baseline, and guard every load", async () => {
@@ -10,13 +10,15 @@ test("skill-load requests share startup, fold the replay fallback before the bas
 	let watchCalls = 0;
 	let tick = 0;
 	const order: string[] = [];
+	const fallbacks: WorkspaceFsChangedPayload[] = [];
 	const requests = createSkillLoadRequests({
 		watchReady: () => {
 			watchCalls += 1;
 			return watchCalls === 1 ? firstReady : Promise.resolve({ startupNudge: false });
 		},
-		noteFsChanged: () => {
+		noteFsChanged: (payload) => {
 			order.push("fallback");
+			fallbacks.push(payload);
 			tick += 1;
 		},
 		workspaceTick: () => {
@@ -63,6 +65,9 @@ test("skill-load requests share startup, fold the replay fallback before the bas
 	expect(messages.syncedTick).toBe(1);
 	expect(order.slice(0, 2)).toEqual(["fallback", "baseline"]);
 	expect(order.filter((step) => step === "fallback")).toHaveLength(1);
+	expect(fallbacks).toEqual([
+		{ workspaceId: "ws1", paths: [], truncated: true, skillChange: "unknown" },
+	]);
 	expect(order).toContain("create");
 	expect(order).toContain("messages");
 	expect(tick).toBe(2);

--- a/apps/web/src/transport/skillLoad.ts
+++ b/apps/web/src/transport/skillLoad.ts
@@ -34,7 +34,12 @@ export function createSkillLoadRequests(deps: SkillLoadDependencies) {
 
 		const started = deps.watchReady(workspaceId).then(({ startupNudge }) => {
 			if (startupNudge) {
-				deps.noteFsChanged({ workspaceId, paths: [], truncated: true });
+				deps.noteFsChanged({
+					workspaceId,
+					paths: [],
+					truncated: true,
+					skillChange: "unknown",
+				});
 			}
 			return deps.workspaceTick(workspaceId);
 		});

--- a/e2e/skills-reload.live.spec.ts
+++ b/e2e/skills-reload.live.spec.ts
@@ -7,10 +7,10 @@ import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 // a real session. No prompt is ever sent — the session only has to exist — so this stays fast and never
 // spends provider tokens (session create + session.reloadResources are config/fs work, no model round-trip).
 //
-// The bugs this pins: watcher startup must not look like a skill change, and the badge must remain
-// store-derived per session across CenterTabs remounts. A reload clears it for good and a sibling chat that
-// loaded the current skills is never flagged.
-test("skills badge: flags a worktree skill change, clears on reload, and survives a tab switch", {
+// The bugs this pins: watcher startup and capped non-skill worktree churn must not look like a skill change,
+// and the badge must remain store-derived per session across CenterTabs remounts. A reload clears it for good
+// and a sibling chat that loaded the current skills is never flagged.
+test("skills badge: ignores capped build churn, flags a skill change, and clears per chat", {
 	tag: "@agent",
 }, async ({ page }) => {
 	test.setTimeout(120_000);
@@ -29,6 +29,19 @@ test("skills badge: flags a worktree skill change, clears on reload, and survive
 	await page.getByTestId("tab-files").click();
 	await expect(page.getByTestId("file-node").filter({ hasText: "README.md" })).toBeVisible();
 	await page.waitForTimeout(1200);
+	await expect(skillsBtn).not.toHaveAttribute("data-stale", "true");
+
+	// Reproduce the live report: a build writes more files than the watcher's retained-path cap inside this
+	// linked worktree. The generic frame is truncated, but every event is concretely non-skill — Files must
+	// refresh while the Skills badge stays clean.
+	const generated = join(worktree, "generated-build");
+	mkdirSync(generated, { recursive: true });
+	for (let i = 0; i < 150; i += 1) {
+		writeFileSync(join(generated, `chunk-${i}.js`), `export const chunk = ${i};\n`);
+	}
+	await expect(page.getByTestId("file-node").filter({ hasText: "generated-build" })).toBeVisible({
+		timeout: 15_000,
+	});
 	await expect(skillsBtn).not.toHaveAttribute("data-stale", "true");
 
 	// A skill file appears on disk (a pull/branch/edit) → the loaded session is flagged for a reload.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -289,12 +289,14 @@ of the host.
   state changed (emitted by the server's `reviews` publisher on every mutation — UI edits, agent
   `resolve_comment` calls, re-anchoring — so all clients converge, same pattern as the trio) /
   **`workspace.fsChanged`** — the worktree
-  change-notifier push (**`WorkspaceFsChangedPayload`**: `{ workspaceId, paths, truncated }`,
-  worktree-relative deduped paths, capped — `truncated` means path uncertainty remains (an observed batch
-  was incomplete, or a fresh watcher's registration window may have hidden an event) and must be treated as
-  a wildcard; a pathless non-truncated frame is a whole-workspace invalidation such as repo-metadata drift);
-  an **invalidation nudge, not data**: clients re-read via the existing read methods, so a
-  duplicate/replayed frame is harmless.
+  change-notifier push (**`WorkspaceFsChangedPayload`**: `{ workspaceId, paths, truncated, skillChange }`,
+  worktree-relative deduped paths, capped — `truncated` means the generic path list is incomplete and must
+  be treated as a wildcard; `skillChange: "none" | "detected" | "unknown"` is an **independent semantic
+  fact**, accumulated before that cap, so a concrete non-skill overflow stays `none`, a skill path omitted
+  after the cap stays `detected`, and only a pathless platform/startup uncertainty is `unknown`; a pathless
+  non-truncated/`none` frame is a whole-workspace invalidation such as repo-metadata drift); an
+  **invalidation nudge, not data**: clients re-read via the existing read methods, so a duplicate/replayed
+  frame is harmless.
   The `WsMethodMap` typed request/result map +
   `WsParams`/`WsResult` helpers, and `PROTOCOL_VERSION`. Request ids are also the reconnect idempotency key:
   an unresolved client replays the same frame/id, and the host returns the one cached result for

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -131,18 +131,24 @@ export interface EditorInfo {
  * on-disk change (agent edit, terminal command, Finder) or a pathless synchronization nudge. An
  * **invalidation nudge, not data** — clients re-read via the existing read methods, so a duplicate or
  * replayed frame is harmless. `paths` are worktree-relative and deduped, capped host-side;
- * `truncated: true` means path uncertainty remains — an observed watcher batch was incomplete or a fresh
- * watcher's registration window may have hidden an event — so clients treat it as a wildcard.
+ * `truncated: true` means that generic path list is incomplete, so path consumers treat it as a wildcard.
+ * `skillChange` is independent evidence accumulated before the cap: `detected` means a concrete project
+ * skill path was observed, `unknown` means the platform supplied no classifiable path (including watcher
+ * startup uncertainty), and `none` means no skill path was observed and no such uncertainty remains.
  *
- * An **empty, non-truncated** frame (`paths: []`, `truncated: false`) is the pathless variant: re-read the
- * workspace without claiming a file changed. The host emits it when worktree git metadata moves (a
- * `commit`/`reset`/`switch` in a terminal), which invalidates git-derived reads (`git.status`, an
- * `uncommitted`-scope diff) while leaving the working tree untouched. Same contract: re-read, don't patch.
+ * An **empty, non-truncated, skill-neutral** frame (`paths: []`, `truncated: false`,
+ * `skillChange: "none"`) is the pathless variant: re-read the workspace without claiming a file changed.
+ * The host emits it when worktree git metadata moves (a `commit`/`reset`/`switch` in a terminal), which
+ * invalidates git-derived reads (`git.status`, an `uncommitted`-scope diff) while leaving the working tree
+ * untouched. Same contract: re-read, don't patch.
  */
+export type WorkspaceSkillChange = "none" | "detected" | "unknown";
+
 export interface WorkspaceFsChangedPayload {
 	workspaceId: string;
 	paths: string[];
 	truncated: boolean;
+	skillChange: WorkspaceSkillChange;
 }
 
 /** A chat tab bound to a workspace. `id` is the UI tab id; `sessionId` is the pi `AgentSession` id. */

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -200,7 +200,10 @@ export interface TerminalTabsPush {
 // its socket before that baseline is captured.
 // v32: `agent_settled` is the automatic-run terminal and carries final assistant metadata;
 // `SessionSummary.lastSettlement` closes live reconnect gaps after Pi rebuilds context.
-export const PROTOCOL_VERSION = 32;
+// v33: `WorkspaceFsChangedPayload.skillChange` separates detected/unknown skill evidence from generic path
+// truncation, so a large non-skill build cannot masquerade as a skill edit while over-cap skill paths remain
+// detectable.
+export const PROTOCOL_VERSION = 33;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -191,9 +191,13 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     (`~/.copilot/skills`), and Gemini (`${GEMINI_CLI_HOME:-~}/.gemini/skills`), **plus each installed Claude
     plugin's `skills/` dir** (read from `~/.claude/plugins/installed_plugins.json` — the resolved `installPath`,
     never a cache sweep, so stale versions and transitive `node_modules/**/skills` are excluded); project-root
-    aliases are `.claude/skills`, `.github/skills`, and `.gemini/skills`. The fixed project/personal alias roots are
-    registered as candidate skill paths **whether or not they exist yet**, so a `loader.reload()` picks up one a branch
-    switch / pull / clone creates mid-session (plugin dirs are the set installed at construction — a plugin added later
+    aliases are `.claude/skills`, `.github/skills`, and `.gemini/skills`. The pure
+    **`isProjectSkillPath(relativePath)`** predicate is the one server-side definition used by the worktree
+    watcher (injected through `host`): it recognizes those aliases plus Pi's native `.pi/skills` and
+    `.agents/skills`, so capped filesystem batches carry truthful skill-change evidence without making
+    `watch` depend on `agent`. The fixed project/personal alias roots are registered as candidate skill paths
+    **whether or not they exist yet**, so a `loader.reload()` picks up one a branch switch / pull / clone
+    creates mid-session (plugin dirs are the set installed at construction — a plugin added later
     needs a fresh session); classification still only counts dirs that actually exist. Still never arbitrary
     dot-directory scanning, plugin caches, commands, or nested downward discovery. Pi remains the parser:
     vendor-only macros/hooks/models/subagents/metadata are not emulated. First-name-wins precedence is
@@ -257,7 +261,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
   `buildAnswersMessage`); `repairDanglingToolCalls`; the skill catalog helpers
   `listSkillCommands(cwd, admission)` (filtered, pre-session autocomplete) / `listSkillCatalog(cwd, admission)`
-  (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count);
+  (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count) /
+  `isProjectSkillPath(relativePath)` (watch-classification predicate);
   `reloadSessionResources(sessionId)` (active-chat reload); the **`setSkillAdmissionResolver`** seam (host
   wires `workspaceId` → the admission context);
   the compiled-binary seam (`registerBundledRuntime` +

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -19,4 +19,5 @@ export {
 } from "./reviewTool";
 export * from "./sessionRepair";
 export type { SkillAdmissionContext, SkillDecision, SkillFacts } from "./skillAdmission";
+export { isProjectSkillPath } from "./skillSources";
 export * from "./webUiContext";

--- a/packages/server/src/agent/skillSources.test.ts
+++ b/packages/server/src/agent/skillSources.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { discoverCompatibilitySkillSources } from "./skillSources";
+import { discoverCompatibilitySkillSources, isProjectSkillPath } from "./skillSources";
 
 const temporaryRoots: string[] = [];
 
@@ -19,6 +19,31 @@ function directory(path: string): string {
 
 afterEach(() => {
 	for (const path of temporaryRoots.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("isProjectSkillPath", () => {
+	it("matches exactly the five project-root skill directories", () => {
+		for (const path of [
+			".claude/skills/foo/SKILL.md",
+			".github/skills/x.md",
+			".gemini/skills",
+			".agents/skills/z",
+			".pi/skills/y.md",
+			".claude\\skills\\windows\\SKILL.md",
+		]) {
+			expect(isProjectSkillPath(path)).toBe(true);
+		}
+		for (const path of [
+			"README.md",
+			".claude/settings.json",
+			".claudeskills/x",
+			"src/claude/skills/x",
+			"nested/.pi/skills/y.md",
+			"skills/x",
+		]) {
+			expect(isProjectSkillPath(path)).toBe(false);
+		}
+	});
 });
 
 describe("discoverCompatibilitySkillSources", () => {

--- a/packages/server/src/agent/skillSources.ts
+++ b/packages/server/src/agent/skillSources.ts
@@ -4,6 +4,17 @@ import { join, resolve } from "node:path";
 
 export type CompatibilitySkillProvider = "claude" | "codex" | "github-copilot" | "gemini";
 
+const PROJECT_SKILL_PATH = /^\.(claude|github|gemini|pi|agents)\/skills(?:\/|$)/;
+
+/**
+ * Whether a worktree-relative path belongs to one of the project skill roots the session loader sees:
+ * ThinkRail's three compatibility aliases plus Pi's two native roots. Kept here, beside skill discovery,
+ * then injected into the watcher by the host so generic filesystem batching never duplicates this policy.
+ */
+export function isProjectSkillPath(relativePath: string): boolean {
+	return PROJECT_SKILL_PATH.test(relativePath.replaceAll("\\", "/"));
+}
+
 /** One conventional, existing skill root that another Agent Skills-compatible harness owns. */
 export interface CompatibilitySkillSource {
 	path: string;

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -48,14 +48,17 @@ channel fan-out, and the process-boot wrapper both launchers share.
   record of work that finished and drops only its answer,
   the **`provider.login`** channel publish (the `auth` module's session-less login-frame bridge, wired like
   `pi.extensionUi`) and the `provider.*` login handlers, the **`watch` wiring** (inject the
-  `workspace.fsChanged` publish callback into `watch`; expose **`workspace.watchReady`** as the typed
-  preflight that awaits a fresh watcher's conservative startup nudge before a web skill-loading flow
+  `workspace.fsChanged` publish callback into `watch` and inject `agent`'s project-skill path classifier so
+  each capped batch carries independent `skillChange: none|detected|unknown` evidence; expose
+  **`workspace.watchReady`** as the typed preflight that awaits a fresh watcher's conservative startup nudge
+  before a web skill-loading flow
   captures its baseline and reports whether the watcher was already known ready (the client's replay-safe
   conservative fallback); plus the **repo-metadata** callback (`setRepoMetaPublisher`) fanned out to **two**
   convergences for a git-metadata write in a watched worktree:
   `refreshUserOwnedWorkspace` (**re-sync a user-owned workspace's folder-truth branch** — host-mediated,
   since `watch` has no `workspaces` edge, and self-publishing through the workspace-lifecycle tee) **and** a
-  pathless `fsChanged` frame (`paths: []`, `truncated: false`) so the clients' `HEAD`-relative reads
+  pathless, skill-neutral `fsChanged` frame (`paths: []`, `truncated: false`, `skillChange: "none"`) so the
+  clients' `HEAD`-relative reads
   (`git.status`, an `uncommitted`-scope diff tab) re-read when a terminal `commit`/`reset` moves a ref;
   the same publish also feeds the **fsNudge seam** (`fsNudge.ts`: `setFsNudgePublisher` +
   `nudgeBaseRefWorkspaces`), the host mediation the `git.prefetch` handler triggers when the app's own

--- a/packages/server/src/host/fsNudge.test.ts
+++ b/packages/server/src/host/fsNudge.test.ts
@@ -53,10 +53,11 @@ test("nudges exactly the project's workspaces whose diff base is the moved ref, 
 
 	nudgeBaseRefWorkspaces("p1", "origin/main");
 
-	// Pathless (an invalidation, not data — no `.git` path may reach a client), never truncated.
+	// Pathless (an invalidation, not data — no `.git` path may reach a client), never truncated or
+	// skill-relevant.
 	expect(frames).toEqual([
-		{ workspaceId: "w-base", paths: [], truncated: false },
-		{ workspaceId: "w-repointed", paths: [], truncated: false },
+		{ workspaceId: "w-base", paths: [], truncated: false, skillChange: "none" },
+		{ workspaceId: "w-repointed", paths: [], truncated: false, skillChange: "none" },
 	]);
 });
 

--- a/packages/server/src/host/fsNudge.ts
+++ b/packages/server/src/host/fsNudge.ts
@@ -34,6 +34,7 @@ export function setFsNudgePublisher(publisher: FsNudgePublisher | null): void {
 export function nudgeBaseRefWorkspaces(projectId: string, ref: string): void {
 	if (!publish) return;
 	for (const ws of listWorkspaceRecords(projectId)) {
-		if (diffBaseRef(ws) === ref) publish({ workspaceId: ws.id, paths: [], truncated: false });
+		if (diffBaseRef(ws) === ref)
+			publish({ workspaceId: ws.id, paths: [], truncated: false, skillChange: "none" });
 	}
 }

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -10,6 +10,7 @@ import { errorCodeOf } from "@thinkrail/shared/codedError";
 import {
 	disposeAllSessions,
 	getSessionWorkspaceId,
+	isProjectSkillPath,
 	setExtUiPublisher,
 	setReviewCommentHandler,
 	setSessionPublisher,
@@ -40,7 +41,12 @@ import {
 	setTerminalPublisher,
 	setTerminalTabsPublisher,
 } from "../terminal";
-import { setRepoMetaPublisher, setWatchPublisher, stopAllWatches } from "../watch";
+import {
+	setRepoMetaPublisher,
+	setSkillPathClassifier,
+	setWatchPublisher,
+	stopAllWatches,
+} from "../watch";
 import { getWorkspace, refreshUserOwnedWorkspace, setWorkspacePublisher } from "../workspaces";
 import {
 	isPromptCommitted,
@@ -409,6 +415,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 		reanchorWorkspace(payload.workspaceId);
 	};
 	setWatchPublisher(publishFsChanged);
+	setSkillPathClassifier(isProjectSkillPath);
 	// The same frame, publishable from the `git.prefetch` handler: the app's own background fetch moves
 	// `refs/remotes/…` in the project repo's shared `.git` — a location no worktree watcher can see — so the
 	// handler nudges the workspaces whose diff base that ref is (see `fsNudge.ts`).
@@ -429,7 +436,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 	//      badge) correctly see nothing of interest.
 	setRepoMetaPublisher((workspaceId) => {
 		refreshUserOwnedWorkspace(workspaceId);
-		publishFsChanged({ workspaceId, paths: [], truncated: false });
+		publishFsChanged({ workspaceId, paths: [], truncated: false, skillChange: "none" });
 	});
 
 	// Fan `review.changed` snapshots out to every client (the reviews module stays channel-ignorant),

--- a/packages/server/src/watch/SPEC.md
+++ b/packages/server/src/watch/SPEC.md
@@ -13,7 +13,7 @@ tags: [v1, live-refresh]
 The filesystem change notifier behind the UI's live refresh: one recursive watcher per watched
 workspace worktree (Bun's native `fs.watch(root, { recursive: true })` — no watcher dependency),
 coalescing events into a debounced **`workspace.fsChanged`** publish (`WorkspaceFsChangedPayload`:
-`{ workspaceId, paths, truncated }`). The frame is an **invalidation nudge, not data** — clients
+`{ workspaceId, paths, truncated, skillChange }`). The frame is an **invalidation nudge, not data** — clients
 re-read through the existing read methods (`fs.*` / `git.*` / `spec.graph`), so the reads stay the
 single source of truth and a duplicate/replayed frame is harmless (one extra refetch, never wrong
 state). Chosen over per-path client-side tree patching (would make the client a second source of
@@ -28,18 +28,24 @@ truth) and visible-panel polling (laggy, wasteful over Tailscale).
   in `workspace.remove`'s fast path),
   `stopAllWatches()` (called in `server.stop()`); the ignore filter (any path segment `.git` or
   `node_modules`, plus `.DS_Store`); per-workspace coalescing (deduped relative paths, flushed after
-  300ms quiet / 1s max-wait, capped at 100 paths → `truncated: true` = wildcard — the ≤ ~1 frame/sec
+  300ms quiet / 1s max-wait, capped at 100 paths → `truncated: true` = a generic wildcard — the ≤ ~1 frame/sec
   bound is **pinned by the e2e churn canary** in `live-refresh.spec.ts`: ~200 writes over ~3s must
-  reach the client as ≤ 8 frames while a mid-storm `/health` round-trip stays fast); the **startup
-  nudge** — a fresh watcher publishes one synthetic **truncated wildcard** after the platform stream's
+  reach the client as ≤ 8 frames while a mid-storm `/health` round-trip stays fast). Skill relevance is
+  accumulated **before and independently of** that cap as `skillChange: "none" | "detected" | "unknown"`:
+  `host` injects `agent`'s project-skill path predicate; every concrete event contributes `detected`/`none`
+  even when its path cannot be retained, while a null filename contributes `unknown` (`detected` wins). A
+  duplicate already in the retained set does not make the batch truncated. Thus a 100+ file build cannot
+  masquerade as a skill edit, while a skill path after the cap is still detected. The **startup nudge** — a
+  fresh watcher publishes one synthetic **truncated / skill-unknown wildcard** after the platform stream's
   registration window (~750ms), because a write landing inside that window can lose its event forever.
   Its readiness promise resolves only after that publish. The web's skill-loading flows await the typed
   `workspace.watchReady` host preflight *before* capturing their start-of-load freshness tick, so startup
   uncertainty is absorbed into the new session's baseline instead of falsely marking it stale; a real edit
   after readiness stays newer than that baseline. Unless the watcher was already known ready, the result
-  tells the web to fold a duplicate wildcard fallback if the broadcast died with its socket while the request
-  response survived replay — or if startup failed before publishing. Ordinary workspace reads do not await
-  readiness and never gain startup latency. Stopping a watcher settles its pending readiness and cancels the nudge, so callers cannot
+  tells the web to fold a duplicate `skillChange: "unknown"` fallback if the broadcast died with its socket
+  while the request response survived replay — or if startup failed before publishing. Ordinary workspace
+  reads do not await readiness and never gain startup latency. Stopping a watcher settles its pending
+  readiness and cancels the nudge, so callers cannot
   hang and torn-down watchers cannot publish. An invalidation nudge remains idempotent, so the fallback's
   possible duplicate is one cheap no-op refetch.
 - **Repo-metadata nudge (second seam):** a git-metadata write is *metadata, not content*, so it never
@@ -62,11 +68,13 @@ truth) and visible-panel polling (laggy, wasteful over Tailscale).
     pure storms; a missing/unreadable git dir (non-git folder) or a failed start degrades silently.
 
   `host` fans the nudge out to two convergences: `refreshUserOwnedWorkspace` (a user-owned workspace's
-  folder-truth branch labels) **and** a pathless `fsChanged` frame (`paths: []`, `truncated: false`) so the
-  clients' git-derived reads re-read — `git.status` and an open `uncommitted`-scope diff tab are relative to
-  `HEAD`, and would otherwise keep reporting a committed change as uncommitted until the next file edit.
-- **Publish seam:** never imports `host` — `host` injects the publish callback at wiring time (the
-  session-publisher tee pattern).
+  folder-truth branch labels) **and** a pathless, skill-neutral `fsChanged` frame (`paths: []`,
+  `truncated: false`, `skillChange: "none"`) so the clients' git-derived reads re-read — `git.status` and an
+  open `uncommitted`-scope diff tab are relative to `HEAD`, and would otherwise keep reporting a committed
+  change as uncommitted until the next file edit.
+- **Composition seams:** never imports `host` or `agent` — `host` injects both the publish callback and
+  `agent`'s pure project-skill path classifier at wiring time (the publisher-tee pattern). A missing
+  classifier degrades concrete events to `skillChange: "unknown"`, never false-clean.
 - **Self-healing per read (out-of-band worktree churn is normal — e2e resets, `rm -rf` in a terminal):**
   every `ensureWatch` re-stats the root and **re-creates the watcher when the inode changed** (a
   deleted+recreated path leaves the old stream silently following a dead inode), **reaps zombie
@@ -76,6 +84,6 @@ truth) and visible-panel polling (laggy, wasteful over Tailscale).
   panels fall back to read-on-demand until a later read re-creates it. No idle-stop in V1 (bounded by
   workspaces actually visited).
 - **Public surface (barrel):** `ensureWatch`, `stopWatch`, `stopAllWatches`, `setWatchPublisher`,
-  `setRepoMetaPublisher`.
+  `setRepoMetaPublisher`, `setSkillPathClassifier`.
 - **Allowed deps:** `persistence` (workspace lookup); `contracts` (payload type); Bun/Node.
 - **Forbidden:** `host`; sibling features; any pi package.

--- a/packages/server/src/watch/coalesce.ts
+++ b/packages/server/src/watch/coalesce.ts
@@ -2,19 +2,25 @@
 // unit-testable: paths accumulate into a deduped set and flush as ONE batch after a quiet gap, with a
 // max-wait bound so continuous churn (a build, `git checkout`) still flushes periodically.
 
+import type { WorkspaceSkillChange } from "@thinkrail/contracts";
+
 export interface CoalescerOptions {
 	/** Flush after this long with no new events. */
 	quietMs: number;
 	/** Flush at least this often under continuous events. */
 	maxWaitMs: number;
-	/** Cap the batch; beyond it the batch turns `truncated` (= wildcard, receivers refetch everything). */
+	/** Cap the generic path list; skill evidence is accumulated independently before this limit. */
 	maxPaths: number;
-	onFlush: (batch: { paths: string[]; truncated: boolean }) => void;
+	onFlush: (batch: {
+		paths: string[];
+		truncated: boolean;
+		skillChange: WorkspaceSkillChange;
+	}) => void;
 }
 
 export interface Coalescer {
-	/** Record one changed path (worktree-relative); `null` = unknown path → the batch turns truncated. */
-	add(path: string | null): void;
+	/** Record one event's path + independently classified skill evidence. `null` makes paths uncertain. */
+	add(path: string | null, skillChange: WorkspaceSkillChange): void;
 	/** Drop pending state + timers without flushing (watcher teardown). */
 	dispose(): void;
 }
@@ -23,6 +29,7 @@ export function createCoalescer(options: CoalescerOptions): Coalescer {
 	const { quietMs, maxWaitMs, maxPaths, onFlush } = options;
 	let pending = new Set<string>();
 	let truncated = false;
+	let skillChange: WorkspaceSkillChange = "none";
 	let quietTimer: ReturnType<typeof setTimeout> | null = null;
 	let maxTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -35,17 +42,25 @@ export function createCoalescer(options: CoalescerOptions): Coalescer {
 
 	const flush = (): void => {
 		clearTimers();
-		if (pending.size === 0 && !truncated) return;
-		const batch = { paths: [...pending], truncated };
+		if (pending.size === 0 && !truncated && skillChange === "none") return;
+		const batch = { paths: [...pending], truncated, skillChange };
 		pending = new Set();
 		truncated = false;
+		skillChange = "none";
 		onFlush(batch);
 	};
 
 	return {
-		add(path) {
+		add(path, eventSkillChange) {
+			// Evidence is independent of path retention: a skill event after the cap must survive. A concrete
+			// detection is stronger than path uncertainty, which is stronger than no skill impact.
+			if (eventSkillChange === "detected" || skillChange === "none") {
+				skillChange = eventSkillChange;
+			}
 			if (path === null) truncated = true;
-			else if (pending.size >= maxPaths) truncated = true;
+			else if (pending.has(path)) {
+				// Already retained: a noisy duplicate does not make the generic path list incomplete.
+			} else if (pending.size >= maxPaths) truncated = true;
 			else pending.add(path);
 			if (quietTimer) clearTimeout(quietTimer);
 			quietTimer = setTimeout(flush, quietMs);
@@ -55,6 +70,7 @@ export function createCoalescer(options: CoalescerOptions): Coalescer {
 			clearTimers();
 			pending = new Set();
 			truncated = false;
+			skillChange = "none";
 		},
 	};
 }

--- a/packages/server/src/watch/index.ts
+++ b/packages/server/src/watch/index.ts
@@ -3,6 +3,7 @@ export {
 	ensureWatch,
 	isIgnoredPath,
 	setRepoMetaPublisher,
+	setSkillPathClassifier,
 	setWatchPublisher,
 	stopAllWatches,
 	stopWatch,

--- a/packages/server/src/watch/watch.test.ts
+++ b/packages/server/src/watch/watch.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { WorkspaceFsChangedPayload } from "@thinkrail/contracts";
+import type { WorkspaceFsChangedPayload, WorkspaceSkillChange } from "@thinkrail/contracts";
 import { createCoalescer } from "./coalesce";
 import {
 	ensureWatch,
 	isIgnoredPath,
 	setRepoMetaPublisher,
+	setSkillPathClassifier,
 	setWatchPublisher,
 	stopAllWatches,
 	stopWatch,
@@ -23,28 +24,37 @@ async function waitFor(check: () => boolean, timeoutMs = 3000): Promise<void> {
 	}
 }
 
+type CoalescedBatch = {
+	paths: string[];
+	truncated: boolean;
+	skillChange: WorkspaceSkillChange;
+};
+
 // ---- coalesce.ts ----
 
 test("coalescer dedupes and flushes one batch after the quiet gap", async () => {
-	const flushes: { paths: string[]; truncated: boolean }[] = [];
+	const flushes: CoalescedBatch[] = [];
 	const c = createCoalescer({
 		quietMs: 30,
 		maxWaitMs: 500,
 		maxPaths: 10,
 		onFlush: (b) => flushes.push(b),
 	});
-	c.add("a.ts");
-	c.add("b.ts");
-	c.add("a.ts");
+	c.add("a.ts", "none");
+	c.add("b.ts", "none");
+	c.add("a.ts", "none");
 	await waitFor(() => flushes.length > 0);
 	expect(flushes).toHaveLength(1);
-	expect(flushes[0]?.paths.toSorted()).toEqual(["a.ts", "b.ts"]);
-	expect(flushes[0]?.truncated).toBe(false);
+	expect(flushes[0]).toEqual({
+		paths: ["a.ts", "b.ts"],
+		truncated: false,
+		skillChange: "none",
+	});
 	c.dispose();
 });
 
 test("coalescer max-wait flushes under continuous churn (quiet never reached)", async () => {
-	const flushes: { paths: string[]; truncated: boolean }[] = [];
+	const flushes: CoalescedBatch[] = [];
 	const c = createCoalescer({
 		quietMs: 60,
 		maxWaitMs: 120,
@@ -54,31 +64,64 @@ test("coalescer max-wait flushes under continuous churn (quiet never reached)", 
 	// Feed an event every 20ms for ~300ms: the 60ms quiet timer keeps resetting, so only the
 	// 120ms max-wait timer can flush mid-stream.
 	for (let i = 0; i < 15; i++) {
-		c.add(`f${i}.ts`);
+		c.add(`f${i}.ts`, "none");
 		await sleep(20);
 	}
 	expect(flushes.length).toBeGreaterThanOrEqual(1);
 	c.dispose();
 });
 
-test("coalescer caps the batch (truncated) and treats a null path as wildcard", async () => {
-	const flushes: { paths: string[]; truncated: boolean }[] = [];
+test("coalescer separates generic truncation from skill evidence and keeps evidence beyond the cap", async () => {
+	const flushes: CoalescedBatch[] = [];
 	const c = createCoalescer({
 		quietMs: 20,
 		maxWaitMs: 500,
 		maxPaths: 2,
 		onFlush: (b) => flushes.push(b),
 	});
-	c.add("a.ts");
-	c.add("b.ts");
-	c.add("c.ts"); // over the cap
+	c.add("a.ts", "none");
+	c.add("b.ts", "none");
+	c.add("c.ts", "none"); // over the cap, but concretely non-skill
 	await waitFor(() => flushes.length > 0);
-	expect(flushes[0]?.paths.toSorted()).toEqual(["a.ts", "b.ts"]);
-	expect(flushes[0]?.truncated).toBe(true);
+	expect(flushes[0]).toEqual({
+		paths: ["a.ts", "b.ts"],
+		truncated: true,
+		skillChange: "none",
+	});
 
-	c.add(null); // unknown path → wildcard batch even with no paths
+	c.add("d.ts", "none");
+	c.add("e.ts", "none");
+	c.add(".claude/skills/demo/SKILL.md", "detected"); // over-cap; evidence must survive
 	await waitFor(() => flushes.length > 1);
-	expect(flushes[1]).toEqual({ paths: [], truncated: true });
+	expect(flushes[1]).toEqual({
+		paths: ["d.ts", "e.ts"],
+		truncated: true,
+		skillChange: "detected",
+	});
+
+	c.add(null, "unknown"); // unknown path → wildcard + conservative skill impact
+	await waitFor(() => flushes.length > 2);
+	expect(flushes[2]).toEqual({ paths: [], truncated: true, skillChange: "unknown" });
+	c.dispose();
+});
+
+test("coalescer does not call a duplicate retained path truncated at the cap", async () => {
+	const flushes: CoalescedBatch[] = [];
+	const c = createCoalescer({
+		quietMs: 20,
+		maxWaitMs: 500,
+		maxPaths: 2,
+		onFlush: (batch) => flushes.push(batch),
+	});
+	c.add("a.ts", "none");
+	c.add("b.ts", "none");
+	c.add("a.ts", "none");
+	await waitFor(() => flushes.length > 0);
+	expect(flushes[0]).toEqual({
+		paths: ["a.ts", "b.ts"],
+		truncated: false,
+		skillChange: "none",
+	});
 	c.dispose();
 });
 
@@ -90,7 +133,7 @@ test("coalescer dispose drops pending state without flushing", async () => {
 		maxPaths: 10,
 		onFlush: (b) => flushes.push(b),
 	});
-	c.add("a.ts");
+	c.add("a.ts", "none");
 	c.dispose();
 	await sleep(150);
 	expect(flushes).toHaveLength(0);
@@ -141,12 +184,14 @@ beforeEach(() => {
 	);
 	payloads = [];
 	setWatchPublisher((p) => payloads.push(p));
+	setSkillPathClassifier((path) => path.startsWith(".claude/skills/"));
 });
 
 afterEach(() => {
 	stopAllWatches();
 	setWatchPublisher(null);
 	setRepoMetaPublisher(null);
+	setSkillPathClassifier(null);
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
@@ -161,6 +206,29 @@ test("a watched worktree publishes a debounced fsChanged batch for a new file", 
 	expect(payloads[0]?.workspaceId).toBe("ws1");
 	expect(payloads[0]?.truncated).toBe(false);
 	expect(payloads[0]?.paths).toContain("hello.ts");
+	expect(payloads[0]?.skillChange).toBe("none");
+});
+
+test("a watched project-skill path carries detected evidence", async () => {
+	mkdirSync(join(worktree, ".claude", "skills", "demo"), { recursive: true });
+	ensureWatch("ws1");
+	await sleep(100);
+	writeFileSync(join(worktree, ".claude", "skills", "demo", "SKILL.md"), "# Demo\n");
+	await waitFor(() => payloads.some((payload) => payload.skillChange === "detected"));
+	expect(
+		payloads.some((payload) => payload.paths.some((path) => path.includes(".claude/skills"))),
+	).toBe(true);
+});
+
+test("a missing classifier degrades a concrete event to unknown", async () => {
+	setSkillPathClassifier(null);
+	ensureWatch("ws1");
+	await sleep(100);
+	writeFileSync(join(worktree, "unclassified.ts"), "export {};\n");
+	await waitFor(() => payloads.some((payload) => payload.paths.includes("unclassified.ts")));
+	expect(payloads.find((payload) => payload.paths.includes("unclassified.ts"))?.skillChange).toBe(
+		"unknown",
+	);
 });
 
 test("a .git write nudges the repo-meta sink without ever becoming an fsChanged path", async () => {
@@ -256,7 +324,9 @@ test("a fresh watcher shares readiness, publishes its wildcard first, then repor
 	await sleep(100);
 	expect(order).toEqual([]);
 	expect(await settled).toEqual({ startupNudge: true });
-	expect(payloads).toEqual([{ workspaceId: "ws1", paths: [], truncated: true }]);
+	expect(payloads).toEqual([
+		{ workspaceId: "ws1", paths: [], truncated: true, skillChange: "unknown" },
+	]);
 	expect(order).toEqual(["publish", "ready"]);
 	expect(await ensureWatch("ws1")).toEqual({ startupNudge: false });
 	await sleep(300);

--- a/packages/server/src/watch/watch.ts
+++ b/packages/server/src/watch/watch.ts
@@ -7,7 +7,11 @@
 
 import { type FSWatcher, readFileSync, statSync, watch } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
-import type { WorkspaceFsChangedPayload, WorkspaceWatchReadyResult } from "@thinkrail/contracts";
+import type {
+	WorkspaceFsChangedPayload,
+	WorkspaceSkillChange,
+	WorkspaceWatchReadyResult,
+} from "@thinkrail/contracts";
 import { loadWorkspaces } from "../persistence";
 import { type Coalescer, createCoalescer } from "./coalesce";
 
@@ -35,6 +39,7 @@ const IGNORED_NAMES = new Set([".DS_Store"]);
 const REPO_META_DEBOUNCE_MS = 300;
 
 type WatchPublisher = (payload: WorkspaceFsChangedPayload) => void;
+type SkillPathClassifier = (relativePath: string) => boolean;
 /** The repo-metadata nudge: "this workspace's git metadata moved" — no paths, it isn't file data. */
 type RepoMetaPublisher = (workspaceId: string) => void;
 
@@ -45,10 +50,19 @@ const startupFallback = Promise.resolve(STARTUP_NUDGE);
 
 let publish: WatchPublisher | null = null;
 let publishRepoMeta: RepoMetaPublisher | null = null;
+let isSkillPath: SkillPathClassifier | null = null;
 
 /** Host injects the `workspace.fsChanged` publish callback at wiring time (the tee pattern). */
 export function setWatchPublisher(publisher: WatchPublisher | null): void {
 	publish = publisher;
+}
+
+/**
+ * Install (or clear) the project-skill path classifier. `host` injects `agent`'s source-of-truth predicate
+ * so this module never imports its sibling; absent classification stays conservative rather than false-clean.
+ */
+export function setSkillPathClassifier(classifier: SkillPathClassifier | null): void {
+	isSkillPath = classifier;
 }
 
 /**
@@ -214,8 +228,8 @@ export function ensureWatch(workspaceId: string): Promise<WorkspaceWatchReadyRes
 		quietMs: QUIET_MS,
 		maxWaitMs: MAX_WAIT_MS,
 		maxPaths: MAX_PATHS,
-		onFlush: ({ paths, truncated }) => {
-			publish?.({ workspaceId, paths, truncated });
+		onFlush: ({ paths, truncated, skillChange }) => {
+			publish?.({ workspaceId, paths, truncated, skillChange });
 		},
 	});
 
@@ -228,7 +242,15 @@ export function ensureWatch(workspaceId: string): Promise<WorkspaceWatchReadyRes
 			// A wildcard (unknown path) nudges both, since it may well *be* a metadata change.
 			if (rel === null || isRepoMetaPath(rel)) scheduleRepoMeta(workspaceId, watcher);
 			if (rel !== null && isIgnoredPath(rel)) return;
-			coalescer.add(rel);
+			const skillChange: WorkspaceSkillChange =
+				rel === null
+					? "unknown"
+					: isSkillPath === null
+						? "unknown"
+						: isSkillPath(rel)
+							? "detected"
+							: "none";
+			coalescer.add(rel, skillChange);
 		});
 		// A mid-flight error (worktree root deleted externally, ENOSPC): drop the watcher — the next
 		// workspace read re-creates it if the root is back, else panels degrade to read-on-demand.
@@ -256,7 +278,7 @@ export function ensureWatch(workspaceId: string): Promise<WorkspaceWatchReadyRes
 			if (entries.get(workspaceId) !== entry) return;
 			entry.nudgeTimer = null;
 			try {
-				publish?.({ workspaceId, paths: [], truncated: true });
+				publish?.({ workspaceId, paths: [], truncated: true, skillChange: "unknown" });
 			} finally {
 				settleReady(entry);
 			}


### PR DESCRIPTION
## Summary

- Separate skill-change evidence from generic filesystem path truncation.
- Preserve detection for over-cap skill paths and conservative path-unknown events.
- Add unit and linked-worktree E2E regressions.

## Related issues

Follow-up to #207.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, plus targeted Skills `@agent` coverage)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect boundary, contract, and behavior changes
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
