### PR TITLE
feat(web): render mermaid fences as diagrams in markdown views

### DIFF
--- a/apps/web/src/chat/Markdown.tsx
+++ b/apps/web/src/chat/Markdown.tsx
@@ -2,6 +2,7 @@ import { type ComponentProps, type ReactNode, useEffect, useState } from "react"
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { highlightCode } from "@/lib/highlighter";
+import { MermaidView } from "./tools/visualize/MermaidView";
 
 /**
  * The chat prose skin: `tr-prose-chat` (the generated markdown typography for a chat bubble — see
@@ -70,6 +71,7 @@ function CodeBlock({
 }) {
 	const lang = /language-(\w+)/.exec(className ?? "")?.[1];
 	const code = String(children ?? "").replace(/\n$/, "");
+	if (lang === "mermaid") return <MermaidBlock code={code} />;
 	if (!lang) {
 		if (!code.includes("\n")) {
 			// Inline code sits directly behind a text run → the 2px inline-highlight tier (`xs`), not the
@@ -87,6 +89,30 @@ function CodeBlock({
 		);
 	}
 	return <ShikiBlock code={code} lang={lang} />;
+}
+
+/**
+ * Fenced ```mermaid → themed diagram via the visualize kit's `MermaidView` (theme-swap aware,
+ * fullscreen pan-zoom, error → source). Shows the source block until the fence text has been stable
+ * for a beat — so streaming chat deltas read as code instead of flickering parse errors — and always
+ * on the very first pass, so static rendering (`RenderedDiff`'s `renderToStaticMarkup`, where effects
+ * never run) degrades to code like every other fence. `whitespace-normal` resets the inherited
+ * `white-space: pre` from react-markdown's native `<pre>` wrapper.
+ */
+function MermaidBlock({ code }: { code: string }) {
+	const [settled, setSettled] = useState<string | null>(null);
+	useEffect(() => {
+		const timer = setTimeout(() => setSettled(code), 200);
+		return () => clearTimeout(timer);
+	}, [code]);
+
+	const source = <ShikiBlock code={code} lang="mermaid" />;
+	if (settled !== code) return source;
+	return (
+		<div className="whitespace-normal">
+			<MermaidView source={code} fallback={source} />
+		</div>
+	);
 }
 
 function ShikiBlock({ code, lang }: { code: string; lang: string }) {

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -56,7 +56,11 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   a failed turn can't look like nothing happened. Live settlement and transcript hydration share the
   same assistant-failure classifier, so reload cannot turn the latest unresolved failure into success;
   recovered historical `length` attempts followed by later work are not re-labeled as current failures.
-- `markdown` — a non-empty assistant text block (react-markdown + remark-gfm + shiki).
+- `markdown` — a non-empty assistant text block (react-markdown + remark-gfm + shiki). A fenced
+  ```mermaid block renders as a themed diagram via `tools/visualize`'s `MermaidView` (fullscreen
+  pan-zoom, error → source fallback) — uniform across every `Markdown` surface (chat, file/specs
+  preview); until mounted it renders as highlighted source, so static contexts (`RenderedDiff`'s
+  `renderToStaticMarkup`) degrade to code exactly like shiki blocks do.
 - `tool` — a **primary** tool call: the collapsible `ToolCard` frame (collapsed unless registered
   `defaultExpanded`; errors auto-expand; a manual toggle wins), or a `"bare"` renderer that owns its
   frame. A `"bare"` call on a dead message (`stopReason` aborted/error — pi never executes those calls)
@@ -609,7 +613,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   from *any* consumer. `model.list` answers from *before* the
   detached refresh it triggers, so it is never a basis for concluding a model is gone);
   `react-markdown` / `remark-gfm` / `shiki` (via `lib/highlighter`); `mermaid`
-  (**lazy, `tools/visualize` only**); `react-virtuoso`; `lucide-react`; `components/ui`; `lib`.
+  (**lazy, `tools/visualize` only** — `Markdown` consumes the `MermaidView` *component*, never the
+  package); `react-virtuoso`; `lucide-react`; `components/ui`; `lib`.
 - **Forbidden:** value-importing any `pi` package; a **presentational** renderer importing
   `store`/`transport` (only the app-integration files enumerated above may — keep the renderers reusable).
 - **`ChatView`** is the primary app-integration file: wires this session's runtime

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -56,7 +56,10 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 - **`visualize/`** — `VisualizationCard` dispatches on `args.type` to `DiagramCard` (mermaid → themed
   SVG via the **lazy-loaded** `mermaid`, source fallback on parse error) and `ComparisonCard` (option
   cards with pros/cons + `recommended` highlight); shared `MermaidView` re-renders on `[data-theme]`
-  change and offers a full-screen pan/zoom Dialog. Registered **primary + `defaultExpanded`** — a
+  change, offers a full-screen pan/zoom Dialog, and takes an optional `fallback` node shown while the
+  SVG is pending (default: a "Rendering…" line). It is also consumed by the **parent `Markdown`
+  primitive** for fenced ```mermaid blocks — the `mermaid` *package* import stays lazy and confined to
+  `visualize/mermaid.ts`. Registered **primary + `defaultExpanded`** — a
   visualization is output *for the user*, not plumbing: it escapes the activity fold and renders open on
   completion (while its args stream it stays a slim running row). Capability: the bundled
   `pi-visualize` extension.
@@ -68,7 +71,7 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 ## Boundary
 
 - **Public surface:** the side-effect `register` import + the shared `CodeBlock`/`Collapsible`/
-  `toolHelpers` for sibling renderers. No barrel (chat pulls shiki — per-file imports, as in the parent).
+  `toolHelpers` for sibling renderers + `visualize/MermaidView` for the parent `Markdown` primitive. No barrel (chat pulls shiki — per-file imports, as in the parent).
 - **Allowed deps:** parent chat primitives (`toolRegistry`, `Markdown`, `ChatActions`, `askState`);
   `contracts` (type-only + the `ASK_USER_ANSWERS_CUSTOM_TYPE` constant); `components/ui`; `lib`;
   `lucide-react`; `mermaid` (**lazy, `visualize/` only**).

--- a/apps/web/src/chat/tools/visualize/MermaidView.tsx
+++ b/apps/web/src/chat/tools/visualize/MermaidView.tsx
@@ -1,5 +1,5 @@
 import { Maximize2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { onThemeSwap } from "@/themes";
 import { CodeBlock } from "../CodeBlock";
@@ -10,9 +10,18 @@ import { PanZoomView } from "./PanZoomView";
  * Render mermaid `source` to a themed SVG, re-rendering on `[data-theme]` changes. On a parse/render
  * error, falls back to showing the raw source (still copy-pasteable) — mermaid *syntax* is the model's
  * concern, so we surface it rather than swallow it. A "full screen" button opens the diagram large in a
- * `Dialog` (which brings its own close button + Esc / overlay dismissal).
+ * `Dialog` (which brings its own close button + Esc / overlay dismissal). While the SVG is pending,
+ * renders `fallback` (the markdown path passes the source block) or a default "Rendering…" line.
  */
-export function MermaidView({ source, title }: { source: string; title?: string }) {
+export function MermaidView({
+	source,
+	title,
+	fallback,
+}: {
+	source: string;
+	title?: string;
+	fallback?: ReactNode;
+}) {
 	const [svg, setSvg] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [open, setOpen] = useState(false);
@@ -52,7 +61,7 @@ export function MermaidView({ source, title }: { source: string; title?: string 
 		);
 	}
 	if (svg === null) {
-		return <span className="text-text-muted tr-text-metadata">Rendering diagram…</span>;
+		return fallback ?? <span className="text-text-muted tr-text-metadata">Rendering diagram…</span>;
 	}
 	return (
 		<div className="relative">

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -879,7 +879,9 @@ a project picker, the prompt hero, and the reused
   only what is *not* typography: h1/h2 section rules, a capped reading measure (~78ch) with wide
   tables/code scrolling inside it, zebra-striped bordered tables, muted accent blockquotes, crisp
   rules, and **GitHub-style alert callouts** (`> [!NOTE]`…`[!CAUTION]`, via the in-repo
-  `markdownAlerts` remark transform + a lucide/token `AlertCallout`, wired in only here — not chat) — in
+  `markdownAlerts` remark transform + a lucide/token `AlertCallout`, wired in only here — not chat), and
+  **```mermaid fences render as themed diagrams** (the shared `Markdown` primitive's mermaid path —
+  `chat/SPEC.md`; the rendered *diff* keeps the source-code degradation, like shiki) — in
   a centered reading column; strips a leading YAML frontmatter block via
   `lib.stripFrontmatter` so a spec's metadata doesn't render as a stray heading — source view still shows
   it) and source being the lazy read-only `MonacoEditor`. The choice

--- a/e2e/fixtures/repo.ts
+++ b/e2e/fixtures/repo.ts
@@ -62,6 +62,27 @@ export function seedFixtureRepo(): void {
 			"",
 		].join("\n"),
 	);
+	// A markdown file with a valid mermaid fence, an invalid one, and a plain code fence, for the
+	// rendered-preview diagram suite (see e2e/markdown-mermaid.spec.ts).
+	writeFileSync(
+		join(E2E_FIXTURE_REPO, "DIAGRAM.md"),
+		[
+			"# Diagram demo",
+			"",
+			"```mermaid",
+			"flowchart TD; Start --> Finish",
+			"```",
+			"",
+			"```mermaid",
+			"flowchart TD; Start --> --> broken",
+			"```",
+			"",
+			"```bash",
+			"echo plain-fence-stays-code",
+			"```",
+			"",
+		].join("\n"),
+	);
 	// A large, highly repetitive markdown doc (hundreds of identical list rows) — the worst case
 	// for node-htmldiff's matcher — for the rendered-diff main-thread test (see e2e/changes.spec.ts):
 	// diffing this inline used to block the UI for seconds, so the suite pins that the merge stays off

--- a/e2e/markdown-mermaid.spec.ts
+++ b/e2e/markdown-mermaid.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+
+// Fenced ```mermaid blocks render as themed diagrams in the rendered markdown view (the shared
+// `chat/Markdown` mermaid path): a valid fence becomes an SVG with the fullscreen affordance, an
+// invalid fence falls back to the error + source view, and a plain code fence is untouched. Backed
+// by the DIAGRAM.md fixture seeded in global-setup.
+test("renders mermaid fences as diagrams in the rendered markdown view", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await page.getByTestId("tab-files").click();
+
+	const file = page.getByTestId("file-node").filter({ hasText: "DIAGRAM.md" });
+	await expect(file).toBeVisible();
+	await file.dblclick();
+
+	const preview = page.getByTestId("markdown-preview");
+	await expect(preview).toBeVisible();
+
+	// The valid fence renders a real <svg> (lazy mermaid chunk → generous timeout), the invalid one
+	// surfaces the parse error with its source still shown; exactly one of each.
+	await expect(preview.getByTestId("mermaid-svg").locator("svg")).toBeVisible({ timeout: 20_000 });
+	await expect(preview.getByTestId("mermaid-svg")).toHaveCount(1);
+	const error = preview.getByTestId("mermaid-error");
+	await expect(error).toHaveCount(1);
+	await expect(error).toContainText("broken");
+
+	// A non-mermaid fence stays an ordinary code block.
+	await expect(preview.locator("pre.shiki", { hasText: "plain-fence-stays-code" })).toBeVisible();
+
+	// Fullscreen opens the pan-zoom dialog.
+	await preview.getByTestId("mermaid-fullscreen").click();
+	const dialog = page.getByTestId("mermaid-fullscreen-dialog");
+	await expect(dialog).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(dialog).toHaveCount(0);
+
+	// Source view shows the raw fence again.
+	await page.getByTestId("md-toggle-source").click();
+	await expect(page.getByTestId("editor-pane")).toContainText("flowchart TD; Start --> Finish");
+});


### PR DESCRIPTION
## Summary

Fenced ```mermaid blocks in markdown now render as themed diagrams instead of highlighted source.

- **One change point, uniform everywhere:** `chat/Markdown`'s internal `CodeBlock` routes `lang === "mermaid"` to a new `MermaidBlock`, so the `.md` file preview, the Specs preview, and chat prose all get diagrams from the same shared code path.
- **Reuses the visualize kit:** the existing `MermaidView` (token-themed SVG, re-renders on theme swap, fullscreen pan-zoom dialog, error → source fallback) gains an optional `fallback` node shown while the SVG is pending — the visualize tool card is unchanged.
- **Graceful degradation:** the fence renders as highlighted source until its text settles (200 ms), so streaming chat deltas read as code instead of flickering parse errors, and static contexts (the rendered markdown **diff**, built via `renderToStaticMarkup`) keep showing source — exactly the accepted shiki degradation.
- **Boundary held:** the `mermaid` package import stays lazy and confined to `tools/visualize/mermaid.ts`; only the component is consumed one level up.

### Screenshots

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/SBOne-Kenobi/660bad243da61ee4dc0e45afe92c77d6/raw/before.png) | ![after](https://gist.githubusercontent.com/SBOne-Kenobi/660bad243da61ee4dc0e45afe92c77d6/raw/after.png) |

The invalid fence (middle block) demonstrates the error fallback: parse error + the source, still copy-pasteable. Fullscreen pan-zoom dialog:

<img src="https://gist.githubusercontent.com/SBOne-Kenobi/660bad243da61ee4dc0e45afe92c77d6/raw/fullscreen.png" width="640" alt="fullscreen dialog" />

### Tests

New no-agent `e2e/markdown-mermaid.spec.ts` + seeded `DIAGRAM.md` fixture: valid fence → SVG, invalid fence → error + source, plain fence stays a code block, fullscreen dialog opens, source view intact.

## Related issues

None.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior) — all 8 shards
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change (`chat`, `chat/tools`, `panels`)
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
