### PR TITLE
feat(web): centralized radius scale — 4px default, capped at 8px

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -93,8 +93,10 @@ The module set: `transport` / `store` / branded `shell`; `ProjectTree`; `FileTre
   drops an unknown utility silently, so an unpublished token renders as nothing at all).
 - **A radius or spacing utility names a scale step, never a raw pixel length** — `rounded-[var(--radius-md)]`
   and `p-md` / `py-0.5`, not `rounded-[7px]` or `py-[3px]`. Two scales are legitimate and both are
-  token-backed: the project family (`--radius-xs/sm/md` — a small primitive geometry capped at 6px, no
-  step above it — and `--space-xs…xl`) and Tailwind's numeric steps
+  token-backed: the project family (`--radius-xs/sm/md/lg` — a small primitive geometry capped at 8px:
+  `sm` (4px) is the default corner, `md` (6px) the outer corner for surfaces nesting 4px children, `lg`
+  (8px) the exception for large standalone elevated surfaces (dialogs, user-message bubbles) — and
+  `--space-xs…xl`) and Tailwind's numeric steps
   for the sub-`--space-xs` tier the project family does not cover. `src/styles/spacingUsage.test.ts` is
   that adoption guard, and it exists because this class of drift is **invisible**: unlike a colour
   utility, an arbitrary length always renders, so an off-scale value looks correct in review and passes

--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -93,7 +93,8 @@ The module set: `transport` / `store` / branded `shell`; `ProjectTree`; `FileTre
   drops an unknown utility silently, so an unpublished token renders as nothing at all).
 - **A radius or spacing utility names a scale step, never a raw pixel length** — `rounded-[var(--radius-md)]`
   and `p-md` / `py-0.5`, not `rounded-[7px]` or `py-[3px]`. Two scales are legitimate and both are
-  token-backed: the project family (`--radius-xs/sm/md/lg`, `--space-xs…xl`) and Tailwind's numeric steps
+  token-backed: the project family (`--radius-xs/sm/md` — a small primitive geometry capped at 6px, no
+  step above it — and `--space-xs…xl`) and Tailwind's numeric steps
   for the sub-`--space-xs` tier the project family does not cover. `src/styles/spacingUsage.test.ts` is
   that adoption guard, and it exists because this class of drift is **invisible**: unlike a colour
   utility, an arbitrary length always renders, so an off-scale value looks correct in review and passes

