### PR TITLE
fix(web): align workspace tab bars

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -46,6 +46,7 @@
 	--spacing-md: var(--space-md);
 	--spacing-lg: var(--space-lg);
 	--spacing-xl: var(--space-xl);
+	--spacing-panel-tab-strip: var(--panel-tab-strip-height);
 
 	/* A block appearing in place (e.g. the ask-question card's atomic reveal once its args are final). */
 	--animate-reveal: reveal 150ms ease-out;

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -374,7 +374,10 @@ export function CenterTabs() {
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
-			<div className="flex h-8 shrink-0 items-stretch border-border-muted border-b bg-container-workspace-bg">
+			<div
+				data-testid="center-tab-strip"
+				className="flex h-panel-tab-strip shrink-0 items-stretch border-border-muted border-b bg-container-workspace-bg"
+			>
 				<div role="tablist" className="flex flex-1 items-stretch overflow-x-auto">
 					{openTabs.map((tab) => {
 						const isActive = tab.id === activeTabId;

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -51,7 +51,10 @@ export function RightPanel() {
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
-			<div className="flex h-7 shrink-0 items-center gap-md border-b border-border-default px-sm">
+			<div
+				data-testid="right-tab-strip"
+				className="flex h-panel-tab-strip shrink-0 items-center gap-md border-b border-border-default px-sm"
+			>
 				<TabButton testid="tab-specs" active={tab === "specs"} onClick={() => setTab("specs")}>
 					Specs
 				</TabButton>

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -19,12 +19,15 @@
 	--transition-fast: 120ms ease;
 	--transition-normal: 200ms ease;
 
-	/* Spacing (only calc family — tracks --space-base) */
+	/* General spacing (one calc family — tracks --space-base) */
 	--space-xs: calc(var(--space-base) * 0.31);
 	--space-sm: calc(var(--space-base) * 0.62);
 	--space-md: calc(var(--space-base) * 0.92);
 	--space-lg: calc(var(--space-base) * 1.23);
 	--space-xl: calc(var(--space-base) * 1.85);
+
+	/* Shared chrome geometry stays independent from typography. */
+	--panel-tab-strip-height: 28px;
 }
 
 /*

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -1,11 +1,26 @@
 import { expect, test } from "@playwright/test";
-import { openFixtureProject } from "./fixtures/app";
+import { enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
 
 async function width(page: import("@playwright/test").Page, testId: string): Promise<number> {
 	const box = await page.getByTestId(testId).boundingBox();
 	if (!box) throw new Error(`no bounding box for ${testId}`);
 	return box.width;
 }
+
+test("center and right tab strips share one aligned height", async ({ page }) => {
+	await openFixtureProject(page);
+	await enterDefaultWorkspace(page);
+	await page.getByTestId("start-chat").click();
+	await expect(page.getByTestId("center-tab-strip")).toBeVisible();
+
+	const center = await page.getByTestId("center-tab-strip").boundingBox();
+	const right = await page.getByTestId("right-tab-strip").boundingBox();
+	if (!center || !right) throw new Error("tab strip has no bounding box");
+
+	expect(center.y).toBe(right.y);
+	expect(center.height).toBe(28);
+	expect(right.height).toBe(center.height);
+});
 
 test("the left|center divider is draggable and resizes the panels", async ({ page }) => {
 	await openFixtureProject(page);


### PR DESCRIPTION
## Summary
- align center and right tab strips at 28px
- drive both from one structural layout token
- add an e2e alignment regression check

## Verification
- `bun run typecheck`
- `bun run build:web`
- `bun run e2e` (190 passed)
- `bun run e2e -- e2e/layout.spec.ts` (2 passed)