### PR TITLE
fix nightly buid (cli): seed the smoke transcript at the host's worktree path

### DIFF
--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -201,11 +201,15 @@ and `trash`'s **native helper sidecars** (which macOS/Windows must execute from 
   artifact — the frames are hand-rolled JSON, keeping `contracts` out of the cli), **moves a seeded pi
   transcript through `session.delete` into the OS trash** (pinning the static `processMountinfo` parser
   inclusion that `trash`'s Linux implementation otherwise reaches through a binary-opaque CommonJS
-  require), verifies both macOS/Windows helpers were staged from the artifact, and SIGTERM exits 0. CI
-  builds + smokes the binary on every PR
-  (its host target — the generation/bundling/staging logic is platform-independent). What it can't cover
-  without provider auth: the factories registering inside a live session (that's `e2e:agent` territory,
-  run-from-source). The smoke's **broad-net sibling** is `bun run e2e:binary` (root
+  require; the fixture is seeded at the **host-reported `worktreePath`**, never the smoke's own temp path,
+  because the host stores git's symlink-resolved root — macOS `/var` → `/private/var`, Windows' 8.3 `TEMP`
+  — so a fixture written at an unresolved path lands in an encoded session dir the host never scans, and
+  the delete then truthfully no-ops while the file stays put), verifies both macOS/Windows helpers were
+  staged from the artifact, and SIGTERM exits 0. CI builds + smokes the binary on every PR (its host
+  target — the generation/bundling/staging logic is platform-independent, but a Linux-only smoke cannot
+  see path-canonicalization or real-OS-trash divergence: those first surface on the release matrix's
+  macOS/Windows runners). What it can't cover without provider auth: the factories registering inside a
+  live session (that's `e2e:agent` territory, run-from-source). The smoke's **broad-net sibling** is `bun run e2e:binary` (root
   `playwright.binary.config.ts`): the whole no-agent e2e suite executed against this binary — also in CI
   on every PR. And `bun run check:seams` (root `scripts/check-binary-seams.ts`) is the build-time canary
   for the seam class: it fails when a pi bump introduces a new bundler-opaque dynamic import the server's

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -26,8 +26,19 @@ const projectDir = join(tmp, "project");
 const dataDir = join(tmp, "data");
 const agentDir = join(tmp, "pi-agent");
 
+/** Kills the spawned host once it exists; a no-op for the failures that happen before it is up. */
+let killHost: () => void = () => {};
+
 function fail(message: string): never {
 	console.error(`smoke FAILED: ${message}`);
+	// `process.exit` unwinds nothing — the `finally` at the bottom never runs — so the host has to be
+	// killed right here. Left alive it outlives the smoke: CI reports "Terminate orphan process: pid (…)
+	// (thinkrail-…)", and locally it keeps the inherited stdout pipe open, so a piped invocation hangs
+	// forever after the failure has already been printed.
+	killHost();
+	// The throwaway dirs are deliberately KEPT on failure — they are the post-mortem (which encoded
+	// session dir a transcript landed in, what got staged). A CI runner discards them with the job.
+	console.error(`smoke state kept for inspection: ${tmp}`);
 	process.exit(1);
 }
 
@@ -126,6 +137,7 @@ const proc = Bun.spawn([binary, "--no-open", "--port", "24262"], {
 	stdout: "pipe",
 	stderr: "inherit",
 });
+killHost = () => proc.kill("SIGKILL");
 
 async function connectRpc(baseUrl: string): Promise<WebSocket> {
 	const socket = new WebSocket(`${baseUrl.replace(/^http/, "ws")}/ws`);
@@ -397,9 +409,10 @@ try {
 		`smoke OK: ${binary} booted at ${url}, served the UI + staged skills + portable alias, trashed a transcript, OAuth reached its auth URL, exited cleanly.`,
 	);
 } catch (err) {
-	proc.kill("SIGKILL");
+	// `fail` kills the host itself, so every exit path — thrown or asserted — sheds the process.
 	fail(err instanceof Error ? err.message : String(err));
 } finally {
+	// Success only: `fail` exits before this can run, and keeps `tmp` on purpose for the post-mortem.
 	rpcSocket?.close();
 	rmSync(tmp, { recursive: true, force: true });
 }

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -107,15 +107,6 @@ const gitCommit = Bun.spawnSync([
 ]);
 if (gitCommit.exitCode !== 0) fail("could not commit the portable-skill smoke project");
 
-// A real transcript drives the binary-only Linux trash path. `trash` loads processMountinfo through a
-// template-literal CommonJS require; without the server's static inclusion seam this exact RPC fails only
-// inside the artifact, even though source e2e stays green.
-const doomedTranscript = writeFixtureSession(defaultSessionDirFor(agentDir, projectDir), {
-	cwd: projectDir,
-	name: "compiled trash probe",
-	messages: [{ role: "user", text: "move this transcript to trash", timestamp: Date.now() }],
-});
-
 // 24262 is only the scan start: the CLI free-picks past a taken port and we read the actually served
 // URL from stdout below — so concurrent runs (other worktrees, dev hosts, e2e suites) never collide.
 const proc = Bun.spawn([binary, "--no-open", "--port", "24262"], {
@@ -291,9 +282,30 @@ try {
 		rpc(rpcSocket, "workspace.list", { projectId: project.id }),
 		10_000,
 		"workspace.list",
-	)) as { id?: string; kind?: string }[];
-	const workspaceId = workspaces.find((workspace) => workspace.kind === "default")?.id;
+	)) as { id?: string; kind?: string; worktreePath?: string }[];
+	const defaultWorkspace = workspaces.find((workspace) => workspace.kind === "default");
+	const workspaceId = defaultWorkspace?.id;
 	if (!workspaceId) fail("workspace.list returned no Default workspace");
