### PR TITLE
fix(web): hide vertical tab-strip scrollbar

### DIFF
--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -378,7 +378,7 @@ export function CenterTabs() {
 				data-testid="center-tab-strip"
 				className="flex h-panel-tab-strip shrink-0 items-stretch border-border-muted border-b bg-container-workspace-bg"
 			>
-				<div role="tablist" className="flex flex-1 items-stretch overflow-x-auto">
+				<div role="tablist" className="flex flex-1 items-stretch overflow-x-auto overflow-y-hidden">
 					{openTabs.map((tab) => {
 						const isActive = tab.id === activeTabId;
 						const isPreview = tab.id === previewTabId;

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -7,11 +7,15 @@ async function width(page: import("@playwright/test").Page, testId: string): Pro
 	return box.width;
 }
 
-test("center and right tab strips share one aligned height", async ({ page }) => {
+test("center and right tab strips align and the center strip scrolls only horizontally", async ({
+	page,
+}) => {
 	await openFixtureProject(page);
 	await enterDefaultWorkspace(page);
 	await page.getByTestId("start-chat").click();
 	await expect(page.getByTestId("center-tab-strip")).toBeVisible();
+	await expect(page.getByRole("tablist")).toHaveCSS("overflow-x", "auto");
+	await expect(page.getByRole("tablist")).toHaveCSS("overflow-y", "hidden");
 
 	const center = await page.getByTestId("center-tab-strip").boundingBox();
 	const right = await page.getByTestId("right-tab-strip").boundingBox();


### PR DESCRIPTION
Follow-up to #213.

Hides unintended vertical overflow while preserving horizontal tab scrolling.