### PR TITLE
fix(terminal): use login shells on macOS

### DIFF
--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -29,6 +29,9 @@ tabs**. A tab's shell outlives every client that looks at it.
 
 ## Decisions
 
+- **macOS PTYs start the user's shell in login mode (`-l`)** to match Terminal.app and the platform's
+  terminal convention; other platforms keep a plain interactive shell. The PTY itself supplies
+  interactivity, so no explicit `-i` is needed.
 - **A shell is keyed by `(workspaceId, tabKey)`**, never by a socket, a client, or a component. `tabKey` is
   durable and client-supplied; PTY ids are per-run and **never persisted** (attaching to an id that outlived
   its process is Theia's `Couldn't attach - can't find terminal with id`).

--- a/packages/server/src/terminal/shellArgs.test.ts
+++ b/packages/server/src/terminal/shellArgs.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { terminalShellArgs } from "./shellArgs";
+
+test("macOS terminals start login shells", () => {
+	expect(terminalShellArgs("darwin")).toEqual(["-l"]);
+});
+
+test("other platforms keep non-login shells", () => {
+	expect(terminalShellArgs("linux")).toEqual([]);
+	expect(terminalShellArgs("win32")).toEqual([]);
+});

--- a/packages/server/src/terminal/shellArgs.ts
+++ b/packages/server/src/terminal/shellArgs.ts
@@ -1,0 +1,4 @@
+/** Shell arguments matching each platform's terminal convention. */
+export function terminalShellArgs(platform: string): string[] {
+	return platform === "darwin" ? ["-l"] : [];
+}

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -21,6 +21,7 @@ import {
 	type TerminalDeliveryResult,
 } from "./outputBatcher";
 import { createOutputRecorder, type OutputRecorder } from "./outputRecorder";
+import { terminalShellArgs } from "./shellArgs";
 import { hasChildProcesses } from "./shellBusy";
 
 /** Push one addressed frame and report whether it was accepted and whether another may follow. */
@@ -186,7 +187,7 @@ function spawnForTab(
 	if (!ws) throw new Error(`Unknown workspace: ${workspaceId}`);
 
 	const shell = process.env.SHELL ?? "/bin/bash";
-	const pty = spawn(shell, [], {
+	const pty = spawn(shell, terminalShellArgs(process.platform), {
 		name: "xterm-256color",
 		cwd: ws.worktreePath,
 		cols: size.cols ?? DEFAULT_PTY_SIZE.cols,


### PR DESCRIPTION
Unlike other Unix-based systems, macOS uses all shells as login by default.

## Summary
- start macOS PTY shells with `-l` to match platform terminal behavior
- keep non-macOS shell startup unchanged
- cover platform argument selection with unit tests

## Verification
- `bun run check:deps`
- `bun run check:seams`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- e2e not run locally, as requested