### PR TITLE
feat(website): add OS-aware install tabs

### DIFF
--- a/apps/website/SPEC.md
+++ b/apps/website/SPEC.md
@@ -39,8 +39,15 @@ binary.
   own CSS custom properties under `[data-theme]`; the site never reaches into `apps/web` at build time
   (the app's tokens assume the theme engine's runtime swap).
 - All marketing copy is static DOM text; JS only *enhances* (scroll-spy, terminal typing, chat
-  streaming replay, theme switcher, copy buttons, star count). The page must read complete with JS
-  disabled, and animations are skipped under `prefers-reduced-motion`.
+  streaming replay, theme switcher, copy buttons, star count, install-platform selection). The page
+  must read complete with JS disabled, and animations are skipped under `prefers-reduced-motion`.
+- The hero's install command has **macOS / Linux / Windows** tabs. Browser hints choose only the
+  initial supported desktop OS; they never hide alternatives or claim to detect an ambiguous mobile
+  platform. Windows adds **PowerShell / Command Prompt / WSL** tabs: native shells use `install.ps1`
+  (the stable command is deliberately identical in both), while WSL uses `install.sh` and therefore
+  installs the Linux build inside that distro. Every hero panel remains in the static DOM; JS turns the
+  complete fallback into the tabbed view. The detailed Install section keeps its existing complete,
+  mixed-platform reference rather than duplicating the picker.
 
 ## Analytics
 

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -322,15 +322,82 @@
 								with a real agent across Monaco tabs, terminals, and diffs — while your project's
 								intent lives in a <strong>spec graph the agent actually reads</strong>.
 							</p>