+
+	// A real transcript drives the binary-only Linux trash path. `trash` loads processMountinfo through a
+	// template-literal CommonJS require; without the server's static inclusion seam this exact RPC fails only
+	// inside the artifact, even though source e2e stays green.
+	//
+	// Seed it against the **host-reported** worktree path, never our own `projectDir` string: the host stores
+	// git's symlink-resolved root, and a handed-in temp path is only incidentally canonical (macOS resolves
+	// `/var` → `/private/var`, Windows' `TEMP` is the 8.3 `RUNNER~1` form of `runneradmin`). `session.delete`
+	// matches a transcript on that exact cwd — both the encoded session dir *and* the file's header — so
+	// seeding from an unresolved path strands the file in a directory the host never scans, and the delete
+	// then truthfully reports "nothing in this workspace matched" while the file stays put. Same contract as
+	// e2e's `seedWorkspaceSession(worktreePath, …)`.
+	const worktreePath = defaultWorkspace?.worktreePath;
+	if (!worktreePath) fail("workspace.list returned no worktreePath for the Default workspace");
+	const doomedTranscript = writeFixtureSession(defaultSessionDirFor(agentDir, worktreePath), {
+		cwd: worktreePath,
+		name: "compiled trash probe",
+		messages: [{ role: "user", text: "move this transcript to trash", timestamp: Date.now() }],
+	});
+
 	await within(
 		rpc(rpcSocket, "session.delete", { sessionId: doomedTranscript.id, workspaceId }),
 		10_000,


### PR DESCRIPTION
## Why

The nightly release matrix has been red since **2026-08-13** (last green Aug 12). `macos-14 / bun-darwin-arm64` and `windows-latest / bun-windows-x64` both fail their boot-smoke inside `.github/actions/build-binary`:

```
smoke FAILED: session.delete left the seeded transcript on disk
```

Both Linux jobs pass, so `sign` and `release` never run and **no nightly ships**. Introduced by #218 (`4ebad6e`), the commit that added both `packages/server/src/agent/trash.ts` and this smoke probe.

## Root cause

The smoke seeded its throwaway pi transcript at *its own* temp path, but the host stores git's **symlink-resolved** root — `openProject` keeps `gitToplevel(path)` (`projects.ts:74`) and the Default workspace inherits it verbatim as `worktreePath` (`workspaces.ts:429`). A handed-in temp path is only *incidentally* canonical:

- macOS resolves `/var` → `/private/var`
- Windows' `TEMP` is the 8.3 `RUNNER~1` form of `runneradmin`

pi keys session dirs by the exact cwd string, so the fixture landed in a directory the host never scans. From the local repro — two dirs, one stranded file:

```
pi-agent/sessions/--tmp-tr-real-…-project--          ← host scans this (empty)
pi-agent/sessions/--tmp-tr-link-…-project--/….jsonl  ← smoke seeded here
```

The RPC then *succeeded*: `deleteSession` does `if (path) await trashFile(path)` with no else (`agentSessionManager.ts:919`), because a stray id trashing nothing is documented, intentional idempotency. So the delete truthfully reported "nothing in this workspace matched" and the file stayed put. `/tmp` on Linux is already canonical, which is why only the release matrix saw it — CI smokes the binary on ubuntu only (`ci.yml:102`).

**This is a test-harness bug, not a product bug.** Real sessions are always created with the host's own resolved cwd, so that side never diverged.

## Fix

Seed against the host-reported `worktreePath` from `workspace.list` — the same contract e2e already uses (`seedWorkspaceSession(worktreePath, …)`); `e2e/auto-open-chats.spec.ts:27` already guards this exact hazard with `realpathSync` and a comment naming `/tmp` → `/private/tmp`, so the smoke was the one place that missed it. Taking the host's own string is strictly better than `realpathSync` here, because it also matches on Windows, where git reports forward slashes and `realpathSync` reports backslashes.

`apps/cli/SPEC.md` is updated too: its "the generation/bundling/staging logic is platform-independent" rationale is what licensed the Linux-only smoke, so it now records that a Linux-only smoke cannot see path-canonicalization or real-OS-trash divergence.

## Verification

- **Reproduced the CI failure on Linux** by pointing `TMPDIR` at a symlink (`/tmp/tr-link` → `/tmp/tr-real`) — identical message, transcript stranded in the unscanned encoded dir.
- Same symlinked-`TMPDIR` run **green after the fix**; baseline real-tmpdir smoke green.
- `lint`, `typecheck`, `check:deps`, `check:seams` pass (pre-commit gates ran clean).

✅ **Verified on the real runners** (see the comment below): `bun-darwin-arm64` on `macos-14` and `bun-windows-x64` on `windows-latest` both pass, via the same `build-binary` composite action the release matrix runs. The OS-trash call itself is fine on both platforms, so path canonicalization was the entire bug.

## Second commit: the orphan-process leak

`fail()` calls `process.exit(1)`, which unwinds nothing — the `finally` at the bottom never runs — so every assertion failure after the spawn left the host running. On CI that is the `Terminate orphan process: pid (1334) (thinkrail-darwi)` line in the teardown of this very nightly job; locally it's worse, since the orphan holds the inherited stdout pipe open and any piped invocation hangs indefinitely *after* the failure has printed (this is what made the original diagnosis take longer than it should have).

`fail()` now kills the host itself through a `killHost` hook that is a no-op until the spawn installs it, so the pre-boot assertions stay safe to call and the `catch` no longer needs its own `SIGKILL`.

The throwaway dirs are deliberately **kept** on failure now, with their location printed — they're the post-mortem for exactly this class of bug (which encoded session dir a transcript landed in, what got staged), and a CI runner discards them with the job anyway. The success path still cleans up.

Verified both paths against a copy of the script with one assertion deliberately broken: fails in ~2s, no orphan process, state dir preserved; the unmodified smoke still exits 0 leaving nothing behind.
