### PR TITLE
Add start_new_chat: agent-triggered handoff to a new chat

### DIFF
--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -53,6 +53,12 @@ registration runs once when the chat module mounts. Unregistered tools fall back
     color). Shown up front for every recommended option, not gated on selection: more discoverable than
     a tooltip and, being ordinary visible text, it reads on touch and for AT without a popover.
     **Active card only** — the resolved record shows selections only, no rationale.
+- **`StartNewChatCard`** — the in-transcript receipt for the host-owned `start_new_chat` handoff tool
+  (capability: the server's `agent/startNewChat` + the host compose — see [[submodule-server-agent]]):
+  the new chat's title + the kickoff prompt it was started with. **Primary** — a handoff is a
+  user-visible outcome, not plumbing, so it escapes the activity fold (the collapsed header's summary is
+  the new chat's title). The card is deliberately passive: the tab itself opens + focuses via the
+  `session.created` store fold, so the card carries no interactive Open action.
 - **`visualize/`** — `VisualizationCard` dispatches on `args.type` to `DiagramCard` (mermaid → themed
   SVG via the **lazy-loaded** `mermaid`, source fallback on parse error) and `ComparisonCard` (option
   cards with pros/cons + `recommended` highlight); shared `MermaidView` re-renders on `[data-theme]`

--- a/apps/web/src/chat/tools/StartNewChatCard.tsx
+++ b/apps/web/src/chat/tools/StartNewChatCard.tsx
@@ -1,0 +1,33 @@
+import { MessageSquarePlus } from "lucide-react";
+import type { ReactNode } from "react";
+import type { ToolRenderProps } from "../toolRegistry";
+import { strArg } from "./toolHelpers";
+
+/**
+ * The in-transcript receipt for the host-owned `start_new_chat` handoff tool (see chat/tools/SPEC.md):
+ * the new chat's title + the kickoff prompt it was started with. Deliberately passive — the new tab
+ * opens and takes focus via the `session.created` store fold, so the card needs no Open action; on a
+ * hydrated transcript it stays the record of what was handed off.
+ */
+export function StartNewChatCard({ args, status }: ToolRenderProps): ReactNode {
+	const title = strArg(args, "title") || "New chat";
+	const prompt = strArg(args, "prompt");
+	return (
+		<div className="flex items-start gap-xs tr-text-ui">
+			<MessageSquarePlus
+				className={`mt-0.5 size-3.5 shrink-0 ${status === "error" ? "text-feedback-error" : "text-feedback-success"}`}
+			/>
+			<div className="min-w-0">
+				<span className="text-text-default">{title}</span>
+				{status === "error" ? (
+					<span className="ml-xs text-feedback-error">couldn't be started</span>
+				) : (
+					<span className="ml-xs text-text-muted">started</span>
+				)}
+				{prompt && (
+					<p className="mt-1 whitespace-pre-wrap break-words text-text-subtle">{prompt}</p>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/chat/tools/register.ts
+++ b/apps/web/src/chat/tools/register.ts
@@ -8,6 +8,7 @@ import { BashCard } from "./BashCard";
 import { EditCard } from "./EditCard";
 import { ReadCard } from "./ReadCard";
 import { ResolveCommentCard } from "./ResolveCommentCard";
+import { StartNewChatCard } from "./StartNewChatCard";
 import { strArg } from "./toolHelpers";
 import "./visualize/register";
 import "./web/register";
@@ -30,6 +31,14 @@ registerToolRenderer("write", WriteCard, {
 // Routine: the sidebar carries resolution state; the card is the in-transcript trace.
 registerToolRenderer("resolve_comment", ResolveCommentCard, {
 	summary: ({ args }) => strArg(args, "commentId"),
+});
+
+// The handoff receipt (host-owned `start_new_chat` tool — capability: server `agent` + host compose).
+// PRIMARY: starting a new chat is a user-visible outcome, never activity-fold plumbing; the tab itself
+// opens via the `session.created` store fold, so the card stays passive.
+registerToolRenderer("start_new_chat", StartNewChatCard, {
+	prominence: "primary",
+	summary: ({ args }) => strArg(args, "title") || "New chat",
 });
 
 // The inline clarifying-questions questionnaire (host-owned `ask_user_question` tool). Registered with

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -122,13 +122,22 @@ editor tabs + terminals (switching workspaces swaps both), and a **per-session c
   chat that survived a host restart is reopenable. **`deleteChat(workspaceId, sessionId)`** is the idempotent
   fold for both a confirmed local `session.delete` and the `session.deleted` broadcast: it atomically drops
   that chat's tab/history row/runtime + skill baseline (choosing the normal active-tab fallback) and records
-  a page-lifetime tombstone. **`noteClosedChats`** and **`hydrateSession`** reject tombstoned session ids, so
+  a page-lifetime tombstone. **`noteClosedChats`**, **`hydrateSession`** and **`applySessionCreated`** reject tombstoned session ids, so
   stale `session.list` / `session.getMessages` results already in flight cannot recreate a deleted chat;
   the tombstone survives workspace teardown because an older read can still settle afterward. The
   active-workspace hydration pass snapshots **`selectWorkspaceSessionIds`** before each `session.list`; when
   that authoritative read lands, **`reconcileWorkspaceSessions`** applies the same tombstone fold to every
   baseline id absent from the host result, repairing deletion events missed while disconnected without
-  deleting a session created after the read began. Otherwise **`hydrateSession`** rebuilds a runtime + tab
+  deleting a session created after the read began. **`applySessionCreated(summary)`** is the `session.created` fold (a host-created chat — the agent's
+  `start_new_chat` handoff, pushed before the new session's first `pi.event`): idempotent (an existing
+  runtime wins) and tombstone-checked, it always builds the empty runtime — the kickoff prompt arrives
+  as the stream's `message_start`, the host-fired-user-message fold — and anchors the skill-sync tick to
+  the current workspace tick (the session just loaded current disk skills, `openChatSession`'s rule).
+  The TAB is per-client view state: iff the payload's workspace is this client's **active workspace**,
+  the tab opens and takes focus (a navigation — nav tick bumped; the user asked the agent for this
+  chat); any other client records a `closedChatsByWorkspace` history row instead (the
+  `closeChatToHistory` runtime-alive shape — discoverable, reopenable live, no tab spam).
+  Otherwise **`hydrateSession`** rebuilds a runtime + tab
   from a host `SessionSummary` + converted transcript on connect — the live summary's `lastSettlement` is authoritative when present; otherwise only a failure on
   the persisted transcript's final conversational message is current (historical `length` attempts followed
   by later work must not become stale warnings). Hydration is a no-op if a runtime already exists, so a

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -811,6 +811,70 @@ test("hydrateSession(activate) reopens a disk-only chat: builds it, focuses it, 
 	expect(st.activeTabByWorkspace.ws1).toBe("ws1:disk1"); // focused, despite an existing active tab
 });
 
+const createdSummary = (over: Partial<SessionSummary> = {}): SessionSummary => ({
+	sessionId: "new1",
+	workspaceId: "ws1",
+	title: "Implement X",
+	model: null,
+	thinkingLevel: "medium",
+	isStreaming: false,
+	messageCount: 0,
+	updatedAt: 42,
+	live: true,
+	...over,
+});
+
+test("applySessionCreated in the active workspace opens + focuses the new chat tab (a navigation)", () => {
+	const store = useAppStore.getState();
+	useAppStore.setState({ activeWorkspaceId: "ws1" });
+	store.openChatSession("ws1", "other", null, "medium"); // the origin chat the user was in
+	const navBefore = useAppStore.getState().navTickByWorkspace.ws1 ?? 0;
+
+	store.applySessionCreated(createdSummary());
+
+	const st = useAppStore.getState();
+	expect(st.sessions.new1).toBeDefined(); // runtime exists before the kickoff's pi events land
+	const tab = st.tabsByWorkspace.ws1?.find((t) => t.kind === "chat" && t.sessionId === "new1");
+	expect(tab?.name).toBe("Implement X");
+	expect(st.activeTabByWorkspace.ws1).toBe("ws1:new1"); // focused — the user asked the agent for it
+	expect((st.navTickByWorkspace.ws1 ?? 0) > navBefore).toBe(true);
+});
+
+test("applySessionCreated in a non-active workspace records a runtime-alive history row, never a tab", () => {
+	const store = useAppStore.getState();
+	useAppStore.setState({ activeWorkspaceId: "ws2" }); // this client is elsewhere
+
+	store.applySessionCreated(createdSummary());
+
+	const st = useAppStore.getState();
+	expect(st.sessions.new1).toBeDefined(); // events still fold from message one
+	expect(st.tabsByWorkspace.ws1 ?? []).toHaveLength(0); // no unrequested tab
+	expect(st.activeTabByWorkspace.ws1).toBeUndefined();
+	expect(st.closedChatsByWorkspace.ws1).toEqual([
+		{ sessionId: "new1", title: "Implement X", closedAt: 42 },
+	]);
+});
+
+test("applySessionCreated is idempotent and tombstone-checked", () => {
+	const store = useAppStore.getState();
+	useAppStore.setState({ activeWorkspaceId: "ws1" });
+
+	// Idempotent: a second fold (event replayed by any path) must not clobber the runtime or dup the tab.
+	store.applySessionCreated(createdSummary());
+	store.appendUserMessage("new1", "kickoff");
+	store.applySessionCreated(createdSummary());
+	let st = useAppStore.getState();
+	expect(st.sessions.new1?.turns).toHaveLength(1);
+	expect(st.tabsByWorkspace.ws1?.filter((t) => t.kind === "chat")).toHaveLength(1);
+
+	// Tombstoned: a deleted session id can never be resurrected by a stale creation event.
+	store.deleteChat("ws1", "late");
+	store.applySessionCreated(createdSummary({ sessionId: "late" }));
+	st = useAppStore.getState();
+	expect(st.sessions.late).toBeUndefined();
+	expect(st.closedChatsByWorkspace.ws1 ?? []).toHaveLength(0);
+});
+
 test("clearWorkspaceTabs drops both open and closed chat runtimes + clears history", () => {
 	const store = useAppStore.getState();
 	useAppStore.setState({ activeWorkspaceId: "ws1" });

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -837,6 +837,14 @@ interface AppState {
 	 */
 	noteClosedChats: (workspaceId: string, entries: ClosedChat[]) => void;
 	/**
+	 * The `session.created` fold — a HOST-created chat (the agent's `start_new_chat` handoff), pushed
+	 * before the new session's first `pi.event`. Idempotent (an existing runtime wins) + tombstone-checked.
+	 * Always builds the empty runtime (the kickoff prompt arrives as the stream's host-fired
+	 * `message_start`); the TAB is per-client view state — the active-workspace client opens + focuses it
+	 * (the user asked the agent for this chat), any other client records a runtime-alive history row.
+	 */
+	applySessionCreated: (summary: SessionSummary) => void;
+	/**
 	 * Rebuild a chat's runtime + tab from the host's report on connect — a no-op if a runtime already exists.
 	 * Drops the session from chat-history (it's open now). `activate` focuses the tab (a user-driven reopen);
 	 * otherwise it only takes focus if the workspace has none yet (auto-restore must not steal focus).
@@ -1756,6 +1764,45 @@ export const useAppStore = create<AppState>((set, get) => ({
 					// Newest-first; disk entries carry their last-modified time as `closedAt`.
 					[workspaceId]: [...existing, ...fresh].sort((a, b) => b.closedAt - a.closedAt),
 				},
+			};
+		}),
+	applySessionCreated: (summary) =>
+		set((s) => {
+			const wsId = summary.workspaceId;
+			const sessionId = summary.sessionId;
+			if (isSessionDeleted(s, wsId, sessionId)) return {};
+			if (s.sessions[sessionId]) return {};
+			const base = {
+				sessions: { ...s.sessions, [sessionId]: newRuntime(summary.model, summary.thinkingLevel) },
+				// The session just loaded the current on-disk skills (`openChatSession`'s anchoring rule).
+				skillsSyncedTickBySession: {
+					...s.skillsSyncedTickBySession,
+					[sessionId]: selectWorkspaceTick(s, wsId),
+				},
+			};
+			if (s.activeWorkspaceId !== wsId) {
+				// Not this client's context: a runtime-alive history row (the `closeChatToHistory` shape) —
+				// discoverable and reopenable live, never an unrequested tab.
+				const entry: ClosedChat = { sessionId, title: summary.title, closedAt: summary.updatedAt };
+				return {
+					...base,
+					closedChatsByWorkspace: {
+						...s.closedChatsByWorkspace,
+						[wsId]: [entry, ...(s.closedChatsByWorkspace[wsId] ?? [])],
+					},
+				};
+			}
+			const id = `${wsId}:${sessionId}`;
+			const tab: ChatTab = { kind: "chat", id, workspaceId: wsId, name: summary.title, sessionId };
+			const tabs = s.tabsByWorkspace[wsId] ?? [];
+			return {
+				...base,
+				tabsByWorkspace: tabs.some((t) => t.id === id)
+					? s.tabsByWorkspace
+					: { ...s.tabsByWorkspace, [wsId]: [...tabs, tab] },
+				activeTabByWorkspace: { ...s.activeTabByWorkspace, [wsId]: id },
+				// Taking focus IS a navigation — the user asked the agent for this chat.
+				navTickByWorkspace: bumpNav(s, wsId),
 			};
 		}),
 	hydrateSession: (summary, hydrated, activate = false, syncedTick) =>

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -42,7 +42,11 @@ The single WebSocket client to the host, and its app-wide singleton.
   `workspace.removed` via `applyWorkspaceRemoved(projectId, id)`, `session.deleted` via the idempotent
   `deleteChat(workspaceId, sessionId)` tombstone fold (an online fast path; because this event channel is
   deliberately not replayed, `CenterTabs` repairs any deletion missed while disconnected from the next
-  authoritative `session.list`), `workspace.fsChanged` via `noteFsChanged(payload)`, and
+  authoritative `session.list`), **`session.created`** via the idempotent
+  `applySessionCreated(summary)` fold (a host-created chat — the agent's `start_new_chat` handoff;
+  an **event** channel like `session.deleted`, in `NON_REPLAYABLE_CHANNELS` — replaying a past creation
+  to a late subscriber could resurrect a since-deleted chat; a client that missed it while disconnected
+  converges from the next authoritative `session.list`), `workspace.fsChanged` via `noteFsChanged(payload)`, and
   **`settings.changed`** (+ the `config` field in `server.welcome`) via
   `applyConfig(config)` — the server-synced app config (theme, …), applied on connect + on every broadcast
   so clients converge; all subscriptions happen once at init, never in component effects);
@@ -62,6 +66,7 @@ The single WebSocket client to the host, and its app-wide singleton.
 - **Allowed deps:** `contracts` (method maps, `WS_CHANNELS`, `Project` for welcome + `project.updated`, `SessionEventPayload`
   for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.created`/`updated`,
   `WorkspaceRemoved` for `workspace.removed`, `SessionDeletedPayload` for `session.deleted`,
+  `SessionCreatedPayload` for `session.created`,
   `WorkspaceFsChangedPayload` for `workspace.fsChanged`,
   `AppConfig` for `server.welcome`'s config + `settings.changed`); `store`
   (welcome + event routing — a runtime edge owned by the parent graph); the browser `WebSocket`.

--- a/apps/web/src/transport/transport.test.ts
+++ b/apps/web/src/transport/transport.test.ts
@@ -70,6 +70,41 @@ afterEach(() => {
 	globalThis.WebSocket = originalWebSocket;
 });
 
+describe("WsTransport channel replay classification", () => {
+	test("event channels (session created/deleted, terminal data/exit) are never replayed to a late subscriber", async () => {
+		const transport = new WsTransport({ url: "ws://test/ws" });
+		transport.connect();
+		const socket = TestWebSocket.instances[0];
+		if (!socket) throw new Error("expected a socket");
+		socket.open();
+
+		// A snapshot channel replays its last value to a late subscriber; an EVENT channel must not — a
+		// replayed `session.created` could resurrect a since-deleted chat, a replayed deletion re-fires
+		// a tombstone fold, replayed terminal bytes paint twice.
+		socket.message(JSON.stringify({ channel: "settings.changed", data: { theme: "t" } }));
+		for (const channel of [
+			"session.created",
+			"session.deleted",
+			"terminal.data",
+			"terminal.exit",
+		]) {
+			socket.message(JSON.stringify({ channel, data: { marker: channel } }));
+		}
+
+		const seen: string[] = [];
+		transport.subscribe("settings.changed", () => seen.push("settings.changed"));
+		for (const channel of [
+			"session.created",
+			"session.deleted",
+			"terminal.data",
+			"terminal.exit",
+		]) {
+			transport.subscribe(channel, () => seen.push(channel));
+		}
+		expect(seen).toEqual(["settings.changed"]); // only the snapshot replays
+	});
+});
+
 describe("WsTransport reconnect delivery", () => {
 	test("replays an unresolved frame under the same id and resolves from the replacement socket", async () => {
 		const statuses: string[] = [];

--- a/apps/web/src/transport/transport.ts
+++ b/apps/web/src/transport/transport.ts
@@ -19,15 +19,17 @@ const DEFAULT_TIMEOUT_MS = 60_000;
  *
  * Most push channels carry a *snapshot* — the newest value is the whole truth, so handing it to a late
  * subscriber is exactly right and is why `latest` exists. These channels carry **events**: terminal data is
- * an append-only byte stream, terminal exit is a one-time announcement, and session deletion is folded into
- * a store tombstone when witnessed (a reconnecting active workspace repairs a missed event from authoritative
- * `session.list`). Replaying one re-delivers something that already happened rather than a current snapshot
- * (for terminal data that visibly paints output twice).
+ * an append-only byte stream, terminal exit is a one-time announcement, and session deletion/creation is
+ * folded into the store when witnessed (a reconnecting active workspace repairs a missed event from
+ * authoritative `session.list`). Replaying one re-delivers something that already happened rather than a
+ * current snapshot (for terminal data that visibly paints output twice; for a past `session.created`,
+ * possibly resurrecting a since-deleted chat).
  */
 const NON_REPLAYABLE_CHANNELS: ReadonlySet<string> = new Set([
 	WS_CHANNELS.terminalData,
 	WS_CHANNELS.terminalExit,
 	WS_CHANNELS.sessionDeleted,
+	WS_CHANNELS.sessionCreated,
 ]);
 
 /** 16 random bytes as hex. `getRandomValues` works in an insecure context, unlike `randomUUID`. */

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -5,6 +5,7 @@ import type {
 	Project,
 	ReviewChangedPayload,
 	ServerWelcome,
+	SessionCreatedPayload,
 	SessionDeletedPayload,
 	SessionEventPayload,
 	Workspace,
@@ -63,6 +64,13 @@ export function initTransport(): WsTransport {
 	transport.subscribe(WS_CHANNELS.sessionDeleted, (data) => {
 		const { workspaceId, sessionId } = data as SessionDeletedPayload;
 		useAppStore.getState().deleteChat(workspaceId, sessionId);
+	});
+
+	// A host-created chat (the agent's `start_new_chat` handoff) — published before the new session's
+	// first `pi.event`, so folding it here is what makes that stream land in a live runtime.
+	transport.subscribe(WS_CHANNELS.sessionCreated, (data) => {
+		const { summary } = data as SessionCreatedPayload;
+		useAppStore.getState().applySessionCreated(summary);
 	});
 
 	transport.subscribe(WS_CHANNELS.providerLogin, (data) => {

--- a/e2e/new-chat-handoff.live.spec.ts
+++ b/e2e/new-chat-handoff.live.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+
+// Tagged @agent (see agent.live.spec.ts): runs a REAL pi agent. Proves the `start_new_chat` handoff
+// end to end: the agent in one chat calls the tool, the host creates a sibling session in the same
+// workspace and fires the kickoff prompt, the `session.created` push opens + focuses a second chat tab
+// on this (active-workspace) client, and the new chat streams its kickoff turn. The compose ordering
+// and store-fold matrix are unit-tested (server host/startNewChatCompose.test.ts, web store/appStore.test.ts).
+test("'implement in new session' starts a second chat that opens focused and runs its kickoff", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(180_000);
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
+
+	const chatTabs = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
+	const doneNotice = page
+		.locator('[data-testid="chat-message"][data-role="system"]')
+		.filter({ hasText: "Done" });
+
+	// Ask the origin chat to hand off. Name the tool explicitly so the run is deterministic — the
+	// discovery-by-phrasing quality ("ok, implement in new session") is prompt-tuning, not wiring.
+	await expect(chatTabs).toHaveCount(1);
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			'Use the start_new_chat tool now, with title "Handoff Target" and prompt "Reply with the single word: kicked". Do nothing else.',
+		);
+	await page.getByTestId("chat-send").click();
+
+	// The session.created push opens the new chat tab on this client (its workspace is active here)…
+	await expect(chatTabs).toHaveCount(2, { timeout: 120_000 });
+	// …focused (the fold activates the tab), and named by the tool's title.
+	const newTab = chatTabs.nth(1);
+	await expect(newTab).toHaveAttribute("data-active", "true");
+	await expect(newTab).toContainText("Handoff Target");
+
+	// The kickoff prompt arrived via the event stream (a host-fired user message — no client sent it)
+	// and the new chat ran it to completion.
+	await expect(
+		page.locator('[data-testid="chat-message"][data-role="user"]').filter({ hasText: "kicked" }),
+	).toBeVisible({ timeout: 60_000 });
+	await expect(doneNotice).toBeVisible({ timeout: 120_000 });
+
+	// The origin chat holds the handoff receipt: switch back and find the tool card's title.
+	await chatTabs.first().locator("button").first().click();
+	await expect(page.getByText("Handoff Target").first()).toBeVisible({ timeout: 30_000 });
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -104,6 +104,11 @@ of the host.
     is a **host-owned pi custom tool** (server `agent/askUserQuestion` — see its SPEC for the design
     rationale); the chat renders the questionnaire **inline** and replies via `session.answerQuestion`
     (correlated by the tool call id; rejected loud when the call is unknown/answered/superseded).
+  - the **`start_new_chat`** wire types — **`StartNewChatArgs`** (`{ title?, prompt }`: what the agent
+    authors when the user asks to continue work in a new chat) and **`StartNewChatDetails`**
+    (`{ sessionId }`: the created chat, in the tool result's `details`). The capability is a host-owned
+    pi custom tool (server `agent/startNewChat`); the created session reaches clients via the
+    `session.created` broadcast above, and the web renders the call through its registered tool card.
 - **domain.ts** — app entities: `Project` (git repo + unique `slug` + optional **`closed: true`** — the
   persisted open-rail membership bit; absence means open for backward compatibility, and closing never
   changes the project's id or deletes its workspace associations — plus the skill-trust fields **`trusted`**
@@ -284,7 +289,12 @@ of the host.
   full persisted `Project` snapshot after open/reopen/close, including `closed` membership, so every client
   atomically converges its rail + Recents without optimistic removal / `pi.event` / `pi.extensionUi` /
   **`session.deleted`** (workspace + session id; a non-replayable domain event broadcast after permanent
-  deletion so every client removes the chat and blocks stale hydration) /
+  deletion so every client removes the chat and blocks stale hydration) / **`session.created`**
+  (**`SessionCreatedPayload`** — the new chat's full `SessionSummary`; a non-replayable domain event,
+  broadcast when the **host** creates a session outside any client's request — today the agent-called
+  `start_new_chat` tool — so every client converges: the push precedes the new session's `pi.event`
+  stream by per-socket FIFO, letting a client build the runtime before the kickoff prompt's
+  `message_start` arrives; client-request creates still converge via the `session.create` response) /
   **`settings.changed`** (the full `AppConfig`, broadcast so every client
   converges) / **`provider.login`** — the session-less in-app login stream (a `LoginPush`
   per frame, keyed by `loginId`; the sibling of `pi.extensionUi`, since a login runs on the Welcome screen

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -326,6 +326,21 @@ export interface AskUserAnswersDetails {
 }
 
 /**
+ * The `start_new_chat` tool-call arguments (what the agent authors when the user asks to hand work off
+ * to a fresh chat). The kickoff `prompt` must be self-contained — the new session shares the worktree
+ * but has no memory of the calling conversation; `title` names the new chat's tab.
+ */
+export interface StartNewChatArgs {
+	title?: string;
+	prompt: string;
+}
+
+/** The `start_new_chat` tool result's `details`: the chat it created. */
+export interface StartNewChatDetails {
+	sessionId: string;
+}
+
+/**
  * MIRROR of pi-coding-agent's `CustomMessage` (that package is Node-only, so the shape is re-declared
  * type-only for the wire; pi exports it from `core/messages`, not the package root, so it is not
  * mechanically checkable the way `PiEvent` is):

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -213,7 +213,9 @@ export interface TerminalTabsPush {
 // v37: `workspace.openReview` returns the active branch's optional GitHub PR / GitLab MR number.
 // v38: `session.getMessages` keeps pi's `compactionSummary` messages, so a hydrated transcript can say
 // where compaction replaced earlier messages instead of starting mid-conversation.
-export const PROTOCOL_VERSION = 38;
+// v39: `session.created` broadcasts a host-created chat (the agent-called `start_new_chat` tool) so every
+// client converges on it before the new session's `pi.event` stream begins.
+export const PROTOCOL_VERSION = 39;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -246,6 +248,16 @@ export interface WorkspaceRemoved {
 export interface SessionDeletedPayload {
 	workspaceId: string;
 	sessionId: string;
+}
+
+/**
+ * A chat the HOST created outside any client's request — today the agent-called `start_new_chat` tool.
+ * Broadcast BEFORE the kickoff prompt fires, so on each socket the push precedes the new session's
+ * `pi.event` stream and a client can build the runtime before the prompt's `message_start` arrives.
+ * (Client-request creates don't broadcast — they converge via the `session.create` response.)
+ */
+export interface SessionCreatedPayload {
+	summary: SessionSummary;
 }
 
 /** Request/response methods. `session.*` drives the pi engine. */
@@ -407,6 +419,10 @@ export const WS_CHANNELS = {
 	// Permanent chat deletion is shared domain state. This event carries the owning workspace + session id;
 	// clients retain a tombstone so an older session.list/getMessages response cannot resurrect the chat.
 	sessionDeleted: "session.deleted",
+	// A host-created chat (`SessionCreatedPayload`) — the agent-called `start_new_chat` tool. A domain
+	// EVENT like `session.deleted` (never replayed to late subscribers), published before the new session's
+	// first `pi.event` so clients can build the runtime in time.
+	sessionCreated: "session.created",
 	// In-app login flow updates (a `LoginPush` per frame), keyed by loginId. Session-less — a login runs on
 	// the Welcome screen before any session exists, so this is the sibling of pi.extensionUi, not scoped to one.
 	providerLogin: "provider.login",

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -70,7 +70,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `refresh()`, and on login/logout), and being the one read makes it the same universe everywhere —
     picker, default and `resolveWireModel` cannot disagree.
   - `agentSessionManager` — sessions keyed by `session.sessionId` (each `Entry` also tracks its
-    `workspaceId`), `createSession({ cwd, workspaceId, model?, thinkingLevel? })` → `createAgentSession(...)`
+    `workspaceId`), `createSession({ cwd, workspaceId, model?, thinkingLevel?, title? })` → `createAgentSession(...)`
+    (`title` → pi's `setSessionName`, so a handoff chat's tab is named at birth)
     with a per-session `SessionManager` **and a `buildSessionSettings(cwd)` settings manager** (the user's
     real settings + an in-memory `images.autoResize:false` override — never persisted — so the `read` tool
     sends image files **raw**, bypassing pi's photon/WASM resizer that the single-file binary can't bundle;
@@ -203,6 +204,19 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     WS bridge; and like every blocking ask-extension it inherits the restart hole. The LLM-facing contract
     (TypeBox schema, validation, envelope — mirroring rpiv's so the model behaves the same) stays
     re-implemented here so we own it and avoid the package's pi-tui/i18n peer deps.
+  - `startNewChat` — the host-owned **`start_new_chat`** pi custom tool (`createStartNewChatTool`,
+    registered on every session via `startNewChatExtension` in `extensions`, like `ask_user_question` /
+    `resolve_comment`): the "ok, implement in a new session" handoff. The agent calls it with
+    `{ title?, prompt }`; `execute` reads its own session id from `ctx.sessionManager.getSessionId()`
+    and the caller's current `ctx.model`/`ctx.thinkingLevel`, then delegates through the host-installed
+    **`setStartNewChatHandler`** seam (the `resolve_comment` delegation pattern — this module gains no
+    dep): the host creates the sibling session in the same workspace (inheriting model + effort),
+    broadcasts `session.created`, and fires the kickoff prompt, returning `{ sessionId }`
+    (`StartNewChatDetails`) or throwing loud — a rejected kickoff is the TOOL's error, reported by the
+    calling agent in-conversation, never a silent empty chat. The description teaches the context
+    contract: the new session has no memory of the calling one, so the prompt must be self-contained —
+    prefer pointing at a task-spec / handoff doc under `.thinkrail/context/`; call at most once per user
+    request and never in response to a kickoff prompt this tool produced.
   - `sessionRepair` — `repairDanglingToolCalls(sessionManager)`: the restart safety net (rationale under
     the manager bullet above). Pure over pi's `SessionManager` (compaction-aware via
     `buildSessionContext`; idempotent; appends at the leaf, where orphans sit by construction) —
@@ -292,7 +306,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   `configurePiRuntime`/`getPiRuntime`; `completeOnce`/`pickModel` +
   `OneShotRequest`/`OneShotResult`/`ModelTier`; the `webUiContext` seams; the `askUserQuestion` pure
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
-  `buildAnswersMessage`); `repairDanglingToolCalls`; the skill catalog helpers
+  `buildAnswersMessage`); the **`setStartNewChatHandler`** seam + `StartNewChatRequest`/`StartNewChatOutcome`
+  (host wires the `start_new_chat` tool's execution); `repairDanglingToolCalls`; the skill catalog helpers
   `listSkillCommands(cwd, admission)` (filtered, pre-session autocomplete) / `listSkillCatalog(cwd, admission)`
   (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count) /
   `isProjectSkillPath(relativePath)` (watch-classification predicate);

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -19,6 +19,7 @@ import {
 	ensureSessionAttached,
 	followUpSession,
 	getDefaultModel,
+	getLiveSessionSummary,
 	getSessionCommands,
 	getSessionMessages,
 	getSessionStats,
@@ -482,6 +483,20 @@ test("createSession rejects an unknown/unavailable model ref (no arbitrary baseU
 	await expect(
 		createSession({ cwd: tmpCwd("trpi-bad-"), workspaceId: "ws-bad", model: bogus }),
 	).rejects.toThrow(/Unknown or unavailable model/);
+});
+
+test("createSession(title) names the chat at birth; getLiveSessionSummary reads the live summary", async () => {
+	const s = await createSession({
+		cwd: tmpCwd("trpi-title-"),
+		workspaceId: "ws-t",
+		title: "Implement X",
+	});
+	const summary = getLiveSessionSummary(s.sessionId);
+	expect(summary?.title).toBe("Implement X");
+	expect(summary?.workspaceId).toBe("ws-t");
+	expect(summary?.live).toBe(true);
+	expect(getLiveSessionSummary("no-such-session")).toBeUndefined();
+	removeSession(s.sessionId);
 });
 
 test("getSessionStats + getSessionCommands read live session info (cheap wins #3, #2)", async () => {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -170,9 +170,11 @@ export interface CreateSessionInput {
 	cwd: string;
 	/** The workspace id, kept alongside the session so it can be listed back per workspace. */
 	workspaceId: string;
-	/** A wire model reference (`{provider,id}` + display metadata, no `baseUrl`) — re-resolved host-side. */
-	model?: WireModel;
+	/** A wire model reference (`{provider,id}` is all that's read, no `baseUrl`) — re-resolved host-side. */
+	model?: Pick<WireModel, "provider" | "id">;
 	thinkingLevel?: ThinkingLevel;
+	/** Optional display name for the chat (pi `setSessionName`) — the handoff tool names tabs at birth. */
+	title?: string;
 }
 
 /** The resolved session + the model/thinking it starts with (pi picks defaults from auth + settings). */
@@ -288,7 +290,15 @@ export async function createSession(input: CreateSessionInput): Promise<CreateSe
 		...(input.model ? { model: await resolveWireModel(input.model) } : {}),
 		...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
 	});
+	if (input.title) session.setSessionName(input.title);
 	return registerSession(session, input.workspaceId);
+}
+
+/** A LIVE session's current summary, or undefined when the id isn't live — the `session.created`
+ * broadcast's read (the host publishes right after `createSession`, before the kickoff prompt fires). */
+export function getLiveSessionSummary(sessionId: string): SessionSummary | undefined {
+	const entry = sessions.get(sessionId);
+	return entry ? summaryOf(sessionId, entry) : undefined;
 }
 
 /** A live session's summary (drawn from the running `AgentSession`). */

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -37,6 +37,7 @@ import {
 	candidateCompatibilitySkillRoots,
 	discoverCompatibilitySkillSources,
 } from "./skillSources";
+import { startNewChatExtension } from "./startNewChat";
 import { type BundledTrashHelpers, setBundledTrashHelpers } from "./trash";
 
 /** A bundled extension entry's default export — the pi factory shape the loader invokes. */
@@ -247,7 +248,12 @@ export async function buildResourceLoader(
 	settingsManager: SettingsManager,
 	getAdmission: () => SkillAdmissionContext,
 ): Promise<ResourceLoader> {
-	const sharedFactories = [headlessSearchPolicy, askUserQuestionExtension, reviewToolExtension];
+	const sharedFactories = [
+		headlessSearchPolicy,
+		askUserQuestionExtension,
+		reviewToolExtension,
+		startNewChatExtension,
+	];
 	const skillInputs = resolveSkillInputs(cwd, getAdmission);
 	const common = {
 		cwd,

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -20,4 +20,10 @@ export {
 export * from "./sessionRepair";
 export type { SkillAdmissionContext, SkillDecision, SkillFacts } from "./skillAdmission";
 export { isProjectSkillPath } from "./skillSources";
+export {
+	START_NEW_CHAT_TOOL_NAME,
+	type StartNewChatOutcome,
+	type StartNewChatRequest,
+	setStartNewChatHandler,
+} from "./startNewChat";
 export * from "./webUiContext";

--- a/packages/server/src/agent/startNewChat.test.ts
+++ b/packages/server/src/agent/startNewChat.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, expect, test } from "bun:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { StartNewChatDetails } from "@thinkrail/contracts";
+import {
+	createStartNewChatTool,
+	START_NEW_CHAT_TOOL_NAME,
+	type StartNewChatRequest,
+	setStartNewChatHandler,
+} from "./startNewChat";
+
+/** A minimal `ExtensionContext`: the tool reads the session id, the current model, and the effort. */
+const ctx = (over: Partial<{ model: unknown; thinkingLevel: string }> = {}): ExtensionContext =>
+	({
+		sessionManager: { getSessionId: () => "origin-1" },
+		model: over.model,
+		thinkingLevel: over.thinkingLevel,
+	}) as unknown as ExtensionContext;
+
+const run = (params: { title?: string; prompt: string }, context = ctx()) =>
+	createStartNewChatTool().execute("tc-1", params as never, undefined, undefined, context);
+
+afterEach(() => {
+	// Restore the fail-loud default so test order can't leak a stub handler.
+	setStartNewChatHandler(() => {
+		throw new Error("Starting new chats is not available on this host.");
+	});
+});
+
+test("delegates to the host seam with the calling session's identity, model and effort", async () => {
+	let seen: StartNewChatRequest | undefined;
+	setStartNewChatHandler(async (request) => {
+		seen = request;
+		return { sessionId: "new-1", title: "Implement X" };
+	});
+	const result = await run(
+		{ title: "Implement X", prompt: "Read the handoff and implement." },
+		ctx({
+			model: { provider: "anthropic", id: "claude-x", baseUrl: "secret" },
+			thinkingLevel: "high",
+		}),
+	);
+	expect(seen).toEqual({
+		originSessionId: "origin-1",
+		prompt: "Read the handoff and implement.",
+		title: "Implement X",
+		model: { provider: "anthropic", id: "claude-x" }, // the ref only — never the full Model (baseUrl)
+		thinkingLevel: "high",
+	});
+	expect((result.details as StartNewChatDetails).sessionId).toBe("new-1");
+	expect(result.content[0]?.type).toBe("text");
+});
+
+test("omits absent title/model/effort rather than passing placeholders", async () => {
+	let seen: StartNewChatRequest | undefined;
+	setStartNewChatHandler(async (request) => {
+		seen = request;
+		return { sessionId: "new-2", title: "Chat" };
+	});
+	await run({ prompt: "Go." });
+	expect(seen).toEqual({ originSessionId: "origin-1", prompt: "Go." });
+});
+
+test("an empty prompt fails loud before reaching the seam", async () => {
+	let called = false;
+	setStartNewChatHandler(async () => {
+		called = true;
+		return { sessionId: "x", title: "x" };
+	});
+	await expect(run({ prompt: "   " })).rejects.toThrow(/prompt/);
+	expect(called).toBe(false);
+});
+
+test("a seam rejection (e.g. kickoff not accepted) propagates as the tool's error", async () => {
+	setStartNewChatHandler(async () => {
+		throw new Error("No API key for model");
+	});
+	await expect(run({ prompt: "Go." })).rejects.toThrow("No API key for model");
+});
+
+test("the default handler fails loud until the host installs the seam", async () => {
+	await expect(run({ prompt: "Go." })).rejects.toThrow(/not available/);
+});
+
+test("tool name matches the wire/renderer join key", () => {
+	expect(createStartNewChatTool().name).toBe(START_NEW_CHAT_TOOL_NAME);
+	expect(START_NEW_CHAT_TOOL_NAME).toBe("start_new_chat");
+});

--- a/packages/server/src/agent/startNewChat.ts
+++ b/packages/server/src/agent/startNewChat.ts
@@ -1,0 +1,98 @@
+// The `start_new_chat` capability — a HOST-OWNED pi custom tool registered on every session (like
+// `ask_user_question` / `resolve_comment`): the "ok, implement in a new session" handoff. The agent in a
+// live chat calls it to spin up a sibling chat in the same workspace with a prepared kickoff prompt; the
+// host creates the session (inheriting the caller's model + thinking effort), broadcasts it so every
+// client converges, and fires the prompt — the new chat starts working immediately. Execution is
+// DELEGATED through a host-installed seam — this module never imports `host` or the workspace registry
+// (the agent module has no internal deps by contract). A rejected kickoff (bad model, missing key) is
+// the TOOL's failure: pi turns the throw into an error tool result the calling agent relays
+// in-conversation — never a silent empty chat.
+
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { StartNewChatDetails, ThinkingLevel, WireModel } from "@thinkrail/contracts";
+import { type Static, Type } from "typebox";
+
+export const START_NEW_CHAT_TOOL_NAME = "start_new_chat";
+
+export const StartNewChatSchema = Type.Object({
+	title: Type.Optional(
+		Type.String({
+			description:
+				'Short display name for the new chat\'s tab (3-6 words, e.g. "Implement auth flow").',
+		}),
+	),
+	prompt: Type.String({
+		description:
+			"The new chat's first message. It must be SELF-CONTAINED — the new session shares the working " +
+			"directory but has NO memory of this conversation. For substantial context, first write a handoff " +
+			"doc (or point at an existing task spec) under .thinkrail/context/ and reference it here.",
+	}),
+});
+
+export type StartNewChatParams = Static<typeof StartNewChatSchema>;
+
+const DESCRIPTION = `Start a NEW chat session in this workspace and kick it off with the given prompt. The new chat opens for the user and starts working immediately. Use ONLY when the user explicitly asks to continue or implement something in a new/fresh session or chat. Call it at most once per such request, and never in response to a kickoff prompt you yourself received from this tool. The new session has no memory of this conversation: make the prompt self-contained, preferably by referencing a handoff doc or task spec you wrote under .thinkrail/context/.`;
+
+/** What the tool hands the host seam: the calling session + what the new chat should inherit and run. */
+export interface StartNewChatRequest {
+	originSessionId: string;
+	prompt: string;
+	title?: string;
+	/** The calling session's current model ref, re-resolved host-side like any inbound ref. */
+	model?: Pick<WireModel, "provider" | "id">;
+	thinkingLevel?: ThinkingLevel;
+}
+
+/** What the seam's handler returns for the tool result. */
+export interface StartNewChatOutcome {
+	sessionId: string;
+	title: string;
+}
+
+let handler: (request: StartNewChatRequest) => Promise<StartNewChatOutcome> = () => {
+	throw new Error("Starting new chats is not available on this host.");
+};
+
+/** Host seam: wire the tool's execution to the host's session-creation compose. */
+export function setStartNewChatHandler(
+	fn: (request: StartNewChatRequest) => Promise<StartNewChatOutcome>,
+): void {
+	handler = fn;
+}
+
+export function createStartNewChatTool(): ToolDefinition<typeof StartNewChatSchema> {
+	return {
+		name: START_NEW_CHAT_TOOL_NAME,
+		label: "Start New Chat",
+		description: DESCRIPTION,
+		parameters: StartNewChatSchema,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const { title, prompt } = params as StartNewChatParams;
+			if (!prompt.trim()) throw new Error("start_new_chat: `prompt` must not be empty.");
+			// The calling session's identity + current model/effort come from pi's execution context — the
+			// one place a shared (per-loader, pre-session-id) tool registration can learn who called it.
+			const outcome = await handler({
+				originSessionId: ctx.sessionManager.getSessionId(),
+				prompt,
+				...(title?.trim() ? { title: title.trim() } : {}),
+				...(ctx.model ? { model: { provider: ctx.model.provider, id: ctx.model.id } } : {}),
+				...(ctx.thinkingLevel ? { thinkingLevel: ctx.thinkingLevel } : {}),
+			});
+			const details: StartNewChatDetails = { sessionId: outcome.sessionId };
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Started new chat "${outcome.title}" (${outcome.sessionId}) — it is now running the kickoff prompt.`,
+					},
+				],
+				details,
+			};
+		},
+	};
+}
+
+/** Extension factory (mirrors `reviewToolExtension`): registers the tool on each session's `pi`. */
+export function startNewChatExtension(pi: ExtensionAPI): void {
+	pi.registerTool(createStartNewChatTool());
+}

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -195,6 +195,18 @@ channel fan-out, and the process-boot wrapper both launchers share.
   `ensureWorkspaceScratchDir` before creating the session — the Default workspace's gitignored
   `.thinkrail/context/` lands in the user's repo only when a chat actually starts there (and a
   worktree's deleted scratch dir self-heals). Host-composed — no new module edges.
+- **Agent-initiated chats are host-composed** (`startNewChatFromOrigin` in `handlers.ts`, installed into
+  `agent`'s `setStartNewChatHandler` seam by `createServer` — the `resolve_comment` seam pattern): the
+  `start_new_chat` tool's request resolves the origin's workspace (`getSessionWorkspaceId` →
+  `getWorkspace`), then mirrors the `session.create` handler — `ensureWorkspaceScratchDir` →
+  `createSession` (origin's model/effort + the tool's `title`) → the same `chat_started` track — then
+  **broadcasts `session.created`** (the new chat's live `SessionSummary`) **before** awaiting the
+  kickoff prompt's accept-ack (`ackSend(promptSession(…))`), so on every socket the push precedes the
+  new session's `pi.event` stream and clients build the runtime before the prompt's `message_start`
+  lands. A pre-accept rejection propagates as the TOOL call's error (the calling agent reports it
+  in-conversation); a post-accept fault rides the new chat's event stream, like any send. The
+  `session.created` publish is a `createServer` closure beside the `session.deleted` one; the channel is
+  `ws.subscribe`d in the WS `open` handler with the rest.
 - **Project lifecycle fan-out:** `createServer` installs the `projects` module's publisher and maps every
   authoritative open/reopen/close snapshot to **`project.updated`**. The WS `open` handler subscribes to
   that channel and hydrates two views in `server.welcome`: `projects` (open records only) and

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -11,6 +11,7 @@ import type {
 	ReviewCommentKind,
 	ReviewCommentStatus,
 	ReviewSendResult,
+	SessionCreatedPayload,
 	TemplateScope,
 	ThinkingLevel,
 	TodoStatus,
@@ -28,9 +29,11 @@ import {
 	ensureSessionAttached,
 	followUpSession,
 	getDefaultModel,
+	getLiveSessionSummary,
 	getSessionCommands,
 	getSessionMessages,
 	getSessionStats,
+	getSessionWorkspaceId,
 	hasSession,
 	listAvailableModels,
 	listProjectAliasSkillNames,
@@ -44,6 +47,8 @@ import {
 	removeSession,
 	removeWorkspaceSessions,
 	resolveExtUi,
+	type StartNewChatOutcome,
+	type StartNewChatRequest,
 	setSessionModel,
 	setSessionThinkingLevel,
 	steerSession,
@@ -170,6 +175,46 @@ async function archiveTeardown(ws: Workspace): Promise<void> {
 function trackSend(mode: SendMode, text: string): void {
 	if (isControlMessage(text)) return;
 	track({ name: "message_sent", params: { mode } });
+}
+
+/**
+ * The `start_new_chat` tool's host compose (`agent`'s `setStartNewChatHandler` seam — wired by
+ * `createServer` with the `session.created` publish): the "implement in a new session" handoff. Mirrors
+ * the `session.create` handler — resolve the origin's workspace, seed the scratch dir, create the
+ * sibling session (origin's model/effort, the tool's `title`), track — then BROADCAST the new chat
+ * before awaiting the kickoff prompt's accept-ack, so on every socket the `session.created` push
+ * precedes the new session's `pi.event` stream (clients build the runtime before the prompt's
+ * `message_start` lands). Unlike review sends this is NOT detached: a tool call taking a few seconds is
+ * normal, and a pre-accept rejection propagating as the tool's error puts the failure in front of the
+ * user via the calling agent — never a silent empty chat. A post-accept fault rides the new chat's
+ * event stream, like any send.
+ */
+export async function startNewChatFromOrigin(
+	request: StartNewChatRequest,
+	publishSessionCreated: (payload: SessionCreatedPayload) => void,
+): Promise<StartNewChatOutcome> {
+	const workspaceId = getSessionWorkspaceId(request.originSessionId);
+	if (!workspaceId)
+		throw new Error("start_new_chat: the calling session is not attached to a workspace.");
+	const ws = getWorkspace(workspaceId);
+	ensureWorkspaceScratchDir(ws);
+	const created = await createSession({
+		cwd: ws.worktreePath,
+		workspaceId,
+		...(request.model ? { model: request.model } : {}),
+		...(request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {}),
+		...(request.title ? { title: request.title } : {}),
+	});
+	if (created.model) {
+		track({
+			name: "chat_started",
+			params: bucketProviderModel(created.model.provider, created.model.id),
+		});
+	}
+	const summary = getLiveSessionSummary(created.sessionId);
+	if (summary) publishSessionCreated({ summary });
+	await ackSend(promptSession(created.sessionId, request.prompt));
+	return { sessionId: created.sessionId, title: summary?.title ?? request.title ?? "Chat" };
 }
 
 /**

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -17,6 +17,7 @@ import {
 	setSessionDeletedPublisher,
 	setSessionPublisher,
 	setSkillAdmissionResolver,
+	setStartNewChatHandler,
 } from "../agent";
 import {
 	type AnalyticsOptions,
@@ -57,7 +58,7 @@ import {
 	maybeNaiveNameWorkspace,
 } from "./autoRename";
 import { setFsNudgePublisher } from "./fsNudge";
-import { handleRequest } from "./handlers";
+import { handleRequest, startNewChatFromOrigin } from "./handlers";
 import { trackLoginOutcome } from "./loginAnalytics";
 import { RequestReplayCache } from "./requestReplayCache";
 import { terminalDeliveryForSendStatus } from "./terminalSend";
@@ -201,6 +202,7 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 				ws.subscribe(WS_CHANNELS.piEvent);
 				ws.subscribe(WS_CHANNELS.piExtensionUi);
 				ws.subscribe(WS_CHANNELS.sessionDeleted);
+				ws.subscribe(WS_CHANNELS.sessionCreated);
 				ws.subscribe(WS_CHANNELS.providerLogin);
 				ws.subscribe(WS_CHANNELS.projectUpdated);
 				ws.subscribe(WS_CHANNELS.terminalTabs);
@@ -475,6 +477,18 @@ export function createServer(options: CreateServerOptions = {}): RunningServer {
 			JSON.stringify({ channel: WS_CHANNELS.sessionDeleted, data: payload }),
 		);
 	});
+
+	// The agent-side `start_new_chat` tool's execution — host-composed session creation (the
+	// `resolve_comment` seam pattern), broadcasting the new chat before its kickoff prompt fires so every
+	// client's runtime exists when the first `pi.event` lands.
+	setStartNewChatHandler((request) =>
+		startNewChatFromOrigin(request, (payload) => {
+			server.publish(
+				WS_CHANNELS.sessionCreated,
+				JSON.stringify({ channel: WS_CHANNELS.sessionCreated, data: payload }),
+			);
+		}),
+	);
 
 	// Stream each in-process AgentSession's events to subscribed clients over the pi.event channel, and
 	// tee the best-effort workspace auto-rename off two points, fire-and-forget (`void` — the hooks never

--- a/packages/server/src/host/startNewChatCompose.test.ts
+++ b/packages/server/src/host/startNewChatCompose.test.ts
@@ -1,0 +1,164 @@
+// The `start_new_chat` host compose (`startNewChatFromOrigin`) against a REAL workspace registry and a
+// REAL in-process pi session on a faux provider — pinning the contracts the web fold depends on:
+// the `session.created` publish carries the titled live summary and lands BEFORE the kickoff prompt's
+// first pi event (per-socket FIFO is what lets a client build the runtime in time), and failures
+// (unknown origin session) stay loud and publish nothing.
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
+import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
+import type { SessionCreatedPayload, Workspace } from "@thinkrail/contracts";
+import {
+	createSession,
+	disposeAllSessions,
+	setSessionManagerFactory,
+	setSessionPublisher,
+} from "../agent";
+import { configurePiRuntime } from "../agent/piRuntime";
+import { handleRequest, startNewChatFromOrigin } from "./handlers";
+
+const CTX = { clientKey: "test-client" };
+
+function git(cwd: string, ...args: string[]): void {
+	const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "ignore", stderr: "ignore" });
+	if (!result.success) throw new Error(`git ${args.join(" ")} failed`);
+}
+
+function modelDef(id: string) {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 4096,
+	};
+}
+
+const faux = createFauxCore({
+	provider: "fauxa",
+	api: "fauxa",
+	models: [modelDef("fauxa")],
+	tokensPerSecond: 2000,
+});
+
+let dataDir: string;
+const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+let priorAgentDir: string | undefined;
+let priorOffline: string | undefined;
+/** Everything observed in publish order: `created:<id>` frames and `event:<id>:<type>` pi events. */
+const sequence: string[] = [];
+
+beforeAll(async () => {
+	priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "trpi-compose-agent-"));
+	priorOffline = process.env.PI_OFFLINE;
+	process.env.PI_OFFLINE = "1";
+
+	dataDir = mkdtempSync(join(tmpdir(), "trpi-compose-data-"));
+	process.env.THINKRAIL_DATA_DIR = dataDir;
+	const repo = join(dataDir, "repo");
+	mkdirSync(repo);
+	git(repo, "init", "-b", "main");
+	git(repo, "config", "user.email", "t@thinkrail.test");
+	git(repo, "config", "user.name", "test");
+	writeFileSync(join(repo, "README.md"), "# repo\n");
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "init");
+	writeFileSync(
+		join(dataDir, "projects.json"),
+		JSON.stringify([{ id: "p1", name: "repo", path: repo, slug: "repo", lastOpened: 1 }]),
+	);
+
+	const runtime = await ModelRuntime.create({
+		credentials: new InMemoryCredentialStore(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	runtime.registerProvider("fauxa", {
+		api: faux.api,
+		baseUrl: "http://faux.local",
+		apiKey: "faux",
+		streamSimple: faux.streamSimple,
+		models: [{ ...modelDef("fauxa"), api: faux.api }],
+	});
+	configurePiRuntime(runtime);
+	setSessionManagerFactory(() => SessionManager.inMemory());
+	setSessionPublisher(({ sessionId, event }) => {
+		sequence.push(`event:${sessionId}:${(event as { type: string }).type}`);
+	});
+});
+
+afterAll(() => {
+	disposeAllSessions();
+	rmSync(dataDir, { recursive: true, force: true });
+	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
+	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+	if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+	if (priorOffline === undefined) delete process.env.PI_OFFLINE;
+	else process.env.PI_OFFLINE = priorOffline;
+});
+
+test("the compose creates a titled sibling chat, publishes it BEFORE the kickoff's pi events, and prompts it", async () => {
+	const rows = (await handleRequest("workspace.list", { projectId: "p1" }, CTX)) as Workspace[];
+	const ws = rows[0];
+	if (!ws) throw new Error("expected the Default workspace");
+
+	// The origin chat the user is talking in.
+	faux.setResponses([fauxAssistantMessage("KICKOFF_REPLY")]);
+	const origin = await createSession({
+		cwd: ws.worktreePath,
+		workspaceId: ws.id,
+		model: { provider: "fauxa", id: "fauxa" },
+	});
+
+	const published: SessionCreatedPayload[] = [];
+	const outcome = await startNewChatFromOrigin(
+		{
+			originSessionId: origin.sessionId,
+			prompt: "Read the handoff and implement.",
+			title: "Implement X",
+			model: { provider: "fauxa", id: "fauxa" },
+		},
+		(payload) => {
+			published.push(payload);
+			sequence.push(`created:${payload.summary.sessionId}`);
+		},
+	);
+
+	// The broadcast carries the titled LIVE summary of a session in the origin's workspace.
+	expect(published).toHaveLength(1);
+	const summary = published[0]?.summary;
+	expect(summary?.sessionId).toBe(outcome.sessionId);
+	expect(summary?.workspaceId).toBe(ws.id);
+	expect(summary?.title).toBe("Implement X");
+	expect(summary?.live).toBe(true);
+	expect(outcome.title).toBe("Implement X");
+	expect(outcome.sessionId).not.toBe(origin.sessionId);
+
+	// Ordering: the created frame precedes every pi event of the NEW session (the web fold's contract).
+	const createdAt = sequence.indexOf(`created:${outcome.sessionId}`);
+	const firstEvent = sequence.findIndex((s) => s.startsWith(`event:${outcome.sessionId}:`));
+	expect(createdAt).toBeGreaterThanOrEqual(0);
+	expect(firstEvent).toBeGreaterThan(createdAt);
+
+	// The kickoff prompt actually ran in the new chat (accept-ack resolved; faux streamed its reply).
+	const kicked = sequence.filter((s) => s.startsWith(`event:${outcome.sessionId}:`));
+	expect(kicked.length).toBeGreaterThan(0);
+});
+
+test("an unknown origin session fails loud and publishes nothing", async () => {
+	const published: SessionCreatedPayload[] = [];
+	await expect(
+		startNewChatFromOrigin({ originSessionId: "no-such-session", prompt: "Go." }, (payload) =>
+			published.push(payload),
+		),
+	).rejects.toThrow(/not attached to a workspace/);
+	expect(published).toHaveLength(0);
+});


### PR DESCRIPTION
## What

You can now tell the agent **"ok, implement in new session"** and it starts a new chat — focused, seeded with a prepared kickoff prompt, and already working.

The agent calls the new host-owned **`start_new_chat`** tool (`{ title?, prompt }`). The host creates a sibling session in the same workspace (inheriting the caller's model + thinking effort, named at birth via pi's `setSessionName`), **broadcasts `session.created`**, then fires the kickoff prompt. The client whose active workspace matches opens + focuses the new tab; every other client gets a reopenable, runtime-alive history row (no tab spam). A rejected kickoff (bad model, missing key) fails the tool call loud, so the calling agent reports it in-conversation — never a silent empty chat.

The tool description carries the context contract: the new session has no memory of the calling one, so the prompt must be self-contained — preferably pointing at a task-spec / handoff doc under `.thinkrail/context/`.

## How

Follows three established patterns, one per ring:

- **contracts** — protocol **v39**: `session.created` channel + `SessionCreatedPayload` (the `session.deleted` sibling — a non-replayable domain *event*, not a snapshot), plus `StartNewChatArgs`/`StartNewChatDetails`.
- **server/agent** — `startNewChat.ts`: the tool + the host-installed `setStartNewChatHandler` seam (the `resolve_comment` delegation pattern — the agent module gains no new deps). The tool reads its own session id / model / effort from pi's `ExtensionContext`. `CreateSessionInput.title` → `setSessionName`; new `getLiveSessionSummary` read for the broadcast.
- **server/host** — `startNewChatFromOrigin` mirrors the `session.create` handler (workspace resolve → scratch-dir seed → create → `chat_started` track), then **broadcasts before awaiting the kickoff's accept-ack** (`ackSend(promptSession(…))`): per-socket FIFO guarantees the push precedes the new session's `pi.event` stream, so every client builds the runtime before the prompt's `message_start` arrives. Unlike review sends this is deliberately *not* detached — a tool call taking seconds is normal, and the error path stays in front of the user.
- **web** — transport subscription (+ `NON_REPLAYABLE_CHANNELS` classification: replaying a past creation could resurrect a since-deleted chat), the idempotent + tombstone-checked `applySessionCreated` store fold, and a passive `StartNewChatCard` receipt (primary prominence; the tab opens via the fold, so no interactive Open action).

Module SPECs updated across contracts / agent / host / transport / store / chat-tools (spec leads code).

## Tests

- **`start_new_chat` tool suite** — seam delegation carries `{provider,id}` only (never the full `Model` with `baseUrl`), empty-prompt fail-fast, seam-rejection propagation, fail-loud default handler.
- **Host compose integration test** (faux provider, real workspace registry): the `session.created` publish carries the titled live summary and lands **before** every pi event of the new session; unknown origin fails loud and publishes nothing.
- **Store fold matrix** — active workspace → tab + focus (+ nav tick); non-active → runtime-alive history row, no tab; idempotent; tombstone-checked.
- **Transport replay classification** — event channels are never replayed to late subscribers.
- **`@agent` e2e** (`new-chat-handoff.live.spec.ts`, on-demand suite) — **passed against a real provider**: the model calls the tool, a second chat tab opens focused and titled, the host-fired kickoff prompt renders as a user message and runs to completion, the origin chat shows the receipt card.

Gates: typecheck / lint / check:deps / check:seams / unit suites green. No-agent e2e run: every failure reproduced on the pristine tree (machine-environmental: layout-drag ×3, terminal-survive-navigation ×1, plus shard-contention flakes) — none in areas this change touches.

## Deferred (recorded in the task-spec)

Cross-worktree handoff (new branch/worktree), a brainstorming-skill mention of the tool, unifying review-send chat creation onto the same broadcast, and phrasing-discovery tuning (the e2e names the tool explicitly to stay deterministic).