-							<div class="install-line">
-								<code
-									id="install-cmd"
-									>curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash</code
-								>
-								<button type="button" class="copy-btn" data-copy="curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash" aria-label="Copy install command">
-									<svg class="i" aria-hidden="true"><use href="#i-copy" /></svg>
-									<svg class="i i-done" aria-hidden="true"><use href="#i-check" /></svg>
-								</button>
+							<div class="install-picker install-picker-hero" data-install-picker>
+								<div class="install-tabs" role="tablist" aria-label="Choose your operating system">
+									<button type="button" class="install-tab" role="tab" id="hero-install-macos-tab" aria-controls="hero-install-macos" aria-selected="false" tabindex="-1" data-install-platform="macos">
+										macOS
+										<span class="detected-marker" data-detected-platform="macos" hidden><span class="detected-dot" aria-hidden="true"></span><span class="detected-label">detected</span></span>
+									</button>
+									<button type="button" class="install-tab" role="tab" id="hero-install-linux-tab" aria-controls="hero-install-linux" aria-selected="true" data-install-platform="linux">
+										Linux
+										<span class="detected-marker" data-detected-platform="linux" hidden><span class="detected-dot" aria-hidden="true"></span><span class="detected-label">detected</span></span>
+									</button>
+									<button type="button" class="install-tab" role="tab" id="hero-install-windows-tab" aria-controls="hero-install-windows" aria-selected="false" tabindex="-1" data-install-platform="windows">
+										Windows
+										<span class="detected-marker" data-detected-platform="windows" hidden><span class="detected-dot" aria-hidden="true"></span><span class="detected-label">detected</span></span>
+									</button>
+								</div>
+								<div class="install-panel" id="hero-install-macos" role="tabpanel" aria-labelledby="hero-install-macos-tab" data-install-panel="macos">
+									<p class="install-fallback-heading">macOS</p>
+									<div class="install-line">
+										<code>curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash</code>
+										<button type="button" class="copy-btn" data-copy="curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash" aria-label="Copy macOS install command">
+											<svg class="i" aria-hidden="true"><use href="#i-copy" /></svg>
+											<svg class="i i-done" aria-hidden="true"><use href="#i-check" /></svg>
+										</button>
+									</div>
+								</div>
+								<div class="install-panel" id="hero-install-linux" role="tabpanel" aria-labelledby="hero-install-linux-tab" data-install-panel="linux">
+									<p class="install-fallback-heading">Linux</p>
+									<div class="install-line">
+										<code>curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash</code>
+										<button type="button" class="copy-btn" data-copy="curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash" aria-label="Copy Linux install command">
+											<svg class="i" aria-hidden="true"><use href="#i-copy" /></svg>
+											<svg class="i i-done" aria-hidden="true"><use href="#i-check" /></svg>
+										</button>
+									</div>
+								</div>
+								<div class="install-panel" id="hero-install-windows" role="tabpanel" aria-labelledby="hero-install-windows-tab" data-install-panel="windows">
+									<p class="install-fallback-heading">Windows</p>
+									<div class="windows-shell-picker">
+										<div class="windows-shell-tabs" role="tablist" aria-label="Choose your Windows shell">
+											<button type="button" class="windows-shell-tab" role="tab" id="hero-shell-powershell-tab" aria-controls="hero-shell-powershell" aria-selected="true" data-windows-shell="powershell">PowerShell</button>
+											<button type="button" class="windows-shell-tab" role="tab" id="hero-shell-cmd-tab" aria-controls="hero-shell-cmd" aria-selected="false" tabindex="-1" data-windows-shell="cmd">Command Prompt</button>
+											<button type="button" class="windows-shell-tab" role="tab" id="hero-shell-wsl-tab" aria-controls="hero-shell-wsl" aria-selected="false" tabindex="-1" data-windows-shell="wsl">WSL</button>
+										</div>
+										<div class="windows-shell-panel" id="hero-shell-powershell" role="tabpanel" aria-labelledby="hero-shell-powershell-tab" data-windows-shell-panel="powershell">
+											<p class="install-fallback-heading">PowerShell</p>
+											<div class="install-line">
+												<code>powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"</code>
+												<button type="button" class="copy-btn" data-copy="powershell -c &quot;irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex&quot;" aria-label="Copy PowerShell install command">
+													<svg class="i" aria-hidden="true"><use href="#i-copy" /></svg>
+													<svg class="i i-done" aria-hidden="true"><use href="#i-check" /></svg>
+												</button>
+											</div>
+										</div>
+										<div class="windows-shell-panel" id="hero-shell-cmd" role="tabpanel" aria-labelledby="hero-shell-cmd-tab" data-windows-shell-panel="cmd">
+											<p class="install-fallback-heading">Command Prompt</p>
+											<div class="install-line">
+												<code>powershell -c "irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex"</code>
+												<button type="button" class="copy-btn" data-copy="powershell -c &quot;irm https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.ps1 | iex&quot;" aria-label="Copy Command Prompt install command">
+													<svg class="i" aria-hidden="true"><use href="#i-copy" /></svg>
+													<svg class="i i-done" aria-hidden="true"><use href="#i-check" /></svg>
+												</button>
+											</div>
+										</div>
+										<div class="windows-shell-panel" id="hero-shell-wsl" role="tabpanel" aria-labelledby="hero-shell-wsl-tab" data-windows-shell-panel="wsl">
+											<p class="install-fallback-heading">WSL</p>
+											<div class="install-line">
+												<code>curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash</code>
+												<button type="button" class="copy-btn" data-copy="curl -fsSL https://raw.githubusercontent.com/JetBrains/thinkrail/main/install.sh | bash" aria-label="Copy WSL install command">
+													<svg class="i" aria-hidden="true"><use href="#i-copy" /></svg>
+													<svg class="i i-done" aria-hidden="true"><use href="#i-check" /></svg>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+								<p class="install-detection-note" data-install-detection-note>Choose your OS. You can switch at any time.</p>
 							</div>
 							<p class="hero-platforms">
 								One self-contained binary. macOS (Apple Silicon) · Linux arm64 / x64 · Windows x64.

