### PR TITLE
fix(web): align panel header rows

### DIFF
--- a/apps/web/src/chat/ChatHeader.tsx
+++ b/apps/web/src/chat/ChatHeader.tsx
@@ -21,19 +21,22 @@ export function ChatHeader({
 	skillsStale?: boolean;
 }) {
 	return (
-		<div className="flex min-h-9 shrink-0 items-center gap-md border-border-muted border-b bg-container-workspace-bg px-sm py-xs">
-			<div className="flex min-w-0 flex-1 items-center">{left}</div>
-			<div className="flex min-w-0 flex-wrap items-center justify-end gap-md">
+		<div
+			data-testid="chat-toolbar"
+			className="flex h-panel-header-row shrink-0 items-center gap-md overflow-clip border-border-muted border-b bg-container-workspace-bg px-sm"
+		>
+			<div className="flex min-w-0 flex-1 items-center overflow-clip">{left}</div>
+			<div className="flex min-w-0 items-center justify-end gap-md overflow-clip">
 				{statusEntries.map(([key, text]) => (
-					<span key={key} className="text-text-muted tr-text-metadata">
+					<span key={key} className="shrink-0 whitespace-nowrap text-text-muted tr-text-metadata">
 						{text}
 					</span>
 				))}
 				<SessionStatsBar stats={stats} />
-				{onOpenSkills ? (
-					<SkillsButton onOpen={onOpenSkills} testId="open-skills" stale={skillsStale ?? false} />
-				) : null}
 			</div>
+			{onOpenSkills ? (
+				<SkillsButton onOpen={onOpenSkills} testId="open-skills" stale={skillsStale ?? false} />
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -601,7 +601,7 @@ export default function ChatView({
 													type="button"
 													data-testid="chat-plan-toggle"
 													data-open={planOpen}
-													className="flex min-w-0 items-center gap-xs text-text-muted tr-text-metadata hover:text-text-default"
+													className="flex min-w-0 max-w-full items-center gap-xs overflow-clip whitespace-nowrap text-text-muted tr-text-metadata hover:text-text-default"
 												>
 													<ChatPlanStripContent
 														plan={plan}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -180,8 +180,10 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   directly via `thinking_level_changed`. Its rows follow the **live catalog** — `ChatView` resolves the
   session's model through `store`'s `selectCatalogModel` before passing it down, rather than reading the
   session's own snapshot, so a `model.refresh` that changes what a model supports changes the offered
-  levels with it), `SessionStatsBar`, `ChatHeader`
-  (its `left` slot carries the plan strip; its **Skills** button is the presentational **`SkillsButton`**
+  levels with it), `SessionStatsBar`, `ChatHeader` (the fixed, single-line **28px panel-header row** —
+  the same structural geometry as the center/right tab strips and the Changes toolbar; it never scrolls,
+  and constrained widths clip/truncate TODO + status/usage text while preserving the trailing Skills
+  action. Its `left` slot carries the plan strip; its **Skills** button is the presentational **`SkillsButton`**
   primitive — a `BookOpen` pill, badged when a skill dir changed on disk — also shared with
   `NewWorkspaceDialog` so the two triggers cannot drift), `ExtUiDialog`, and **`SkillsDialog`** (the **Skills manager**: a catalog
   grouped by source with **sticky section headers** — the first-party **ThinkRail** and **Pi** groups lead

--- a/apps/web/src/chat/SessionStatsBar.test.ts
+++ b/apps/web/src/chat/SessionStatsBar.test.ts
@@ -53,7 +53,7 @@ describe("SessionStatsBar pi-style formatting", () => {
 		});
 	});
 
-	it("separates fields with middle dots and lets the line wrap only between fields", () => {
+	it("separates fields with middle dots and keeps the compact header line unwrapped", () => {
 		const value = stats({
 			tokens: { input: 12_345, output: 342, cacheRead: 0, cacheWrite: 0, total: 12_687 },
 			cost: 0.125,
@@ -61,7 +61,7 @@ describe("SessionStatsBar pi-style formatting", () => {
 		});
 		const markup = renderToStaticMarkup(SessionStatsBar({ stats: value }));
 		expect(markup.replace(/<[^>]+>/g, "")).toBe("↑12k·↓342·$0.125·▰▰▰▱▱60.0%/200k");
-		expect(markup).toContain("flex-wrap");
+		expect(markup).toContain("flex-nowrap");
 		expect(markup.match(/whitespace-nowrap/g)).toHaveLength(4);
 	});
 });

--- a/apps/web/src/chat/SessionStatsBar.tsx
+++ b/apps/web/src/chat/SessionStatsBar.tsx
@@ -43,7 +43,7 @@ export function SessionStatsBar({ stats }: { stats: SessionStats | null }) {
 	return (
 		<div
 			data-testid="session-stats"
-			className="flex min-w-0 flex-wrap items-center justify-end gap-x-xs gap-y-0 text-text-muted tr-text-metadata"
+			className="flex shrink-0 flex-nowrap items-center justify-end gap-x-xs text-text-muted tr-text-metadata"
 			title="Cumulative usage: ↑ input · ↓ output · R cache read · W cache write"
 		>
 			{parts.map((part, index) => (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -46,7 +46,7 @@
 	--spacing-md: var(--space-md);
 	--spacing-lg: var(--space-lg);
 	--spacing-xl: var(--space-xl);
-	--spacing-panel-tab-strip: var(--panel-tab-strip-height);
+	--spacing-panel-header-row: var(--panel-header-row-height);
 
 	/* A block appearing in place (e.g. the ask-question card's atomic reveal once its args are final). */
 	--animate-reveal: reveal 150ms ease-out;

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -376,7 +376,7 @@ export function CenterTabs() {
 		<div className="flex h-full min-h-0 flex-col">
 			<div
 				data-testid="center-tab-strip"
-				className="flex h-panel-tab-strip shrink-0 items-stretch border-border-muted border-b bg-container-workspace-bg"
+				className="flex h-panel-header-row shrink-0 items-stretch border-border-muted border-b bg-container-workspace-bg"
 			>
 				<div role="tablist" className="flex flex-1 items-stretch overflow-x-auto overflow-y-hidden">
 					{openTabs.map((tab) => {

--- a/apps/web/src/panels/ChangesPanel.tsx
+++ b/apps/web/src/panels/ChangesPanel.tsx
@@ -185,7 +185,7 @@ export function ChangesPanel({ workspaceId }: { workspaceId: string }) {
 				// The toolbar holds the scope selector and the target-branch picker as well as the List|Tree
 				// segments, so it is named for what it is, not for the one control it used to hold.
 				aria-label="Changes scope and view"
-				className="flex h-8 shrink-0 items-center gap-xs border-border-default border-b bg-container-header-bg px-sm"
+				className="flex h-panel-header-row shrink-0 items-center gap-xs overflow-clip border-border-default border-b bg-container-header-bg px-sm"
 			>
 				<div className="mr-auto flex min-w-0 items-center gap-xs">
 					{/* Keyed ON PURPOSE (do not "clean up") by the menu's full identity — workspace **and** target ref:

--- a/apps/web/src/panels/RightPanel.tsx
+++ b/apps/web/src/panels/RightPanel.tsx
@@ -53,7 +53,7 @@ export function RightPanel() {
 		<div className="flex h-full min-h-0 flex-col">
 			<div
 				data-testid="right-tab-strip"
-				className="flex h-panel-tab-strip shrink-0 items-center gap-md border-b border-border-default px-sm"
+				className="flex h-panel-header-row shrink-0 items-center gap-md border-b border-border-default px-sm"
 			>
 				<TabButton testid="tab-specs" active={tab === "specs"} onClick={() => setTab("specs")}>
 					Specs

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -90,8 +90,9 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   screen comes back too. **Only `terminal.close`, from the user closing a tab, kills a PTY** — and it refuses
   a shell with child processes until a `ConfirmDialog` is accepted. Also
   `FileTree`, `SpecsPanel`, `RightPanel`,
-  `ChangesPanel` (the changed files under a header that says **what** is being diffed — the
-  **`ChangesScopeMenu`** scope pill + the shared **`BranchPicker`** target-branch pill — plus the
+  `ChangesPanel` (the changed files under a fixed **28px panel-header row** — shared structural geometry
+  with the center/right tab strips and chat header — that says **what** is being diffed via the
+  **`ChangesScopeMenu`** scope pill + the shared **`BranchPicker`** target-branch pill, plus the
   **List | Tree** toggle (`store.changesView`, app-wide) switching a flat list and a folder
   **`ChangesTree`**; clicking a file in either opens/focuses its **center Monaco diff tab**, and every file
   row carries the shared **`ChangeRowActions`** menu),

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -27,7 +27,7 @@
 	--space-xl: calc(var(--space-base) * 1.85);
 
 	/* Shared chrome geometry stays independent from typography. */
-	--panel-tab-strip-height: 28px;
+	--panel-header-row-height: 28px;
 }
 
 /*

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -7,9 +7,7 @@ async function width(page: import("@playwright/test").Page, testId: string): Pro
 	return box.width;
 }
 
-test("center and right tab strips align and the center strip scrolls only horizontally", async ({
-	page,
-}) => {
+test("panel header rows align without making the chat toolbar scrollable", async ({ page }) => {
 	await openFixtureProject(page);
 	await enterDefaultWorkspace(page);
 	await page.getByTestId("start-chat").click();
@@ -24,6 +22,21 @@ test("center and right tab strips align and the center strip scrolls only horizo
 	expect(center.y).toBe(right.y);
 	expect(center.height).toBe(28);
 	expect(right.height).toBe(center.height);
+
+	await page.getByTestId("tab-changes").click();
+	const chat = page.getByTestId("chat-toolbar");
+	const changes = page.getByTestId("changes-view-toggle");
+	await expect(chat).toHaveCSS("overflow-x", "clip");
+	await expect(chat).toHaveCSS("overflow-y", "clip");
+	await expect(page.getByTestId("open-skills")).toBeVisible();
+
+	const chatBox = await chat.boundingBox();
+	const changesBox = await changes.boundingBox();
+	if (!chatBox || !changesBox) throw new Error("panel toolbar has no bounding box");
+
+	expect(chatBox.y).toBe(changesBox.y);
+	expect(chatBox.height).toBe(28);
+	expect(changesBox.height).toBe(chatBox.height);
 });
 
 test("the left|center divider is draggable and resizes the panels", async ({ page }) => {


### PR DESCRIPTION
## Summary
- share one 28px height across panel header rows
- keep the chat TODO/status/Skills row single-line and non-scrollable
- add alignment and overflow regression coverage

## Verification
- `bun run test`
- `bun run e2e` (191 passed)
- `bun run check:deps && bun run check:seams && bun run lint && bun run typecheck`