### PR TITLE
Remove change counts from workspace rows

### DIFF
--- a/apps/web/UI-TERMINOLOGY.md
+++ b/apps/web/UI-TERMINOLOGY.md
@@ -103,7 +103,6 @@ Children:
 | Workspace Row | inline row in `ProjectTree` | `workspace-item` | A workspace (git worktree); two-line: name + branch |
 | — Workspace Name | inline `<span>` | `workspace-name` | Display name |
 | — Workspace Branch | inline `<span>` | `workspace-branch` | Git branch (muted, proportional metadata; hidden if it equals the name) |
-| — Diff-Stat Badge | `panels/DiffStatBadge.tsx` → `DiffStatBadge` | — | `+N −M` per-worktree change counts |
 | — Workspace Actions Menu | `MoreVertical` Dropdown Menu | `workspace-menu` / `workspace-actions` | Open in (`workspace-open-in`) / Copy path / Reveal / Remove workspace |
 | — Remove-Workspace Item | menu item in the actions menu | `workspace-remove` | Opens a Confirm Dialog; not shown on the Default workspace |
 

--- a/apps/web/src/panels/ChangesTree.tsx
+++ b/apps/web/src/panels/ChangesTree.tsx
@@ -9,8 +9,8 @@ import { TreeRow } from "./TreeRow";
 /**
  * The Changes panel's folder view: the changed files laid out as a tree with single-directory runs
  * compacted into slash-joined rows, styled exactly like the All-files tree (shared `TreeRow`) with a
- * per-file / per-folder `+/−` badge (shared `DiffStatBadge`) mirroring the
- * project rail's worktree stats. **File** rows carry the same action menu the flat list does
+ * per-file / per-folder `+/−` badge (shared `DiffStatBadge`). **File** rows carry the same action menu the
+ * flat list does
  * (`ChangeRowActions` — hover `⌄` + right-click); folder rows get none, since nothing in that menu applies to
  * a folder. Presentational — the flat list and this view share the same `onOpen` (open/focus the file's diff
  * tab, at the gesture's `TabIntent`) and `isActive` (selected row) from `ChangesPanel`.

--- a/apps/web/src/panels/DiffStatBadge.tsx
+++ b/apps/web/src/panels/DiffStatBadge.tsx
@@ -1,8 +1,7 @@
 /**
- * The `+N −M` diff-count badge — one visual, shared by the project rail's per-worktree stats and the
- * Changes tree's per-file / per-folder counts. Renders nothing when there's nothing added or removed.
- * Layout-only extras (e.g. the rail's `group-hover:hidden`, its `self-start` alignment) come in via
- * `className`.
+ * The Changes views' `+N −M` diff-count badge, shared by flat file rows and the tree's per-file /
+ * per-folder counts. Renders nothing when there's nothing added or removed; layout-only extras come in
+ * via `className`.
  */
 export function DiffStatBadge({
 	added,

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -43,7 +43,6 @@ import {
 import { errorText, getTransport } from "../transport";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { DiffStatBadge } from "./DiffStatBadge";
 import { ExistingWorktreeDialog } from "./ExistingWorktreeDialog";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { useOpenProject } from "./useOpenProject";
@@ -527,7 +526,6 @@ function WorkspaceRow({
 	onReveal: () => void;
 	onRemove: () => void;
 }) {
-	const stats = workspace.diffStats;
 	// Default is non-removable; external is removable from ThinkRail but its user-owned checkout is not.
 	// Icons make the three ownership modes legible without adding another text badge to the compact row.
 	const isDefault = isDefaultWorkspace(workspace);
@@ -581,11 +579,6 @@ function WorkspaceRow({
 						)}
 					</span>
 				</button>
-				<DiffStatBadge
-					added={stats?.added ?? 0}
-					removed={stats?.removed ?? 0}
-					className="self-start group-hover:hidden"
-				/>
 				<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
 					<DropdownMenuTrigger
 						data-testid="workspace-menu"

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -51,7 +51,9 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   in place. Each **workspace row** is **two-line**: the display
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
-  name is decoupled from the git branch (see [[submodule-server-workspaces]]). The **Default workspace**
+  name is decoupled from the git branch (see [[submodule-server-workspaces]]). Workspace rows deliberately
+  show **no `+N −M` change badge**: the left rail is for navigation and identity; change detail stays in
+  the dedicated Changes views. The **Default workspace**
   (`kind === "default"` — the project folder itself) renders **pinned first** (the server pins it in
   `workspace.list`; `addWorkspace` appends created worktree rows after it), with a **`House` icon** in
   place of the `GitBranch` glyph and **no Remove item** (non-removable — the server enforces it; the menu
@@ -108,9 +110,9 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   one child and that child is another directory, and the compact row expands/collapses the deepest
   directory as one unit. `ChangesTree` evaluates this against the changed-file tree; `FileTree` resolves
   only visible compact runs through its existing client-side directory reads, so the wire remains a plain
-  immediate-directory listing. The **`+N −M` diff-count badge** is the
-  shared **`DiffStatBadge`**, used by the project-rail worktree stats and the Changes tree's per-file /
-  per-folder counts. `ChangesTree`'s tree build + `+/−` aggregation + shared status glyphs live in the pure
+  immediate-directory listing. The **`+N −M` diff-count badge** is the shared **`DiffStatBadge`**, used
+  only inside Changes: the flat list's file rows and the tree's per-file / per-folder counts.
+  `ChangesTree`'s tree build + `+/−` aggregation + shared status glyphs live in the pure
   **`changesModel.ts`** (unit-tested; no store/transport — `ChangesTree` is presentational, fed `changes` +
   `onOpen`/`isActive` by `ChangesPanel`), together with the **diff-tab identity + scope vocabulary**:
   `scopeKey` / `diffTabId(workspaceId, scope, path)` / `diffTabName` / `scopeLabel` and the `splitPath`
@@ -636,9 +638,8 @@ a project picker, the prompt hero, and the reused
   stale — stamp, so neither effect sees any drift and the pane keeps the old target's diff under the new
   target's label indefinitely. Dropping the superseded read costs nothing: the read that superseded it is
   the one the user is waiting for. Panels are mounted only for the active workspace,
-  so scoping is natural; a degraded watcher just means back to read-on-demand. Deliberately **not**
-  live (deferred): the project-rail workspace diffStats badges; editable-file conflict handling waits
-  for `fs.writeFile` (the viewer is read-only today).
+  so scoping is natural; a degraded watcher just means back to read-on-demand. Editable-file conflict
+  handling waits for `fs.writeFile` (the viewer is read-only today).
 - **`useWorkspaceSpecs` owns the `spec.graph` read** (one fetcher, one definition of "this file is a spec"):
   the snapshot lands in the store (`specsByWorkspace`), not panel state, because the chat's turn divider
   needs the same answer to route its chips. It is called by **`RightPanel`**, not by `SpecsPanel` — the

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -40,7 +40,7 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   `workspace.list` rather than seeding a partial one-row list; else add-if-absent / merge-if-present,
   idempotent with the creating client's own post-create re-list); **`updateWorkspace(ws)`** folds a
   `workspace.updated` snapshot in: **replace** the record by `id` in `workspaces[ws.projectId]`, carrying
-  over only the locally-computed `diffStats` badge (the snapshot is the persisted record, which has none).
+  over only the list-computed `diffStats` aggregate (the snapshot is the persisted record, which has none).
   The push is authoritative, so a *replace* — never a merge: a merge could not clear an **optional field the
   host dropped** (`diffBase` re-pointed back to the creation base, the last `skillOverrides` entry removed),
   leaving the client labelling and keying reads off a value the host no longer has; a project never fetched or an id absent from its list is a **no-op** — the next

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1054,7 +1054,7 @@ test("updateWorkspace applies a pushed snapshot authoritatively: dropped fields 
 	expect(ws?.diffStats).toEqual({ added: 3, removed: 1 }); // locally computed — survives the replace
 });
 
-test("updateWorkspace applies the pushed snapshot by id, keeping the computed diffStats badge", () => {
+test("updateWorkspace applies the pushed snapshot by id, keeping the computed diffStats aggregate", () => {
 	useAppStore.setState({
 		workspaces: {
 			p1: [

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1292,7 +1292,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 					...s.workspaces,
 					// The push replaces the record (so a field the server *dropped* clears here too), except for
 					// `diffStats`: the persisted snapshot carries no computed stats, and a bare replace would wipe
-					// the +/− badge until the next list.
+					// the list-computed aggregate until the next list.
 					[workspace.projectId]: list.map((w) =>
 						w.id === workspace.id
 							? { ...workspace, ...(w.diffStats ? { diffStats: w.diffStats } : {}) }

--- a/e2e/workspaces.spec.ts
+++ b/e2e/workspaces.spec.ts
@@ -97,6 +97,8 @@ test("opens and safely forgets an existing user-owned worktree", async ({ page }
 		);
 		await expect(row).toContainText("existing-worktree-fixture");
 		await expect(row).toContainText("feature/existing");
+		// Dirty-worktree counts belong in Changes, not beside workspace navigation in the left rail.
+		await expect(row).not.toContainText(/\+\d+\s+−\d+/);
 		const receipt = page.getByTestId("workspace-ready");
 		await expect(receipt).toContainText("Existing worktree");
 		await expect(receipt).toContainText("on feature/existing");

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -87,8 +87,8 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   against; collapsing them would make a re-pointed target lie about provenance (the `branch · from
   baseBranch` receipt). Every read of "the base" resolves through the `git` module, never inline —
   `diffStats` composes the git module's **branch-scope range** (`resolveDiffRange` +
-  `changedFileArgs(…, "--shortstat")`), so the rail badge measures exactly what the Changes panel shows
-  (merge-base semantics included — upstream commits on the base never inflate the badge) and reaches git
+  `changedFileArgs(…, "--shortstat")`), so the workspace aggregate measures exactly what the Changes panel
+  shows (merge-base semantics included — upstream commits on the base never inflate it) and reaches git
   bracketed by `--end-of-options` … `--` like every other rev this app passes. `diffStats` yields **no stats at all** (logged) when git couldn't
   answer, rather than a fabricated `+0 −0` — a failed read must not paint a dirty worktree as clean; the
   `Workspace.diffStats` field is simply absent, and `workspaceDiffStats` rejects,


### PR DESCRIPTION
## Summary
- remove the `+N −M` change badge from workspace rows in the left project rail
- keep diff-stat badges in the dedicated Changes views and align the specs/terminology
- add an e2e regression assertion for a dirty workspace row

## Testing
- `bun run check:deps`
- `bun run check:seams`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run e2e -- e2e/workspaces.spec.ts` (3 passed)
- `bun run e2e` (205 passed; one unrelated history-search timing failure)
- `bun run e2e -- --last-failed` (the failed history-search test passed)