--- a/apps/web/src/auth/LoginDialog.tsx
+++ b/apps/web/src/auth/LoginDialog.tsx
@@ -119,7 +119,7 @@ export function LoginDialog({
 
 						{state.deviceCode ? (
 							<div
-								className="flex flex-col gap-xs rounded-[var(--radius-md)] border border-border-default bg-control-bg p-md"
+								className="flex flex-col gap-xs rounded-[var(--radius-sm)] border border-border-default bg-control-bg p-md"
 								data-testid="login-device-code"
 							>
 								<span className="text-text-muted tr-text-metadata">
@@ -153,7 +153,7 @@ export function LoginDialog({
 										data-testid="login-option"
 										data-option={option.id}
 										onClick={() => onReply(option.id)}
-										className="rounded-[var(--radius-md)] border border-control-border-default bg-control-bg px-md py-sm text-left tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary"
+										className="rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-md py-sm text-left tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary"
 									>
 										{option.label}
 									</button>
@@ -179,7 +179,7 @@ export function LoginDialog({
 												submitPrompt();
 											}
 										}}
-										className="min-w-0 flex-1 rounded-[var(--radius-md)] border border-control-border-default bg-control-bg px-sm py-xs tr-text-ui text-text-default outline-none placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft"
+										className="min-w-0 flex-1 rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-sm py-xs tr-text-ui text-text-default outline-none placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft"
 									/>
 									<Button data-testid="login-submit" onClick={submitPrompt}>
 										Submit

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -655,7 +655,7 @@ export default function ChatView({
 							itemContent={(_, row) => (
 								<div
 									data-flash={row.id === flashRowId || undefined}
-									className="mx-auto max-w-3xl rounded-[var(--radius-md)] px-md py-xs transition-colors data-[flash]:bg-primary-subtle"
+									className="mx-auto max-w-3xl rounded-[var(--radius-sm)] px-md py-xs transition-colors data-[flash]:bg-primary-subtle"
 								>
 									<ChatTurnView
 										row={row}
@@ -672,7 +672,7 @@ export default function ChatView({
 								type="button"
 								data-testid="scroll-to-bottom"
 								onClick={scrollToBottom}
-								className="-translate-x-1/2 absolute bottom-md left-1/2 flex items-center gap-xs rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-muted tr-text-metadata shadow-[var(--shadow-md)] hover:bg-control-bg-hovered hover:text-text-default"
+								className="-translate-x-1/2 absolute bottom-md left-1/2 flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-muted tr-text-metadata shadow-[var(--shadow-md)] hover:bg-control-bg-hovered hover:text-text-default"
 							>
 								<ArrowDown className="size-3" />
 								New messages

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -672,7 +672,7 @@ export default function ChatView({
 								type="button"
 								data-testid="scroll-to-bottom"
 								onClick={scrollToBottom}
-								className="-translate-x-1/2 absolute bottom-md left-1/2 flex items-center gap-xs rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-muted tr-text-metadata shadow-[var(--shadow-md)] hover:bg-control-bg-hovered hover:text-text-default"
+								className="-translate-x-1/2 absolute bottom-md left-1/2 flex items-center gap-xs rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-sm py-xs text-text-muted tr-text-metadata shadow-[var(--shadow-md)] hover:bg-control-bg-hovered hover:text-text-default"
 							>
 								<ArrowDown className="size-3" />
 								New messages

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -795,7 +795,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 						// `relative` keeps the textarea a positioned participant so it paints ABOVE the absolute
 						// slot-highlight backdrop (its earlier DOM sibling) — otherwise a static textarea paints
 						// under the backdrop and the native caret/selection get dimmed by the active-slot tint.
-						className="relative min-h-[108px] w-full resize-none rounded-[var(--radius-md)] bg-transparent px-md py-sm tr-text-ui text-text-default outline-none placeholder:text-text-muted"
+						className="relative min-h-[108px] w-full resize-none rounded-[var(--radius-sm)] bg-transparent px-md py-sm tr-text-ui text-text-default outline-none placeholder:text-text-muted"
 					/>
 				</div>
 				<div className="flex flex-wrap items-center gap-sm">
@@ -821,7 +821,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							data-testid="history-open"
 							aria-label="Search history"
 							onClick={openHistory}
-							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg text-text-default hover:bg-control-bg-hovered"
+							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg text-text-default hover:bg-control-bg-hovered"
 						>
 							<History className="size-3.5" />
 						</button>
@@ -831,7 +831,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 								data-testid="chat-abort"
 								aria-label="Stop"
 								onClick={onAbort}
-								className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg text-text-default hover:bg-control-bg-hovered"
+								className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg text-text-default hover:bg-control-bg-hovered"
 							>
 								<Square className="size-3.5" />
 							</button>
@@ -842,7 +842,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							aria-label={isStreaming ? "Steer" : "Send"}
 							onClick={() => submit(isStreaming ? "steer" : "send")}
 							disabled={!value.trim() && images.length === 0}
-							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-control-primary-bg text-control-primary-text hover:bg-control-primary-bg-hovered disabled:pointer-events-none disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
+							className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-control-primary-bg text-control-primary-text hover:bg-control-primary-bg-hovered disabled:pointer-events-none disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
 						>
 							<ArrowUp className="size-4" />
 						</button>

--- a/apps/web/src/chat/ExtUiDialog.tsx
+++ b/apps/web/src/chat/ExtUiDialog.tsx
@@ -48,7 +48,7 @@ export function ExtUiDialog({
 								type="button"
 								data-testid="ext-ui-option"
 								onClick={() => onReply(option)}
-								className="rounded-[var(--radius-md)] border border-control-border-default bg-control-bg px-md py-sm text-left tr-text-ui text-text-default outline-none hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary"
+								className="rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-md py-sm text-left tr-text-ui text-text-default outline-none hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary"
 							>
 								{option}
 							</button>
@@ -69,7 +69,7 @@ export function ExtUiDialog({
 								onReply(text);
 							}
 						}}
-						className="rounded-[var(--radius-md)] border border-control-border-default bg-control-bg px-sm py-xs tr-text-ui text-text-default outline-none placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft"
+						className="rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-sm py-xs tr-text-ui text-text-default outline-none placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft"
 					/>
 				) : null}
 
@@ -80,7 +80,7 @@ export function ExtUiDialog({
 						value={text}
 						rows={8}
 						onChange={(e) => setText(e.target.value)}
-						className="resize-none rounded-[var(--radius-md)] border border-control-border-default bg-control-bg px-sm py-xs tr-code-text text-text-default outline-none focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft"
+						className="resize-none rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-sm py-xs tr-code-text text-text-default outline-none focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft"
 					/>
 				) : null}
 

--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -606,7 +606,7 @@ export function HistoryOverlay({
 		<div
 			data-testid="history-overlay"
 			data-stage={stage}
-			className="absolute bottom-full left-sm right-sm mb-xs flex flex-col overflow-hidden rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg shadow-[var(--shadow-md)]"
+			className="absolute bottom-full left-sm right-sm mb-xs flex flex-col overflow-hidden rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg shadow-[var(--shadow-md)]"
 		>
 			<div className="flex items-center gap-sm border-b border-border-default p-sm">
 				<input

--- a/apps/web/src/chat/Markdown.tsx
+++ b/apps/web/src/chat/Markdown.tsx
@@ -72,8 +72,10 @@ function CodeBlock({
 	const code = String(children ?? "").replace(/\n$/, "");
 	if (!lang) {
 		if (!code.includes("\n")) {
+			// Inline code sits directly behind a text run → the 2px inline-highlight tier (`xs`), not the
+			// 4px default the fenced block below uses as a standalone container.
 			return (
-				<code className="rounded-[var(--radius-sm)] bg-container-elevated-bg px-1 py-0.5">
+				<code className="rounded-[var(--radius-xs)] bg-container-elevated-bg px-1 py-0.5">
 					{children}
 				</code>
 			);

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -73,7 +73,7 @@ export function ModelSelector({
 			<PopoverTrigger
 				data-testid="model-selector"
 				data-open={open}
-				className="flex h-8 max-w-[220px] items-center gap-sm rounded-[var(--radius-md)] border border-control-border-default bg-clip-padding bg-control-bg px-sm tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
+				className="flex h-8 max-w-[220px] items-center gap-sm rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-sm tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
 			>
 				<span className="truncate text-text-muted tr-text-metadata">
 					{current?.name ?? "Select model"}

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -260,7 +260,7 @@ export function SkillsDialog({
 				{workspace?.stale ? (
 					<div
 						data-testid="skills-stale"
-						className="rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-sm text-text-muted tr-text-metadata"
+						className="rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-md py-sm text-text-muted tr-text-metadata"
 					>
 						This worktree's skills changed on disk —{" "}
 						<span className="text-text-default">Reload</span> to apply them to this chat.
@@ -270,7 +270,7 @@ export function SkillsDialog({
 				{untrustedCount > 0 ? (
 					<div
 						data-testid="skills-trust-all"
-						className="flex items-center gap-sm rounded-[var(--radius-md)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm"
+						className="flex items-center gap-sm rounded-[var(--radius-sm)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm"
 					>
 						<span className="min-w-0 flex-1 tr-text-ui text-text-default">
 							{untrustedCount} project skill{untrustedCount === 1 ? "" : "s"} off until you trust

--- a/apps/web/src/chat/TemplateEditorDialog.tsx
+++ b/apps/web/src/chat/TemplateEditorDialog.tsx
@@ -21,7 +21,7 @@ import { assembleTemplate, stripFrontmatter } from "./templateText";
 const SYNTAX_HINT = `$1, $ARGUMENTS, \${1:-default} — pi prompt-template syntax`;
 
 const INPUT_CLASS =
-	"w-full rounded-[var(--radius-md)] border border-control-border-default bg-control-bg px-md py-sm tr-text-ui text-text-default outline-none transition-colors placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft disabled:bg-control-disabled-bg disabled:text-control-disabled-text";
+	"w-full rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-md py-sm tr-text-ui text-text-default outline-none transition-colors placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft disabled:bg-control-disabled-bg disabled:text-control-disabled-text";
 
 /**
  * Mirrors the server's `isValidTemplateName` (`packages/server/src/templates/templates.ts`) exactly — a
@@ -325,7 +325,7 @@ function ScopeOption({
 			disabled={disabled}
 			onClick={onSelect}
 			className={cn(
-				"flex-1 rounded-[var(--radius-md)] border px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:bg-control-disabled-bg disabled:text-control-disabled-text",
+				"flex-1 rounded-[var(--radius-sm)] border px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:bg-control-disabled-bg disabled:text-control-disabled-text",
 				active
 					? "border-primary-muted bg-clip-padding bg-primary-subtle text-text-default"
 					: "border-border-default text-text-muted hover:bg-control-bg-hovered hover:text-text-default",

--- a/apps/web/src/chat/ThinkingSelector.tsx
+++ b/apps/web/src/chat/ThinkingSelector.tsx
@@ -29,7 +29,7 @@ export function ThinkingSelector({
 				data-testid="thinking-selector"
 				data-open={open}
 				disabled={levels.length === 0}
-				className="flex h-8 items-center gap-sm rounded-[var(--radius-md)] border border-control-border-default bg-clip-padding bg-control-bg px-sm tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
+				className="flex h-8 items-center gap-sm rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-sm tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
 			>
 				<span className="tr-text-eyebrow text-text-muted">Effort</span>
 				<span className="capitalize">{level}</span>

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -278,7 +278,7 @@ export function AskUserQuestionCard({
 			<div
 				data-testid="ask-user-question"
 				data-tone="active"
-				className="overflow-hidden rounded-[var(--radius-md)] border border-primary-muted bg-clip-padding bg-container-elevated-bg ring-1 ring-primary-soft"
+				className="overflow-hidden rounded-[var(--radius-lg)] border border-primary-muted bg-clip-padding bg-container-elevated-bg ring-1 ring-primary-soft"
 			>
 				{multi ? (
 					<div className="flex items-center gap-xs overflow-x-auto border-border-default border-b px-md py-sm">
@@ -345,7 +345,7 @@ export function AskUserQuestionCard({
 									type="button"
 									data-testid="ask-continue"
 									onClick={() => setTab(Math.min(tab + 1, reviewTab))}
-									className="rounded-[var(--radius-md)] bg-control-primary-bg px-md py-1.5 tr-text-action text-control-primary-text hover:bg-control-primary-bg-hovered"
+									className="rounded-[var(--radius-sm)] bg-control-primary-bg px-md py-1.5 tr-text-action text-control-primary-text hover:bg-control-primary-bg-hovered"
 								>
 									Next →
 								</button>
@@ -355,7 +355,7 @@ export function AskUserQuestionCard({
 									data-testid="ask-submit"
 									onClick={() => reply({ answers, cancelled: false })}
 									disabled={!canSubmit}
-									className="rounded-[var(--radius-md)] bg-control-primary-bg px-md py-1.5 tr-text-action text-control-primary-text hover:bg-control-primary-bg-hovered disabled:cursor-not-allowed disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
+									className="rounded-[var(--radius-sm)] bg-control-primary-bg px-md py-1.5 tr-text-action text-control-primary-text hover:bg-control-primary-bg-hovered disabled:cursor-not-allowed disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
 								>
 									Submit
 								</button>
@@ -406,7 +406,7 @@ function WaitingCard({ children }: { children: React.ReactNode }) {
 			<div
 				data-testid="ask-user-question"
 				data-tone="pending"
-				className="flex items-center gap-xs rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-sm text-text-muted tr-text-metadata"
+				className="flex items-center gap-xs rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg px-md py-sm text-text-muted tr-text-metadata"
 			>
 				<MessageCircleQuestion className="size-3.5 shrink-0" />
 				{children}
@@ -427,15 +427,15 @@ function ComposingCard({ count }: { count: number }) {
 			<div
 				data-testid="ask-user-question"
 				data-tone="pending"
-				className="flex flex-col gap-sm rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-sm"
+				className="flex flex-col gap-sm rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg px-md py-sm"
 			>
 				<div className="flex items-center gap-xs text-text-muted tr-text-metadata">
 					<MessageCircleQuestion className="size-3.5 shrink-0" />
 					Preparing questions…{count > 0 ? ` (${count} ready)` : ""}
 				</div>
 				<div className="flex animate-pulse flex-col gap-xs" aria-hidden="true">
-					<div className="h-8 rounded-[var(--radius-md)] bg-control-bg-selected" />
-					<div className="h-8 rounded-[var(--radius-md)] bg-control-bg-selected" />
+					<div className="h-8 rounded-[var(--radius-sm)] bg-control-bg-selected" />
+					<div className="h-8 rounded-[var(--radius-sm)] bg-control-bg-selected" />
 				</div>
 			</div>
 		</div>
@@ -605,7 +605,7 @@ function QuestionBody({
 				{anyPreview && previewSource?.preview ? (
 					<div
 						data-testid="ask-preview"
-						className="min-w-0 overflow-auto rounded-[var(--radius-md)] border border-border-default bg-control-bg px-sm py-xs tr-text-metadata"
+						className="min-w-0 overflow-auto rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-sm py-xs tr-text-metadata"
 					>
 						<div className="mb-xs text-text-muted tr-text-metadata">
 							Preview · {previewSource.label}
@@ -641,7 +641,7 @@ function OptionRow({
 			data-selected={selected}
 			onClick={onClick}
 			className={cn(
-				"flex items-start gap-sm rounded-[var(--radius-md)] border px-md py-sm text-left transition-colors",
+				"flex items-start gap-sm rounded-[var(--radius-sm)] border px-md py-sm text-left transition-colors",
 				selected
 					? "border-primary bg-primary-subtle"
 					: "border-border-default hover:bg-control-bg-hovered",
@@ -701,7 +701,7 @@ function OtherOptionRow({
 			data-testid="ask-custom-row"
 			data-selected={active}
 			className={cn(
-				"flex cursor-text items-center gap-sm rounded-[var(--radius-md)] border px-md py-sm transition-colors",
+				"flex cursor-text items-center gap-sm rounded-[var(--radius-sm)] border px-md py-sm transition-colors",
 				active
 					? "border-primary bg-primary-subtle"
 					: "border-border-default hover:bg-control-bg-hovered",

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -278,7 +278,7 @@ export function AskUserQuestionCard({
 			<div
 				data-testid="ask-user-question"
 				data-tone="active"
-				className="overflow-hidden rounded-[var(--radius-lg)] border border-primary-muted bg-clip-padding bg-container-elevated-bg ring-1 ring-primary-soft"
+				className="overflow-hidden rounded-[var(--radius-md)] border border-primary-muted bg-clip-padding bg-container-elevated-bg ring-1 ring-primary-soft"
 			>
 				{multi ? (
 					<div className="flex items-center gap-xs overflow-x-auto border-border-default border-b px-md py-sm">
@@ -406,7 +406,7 @@ function WaitingCard({ children }: { children: React.ReactNode }) {
 			<div
 				data-testid="ask-user-question"
 				data-tone="pending"
-				className="flex items-center gap-xs rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg px-md py-sm text-text-muted tr-text-metadata"
+				className="flex items-center gap-xs rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-sm text-text-muted tr-text-metadata"
 			>
 				<MessageCircleQuestion className="size-3.5 shrink-0" />
 				{children}
@@ -427,7 +427,7 @@ function ComposingCard({ count }: { count: number }) {
 			<div
 				data-testid="ask-user-question"
 				data-tone="pending"
-				className="flex flex-col gap-sm rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg px-md py-sm"
+				className="flex flex-col gap-sm rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-sm"
 			>
 				<div className="flex items-center gap-xs text-text-muted tr-text-metadata">
 					<MessageCircleQuestion className="size-3.5 shrink-0" />

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -105,7 +105,7 @@ function UserTurn({ id, message }: { id: string; message: UserMessage }) {
 	const review = parseReviewPackage(text);
 	return (
 		<div data-testid="chat-message" data-role="user" className="flex justify-end">
-			<div className="max-w-[85%] whitespace-pre-wrap rounded-[var(--radius-md)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-md py-sm tr-text-reading text-text-muted">
+			<div className="max-w-[85%] whitespace-pre-wrap rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-md py-sm tr-text-reading text-text-muted">
 				{review ? (
 					<div data-testid="review-package-card" className="whitespace-normal">
 						<span data-testid="review-package-summary" className="block text-text-default">
@@ -241,7 +241,7 @@ function ErrorTurn({ text }: { text: string }) {
 		<div
 			data-testid="chat-message"
 			data-role="error"
-			className="flex items-start gap-sm rounded-[var(--radius-md)] border border-feedback-error-muted bg-clip-padding bg-feedback-error-subtle px-md py-sm text-feedback-error tr-text-ui"
+			className="flex items-start gap-sm rounded-[var(--radius-sm)] border border-feedback-error-muted bg-clip-padding bg-feedback-error-subtle px-md py-sm text-feedback-error tr-text-ui"
 		>
 			<TriangleAlert className="mt-0.5 size-4 shrink-0" />
 			<span className="min-w-0 whitespace-pre-wrap break-words">{text}</span>

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -96,7 +96,7 @@ function PanelErrorFallback({
 						type="button"
 						data-testid="error-reload"
 						onClick={() => window.location.reload()}
-						className="flex items-center gap-xs rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
+						className="flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
 					>
 						<RefreshCw className="size-4" /> Reload page
 					</button>
@@ -105,7 +105,7 @@ function PanelErrorFallback({
 						type="button"
 						data-testid="error-retry"
 						onClick={reset}
-						className="flex items-center gap-xs rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
+						className="flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
 					>
 						<RotateCcw className="size-4" /> Try again
 					</button>

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import type * as React from "react";
 import { cn } from "@/lib";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-sm whitespace-nowrap rounded-[var(--radius-md)] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+	"inline-flex items-center justify-center gap-sm whitespace-nowrap rounded-[var(--radius-sm)] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
 	{
 		variants: {
 			variant: {

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogContent({
 			<DialogOverlay />
 			<DialogPrimitive.Content
 				className={cn(
-					"-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2 z-50 flex w-full max-w-[28rem] flex-col gap-lg rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg p-lg text-text-default shadow-[var(--shadow-lg)]",
+					"-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2 z-50 flex w-full max-w-[28rem] flex-col gap-lg rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg p-lg text-text-default shadow-[var(--shadow-lg)]",
 					className,
 				)}
 				{...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogContent({
 			<DialogOverlay />
 			<DialogPrimitive.Content
 				className={cn(
-					"-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2 z-50 flex w-full max-w-[28rem] flex-col gap-lg rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg p-lg text-text-default shadow-[var(--shadow-lg)]",
+					"-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2 z-50 flex w-full max-w-[28rem] flex-col gap-lg rounded-[var(--radius-lg)] border border-border-default bg-container-elevated-bg p-lg text-text-default shadow-[var(--shadow-lg)]",
 					className,
 				)}
 				{...props}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -6,7 +6,7 @@ export function Textarea({ className, ...props }: React.ComponentProps<"textarea
 	return (
 		<textarea
 			className={cn(
-				"w-full resize-none rounded-[var(--radius-md)] border border-control-border-default bg-control-bg px-md py-sm tr-text-ui text-text-default outline-none transition-colors placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft disabled:bg-control-disabled-bg disabled:text-control-disabled-text",
+				"w-full resize-none rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-md py-sm tr-text-ui text-text-default outline-none transition-colors placeholder:text-text-muted focus-visible:border-control-border-active focus-visible:ring-2 focus-visible:ring-primary-soft disabled:bg-control-disabled-bg disabled:text-control-disabled-text",
 				className,
 			)}
 			{...props}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -25,7 +25,7 @@ function ToastViewport({
 // The left accent bar + icon tint carry the variant; the surface stays the elevated panel so toasts read
 // as one family regardless of severity (color signals meaning, it doesn't repaint the whole card).
 const toastVariants = cva(
-	"group pointer-events-auto relative flex w-full items-start gap-sm overflow-hidden rounded-[var(--radius-md)] border border-l-4 bg-container-elevated-bg p-md text-text-default shadow-[var(--shadow-md)] data-[state=closed]:animate-[toast-out_120ms_ease-in] data-[state=open]:animate-[toast-in_150ms_ease-out] data-[swipe=cancel]:translate-x-0 data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[swipe=end]:animate-[toast-out_120ms_ease-in]",
+	"group pointer-events-auto relative flex w-full items-start gap-sm overflow-hidden rounded-[var(--radius-sm)] border border-l-4 bg-container-elevated-bg p-md text-text-default shadow-[var(--shadow-md)] data-[state=closed]:animate-[toast-out_120ms_ease-in] data-[state=open]:animate-[toast-in_150ms_ease-out] data-[swipe=cancel]:translate-x-0 data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[swipe=end]:animate-[toast-out_120ms_ease-in]",
 	{
 		variants: {
 			variant: {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -193,7 +193,7 @@
 	overflow-y: auto;
 	overflow-wrap: break-word;
 	padding: 8px 12px;
-	border-radius: var(--radius-md);
+	border-radius: var(--radius-sm);
 	border: 1px solid var(--border-default);
 	background: var(--control-bg);
 	color: var(--text);
@@ -215,7 +215,7 @@
 /* Typography comes from the generated `tr-text-action` class on the node. */
 .review-composer-btn {
 	padding: 2px var(--space-sm);
-	border-radius: var(--radius-md);
+	border-radius: var(--radius-sm);
 	border: 1px solid var(--border-default);
 	background: var(--container-elevated-bg);
 	color: var(--text);
@@ -296,7 +296,7 @@
 	color: var(--text);
 }
 /* A DRAFT's body is editable in place — the same input surface as the composer's field (input-bg,
-   border2, radius-md, primary focus ring). Auto-grown by its controller; wraps, never scrolls. */
+   border2, radius-sm, primary focus ring). Auto-grown by its controller; wraps, never scrolls. */
 .review-thread-edit {
 	width: 100%;
 	min-height: 2.2em;
@@ -304,7 +304,7 @@
 	margin: 0;
 	padding: 8px 12px;
 	border: 1px solid var(--border-default);
-	border-radius: var(--radius-md);
+	border-radius: var(--radius-sm);
 	resize: none;
 	overflow-x: hidden;
 	overflow-y: hidden;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -269,11 +269,12 @@
 	display: flex;
 	gap: 4px;
 }
+/* A 6px status circle. Full radius (a pill/circle, not a scale step) via the shared `rounded-full`
+   utility on the node — see ReviewThreadCard.tsx / reviewWidgets.ts. */
 .review-thread-dot {
 	flex-shrink: 0;
 	width: 6px;
 	height: 6px;
-	border-radius: 9999px;
 }
 .review-thread-dot-draft {
 	background: var(--primary);

--- a/apps/web/src/panels/AppearanceSettings.tsx
+++ b/apps/web/src/panels/AppearanceSettings.tsx
@@ -46,7 +46,7 @@ export function AppearanceSettings() {
 							data-active={active}
 							onClick={() => select(id)}
 							className={cn(
-								"flex items-center gap-sm rounded-[var(--radius-md)] border px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+								"flex items-center gap-sm rounded-[var(--radius-sm)] border px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
 								active
 									? "border-primary-muted bg-clip-padding bg-primary-subtle text-text-default"
 									: "border-border-default text-text-muted hover:bg-control-bg-hovered hover:text-text-default",

--- a/apps/web/src/panels/CenterTabs.tsx
+++ b/apps/web/src/panels/CenterTabs.tsx
@@ -402,7 +402,7 @@ export function CenterTabs() {
 					type="button"
 					data-testid="start-chat"
 					onClick={() => void startChat()}
-					className="flex items-center gap-xs rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
+					className="flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
 				>
 					<MessageSquarePlus className="size-4" /> New chat
 				</button>

--- a/apps/web/src/panels/ExistingWorktreeDialog.tsx
+++ b/apps/web/src/panels/ExistingWorktreeDialog.tsx
@@ -116,7 +116,7 @@ export function ExistingWorktreeDialog({
 				) : null}
 
 				{loadError ? (
-					<div className="flex flex-col items-start gap-sm rounded-[var(--radius-md)] bg-feedback-error-subtle p-md text-feedback-error tr-text-ui">
+					<div className="flex flex-col items-start gap-sm rounded-[var(--radius-sm)] bg-feedback-error-subtle p-md text-feedback-error tr-text-ui">
 						<p>{loadError}</p>
 						<Button
 							variant="outline"
@@ -132,7 +132,7 @@ export function ExistingWorktreeDialog({
 
 				{candidates?.length === 0 ? (
 					<div
-						className="rounded-[var(--radius-md)] border border-border-default bg-control-bg p-md text-text-muted tr-text-ui"
+						className="rounded-[var(--radius-sm)] border border-border-default bg-control-bg p-md text-text-muted tr-text-ui"
 						data-testid="existing-worktree-empty"
 					>
 						No unattached worktrees found. Create one with Git, then reopen this chooser.
@@ -156,9 +156,9 @@ export function ExistingWorktreeDialog({
 									data-testid="existing-worktree-candidate"
 									data-status={candidate.status}
 									onClick={() => void openCandidate(candidate)}
-									className="flex w-full items-start gap-md rounded-[var(--radius-md)] border border-border-default bg-control-bg p-md text-left outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+									className="flex w-full items-start gap-md rounded-[var(--radius-sm)] border border-border-default bg-control-bg p-md text-left outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
 								>
-									<div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-container-elevated-bg text-text-muted">
+									<div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-container-elevated-bg text-text-muted">
 										{opening ? (
 											<Loader2 className="size-4 animate-spin" />
 										) : (
@@ -186,7 +186,7 @@ export function ExistingWorktreeDialog({
 
 				{openError ? (
 					<p
-						className="rounded-[var(--radius-md)] bg-feedback-error-subtle px-md py-sm text-feedback-error tr-text-ui"
+						className="rounded-[var(--radius-sm)] bg-feedback-error-subtle px-md py-sm text-feedback-error tr-text-ui"
 						data-testid="existing-worktree-error"
 					>
 						{openError}

--- a/apps/web/src/panels/GithubSettings.tsx
+++ b/apps/web/src/panels/GithubSettings.tsx
@@ -45,7 +45,7 @@ export function GithubSettings() {
 					Authenticate the GitHub CLI to create workspaces from remote branches.
 				</p>
 			</div>
-			<div className="flex items-center gap-sm rounded-[var(--radius-md)] border border-border-default bg-control-bg px-md py-sm">
+			<div className="flex items-center gap-sm rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-md py-sm">
 				<span
 					data-testid="settings-gh-status"
 					data-connected={connected}

--- a/apps/web/src/panels/JetBrainsAiCard.tsx
+++ b/apps/web/src/panels/JetBrainsAiCard.tsx
@@ -117,10 +117,10 @@ export function JetBrainsAiCard({
 			data-testid="jetbrains-ai-card"
 			data-wired={wired}
 			data-installed={installed}
-			className="flex flex-col gap-sm rounded-[var(--radius-md)] border border-border-default bg-control-bg p-md"
+			className="flex flex-col gap-sm rounded-[var(--radius-sm)] border border-border-default bg-control-bg p-md"
 		>
 			<div className="flex items-center gap-md">
-				<span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-primary-subtle text-primary">
+				<span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-primary-subtle text-primary">
 					<Zap className="size-4" />
 				</span>
 				<div className="flex min-w-0 flex-col">
@@ -251,7 +251,7 @@ function CopyableCommand({ command }: { command: string }) {
 		setTimeout(() => setCopied(false), 1500);
 	};
 	return (
-		<div className="flex items-center gap-sm rounded-[var(--radius-md)] border border-border-default bg-container-workspace-bg px-sm py-xs">
+		<div className="flex items-center gap-sm rounded-[var(--radius-sm)] border border-border-default bg-container-workspace-bg px-sm py-xs">
 			<code className="min-w-0 flex-1 select-all break-all tr-code-text text-text-default">
 				{command}
 			</code>

--- a/apps/web/src/panels/JetBrainsAiCard.tsx
+++ b/apps/web/src/panels/JetBrainsAiCard.tsx
@@ -117,7 +117,7 @@ export function JetBrainsAiCard({
 			data-testid="jetbrains-ai-card"
 			data-wired={wired}
 			data-installed={installed}
-			className="flex flex-col gap-sm rounded-[var(--radius-lg)] border border-border-default bg-control-bg p-md"
+			className="flex flex-col gap-sm rounded-[var(--radius-md)] border border-border-default bg-control-bg p-md"
 		>
 			<div className="flex items-center gap-md">
 				<span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-primary-subtle text-primary">

--- a/apps/web/src/panels/MarkdownPreview.tsx
+++ b/apps/web/src/panels/MarkdownPreview.tsx
@@ -50,7 +50,7 @@ const DOCUMENT_PROSE = [
 	// Code blocks — spacing only; size/leading come from the doc prose system.
 	"[&_pre]:my-md",
 	// Images.
-	"[&_img]:my-md [&_img]:max-w-full [&_img]:rounded-[var(--radius-md)]",
+	"[&_img]:my-md [&_img]:max-w-full [&_img]:rounded-[var(--radius-sm)]",
 ].join(" ");
 
 /**

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -84,7 +84,7 @@ export function reconcileModel(
 
 /** A shared pill-trigger look for the project + branch pickers (mockup `.pill`). */
 const PILL =
-	"flex h-8 min-w-0 items-center gap-sm rounded-[var(--radius-md)] border border-control-border-default bg-clip-padding bg-control-bg px-sm tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected";
+	"flex h-8 min-w-0 items-center gap-sm rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-sm tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected";
 
 /**
  * The start-working surface: a **target control** chooses where the work runs — an isolated worktree
@@ -513,7 +513,7 @@ export function NewWorkspaceDialog({
 				{selectedProject && selectedProject.trusted !== true && aliasSkills.length > 0 ? (
 					<div
 						data-testid="ws-trust-notice"
-						className="flex w-full items-center gap-sm rounded-[var(--radius-md)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm text-left"
+						className="flex w-full items-center gap-sm rounded-[var(--radius-sm)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm text-left"
 					>
 						<TriangleAlert className="size-4 shrink-0 text-feedback-warning" />
 						<span className="min-w-0 flex-1 tr-text-ui text-text-default">
@@ -537,7 +537,7 @@ export function NewWorkspaceDialog({
 					{promptNote ? (
 						<p
 							data-testid="ws-prompt-note"
-							className="mb-xs flex items-start gap-sm rounded-[var(--radius-md)] border border-primary-muted bg-clip-padding bg-primary-subtle px-md py-sm text-left text-text-muted tr-text-metadata leading-snug"
+							className="mb-xs flex items-start gap-sm rounded-[var(--radius-sm)] border border-primary-muted bg-clip-padding bg-primary-subtle px-md py-sm text-left text-text-muted tr-text-metadata leading-snug"
 						>
 							<Sparkles className="mt-0.5 size-3.5 shrink-0 text-primary" />
 							<span>{promptNote}</span>
@@ -609,7 +609,7 @@ export function NewWorkspaceDialog({
 						data-testid="create-workspace"
 						disabled={creating}
 						onClick={() => void create()}
-						className="flex h-8 shrink-0 items-center gap-sm rounded-[var(--radius-md)] bg-control-primary-bg px-md tr-text-action text-control-primary-text outline-none transition-colors hover:bg-control-primary-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
+						className="flex h-8 shrink-0 items-center gap-sm rounded-[var(--radius-sm)] bg-control-primary-bg px-md tr-text-action text-control-primary-text outline-none transition-colors hover:bg-control-primary-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
 					>
 						{isolated ? "Create" : "Start"}
 						<span className="inline-flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-sm)] bg-on-primary-soft px-1 tr-code-text">
@@ -654,7 +654,7 @@ function TargetOption({
 			data-testid={testid}
 			data-active={active}
 			className={cn(
-				"flex h-7 cursor-pointer items-center gap-sm rounded-[var(--radius-md)] px-md tr-text-ui transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary",
+				"flex h-7 cursor-pointer items-center gap-sm rounded-[var(--radius-sm)] px-md tr-text-ui transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary",
 				active ? "bg-primary-subtle text-primary" : "text-text-muted hover:text-text-default",
 			)}
 		>

--- a/apps/web/src/panels/PrivacySettings.tsx
+++ b/apps/web/src/panels/PrivacySettings.tsx
@@ -28,7 +28,7 @@ export function PrivacySettings() {
 				</p>
 			</div>
 
-			<div className="flex items-center justify-between gap-md rounded-[var(--radius-md)] border border-border-default bg-control-bg px-md py-sm">
+			<div className="flex items-center justify-between gap-md rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-md py-sm">
 				<div className="flex flex-col gap-0.5">
 					<span className="tr-title-compact text-text-default">
 						Share anonymous usage analytics

--- a/apps/web/src/panels/ProjectSkillsNotice.tsx
+++ b/apps/web/src/panels/ProjectSkillsNotice.tsx
@@ -77,7 +77,7 @@ export function ProjectSkillsNotice({ projectId }: { projectId: string }) {
 		<div
 			data-testid="project-skills-notice"
 			data-state={isPending ? "pending" : "untrusted"}
-			className="mt-lg flex w-full max-w-[560px] items-center gap-sm rounded-[var(--radius-md)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm text-left"
+			className="mt-lg flex w-full max-w-[560px] items-center gap-sm rounded-[var(--radius-sm)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm text-left"
 		>
 			<TriangleAlert className="size-4 shrink-0 text-feedback-warning" />
 			<span className="min-w-0 flex-1 tr-text-ui text-text-default">

--- a/apps/web/src/panels/ProviderWarningBanner.tsx
+++ b/apps/web/src/panels/ProviderWarningBanner.tsx
@@ -36,7 +36,7 @@ export function ProviderWarningBanner() {
 	return (
 		<div
 			data-testid="welcome-provider-warning"
-			className="mt-lg flex w-full max-w-[560px] items-center gap-sm rounded-[var(--radius-md)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm text-left"
+			className="mt-lg flex w-full max-w-[560px] items-center gap-sm rounded-[var(--radius-sm)] border border-border-default border-l-[3px] border-l-feedback-warning bg-feedback-warning-subtle px-md py-sm text-left"
 		>
 			<TriangleAlert className="size-4 shrink-0 text-feedback-warning" />
 			<span className="min-w-0 flex-1 tr-text-reading text-text-default">

--- a/apps/web/src/panels/ProvidersSettings.tsx
+++ b/apps/web/src/panels/ProvidersSettings.tsx
@@ -151,7 +151,7 @@ export function ProvidersSettings() {
 					{subscriptionRows.length > 0 ? (
 						<section
 							data-testid="providers-subscriptions"
-							className="flex flex-col gap-sm rounded-[var(--radius-md)] border border-primary-muted bg-clip-padding bg-primary-subtle p-md"
+							className="flex flex-col gap-sm rounded-[var(--radius-sm)] border border-primary-muted bg-clip-padding bg-primary-subtle p-md"
 						>
 							<div className="flex flex-col gap-0.5">
 								<h4 className="tr-title-compact text-text-default">Sign in with a subscription</h4>
@@ -273,9 +273,9 @@ function ConnectedCard({
 			data-testid="provider-row"
 			data-provider={provider.id}
 			data-configured="true"
-			className="flex items-center gap-md rounded-[var(--radius-md)] border border-border-default bg-control-bg px-md py-sm"
+			className="flex items-center gap-md rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-md py-sm"
 		>
-			<span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-feedback-success-subtle text-feedback-success">
+			<span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-feedback-success-subtle text-feedback-success">
 				<Check className="size-4" />
 			</span>
 			<div className="flex min-w-0 flex-col">
@@ -335,10 +335,10 @@ function ProviderActionRow({
 			data-testid="provider-signin-row"
 			data-provider={provider.id}
 			data-configured="false"
-			className="flex flex-col gap-xs rounded-[var(--radius-md)] border border-border-default bg-control-bg px-md py-sm"
+			className="flex flex-col gap-xs rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-md py-sm"
 		>
 			<div className="flex items-center gap-sm tr-text-ui">
-				<span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-control-bg-selected text-text-muted">
+				<span className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-control-bg-selected text-text-muted">
 					<Boxes className="size-4" />
 				</span>
 				<span className="min-w-0 flex-1 truncate text-text-default">{provider.name}</span>

--- a/apps/web/src/panels/ProvidersSettings.tsx
+++ b/apps/web/src/panels/ProvidersSettings.tsx
@@ -151,7 +151,7 @@ export function ProvidersSettings() {
 					{subscriptionRows.length > 0 ? (
 						<section
 							data-testid="providers-subscriptions"
-							className="flex flex-col gap-sm rounded-[var(--radius-lg)] border border-primary-muted bg-clip-padding bg-primary-subtle p-md"
+							className="flex flex-col gap-sm rounded-[var(--radius-md)] border border-primary-muted bg-clip-padding bg-primary-subtle p-md"
 						>
 							<div className="flex flex-col gap-0.5">
 								<h4 className="tr-title-compact text-text-default">Sign in with a subscription</h4>

--- a/apps/web/src/panels/ReviewThreadCard.tsx
+++ b/apps/web/src/panels/ReviewThreadCard.tsx
@@ -64,7 +64,7 @@ export function ReviewThreadCard({
 		>
 			<div className="review-thread-head">
 				<span
-					className={`review-thread-dot review-thread-dot-${thread.status === "sent" ? "sent" : "draft"}`}
+					className={`review-thread-dot rounded-full review-thread-dot-${thread.status === "sent" ? "sent" : "draft"}`}
 				/>
 				<span className="review-thread-label tr-text-eyebrow">
 					{thread.anchorState === "outdated" ? `${thread.status} · outdated` : thread.status}

--- a/apps/web/src/panels/SendReviewButton.tsx
+++ b/apps/web/src/panels/SendReviewButton.tsx
@@ -84,7 +84,7 @@ function SendButtonBase({
 			data-testid={testid}
 			disabled={busy}
 			onClick={() => void run()}
-			className="flex h-6 shrink-0 items-center gap-xs rounded-[var(--radius-md)] bg-control-primary-bg px-sm text-control-primary-text tr-text-action transition-colors hover:bg-control-primary-bg-hovered disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
+			className="flex h-6 shrink-0 items-center gap-xs rounded-[var(--radius-sm)] bg-control-primary-bg px-sm text-control-primary-text tr-text-action transition-colors hover:bg-control-primary-bg-hovered disabled:bg-control-disabled-bg disabled:text-control-disabled-text"
 		>
 			<Send className="size-3" />
 			{label}

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -69,7 +69,7 @@ export function SettingsDialog() {
 									data-active={active}
 									onClick={() => useAppStore.getState().setSettingsSection(id)}
 									className={cn(
-										"flex shrink-0 items-center gap-sm rounded-[var(--radius-md)] px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+										"flex shrink-0 items-center gap-sm rounded-[var(--radius-sm)] px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
 										active
 											? "bg-primary-subtle text-primary"
 											: "text-text-muted hover:bg-control-bg-hovered hover:text-text-default",
@@ -83,7 +83,7 @@ export function SettingsDialog() {
 						{SOON.map(({ label, icon: Icon }) => (
 							<span
 								key={label}
-								className="flex shrink-0 cursor-default items-center gap-sm rounded-[var(--radius-md)] px-md py-sm text-text-disabled tr-text-ui"
+								className="flex shrink-0 cursor-default items-center gap-sm rounded-[var(--radius-sm)] px-md py-sm text-text-disabled tr-text-ui"
 							>
 								<Icon className="size-4 shrink-0" />
 								{label}

--- a/apps/web/src/panels/TemplatesSettings.tsx
+++ b/apps/web/src/panels/TemplatesSettings.tsx
@@ -377,7 +377,7 @@ function TemplateRow({
 				data-testid="template-row"
 				data-name={template.name}
 				data-scope={template.scope}
-				className="group flex items-center gap-sm rounded-[var(--radius-md)] border border-border-default bg-control-bg px-md py-sm"
+				className="group flex items-center gap-sm rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-md py-sm"
 			>
 				<div className="flex min-w-0 flex-1 flex-col">
 					<span className="truncate tr-text-ui text-text-default">{template.name}</span>

--- a/apps/web/src/panels/TerminalSettings.tsx
+++ b/apps/web/src/panels/TerminalSettings.tsx
@@ -55,7 +55,7 @@ export function TerminalSettings() {
 							data-active={active}
 							onClick={() => select(kb)}
 							className={cn(
-								"flex items-center gap-sm rounded-[var(--radius-md)] border px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+								"flex items-center gap-sm rounded-[var(--radius-sm)] border px-md py-sm text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
 								active
 									? "border-primary-muted bg-clip-padding bg-primary-subtle text-text-default"
 									: "border-border-default text-text-muted hover:bg-control-bg-hovered hover:text-text-default",

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -236,7 +236,7 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			data-testid={cta ? "welcome-cta" : "welcome-action"}
 			{...rest}
 			className={cn(
-				"relative flex h-[150px] w-[220px] flex-col items-start justify-between rounded-[var(--radius-md)] border bg-clip-padding p-lg text-left transition-colors",
+				"relative flex h-[150px] w-[220px] flex-col items-start justify-between rounded-[var(--radius-sm)] border bg-clip-padding p-lg text-left transition-colors",
 				primary
 					? "border-primary-muted bg-primary-subtle hover:bg-primary-soft"
 					: "border-border-default bg-container-workspace-bg hover:border-primary-muted hover:bg-container-elevated-bg",
@@ -250,7 +250,7 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			) : null}
 			<span
 				className={cn(
-					"flex size-9 items-center justify-center rounded-[var(--radius-md)]",
+					"flex size-9 items-center justify-center rounded-[var(--radius-sm)]",
 					primary ? "bg-primary text-text-on-primary" : "bg-control-bg-selected text-text-muted",
 				)}
 			>

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -236,7 +236,7 @@ const Card = forwardRef<HTMLButtonElement, CardProps>(function Card(
 			data-testid={cta ? "welcome-cta" : "welcome-action"}
 			{...rest}
 			className={cn(
-				"relative flex h-[150px] w-[220px] flex-col items-start justify-between rounded-[var(--radius-lg)] border bg-clip-padding p-lg text-left transition-colors",
+				"relative flex h-[150px] w-[220px] flex-col items-start justify-between rounded-[var(--radius-md)] border bg-clip-padding p-lg text-left transition-colors",
 				primary
 					? "border-primary-muted bg-primary-subtle hover:bg-primary-soft"
 					: "border-border-default bg-container-workspace-bg hover:border-primary-muted hover:bg-container-elevated-bg",

--- a/apps/web/src/panels/reviewWidgets.ts
+++ b/apps/web/src/panels/reviewWidgets.ts
@@ -309,7 +309,7 @@ export function attachReviewThreads(
 		const head = document.createElement("div");
 		head.className = "review-thread-head";
 		const dot = document.createElement("span");
-		dot.className = `review-thread-dot review-thread-dot-${thread.status === "sent" ? "sent" : "draft"}`;
+		dot.className = `review-thread-dot rounded-full review-thread-dot-${thread.status === "sent" ? "sent" : "draft"}`;
 		const label = document.createElement("span");
 		label.className = "review-thread-label tr-text-eyebrow";
 		label.textContent =

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -35,5 +35,5 @@ a {
 }
 ::-webkit-scrollbar-thumb {
 	background: var(--border-default);
-	border-radius: var(--radius-md);
+	border-radius: var(--radius-sm);
 }

--- a/apps/web/src/styles/spacingUsage.test.ts
+++ b/apps/web/src/styles/spacingUsage.test.ts
@@ -97,6 +97,18 @@ describe("radius at a call site", () => {
 			.filter((step) => !used.has(step));
 		expect(orphans).toEqual([]);
 	});
+
+	// The scale is a small primitive geometry, capped at 6px: exactly `xs`/`sm`/`md`, nothing above 6px,
+	// and no `lg` (the removed 12px step). `rounded-full` is a pill, not a scale step, so it is exempt —
+	// the 6px cap governs normal UI surfaces, not intentional circles/pills.
+	it("declares exactly xs/sm/md, none above 6px, and no lg", () => {
+		const steps = [...read(TOKENS).matchAll(/^\s*--radius-([a-z0-9]+)\s*:\s*(\d+)px\s*;/gm)].map(
+			(m) => [m[1] as string, Number(m[2])] as const,
+		);
+		expect(steps.map(([name]) => name).sort()).toEqual(["md", "sm", "xs"]);
+		expect(steps.map(([name]) => name)).not.toContain("lg");
+		expect(steps.filter(([, px]) => px > 6)).toEqual([]);
+	});
 });
 
 describe("spacing at a call site", () => {

--- a/apps/web/src/styles/spacingUsage.test.ts
+++ b/apps/web/src/styles/spacingUsage.test.ts
@@ -98,16 +98,16 @@ describe("radius at a call site", () => {
 		expect(orphans).toEqual([]);
 	});
 
-	// The scale is a small primitive geometry, capped at 6px: exactly `xs`/`sm`/`md`, nothing above 6px,
-	// and no `lg` (the removed 12px step). `rounded-full` is a pill, not a scale step, so it is exempt —
-	// the 6px cap governs normal UI surfaces, not intentional circles/pills.
-	it("declares exactly xs/sm/md, none above 6px, and no lg", () => {
+	// The scale is a small primitive geometry, capped at 8px: exactly `xs`/`sm`/`md`/`lg` (2/4/6/8px).
+	// `sm` (4px) is the default corner; `md` (6px) is the outer corner for surfaces nesting 4px children;
+	// `lg` (8px) is the exception for large standalone elevated surfaces. Nothing above 8px. `rounded-full`
+	// (a pill/circle) is not a scale step, so it is exempt — the 8px cap governs normal UI surfaces only.
+	it("declares exactly xs/sm/md/lg, none above 8px", () => {
 		const steps = [...read(TOKENS).matchAll(/^\s*--radius-([a-z0-9]+)\s*:\s*(\d+)px\s*;/gm)].map(
 			(m) => [m[1] as string, Number(m[2])] as const,
 		);
-		expect(steps.map(([name]) => name).sort()).toEqual(["md", "sm", "xs"]);
-		expect(steps.map(([name]) => name)).not.toContain("lg");
-		expect(steps.filter(([, px]) => px > 6)).toEqual([]);
+		expect(steps.map(([name]) => name).sort()).toEqual(["lg", "md", "sm", "xs"]);
+		expect(steps.filter(([, px]) => px > 8)).toEqual([]);
 	});
 });
 

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -16,8 +16,7 @@
 	   (a `<mark>` search hit, a composer slot placeholder), where `sm` would read as a chip. */
 	--radius-xs: 2px;
 	--radius-sm: 4px;
-	--radius-md: 8px;
-	--radius-lg: 12px;
+	--radius-md: 6px;
 	--transition-fast: 120ms ease;
 	--transition-normal: 200ms ease;
 

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -12,11 +12,18 @@
 	 */
 	--space-base: 13px;
 
-	/* Shape + motion. `xs` is the text-run tier: the corner on a tint that sits BEHIND running text
-	   (a `<mark>` search hit, a composer slot placeholder), where `sm` would read as a chip. */
+	/* Shape + motion. A four-step primitive scale, `sm` (4px) is the DEFAULT corner for ordinary
+	   standalone controls (buttons, inputs, rows, tabs, tool cards). `xs` (2px) is the text-run tier:
+	   a corner on a tint that sits BEHIND running text (a `<mark>` search hit, a composer slot
+	   placeholder), where `sm` would read as a chip. `md` (6px) is the OUTER corner when a surface
+	   nests `sm` (4px) children and needs the extra step to read correctly — chosen by design, not a
+	   runtime `child + 2px`. `lg` (8px) is reserved for large, visually independent elevated surfaces
+	   (dialogs, user-message bubbles, the AskUserQuestion outer card); it is the exception, never the
+	   default for a card. Nothing above 8px. `rounded-full` (a pill/circle) is not on this scale. */
 	--radius-xs: 2px;
 	--radius-sm: 4px;
 	--radius-md: 6px;
+	--radius-lg: 8px;
 	--transition-fast: 120ms ease;
 	--transition-normal: 200ms ease;
 


### PR DESCRIPTION
## Summary

Reworks the web app's centralized border-radius system into a small primitive geometric scale whose **default is 4px** and whose **maximum is 8px**, migrating every consumer by UI role. No new radius system, no semantic aliases, no per-component tokens — the existing `tokens.css` source of truth and the `spacingUsage.test.ts` usage guard are preserved and tightened.

Two independently-revertable commits:
1. `three-step radius scale capped at 6px` — collapse to `xs/sm/md` (2/4/6), drop the old 12px `lg`, replace the lone `9999px` hardcode with the shared `rounded-full` pill convention.
2. `4px-default radius scale (2/4/6/8 + full)` — reintroduce `lg` as **8px** and reclassify every `radius-md` consumer by role.

## Final scale

`--radius-xs: 2px` · `--radius-sm: 4px` · `--radius-md: 6px` · `--radius-lg: 8px` · `+ rounded-full`

- **4px (`sm`) — default**, now dominant: buttons, inputs, textareas, selector triggers, tabs, rows, tool/small/medium cards, CTAs, composer inner controls, code/preview surfaces, settings rows/cards, banners, icon buttons, menu/command items.
- **6px (`md`) — nesting only**: surfaces that enclose flush 4px children (Popover/Dropdown/menu/completion content, the Composer shell + clip layer, the segmented target control, the review composer/thread outer cards).
- **8px (`lg`) — large standalone elevated surfaces only**: Dialog, user-message bubble, `AskUserQuestionCard` (+ its waiting/composing frames), the history search overlay.
- **`rounded-full`** preserved strictly for circles/pills (status dots, radio/checkbox circles, toggle knob+track, count badges, stream dots, tab underline pill).

## Guard

`spacingUsage.test.ts` now pins the scale to exactly `xs/sm/md/lg`, rejects any step above 8px, keeps banning raw/arbitrary radii, forbids undeclared steps, and requires every declared step to have consumers.

## Scope / invariants

Frontend-only — no backend/wire/contract changes. Only corner rounding changes; no colors, typography, spacing, dimensions, layout, or behavior. V1 tab/session lifecycle, domain/view-state ownership, and hydrate-then-stream architecture untouched. Docs (`apps/web/SPEC.md`, `tokens.css`) updated to describe the scale.

## Verification

- `bun test apps/web/src/styles/spacingUsage.test.ts` — 6/6 pass.
- Pre-commit gates green: `check:deps`, `check:seams`, typography/colors, biome (only pre-existing unrelated `apps/website` warnings), `turbo typecheck` across all 10 packages.
