### PR TITLE
Fix terminal replay injecting input

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -918,7 +918,10 @@ a project picker, the prompt hero, and the reused
   re-measure, non-Latin glyphs render into cells sized for the fallback font and the PTY holds the wrong
   cols/rows; the panel drives `relayout()` itself so it knows when to re-`fit()`. Its pre-bind output buffer is
   a bounded waiting state: successful bind filters it to the adopted PTY, while permanent creation failure
-  clears it and stops accepting page-wide terminal frames. PTY sizing distinguishes desired, in-flight, and
+  clears it and stops accepting page-wide terminal frames. **Historical replay is input-inert:** the PTY id
+  remains unadopted until xterm's replay callback, which rechecks attach freshness before binding and draining
+  genuinely live frames; replies xterm synthesizes for recorded terminal queries can therefore never enter the
+  live shell. PTY sizing distinguishes desired, in-flight, and
   host-acknowledged grids; only a successful `terminal.resize` advances the acknowledgement, so reconnect
   replay cannot leave a full-screen app permanently sized to a request the host never applied.
 - Heavy deps (Monaco / shiki / xterm) load via `React.lazy(() => import())` to stay out of the eager bundle.

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -348,41 +348,49 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 					if (disposed) return;
 					// Someone took the tab over while this was in flight, so this answer is already stale. A newer
 					// attempt owns `prebind` by now; only this attempt's own buffer is ours to retire.
