### PR TITLE
Mark where compaction dropped earlier messages

### DIFF
--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -138,7 +138,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   followed by later messages remain history, not a stale current warning. It also
   returns `turnIdByMessageIndex` (message-position → minted turn id) — the jump anchor map a
   history-search "jump to message" deep link (`chatLocationRequest`, see `store/SPEC.md`) resolves
-  against; entries are `null` for a `toolResult`/`custom` message (never its own turn), and a message that
+  against; entries are `null` for a `toolResult`/`custom` message (never its own turn) and for a
+  `compactionSummary` (its own turn, but never a search hit — the host's index consumes the same slot, so
+  the two stay aligned), and a message that
   ended in `stopReason: "error"` maps to its own assistant turn's id, never the synthesized error turn's.
   `custom` messages never become turns: known ones (`ask-user-answers`) index into `askAnswers`; unknown
   customTypes are ignored. No store/transport/shiki.

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -22,12 +22,15 @@ a future `packages/chat-ui`). Built-in tool renderers live in the child
 ## Rendering model — rows and progressive disclosure
 
 The transcript is pi-canonical turns (`ChatTurn` in `types.ts`: user/assistant are pi messages; `system`,
-`error`, `retry` are web-local notices), but the list renders **derived rows, not raw turns** — folding
+`error`, `retry` are web-local notices; `compaction` marks where pi replaced earlier messages with a
+summary — hydration-only, since a live transcript still holds everything it streamed), but the list renders
+**derived rows, not raw turns** — folding
 spans assistant-message boundaries (pi emits one assistant message per tool round), so a per-turn item
 model can't group. The pure **`deriveRows(turns, toolResults, isStreaming, isSpec?)`** (`rows.ts`) walks
 blocks in order into rows; `ChatTurnView` dispatches on row kind:
 