--- a/apps/website/src/installPlatform.test.ts
+++ b/apps/website/src/installPlatform.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { detectInstallPlatform } from "./installPlatform";
+
+describe("detectInstallPlatform", () => {
+	test("prefers the user-agent data platform", () => {
+		expect(
+			detectInstallPlatform({
+				userAgentDataPlatform: "Windows",
+				platform: "MacIntel",
+				userAgent: "Mozilla/5.0",
+			}),
+		).toBe("windows");
+	});
+
+	test.each([
+		[{ platform: "MacIntel" }, "macos"],
+		[{ platform: "Linux x86_64" }, "linux"],
+		[{ platform: "Win32" }, "windows"],
+		[{ platform: "X11" }, "linux"],
+	] as const)("maps desktop browser hints %#", (hints, expected) => {
+		expect(detectInstallPlatform(hints)).toBe(expected);
+	});
+
+	test.each([
+		{ platform: "Linux armv8l", userAgent: "Mozilla/5.0 (Linux; Android 15)" },
+		{ platform: "iPhone", userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)" },
+		{ platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh)", maxTouchPoints: 5 },
+		{ platform: "Linux x86_64", userAgent: "Mozilla/5.0 (X11; CrOS x86_64)" },
+		{ platform: "Plan9" },
+	] as const)("does not claim an unsupported or ambiguous platform %#", (hints) => {
+		expect(detectInstallPlatform(hints)).toBeUndefined();
+	});
+});

--- a/apps/website/src/installPlatform.ts
+++ b/apps/website/src/installPlatform.ts
@@ -1,0 +1,28 @@
+export type InstallPlatform = "macos" | "linux" | "windows";
+
+export interface BrowserPlatformHints {
+	userAgentDataPlatform?: string | undefined;
+	platform?: string | undefined;
+	userAgent?: string | undefined;
+	maxTouchPoints?: number | undefined;
+}
+
+/**
+ * Resolve only desktop platforms for which ThinkRail publishes an installer. Mobile and ChromeOS
+ * browsers deliberately return undefined: their user agents often contain "Mac" or "Linux", but
+ * neither can run the corresponding desktop binary.
+ */
+export function detectInstallPlatform(hints: BrowserPlatformHints): InstallPlatform | undefined {
+	const platform = hints.userAgentDataPlatform?.trim() || hints.platform?.trim() || "";
+	const userAgent = hints.userAgent ?? "";
+	const combined = `${platform} ${userAgent}`.toLowerCase();
+
+	if (/android|iphone|ipad|ipod|cros/.test(combined)) return undefined;
+	if (hints.maxTouchPoints && hints.maxTouchPoints > 1 && /mac/.test(platform.toLowerCase())) {
+		return undefined;
+	}
+	if (/win/.test(platform.toLowerCase()) || /windows/.test(combined)) return "windows";
+	if (/mac/.test(platform.toLowerCase())) return "macos";
+	if (/linux|x11/.test(platform.toLowerCase())) return "linux";
+	return undefined;
+}

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -3,6 +3,7 @@
 
 import { initAnalytics } from "./analytics";
 import { initGtm } from "./gtm";
+import { detectInstallPlatform, type InstallPlatform } from "./installPlatform";
 
 // Production-only, cookieless PostHog (self-gates on hostname). See src/analytics.ts.
 initAnalytics();
@@ -162,6 +163,156 @@ if (themeToggle) {
 			apply(getSystemTheme(), false);
 		}
 	});
