### PR TITLE
Report a chat that fails to hydrate

### DIFF
--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -194,8 +194,14 @@ export function CenterTabs() {
 		// wrapper single-flights watcher readiness, then captures each load's conservative start tick.
 		const fetchMessages = (sessionId: string) =>
 			getSessionMessagesWithSkillBaseline({ sessionId, workspaceId })
-				// A session that failed to load is skipped; the others still hydrate.
-				.catch(() => null);
+				// One session failing must not cost the others their hydrate — but it must not read as "no such
+				// chat" either, so it says so and lands in chat-history below instead of vanishing until the
+				// next reconnect. Silent after the effect is cancelled: leaving the workspace cancels its
+				// in-flight reads, and an archived workspace's reads fail by design.
+				.catch((err: unknown) => {
+					if (!cancelled) toast.error(errorText(err), "Couldn't load this chat");
+					return null;
+				});
 		const applyHydrate = (loaded: Awaited<ReturnType<typeof fetchMessages>>, live: boolean) => {
 			if (!loaded || cancelled) return;
 			// A live restore reused the server's already-loaded resources → no baseline (stays
@@ -239,8 +245,14 @@ export function CenterTabs() {
 				}
 				if (cancelled) return;
 				// All reads start now; applying them newest-first keeps focus deterministic (see above).
-				const inFlight = toOpen.map((s) => ({ live: s.live, result: fetchMessages(s.sessionId) }));
-				for (const { live, result } of inFlight) applyHydrate(await result, live);
+				const inFlight = toOpen.map((s) => ({ summary: s, result: fetchMessages(s.sessionId) }));
+				/** Auto-opens whose transcript never arrived — history entries, not silent absences. */
+				const failed: typeof summaries = [];
+				for (const { summary, result } of inFlight) {
+					const loaded = await result;
+					if (loaded) applyHydrate(loaded, summary.live);
+					else failed.push(summary);
+				}
 				if (cancelled) return;
 				// Fallback: nothing opened (and nothing was deliberately closed) → open the newest disk chat.
 				const state = useAppStore.getState();
@@ -251,10 +263,11 @@ export function CenterTabs() {
 					const newest = toHistory.shift(); // `ordered` kept them newest-first
 					if (newest) await hydrateFromHost(newest.sessionId, newest.live);
 				}
-				if (!cancelled && toHistory.length > 0) {
+				const toList = [...toHistory, ...failed];
+				if (!cancelled && toList.length > 0) {
 					useAppStore.getState().noteClosedChats(
 						workspaceId,
-						toHistory.map((s) => ({
+						toList.map((s) => ({
 							sessionId: s.sessionId,
 							title: s.title,
 							closedAt: s.updatedAt,
@@ -262,7 +275,10 @@ export function CenterTabs() {
 					);
 				}
 			})
-			.catch(() => {});
+			.catch((err: unknown) => {
+				// Same rule as a single transcript above: a failed list leaves the center empty, so say why.
+				if (!cancelled) toast.error(errorText(err), "Couldn't load this workspace's chats");
+			});
 		return () => {
 			cancelled = true;
 		};

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -212,8 +212,6 @@ export function CenterTabs() {
 				.getState()
 				.hydrateSession(summary, messagesToRuntime(messages, summary.lastSettlement), false, tick);
 		};
-		const hydrateFromHost = async (sessionId: string, live: boolean) =>
-			applyHydrate(await fetchMessages(sessionId), live);
 		void getTransport()
 			.request("session.list", { workspaceId })
 			.then(async (summaries) => {
@@ -261,7 +259,13 @@ export function CenterTabs() {
 				);
 				if (!hasChatTab && !sawKnown && toHistory.length > 0) {
 					const newest = toHistory.shift(); // `ordered` kept them newest-first
-					if (newest) await hydrateFromHost(newest.sessionId, newest.live);
+					if (newest) {
+						// Taken out of `toHistory` before its read, so a failure has to put it back — otherwise the
+						// one chat a never-empty workspace has would be in neither list and reachable from nowhere.
+						const loaded = await fetchMessages(newest.sessionId);
+						if (loaded) applyHydrate(loaded, newest.live);
+						else failed.push(newest);
+					}
 				}
 				const toList = [...toHistory, ...failed];
 				if (!cancelled && toList.length > 0) {

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -354,7 +354,12 @@ a project picker, the prompt hero, and the reused
   lands focused without ever stealing an existing selection (e2e: `auto-open-chats.spec.ts`). Reopening restores a live runtime's tab, or for a disk-only chat re-opens it
   on the host (`getMessages`) + hydrates — so a reload, a second tab, or a host restart all rebuild from the
   host. A rejected new-chat `session.create` or history-reopen `getMessages` raises a `store.toast.error`
-  (the click would otherwise do nothing, silently; a failed reopen stays in history for a retry).
+  (the click would otherwise do nothing, silently; a failed reopen stays in history for a retry). **A
+  hydrate read that fails does the same** — an auto-open whose `getMessages` rejects, or a `session.list`
+  that rejects outright — because a swallowed read is indistinguishable from a workspace with no chats;
+  the failed session becomes a history entry (clickable for a retry) instead of vanishing until the next
+  reconnect. Both toasts fall silent once the pass is cancelled: leaving a workspace cancels its reads,
+  and an archived workspace's reads fail by design.
   `CenterTabs` also resolves the history-search **`chatLocationRequest`** deep link (see `store/SPEC.md`):
   once its workspace is active, it focuses an already-open tab, `reopenChat`s a live-but-closed one, or
   fetches + hydrates a disk-only one — the reopen flow's two cases above, plus a third case for an

--- a/e2e/hydrate-failure.spec.ts
+++ b/e2e/hydrate-failure.spec.ts
@@ -93,3 +93,35 @@ test("a transcript that fails to load says so and stays in history", async ({ pa
 		page.getByTestId("closed-chat-item").filter({ hasText: "the unreadable chat" }),
 	).toHaveCount(1);
 });
+
+// The never-empty fallback: a workspace whose only chat is an ordinary disk chat opens it without any
+// TODO to justify it. That summary leaves `toHistory` before its read, so a failure has to put it back —
+// or the one chat the workspace has would be in neither list and reachable from nowhere.
+test("a failed never-empty fallback keeps its chat reachable too", async ({ page }) => {
+	let onlyId = "";
+	await failGetMessagesFor(page, () => onlyId);
+	await openFixtureProject(page);
+
+	const only = seedWorkspaceSession(repoCwd(), {
+		name: "the only chat",
+		messages: [{ role: "user", text: "the only transcript", timestamp: BASE_TS }],
+	});
+	onlyId = only.id;
+	utimesSync(only.path, new Date(BASE_TS), new Date(BASE_TS));
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+
+	await expect(
+		page
+			.locator('[data-testid="toast"][data-variant="error"]')
+			.filter({ hasText: "transcript read failed" }),
+	).toBeVisible();
+
+	// Nothing opened, so the history list is only reachable once a chat exists — but the entry is there.
+	await page.getByTestId("start-chat").click();
+	await page.getByTestId("chat-history").click();
+	await expect(
+		page.getByTestId("closed-chat-item").filter({ hasText: "the only chat" }),
+	).toHaveCount(1);
+});

--- a/e2e/hydrate-failure.spec.ts
+++ b/e2e/hydrate-failure.spec.ts
@@ -1,0 +1,95 @@
+import { mkdirSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+import { TodoStore } from "pi-todos/core";
+import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+// A hydrate read that fails used to be swallowed: no tab, no history entry, no notice — indistinguishable
+// from a workspace that simply has no such chat. That is what made a missing transcript undiagnosable, so
+// the failure now says so and the chat it could not open stays reachable from history.
+
+const BASE_TS = 1_700_400_000_000;
+
+const repoCwd = () => realpathSync(E2E_FIXTURE_REPO);
+
+/** Auto-open needs a reason: an unfinished TODO is the one that works for a disk-only chat. */
+function seedOpenTodo(sessionId: string, title: string): void {
+	const contextDir = join(repoCwd(), ".thinkrail", "context");
+	mkdirSync(contextDir, { recursive: true });
+	writeFileSync(join(contextDir, ".gitignore"), "*\n");
+	new TodoStore(repoCwd(), sessionId).add({ title });
+}
+
+/** Fail `session.getMessages` for ONE session, relaying every other frame verbatim (the regex and the
+ * relay mirror `error-turn.live.spec.ts` — a glob would stop matching the `?client=` suffix). */
+async function failGetMessagesFor(page: Page, sessionId: () => string): Promise<void> {
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			let frame: { id?: string; method?: string; params?: { sessionId?: string } };
+			try {
+				frame = JSON.parse(raw) as typeof frame;
+			} catch {
+				server.send(message);
+				return;
+			}
+			if (
+				frame.method === "session.getMessages" &&
+				frame.id &&
+				frame.params?.sessionId === sessionId()
+			) {
+				ws.send(JSON.stringify({ id: frame.id, ok: false, error: "transcript read failed" }));
+				return;
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+}
+
+test.afterEach(() => {
+	rmSync(join(E2E_FIXTURE_REPO, ".thinkrail"), { recursive: true, force: true });
+});
+
+test("a transcript that fails to load says so and stays in history", async ({ page }) => {
+	let unreadableId = "";
+	// Ahead of the first navigation: `routeWebSocket` only claims sockets opened after it is installed.
+	await failGetMessagesFor(page, () => unreadableId);
+	await openFixtureProject(page); // resets state — seed after
+
+	const unreadable = seedWorkspaceSession(repoCwd(), {
+		name: "the unreadable chat",
+		messages: [{ role: "user", text: "cannot load me", timestamp: BASE_TS }],
+	});
+	unreadableId = unreadable.id;
+	utimesSync(unreadable.path, new Date(BASE_TS), new Date(BASE_TS));
+	seedOpenTodo(unreadable.id, "finish the unreadable work");
+
+	const readable = seedWorkspaceSession(repoCwd(), {
+		name: "the readable chat",
+		messages: [{ role: "user", text: "load me fine", timestamp: BASE_TS + 1_000 }],
+	});
+	utimesSync(readable.path, new Date(BASE_TS + 1_000), new Date(BASE_TS + 1_000));
+	seedOpenTodo(readable.id, "finish the readable work");
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+
+	// One of the two auto-opens failed: the other still hydrated…
+	await expect(page.getByText("load me fine")).toBeVisible();
+	// …the failure is named rather than swallowed…
+	await expect(
+		page
+			.locator('[data-testid="toast"][data-variant="error"]')
+			.filter({ hasText: "transcript read failed" }),
+	).toBeVisible();
+
+	// …and the chat that could not open is reachable for a retry instead of gone.
+	await page.getByTestId("chat-history").click();
+	await expect(
+		page.getByTestId("closed-chat-item").filter({ hasText: "the unreadable chat" }),
+	).toHaveCount(1);
+});


### PR DESCRIPTION
Problem: `CenterTabs`' hydrate pass swallowed both of its reads (`.catch(() => null)`, `.catch(() => {})`). A transcript that failed to load left no tab, no history entry and no notice — identical to a workspace with no such chat, which is what made a missing chat impossible to diagnose.

Solution: name the failure with an error toast (silenced once the pass is cancelled, so leaving a workspace stays quiet) and keep the session as a history entry, clickable for a retry, instead of dropping it until the next reconnect.

Stacked on #244.