### PR TITLE
Show open PR or MR in workspace header

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -56,7 +56,7 @@ screen, not a blank root).
 
 ### Dependency graph
 
-- `shell` → `panels`, `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`, `themes` (the single owner of the atomic `applyTheme` DOM effect, driven by `store.theme`)
+- `shell` → `panels`, `store`, `transport`, `contracts` (type-only), `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`, `themes` (the single owner of the atomic `applyTheme` DOM effect, driven by `store.theme`)
 - `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` — `CenterTabs`'s per-tab boundary), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`CenterTabs` lazy-mounts `chat/ChatView`; `NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector`+`useModelCatalog` — these are shiki-free, so the eager import stays split-safe; `TemplatesSettings` reuses `chat/TemplateEditorDialog` for its New/Edit flows — see `panels/SPEC.md`'s `TemplatesSettings` paragraph), `auth` (`ProvidersSettings` mounts `auth/LoginDialog`), `themes` (`AppearanceSettings` consumes the live catalog; code surfaces consume generic theme variables/syntax mapping)
 - `chat` → `contracts` (pi message types, **type-only**), `components/ui`, `lib`; `store` + `transport`
   (**app-integration files only** — the renderers stay store-free; see `chat/SPEC.md` for the current set)

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -21,7 +21,7 @@ later, the mobile single-view-with-switcher).
   `store.openSettings()` — open state lives in the store, not local, so other surfaces (the Welcome
   provider warning) can open it too) over a body that branches on whether a workspace is active. The
   location context makes scope persistent rather than rail-dependent: an **active workspace** renders two
-  lines — `project / workspace display name`, then the git `branch · from baseBranch` metadata line
+  lines — `project / workspace display name`, then the git `branch · from baseBranch` metadata line with an optional plain ` · PR #N` (GitHub) or ` · MR !N` (GitLab) suffix
   (proportional `tr-text-metadata text-text-subtle` per [[web-typography]]); a selected
   project with no active workspace renders `project / Project home`; no project leaves the logo alone.
   It follows the existing workspace lifecycle snapshots, so auto-renames update live. Responsive
@@ -42,7 +42,7 @@ later, the mobile single-view-with-switcher).
   "Global chords" below.
 - **Public surface:** `Shell`.
 - **Allowed deps:** `panels`, `store` (status + theme + project/workspace context + the active-chat
-  selector and `requestHistoryOpen`), `transport` (`ConnectionStatus` type), `components/ui`
+  selector and `requestHistoryOpen`), `transport`, `contracts` (types only), `components/ui`
   (resizable), `components/ErrorBoundary`, `constants` (branding), `themes` (`applyTheme`/`writeThemeHint`).
 - **Forbidden:** `server`/`shared`/`pi`; being imported by `panels`/`store`/`transport`.
 

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -19,6 +19,7 @@ import { applyTheme, writeThemeHint } from "../themes";
 import type { ConnectionStatus } from "../transport";
 import { BrandLogo } from "./BrandLogo";
 import { useGlobalHotkeys } from "./useGlobalHotkeys";
+import { openReviewLabel, useOpenBranchReview } from "./useOpenBranchReview";
 
 const STATUS_LABEL: Record<ConnectionStatus, string> = {
 	connected: "Connected",
@@ -37,6 +38,7 @@ export function Shell() {
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 	const activeWorkspace = useAppStore(selectActiveWorkspace);
 	const contextProject = useAppStore(selectContextProject);
+	const openReview = useOpenBranchReview(activeWorkspace, status);
 	const hasActiveWorkspace = activeWorkspaceId != null;
 	// The single owner of the theme DOM side-effect: apply the store's (host-owned) theme + cache it as the
 	// next load's first-paint hint. The store is fed by transport (welcome / settings.changed).
@@ -85,6 +87,15 @@ export function Shell() {
 											· from {activeWorkspace.baseBranch}
 										</span>
 									)}
+									{openReview ? (
+										<span
+											data-testid="scope-review"
+											data-kind={openReview.kind}
+											className="shrink-0"
+										>
+											· {openReviewLabel(openReview)}
+										</span>
+									) : null}
 								</div>
 							) : null}
 						</div>