+}
+
+/* ── Install platform + Windows shell pickers ───────────────────────────── */
+
+type WindowsShell = "powershell" | "cmd" | "wsl";
+
+interface NavigatorUserAgentData {
+	readonly platform?: string;
+}
+
+interface NavigatorWithUserAgentData extends Navigator {
+	readonly userAgentData?: NavigatorUserAgentData;
+}
+
+function platformFrom(value: string | undefined): InstallPlatform | undefined {
+	switch (value) {
+		case "macos":
+		case "linux":
+		case "windows":
+			return value;
+		default:
+			return undefined;
+	}
+}
+
+function windowsShellFrom(value: string | undefined): WindowsShell | undefined {
+	switch (value) {
+		case "powershell":
+		case "cmd":
+		case "wsl":
+			return value;
+		default:
+			return undefined;
+	}
+}
+
+const installPicker = document.querySelector<HTMLElement>("[data-install-picker]");
+if (installPicker) {
+	const browserNavigator: NavigatorWithUserAgentData = navigator;
+	const detectedPlatform = detectInstallPlatform({
+		userAgentDataPlatform: browserNavigator.userAgentData?.platform,
+		platform: browserNavigator.platform,
+		userAgent: browserNavigator.userAgent,
+		maxTouchPoints: browserNavigator.maxTouchPoints,
+	});
+	const platformLabel: Record<InstallPlatform, string> = {
+		macos: "macOS",
+		linux: "Linux",
+		windows: "Windows",
+	};
+
+	const platformTabs = document.querySelectorAll<HTMLButtonElement>("[data-install-platform]");
+	const platformPanels = document.querySelectorAll<HTMLElement>("[data-install-panel]");
+	const shellTabs = document.querySelectorAll<HTMLButtonElement>("[data-windows-shell]");
+	const shellPanels = document.querySelectorAll<HTMLElement>("[data-windows-shell-panel]");
+	let selectedPlatform: InstallPlatform = detectedPlatform ?? "linux";
+	const initialShell: WindowsShell = "powershell";
+
+	const updateDetectionNote = () => {
+		for (const note of document.querySelectorAll<HTMLElement>("[data-install-detection-note]")) {
+			if (selectedPlatform === "windows") {
+				note.textContent =
+					detectedPlatform === "windows"
+						? "Windows detected — choose your shell."
+						: "Choose your Windows shell.";
+			} else if (detectedPlatform) {
+				note.textContent = `Detected ${platformLabel[detectedPlatform]}. You can switch at any time.`;
+			} else {
+				note.textContent = "Choose your OS. You can switch at any time.";
+			}
+		}
+	};
+
+	const selectPlatform = (platform: InstallPlatform) => {
+		selectedPlatform = platform;
+		for (const tab of platformTabs) {
+			const selected = platformFrom(tab.dataset.installPlatform) === platform;
+			tab.setAttribute("aria-selected", String(selected));
+			tab.tabIndex = selected ? 0 : -1;
+		}
+		for (const panel of platformPanels) {
+			panel.hidden = platformFrom(panel.dataset.installPanel) !== platform;
+		}
+		updateDetectionNote();
+	};
+
+	const selectShell = (shell: WindowsShell) => {
+		for (const tab of shellTabs) {
+			const selected = windowsShellFrom(tab.dataset.windowsShell) === shell;
+			tab.setAttribute("aria-selected", String(selected));
+			tab.tabIndex = selected ? 0 : -1;
+		}
+		for (const panel of shellPanels) {
+			panel.hidden = windowsShellFrom(panel.dataset.windowsShellPanel) !== shell;
+		}
+	};
+
+	const nextTab = (
+		event: KeyboardEvent,
+		button: HTMLButtonElement,
+		selector: string,
+		activate: (button: HTMLButtonElement) => void,
+	) => {
+		if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+		const tablist = button.closest<HTMLElement>("[role=tablist]");
+		if (!tablist) return;
+		const tabs = Array.from(tablist.querySelectorAll<HTMLButtonElement>(selector));
+		const index = tabs.indexOf(button);
+		if (index < 0) return;
+
+		let nextIndex = index;
+		if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
+		if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
+		if (event.key === "Home") nextIndex = 0;
+		if (event.key === "End") nextIndex = tabs.length - 1;
+		const target = tabs[nextIndex];
+		if (!target) return;
+		event.preventDefault();
+		activate(target);
+		target.focus();
+	};
+
+	for (const tab of platformTabs) {
+		const activate = (button: HTMLButtonElement) => {
+			const platform = platformFrom(button.dataset.installPlatform);
+			if (platform) selectPlatform(platform);
+		};
+		tab.addEventListener("click", () => activate(tab));
+		tab.addEventListener("keydown", (event) =>
+			nextTab(event, tab, "[data-install-platform]", activate),
+		);
+	}
+
+	for (const tab of shellTabs) {
+		const activate = (button: HTMLButtonElement) => {
+			const shell = windowsShellFrom(button.dataset.windowsShell);
+			if (shell) selectShell(shell);
+		};
+		tab.addEventListener("click", () => activate(tab));
+		tab.addEventListener("keydown", (event) =>
+			nextTab(event, tab, "[data-windows-shell]", activate),
+		);
+	}
+
+	for (const marker of document.querySelectorAll<HTMLElement>("[data-detected-platform]")) {
+		marker.hidden = platformFrom(marker.dataset.detectedPlatform) !== detectedPlatform;
+	}
+	selectShell(initialShell);
+	selectPlatform(selectedPlatform);
+	document.documentElement.classList.add("install-tabs-ready");
 }
 
 /* ── Copy affordances ───────────────────────────────────────────────────── */

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -904,6 +904,193 @@ p.hero-lede {
 	display: none;
 }
 
