### PR TITLE
Write a crash report when the host dies

### DIFF
--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -75,7 +75,7 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `branch-review`, `fs`, `spec`, `todos`, `reviews`, `watch`, `terminal`, `dialog`, `editors`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`, `analytics`
+- `host` → `projects`, `workspaces`, `git`, `github`, `branch-review`, `fs`, `spec`, `todos`, `reviews`, `watch`, `terminal`, `dialog`, `editors`, `agent`, `auth`, `assist`, `settings`, `history`, `templates`, `analytics`, `persistence` (`dataDir`, for the crash report)
 - `workspaces` → `projects`, `git`, `persistence`
 - `branch-review` → `git`
 - `projects` → `git` (shared runner), `persistence`

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -87,7 +87,11 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `provider.jbcentralConnect`→connected (central) — per `submodule-server-analytics`,
   feature modules never track), and
   `stop()` → agent-session cleanup, then `persistTerminalSessions()` **before** `closeAllTerminals()`, then
-  socket close); `boot.ts` (`bootHost` → resolve the
+  socket close); `crashLog.ts` (`installCrashLog` — the `uncaughtException`/`unhandledRejection` report
+  appended to `<dataDir>/logs/crash.log` and echoed to stderr, then `exit(1)`: in-process pi means such a
+  fault is the whole host's, and a launcher started without a terminal otherwise loses its only trace.
+  Never a recovery, and never installed under `NODE_ENV=test` — a unit-test process reports its own
+  faults); `boot.ts` (`bootHost` → install that report first, resolve the
   login-shell PATH, pick the port per `portMode` (`"exact"` vs `"free"`), start `createServer`, and
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort
   streaming sessions and wait bounded, so pi persists their "Operation aborted" tool results and
@@ -211,7 +215,7 @@ channel fan-out, and the process-boot wrapper both launchers share.
 - **Public surface (barrel):** `createServer`, `CreateServerOptions`, `RunningServer`, `bootHost`,
   `BootHostOptions`, `BootedHost`.
 - **Allowed deps:** `contracts` (`PROTOCOL_VERSION`, `WS_CHANNELS`); `shared` (`freePort`, `shellEnv` — for
-  `boot.ts`); the feature modules it composes (per the parent dependency graph, incl. `fs`'s
+  `boot.ts`); `persistence` (`dataDir` — where `crashLog.ts` writes); the feature modules it composes (per the parent dependency graph, incl. `fs`'s
   `resolveWorktreeFile` for the `/files` route); Bun/Node.
 - **Forbidden:** being imported by any feature module; importing `web`/`cli`/`desktop`.
 

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -2,6 +2,7 @@ import { findFreePort } from "@thinkrail/shared/freePort";
 import { resolveShellEnv } from "@thinkrail/shared/shellEnv";
 import { settleSessionsForShutdown } from "../agent";
 import { shutdownAnalytics } from "../analytics";
+import { installCrashLog } from "./crashLog";
 import { type CreateServerOptions, createServer, type RunningServer } from "./server";
 
 export interface BootHostOptions {
@@ -40,6 +41,9 @@ export interface BootedHost {
  * before exiting.
  */
 export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
+	// First thing: from here on a fatal fault leaves a report behind (in-process pi means any such fault is
+	// the whole host's, and this is the only trace it gets).
+	installCrashLog(options.appVersion);
 	// Must precede any AgentSession creation; createServer makes sessions lazily, so here is early enough.
 	resolveShellEnv();
 

--- a/packages/server/src/host/crashLog.test.ts
+++ b/packages/server/src/host/crashLog.test.ts
@@ -23,17 +23,38 @@ test("a run from source says so, and a stack-less throw still reports what it wa
 });
 
 // Formatting must not throw: it runs before the record reaches stderr or the file, so a value that
-// resists rendering would destroy the report instead of appearing in it.
-test("a value that cannot be serialized is still reported", () => {
+// resists rendering would destroy the report instead of appearing in it. Every rendering step is hostile
+// in some case — classification included — so each one degrades rather than escaping.
+test("a value that resists rendering is still reported", () => {
 	const cyclic: { self?: unknown } = {};
 	cyclic.self = cyclic;
-	expect(formatCrashRecord("uncaughtException", cyclic, AT, 1)).toContain("unserializable");
-	expect(formatCrashRecord("unhandledRejection", { big: 1n }, AT, 1)).toContain("unserializable");
+	expect(formatCrashRecord("uncaughtException", cyclic, AT, 1)).toContain("Unrenderable throw:");
+	expect(formatCrashRecord("unhandledRejection", { big: 1n }, AT, 1)).toContain(
+		"Unrenderable throw:",
+	);
 
-	// No prototype ⇒ no `toString` either, so even the fallback rendering throws.
-	const hostile = Object.assign(Object.create(null), { big: 1n }) as object;
-	expect(formatCrashRecord("uncaughtException", hostile, AT, 1)).toContain(
-		"Non-Error thrown (unserializable object)",
+	// An Error whose `stack` accessor throws: classification succeeded, the read did not.
+	const badStack = new Error("hostile");
+	Object.defineProperty(badStack, "stack", {
+		get() {
+			throw new Error("no stack for you");
+		},
+	});
+	expect(formatCrashRecord("uncaughtException", badStack, AT, 1)).toContain(
+		"Unrenderable throw: Error: hostile",
+	);
+
+	// No prototype ⇒ no `toString` to borrow, so even the fallback rendering throws.
+	const noProto = Object.assign(Object.create(null), { big: 1n }) as object;
+	expect(formatCrashRecord("uncaughtException", noProto, AT, 1)).toContain(
+		"Unrenderable throw (object)",
+	);
+
+	// A revoked Proxy traps every operation, `instanceof` included — the type is all that survives.
+	const { proxy, revoke } = Proxy.revocable({}, {});
+	revoke();
+	expect(formatCrashRecord("unhandledRejection", proxy, AT, 1)).toContain(
+		"Unrenderable throw (object)",
 	);
 });
 

--- a/packages/server/src/host/crashLog.test.ts
+++ b/packages/server/src/host/crashLog.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { formatCrashRecord } from "./crashLog";
+
+const AT = new Date("2026-08-16T18:22:03.911Z");
+
+test("a record names the fault, the build and the uptime, and keeps the stack", () => {
+	const error = new Error("provider stream died");
+	error.stack = "Error: provider stream died\n    at stream (pi.js:1:1)";
+	const record = formatCrashRecord("uncaughtException", error, AT, 11_523.4, "0.4.1");
+	expect(record).toBe(
+		"[2026-08-16T18:22:03.911Z] uncaughtException (thinkrail 0.4.1, up 11523s)\n" +
+			"Error: provider stream died\n    at stream (pi.js:1:1)\n\n",
+	);
+});
+
+test("a run from source says so, and a stack-less throw still reports what it was", () => {
+	const record = formatCrashRecord("unhandledRejection", "just a string", AT, 2);
+	expect(record).toContain("unhandledRejection (thinkrail source, up 2s)");
+	expect(record).toContain("Non-Error thrown: just a string");
+});
+
+// The wiring, in a real process: installing a handler suppresses Bun's own report, so the point is that
+// BOTH the file and stderr get the fault, and that the process still dies rather than serving on broken.
+const dirs: string[] = [];
+
+afterAll(() => {
+	for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+});
+
+async function runCrashing(
+	body: string,
+): Promise<{ exitCode: number; stderr: string; log: string }> {
+	const dir = mkdtempSync(join(tmpdir(), "trpi-crashlog-"));
+	dirs.push(dir);
+	const script = join(dir, "boom.ts");
+	writeFileSync(
+		script,
+		`import { installCrashLog } from ${JSON.stringify(join(import.meta.dir, "crashLog.ts"))};\n` +
+			`installCrashLog("9.9.9-test");\n${body}\n` +
+			// Keep the loop alive so the process can only end by the fault itself.
+			`setInterval(() => {}, 1_000);\n`,
+	);
+	const proc = Bun.spawn([process.execPath, script], {
+		// Not a test process: `bun test`'s own `NODE_ENV=test` is exactly what the installer declines on.
+		env: { ...process.env, NODE_ENV: "production", THINKRAIL_DATA_DIR: dir },
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	const stderr = await new Response(proc.stderr).text();
+	const exitCode = await proc.exited;
+	return { exitCode, stderr, log: readFileSync(join(dir, "logs", "crash.log"), "utf8") };
+}
+
+test("an uncaught exception is written to the crash log, echoed to stderr, and still fatal", async () => {
+	const { exitCode, stderr, log } = await runCrashing(
+		`setTimeout(() => { throw new Error("boom from the agent"); }, 0);`,
+	);
+	expect(exitCode).toBe(1);
+	expect(log).toContain("uncaughtException (thinkrail 9.9.9-test");
+	expect(log).toContain("boom from the agent");
+	expect(stderr).toContain("boom from the agent");
+	expect(stderr).toContain("wrote crash report to");
+});
+
+test("an unhandled rejection is recorded the same way", async () => {
+	const { exitCode, log } = await runCrashing(
+		`setTimeout(() => { void Promise.reject(new Error("rejected mid-turn")); }, 0);`,
+	);
+	expect(exitCode).toBe(1);
+	expect(log).toContain("unhandledRejection (thinkrail 9.9.9-test");
+	expect(log).toContain("rejected mid-turn");
+});
+
+test("a test runner's own process is left alone — it reports faults itself", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "trpi-crashlog-"));
+	dirs.push(dir);
+	const script = join(dir, "boom.ts");
+	writeFileSync(
+		script,
+		`import { installCrashLog } from ${JSON.stringify(join(import.meta.dir, "crashLog.ts"))};\n` +
+			`installCrashLog("9.9.9-test");\n` +
+			`process.stderr.write(String(process.listenerCount("uncaughtException")));\n`,
+	);
+	const proc = Bun.spawn([process.execPath, script], {
+		env: { ...process.env, NODE_ENV: "test", THINKRAIL_DATA_DIR: dir },
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	expect(await new Response(proc.stderr).text()).toBe("0");
+	expect(await proc.exited).toBe(0);
+});

--- a/packages/server/src/host/crashLog.test.ts
+++ b/packages/server/src/host/crashLog.test.ts
@@ -50,6 +50,13 @@ test("a value that resists rendering is still reported", () => {
 		"Unrenderable throw (object)",
 	);
 
+	// A `stack` that is not a string at all: returning it would move the coercion outside the guard.
+	const proxyStack = new Error("proxy stack");
+	const revocable = Proxy.revocable({}, {});
+	revocable.revoke();
+	Object.defineProperty(proxyStack, "stack", { value: revocable.proxy });
+	expect(formatCrashRecord("uncaughtException", proxyStack, AT, 1)).toContain("Error: proxy stack");
+
 	// A revoked Proxy traps every operation, `instanceof` included — the type is all that survives.
 	const { proxy, revoke } = Proxy.revocable({}, {});
 	revoke();

--- a/packages/server/src/host/crashLog.test.ts
+++ b/packages/server/src/host/crashLog.test.ts
@@ -22,6 +22,21 @@ test("a run from source says so, and a stack-less throw still reports what it wa
 	expect(record).toContain("Non-Error thrown: just a string");
 });
 
+// Formatting must not throw: it runs before the record reaches stderr or the file, so a value that
+// resists rendering would destroy the report instead of appearing in it.
+test("a value that cannot be serialized is still reported", () => {
+	const cyclic: { self?: unknown } = {};
+	cyclic.self = cyclic;
+	expect(formatCrashRecord("uncaughtException", cyclic, AT, 1)).toContain("unserializable");
+	expect(formatCrashRecord("unhandledRejection", { big: 1n }, AT, 1)).toContain("unserializable");
+
+	// No prototype ⇒ no `toString` either, so even the fallback rendering throws.
+	const hostile = Object.assign(Object.create(null), { big: 1n }) as object;
+	expect(formatCrashRecord("uncaughtException", hostile, AT, 1)).toContain(
+		"Non-Error thrown (unserializable object)",
+	);
+});
+
 // The wiring, in a real process: installing a handler suppresses Bun's own report, so the point is that
 // BOTH the file and stderr get the fault, and that the process still dies rather than serving on broken.
 const dirs: string[] = [];

--- a/packages/server/src/host/crashLog.ts
+++ b/packages/server/src/host/crashLog.ts
@@ -38,7 +38,12 @@ export function formatCrashRecord(
  */
 function describe(error: unknown): string {
 	try {
-		if (error instanceof Error) return error.stack || `${error.name}: ${error.message}`;
+		if (error instanceof Error) {
+			// `stack` is typed `string | undefined` but is whatever the thrower left there; anything else
+			// would only be coerced later, by the caller's interpolation, outside this guard.
+			const { stack } = error;
+			return typeof stack === "string" && stack ? stack : `${error.name}: ${error.message}`;
+		}
 		if (typeof error === "string") return `Non-Error thrown: ${error}`;
 		return `Non-Error thrown: ${JSON.stringify(error) ?? String(error)}`;
 	} catch {

--- a/packages/server/src/host/crashLog.ts
+++ b/packages/server/src/host/crashLog.ts
@@ -1,0 +1,71 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { dataDir } from "../persistence";
+
+/** What killed the process — the two faults that reach a Bun process as a top-level event. */
+export type CrashKind = "uncaughtException" | "unhandledRejection";
+
+/** Where crash reports are appended, under the data dir so they sit beside the state they describe. */
+export function crashLogPath(): string {
+	return join(dataDir(), "logs", "crash.log");
+}
+
+/**
+ * One crash report: when, what kind of fault, which build, how long the host had been up, and the stack.
+ * Pure so the format is unit-testable — this text is the only account of a fault that leaves nothing else
+ * behind, so it has to survive a stack-less throw (a string, a rejected non-Error) intact.
+ */
+export function formatCrashRecord(
+	kind: CrashKind,
+	error: unknown,
+	at: Date,
+	uptimeSeconds: number,
+	appVersion?: string,
+): string {
+	const build = appVersion ?? "source";
+	const detail =
+		error instanceof Error
+			? (error.stack ?? `${error.name}: ${error.message}`)
+			: `Non-Error thrown: ${typeof error === "string" ? error : (JSON.stringify(error) ?? String(error))}`;
+	return `[${at.toISOString()}] ${kind} (thinkrail ${build}, up ${Math.round(uptimeSeconds)}s)\n${detail}\n\n`;
+}
+
+let installed = false;
+
+/**
+ * Record a fatal fault before the process goes, then let it go.
+ *
+ * The host runs `pi` **in-process**, so a fatal agent/provider fault takes the whole thing down (see
+ * `AGENTS.md`) — and until now it took the only account of itself with it: a launcher started from a GUI
+ * or an `npx` shim has no terminal left to read, and `bun --watch` scrolls the stack away behind whatever
+ * came next. A file under the data dir is what makes the next crash answerable.
+ *
+ * Deliberately **not** a recovery: an uncaught fault leaves the process in an unknown state, and Bun's own
+ * default is to exit, so this exits too (code 1) rather than keeping a half-broken host serving. Because
+ * installing a handler suppresses Bun's own report, the stack is echoed to stderr as well — the terminal
+ * must not get *less* than before.
+ *
+ * Skipped under `NODE_ENV=test` (which `bun test` sets, the same fact `analytics/mute.ts` reads for its own
+ * reason): unit tests boot hosts in the runner's own process, and handing that process a handler that
+ * exits would take the suite down instead of letting bun test report the fault.
+ */
+export function installCrashLog(appVersion?: string): void {
+	if (installed || process.env.NODE_ENV === "test") return;
+	installed = true;
+	const report = (kind: CrashKind, error: unknown): never => {
+		const record = formatCrashRecord(kind, error, new Date(), process.uptime(), appVersion);
+		process.stderr.write(`\nthinkrail host: fatal ${kind}\n${record}`);
+		try {
+			const path = crashLogPath();
+			mkdirSync(join(path, ".."), { recursive: true });
+			appendFileSync(path, record);
+			process.stderr.write(`thinkrail host: wrote crash report to ${path}\n`);
+		} catch (writeError) {
+			// The report is the fallback for everything else; nothing is left to fall back to but stderr.
+			process.stderr.write(`thinkrail host: could not write the crash report: ${writeError}\n`);
+		}
+		process.exit(1);
+	};
+	process.on("uncaughtException", (error) => report("uncaughtException", error));
+	process.on("unhandledRejection", (reason) => report("unhandledRejection", reason));
+}

--- a/packages/server/src/host/crashLog.ts
+++ b/packages/server/src/host/crashLog.ts
@@ -29,23 +29,26 @@ export function formatCrashRecord(
 /**
  * What was thrown, as text that can always be produced.
  *
- * Anything can be thrown or rejected with, and both obvious ways to render an unknown value can throw in
- * turn: `JSON.stringify` on a cycle or a BigInt, `String()` on a null-prototype object or a hostile
- * `toString`. A crash reporter that throws while reporting destroys the very fault it exists to record —
- * and it would throw from inside the handler, before anything reached stderr or the file — so every step
- * here degrades instead, down to naming the type alone.
+ * Anything can be thrown or rejected with, and every step of rendering an unknown value can itself throw:
+ * `instanceof` and any property read trap on a revoked `Proxy`, `stack` may be an accessor that throws,
+ * `JSON.stringify` rejects cycles and BigInts, and `String()` has neither `toString` nor a prototype to
+ * borrow one from on a null-prototype object. A crash reporter that throws while reporting destroys the
+ * very fault it exists to record — and it would throw from inside the handler, before anything reached
+ * stderr or the file — so classification and every read sit inside the guard, degrading to the type alone.
  */
 function describe(error: unknown): string {
-	if (error instanceof Error) return error.stack ?? `${error.name}: ${error.message}`;
-	if (typeof error === "string") return `Non-Error thrown: ${error}`;
 	try {
+		if (error instanceof Error) return error.stack || `${error.name}: ${error.message}`;
+		if (typeof error === "string") return `Non-Error thrown: ${error}`;
 		return `Non-Error thrown: ${JSON.stringify(error) ?? String(error)}`;
 	} catch {
-		try {
-			return `Non-Error thrown (unserializable): ${String(error)}`;
-		} catch {
-			return `Non-Error thrown (unserializable ${typeof error})`;
-		}
+		// Fall through: whatever this is, it resists the ordinary renderings.
+	}
+	try {
+		return `Unrenderable throw: ${String(error)}`;
+	} catch {
+		// `typeof` is the one operator left that cannot trap.
+		return `Unrenderable throw (${typeof error})`;
 	}
 }
 

--- a/packages/server/src/host/crashLog.ts
+++ b/packages/server/src/host/crashLog.ts
@@ -23,11 +23,30 @@ export function formatCrashRecord(
 	appVersion?: string,
 ): string {
 	const build = appVersion ?? "source";
-	const detail =
-		error instanceof Error
-			? (error.stack ?? `${error.name}: ${error.message}`)
-			: `Non-Error thrown: ${typeof error === "string" ? error : (JSON.stringify(error) ?? String(error))}`;
-	return `[${at.toISOString()}] ${kind} (thinkrail ${build}, up ${Math.round(uptimeSeconds)}s)\n${detail}\n\n`;
+	return `[${at.toISOString()}] ${kind} (thinkrail ${build}, up ${Math.round(uptimeSeconds)}s)\n${describe(error)}\n\n`;
+}
+
+/**
+ * What was thrown, as text that can always be produced.
+ *
+ * Anything can be thrown or rejected with, and both obvious ways to render an unknown value can throw in
+ * turn: `JSON.stringify` on a cycle or a BigInt, `String()` on a null-prototype object or a hostile
+ * `toString`. A crash reporter that throws while reporting destroys the very fault it exists to record —
+ * and it would throw from inside the handler, before anything reached stderr or the file — so every step
+ * here degrades instead, down to naming the type alone.
+ */
+function describe(error: unknown): string {
+	if (error instanceof Error) return error.stack ?? `${error.name}: ${error.message}`;
+	if (typeof error === "string") return `Non-Error thrown: ${error}`;
+	try {
+		return `Non-Error thrown: ${JSON.stringify(error) ?? String(error)}`;
+	} catch {
+		try {
+			return `Non-Error thrown (unserializable): ${String(error)}`;
+		} catch {
+			return `Non-Error thrown (unserializable ${typeof error})`;
+		}
+	}
 }
 
 let installed = false;


### PR DESCRIPTION
Problem: the host runs pi in-process, so a fatal agent/provider fault kills the whole thing — and left no account of itself. There were no `uncaughtException`/`unhandledRejection` handlers and no log anywhere, so a launcher started without a terminal lost the stack entirely and `bun --watch` scrolled it away.

Solution: `bootHost` installs a handler that appends the fault, build and uptime to `<dataDir>/logs/crash.log`, echoes it to stderr (installing a handler suppresses Bun's own report), then exits 1 as before. Not a recovery — just a trace. Skipped under `NODE_ENV=test` so a unit-test process keeps reporting its own faults.

Stacked on #245.