-					if (attachGeneration !== startedAt) {
+					if (attachGeneration !== startedAt || prebind !== attemptPrebind) {
 						attemptPrebind.stop();
 						return;
 					}
-					sizeSync.acknowledge(spawnedAt);
-					// Repaint what this shell last showed before live frames resume: a remount is a fresh xterm
-					// buffer, so without this a surviving shell comes back behind a blank screen and looks dead.
-					// After a host restart this is the revived tab's picture, over a genuinely new shell.
-					if (replay) term.write(replay);
-					serverIdRef.current = id;
-					const buffered = attemptPrebind.bind(id);
-					if (buffered.truncated) writeTruncation();
-					for (const ev of buffered.frames) writeFrame(ev);
-					// The host now knows this tab, so it is no longer exempt from an authoritative list.
-					useAppStore.getState().settleTerminalAttach(workspaceId, tabKey);
-					setDetached(false);
-					setExited(false);
-					setReady(true);
-					// A very short-lived shell can send its addressed exit before the response names its id.
-					// Paint buffered data first, then apply that matching exit exactly as a live subscription would.
-					if (buffered.exit) handleExit(buffered.exit);
-					// Catch up if the grid moved while we were waiting; a no-op when it didn't.
-					applyFit();
-					if (created && serverIdRef.current === id && initialCommandRef.current) {
-						sendTerminalWrite(
-							getTransport().request("terminal.write", {
-								id,
-								data: `${initialCommandRef.current}\r`,
-							}),
-						);
-						// Spend it: `created` is also true when a tab's previous shell exited and this attach spawned
-						// a replacement, so gating on that alone would reopen vim on every revisit.
-						initialCommandRef.current = undefined;
-						useAppStore.getState().consumeTerminalInitialCommand(workspaceId, tabKey);
-					}
+					const finishAttach = (): void => {
+						// Parsing the replay is asynchronous. A takeover or newer attempt can land while it is queued,
+						// so adoption needs the same freshness check at the point the PTY becomes writable.
+						if (disposed || attachGeneration !== startedAt || prebind !== attemptPrebind) {
+							attemptPrebind.stop();
+							return;
+						}
+						sizeSync.acknowledge(spawnedAt);
+						serverIdRef.current = id;
+						const buffered = attemptPrebind.bind(id);
+						if (buffered.truncated) writeTruncation();
+						for (const ev of buffered.frames) writeFrame(ev);
+						// The host now knows this tab, so it is no longer exempt from an authoritative list.
+						useAppStore.getState().settleTerminalAttach(workspaceId, tabKey);
+						setDetached(false);
+						setExited(false);
+						setReady(true);
+						// A very short-lived shell can send its addressed exit before the response names its id.
+						// Paint buffered data first, then apply that matching exit exactly as a live subscription would.
+						if (buffered.exit) handleExit(buffered.exit);
+						// Catch up if the grid moved while we were waiting; a no-op when it didn't.
+						applyFit();
+						if (created && serverIdRef.current === id && initialCommandRef.current) {
+							sendTerminalWrite(
+								getTransport().request("terminal.write", {
+									id,
+									data: `${initialCommandRef.current}\r`,
+								}),
+							);
+							// Spend it: `created` is also true when a tab's previous shell exited and this attach spawned
+							// a replacement, so gating on that alone would reopen vim on every revisit.
+							initialCommandRef.current = undefined;
+							useAppStore.getState().consumeTerminalInitialCommand(workspaceId, tabKey);
+						}
+					};
+					// Repaint before the PTY id becomes writable. Queries in historical output must not be answered
+					// into the live shell; genuinely live frames stay in `attemptPrebind` until this parse completes.
+					if (replay) term.write(replay, finishAttach);
+					else finishAttach();
 				})
 				.catch(() => {
 					if (disposed) return;

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -10,6 +10,15 @@ import {
 	worktreeRows,
 } from "./fixtures/app";
 
+const ESC = "\u001b";
+const CURSOR_POSITION_REPLY = new RegExp(`^${ESC}\\[\\d+;\\d+R$`);
+const CURSOR_POSITION_QUERY_COMMAND = [
+	'python3 -c "import os,select,termios,tty;',
+	"old=termios.tcgetattr(0); tty.setraw(0); os.write(1,b'\\x1b[6n');",
+	"ready=select.select([0],[],[],2)[0]; reply=os.read(0,64) if ready else b'NO_REPLY';",
+	"termios.tcsetattr(0,termios.TCSADRAIN,old); print('TR_DSR_CONSUMED='+repr(reply))\"",
+].join(" ");
+
 test("a workspace opens a terminal automatically, rooted in the worktree, with working I/O", async ({
 	page,
 }) => {
@@ -134,6 +143,47 @@ test("a shell survives a trip to Project Home and back", async ({ page }) => {
 	// And it is genuinely the same process, not a repainted picture of a dead one.
 	await runInTerminal(page, 'echo "AGAIN=$TR_SURVIVOR"');
 	await expect(visibleTerminalScreen(page)).toContainText("AGAIN=alive");
+});
+
+test("historical terminal queries do not become input on remount", async ({ page }) => {
+	const writes: string[] = [];
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const text = message.toString();
+			try {
+				const frame = JSON.parse(text) as {
+					method?: string;
+					params?: { data?: string };
+				};
+				if (frame.method === "terminal.write" && frame.params?.data) writes.push(frame.params.data);
+			} catch {
+				// Forward non-JSON frames unchanged.
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+
+	// The application consumes this live answer; only the historical query remains in the recording.
+	await runInTerminal(page, CURSOR_POSITION_QUERY_COMMAND);
+	await expect(visibleTerminalScreen(page)).toContainText("TR_DSR_CONSUMED");
+	await expect.poll(() => writes.some((data) => CURSOR_POSITION_REPLY.test(data))).toBe(true);
+	writes.length = 0;
+
+	await page.getByTestId("project-item").first().click();
+	await worktreeRows(page).first().getByRole("button").first().click();
+	await waitTerminalReady(page);
+	await expect(visibleTerminalScreen(page)).toContainText("TR_DSR_CONSUMED");
+	expect(writes.filter((data) => CURSOR_POSITION_REPLY.test(data))).toEqual([]);
+
+	// Gating ends with replay: a genuinely live query still round-trips.
+	await runInTerminal(page, CURSOR_POSITION_QUERY_COMMAND);
+	await expect.poll(() => writes.some((data) => CURSOR_POSITION_REPLY.test(data))).toBe(true);
 });
 
 // The race the attach redesign exists for. Leaving and re-entering faster than one round trip used to find an


### PR DESCRIPTION
## Summary

Prevent historical terminal queries from writing replies into the live PTY during remount. Keep live frames buffered until replay completes and add a CPR regression test.

## Related issues

None.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes: `bun run e2e`
- [x] Relevant `SPEC.md` updated
- [x] Contributing guide and Code of Conduct reviewed