+/* OS tabs attach to the command surface like editor tabs. Without JS the controls stay hidden and all
+   labelled instruction panels remain visible; main.ts adds install-tabs-ready only after wiring them. */
+.install-picker {
+	max-width: 100%;
+}
+
+.install-picker-hero {
+	margin: 26px 0 10px;
+}
+
+.install-tabs,
+.windows-shell-tabs {
+	display: none;
+}
+
+html.install-tabs-ready .install-tabs {
+	display: flex;
+	align-items: flex-end;
+	gap: 2px;
+	padding: 0 4px;
+	border-bottom: 1px solid var(--border2);
+}
+
+.install-tab {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	min-height: 34px;
+	padding: 7px 13px 8px;
+	margin-bottom: -1px;
+	border: 1px solid transparent;
+	border-bottom-color: var(--border2);
+	border-radius: 7px 7px 0 0;
+	background: transparent;
+	color: var(--hint);
+	font-family: var(--font-mono);
+	font-size: 11.5px;
+	cursor: pointer;
+}
+
+.install-tab:hover {
+	color: var(--text);
+	background: var(--hover);
+}
+
+.install-tab[aria-selected="true"] {
+	z-index: 1;
+	border-color: var(--border2);
+	border-bottom-color: var(--input);
+	background: var(--input);
+	color: var(--text);
+}
+
+.install-tab[aria-selected="true"]::before {
+	content: "";
+	position: absolute;
+	top: -1px;
+	left: 9px;
+	right: 9px;
+	height: 2px;
+	border-radius: 2px;
+	background: var(--accent);
+}
+
+.install-tab:focus-visible,
+.windows-shell-tab:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: -3px;
+}
+
+.detected-marker:not([hidden]) {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.detected-dot {
+	width: 5px;
+	height: 5px;
+	border-radius: 999px;
+	background: var(--accent);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.detected-label {
+	color: var(--accent);
+	font-size: 9px;
+	letter-spacing: 0.45px;
+	text-transform: uppercase;
+}
+
+.install-panel[hidden],
+.windows-shell-panel[hidden] {
+	display: none;
+}
+
+p.install-fallback-heading {
+	margin: 18px 2px 6px;
+	color: var(--text);
+	font-family: var(--font-mono);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+html.install-tabs-ready p.install-fallback-heading {
+	display: none;
+}
+
+.install-picker-hero .install-line {
+	margin: 8px 0 16px;
+}
+
+html.install-tabs-ready .install-picker-hero > .install-panel > .install-line {
+	margin: 0;
+	border-top: 0;
+	border-radius: 0 0 8px 8px;
+}
+
+.windows-shell-picker {
+	overflow: hidden;
+	border: 1px solid var(--border2);
+	border-radius: 8px;
+	background: var(--input);
+}
+
+html.install-tabs-ready .install-picker-hero .windows-shell-picker {
+	border-top: 0;
+	border-radius: 0 0 8px 8px;
+}
+
+html.install-tabs-ready .windows-shell-tabs {
+	display: flex;
+	gap: 5px;
+	padding: 8px 10px;
+	border-bottom: 1px solid var(--border);
+}
+
+.windows-shell-tab {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 27px;
+	padding: 5px 10px;
+	border: 1px solid var(--border2);
+	border-radius: 5px;
+	background: transparent;
+	color: var(--hint);
+	font-family: var(--font-mono);
+	font-size: 10.5px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.windows-shell-tab:hover {
+	color: var(--text);
+	background: var(--hover);
+}
+
+.windows-shell-tab[aria-selected="true"] {
+	border-color: color-mix(in srgb, var(--accent) 45%, var(--border2));
+	background: color-mix(in srgb, var(--accent) 9%, transparent);
+	color: var(--accent);
+}
+
+html.install-tabs-ready .windows-shell-picker .install-line {
+	margin: 0;
+	border: 0;
+	border-radius: 0;
+}
+
+p.install-detection-note {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	margin: 8px 2px 0;
+	color: var(--hint);
+	font-family: var(--font-mono);
+	font-size: 11px;
+	line-height: 1.4;
+}
+
+p.install-detection-note::before {
+	content: "↳";
+	color: var(--accent);
+}
+
 p.hero-platforms {
 	font-size: 12.5px;
 	color: var(--hint);
@@ -1727,6 +1914,34 @@ html.anim .terminal.armed [data-out] {
 @media (max-width: 560px) {
 	.scope {
 		display: none;
+	}
+
+	html.install-tabs-ready .install-tabs {
+		padding-inline: 0;
+	}
+
+	.install-tab {
+		flex: 1;
+		justify-content: center;
+		padding-inline: 7px;
+	}
+
+	.detected-label {
+		display: none;
+	}
+
+	html.install-tabs-ready .windows-shell-tabs {
+		padding-inline: 7px;
+	}
+
+	.windows-shell-tab {
+		flex: 1;
+		padding-inline: 5px;
+		font-size: 9.5px;
+	}
+
+	.install-picker-hero .install-line > code {
+		font-size: 11.5px;
 	}
 
 	.hero-ctas .btn {


### PR DESCRIPTION
## Summary

- replace the landing hero's Unix-only install command with macOS, Linux, and Windows tabs
- detect supported desktop platforms from browser hints while leaving every option manually selectable
- give Windows visitors explicit PowerShell, Command Prompt, and WSL choices; native shells keep the README's canonical `install.ps1` command, while WSL uses `install.sh`
- preserve the existing detailed Install section and a complete no-JavaScript fallback

## Related issues

None.

## Verification

- `bun run check:deps`
- `bun run check:seams`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `cd apps/website && bun run build`
- focused Playwright verification: Windows detection, PowerShell/Command Prompt/WSL switching, copy behavior, keyboard navigation, mobile/unknown fallback, and JavaScript-disabled rendering

The product e2e suite is not applicable to this standalone website change and does not exercise `apps/website`.

## Screenshots

Before/after desktop and mobile browser captures were reviewed interactively. I can attach the final captures here if useful.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E assessed: not applicable to the standalone website; focused browser verification passed
- [x] Relevant `SPEC.md` updated to reflect the behavior change
- [x] I have read the Contributing guide and agree to the Code of Conduct