--- a/apps/web/src/shell/useOpenBranchReview.test.ts
+++ b/apps/web/src/shell/useOpenBranchReview.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test";
+import { openReviewLabel } from "./useOpenBranchReview";
+
+test("formats provider-native review references", () => {
+	expect(openReviewLabel({ kind: "pull-request", number: 214 })).toBe("PR #214");
+	expect(openReviewLabel({ kind: "merge-request", number: 73 })).toBe("MR !73");
+});

--- a/apps/web/src/shell/useOpenBranchReview.ts
+++ b/apps/web/src/shell/useOpenBranchReview.ts
@@ -1,0 +1,48 @@
+import type { OpenBranchReview, Workspace } from "@thinkrail/contracts";
+import { useEffect, useRef, useState } from "react";
+import { type ConnectionStatus, getTransport } from "../transport";
+
+type LoadedReview = { key: string; review: OpenBranchReview | null };
+
+/** Read ephemeral open-review metadata only for the workspace currently shown in the shell. */
+export function useOpenBranchReview(
+	workspace: Workspace | null,
+	status: ConnectionStatus,
+): OpenBranchReview | null {
+	const workspaceId = workspace?.id ?? null;
+	const key = workspace ? `${workspace.id}\0${workspace.branch}` : null;
+	const [loaded, setLoaded] = useState<LoadedReview | null>(null);
+	const requestToken = useRef(0);
+
+	useEffect(() => {
+		requestToken.current += 1;
+		if (!workspaceId || !key || status !== "connected") return;
+
+		const load = () => {
+			const token = ++requestToken.current;
+			void getTransport()
+				.request("workspace.openReview", { workspaceId })
+				.then(
+					(review) => {
+						if (requestToken.current === token) setLoaded({ key, review });
+					},
+					() => {
+						if (requestToken.current === token) setLoaded({ key, review: null });
+					},
+				);
+		};
+
+		load();
+		window.addEventListener("focus", load);
+		return () => {
+			requestToken.current += 1;
+			window.removeEventListener("focus", load);
+		};
+	}, [key, status, workspaceId]);
+
+	return status === "connected" && loaded?.key === key ? loaded.review : null;
+}
+
+export function openReviewLabel(review: OpenBranchReview): string {
+	return review.kind === "pull-request" ? `PR #${review.number}` : `MR !${review.number}`;
+}

--- a/architecture.md
+++ b/architecture.md
@@ -66,7 +66,7 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    worktree model; and an **existing worktree** the user explicitly attaches in place
    (`kind: "external"`), which ThinkRail may forget but never mutates (see
    [[submodule-server-workspaces]]). The shell is built first,
-   `pi` connected last. Provider-backed PR / Checks stay V2; workspace-local Review is V1.
+   `pi` connected last. Provider-backed PR / Checks stay V2 beyond a best-effort open GitHub PR or GitLab MR number in active-workspace metadata; workspace-local Review is V1.
 7. **Auth is external.** Tailscale ACLs / device identity are the auth; the app carries an `owner` field,
    not a login UI.
 8. **Hydrate-then-stream (every client reconstructs from the host).** A client never relies on having

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -54,7 +54,7 @@ V1 is explicitly **not**: the workflow **product layer** (a runtime/engine, conf
 the skill-based workflow *system*, skills + an always-on rule with no runtime machinery, ships as the
 bundled `pi-thinkrail-workflow` extension); the spec-graph **product layer** beyond the read-only viewer
 (drift detection, pre-build approval, living graph — the pi-side spec capability ships as the bundled
-extension above); PR / Checks, self-improvement, automations, per-step model routing, cost ledger.
+extension above); PR / Checks beyond the active workspace's optional open GitHub PR / GitLab MR number, self-improvement, automations, per-step model routing, cost ledger.
 
 ## V2 — the product
 

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -116,6 +116,7 @@ of the host.
   non-removable and non-renamable server-side; **`kind: "external"`** marks an explicitly attached,
   user-owned worktree ThinkRail may forget but must never rename or reclaim; absent = a ThinkRail-managed
   worktree workspace — an explicit wire field, never an id convention),