-- `user` / `system` / `retry` — 1:1 renderers. A user message that IS a review context package
+- `user` / `system` / `retry` / `compaction` — 1:1 renderers (`CompactionTurn` is a labelled rule that
+  opens pi's summary on click, so a reloaded long chat explains its gap instead of starting mid-conversation). A user message that IS a review context package
   (`reviewPackage.ts` recognizes the `<review …>` header + `<comment …>` items the server's
   `packageRender` emits — the parser is the read half of that format, pinned in unit tests against the
   renderer's verbatim output) renders as a **compact card**: the one-sentence

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -258,3 +258,18 @@ test("unknown custom messages are ignored entirely", () => {
 	expect(turns).toHaveLength(0);
 	expect(Object.keys(askAnswers)).toHaveLength(0);
 });
+
+test("a compaction summary becomes its own turn without claiming a jump anchor", () => {
+	const { turns, turnIdByMessageIndex } = messagesToRuntime([
+		{ role: "user", content: "start", timestamp: 1 },
+		{ role: "compactionSummary", summary: "## Goal\nship it", tokensBefore: 148_000, timestamp: 2 },
+		{ role: "assistant", content: [{ type: "text", text: "carrying on" }] },
+	] as unknown as Message[]);
+
+	expect(turns.map((t) => t.kind)).toEqual(["user", "compaction", "assistant"]);
+	const compaction = turns[1];
+	expect(compaction?.kind === "compaction" && compaction.summary).toBe("## Goal\nship it");
+	expect(compaction?.kind === "compaction" && compaction.tokensBefore).toBe(148_000);
+	// The slot is consumed but unanchored — history search indexes user/assistant text only.
+	expect(turnIdByMessageIndex).toEqual([turns[0]?.id ?? null, null, turns[2]?.id ?? null]);
+});

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -63,6 +63,15 @@ export function messagesToRuntime(
 				status: message.isError ? "error" : "done",
 				raw: { content: message.content, details: message.details },
 			};
+		} else if (message.role === "compactionSummary") {
+			// Its own turn, but no anchor: history search indexes user/assistant text only, so this slot stays
+			// `null` like every other non-conversation message.
+			turns.push({
+				kind: "compaction",
+				id: crypto.randomUUID(),
+				summary: message.summary,
+				tokensBefore: message.tokensBefore,
+			});
 		} else if (isAskUserAnswersMessage(message)) {
 			// The shared guard validates the details shape (not just the tag) — a malformed reply is ignored.
 			askAnswers[message.details.toolCallId] = message.details.result;

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -16,7 +16,8 @@ export interface HydratedRuntime {
 	askAnswers: Record<string, AskUserAnswersDetails["result"]>;
 	/**
 	 * Parallel to `messages`: `turnIdByMessageIndex[i]` is the turn id minted for `messages[i]` (`null` for
-	 * a `toolResult`/`custom` message, which never becomes its own turn) — the jump anchor map a
+	 * a `toolResult`/`custom` message, which never becomes its own turn, and for a `compactionSummary`,
+	 * which becomes a turn but is never a search hit) — the jump anchor map a
 	 * history-search "jump to message" deep link (`chatLocationRequest`) resolves against. A message that
 	 * ended in `stopReason: "error"` maps to its own assistant turn's id, never the synthesized error
 	 * turn's (the error turn has no message index of its own).

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -39,6 +39,7 @@ export type ChatRow =
 	| { kind: "user"; id: string; message: UserMessage }
 	| { kind: "system"; id: string; text: string }
 	| { kind: "error"; id: string; text: string }
+	| { kind: "compaction"; id: string; summary: string; tokensBefore: number }
 	| {
 			kind: "retry";
 			id: string;
@@ -135,6 +136,14 @@ export function deriveRows(
 					break;
 				case "error":
 					rows.push({ kind: "error", id: turn.id, text: turn.text });
+					break;
+				case "compaction":
+					rows.push({
+						kind: "compaction",
+						id: turn.id,
+						summary: turn.summary,
+						tokensBefore: turn.tokensBefore,
+					});
 					break;
 				case "retry":
 					rows.push({

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -16,6 +16,7 @@ import { useFold, useSelection } from "./foldState";
 import { Markdown } from "./Markdown";
 import { parseReviewPackage, type ReviewPackageItem, reviewPackageLabel } from "./reviewPackage";
 import type { ChatRow, TurnDividerData } from "./rows";
+import { formatTokens } from "./SessionStatsBar";
 import { ToolCard } from "./ToolCard";
 import { getToolChrome, getToolRenderer } from "./toolRegistry";
 
@@ -48,6 +49,8 @@ export function ChatTurnView({
 			return <SystemTurn text={row.text} />;
 		case "error":
 			return <ErrorTurn text={row.text} />;
+		case "compaction":
+			return <CompactionTurn summary={row.summary} tokensBefore={row.tokensBefore} />;
 		case "retry":
 			return (
 				<RetryIndicator
@@ -228,6 +231,37 @@ function SystemTurn({ text }: { text: string }) {
 			className="text-center text-text-muted tr-text-metadata"
 		>
 			{text}
+		</div>
+	);
+}
+
+/**
+ * The compaction boundary: a rule where pi replaced earlier messages with a summary. Without it a
+ * reloaded long chat simply starts mid-conversation, which reads as lost history. The summary is what pi
+ * kept of those messages, so it opens on click rather than being hidden outright.
+ */
+function CompactionTurn({ summary, tokensBefore }: { summary: string; tokensBefore: number }) {
+	const [open, setOpen] = useState(false);
+	return (
+		<div data-testid="chat-compaction" className="flex flex-col gap-sm">
+			<button
+				type="button"
+				aria-expanded={open}
+				onClick={() => setOpen(!open)}
+				className="flex items-center gap-sm text-text-muted tr-text-metadata hover:text-text-default"
+			>
+				<span className="h-px flex-1 bg-border-default" />
+				{open ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+				<span>
+					Earlier messages summarized ({formatTokens(tokensBefore)} tokens of context compacted)
+				</span>
+				<span className="h-px flex-1 bg-border-default" />
+			</button>
+			{open ? (
+				<div className="tr-text-reading text-text-muted">
+					<Markdown text={summary} />
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -50,7 +50,7 @@ export function ChatTurnView({
 		case "error":
 			return <ErrorTurn text={row.text} />;
 		case "compaction":
-			return <CompactionTurn summary={row.summary} tokensBefore={row.tokensBefore} />;
+			return <CompactionTurn id={row.id} summary={row.summary} tokensBefore={row.tokensBefore} />;
 		case "retry":
 			return (
 				<RetryIndicator
@@ -240,14 +240,24 @@ function SystemTurn({ text }: { text: string }) {
  * reloaded long chat simply starts mid-conversation, which reads as lost history. The summary is what pi
  * kept of those messages, so it opens on click rather than being hidden outright.
  */
-function CompactionTurn({ summary, tokensBefore }: { summary: string; tokensBefore: number }) {
-	const [open, setOpen] = useState(false);
+function CompactionTurn({
+	id,
+	summary,
+	tokensBefore,
+}: {
+	id: string;
+	summary: string;
+	tokensBefore: number;
+}) {
+	// The shared fold cache, like every other manual open/close in the transcript: a summary is long
+	// enough to scroll past, and Virtuoso unmounting the row must not collapse what the reader opened.
+	const [open, toggle] = useFold(id);
 	return (
 		<div data-testid="chat-compaction" className="flex flex-col gap-sm">
 			<button
 				type="button"
 				aria-expanded={open}
-				onClick={() => setOpen(!open)}
+				onClick={toggle}
 				className="flex items-center gap-sm text-text-muted tr-text-metadata hover:text-text-default"
 			>
 				<span className="h-px flex-1 bg-border-default" />

--- a/apps/web/src/chat/types.ts
+++ b/apps/web/src/chat/types.ts
@@ -21,6 +21,12 @@ export type ChatTurn =
 	/** A failure notice: the run ended in an error, or the host rejected a send. `text` is the reason. */
 	| { kind: "error"; id: string; text: string }
 	/**
+	 * Where compaction replaced earlier messages with `summary` (pi's `compactionSummary`). Hydration-only:
+	 * a live transcript still holds every message it streamed, so there is no gap to mark until a reload
+	 * rebuilds the chat from what pi kept.
+	 */
+	| { kind: "compaction"; id: string; summary: string; tokensBefore: number }
+	/**
 	 * A live retry countdown (shown during the back-off, cleared when the retry resolves). `source`
 	 * separates the two flows that can overlap — a `turn` retry (pi `auto_retry_*`) and a `summarization`
 	 * retry (compaction / branch-summary, pi `summarization_retry_*`) — so one flow's end event never

--- a/e2e/compaction.spec.ts
+++ b/e2e/compaction.spec.ts
@@ -1,0 +1,59 @@
+import { appendFileSync, realpathSync, utimesSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+// Compaction is the one gap a hydrated transcript cannot explain by itself: pi resolves a compacted
+// session to its summary plus what followed, so the messages before it are simply gone from what
+// `session.getMessages` can return. Without the marker the chat just starts mid-conversation, which reads
+// as lost history — so the summary crosses the wire and renders as a rule the reader can open.
+//
+// Driven through a real compacted session file: pi's own resolver decides what survives, not a fixture.
+
+const BASE_TS = 1_700_300_000_000;
+
+const repoCwd = () => realpathSync(E2E_FIXTURE_REPO);
+
+test("a compacted transcript marks where the summarized messages were", async ({ page }) => {
+	await openFixtureProject(page); // resets state — seed after
+
+	const chat = seedWorkspaceSession(repoCwd(), {
+		name: "the long chat",
+		messages: [
+			{ role: "user", text: "summarized question", timestamp: BASE_TS },
+			{ role: "assistant", text: "summarized answer", timestamp: BASE_TS + 1_000 },
+			{ role: "user", text: "kept question", timestamp: BASE_TS + 2_000 },
+			{ role: "assistant", text: "kept answer", timestamp: BASE_TS + 3_000 },
+		],
+	});
+	// A real compaction entry: everything before `firstKeptEntryId` (the third message) is summarized away.
+	appendFileSync(
+		chat.path,
+		`${JSON.stringify({
+			type: "compaction",
+			id: `${chat.id}-c0`,
+			parentId: `${chat.id}-m3`,
+			firstKeptEntryId: `${chat.id}-m2`,
+			summary: "## Earlier work\nRenamed the widget factory.",
+			tokensBefore: 148_000,
+			timestamp: new Date(BASE_TS + 4_000).toISOString(),
+		})}\n`,
+	);
+	utimesSync(chat.path, new Date(BASE_TS), new Date(BASE_TS));
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+
+	// The only chat, so the hydrate fallback opens it: pi kept the later exchange and dropped the earlier.
+	await expect(page.getByText("kept question")).toBeVisible();
+	await expect(page.getByText("summarized question")).toHaveCount(0);
+
+	// …and the gap is accounted for, with pi's summary one click away.
+	const marker = page.getByTestId("chat-compaction");
+	await expect(marker).toContainText("Earlier messages summarized");
+	await expect(marker).toContainText("148k tokens");
+	await expect(page.getByText("Renamed the widget factory.")).toHaveCount(0);
+	await marker.getByRole("button").click();
+	await expect(page.getByText("Renamed the widget factory.")).toBeVisible();
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -26,7 +26,10 @@ of the host.
   `DEFAULT_CONFIG`, `MAX_HISTORY_LIMIT`, `MAX_HISTORY_QUERY_LENGTH`, `TODO_NUDGE_PREFIX` +
   **`isControlMessage(text)`** (the one shared reading of that marker — the client hides such sends on
   hydrate, the host skips them in the history index and does not count them as `message_sent`; both
-  sides agree here rather than each re-deriving `startsWith`) from `domain`; `export *` (value) of `wsProtocol`
+  sides agree here rather than each re-deriving `startsWith`) from `domain`; **`isTranscriptMessageRole(role)`**
+  from `piProtocol` (the one definition of which roles a transcript carries: the host filters
+  `session.getMessages` by it *and* `history` counts `messageIndex` by it, so two copies differing by a role
+  would silently shift every later jump anchor); `export *` (value) of `wsProtocol`
   (`WS_METHODS`, `WS_CHANNELS`, the typed maps, `PROTOCOL_VERSION`).
 - **Allowed deps:** none at runtime. **Type-only** devDeps on `@earendil-works/pi-ai` +
   `@earendil-works/pi-agent-core`, imported **from their package roots** (type-only → erased at build).

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -77,7 +77,11 @@ of the host.
     `session.getMessages` returns `{ summary, messages }` (the transcript is
     **`TranscriptMessage[]`** — the pi-canonical `Message` union widened with **`WireCustomMessage`**, a
     type-only mirror of pi-coding-agent's Node-only `CustomMessage`, so extension-injected messages like
-    the ask replies cross the wire; the summary reflects the now-live session after a disk re-open).
+    the ask replies cross the wire, and with **`WireCompactionSummary`** (protocol v38), the same kind of
+    mirror for the entry pi leaves where compaction replaced earlier messages: it is the only record that
+    a gap exists — pi drops the summarized messages themselves — so the client can mark it instead of
+    rendering a transcript that begins mid-conversation; the summary reflects the now-live session after a
+    disk re-open).
   - the **extension-UI frames** **`ExtUiRequest`** / **`ExtUiResponse`** — our wire shape for pi's in-process
     `uiContext` calls (`select`/`confirm`/`input`/`editor` round-trip; `notify`/`setStatus`/`setWidget`/
     `setTitle`/`dismiss` are fire-and-forget), carried on the `pi.extensionUi` channel.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,8 @@
 // The wire spine. Types-only except the WS method/channel constants + protocol version (wsProtocol), the
 // app-config default (`DEFAULT_CONFIG`), the history-search caps (`MAX_HISTORY_LIMIT`,
 // `MAX_HISTORY_QUERY_LENGTH`), and the internal control-message marker (`TODO_NUDGE_PREFIX` +
-// its shared `isControlMessage` reading) — small
+// its shared `isControlMessage` reading), and the transcript-role policy (`isTranscriptMessageRole`, the
+// one set the host's transcript filter and its search index must share) — small
 // plain constants both sides must agree on. Theme catalogs stay browser-side; the wire carries an opaque id.
 
 export type * from "./domain";
@@ -14,4 +15,5 @@ export {
 	TODO_NUDGE_PREFIX,
 } from "./domain";
 export type * from "./piProtocol";
+export { isTranscriptMessageRole } from "./piProtocol";
 export * from "./wsProtocol";

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -342,5 +342,19 @@ export interface WireCustomMessage<T = unknown> {
 	timestamp: number;
 }
 
+/**
+ * MIRROR of pi-coding-agent's `CompactionSummaryMessage` (Node-only package, so re-declared type-only for
+ * the wire, like `WireCustomMessage` above): the entry pi leaves in a resolved transcript where compaction
+ * replaced earlier messages with `summary`. It is the only record of that gap — pi drops the summarized
+ * messages themselves — so the client renders it as the transcript's compaction marker.
+ */
+export interface WireCompactionSummary {
+	role: "compactionSummary";
+	summary: string;
+	/** Context size before the pass, as pi measured it. */
+	tokensBefore: number;
+	timestamp: number;
+}
+
 /** A transcript message as `session.getMessages` reports it: pi-canonical + custom messages. */
-export type TranscriptMessage = Message | WireCustomMessage;
+export type TranscriptMessage = Message | WireCustomMessage | WireCompactionSummary;

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -358,3 +358,25 @@ export interface WireCompactionSummary {
 
 /** A transcript message as `session.getMessages` reports it: pi-canonical + custom messages. */
 export type TranscriptMessage = Message | WireCustomMessage | WireCompactionSummary;
+
+/**
+ * The pi message roles a transcript carries — the ONE definition of that policy, read through the guard
+ * below (the `isControlMessage` pattern).
+ *
+ * Not a display preference: the host filters `session.getMessages` by this set, and `history`'s search
+ * index counts message positions by it, so a hit's `messageIndex` lines up with the client's
+ * `turnIdByMessageIndex` only while both use the *same* set. Two copies differing by one role would shift
+ * every later jump anchor, with nothing to fail — which is why the policy cannot live in either module.
+ */
+const TRANSCRIPT_MESSAGE_ROLES: ReadonlySet<string> = new Set([
+	"user",
+	"assistant",
+	"toolResult",
+	"custom",
+	"compactionSummary",
+]);
+
+/** True when a pi message's role is one a transcript carries (see {@link TRANSCRIPT_MESSAGE_ROLES}). */
+export function isTranscriptMessageRole(role: string): boolean {
+	return TRANSCRIPT_MESSAGE_ROLES.has(role);
+}

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -211,7 +211,9 @@ export interface TerminalTabsPush {
 // v36: `review.close` atomically archives non-draft records and publishes the fresh open snapshot; clients
 // no longer follow it with an initiating-only `review.get` fold.
 // v37: `workspace.openReview` returns the active branch's optional GitHub PR / GitLab MR number.
-export const PROTOCOL_VERSION = 37;
+// v38: `session.getMessages` keeps pi's `compactionSummary` messages, so a hydrated transcript can say
+// where compaction replaced earlier messages instead of starting mid-conversation.
+export const PROTOCOL_VERSION = 38;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -111,8 +111,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `custom` messages**, which carry the `ask-user-answers` replies the questionnaire card pairs by tool
     call id, **plus `compactionSummary`**, pi's marker for the messages compaction summarized away — kept
     precisely because pi's resolved transcript is all that survives, so dropping it would hand the client
-    a chat that starts mid-conversation with nothing to explain the gap; `history`'s search index consumes
-    the same slot to keep `messageIndex` aligned), plus **`ensureSessionAttached(sessionId, workspaceId, cwd)`** — the same single-flighted
+    a chat that starts mid-conversation with nothing to explain the gap. Which roles those are is **not
+    decided here**: the filter is contracts' `isTranscriptMessageRole`, shared with `history`'s index so the
+    two cannot drift and shift `messageIndex`), plus **`ensureSessionAttached(sessionId, workspaceId, cwd)`** — the same single-flighted
     re-open with no transcript read, for a caller that only needs the session *promptable* again (the
     review send's follow-up into an existing chat). It answers **`false` only when the id names no transcript
     in that cwd** — the sole case a caller may recover from by starting a new chat — and **throws** on

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -109,7 +109,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `getSessionMessages(sessionId, workspaceId, cwd)` (re-opens a disk session into the manager if
     not live, then returns `{ summary, messages }` — `TranscriptMessage[]`: the pi-canonical subset **plus
     `custom` messages**, which carry the `ask-user-answers` replies the questionnaire card pairs by tool
-    call id), plus **`ensureSessionAttached(sessionId, workspaceId, cwd)`** — the same single-flighted
+    call id, **plus `compactionSummary`**, pi's marker for the messages compaction summarized away — kept
+    precisely because pi's resolved transcript is all that survives, so dropping it would hand the client
+    a chat that starts mid-conversation with nothing to explain the gap; `history`'s search index consumes
+    the same slot to keep `messageIndex` aligned), plus **`ensureSessionAttached(sessionId, workspaceId, cwd)`** — the same single-flighted
     re-open with no transcript read, for a caller that only needs the session *promptable* again (the
     review send's follow-up into an existing chat). It answers **`false` only when the id names no transcript
     in that cwd** — the sole case a caller may recover from by starting a new chat — and **throws** on

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -29,6 +29,7 @@ import type {
 	TranscriptMessage,
 	WireModel,
 } from "@thinkrail/contracts";
+import { isTranscriptMessageRole } from "@thinkrail/contracts";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import { buildResourceLoader, toSkillCommands } from "./extensions";
 import {
@@ -532,7 +533,7 @@ export async function ensureSessionAttached(
 }
 
 /**
- * A session's transcript (pi-canonical user/assistant/toolResult messages) + its current summary. Re-opens
+ * A session's transcript (the roles `isTranscriptMessageRole` admits) + its current summary. Re-opens
  * the session from disk first if it isn't live, so a reopened chat is continuable and its summary accurate.
  */
 export async function getSessionMessages(
@@ -550,13 +551,12 @@ export async function getSessionMessages(
 		entry = sessions.get(sessionId);
 		if (!entry) throw new Error(`Unknown session: ${sessionId}`);
 	}
-	// `custom` rides along for the ask-user-answers pairing (the card reads `details.toolCallId`); the
-	// web renders only the customTypes it knows and ignores the rest. `compactionSummary` rides along
-	// because pi resolves a compacted session to the summary plus what followed it — dropping the summary
-	// too would leave the client a transcript that begins mid-conversation with nothing to explain why.
-	const renderable = new Set(["user", "assistant", "toolResult", "custom", "compactionSummary"]);
+	// Which roles travel is the wire's policy, not this function's: `history`'s search index counts
+	// positions by the same guard, and a set restated here could drift from it by one role and shift every
+	// later jump anchor (see `isTranscriptMessageRole`). `custom` carries the ask-user-answers pairing;
+	// `compactionSummary` is pi's marker for what compaction summarized away.
 	const messages = entry.session.messages.filter((m) =>
-		renderable.has(m.role),
+		isTranscriptMessageRole(m.role),
 	) as TranscriptMessage[];
 	return { summary: summaryOf(sessionId, entry), messages };
 }

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -551,8 +551,10 @@ export async function getSessionMessages(
 		if (!entry) throw new Error(`Unknown session: ${sessionId}`);
 	}
 	// `custom` rides along for the ask-user-answers pairing (the card reads `details.toolCallId`); the
-	// web renders only the customTypes it knows and ignores the rest.
-	const renderable = new Set(["user", "assistant", "toolResult", "custom"]);
+	// web renders only the customTypes it knows and ignores the rest. `compactionSummary` rides along
+	// because pi resolves a compacted session to the summary plus what followed it — dropping the summary
+	// too would leave the client a transcript that begins mid-conversation with nothing to explain why.
+	const renderable = new Set(["user", "assistant", "toolResult", "custom", "compactionSummary"]);
 	const messages = entry.session.messages.filter((m) =>
 		renderable.has(m.role),
 	) as TranscriptMessage[];

--- a/packages/server/src/history/SPEC.md
+++ b/packages/server/src/history/SPEC.md
@@ -32,7 +32,9 @@ to preserve).
   `migrateSessionEntries` → `buildSessionContext` (follow the current leaf, apply the latest compaction,
   drop summarized/abandoned entries) — then indexes the resolved messages, filtered to the same renderable
   roles `getSessionMessages` sends. So `messageIndex` matches the client's `turnIdByMessageIndex` exactly
-  (no raw-file-order drift), and abandoned/summarized text never becomes a hit. The internal
+  (no raw-file-order drift), and abandoned/summarized text never becomes a hit — the compaction summary is
+  sent (it renders the client's compaction marker), so it consumes an index slot without being searchable.
+  The internal
   `TODO_NUDGE_PREFIX` control message (hidden from the transcript on hydrate) is skipped after its index
   slot is consumed, so alignment holds. Entry text is **full, never truncated** — a hit's `text` is what
   recall inserts and what the overlay's preview presents as the whole prompt, so a cap would silently

--- a/packages/server/src/history/SPEC.md
+++ b/packages/server/src/history/SPEC.md
@@ -30,8 +30,9 @@ to preserve).
   metadata. Pi session files are **trees** (abandoned branches) that compaction rewrites, so it resolves
   the file the way pi does before the client renders it — `parseSessionEntries` →
   `migrateSessionEntries` → `buildSessionContext` (follow the current leaf, apply the latest compaction,
-  drop summarized/abandoned entries) — then indexes the resolved messages, filtered to the same renderable
-  roles `getSessionMessages` sends. So `messageIndex` matches the client's `turnIdByMessageIndex` exactly
+  drop summarized/abandoned entries) — then indexes the resolved messages, filtered through contracts'
+  **`isTranscriptMessageRole`**, the very guard `getSessionMessages` sends by (one policy, not a local copy
+  of it). So `messageIndex` matches the client's `turnIdByMessageIndex` exactly
   (no raw-file-order drift), and abandoned/summarized text never becomes a hit — the compaction summary is
   sent (it renders the client's compaction marker), so it consumes an index slot without being searchable.
   The internal

--- a/packages/server/src/history/extract.test.ts
+++ b/packages/server/src/history/extract.test.ts
@@ -277,10 +277,10 @@ describe("extractSession", () => {
 		]);
 	});
 
-	test("respects compaction — summarized-away messages are dropped and the summary isn't indexed", () => {
-		// u0/a0 precede firstKeptEntryId (u1) so compaction drops them; the compaction summary is a
-		// non-renderable message (no index slot); the kept question + post-compaction answer index from 0,
-		// matching the client's post-compaction transcript.
+	test("respects compaction — summarized-away messages are dropped and the summary isn't a hit", () => {
+		// u0/a0 precede firstKeptEntryId (u1) so compaction drops them. The summary itself is sent to the
+		// client (it renders the compaction marker), so it consumes index 0 without being searchable, and
+		// the kept question + post-compaction answer index from 1 — matching the client's transcript.
 		const jsonl = [
 			header(),
 			line({
@@ -326,8 +326,8 @@ describe("extractSession", () => {
 			}),
 		].join("\n");
 		expect(entriesOf(jsonl)).toEqual([
-			{ text: "kept question", role: "user", timestamp: 300, messageIndex: 0 },
-			{ text: "post-compaction answer", role: "assistant", timestamp: 400, messageIndex: 1 },
+			{ text: "kept question", role: "user", timestamp: 300, messageIndex: 1 },
+			{ text: "post-compaction answer", role: "assistant", timestamp: 400, messageIndex: 2 },
 		]);
 	});
 

--- a/packages/server/src/history/extract.ts
+++ b/packages/server/src/history/extract.ts
@@ -28,7 +28,13 @@ export interface ExtractedSession {
 /** The roles the host surfaces to the client (`getSessionMessages`'s filter) — the exact set the client's
  * `messagesToRuntime` folds into `turnIdByMessageIndex`. Indexing against the same set is what keeps a
  * hit's `messageIndex` aligned with the jump anchor the client resolves it against. */
-const RENDERABLE_ROLES = new Set(["user", "assistant", "toolResult", "custom"]);
+const RENDERABLE_ROLES = new Set([
+	"user",
+	"assistant",
+	"toolResult",
+	"custom",
+	"compactionSummary",
+]);
 
 function textOf(content: unknown): string {
 	if (typeof content === "string") return content;
@@ -82,8 +88,9 @@ export function extractSession(jsonl: string): ExtractedSession | null {
 	const out: HistoryEntry[] = [];
 	let messageIndex = 0;
 	for (const message of messages) {
-		// Non-renderable context messages (compaction/branch summaries) are stripped by the host before
-		// the client sees them, so they must not consume an index slot here either.
+		// Non-renderable context messages (branch summaries) are stripped by the host before the client
+		// sees them, so they must not consume an index slot here either. A `compactionSummary` is sent, so
+		// it does consume one — it just never becomes a searchable entry (the role check below).
 		if (!RENDERABLE_ROLES.has(message.role)) continue;
 		const index = messageIndex++;
 		if (message.role !== "user" && message.role !== "assistant") continue;

--- a/packages/server/src/history/extract.ts
+++ b/packages/server/src/history/extract.ts
@@ -4,14 +4,14 @@ import {
 	parseSessionEntries,
 	type SessionEntry,
 } from "@earendil-works/pi-coding-agent";
-import { isControlMessage } from "@thinkrail/contracts";
+import { isControlMessage, isTranscriptMessageRole } from "@thinkrail/contracts";
 
 /** One searchable message from a session transcript (see SPEC.md for the messageIndex invariant). */
 export interface HistoryEntry {
 	text: string;
 	role: "user" | "assistant";
 	timestamp: number;
-	/** Position among renderable messages (user/assistant/toolResult/custom) — `session.getMessages` order. */
+	/** Position among the roles `isTranscriptMessageRole` admits — `session.getMessages` order. */
 	messageIndex: number;
 }
 
@@ -24,17 +24,6 @@ export interface ExtractedSession {
 	title?: string;
 	entries: HistoryEntry[];
 }
-
-/** The roles the host surfaces to the client (`getSessionMessages`'s filter) — the exact set the client's
- * `messagesToRuntime` folds into `turnIdByMessageIndex`. Indexing against the same set is what keeps a
- * hit's `messageIndex` aligned with the jump anchor the client resolves it against. */
-const RENDERABLE_ROLES = new Set([
-	"user",
-	"assistant",
-	"toolResult",
-	"custom",
-	"compactionSummary",
-]);
 
 function textOf(content: unknown): string {
 	if (typeof content === "string") return content;
@@ -63,9 +52,9 @@ function textOf(content: unknown): string {
  * it — `parseSessionEntries` → `migrateSessionEntries` → `buildSessionContext` (follow the current leaf,
  * apply the latest compaction, drop summarized/abandoned entries), then index the resolved messages.
  * `leafId` is left undefined so pi picks the current leaf as the last entry, exactly as
- * `SessionManager._buildIndex` does on load — and the resolved array is filtered to the same
- * `RENDERABLE_ROLES` the host's `getSessionMessages` sends, so every entry's `messageIndex` lines up with
- * the client's `turnIdByMessageIndex` (the jump anchor). Entry text is full, never truncated — it's what
+ * `SessionManager._buildIndex` does on load — and the resolved array is filtered through the wire's own
+ * `isTranscriptMessageRole`, the same guard `getSessionMessages` sends by (one policy, not a copy of it),
+ * so every entry's `messageIndex` lines up with the client's `turnIdByMessageIndex` (the jump anchor). Entry text is full, never truncated — it's what
  * recall inserts and what the overlay presents as the whole prompt (see SPEC.md). Tolerant:
  * `parseSessionEntries` skips non-JSON/malformed lines; a v1/v2 file is migrated first so it resolves
  * like any current session.
@@ -88,10 +77,11 @@ export function extractSession(jsonl: string): ExtractedSession | null {
 	const out: HistoryEntry[] = [];
 	let messageIndex = 0;
 	for (const message of messages) {
-		// Non-renderable context messages (branch summaries) are stripped by the host before the client
-		// sees them, so they must not consume an index slot here either. A `compactionSummary` is sent, so
-		// it does consume one — it just never becomes a searchable entry (the role check below).
-		if (!RENDERABLE_ROLES.has(message.role)) continue;
+		// Indexing against the wire's own role policy is what keeps a hit's `messageIndex` aligned with the
+		// client's `turnIdByMessageIndex`: a role the host strips (branch summaries) must not consume a slot
+		// here, and one it sends must — a `compactionSummary` does, without ever becoming a searchable entry
+		// (the role check below).
+		if (!isTranscriptMessageRole(message.role)) continue;
 		const index = messageIndex++;
 		if (message.role !== "user" && message.role !== "assistant") continue;
 		const text = textOf(message.content);


### PR DESCRIPTION
Problem: a long chat that has compacted looks like it lost its history on reload — pi resolves a compacted session to the summary plus what followed, and `session.getMessages` filtered that summary out, so the transcript just started mid-conversation with nothing to explain the gap.

Solution: keep pi's `compactionSummary` on the wire (protocol 38) and render it as a labelled rule that opens the summary on click. History search consumes the same index slot so jump anchors stay aligned.