+  **`OpenBranchReview`** (the optional open review reference for the active branch: PR vs MR + number; no status/actions),
   **`ExistingWorktreeCandidate`** (a `workspace.listExisting` row: absolute `path` + `branch`, or a
   `detached` row the chooser disables), `Session` (chat tab),
   `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types — incl. **`GitDiffScope`** (what the Changes
@@ -217,6 +218,7 @@ of the host.
   **`workspace.listExisting`** (the selected project's unattached Git worktrees, with detached rows
   disabled by status) / **`workspace.openExisting`** (revalidate + register one branch-backed checkout as
   `kind: "external"`, emitting the ordinary `workspace.created`, without mutating Git or disk) /
+  **`workspace.openReview`** (the active branch's optional `OpenBranchReview` metadata) /
   **`project.setTrust`** (persist a project's trust grant → the updated `Project`; gates its committed
   cross-agent skill aliases) /
   **`skill.list`** (a pre-session, skill-only `SlashCommandInfo[]` preview for a `projectId`, resolved from

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -105,6 +105,12 @@ export interface Workspace {
 	skillOverrides?: Record<string, "on" | "off">;
 }
 
+/** Minimal open code-review metadata for the active workspace branch. */
+export interface OpenBranchReview {
+	kind: "pull-request" | "merge-request";
+	number: number;
+}
+
 /** One unattached checkout from `git worktree list`, shown in the existing-worktree chooser. */
 export type ExistingWorktreeCandidate =
 	| { path: string; branch: string; status: "available" }

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -15,6 +15,7 @@ import type {
 	HistorySearchResult,
 	JbcentralConnectResult,
 	LoginReply,
+	OpenBranchReview,
 	Project,
 	ProjectPathStatus,
 	ProviderStatusReport,
@@ -209,7 +210,8 @@ export interface TerminalTabsPush {
 // no longer restore the removed chat.
 // v36: `review.close` atomically archives non-draft records and publishes the fresh open snapshot; clients
 // no longer follow it with an initiating-only `review.get` fold.
-export const PROTOCOL_VERSION = 36;
+// v37: `workspace.openReview` returns the active branch's optional GitHub PR / GitLab MR number.
+export const PROTOCOL_VERSION = 37;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -273,6 +275,7 @@ export const WS_METHODS = {
 	workspaceListExisting: "workspace.listExisting",
 	workspaceOpenExisting: "workspace.openExisting",
 	workspaceList: "workspace.list",
+	workspaceOpenReview: "workspace.openReview",
 	workspaceRemove: "workspace.remove",
 	workspaceDiffStats: "workspace.diffStats",
 	// Per-workspace per-skill enable/disable override (over the project baseline).
@@ -567,6 +570,10 @@ export interface WsMethodMap {
 		result: Workspace;
 	};
 	"workspace.list": { params: { projectId: string }; result: Workspace[] };
+	"workspace.openReview": {
+		params: { workspaceId: string };
+		result: OpenBranchReview | null;
+	};
 	"workspace.remove": { params: { id: string }; result: Ack };
 	"workspace.diffStats": { params: { id: string }; result: DiffStats };
 	// Per-workspace per-skill override over the project baseline; `null` clears it. Echoes the `Workspace`.

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -52,6 +52,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | `workspaces` | workspaces = `git worktree`s on their own branch | [workspaces/SPEC.md](src/workspaces/SPEC.md) |
 | `git` | the `git(cwd, args)` runner + worktree status/diff vs base + branch list | [git/SPEC.md](src/git/SPEC.md) |
 | `github` | read-only local `gh` auth status (shell-out) for the New-Workspace surface | [github/SPEC.md](src/github/SPEC.md) |
+| `branch-review` | best-effort open GitHub PR / GitLab MR number for a workspace branch | [branch-review/SPEC.md](src/branch-review/SPEC.md) |
 | `fs` | read dirs/files inside a worktree (path-contained) | [fs/SPEC.md](src/fs/SPEC.md) |
 | `spec` | the worktree's spec-graph snapshot (`spec.graph`) + project-level `projectHasSpecs`, via `pi-spec-graph/core` | [spec/SPEC.md](src/spec/SPEC.md) |
 | `todos` | a chat's per-session TODO plan read/write (`todo.*`), via `pi-todos/core` | [todos/SPEC.md](src/todos/SPEC.md) |
@@ -74,8 +75,9 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `fs`, `spec`, `todos`, `reviews`, `watch`, `terminal`, `dialog`, `editors`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`, `analytics`
+- `host` → `projects`, `workspaces`, `git`, `github`, `branch-review`, `fs`, `spec`, `todos`, `reviews`, `watch`, `terminal`, `dialog`, `editors`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`, `analytics`
 - `workspaces` → `projects`, `git`, `persistence`
+- `branch-review` → `git`
 - `projects` → `git` (shared runner), `persistence`
 - `git`, `fs`, `spec`, `watch`, `terminal`, `settings`, `analytics` → `persistence` (`spec` also → `pi-spec-graph/core`, external; `analytics` also → the pi-ai built-in provider/model catalog + `posthog-node`, external — the identity-bucketing vocabulary and the delivery SDK)
 - `todos` → `workspaces` (worktree path lookup) + `pi-todos/core` (external, value-imported, pi-free)

--- a/packages/server/src/branch-review/SPEC.md
+++ b/packages/server/src/branch-review/SPEC.md
@@ -1,0 +1,22 @@
+---
+id: submodule-server-branch-review
+type: submodule-design
+status: active
+title: branch-review — open PR/MR metadata
+parent: module-server
+depends-on: [module-contracts]
+implements: [task-branch-pr-awareness]
+tags: [github, gitlab, pull-request]
+---
+
+## Responsibility
+
+Best-effort lookup of the open code review associated with a workspace branch: GitHub.com PR via the local `gh` CLI or GitLab.com MR via `glab`.
+
+## Boundary
+
+- **Owns:** remote-host detection and bounded, asynchronous CLI lookup returning an `OpenBranchReview` or `null`.
+- **Public surface:** `findOpenBranchReview(cwd, branch)`.
+- **Allowed deps:** `contracts` for the result type; the server `git` barrel for local remote inspection; Bun/Node process APIs.
+- **Forbidden:** `host`, `workspaces`, browser code, persistence, or any PR/review action beyond this read.
+- Missing CLI/authentication, unsupported remotes, timeouts, malformed output, and no open review all degrade to `null`.

--- a/packages/server/src/branch-review/branchReview.test.ts
+++ b/packages/server/src/branch-review/branchReview.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	detectReviewProvider,
+	findOpenBranchReviewWithRunner,
+	providerFromRemoteUrl,
+	reviewNumber,
+} from "./branchReview";
+
+const dirs: string[] = [];
+afterEach(() => {
+	for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function repo(remote: string): string {
+	const cwd = mkdtempSync(join(tmpdir(), "thinkrail-branch-review-"));
+	dirs.push(cwd);
+	for (const args of [
+		["init", "-q", "-b", "feature"],
+		["remote", "add", "origin", remote],
+	]) {
+		const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stderr: "pipe" });
+		if (!result.success) throw new Error(new TextDecoder().decode(result.stderr));
+	}
+	return cwd;
+}
+
+test("recognizes hosted GitHub and GitLab remote URL forms only", () => {
+	expect(providerFromRemoteUrl("https://github.com/acme/app.git")).toBe("github");
+	expect(providerFromRemoteUrl("git@github.com:acme/app.git")).toBe("github");
+	expect(providerFromRemoteUrl("ssh://git@gitlab.com/acme/app.git")).toBe("gitlab");
+	expect(providerFromRemoteUrl("git@gitlab.internal:acme/app.git")).toBeNull();
+	expect(providerFromRemoteUrl("/tmp/app.git")).toBeNull();
+});
+
+test("prefers the branch push remote", () => {
+	const cwd = repo("https://github.com/acme/app.git");
+	Bun.spawnSync(["git", "-C", cwd, "remote", "add", "mirror", "https://gitlab.com/acme/app.git"]);
+	Bun.spawnSync(["git", "-C", cwd, "config", "branch.feature.pushRemote", "mirror"]);
+	expect(detectReviewProvider(cwd, "feature")).toBe("gitlab");
+});
+
+test("queries an open GitHub PR for the explicit branch", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	let command: string[] = [];
+	const review = await findOpenBranchReviewWithRunner(cwd, "feature", async (_cwd, args) => {
+		command = args;
+		return { ok: true, out: '[{"number":214}]' };
+	});
+
+	expect(command).toEqual([
+		"gh",
+		"pr",
+		"list",
+		"--head",
+		"feature",
+		"--state",
+		"open",
+		"--json",
+		"number",
+		"--limit",
+		"1",
+	]);
+	expect(review).toEqual({ kind: "pull-request", number: 214 });
+});
+
+test("queries an open GitLab MR for the explicit branch", async () => {
+	const cwd = repo("https://gitlab.com/acme/app.git");
+	let command: string[] = [];
+	const review = await findOpenBranchReviewWithRunner(cwd, "feature", async (_cwd, args) => {
+		command = args;
+		return { ok: true, out: '[{"iid":73}]' };
+	});
+
+	expect(command).toEqual([
+		"glab",
+		"mr",
+		"list",
+		"--source-branch",
+		"feature",
+		"--output",
+		"json",
+		"--per-page",
+		"1",
+	]);
+	expect(review).toEqual({ kind: "merge-request", number: 73 });
+});
+
+test("unavailable and malformed lookup results degrade to no review", async () => {
+	const cwd = repo("https://github.com/acme/app.git");
+	expect(
+		await findOpenBranchReviewWithRunner(cwd, "feature", async () => ({ ok: false, out: "" })),
+	).toBeNull();
+	expect(
+		await findOpenBranchReviewWithRunner(cwd, "feature", async () => ({
+			ok: true,
+			out: "not json",
+		})),
+	).toBeNull();
+	expect(reviewNumber("[]", "number")).toBeNull();
+	expect(reviewNumber('[{"number":0}]', "number")).toBeNull();
+});

--- a/packages/server/src/branch-review/branchReview.ts
+++ b/packages/server/src/branch-review/branchReview.ts
@@ -1,0 +1,137 @@
+import type { OpenBranchReview } from "@thinkrail/contracts";
+import { git } from "../git";
+
+const LOOKUP_TIMEOUT_MS = 8_000;
+
+type ReviewProvider = "github" | "gitlab";
+type CommandResult = { ok: boolean; out: string };
+type CommandRunner = (cwd: string, command: string[]) => Promise<CommandResult>;
+
+/** Resolve the first supported push/fetch remote, preferring the branch's configured remote and origin. */
+export function detectReviewProvider(cwd: string, branch: string): ReviewProvider | null {
+	const configured = [
+		git(cwd, ["config", "--get", `branch.${branch}.pushRemote`]).out,
+		git(cwd, ["config", "--get", "remote.pushDefault"]).out,
+		git(cwd, ["config", "--get", `branch.${branch}.remote`]).out,
+	];
+	const listed = git(cwd, ["remote"]);
+	const names = [
+		...new Set([...configured, "origin", ...(listed.ok ? listed.out.split("\n") : [])]),
+	];
+
+	for (const name of names) {
+		if (!name || name === ".") continue;
+		for (const args of [
+			["remote", "get-url", "--push", name],
+			["remote", "get-url", name],
+		]) {
+			const remote = git(cwd, args);
+			if (!remote.ok) continue;
+			const provider = providerFromRemoteUrl(remote.out);
+			if (provider) return provider;
+		}
+	}
+	return null;
+}
+
+/** Recognize only the two hosted forges in the current product contract. */
+export function providerFromRemoteUrl(remoteUrl: string): ReviewProvider | null {
+	const host = remoteHost(remoteUrl);
+	if (host === "github.com") return "github";
+	if (host === "gitlab.com") return "gitlab";
+	return null;
+}
+
+function remoteHost(remoteUrl: string): string | null {
+	try {
+		const host = new URL(remoteUrl).hostname;
+		if (host) return host.toLowerCase();
+	} catch {
+		// SCP-like Git URL (`git@github.com:owner/repo.git`) — not a WHATWG URL.
+	}
+	return /^(?:[^@/:\s]+@)?([^/:\s]+):/.exec(remoteUrl)?.[1]?.toLowerCase() ?? null;
+}
+
+/** Best-effort open PR/MR number for one local branch. Every unavailable state degrades to null. */
+export function findOpenBranchReview(
+	cwd: string,
+	branch: string,
+): Promise<OpenBranchReview | null> {
+	return findOpenBranchReviewWithRunner(cwd, branch, runCommand);
+}
+
+/** Internal test seam; the module barrel deliberately exposes only `findOpenBranchReview`. */
+export async function findOpenBranchReviewWithRunner(
+	cwd: string,
+	branch: string,
+	run: CommandRunner,
+): Promise<OpenBranchReview | null> {
+	try {
+		const provider = detectReviewProvider(cwd, branch);
+		if (!provider) return null;
+
+		const command =
+			provider === "github"
+				? [
+						"gh",
+						"pr",
+						"list",
+						"--head",
+						branch,
+						"--state",
+						"open",
+						"--json",
+						"number",
+						"--limit",
+						"1",
+					]
+				: ["glab", "mr", "list", "--source-branch", branch, "--output", "json", "--per-page", "1"];
+		const result = await run(cwd, command);
+		if (!result.ok) return null;
+
+		const number = reviewNumber(result.out, provider === "github" ? "number" : "iid");
+		if (number === null) return null;
+		return { kind: provider === "github" ? "pull-request" : "merge-request", number };
+	} catch {
+		return null;
+	}
+}
+
+export function reviewNumber(output: string, field: "number" | "iid"): number | null {
+	try {
+		const rows: unknown = JSON.parse(output);
+		if (!Array.isArray(rows) || rows.length === 0) return null;
+		const first: unknown = rows[0];
+		if (typeof first !== "object" || first === null) return null;
+		const value = (first as Record<string, unknown>)[field];
+		return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null;
+	} catch {
+		return null;
+	}
+}
+
+async function runCommand(cwd: string, command: string[]): Promise<CommandResult> {
+	try {
+		const proc = Bun.spawn(command, {
+			cwd,
+			stdout: "pipe",
+			stderr: "ignore",
+			env: {
+				...process.env,
+				GH_PROMPT_DISABLED: "1",
+				GLAB_PROMPT_DISABLED: "1",
+				GIT_TERMINAL_PROMPT: "0",
+				NO_COLOR: "1",
+			},
+		});
+		const timer = setTimeout(() => proc.kill(), LOOKUP_TIMEOUT_MS);
+		try {
+			const [out, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+			return { ok: exitCode === 0, out: out.trim() };
+		} finally {
+			clearTimeout(timer);
+		}
+	} catch {
+		return { ok: false, out: "" };
+	}
+}

--- a/packages/server/src/branch-review/index.ts
+++ b/packages/server/src/branch-review/index.ts
@@ -1,0 +1,3 @@
+/** Best-effort open GitHub PR / GitLab MR metadata for a workspace branch. */
+
+export { findOpenBranchReview } from "./branchReview";

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -59,6 +59,7 @@ import {
 	resolveLogin,
 	startLogin,
 } from "../auth";
+import { findOpenBranchReview } from "../branch-review";
 import { selectDirectory } from "../dialog";
 import { listAvailableEditors, openEditor, revealInFileManager } from "../editors";
 import { readDir, readFile } from "../fs";
@@ -302,6 +303,10 @@ const handlers: Record<string, Handler> = {
 		return openExistingWorktree(p.projectId, p.path);
 	},
 	"workspace.list": (params) => listWorkspaces((params as { projectId: string }).projectId),
+	"workspace.openReview": (params) => {
+		const ws = getWorkspace((params as { workspaceId: string }).workspaceId);
+		return findOpenBranchReview(ws.worktreePath, ws.branch);
+	},
 	"workspace.remove": (params) => {
 		const id = (params as { id: string }).id;
 		// Non-blocking archive: drop the record now (gone from `workspace.list` immediately) + the fast


### PR DESCRIPTION
## Summary
- append an optional `PR #N` or `MR !N` to active-workspace metadata
- detect GitHub.com/GitLab.com remotes and query the explicit branch asynchronously through local `gh`/`glab`
- degrade silently for unsupported remotes, unavailable auth, timeouts, and branches without an open review
- document the initial provider limitation and add focused lookup/formatting tests

## Testing
- `bun run check:deps`
- `bun run check:seams`
- `bun run lint`
- `bun run typecheck`
- focused branch-review and shell-formatting unit tests
- `bun run test`
- `bun run e2e` — 203 passed
