### PR TITLE
Restore workspace and chat navigation on reload

### DIFF
--- a/apps/desktop/SPEC.md
+++ b/apps/desktop/SPEC.md
@@ -2,25 +2,35 @@
 id: module-desktop
 type: module-design
 status: draft
-title: Desktop host launcher (Electrobun)
+title: Desktop launcher/client (Electrobun)
 parent: architecture
 depends-on: [module-server, module-contracts]
 tags: [desktop, deferred]
+references: [submodule-web-navigation]
 ---
 
 ## Responsibility
 
-A native desktop launcher (Electrobun, OS webview). Embeds the same `createServer()` in-process and opens
-a native window instead of a browser. The sibling of `apps/cli`.
+A native Electrobun shell over the same web UI and wire. Its local-host profile embeds `createServer()`
+in-process and opens a native window; a later shared-client profile can dial an existing ThinkRail host
+without introducing a second UI or engine architecture. The sibling of `apps/cli`.
 
 ## Status
 
-Deferred. Not built in early V1 — the CLI host is the V1 entrypoint. This spec exists to keep the module
-graph complete and to reserve the seam: because both launchers embed the same host library, adding the
-desktop shell is a launcher swap, not an architecture change.
+Deferred. Not built in early V1 — the CLI host is the V1 entrypoint. This reserves local-host and
+shared-client profiles over the same server, contracts, web bundle, and navigation model.
+
+## Boundary
+
+- **Owns:** Electrobun lifecycle; local `createServer()` startup; shared-endpoint profile selection; loading the built web artifact; per-window route persistence; native deep-link handoff.
+- **Public surface:** the packaged desktop application.
+- **Allowed deps:** `server` in local-host mode; `contracts` for compatibility/native bridge types; the built web artifact; Electrobun.
+- **Forbidden:** reimplementing agent/domain logic, introducing a desktop-only wire or UI state model, or storing one active location on the backend.
 
 ## Get right (when built)
 
-- Server is embedded, not spawned (same Bun event loop).
-- `port:0` → derive the webview URL from the actual origin (`/ws` + `inferUrl`).
+- The local server is embedded, not spawned (same Bun event loop).
+- `port:0` → derive the webview URL from the actual origin (`/ws` + `inferUrl`); never persist yesterday's loopback port.
+- Persist the web module's backend-relative route locally per `{ backendProfileId, windowId }`, outside webview cache, and append it only after resolving the selected profile/origin.
+- Routes carry no credentials and never become one backend-owned active location shared by all clients.
 - Browser fallback stays free: the standalone host serves the same `web/dist` with native hooks disabled.

--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -15,7 +15,7 @@ event stream as a chat-centric, multi-session IDE shell.
 
 ## Boundary
 
-- **Owns:** the browser UI — transport client, store, panels, the responsive shell, branding tokens.
+- **Owns:** the browser UI — client-local navigation, transport client, store, panels, the responsive shell, branding tokens.
 - **Public surface:** the built static bundle (`dist/`) — a deployable artifact that dials a host.
 - **Allowed deps:** `@thinkrail/contracts` (types + WS constants) ONLY; React / Zustand / Vite / etc.
 - **Forbidden:** importing `server` / `shared` / any `pi` package (value or type). Kept clean by type-only
@@ -23,13 +23,14 @@ event stream as a chat-centric, multi-session IDE shell.
 
 ## Internal modules
 
-Each is a bounded sub-module; `transport`/`store`/`lib` expose an `index.ts` **barrel** (their only public
+Each is a bounded sub-module; `navigation`/`transport`/`store`/`lib` expose an `index.ts` **barrel** (their only public
 surface). `panels`/`components/ui`/`chat` are imported **per-file by design** — barreling them would pull
 the lazily-loaded Monaco/shiki/xterm chunks into the eager bundle and break the shadcn per-primitive
 convention; their boundary is held by convention + spec. Sibling edges live here, not in the leaves.
 
 | module | owns | barrel | spec |
 | --- | --- | --- | --- |
+| `navigation` | backend-relative location model + fragment driver/validated restore | yes | [navigation/SPEC.md](src/navigation/SPEC.md) |
 | `transport` | the WS client + its singleton/store wiring | yes | [transport/SPEC.md](src/transport/SPEC.md) |
 | `store` | Zustand: domain projections, accepted workspace-layout snapshots, local attention, chat runtimes | yes | [store/SPEC.md](src/store/SPEC.md) |
 | `panels` | layout-agnostic, store-driven feature views | no | [panels/SPEC.md](src/panels/SPEC.md) |
@@ -49,13 +50,14 @@ Outside `src/`, **[`scripts/`](scripts/SPEC.md)** is the build-time generator mo
 never ships, and turns those two JSON sources into `styles/generated/`.
 `index.html` names the product and links the local, symbol-only SVG favicon derived from the same
 ThinkRail artwork as the shell logo (compact enough for browser-tab sizes and light/dark browser chrome).
-`main.tsx` is the entry/composition root — it synchronously builds the bundled theme catalog, then
-applies the cached first-paint theme hint pre-React before wrapping `<Shell />` in
+`main.tsx` is the entry/composition root — it synchronously builds the bundled theme catalog, applies the
+cached first-paint theme hint pre-React, initializes transport + client-local navigation, then wraps `<Shell />` in
 `components/ErrorBoundary` as the last-resort boundary (a crash escaping every region shows a reload
 screen, not a blank root).
 
 ### Dependency graph
 
+- `navigation` → `store`, `transport`, `contracts` (type-only); neither dependency imports it, and `main.tsx` initializes the integration
 - `shell` → child `shell/layout`, `panels`, `chat` (app-integration render/hydration only), `store`, `transport`, `contracts` (type-only), `components/ui`, `components` (`ErrorBoundary` around each mounted region), `constants`, `lib` (platform shortcut semantics), `themes` (the single owner of the atomic `applyTheme` DOM effect, driven by `store.theme`)
 - `shell/layout` → `contracts` (types only), `lib` (attention/id primitives), and React / `react-resizable-panels` / `@dnd-kit/core`; the parent injects store state, commit callbacks, and feature renderers, so the child has no feature-module runtime edge
 - `panels` → `store`, `transport`, `components/ui`, `components` (`ErrorBoundary` for feature bodies), `lib`, `contracts`, `constants` (`WelcomePanel`'s wordmark), `chat` (`NewWorkspaceDialog` eagerly reuses `chat/ModelSelector`+`ThinkingSelector`+`useModelCatalog` — these are shiki-free, so the eager import stays split-safe; `TemplatesSettings` reuses `chat/TemplateEditorDialog` for its New/Edit flows — see `panels/SPEC.md`'s `TemplatesSettings` paragraph), `auth` (`ProvidersSettings` mounts `auth/LoginDialog`), `themes` (`AppearanceSettings` consumes the live catalog; code surfaces consume generic theme variables/syntax mapping)

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,7 @@ import "./index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { initNavigation } from "./navigation";
 import { Shell } from "./shell/Shell";
 import { applyTheme, initializeBundledThemes, readThemeHint } from "./themes";
 import { initTransport } from "./transport";
@@ -11,6 +12,7 @@ initializeBundledThemes();
 // against the host's source-of-truth config a moment later.
 applyTheme(readThemeHint());
 initTransport();
+initNavigation();
 
 const root = document.getElementById("root");
 if (root) {

--- a/apps/web/src/navigation/SPEC.md
+++ b/apps/web/src/navigation/SPEC.md
@@ -1,0 +1,55 @@
+---
+id: submodule-web-navigation
+type: submodule-design
+status: active
+title: navigation — client-local routes and restoration
+parent: module-web
+depends-on: [module-contracts]
+tags: [v1, ui, navigation, multi-client]
+references: [architecture, module-desktop]
+---
+
+## Responsibility
+
+The client-local location layer: one backend-relative, serializable route for main/Project Home/workspace/chat, plus the browser fragment driver and the restore coordinator that validates an incoming route against host-owned state before changing the rendered store.
+
+This module makes location portable without making it shared state. Browser tabs own independent fragments; later Electrobun/mobile shells persist the same route per backend profile and window/device. Cross-client continuation is an explicit link/bookmark action, never an automatic backend-owned active location.
+
+## Boundary
+
+- **Owns:** `NavigationLocation`; the versioned fragment codec; the `NavigationDriver` seam (`read`/`replace`/incoming-location subscription); the browser fragment driver; startup/direct-link restoration and canonical fallback; loop/idempotency guards between serialized intent and validated store state.
+- **Public surface (barrel):** route types + codec and `initNavigation(driver?)`; the browser driver is the default. Native adapters may consume/produce the same backend-relative route without changing store or transport.
+- **External deps:** `contracts` (project/workspace/session DTO types, type-only); browser History/Location APIs.
+- **Forbidden:** server/shared/pi; owning project/workspace/session snapshots; persisting credentials or raw backend secrets; importing panels/chat/shell; writing a backend-owned “active location.”
+
+Sibling dependency edges live only in `module-web`. `main.tsx` initializes the integration, while `shell/chatReconciliation` consumes the store's exact-chat target through its existing hydration integration.
+
+## Route contract
+
+The versioned browser fragment represents exactly one of:
+
+- `#/v1` — main/Welcome;
+- `#/v1/projects/<projectId>` — Project Home;
+- `#/v1/projects/<projectId>/workspaces/<workspaceId>` — workspace;
+- `#/v1/projects/<projectId>/workspaces/<workspaceId>/chats/<sessionId>` — exact chat.
+
+Each id is one encoded path segment. Empty ids, extra segments, malformed encoding, and unknown versions are invalid and canonicalize to main. The route is backend-relative: same-origin web gets backend identity from its origin; independently hosted/native clients pair it with a selected backend profile. No credential belongs in it.
+
+Store-driven navigation uses `history.replaceState` in the first slice: the fragment is a reload/shareable-location contract, not yet browser history for every chat click. Directly opened fragments and later incoming fragment changes still run through validation. The driver compares the derived location before writing, so non-navigation store churn — especially streaming Pi events — causes no History API calls.
+
+## Restore contract
+
+An incoming route is intent, never domain truth:
+
+1. wait for the store's **`welcomeGeneration`**, advanced only by its atomic complete-welcome install — connection status, protocol version, and an empty project list are not readiness signals;
+2. validate the project against that open-project snapshot;
+3. fetch/install the project's authoritative `workspace.list({ includeDiffStats: false })` before validating/activating a workspace — membership/order stay complete while the synchronous per-workspace diff-stat fan-out stays off automatic startup;
+4. re-check the route generation and open project after the read, then atomically activate a valid workspace, advance its center-navigation tick (so older deferred reads are superseded), and either install an exact-chat target stamped with the resulting tick or clear any older exact target for a workspace-level route; a workspace route carries no tab intent, so existing browser-local attention remains and ordinary store sync may canonicalize the fragment to an already-selected chat;
+5. let `shell/chatReconciliation` validate/hydrate that session before its ordinary auto-open pass; an exact-target install advances a dedicated generation so this also runs when the workspace was already active, while target consumption does not cause a duplicate pass. While the exact target is unresolved, background hydration cannot activate a different chat or advance the target's navigation tick;
+6. apply every resolved level, including main itself, then canonicalize ids only after **successful authoritative absence**: completed session list lacks chat → workspace, completed workspace list lacks workspace → Project Home, completed welcome lacks project → main. Falling back from a missing chat does not erase an existing shared placement or this browser's attention; after the exact target is consumed, the derived location truthfully reflects whatever remains selected. A timeout, disconnect, unreadable response, or ordinary server error says nothing about existence: navigation leaves route/target unchanged and the data loader performs its standard retry/reconnect or error UI.
+
+Every incoming route advances one monotonic restore generation; every asynchronous continuation checks it. Any project/workspace scope move **or center-navigation tick** cancels a still-pending authoritative read, so a same-workspace file/chat click beats its late response too. The exact-chat target may focus only while its workspace and stamped navigation tick are still current. Store→driver writes pause while an incoming exact route is unresolved, so temporary workspace/no-tab/error state cannot erase the chat fragment. Duplicate initialization/welcome delivery and React Strict Mode are idempotent; reconnect retries unresolved intent but does not replay a completed startup route.
+
+## Later platform adapters
+
+Electrobun persists this route outside webview storage per `{ backendProfileId, windowId }`, then appends it to the actual origin after starting a dynamic-port local host or selecting a shared backend. Mobile persists it per backend profile/device and maps universal/custom links onto it. Those adapters and backend-profile UX are outside this module's V1 browser slice; the route contract is the seam they reuse.

--- a/apps/web/src/navigation/driver.ts
+++ b/apps/web/src/navigation/driver.ts
@@ -1,0 +1,32 @@
+/**
+ * The seam between the navigation coordinator and wherever a client keeps its location. The browser
+ * driver below reads/writes `location.hash`; a later Electrobun/mobile adapter persists the same
+ * backend-relative fragment per backend profile and window/device without touching store or transport.
+ */
+export interface NavigationDriver {
+	/** The current serialized fragment (leading `#` included; `""` when the URL carries none). */
+	read(): string;
+	/** Replace the current fragment in place — never a new history entry (`history.replaceState`). */
+	replace(fragment: string): void;
+	/**
+	 * Subscribe to fragment changes arriving from OUTSIDE the app — the user editing the address bar or
+	 * following a shared link in place. Our own `replace` writes never fire it (`history.replaceState`
+	 * dispatches no `hashchange`), which is what keeps the store→URL sync loop-free.
+	 */
+	onIncoming(handler: (fragment: string) => void): () => void;
+}
+
+/** The V1 browser driver: `location.hash` + `history.replaceState` + `hashchange`. */
+export function browserNavigationDriver(): NavigationDriver {
+	return {
+		read: () => window.location.hash,
+		replace: (fragment) => {
+			history.replaceState(history.state, "", fragment);
+		},
+		onIncoming: (handler) => {
+			const listener = () => handler(window.location.hash);
+			window.addEventListener("hashchange", listener);
+			return () => window.removeEventListener("hashchange", listener);
+		},
+	};
+}

--- a/apps/web/src/navigation/index.ts
+++ b/apps/web/src/navigation/index.ts
@@ -1,0 +1,13 @@
+/**
+ * navigation — client-local routes and restoration (see SPEC.md). The barrel is the module's only public
+ * surface: the route type + fragment codec, the driver seam (native adapters implement it; the browser
+ * driver is `initNavigation`'s default), and the one-shot `initNavigation` the composition root calls.
+ */
+export type { NavigationDriver } from "./driver";
+export { initNavigation } from "./init";
+export {
+	MAIN_LOCATION,
+	type NavigationLocation,
+	parseFragment,
+	serializeLocation,
+} from "./location";

--- a/apps/web/src/navigation/init.ts
+++ b/apps/web/src/navigation/init.ts
@@ -1,0 +1,22 @@
+import { getTransport } from "../transport";
+import { browserNavigationDriver, type NavigationDriver } from "./driver";
+import { startNavigation } from "./restore";
+
+let started = false;
+
+/**
+ * Initialize the navigation layer against the app's transport singleton — called once from `main.tsx`,
+ * after `initTransport()`. Idempotent: a duplicate call is a no-op, and because the coordinator checks the
+ * store's current `welcomeGeneration` before subscribing to its edges, an init that runs after a welcome
+ * already installed cannot miss it. Tests drive `startNavigation` directly with fake deps instead.
+ */
+export function initNavigation(driver: NavigationDriver = browserNavigationDriver()): void {
+	if (started) return;
+	started = true;
+	startNavigation({
+		driver,
+		// The light authoritative list: complete membership/order, no per-workspace diff-stat fan-out.
+		listWorkspaces: (projectId) =>
+			getTransport().request("workspace.list", { projectId, includeDiffStats: false }),
+	});
+}

--- a/apps/web/src/navigation/location.test.ts
+++ b/apps/web/src/navigation/location.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import {
+	MAIN_LOCATION,
+	type NavigationLocation,
+	parseFragment,
+	serializeLocation,
+} from "./location";
+
+test("the codec round-trips all four location kinds", () => {
+	const locations: NavigationLocation[] = [
+		{ kind: "main" },
+		{ kind: "project", projectId: "p1" },
+		{ kind: "workspace", projectId: "p1", workspaceId: "w1" },
+		{ kind: "chat", projectId: "p1", workspaceId: "w1", sessionId: "s1" },
+	];
+	for (const location of locations) {
+		expect(parseFragment(serializeLocation(location))).toEqual(location);
+	}
+});
+
+test("ids that need encoding survive the round trip as single path segments", () => {
+	const location: NavigationLocation = {
+		kind: "chat",
+		projectId: "p/with slash",
+		workspaceId: "w#hash?q",
+		sessionId: "s%25already",
+	};
+	const fragment = serializeLocation(location);
+	// One encoded segment per id — a raw "/" inside an id must never mint an extra segment.
+	expect(fragment.split("/")).toHaveLength(8);
+	expect(parseFragment(fragment)).toEqual(location);
+});
+
+test("parse accepts the fragment with or without its leading '#'", () => {
+	expect(parseFragment("/v1/projects/p1")).toEqual({ kind: "project", projectId: "p1" });
+	expect(parseFragment("#/v1/projects/p1")).toEqual({ kind: "project", projectId: "p1" });
+});
+
+test("malformed and unknown fragments canonicalize safely to main", () => {
+	const invalid = [
+		"", // no fragment at all
+		"#", // bare hash
+		"#/v2/projects/p1", // unknown version
+		"#/projects/p1", // missing version
+		"#v1/projects/p1", // no leading slash
+		"#/v1/project/p1", // wrong collection name
+		"#/v1/projects", // missing id
+		"#/v1/projects/", // empty id
+		"#/v1/projects/p1/", // trailing slash = trailing empty segment
+		"#/v1/projects/p1/workspaces", // missing workspace id
+		"#/v1/projects/p1/workspaces/w1/chats", // missing session id
+		"#/v1/projects/p1/workspaces/w1/chats/s1/extra", // extra segments
+		"#/v1/projects/p1/tabs/t1", // unknown sub-collection
+		"#/v1/projects/%GG", // malformed percent-encoding
+		"#/section-heading", // a plain in-page anchor is not a route
+	];
+	for (const fragment of invalid) {
+		expect(parseFragment(fragment)).toEqual(MAIN_LOCATION);
+	}
+	expect(serializeLocation(MAIN_LOCATION)).toBe("#/v1");
+});

--- a/apps/web/src/navigation/location.ts
+++ b/apps/web/src/navigation/location.ts
@@ -1,0 +1,70 @@
+/**
+ * The client-local, backend-relative location — one serializable route for main/Welcome, Project Home, a
+ * workspace, or an exact chat — and its versioned URL-fragment codec. The route carries backend ids only:
+ * same-origin web gets backend identity from its origin, native shells pair it with a backend profile, and
+ * no credential or transport secret ever belongs in it.
+ */
+export type NavigationLocation =
+	| { kind: "main" }
+	| { kind: "project"; projectId: string }
+	| { kind: "workspace"; projectId: string; workspaceId: string }
+	| { kind: "chat"; projectId: string; workspaceId: string; sessionId: string };
+
+/** The canonical main/Welcome route (also what every invalid fragment canonicalizes to). */
+export const MAIN_LOCATION: NavigationLocation = { kind: "main" };
+
+/** One id as one encoded path segment. */
+function encodeSegment(id: string): string {
+	return encodeURIComponent(id);
+}
+
+/** Decode one path segment; `null` for an empty id or malformed percent-encoding. */
+function decodeSegment(segment: string | undefined): string | null {
+	if (!segment) return null;
+	try {
+		const decoded = decodeURIComponent(segment);
+		return decoded === "" ? null : decoded;
+	} catch {
+		return null;
+	}
+}
+
+/** Serialize a location to its canonical `#/v1/…` fragment (leading `#` included). */
+export function serializeLocation(location: NavigationLocation): string {
+	switch (location.kind) {
+		case "main":
+			return "#/v1";
+		case "project":
+			return `#/v1/projects/${encodeSegment(location.projectId)}`;
+		case "workspace":
+			return `#/v1/projects/${encodeSegment(location.projectId)}/workspaces/${encodeSegment(location.workspaceId)}`;
+		case "chat":
+			return `#/v1/projects/${encodeSegment(location.projectId)}/workspaces/${encodeSegment(location.workspaceId)}/chats/${encodeSegment(location.sessionId)}`;
+	}
+}
+
+/**
+ * Parse a URL fragment (with or without its leading `#`) into a location. Strict: an unknown version, a
+ * wrong collection name, an empty id, malformed encoding, or extra/missing segments all canonicalize
+ * safely to {@link MAIN_LOCATION} — an incoming fragment is intent, and unintelligible intent must land
+ * the user on Welcome rather than throw or half-parse.
+ */
+export function parseFragment(fragment: string): NavigationLocation {
+	const raw = fragment.startsWith("#") ? fragment.slice(1) : fragment;
+	if (raw === "" || raw === "/v1") return MAIN_LOCATION;
+	const segments = raw.split("/");
+	// A canonical fragment starts with "/", so segment 0 is the empty string before it.
+	if (segments[0] !== "" || segments[1] !== "v1") return MAIN_LOCATION;
+	if (segments[2] !== "projects") return MAIN_LOCATION;
+	const projectId = decodeSegment(segments[3]);
+	if (!projectId) return MAIN_LOCATION;
+	if (segments.length === 4) return { kind: "project", projectId };
+	if (segments[4] !== "workspaces") return MAIN_LOCATION;
+	const workspaceId = decodeSegment(segments[5]);
+	if (!workspaceId) return MAIN_LOCATION;
+	if (segments.length === 6) return { kind: "workspace", projectId, workspaceId };
+	if (segments[6] !== "chats" || segments.length !== 8) return MAIN_LOCATION;
+	const sessionId = decodeSegment(segments[7]);
+	if (!sessionId) return MAIN_LOCATION;
+	return { kind: "chat", projectId, workspaceId, sessionId };
+}

--- a/apps/web/src/navigation/restore.test.ts
+++ b/apps/web/src/navigation/restore.test.ts
@@ -1,0 +1,524 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import type { PiEvent, Project, Workspace, WorkspaceLayoutDocument } from "@thinkrail/contracts";
+import { selectAttentionCenterTab, useAppStore } from "../store";
+import type { NavigationDriver } from "./driver";
+import { startNavigation } from "./restore";
+
+// ——— fixtures ————————————————————————————————————————————————————————————————————————————————————
+
+function project(id: string): Project {
+	return { id, name: id, path: `/tmp/${id}`, slug: id, lastOpened: 1 };
+}
+
+function workspace(id: string, projectId = "p1"): Workspace {
+	return {
+		id,
+		projectId,
+		name: id,
+		branch: id,
+		worktreePath: `/tmp/${projectId}/${id}`,
+		baseBranch: "main",
+	};
+}
+
+/** An in-memory driver: records every `replace`, and can push an incoming fragment like a hash edit. */
+function fakeDriver(initial = "") {
+	let fragment = initial;
+	const handlers = new Set<(fragment: string) => void>();
+	const replaces: string[] = [];
+	const driver: NavigationDriver = {
+		read: () => fragment,
+		replace: (next) => {
+			fragment = next;
+			replaces.push(next);
+		},
+		onIncoming: (handler) => {
+			handlers.add(handler);
+			return () => handlers.delete(handler);
+		},
+	};
+	return {
+		driver,
+		replaces,
+		get fragment() {
+			return fragment;
+		},
+		incoming(next: string) {
+			fragment = next;
+			for (const handler of handlers) handler(next);
+		},
+	};
+}
+
+/** A manually-settled `workspace.list` fake, so tests control exactly when each read lands. */
+function fakeLists() {
+	const calls: {
+		projectId: string;
+		resolve: (rows: Workspace[]) => void;
+		reject: (err: Error) => void;
+	}[] = [];
+	const listWorkspaces = (projectId: string) =>
+		new Promise<Workspace[]>((resolve, reject) => {
+			calls.push({ projectId, resolve, reject });
+		});
+	return { calls, listWorkspaces };
+}
+
+/** Let queued promise continuations run. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function installWelcome(projects: Project[]): void {
+	useAppStore.getState().installWelcomeSnapshot(1, projects, projects);
+}
+
+/** Install the host-shared chat placement plus this browser's local selection of it. */
+function selectChatPlacement(workspaceId: string, sessionId: string): void {
+	const tabId = `placed:${sessionId}`;
+	const document: WorkspaceLayoutDocument = {
+		version: 1,
+		center: {
+			kind: "group",
+			id: "center",
+			tabs: [{ kind: "chat", id: tabId, name: "Chat", sessionId }],
+		},
+		left: { visible: false, width: 0.2, groups: [] },
+		right: { visible: false, width: 0.2, groups: [] },
+		toolRestoreTargets: {},
+	};
+	useAppStore.setState((state) => ({
+		layoutDocumentsByWorkspace: {
+			...state.layoutDocumentsByWorkspace,
+			[workspaceId]: document,
+		},
+		layoutAttentionByWorkspace: {
+			...state.layoutAttentionByWorkspace,
+			[workspaceId]: {
+				selectedByGroup: { center: tabId },
+				lastFocusedCenterGroupId: "center",
+				lastFocusedSideGroupId: {},
+				navigationClockByGroup: { center: 0 },
+			},
+		},
+	}));
+}
+
+let stop: (() => void) | null = null;
+
+beforeEach(() => {
+	useAppStore.setState({
+		status: "connecting",
+		connectionGeneration: 0,
+		welcomeGeneration: 0,
+		protocolVersion: null,
+		projects: [],
+		recentProjects: [],
+		workspaces: {},
+		selectedProjectId: null,
+		activeWorkspaceId: null,
+		routeChatTarget: null,
+		routeChatTargetGeneration: 0,
+		layoutSnapshotsByWorkspace: {},
+		layoutDocumentsByWorkspace: {},
+		layoutAttentionByWorkspace: {},
+		layoutPendingByWorkspace: {},
+		layoutRemoteEpochByWorkspace: {},
+		tabsByWorkspace: {},
+		activeTabByWorkspace: {},
+		previewTabByWorkspace: {},
+		navTickByWorkspace: {},
+		closedChatsByWorkspace: {},
+		deletedSessionsByWorkspace: {},
+		sessions: {},
+		skillsSyncedTickBySession: {},
+		fsChangesByWorkspace: {},
+		toasts: [],
+	});
+});
+
+afterEach(() => {
+	stop?.();
+	stop = null;
+});
+
+// ——— readiness ————————————————————————————————————————————————————————————————————————————————————
+
+test("no restore runs before the atomic welcome generation", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1/chats/s1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	await settle();
+	// Connection status alone is NOT readiness — nothing was validated, nothing moved.
+	useAppStore.getState().setStatus("connected");
+	await settle();
+	expect(calls).toHaveLength(0);
+	expect(useAppStore.getState().activeWorkspaceId).toBeNull();
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1/chats/s1"); // the URL is never downgraded early
+
+	installWelcome([project("p1")]);
+	await settle();
+	expect(calls).toHaveLength(1);
+	expect(calls[0]?.projectId).toBe("p1");
+	calls[0]?.resolve([workspace("w1")]);
+	await settle();
+	const state = useAppStore.getState();
+	expect(state.activeWorkspaceId).toBe("w1");
+	expect(state.selectedProjectId).toBe("p1");
+	expect(state.routeChatTarget).toEqual({
+		workspaceId: "w1",
+		sessionId: "s1",
+		navTick: 1,
+		navigation: null,
+		validated: false,
+	});
+	// The exact-chat fragment survives untouched throughout the restore.
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1/chats/s1");
+});
+
+test("duplicate welcome delivery starts at most one active restore read", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	installWelcome([project("p1")]); // e.g. a reconnect racing the first welcome
+	await settle();
+	expect(calls).toHaveLength(1);
+	calls[0]?.resolve([workspace("w1")]);
+	await settle();
+	expect(useAppStore.getState().activeWorkspaceId).toBe("w1");
+	// A welcome AFTER the route resolved must not replay the completed startup route.
+	installWelcome([project("p1")]);
+	await settle();
+	expect(calls).toHaveLength(1);
+});
+
+test("a malformed initial fragment canonicalizes to #/v1 and restores nothing", async () => {
+	const d = fakeDriver("#/v2/projects/p1/bogus");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	expect(d.fragment).toBe("#/v1");
+	expect(calls).toHaveLength(0);
+	expect(useAppStore.getState().activeWorkspaceId).toBeNull();
+});
+
+// ——— generations & cancellation ————————————————————————————————————————————————————————————————————
+
+test("a newer incoming fragment cancels the older restore's landing", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	// A fresh fragment arrives while the first read is still in flight.
+	d.incoming("#/v1/projects/p1/workspaces/w2");
+	await settle();
+	expect(calls).toHaveLength(2);
+	// The OLDER response lands after the newer route took over: it must change nothing.
+	calls[0]?.resolve([workspace("w1"), workspace("w2")]);
+	await settle();
+	expect(useAppStore.getState().activeWorkspaceId).toBeNull();
+	calls[1]?.resolve([workspace("w1"), workspace("w2")]);
+	await settle();
+	expect(useAppStore.getState().activeWorkspaceId).toBe("w2");
+});
+
+test("fresh user navigation wins over a delayed workspace response", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1/chats/s1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	// The user clicks a workspace while the route's list read is still in flight.
+	useAppStore.getState().setWorkspaces("p1", [workspace("w1"), workspace("w2")]);
+	useAppStore.getState().activateWorkspace(workspace("w2"));
+	// The pending route is cancelled the instant the user navigates — the URL follows them immediately,
+	// not once the delayed response lands.
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w2");
+	await settle();
+	calls[0]?.resolve([workspace("w1"), workspace("w2")]);
+	await settle();
+	const state = useAppStore.getState();
+	expect(state.activeWorkspaceId).toBe("w2"); // the user's choice stands
+	expect(state.routeChatTarget).toBeNull(); // the stale chat intent never installs
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w2"); // and the URL follows the user
+});
+
+test("same-workspace center navigation wins over a delayed route response", async () => {
+	const d = fakeDriver("");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	const store = useAppStore.getState();
+	store.setWorkspaces("p1", [workspace("w1")]);
+	store.activateWorkspace(workspace("w1"));
+	store.openChatSession("w1", "s1", null, "medium");
+
+	// An exact-chat hash starts its authoritative workspace read, then the user opens a file without
+	// changing project/workspace scope. The center-navigation tick must still cancel the pending route.
+	d.incoming("#/v1/projects/p1/workspaces/w1/chats/s1");
+	await settle();
+	expect(calls).toHaveLength(1);
+	store.noteNavigation("w1"); // the click stamps its intent before the asynchronous file read lands
+	store.openTab(
+		{
+			kind: "file",
+			id: "w1:README.md",
+			workspaceId: "w1",
+			name: "README.md",
+			path: "README.md",
+			content: "",
+		},
+		"keep",
+	);
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1");
+
+	calls[0]?.resolve([workspace("w1")]);
+	await settle();
+	expect(useAppStore.getState().routeChatTarget).toBeNull();
+	expect(useAppStore.getState().activeTabByWorkspace.w1).toBe("w1:README.md");
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1");
+});
+
+test("user navigation past an installed exact-chat target cancels it and resumes URL sync", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1/chats/s1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	calls[0]?.resolve([workspace("w1")]);
+	await settle();
+	expect(useAppStore.getState().routeChatTarget?.sessionId).toBe("s1");
+	// A center navigation (starting a chat) moves the workspace's nav tick past the stamp.
+	useAppStore.getState().noteNavigation("w1");
+	expect(useAppStore.getState().routeChatTarget).toBeNull();
+	// Sync resumed: the URL now tracks the store again (workspace-level — no chat tab is open).
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1");
+});
+
+// ——— authoritative absence vs transient failure ——————————————————————————————————————————————————————
+
+test("a completed welcome lacking the project canonicalizes to Welcome", async () => {
+	const d = fakeDriver("#/v1/projects/p-gone/workspaces/w1/chats/s1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	expect(calls).toHaveLength(0); // nothing to list — the project is authoritatively absent
+	expect(useAppStore.getState().activeWorkspaceId).toBeNull();
+	expect(d.fragment).toBe("#/v1");
+});
+
+test("a successful list lacking the workspace falls back to its Project Home", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w-gone");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	calls[0]?.resolve([workspace("w1")]);
+	await settle();
+	const state = useAppStore.getState();
+	expect(state.selectedProjectId).toBe("p1");
+	expect(state.activeWorkspaceId).toBeNull();
+	expect(d.fragment).toBe("#/v1/projects/p1");
+});
+
+test("a failed workspace read is not deletion: URL and intent survive, the next welcome retries", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1/chats/s1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	calls[0]?.reject(new Error("socket died"));
+	await settle();
+	// Nothing moved and nothing was rewritten — a timeout says nothing about existence.
+	expect(useAppStore.getState().activeWorkspaceId).toBeNull();
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1/chats/s1");
+	// The reconnect welcome retries the same unresolved intent…
+	installWelcome([project("p1")]);
+	await settle();
+	expect(calls).toHaveLength(2);
+	calls[1]?.resolve([workspace("w1")]);
+	await settle();
+	expect(useAppStore.getState().activeWorkspaceId).toBe("w1");
+	expect(useAppStore.getState().routeChatTarget?.sessionId).toBe("s1");
+});
+
+// ——— store → URL sync ————————————————————————————————————————————————————————————————————————————————
+
+test("internal navigation replaces the fragment; each location writes exactly once", async () => {
+	const d = fakeDriver("");
+	const { listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	expect(d.fragment).toBe("#/v1"); // the empty fragment canonicalizes
+	installWelcome([project("p1")]);
+	await settle();
+
+	const store = useAppStore.getState();
+	store.selectProject("p1");
+	expect(d.fragment).toBe("#/v1/projects/p1");
+	store.setWorkspaces("p1", [workspace("w1")]);
+	store.activateWorkspace(workspace("w1"));
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1");
+	store.openChatSession("w1", "s1", null, "medium");
+	selectChatPlacement("w1", "s1");
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1/chats/s1");
+
+	// Re-asserting the same location is idempotent — no second write for an unchanged fragment.
+	const writes = d.replaces.length;
+	useAppStore.getState().setStatus("connected");
+	expect(d.replaces.length).toBe(writes);
+});
+
+test("streaming pi events cause zero History writes while the location is unchanged", async () => {
+	const d = fakeDriver("");
+	const { listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	const store = useAppStore.getState();
+	store.setWorkspaces("p1", [workspace("w1")]);
+	store.activateWorkspace(workspace("w1"));
+	store.openChatSession("w1", "s1", null, "medium");
+	selectChatPlacement("w1", "s1");
+	await settle();
+
+	const writes = d.replaces.length;
+	const delta = (text: string) =>
+		({
+			type: "message_update",
+			assistantMessageEvent: {
+				type: "text",
+				partial: { role: "assistant", content: [{ type: "text", text }] },
+			},
+		}) as unknown as PiEvent;
+	useAppStore.getState().handlePiEvent({ type: "agent_start" } as unknown as PiEvent, "s1");
+	for (let i = 0; i < 200; i++) {
+		useAppStore.getState().handlePiEvent(delta(`chunk ${i}`), "s1");
+	}
+	expect(d.replaces.length).toBe(writes);
+});
+
+test("an unresolved exact-chat target pauses URL sync until it is consumed", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1/chats/s1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	calls[0]?.resolve([workspace("w1")]);
+	await settle();
+	expect(useAppStore.getState().routeChatTarget?.sessionId).toBe("s1");
+
+	// Temporary no-tab/error state (a background file tab opening takes no navigation tick) must not
+	// overwrite the exact-chat fragment while the target is unresolved.
+	useAppStore.getState().openTab(
+		{
+			kind: "file",
+			id: "w1:README.md",
+			workspaceId: "w1",
+			name: "README.md",
+			path: "README.md",
+			content: "",
+		},
+		"keep",
+	);
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1/chats/s1");
+
+	// Consuming the target (what shell/chatReconciliation does after hydration) resumes sync.
+	useAppStore.getState().clearRouteChatTarget();
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1");
+});
+
+test("an incoming main fragment is applied even when the client is already inside a chat", async () => {
+	const d = fakeDriver("");
+	const { listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	const store = useAppStore.getState();
+	store.setWorkspaces("p1", [workspace("w1")]);
+	store.activateWorkspace(workspace("w1"));
+	store.openChatSession("w1", "s1", null, "medium");
+	selectChatPlacement("w1", "s1");
+	expect(d.fragment).toContain("/chats/s1");
+
+	d.incoming("#/v1");
+	await settle();
+	expect(useAppStore.getState().selectedProjectId).toBeNull();
+	expect(useAppStore.getState().activeWorkspaceId).toBeNull();
+	expect(d.fragment).toBe("#/v1");
+});
+
+test("a missing incoming project falls back to main instead of the previous live location", async () => {
+	const d = fakeDriver("");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	const store = useAppStore.getState();
+	store.setWorkspaces("p1", [workspace("w1")]);
+	store.activateWorkspace(workspace("w1"));
+	store.openChatSession("w1", "s1", null, "medium");
+
+	d.incoming("#/v1/projects/gone/workspaces/w/chats/s");
+	await settle();
+	expect(calls).toHaveLength(0);
+	expect(useAppStore.getState().selectedProjectId).toBeNull();
+	expect(useAppStore.getState().activeWorkspaceId).toBeNull();
+	expect(d.fragment).toBe("#/v1");
+});
+
+test("a workspace-level route retains existing local attention and canonicalizes to its selected chat", async () => {
+	const d = fakeDriver("");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	const store = useAppStore.getState();
+	store.setWorkspaces("p1", [workspace("w1")]);
+	store.activateWorkspace(workspace("w1"));
+	store.openChatSession("w1", "s1", null, "medium");
+	selectChatPlacement("w1", "s1");
+
+	d.incoming("#/v1/projects/p1/workspaces/w1");
+	await settle();
+	expect(calls).toHaveLength(1);
+	calls[0]?.resolve([workspace("w1")]);
+	await settle();
+	const state = useAppStore.getState();
+	expect(selectAttentionCenterTab(state, "w1")?.sessionId).toBe("s1");
+	expect(state.routeChatTarget).toBeNull();
+	// Workspace routes carry no tab intent. Existing browser-local attention survives, then ordinary
+	// store→URL sync truthfully canonicalizes to that selected chat.
+	expect(d.fragment).toBe("#/v1/projects/p1/workspaces/w1/chats/s1");
+});
+
+test("an older response cannot unmark a newer generation's in-flight read", async () => {
+	const d = fakeDriver("#/v1/projects/p1/workspaces/w1");
+	const { calls, listWorkspaces } = fakeLists();
+	stop = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	d.incoming("#/v1/projects/p1/workspaces/w2");
+	await settle();
+	expect(calls).toHaveLength(2);
+
+	// The obsolete generation settles while w2 is still in flight. A reconnect welcome must NOT start a
+	// duplicate w2 read merely because the older continuation finished.
+	calls[0]?.resolve([workspace("w1"), workspace("w2")]);
+	await settle();
+	installWelcome([project("p1")]);
+	await settle();
+	expect(calls).toHaveLength(2);
+	calls[1]?.resolve([workspace("w1"), workspace("w2")]);
+	await settle();
+	expect(useAppStore.getState().activeWorkspaceId).toBe("w2");
+});
+
+test("teardown detaches the coordinator from driver and store", async () => {
+	const d = fakeDriver("");
+	const { listWorkspaces } = fakeLists();
+	const dispose = startNavigation({ driver: d.driver, listWorkspaces });
+	installWelcome([project("p1")]);
+	await settle();
+	dispose();
+	const writes = d.replaces.length;
+	useAppStore.getState().selectProject("p1");
+	expect(d.replaces.length).toBe(writes);
+});

--- a/apps/web/src/navigation/restore.ts
+++ b/apps/web/src/navigation/restore.ts
@@ -1,0 +1,219 @@
+import type { Workspace } from "@thinkrail/contracts";
+import {
+	selectAttentionCenterTab,
+	selectCurrentRouteChatTarget,
+	selectWorkspaceById,
+	useAppStore,
+} from "../store";
+import type { NavigationDriver } from "./driver";
+import { type NavigationLocation, parseFragment, serializeLocation } from "./location";
+
+/** What the coordinator needs from its host wiring — injected so tests drive it with fakes. */
+export interface NavigationDeps {
+	driver: NavigationDriver;
+	/**
+	 * The project's authoritative workspace list, **without** the per-workspace diff-stat fan-out
+	 * (`workspace.list({ includeDiffStats: false })`) — membership/order stay complete while the expensive
+	 * git work stays off automatic startup.
+	 */
+	listWorkspaces: (projectId: string) => Promise<Workspace[]>;
+}
+
+/**
+ * The location the store currently *is*, or `null` while it is momentarily underivable (an active
+ * workspace whose record hasn't landed yet) — a hold, never a downgrade: writing a guessed location
+ * would erase a fragment the user may be about to restore from.
+ */
+export function deriveLocation(state: {
+	activeWorkspaceId: string | null;
+	selectedProjectId: string | null;
+	workspaces: Record<string, Workspace[]>;
+	layoutDocumentsByWorkspace: Parameters<
+		typeof selectAttentionCenterTab
+	>[0]["layoutDocumentsByWorkspace"];
+	layoutAttentionByWorkspace: Parameters<
+		typeof selectAttentionCenterTab
+	>[0]["layoutAttentionByWorkspace"];
+}): NavigationLocation | null {
+	const workspaceId = state.activeWorkspaceId;
+	if (workspaceId) {
+		const workspace = selectWorkspaceById(state, workspaceId);
+		if (!workspace) return null;
+		const active = selectAttentionCenterTab(state, workspaceId);
+		// Shared placement may restore any resource, but the client-local route promises an exact tab only
+		// for chats. Files/diffs/documents remain workspace-level in this slice.
+		if (active?.kind === "chat") {
+			return {
+				kind: "chat",
+				projectId: workspace.projectId,
+				workspaceId,
+				sessionId: active.sessionId,
+			};
+		}
+		return { kind: "workspace", projectId: workspace.projectId, workspaceId };
+	}
+	if (state.selectedProjectId) return { kind: "project", projectId: state.selectedProjectId };
+	return { kind: "main" };
+}
+
+/**
+ * Start the navigation layer against the app store: canonicalize + restore the initial fragment, follow
+ * later incoming fragments, cancel an exact-chat target the user navigated past, and keep the fragment in
+ * sync with validated store state. Returns a teardown (tests; the app runs it for the page's life).
+ *
+ * Ordering rules (see `SPEC.md`): every incoming fragment advances one monotonic restore generation and
+ * every asynchronous continuation re-checks it; an incoming route is *intent* validated against
+ * host-owned state, never applied blind; a failed read proves nothing and leaves route + URL unchanged;
+ * fresh user navigation always wins over an older asynchronous restore.
+ */
+export function startNavigation({ driver, listWorkspaces }: NavigationDeps): () => void {
+	let generation = 0;
+	/** The unresolved incoming route. While set, store→URL sync is paused. */
+	let pending: { generation: number; location: NavigationLocation } | null = null;
+	/** Generations whose workspace reads are in flight — each route gets at most one active read, even when
+	 * an older generation settles while a newer one is still waiting. */
+	const attempting = new Set<number>();
+	/** The last fragment this layer wrote (or adopted) — compared before every write, so non-navigation
+	 * store churn (streaming pi events above all) causes zero History API calls. */
+	let lastWritten = "";
+
+	/** Write the store-derived fragment iff sync is unpaused and the location actually changed. */
+	const syncNow = () => {
+		if (pending) return;
+		const state = useAppStore.getState();
+		// An unresolved exact-chat target owns the location: temporary workspace/no-tab/error state must
+		// not overwrite the chat fragment the user is waiting on.
+		if (state.routeChatTarget) return;
+		const location = deriveLocation(state);
+		if (!location) return;
+		const fragment = serializeLocation(location);
+		if (fragment === lastWritten) return;
+		driver.replace(fragment);
+		lastWritten = fragment;
+	};
+
+	/** Mark a route resolved (only if it is still the pending one) and let sync take over the URL. */
+	const resolvePending = (gen: number) => {
+		if (pending?.generation === gen) pending = null;
+		syncNow();
+	};
+
+	/**
+	 * Try to apply the pending route. Runs at init and on every welcome edge; a no-op until the store's
+	 * atomic complete-welcome install (connection status / protocol version / an empty project list are
+	 * NOT readiness), and a no-op for a superseded generation.
+	 */
+	const attempt = async (gen: number) => {
+		if (pending?.generation !== gen || attempting.has(gen)) return;
+		const location = pending.location;
+		// Main has no host-owned id to validate, but it still has to be APPLIED: an incoming #/v1 while the
+		// client is inside a workspace must clear that old scope rather than letting sync rewrite the hash.
+		if (location.kind === "main") {
+			useAppStore.getState().selectMain();
+			resolvePending(gen);
+			return;
+		}
+		const state = useAppStore.getState();
+		if (state.welcomeGeneration === 0) return; // retried by the welcome subscription
+		// A COMPLETED welcome that lacks the project is authoritative absence → Welcome.
+		if (!state.projects.some((p) => p.id === location.projectId)) {
+			useAppStore.getState().selectMain();
+			resolvePending(gen);
+			return;
+		}
+		if (location.kind === "project") {
+			useAppStore.getState().selectProject(location.projectId);
+			resolvePending(gen);
+			return;
+		}
+		// Workspace/chat routes need the project's authoritative workspace list first.
+		attempting.add(gen);
+		let rows: Workspace[];
+		try {
+			rows = await listWorkspaces(location.projectId);
+		} catch {
+			// A timeout/disconnect/server failure is NOT evidence the workspace is gone: keep the URL and
+			// the pending route untouched. The next welcome edge (reconnect) retries this same intent.
+			attempting.delete(gen);
+			return;
+		}
+		attempting.delete(gen);
+		// Superseded while the read was in flight — by a newer fragment OR by user navigation (the store
+		// subscription below cancels `pending` the instant either scope id moves under a pending route).
+		if (pending?.generation !== gen) return;
+		const now = useAppStore.getState();
+		// The project can close while the read is in flight — re-check against the open snapshot.
+		if (!now.projects.some((p) => p.id === location.projectId)) {
+			useAppStore.getState().selectMain();
+			resolvePending(gen);
+			return;
+		}
+		now.setWorkspaces(location.projectId, rows);
+		const workspace = rows.find((w) => w.id === location.workspaceId);
+		if (!workspace) {
+			// A successful list that lacks the id is authoritative absence → its Project Home.
+			useAppStore.getState().selectProject(location.projectId);
+			resolvePending(gen);
+			return;
+		}
+		useAppStore
+			.getState()
+			.activateWorkspaceFromRoute(
+				workspace,
+				location.kind === "chat" ? location.sessionId : undefined,
+			);
+		// The chat half (if any) now lives in the store's routeChatTarget, which keeps sync paused until
+		// shell/chatReconciliation resolves it — this coordinator's own route is done.
+		resolvePending(gen);
+	};
+
+	/** A new fragment (startup or a later address-bar edit): a fresh generation cancels older intent. */
+	const acceptFragment = (fragment: string) => {
+		const location = parseFragment(fragment);
+		generation += 1;
+		pending = { generation, location };
+		// A fresh navigation cancels the previous exact-chat intent (idempotent when none exists).
+		useAppStore.getState().clearRouteChatTarget();
+		// Canonicalize in place: a malformed/unknown fragment reads back as `#/v1`.
+		const canonical = serializeLocation(location);
+		if (canonical !== fragment) driver.replace(canonical);
+		lastWritten = canonical;
+		void attempt(generation);
+	};
+
+	const unsubscribeDriver = driver.onIncoming(acceptFragment);
+	const unsubscribeStore = useAppStore.subscribe((state, previous) => {
+		// Fresh user navigation wins over an unresolved restore, IMMEDIATELY: a scope move OR a center
+		// navigation tick cancels it, so even a same-workspace file/chat click beats a late workspace-list
+		// response. (The coordinator's own resolution writes fire this too — harmlessly, since it has already
+		// installed the validated state the route asked for.)
+		if (
+			pending &&
+			(state.selectedProjectId !== previous.selectedProjectId ||
+				state.activeWorkspaceId !== previous.activeWorkspaceId ||
+				state.navTickByWorkspace !== previous.navTickByWorkspace)
+		) {
+			pending = null;
+		}
+		// The atomic complete-welcome edge: retry unresolved intent (a reconnect delivers a fresh welcome),
+		// but never replay a completed startup route — `pending` is gone once a route resolved.
+		if (state.welcomeGeneration !== previous.welcomeGeneration && pending) {
+			void attempt(pending.generation);
+		}
+		// Cancel an exact-chat target the user navigated past (another workspace, or a center navigation
+		// that moved the stamped tick): their navigation wins, and sync may resume writing the URL.
+		if (state.routeChatTarget && !selectCurrentRouteChatTarget(state)) {
+			state.clearRouteChatTarget();
+			return; // the nested store write re-enters this subscriber; sync runs there with fresh state
+		}
+		syncNow();
+	});
+
+	acceptFragment(driver.read());
+
+	return () => {
+		unsubscribeDriver();
+		unsubscribeStore();
+		pending = null;
+	};
+}

--- a/apps/web/src/shell/chatReconciliation/SPEC.md
+++ b/apps/web/src/shell/chatReconciliation/SPEC.md
@@ -15,9 +15,10 @@ without turning cache state into placement authority or activating remote restor
 ## Boundary
 
 - **Owns:** generation-qualified placed-chat hydration single-flights; session-list reconciliation and bounded
-  passive auto-open; failed catalog/transcript reporting and retryable history fallback; missing/tombstoned
-  session pruning; restoration of cache/history for accepted remote placements; chat-location/deep-link
-  orchestration; and stale-read/placement rechecks before installation.
+  passive auto-open; **exact-chat route-target validation and first-priority placement/focus**; failed
+  catalog/transcript reporting and retryable history fallback; missing/tombstoned session pruning;
+  restoration of cache/history for accepted remote placements; chat-location/deep-link orchestration; and
+  stale-read/placement rechecks before installation.
 - **Public surface (`index.ts`):** the mounted tombstone, catalog/cache, and chat-location reconciliation
   hooks plus the placed-chat hydration/current-destination operations required by intent handling and retry
   UI.
@@ -28,7 +29,12 @@ without turning cache state into placement authority or activating remote restor
   hydration arrived.
 
 Every asynchronous path verifies connection generation, workspace/session tombstones, current request
-identity, and surviving semantic placement before installing state. A failed passive transcript read is
-reported and retains its summary in local history; a failed session catalog is reported instead of presenting
-an unexplained empty workspace. Cancelled, disconnected, or archived passes stay silent. Chat-location work
-pauses behind pending layout writes so an accepted close cannot be undone by a stale jump.
+identity, and surviving semantic placement before installing state. An exact-chat route target owns its
+session's hydration while unresolved: passive placed-chat hydration skips that session, preventing a failed
+target read from racing an immediate duplicate. It also runs before passive auto-open: only a successful
+catalog absence consumes it; a transcript/catalog failure retains it for
+reconnect, and passive placements may hydrate but cannot take local focus meanwhile. Once its shared placement,
+local attention, and runtime all converge, the target clears and URL sync resumes. A failed passive transcript
+read is reported and retains its summary in local history; a failed session catalog is reported instead of
+presenting an unexplained empty workspace. Cancelled, disconnected, or archived passes stay silent.
+Chat-location work pauses behind pending layout writes so an accepted close cannot be undone by a stale jump.

--- a/apps/web/src/shell/chatReconciliation/chatReconciliation.ts
+++ b/apps/web/src/shell/chatReconciliation/chatReconciliation.ts
@@ -9,6 +9,8 @@ import {
 	type EditorTab,
 	isConnectedGeneration,
 	layoutOpenOptionsForNavigation,
+	selectAttentionCenterTab,
+	selectCurrentRouteChatTarget,
 	selectWorkspaceSessionIds,
 	shouldAdvanceAcceptedNavigation,
 	toast,
@@ -166,10 +168,30 @@ export function useWorkspaceChatCatalogReconciliation(
 	const connectionGeneration = useAppStore((state) => state.connectionGeneration);
 	const document = useAppStore((state) => state.layoutDocumentsByWorkspace[workspaceId]);
 	const layoutReady = document !== undefined;
+	const routeChatTargetGeneration = useAppStore((state) => state.routeChatTargetGeneration);
+	const routeTargetSessionId = useAppStore((state) => {
+		const target = selectCurrentRouteChatTarget(state);
+		return target?.workspaceId === workspaceId ? target.sessionId : null;
+	});
+	const routeTargetResolved = useAppStore((state) => {
+		const target = selectCurrentRouteChatTarget(state);
+		if (!target?.validated || target.workspaceId !== workspaceId) return false;
+		const selected = selectAttentionCenterTab(state, workspaceId);
+		return (
+			state.sessions[target.sessionId] !== undefined &&
+			selected?.kind === "chat" &&
+			selected.sessionId === target.sessionId
+		);
+	});
+
+	useEffect(() => {
+		if (routeTargetResolved) useAppStore.getState().clearRouteChatTarget();
+	}, [routeTargetResolved]);
 
 	useEffect(() => {
 		if (!layoutReady || status !== "connected" || connectionGeneration === 0) return;
 		const stateAtRequest = useAppStore.getState();
+		const startedRouteTargetGeneration = routeChatTargetGeneration;
 		const baselineDocument = stateAtRequest.layoutDocumentsByWorkspace[workspaceId];
 		const baselinePlacedSessionIds = baselineDocument
 			? collectAllGroups(baselineDocument)
@@ -193,6 +215,7 @@ export function useWorkspaceChatCatalogReconciliation(
 			const state = useAppStore.getState();
 			return (
 				current &&
+				state.routeChatTargetGeneration === startedRouteTargetGeneration &&
 				isConnectedGeneration(state, connectionGeneration) &&
 				!state.removedWorkspaceIds[workspaceId]
 			);
@@ -234,11 +257,64 @@ export function useWorkspaceChatCatalogReconciliation(
 								.map((tab) => tab.sessionId)
 						: [],
 				);
+				let handledRouteSessionId: string | null = null;
+				const target = selectCurrentRouteChatTarget(useAppStore.getState());
+				if (target?.workspaceId === workspaceId) {
+					const targetSummary = summaries.find((summary) => summary.sessionId === target.sessionId);
+					if (!targetSummary) {
+						// A successful catalog is authoritative absence: retain the workspace, consume only chat intent.
+						useAppStore.getState().clearRouteChatTarget();
+					} else {
+						handledRouteSessionId = target.sessionId;
+						useAppStore.getState().validateRouteChatTarget(target.sessionId);
+						const targetState = useAppStore.getState();
+						const targetOptions = layoutOpenOptionsForNavigation(
+							targetState,
+							workspaceId,
+							target.navigation,
+						);
+						const cache = targetState.tabsByWorkspace[workspaceId]?.find(
+							(tab): tab is Extract<EditorTab, { kind: "chat" }> =>
+								tab.kind === "chat" && tab.sessionId === target.sessionId,
+						);
+						if (targetState.sessions[target.sessionId]) {
+							targetState.openTab(
+								cache ?? {
+									kind: "chat",
+									id: chatTabId(workspaceId, target.sessionId),
+									workspaceId,
+									name: targetSummary.title,
+									sessionId: target.sessionId,
+								},
+								"keep",
+								true,
+								targetOptions,
+							);
+						} else {
+							const loaded = await fetchMessages(target.sessionId);
+							if (!live()) return;
+							const currentTarget = selectCurrentRouteChatTarget(useAppStore.getState());
+							if (currentTarget?.sessionId === target.sessionId && loaded) {
+								const { summary, messages } = loaded.result;
+								useAppStore
+									.getState()
+									.hydrateSession(
+										summary,
+										messagesToRuntime(messages, summary.lastSettlement),
+										true,
+										summary.live ? undefined : loaded.syncedTick,
+										targetOptions,
+									);
+							}
+						}
+					}
+				}
 				let sawKnown = false;
 				const toOpen: typeof summaries = [];
 				const toHistory: typeof summaries = [];
 				for (const summary of [...summaries].sort((a, b) => b.updatedAt - a.updatedAt)) {
-					if (placed.has(summary.sessionId)) continue;
+					if (summary.sessionId === handledRouteSessionId || placed.has(summary.sessionId))
+						continue;
 					if (useAppStore.getState().sessions[summary.sessionId]) {
 						sawKnown = true;
 						continue;
@@ -252,7 +328,12 @@ export function useWorkspaceChatCatalogReconciliation(
 						toHistory.push(summary);
 					}
 				}
-				if (placed.size === 0 && toOpen.length === 0 && !sawKnown) {
+				if (
+					handledRouteSessionId === null &&
+					placed.size === 0 &&
+					toOpen.length === 0 &&
+					!sawKnown
+				) {
 					const fallback = toHistory.shift();
 					if (fallback) toOpen.push(fallback);
 				}
@@ -287,7 +368,7 @@ export function useWorkspaceChatCatalogReconciliation(
 							tab.kind === "chat" && tab.sessionId === summary.sessionId,
 					);
 					if (!state.sessions[summary.sessionId] || !cache) continue;
-					const activate = openedCount === 0;
+					const activate = handledRouteSessionId === null && openedCount === 0;
 					openedCount += 1;
 					const routed = layoutOpenOptionsForNavigation(state, workspaceId, navigation);
 					state.enqueueLayoutIntent({
@@ -317,7 +398,7 @@ export function useWorkspaceChatCatalogReconciliation(
 		return () => {
 			current = false;
 		};
-	}, [commit, connectionGeneration, layoutReady, status, workspaceId]);
+	}, [commit, connectionGeneration, layoutReady, routeChatTargetGeneration, status, workspaceId]);
 
 	useEffect(() => {
 		if (!document || status !== "connected") return;
@@ -332,7 +413,12 @@ export function useWorkspaceChatCatalogReconciliation(
 				const state = useAppStore.getState();
 				const latestDocument = state.layoutDocumentsByWorkspace[workspaceId];
 				const currentPlacement = latestDocument ? findPlacedResource(latestDocument, tab) : null;
-				if (currentPlacement?.kind !== "chat") continue;
+				if (
+					currentPlacement?.kind !== "chat" ||
+					currentPlacement.sessionId === routeTargetSessionId
+				) {
+					continue;
+				}
 				state.restorePlacedChatCache(
 					workspaceId,
 					currentPlacement.id,
@@ -350,7 +436,7 @@ export function useWorkspaceChatCatalogReconciliation(
 		return () => {
 			current = false;
 		};
-	}, [document, status, workspaceId]);
+	}, [document, routeTargetSessionId, status, workspaceId]);
 }
 
 export function useChatLocationReconciliation(

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -16,25 +16,36 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
 
 ## Boundary
 
-- **Owns:** `appStore.ts` — connection/projects/workspaces state + setters. Connection state includes a
-  monotonic **connected generation**: `setStatus("connected")` advances it in the same write that installs
-  the status, giving reconnect hydration an edge even when the visible status returns to the same value.
-  **`projects`** is the open
-  rail, while **`recentProjects`** is the last-opened-ordered set of every known open + closed project.
-  **`installProjectSnapshot(projects, recentProjects)`** atomically installs both `server.welcome` views;
-  **`applyProjectUpdated(project)`** is the one full-snapshot updater for `project.updated` pushes and
-  authoritative project-mutation responses: it upserts/sorts Recents and either upserts/sorts the rail or
-  removes the row when `closed === true`. Both actions reconcile stale navigation too: only when this
-  client's selected project or active workspace belongs to a record no longer open, they clear the active
-  workspace and select the first remaining project's Home (or `null` when none remain), while deliberately
-  retaining every workspace layout/attention/resource-render/terminal/session map for lossless reopen.
-  Other-client opens never steal
-  navigation, and a background close never moves it. All project response call sites use the same updater,
-  so the open and recent copies cannot drift. The two explicit navigation transitions remain:
-  **`selectProject(projectId)`** enters that Project Home (`selectedProjectId` set + `activeWorkspaceId`
-  cleared in one write), while **`activateWorkspace(workspace)`** enters the workspace and selects its
-  owner (both ids set in one write). There is no generic active-workspace setter that can split that
-  invariant. It also owns the **workspace lifecycle reactions** every client runs
+- **Owns:** `appStore.ts` — connection/projects/workspaces state + setters. Connection state has two
+  monotonic edges with different meanings: `setStatus("connected")` advances **`connectionGeneration`**
+  for reconnect hydration, while **`welcomeGeneration`** advances only when one complete
+  `server.welcome` snapshot lands. **`installWelcomeSnapshot(protocolVersion, projects, recentProjects,
+  config?)`** installs protocol + both sorted project views + optional config + navigation repair and then
+  advances that readiness edge in one Zustand write; route validation never observes a protocol-only or
+  project-only intermediate state. `installProjectSnapshot` remains the project-only primitive for focused
+  callers. **`projects`** is the open rail, while **`recentProjects`** is the last-opened-ordered set of every
+  known open + closed project. **`applyProjectUpdated(project)`** is the one full-snapshot updater for
+  `project.updated` pushes and authoritative project-mutation responses: it upserts/sorts Recents and either
+  upserts/sorts the rail or removes the row when `closed === true`. Both actions reconcile stale navigation
+  too: only when this client's selected project or active workspace belongs to a record no longer open,
+  they clear the active workspace and select the first remaining project's Home (or `null` when none
+  remain), while deliberately retaining every workspace layout/attention/resource-render/terminal/session
+  map for lossless reopen. Other-client opens never steal navigation, and a background close never moves it.
+  All project response call sites use the same updater, so the open and recent copies cannot drift.
+  Explicit local transitions are **`selectMain()`**, **`selectProject(projectId)`**, and
+  **`activateWorkspace(workspace)`**; each updates its coupled scope ids atomically, and there is no generic
+  active-workspace setter that can split the invariant. Validated route restoration uses
+  **`activateWorkspaceFromRoute(workspace, sessionId?)`**: it applies the same scope ids, advances the
+  compatibility workspace navigation tick plus the current destination-group clock, and either installs a
+  transient **`routeChatTarget`** stamped with both clocks or clears an older exact target. A workspace-only
+  route carries no center-tab intent, so it retains existing browser-local attention; ordinary location
+  derivation may then canonicalize it to an already-selected chat. **`routeChatTargetGeneration`** advances
+  only on target installation (including same-workspace deep links), so consumption cannot duplicate the
+  shell reconciliation pass. `selectCurrentRouteChatTarget` is the one check that the target's workspace and
+  navigation stamp still hold. The shell's chat-reconciliation module validates/hydrates that target before
+  passive auto-open; a successful authoritative absence consumes it, while failures retain it for reconnect.
+  The store owns no URL/history/storage access — `navigation` owns serialization and drivers. It also owns
+  the **workspace lifecycle reactions** every client runs
   identically on the `workspace.created`/`updated`/`removed` pushes (no per-client optimism — the backend
   is authoritative): **`addWorkspace(ws)`** upserts a
   `workspace.created` snapshot by `id` (no-op if the project isn't listed yet — reconciles on its next
@@ -371,7 +382,8 @@ branch's review — a commit sha means nothing in another worktree — and dropp
   `selectActiveWorkspaceProjectId`, `selectHistoryTarget` + `HistoryTarget` (the shell's `Ctrl+R` routing
   target: the locally selected chat resource, or the workspace's newest chat otherwise),
   `selectContextProject`, `selectAttentionCenterTab` (the selected resource in local last center focus),
-  `selectSkillsStale`, **`selectDiffScope` + `BRANCH_SCOPE`** (what a workspace's
+  `selectCurrentRouteChatTarget` (exact-chat intent only while its workspace and stamped navigation remain
+  current), `selectSkillsStale`, **`selectDiffScope` + `BRANCH_SCOPE`** (what a workspace's
   Changes panel is diffing, defaulting to the shared branch-scope constant), **`selectDiffBaseRef`** (the ref
   it is measured against — the client-side mirror of the host's one resolution), **`selectDiffTabTargetRef`**
   (that ref *as an open diff tab's live dimension*: the target for a branch-scope tab, `""` for a

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -24,6 +24,7 @@ import {
 	useAppStore,
 } from "./appStore";
 import {
+	selectCurrentRouteChatTarget,
 	selectDiffScope,
 	selectLastOpenChatSession,
 	selectSkillsStale,
@@ -102,6 +103,10 @@ beforeEach(() => {
 	useAppStore.setState({
 		status: "connecting",
 		connectionGeneration: 0,
+		welcomeGeneration: 0,
+		protocolVersion: null,
+		routeChatTarget: null,
+		routeChatTargetGeneration: 0,
 		sessions: {},
 		layoutSnapshotsByWorkspace: {},
 		layoutDocumentsByWorkspace: {},
@@ -1383,6 +1388,96 @@ test("project and workspace navigation update both scope ids atomically", () => 
 	useAppStore.getState().activateWorkspace(pushedWorkspace({ id: "w3", projectId: "p3" }));
 	expect(transitions).toEqual([["p3", "w3"]]);
 	unsubscribe();
+});
+
+// ---- navigation restore: atomic welcome + exact-chat intent --------------------------------------
+
+test("installWelcomeSnapshot lands one complete snapshot and advances its own generation", () => {
+	const p1 = project();
+	const closed = project({
+		id: "p2",
+		path: "/projects/two",
+		slug: "two",
+		lastOpened: 50,
+		closed: true,
+	});
+	let notifications = 0;
+	const unsubscribe = useAppStore.subscribe((state) => {
+		notifications += 1;
+		expect(state).toMatchObject({
+			protocolVersion: 44,
+			theme: "test-theme",
+			welcomeGeneration: 1,
+		});
+		expect(state.projects.map((candidate) => candidate.id)).toEqual(["p1"]);
+		expect(state.recentProjects.map((candidate) => candidate.id)).toEqual(["p1", "p2"]);
+	});
+
+	useAppStore.getState().installWelcomeSnapshot(44, [p1, closed], [p1, closed], {
+		theme: "test-theme",
+		analyticsEnabled: false,
+		terminalReplayKb: 256,
+	});
+	unsubscribe();
+	expect(notifications).toBe(1);
+
+	useAppStore.getState().installWelcomeSnapshot(44, [p1], [p1]);
+	expect(useAppStore.getState().welcomeGeneration).toBe(2);
+});
+
+test("installWelcomeSnapshot reconciles stale project navigation", () => {
+	const p1 = project();
+	useAppStore.setState({
+		projects: [project({ id: "p2", path: "/projects/two", slug: "two" })],
+		selectedProjectId: "p2",
+		activeWorkspaceId: null,
+	});
+
+	useAppStore.getState().installWelcomeSnapshot(44, [p1], [p1]);
+	expect(useAppStore.getState().selectedProjectId).toBe("p1");
+});
+
+test("activateWorkspaceFromRoute atomically stamps exact-chat intent", () => {
+	const workspace = pushedWorkspace();
+	useAppStore.setState({ workspaces: { p1: [workspace] }, navTickByWorkspace: { w1: 3 } });
+
+	useAppStore.getState().activateWorkspaceFromRoute(workspace, "s1");
+	expect(useAppStore.getState()).toMatchObject({
+		selectedProjectId: "p1",
+		activeWorkspaceId: "w1",
+		routeChatTarget: {
+			workspaceId: "w1",
+			sessionId: "s1",
+			navTick: 4,
+			navigation: null,
+			validated: false,
+		},
+		routeChatTargetGeneration: 1,
+	});
+
+	// A workspace-only route carries no center-tab intent: it clears only the exact target and leaves
+	// existing browser-local attention to the workbench. Clearing cannot trigger a duplicate catalog pass.
+	useAppStore.getState().activateWorkspaceFromRoute(workspace);
+	expect(useAppStore.getState().routeChatTarget).toBeNull();
+	expect(selectWorkspaceNavTick(useAppStore.getState(), "w1")).toBe(5);
+	expect(useAppStore.getState().routeChatTargetGeneration).toBe(1);
+	const before = useAppStore.getState();
+	useAppStore.getState().clearRouteChatTarget();
+	expect(useAppStore.getState()).toBe(before);
+});
+
+test("selectCurrentRouteChatTarget rejects overtaken or off-workspace intent", () => {
+	const workspace = pushedWorkspace();
+	useAppStore.setState({ workspaces: { p1: [workspace] } });
+	useAppStore.getState().activateWorkspaceFromRoute(workspace, "s1");
+	expect(selectCurrentRouteChatTarget(useAppStore.getState())?.sessionId).toBe("s1");
+
+	useAppStore.getState().noteNavigation("w1");
+	expect(selectCurrentRouteChatTarget(useAppStore.getState())).toBeNull();
+
+	useAppStore.getState().activateWorkspaceFromRoute(workspace, "s1");
+	useAppStore.getState().selectProject("p1");
+	expect(selectCurrentRouteChatTarget(useAppStore.getState())).toBeNull();
 });
 
 test("updateWorkspace applies a pushed snapshot authoritatively: dropped fields clear", () => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -195,6 +195,16 @@ export interface CenterNavigationStamp {
 	clock: number;
 }
 
+/** Exact-chat intent from the client-local route. The catalog validates membership before the shell opens
+ * the shared placement; the global compatibility tick makes any newer local center navigation cancel it. */
+export interface RouteChatTarget {
+	workspaceId: string;
+	sessionId: string;
+	navTick: number;
+	navigation: CenterNavigationStamp | null;
+	validated: boolean;
+}
+
 export interface LayoutOpenOptions {
 	targetGroupId?: string;
 	activate?: boolean;
@@ -674,6 +684,8 @@ interface AppState {
 	/** Monotonic connection-open generation. Advances with every `connected` status so consumers can
 	 * distinguish a reconnect from the previous open socket even though both settle on the same status. */
 	connectionGeneration: number;
+	/** Advances only when one complete `server.welcome` snapshot lands atomically. */
+	welcomeGeneration: number;
 	protocolVersion: number | null;
 	/** Open projects shown in the Projects tool, newest first. */
 	projects: Project[];
@@ -684,6 +696,10 @@ interface AppState {
 	removedWorkspaceIds: Record<string, true>;
 	selectedProjectId: string | null;
 	activeWorkspaceId: string | null;
+	/** Validated-but-unresolved exact-chat route intent; never backend/shared placement state. */
+	routeChatTarget: RouteChatTarget | null;
+	/** Install edge for same-workspace route targets; clearing does not retrigger catalog reconciliation. */
+	routeChatTargetGeneration: number;
 	/** Latest accepted host snapshot and the optimistic projection currently rendered. */
 	layoutSnapshotsByWorkspace: Record<string, WorkspaceLayoutSnapshot>;
 	layoutDocumentsByWorkspace: Record<string, WorkspaceLayoutDocument>;
@@ -852,7 +868,13 @@ interface AppState {
 	 * at once; a failed wire call that has no better home (no chat tab to host an error turn) lands here. */
 	toasts: Toast[];
 	setStatus: (status: ConnectionStatus) => void;
-	setWelcome: (protocolVersion: number) => void;
+	/** Install protocol, project views, optional config, and the complete-welcome edge in one write. */
+	installWelcomeSnapshot: (
+		protocolVersion: number,
+		projects: Project[],
+		recentProjects: Project[],
+		config?: AppConfig,
+	) => void;
 	/** Install the host's open + recent project views atomically and repair stale navigation. */
 	installProjectSnapshot: (projects: Project[], recentProjects: Project[]) => void;
 	/** Fold one authoritative project snapshot into both views and repair navigation after close. */
@@ -887,8 +909,18 @@ interface AppState {
 	applyWorkspaceRemoved: (projectId: string, workspaceId: string) => void;
 	/** Enter a project's home, atomically clearing any active workspace. */
 	selectProject: (projectId: string) => void;
+	/** Enter the client-local main/Welcome location. */
+	selectMain: () => void;
 	/** Enter a workspace and select its owning project in one state transition. */
 	activateWorkspace: (workspace: Pick<Workspace, "id" | "projectId">) => void;
+	/** Apply a validated route and optionally install its exact-chat target in the same local-state write. */
+	activateWorkspaceFromRoute: (
+		workspace: Pick<Workspace, "id" | "projectId">,
+		sessionId?: string,
+	) => void;
+	/** Mark the current route target present in a successful authoritative session catalog. */
+	validateRouteChatTarget: (sessionId: string) => void;
+	clearRouteChatTarget: () => void;
 	installLayoutSnapshot: (snapshot: WorkspaceLayoutSnapshot, mutationId?: string) => void;
 	applyLayoutChanged: (payload: LayoutChangedPayload) => void;
 	beginLayoutCommit: (
@@ -1136,6 +1168,16 @@ interface AppState {
 /** Newest-first project ordering, copied so a wire array is never mutated in place. */
 function sortProjects(projects: Project[]): Project[] {
 	return [...projects].sort((a, b) => b.lastOpened - a.lastOpened);
+}
+
+/** One config projection shared by startup welcome and later `settings.changed` pushes. */
+function configPatch(config: AppConfig) {
+	return {
+		theme: config.theme,
+		analyticsEnabled: config.analyticsEnabled,
+		terminalReplayKb: config.terminalReplayKb,
+		layoutSettings: config.layout ?? DEFAULT_CONFIG.layout,
+	};
 }
 
 /** Replace one full project snapshot by id, or append it when this client has not seen it yet. */
@@ -1408,6 +1450,8 @@ function withoutChat(
 	const targetsLocation =
 		s.chatLocationRequest?.workspaceId === workspaceId &&
 		s.chatLocationRequest.sessionId === sessionId;
+	const targetsRoute =
+		s.routeChatTarget?.workspaceId === workspaceId && s.routeChatTarget.sessionId === sessionId;
 	const targetsHistory = s.historyOpenRequest?.sessionId === sessionId;
 	const hasStaleLayoutIntent = s.layoutIntents.some((intent) =>
 		layoutIntentTargetsSession(intent, workspaceId, sessionId),
@@ -1419,6 +1463,7 @@ function withoutChat(
 		!hasRuntime &&
 		!hasSkillBaseline &&
 		!targetsLocation &&
+		!targetsRoute &&
 		!targetsHistory &&
 		!hasStaleLayoutIntent
 	) {
@@ -1485,6 +1530,7 @@ function withoutChat(
 			? { skillsSyncedTickBySession: omitKey(s.skillsSyncedTickBySession, sessionId) }
 			: {}),
 		...(targetsLocation ? { chatLocationRequest: null } : {}),
+		...(targetsRoute ? { routeChatTarget: null } : {}),
 		...(targetsHistory ? { historyOpenRequest: null } : {}),
 	};
 }
@@ -1599,6 +1645,7 @@ function nextTerminalTitle(list: TerminalTab[]): string {
 export const useAppStore = create<AppState>((set, get) => ({
 	status: "connecting",
 	connectionGeneration: 0,
+	welcomeGeneration: 0,
 	protocolVersion: null,
 	projects: [],
 	recentProjects: [],
@@ -1606,6 +1653,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 	removedWorkspaceIds: Object.create(null) as Record<string, true>,
 	selectedProjectId: null,
 	activeWorkspaceId: null,
+	routeChatTarget: null,
+	routeChatTargetGeneration: 0,
 	layoutSnapshotsByWorkspace: {},
 	layoutDocumentsByWorkspace: {},
 	layoutAttentionByWorkspace: {},
@@ -1652,7 +1701,18 @@ export const useAppStore = create<AppState>((set, get) => ({
 			connectionGeneration:
 				status === "connected" ? state.connectionGeneration + 1 : state.connectionGeneration,
 		})),
-	setWelcome: (protocolVersion) => set({ protocolVersion }),
+	installWelcomeSnapshot: (protocolVersion, projects, recentProjects, config) =>
+		set((state) => {
+			const openProjects = sortProjects(projects.filter((project) => project.closed !== true));
+			return {
+				protocolVersion,
+				projects: openProjects,
+				recentProjects: sortProjects(recentProjects),
+				...(config ? configPatch(config) : {}),
+				...reconcileProjectNavigation(state, openProjects),
+				welcomeGeneration: state.welcomeGeneration + 1,
+			};
+		}),
 	installProjectSnapshot: (projects, recentProjects) =>
 		set((state) => {
 			const openProjects = sortProjects(projects.filter((project) => project.closed !== true));
@@ -1746,6 +1806,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 				specRequest: state.specRequest?.workspaceId === workspaceId ? null : state.specRequest,
 				chatLocationRequest:
 					state.chatLocationRequest?.workspaceId === workspaceId ? null : state.chatLocationRequest,
+				routeChatTarget:
+					state.routeChatTarget?.workspaceId === workspaceId ? null : state.routeChatTarget,
 				historyOpenRequest:
 					state.historyOpenRequest && removedSessions.has(state.historyOpenRequest.sessionId)
 						? null
@@ -1762,12 +1824,44 @@ export const useAppStore = create<AppState>((set, get) => ({
 		}
 	},
 	selectProject: (selectedProjectId) => set({ selectedProjectId, activeWorkspaceId: null }),
+	selectMain: () =>
+		set({ selectedProjectId: null, activeWorkspaceId: null, routeChatTarget: null }),
 	activateWorkspace: (workspace) =>
 		set((state) =>
 			state.removedWorkspaceIds[workspace.id]
 				? {}
 				: { selectedProjectId: workspace.projectId, activeWorkspaceId: workspace.id },
 		),
+	activateWorkspaceFromRoute: (workspace, sessionId) =>
+		set((state) => {
+			if (state.removedWorkspaceIds[workspace.id]) return {};
+			const advanced = advanceCenterNavigation(state, workspace.id);
+			return {
+				...advanced.patch,
+				selectedProjectId: workspace.projectId,
+				activeWorkspaceId: workspace.id,
+				routeChatTarget: sessionId
+					? {
+							workspaceId: workspace.id,
+							sessionId,
+							navTick: selectWorkspaceNavTick(state, workspace.id) + 1,
+							navigation: advanced.stamp,
+							validated: false,
+						}
+					: null,
+				routeChatTargetGeneration: sessionId
+					? state.routeChatTargetGeneration + 1
+					: state.routeChatTargetGeneration,
+			};
+		}),
+	validateRouteChatTarget: (sessionId) =>
+		set((state) => {
+			const target = state.routeChatTarget;
+			if (!target || target.sessionId !== sessionId || target.validated) return state;
+			return { routeChatTarget: { ...target, validated: true } };
+		}),
+	clearRouteChatTarget: () =>
+		set((state) => (state.routeChatTarget ? { routeChatTarget: null } : state)),
 	installLayoutSnapshot: (snapshot, mutationId) =>
 		set((state) => {
 			const workspaceId = snapshot.workspaceId;
@@ -2504,6 +2598,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 			const targetsLocation =
 				s.chatLocationRequest?.workspaceId === wsId &&
 				s.chatLocationRequest.sessionId === sessionId;
+			const targetsRoute =
+				s.routeChatTarget?.workspaceId === wsId && s.routeChatTarget.sessionId === sessionId;
 			const targetsHistory = s.historyOpenRequest?.sessionId === sessionId;
 			return {
 				...(syncLayout
@@ -2530,6 +2626,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 					[wsId]: [entry, ...(s.closedChatsByWorkspace[wsId] ?? [])],
 				},
 				...(targetsLocation ? { chatLocationRequest: null } : {}),
+				...(targetsRoute ? { routeChatTarget: null } : {}),
 				...(targetsHistory ? { historyOpenRequest: null } : {}),
 			};
 		}),
@@ -2934,13 +3031,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 		set({ settingsOpen: true, settingsSection: section }),
 	closeSettings: () => set({ settingsOpen: false }),
 	setSettingsSection: (section) => set({ settingsSection: section }),
-	applyConfig: (config) =>
-		set({
-			theme: config.theme,
-			analyticsEnabled: config.analyticsEnabled,
-			terminalReplayKb: config.terminalReplayKb,
-			layoutSettings: config.layout ?? DEFAULT_CONFIG.layout,
-		}),
+	applyConfig: (config) => set(configPatch(config)),
 	requestToolView: (workspaceId, tool) =>
 		set((state) =>
 			state.removedWorkspaceIds[workspaceId]

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -15,7 +15,7 @@ import {
 	normalizePath,
 	readLayoutSelection,
 } from "../lib";
-import type { ClosedChat, EditorTab, TerminalTab } from "./appStore";
+import type { ClosedChat, EditorTab, RouteChatTarget, TerminalTab } from "./appStore";
 
 interface ConnectionGenerationState {
 	status: string;
@@ -453,6 +453,17 @@ export function selectWorkspaceTick(
 	workspaceId: string,
 ): number {
 	return state.fsChangesByWorkspace[workspaceId]?.tick ?? 0;
+}
+
+/** Exact-chat route intent only while its workspace remains active and no newer center navigation won. */
+export function selectCurrentRouteChatTarget(state: {
+	routeChatTarget: RouteChatTarget | null;
+	activeWorkspaceId: string | null;
+	navTickByWorkspace: Record<string, number>;
+}): RouteChatTarget | null {
+	const target = state.routeChatTarget;
+	if (!target || state.activeWorkspaceId !== target.workspaceId) return null;
+	return selectWorkspaceNavTick(state, target.workspaceId) === target.navTick ? target : null;
 }
 
 /**

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -42,8 +42,9 @@ The single WebSocket client to the host, and its app-wide singleton.
   `workspace.created`/`updated`/`removed` lifecycle trio, and `workspace.fsChanged`** into the store — and
   folds every connection transition through
   `setStatus`, whose connected generation gives active-workspace hydration a distinct trigger on every
-  reconnect; welcome's open + recent project views via `installProjectSnapshot`, project snapshots via
-  `applyProjectUpdated`, `pi.event` via `handlePiEvent(event, sessionId)`, `pi.extensionUi` via `applyExtUi(request)`,
+  reconnect; the complete welcome (protocol + open/recent project views + optional config) via the atomic
+  `installWelcomeSnapshot`, whose separate `welcomeGeneration` is the cold-navigation readiness edge;
+  project snapshots via `applyProjectUpdated`, `pi.event` via `handlePiEvent(event, sessionId)`, `pi.extensionUi` via `applyExtUi(request)`,
   `workspace.created` via `addWorkspace(workspace)`, `workspace.updated` via `updateWorkspace(workspace)`,
   `workspace.removed` via `applyWorkspaceRemoved(projectId, id)`, `session.deleted` via the idempotent
   `deleteChat(workspaceId, sessionId)` tombstone fold (an online fast path; because this event channel is
@@ -58,9 +59,9 @@ The single WebSocket client to the host, and its app-wide singleton.
   and the shell layout integration cancels an in-progress pointer draft only for a nonmatching accepted
   revision before rendering it),
   `workspace.fsChanged` via `noteFsChanged(payload)`, and
-  **`settings.changed`** (+ the `config` field in `server.welcome`) via
-  `applyConfig(config)` — the server-synced app config (theme, …), applied on connect + on every broadcast
-  so clients converge; all subscriptions happen once at init, never in component effects);
+  **`settings.changed`** via `applyConfig(config)` — the post-startup server-synced app config broadcast;
+  welcome config lands in the atomic install above. All subscriptions happen once at init, never in
+  component effects);
   `errorText.ts` (**`errorText(err, fallback?)`** — normalizes a rejected `request` (the host's error
   string / a timeout / a thrown non-Error) into a short, display-ready line for an error turn/notice);
   `requestError.ts` (**`RequestError`** + **`wsErrorCode(err)`** — a rejection that carries the host's named

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -28,24 +28,17 @@ export function initTransport(): WsTransport {
 
 	transport.subscribe(WS_CHANNELS.serverWelcome, (data) => {
 		const welcome = data as Partial<ServerWelcome>;
-		if (typeof welcome.protocolVersion === "number") {
-			useAppStore.getState().setWelcome(welcome.protocolVersion);
-		}
-		if (Array.isArray(welcome.projects)) {
+		// Cold navigation waits for this one complete snapshot edge; never validate a route against a
+		// protocol-only or project-only intermediate state.
+		if (typeof welcome.protocolVersion !== "number" || !Array.isArray(welcome.projects)) return;
+		useAppStore.getState().installWelcomeSnapshot(
+			welcome.protocolVersion,
+			welcome.projects,
 			// `recentProjects` is required by the current protocol; falling back keeps a stale host's open
 			// projects usable while the shell surfaces the version mismatch.
-			useAppStore
-				.getState()
-				.installProjectSnapshot(
-					welcome.projects,
-					Array.isArray(welcome.recentProjects) ? welcome.recentProjects : welcome.projects,
-				);
-		}
-		// The host's source-of-truth app config (theme, …), applied on connect. Reconciles the pre-React
-		// paint hint; the shell's theme effect performs the DOM swap.
-		if (welcome.config) {
-			useAppStore.getState().applyConfig(welcome.config);
-		}
+			Array.isArray(welcome.recentProjects) ? welcome.recentProjects : welcome.projects,
+			welcome.config,
+		);
 	});
 
 	transport.subscribe(WS_CHANNELS.projectUpdated, (data) => {

--- a/architecture.md
+++ b/architecture.md
@@ -4,21 +4,21 @@ type: architecture-design
 status: active
 title: ThinkRail — top-level architecture
 parent: goal-and-requirements
-covers: [client-host-split, cli-entrypoint, wire-contract, transport-endpoint, ui-shell-panels, git-worktrees, remote-tailscale, hydrate-then-stream, domain-vs-view-state, shared-workspace-layout]
+covers: [client-host-split, cli-entrypoint, wire-contract, transport-endpoint, ui-shell-panels, git-worktrees, remote-tailscale, hydrate-then-stream, domain-vs-view-state, shared-workspace-layout, client-local-navigation]
 tags: [v1, architecture]
 ---
 
 ## Drivers
 
 The product is built around the `pi` agent, run **in-process** (`createAgentSession`). The V1 entrypoint
-is a CLI you run that boots the engine host and opens a browser UI; Electrobun is a later launcher over
-the same host. The UI ships independently of the host and dials it over the network; a phone reaches the
-host over Tailscale.
+is a CLI you run that boots the engine host and opens a browser UI. Electrobun later supports a local-host
+profile over that same host library and a shared-client profile that dials an existing host. The UI ships
+independently of the host and dials it over the network; a phone reaches the selected host over Tailscale.
 
 ## Topology — three rings
 
 - **Engine host** (`packages/server` + `packages/shared`, launched by `apps/cli` now / `apps/desktop`
-  later): owns `pi`, session state, persistence, and serves the wire endpoint. It bundles pi extensions
+  in local-host mode later): owns `pi`, session state, persistence, and serves the wire endpoint. It bundles pi extensions
   (`pi-web-access`, `pi-visualize`, `pi-spec-graph`, `pi-thinkrail-workflow`) into every session.
 - **The wire** (`packages/contracts`): the typed, versioned protocol — the only coupling between client
   and host.
@@ -28,7 +28,7 @@ host over Tailscale.
 ```
 apps/cli        host launcher (V1): boot server + open browser   ── depends on ─▶ packages/server
 apps/web        UI client (mobile-first)                          ── depends on ─▶ packages/contracts
-apps/desktop    Electrobun host launcher (deferred)               ── depends on ─▶ packages/server, packages/contracts
+apps/desktop    Electrobun local-host launcher/shared client (deferred) ── depends on ─▶ packages/server, packages/contracts
 apps/website    public landing page (GitHub Pages)                ── standalone: no workspace deps
 packages/server createServer(): Bun.serve(HTTP+WS) + AgentSessionManager (in-process pi) ── depends on ─▶ packages/contracts, packages/shared
 packages/contracts  the wire (types-only)
@@ -46,12 +46,14 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    only coupling. **Rule: `apps/web` depends on `packages/contracts` only** — never on `server` or
    `shared`. That single edge is what makes the UI shippable without the host.
 2. **CLI is the V1 launcher; `createServer()` is a library.** `apps/cli` is a thin launcher
-   (`resolveShellEnv` → `createServer` → open browser → signal handling). `apps/desktop` is the same
-   launcher with a native window instead of a browser.
+   (`resolveShellEnv` → `createServer` → open browser → signal handling). `apps/desktop` keeps that local
+   profile with a native window and may also run as a shared client without starting a second host; both
+   profiles use the same wire and web artifact.
 3. **The wire is versioned.** `contracts` is types-only; `server.welcome` carries a protocol version so
    an independently-shipped UI can detect host-version drift.
-4. **Transport endpoint is a parameter.** Defaults to same-origin (`location.host`); a remote client
-   points it at the host's Tailscale MagicDNS name.
+4. **Transport endpoint is a parameter.** Defaults to same-origin (`location.host`); a remote browser,
+   desktop, or mobile client points it at the selected host's Tailscale MagicDNS name. Native resume state
+   is keyed by backend profile so ids from one host are never interpreted against another.
 5. **UI = panels + shell.** Layout-agnostic, store-driven panels (project→workspace nav, file tree,
    Monaco editor, changes/diff, workspace-local review, terminal, chat, composer) never know their
    arrangement. The desktop shell owns a host-synchronized IDE workbench: a recursively split center plus
@@ -90,7 +92,11 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    (or create-only absence), and a stale full replacement conflicts with the current snapshot instead of
    making the last arrival win. That is placement only, never resource lifetime. *Attention and
    drafts* — selected tab per group, last-focused group, uncommitted pointer/resize drafts, composer drafts — remain
-   per-client (ephemeral or local reload persistence), so one browser cannot steal another's focus.
+   per-client (ephemeral or local reload persistence), so one browser cannot steal another's focus. The active
+   client location is likewise local: one backend-relative route names main / Project Home / workspace / exact
+   chat; web stores it in a versioned fragment, while later native shells persist it per backend profile and
+   window/device. Incoming ids are validated against hydrated host state, and no backend-owned “current screen”
+   lets one client move another.
    Corollary: closing a file/chat placement is a shared view action, not a domain dispose — the session
    remains; terminal close retains its separate explicit PTY-lifetime semantics. Detail:
    [[submodule-server-layout]] and [[submodule-web-shell-layout]].

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -3,7 +3,7 @@ import { copyFileSync, existsSync, mkdirSync, openSync, rmSync, writeFileSync } 
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
-import { worktreeRows } from "./fixtures/app";
+import { activeWorktreeRow } from "./fixtures/app";
 import {
 	E2E_PI_AGENT_DIR,
 	E2E_RESTART_DATA_DIR,
@@ -160,14 +160,9 @@ test("a pending questionnaire survives a host kill -9: reboot, reopen, answer, a
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 
-	// The project persisted but renders collapsed after a fresh load — select it to reveal its workspaces.
-	await page.getByTestId("project-item").first().click();
-	// The workspace persisted; its session is now DISK-ONLY (the live one died with the host), so it
-	// surfaces in chat history and re-opens through the hydration path.
-	await expect(worktreeRows(page).first()).toBeVisible({ timeout: 15_000 });
-	await worktreeRows(page).first().click();
-	await page.getByTestId("chat-history").click();
-	await page.getByTestId("closed-chat-item").first().click();
+	// The fragment restores the workspace and exact chat across the restart. The session is now disk-only
+	// (the live one died with the host), so the exact target re-opens it through hydration automatically.
+	await expect(activeWorktreeRow(page)).toHaveCount(1, { timeout: 15_000 });
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	// The questionnaire is STILL ANSWERABLE — the awaiting state is pure transcript, no host memory.

--- a/e2e/auto-open-chats.spec.ts
+++ b/e2e/auto-open-chats.spec.ts
@@ -204,7 +204,7 @@ test("a client that misses chat deletion while offline reconciles it after recon
 		window.WebSocket = TrackedWebSocket;
 	});
 	const page2 = await context2.newPage();
-	await page2.goto(page.url());
+	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
 	await page2.getByTestId("project-expand").first().click();
 	await defaultWorkspaceRow(page2).click();

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -47,15 +47,10 @@ test("selecting a same-workspace message hit opens the chat and flashes the matc
 	});
 	await page.waitForTimeout(2_100);
 
-	// A reload doesn't auto-restore the active project/workspace (see `ask-restart.live.spec.ts`) — re-pick
-	// both, so `WorkspaceWorkbench`'s hydrate-on-connect effect re-lists workspace A's sessions from a cold client,
-	// the realistic "come back later" path. (Not load-bearing for the jump itself — case (c) below fetches
-	// the target session directly by id regardless of whether `session.list` ever ran for it — but this
-	// keeps the scenario honest to the brief and exercises the full reload path.)
+	// The fragment restores workspace A and its exact chat; the cold client then re-lists the workspace's
+	// sessions. The seeded session remains unopened until the jump below targets it.
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page.getByTestId("project-item").first().click();
-	await worktreeRows(page).first().click();
 	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
 	// The create's auto-opened chat (still live in the host) auto-restores after the reload — a composer

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -81,12 +81,11 @@ async function dragTabToTarget(page: Page, tab: Locator, target: Locator): Promi
 	return targetBox.height;
 }
 
-async function reenterDefaultAfterReload(page: Page): Promise<void> {
+async function reloadDefaultWorkbench(page: Page): Promise<void> {
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page.getByTestId("welcome-action").filter({ hasText: "Work in project folder" }).click();
-	// A persisted hidden left side intentionally removes ProjectTree (and therefore its active workspace row)
-	// from the workbench, so the center surface—not the rail—is the universal activation receipt.
+	// The workspace route restores without a rail click. A persisted hidden left side can remove ProjectTree,
+	// so the center surface—not a workspace row—is the universal activation receipt.
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 }
 
@@ -171,7 +170,7 @@ test("outer side widths publish on pointer-up and restore after reload", async (
 	await expect.poll(() => width(right)).toBeGreaterThan(before + 70);
 	const resized = await width(right);
 
-	await reenterDefaultAfterReload(page);
+	await reloadDefaultWorkbench(page);
 	await expect.poll(() => width(page.getByTestId("right-stack"))).toBeGreaterThan(before + 50);
 	expect(Math.abs((await width(page.getByTestId("right-stack"))) - resized)).toBeLessThan(24);
 });
@@ -192,7 +191,7 @@ test("dragging outer separators hides both sides and preserves their restore sta
 	await expect(page.getByTestId("right-stack")).toHaveCount(0);
 	await waitForLayoutSettled(page);
 
-	await reenterDefaultAfterReload(page);
+	await reloadDefaultWorkbench(page);
 	await expect(page.getByTestId("left-layout-rail")).toBeVisible();
 	await expect(page.getByTestId("right-layout-rail")).toBeVisible();
 
@@ -351,7 +350,7 @@ test("Mod+B and Mod+J hide and restore synchronized sides, including after reloa
 	await expect(page.getByTestId("right-stack")).toHaveCount(0);
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
 
-	await reenterDefaultAfterReload(page);
+	await reloadDefaultWorkbench(page);
 	await expect(page.getByTestId("left-layout-rail")).toBeVisible();
 	await expect(page.getByTestId("right-layout-rail")).toBeVisible();
 
@@ -707,7 +706,7 @@ test("a narrow viewport compresses locally without rewriting recursive topology"
 	await expect(page.getByRole("menuitem", { name: /Split right/ })).toBeDisabled();
 	await page.keyboard.press("Escape");
 
-	await reenterDefaultAfterReload(page);
+	await reloadDefaultWorkbench(page);
 	await expect(page.getByTestId("center-group")).toHaveCount(2);
 });
 

--- a/e2e/reload-navigation.spec.ts
+++ b/e2e/reload-navigation.spec.ts
@@ -1,0 +1,378 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+import {
+	activeWorktreeRow,
+	createWorkspaceViaDialog,
+	enterDefaultWorkspace,
+	openFixtureProject,
+	worktreeRows,
+} from "./fixtures/app";
+import { E2E_DATA_DIR } from "./fixtures/paths";
+
+// The reload-navigation contract (apps/web/src/navigation/SPEC.md): each browser tab keeps its own
+// backend-relative location in a versioned URL fragment, internal navigation replaces it, and a reload —
+// or a directly opened link — restores the workspace and exact chat the fragment names, validated against
+// host state. Falling back UPWARD happens only on a successful authoritative read that proves the
+// resource gone; a transient failure keeps the URL and retries.
+
+const chatTabs = (page: Page) => page.locator('[data-testid="editor-tab"][data-kind="chat"]');
+const activeTab = (page: Page) => page.locator('[data-testid="editor-tab"][data-active="true"]');
+const currentHash = (page: Page) => page.evaluate(() => window.location.hash);
+
+function chatIdFromHash(hash: string): string {
+	const encoded = hash.split("/chats/")[1]?.split("/")[0];
+	if (!encoded) throw new Error(`hash carries no chat id: ${hash}`);
+	return decodeURIComponent(encoded);
+}
+
+/** The open project's id — from host persistence, which the fixture reset rewrote for this test. */
+function fixtureProjectId(): string {
+	const projects = JSON.parse(readFileSync(join(E2E_DATA_DIR, "projects.json"), "utf8")) as {
+		id: string;
+	}[];
+	const id = projects[0]?.id;
+	if (!id) throw new Error("no fixture project persisted");
+	return id;
+}
+
+/** Cold-load a specific fragment (about:blank in between forces a real navigation, not a hash change). */
+async function coldOpen(page: Page, fragment: string): Promise<void> {
+	await page.goto("about:blank");
+	await page.goto(`/${fragment}`);
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+}
+
+test("reloading from the older of two chats returns to that exact chat without rail clicks", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page); // auto-opens chat 1
+	await expect(chatTabs(page)).toHaveCount(1);
+	await page.getByTestId("new-chat").click();
+	await expect(chatTabs(page)).toHaveCount(2); // chat 2 is focused now
+
+	// Go back to the OLDER chat — the fragment follows the navigation via history.replaceState.
+	const older = chatTabs(page).first();
+	const olderPlacementId = await older.getByRole("tab").getAttribute("data-layout-tab-id");
+	if (!olderPlacementId) throw new Error("chat tab carries no layout id");
+	await older.getByRole("tab").click();
+	await expect(older).toHaveAttribute("data-active", "true");
+	const hash = await currentHash(page);
+	chatIdFromHash(hash);
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	// No rail clicks: the workspace activates and the exact chat hydrates focused on their own.
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	await expect(activeTab(page).getByRole("tab")).toHaveAttribute(
+		"data-layout-tab-id",
+		olderPlacementId,
+	);
+	// Both live chats still auto-restore; focus stays on the routed one, and the fragment is unchanged.
+	await expect(chatTabs(page)).toHaveCount(2);
+	expect(await currentHash(page)).toBe(hash);
+});
+
+test("a directly opened exact-chat fragment restores that chat; two tabs keep independent routes", async ({
+	page,
+	context,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(chatTabs(page)).toHaveCount(1);
+	await page.getByTestId("new-chat").click();
+	await expect(chatTabs(page)).toHaveCount(2);
+
+	// Establish each route↔placement pair through an explicit selection; tab creation and the async layout
+	// acknowledgement may otherwise still be converging when the second tab first appears.
+	const first = chatTabs(page).first();
+	await first.getByRole("tab").click();
+	await expect(first).toHaveAttribute("data-active", "true");
+	const firstHash = await currentHash(page);
+	chatIdFromHash(firstHash);
+	const firstPlacementId = await first.getByRole("tab").getAttribute("data-layout-tab-id");
+	if (!firstPlacementId) throw new Error("first chat carries no layout id");
+
+	const second = chatTabs(page).last();
+	await second.getByRole("tab").click();
+	await expect(second).toHaveAttribute("data-active", "true");
+	await expect.poll(() => currentHash(page)).not.toBe(firstHash);
+	const secondHash = await currentHash(page);
+	chatIdFromHash(secondHash);
+	const secondPlacementId = await second.getByRole("tab").getAttribute("data-layout-tab-id");
+	if (!secondPlacementId) throw new Error("second chat carries no layout id");
+
+	// A second browser tab opens the FIRST chat's link directly — a shareable same-origin deep link.
+	const page2 = await context.newPage();
+	await page2.goto(`/${firstHash}`);
+	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(activeTab(page2).getByRole("tab")).toHaveAttribute(
+		"data-layout-tab-id",
+		firstPlacementId,
+	);
+	expect(await currentHash(page2)).toBe(firstHash);
+
+	// Each browser tab owns its attention and location: the first page never moved off the second chat.
+	await expect(activeTab(page).getByRole("tab")).toHaveAttribute(
+		"data-layout-tab-id",
+		secondPlacementId,
+	);
+	expect(await currentHash(page)).toBe(secondHash);
+
+	// A later incoming fragment in an ALREADY-ACTIVE workspace must trigger exact-chat hydration too — the
+	// activeWorkspaceId does not change here, so this pins shell reconciliation's target-generation edge.
+	await page.evaluate((hash) => {
+		window.location.hash = hash;
+	}, firstHash);
+	await expect(activeTab(page).getByRole("tab")).toHaveAttribute(
+		"data-layout-tab-id",
+		firstPlacementId,
+	);
+	await expect.poll(() => currentHash(page)).toBe(firstHash);
+	// The other browser tab remains independent throughout.
+	await expect(activeTab(page2).getByRole("tab")).toHaveAttribute(
+		"data-layout-tab-id",
+		firstPlacementId,
+	);
+	expect(await currentHash(page2)).toBe(firstHash);
+	await page2.close();
+});
+
+test("missing chat, workspace, and project fall back to the nearest valid location", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	await expect(chatTabs(page)).toHaveCount(1);
+	const projectId = fixtureProjectId();
+
+	// Missing chat → the workspace is retained and the ordinary chat policy runs (the live chat opens);
+	// only the chat half of the route is consumed.
+	await coldOpen(page, `#/v1/projects/${projectId}/workspaces/${workspace.id}/chats/gone`);
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	await expect(chatTabs(page).first()).toBeVisible();
+	await expect
+		.poll(() => currentHash(page))
+		.toContain(`#/v1/projects/${projectId}/workspaces/${workspace.id}`);
+	expect(await currentHash(page)).not.toContain("/chats/gone");
+
+	// Missing workspace → its Project Home.
+	await coldOpen(page, `#/v1/projects/${projectId}/workspaces/gone`);
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect(activeWorktreeRow(page)).toHaveCount(0);
+	await expect.poll(() => currentHash(page)).toBe(`#/v1/projects/${projectId}`);
+
+	// Missing project → ordinary Welcome.
+	await coldOpen(page, "#/v1/projects/gone/workspaces/w/chats/s");
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect.poll(() => currentHash(page)).toBe("#/v1");
+});
+
+test("a transient workspace read failure preserves the URL and restores after reconnect", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(chatTabs(page)).toHaveCount(1);
+	const hash = await currentHash(page);
+	const sessionId = chatIdFromHash(hash);
+
+	// Fail the FIRST navigation-restore read (only that one carries includeDiffStats: false), then drop
+	// the socket so the client reconnects — the fresh welcome retries the same unresolved intent.
+	let injected = false;
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			let frame: { id?: string; method?: string; params?: { includeDiffStats?: boolean } };
+			try {
+				frame = JSON.parse(raw) as typeof frame;
+			} catch {
+				server.send(message);
+				return;
+			}
+			if (
+				!injected &&
+				frame.id &&
+				frame.method === "workspace.list" &&
+				frame.params?.includeDiffStats === false
+			) {
+				injected = true;
+				ws.send(JSON.stringify({ id: frame.id, ok: false, error: "injected transient failure" }));
+				ws.close(); // frames are ordered: the rejection lands, then the reconnect begins
+				return;
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+
+	await page.reload();
+	// The failure is not evidence of deletion: after the reconnect retry, the exact chat is back and the
+	// fragment never downgraded (a wrongly-consumed route would have landed on Welcome with #/v1).
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	await expect(activeTab(page)).toHaveAttribute("data-kind", "chat");
+	expect(chatIdFromHash(await currentHash(page))).toBe(sessionId);
+	expect(await currentHash(page)).toBe(hash);
+	expect(injected).toBe(true);
+});
+
+test("a failed exact-chat transcript waits for reconnect instead of duplicating its read", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(chatTabs(page)).toHaveCount(1);
+	const hash = await currentHash(page);
+	const sessionId = chatIdFromHash(hash);
+
+	let socketNumber = 0;
+	let firstSocketTargetReads = 0;
+	let closeScheduled = false;
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		socketNumber += 1;
+		const thisSocket = socketNumber;
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			let frame: { id?: string; method?: string; params?: { sessionId?: string } };
+			try {
+				frame = JSON.parse(raw) as typeof frame;
+			} catch {
+				server.send(message);
+				return;
+			}
+			if (
+				thisSocket === 1 &&
+				frame.id &&
+				frame.method === "session.getMessages" &&
+				frame.params?.sessionId === sessionId
+			) {
+				firstSocketTargetReads += 1;
+				ws.send(JSON.stringify({ id: frame.id, ok: false, error: "injected transcript failure" }));
+				if (!closeScheduled) {
+					closeScheduled = true;
+					// Leave enough time for an accidental same-pass retry to show itself, then reconnect so the
+					// retained route target gets its legitimate next attempt.
+					setTimeout(() => ws.close(), 150);
+				}
+				return;
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+
+	await page.reload();
+	// Wait for the injected read itself, not the shared placement (which can render before its transcript).
+	await expect.poll(() => firstSocketTargetReads).toBe(1);
+	await expect.poll(() => socketNumber).toBeGreaterThanOrEqual(2);
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(page.getByTestId("chat-input")).toBeVisible();
+	await expect(activeTab(page)).toHaveAttribute("data-kind", "chat");
+	expect(chatIdFromHash(await currentHash(page))).toBe(sessionId);
+	expect(await currentHash(page)).toBe(hash);
+	// Ordinary auto-open did not immediately issue the same request again or turn the still-pending target
+	// into a history row on the first socket.
+	expect(firstSocketTargetReads).toBe(1);
+});
+
+test("user navigation while the restore read is delayed wins over the late response", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(chatTabs(page)).toHaveCount(1);
+	const projectId = fixtureProjectId();
+
+	// Hold the navigation-restore read (never the rail's own listing, which omits includeDiffStats).
+	let heldFrame: string | null = null;
+	let releaseHeld: (() => void) | null = null;
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		releaseHeld = () => {
+			if (heldFrame) server.send(heldFrame);
+			heldFrame = null;
+		};
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			let frame: { method?: string; params?: { includeDiffStats?: boolean } };
+			try {
+				frame = JSON.parse(raw) as typeof frame;
+			} catch {
+				server.send(message);
+				return;
+			}
+			if (
+				heldFrame === null &&
+				releaseHeld !== null &&
+				frame.method === "workspace.list" &&
+				frame.params?.includeDiffStats === false
+			) {
+				heldFrame = raw; // held until the user has navigated
+				return;
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	// While the restore read hangs, the user goes to the project's Welcome — fresh navigation wins.
+	await page.getByTestId("project-item").first().getByText("sample-project").click();
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect.poll(() => currentHash(page)).toBe(`#/v1/projects/${projectId}`);
+
+	releaseHeld?.();
+	// The late response changes nothing: no workspace activates, the URL stays the user's location.
+	await page.waitForTimeout(500);
+	await expect(page.getByTestId("welcome")).toBeVisible();
+	await expect(activeWorktreeRow(page)).toHaveCount(0);
+	expect(await currentHash(page)).toBe(`#/v1/projects/${projectId}`);
+});
+
+test("reload from a file tab restores its shared placement under the workspace route", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await enterDefaultWorkspace(page); // no chats in the Default workspace — the receipt case
+	const projectId = fixtureProjectId();
+
+	// Open a file: the location is workspace-level (a file tab is not part of the route contract).
+	await page.getByTestId("tab-files").click();
+	await page.getByTestId("file-node").filter({ hasText: "README.md" }).click();
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="file"]')).toHaveCount(1);
+	const hash = await currentHash(page);
+	expect(hash).toContain(`#/v1/projects/${projectId}/workspaces/`);
+	expect(hash).not.toContain("/chats/");
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	// Navigation restores the workspace while the host-synchronized workbench independently restores its
+	// file placement. Files still serialize at workspace granularity, never as an exact-chat route.
+	await expect(page.locator('[data-testid="workspace-item"][data-kind="default"]')).toHaveAttribute(
+		"data-active",
+		"true",
+	);
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="file"]')).toHaveCount(1);
+	await expect(activeTab(page)).toContainText("README.md");
+	expect(await currentHash(page)).toBe(hash);
+});
+
+test("workspace rows still list after a reload restore (the light list is complete)", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(chatTabs(page)).toHaveCount(1);
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	// The restore's includeDiffStats:false list seeded the rail: the Default row and the worktree are
+	// both present without any expand click (complete membership, Default pinned first).
+	await expect(page.locator('[data-testid="workspace-item"][data-kind="default"]')).toBeVisible();
+	await expect(worktreeRows(page)).toHaveCount(1);
+});

--- a/e2e/review.spec.ts
+++ b/e2e/review.spec.ts
@@ -918,11 +918,10 @@ test("a draft is server truth: a second client converges by push, and a cold rel
 	await expect(page2.getByTestId("review-pending-badge")).toHaveText("2");
 	await page2.context().close();
 
-	// A cold reload of client 1: nothing lived only in the client, the review hydrates back whole.
+	// A cold reload of client 1: the fragment restores the workspace, and the review hydrates back whole.
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page.getByTestId("project-item").first().click();
-	await worktreeRows(page).first().click();
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
 	await page.getByTestId("tab-review").click();
 	await expect(page.getByTestId("review-pending-badge")).toHaveText("2");
 	await expect(page.getByTestId("review-file-row")).toContainText("2 drafts");

--- a/e2e/templates.live.spec.ts
+++ b/e2e/templates.live.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { activeWorktreeRow, openWorkspaceChat, waitForDone, worktreeRows } from "./fixtures/app";
+import { activeWorktreeRow, openWorkspaceChat, waitForDone } from "./fixtures/app";
 
 // Tagged @agent (see agent.live.spec.ts): drives a REAL pi agent against the seeded prompt-template
 // fixtures (`e2e/fixtures/templates.ts`). The no-agent `templates-compose.spec.ts` already covers the
@@ -80,12 +80,10 @@ test("a typed-through /name command is expanded by pi itself, not the composer's
 	// no in-memory runtime for this session, so `WorkspaceWorkbench`'s hydrate-on-connect effect refetches
 	// `session.getMessages` and rebuilds the transcript from pi's own message list
 	// (`messagesToRuntime`) — the same "come back later" path `history-jump.spec.ts`/
-	// `history-search.spec.ts` use to inspect a session's durable record. A reload doesn't auto-restore
-	// the active project/workspace, so re-pick both.
+	// `history-search.spec.ts` use to inspect a session's durable record. The fragment restores the
+	// workspace and exact chat without rail clicks.
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page.getByTestId("project-item").first().click();
-	await worktreeRows(page).first().click();
 	await expect(activeWorktreeRow(page)).toHaveCount(1);
 
 	// The session is still live in the host's memory (never closed), so it auto-restores as the active

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type WebSocketRoute } from "@playwright/test";
 import {
+	activeWorktreeRow,
 	createWorkspaceViaDialog,
 	openFixtureProject,
 	openTerminal,
@@ -268,9 +269,8 @@ test("a shell survives a page reload", async ({ page }) => {
 
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	// A reload keeps no client state, so the rail comes back collapsed with nothing selected.
-	await page.getByTestId("project-expand").first().click();
-	await worktreeRows(page).nth(0).click();
+	// The fragment restores the workspace; the terminal panel reattaches to the original host-owned shell.
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
 	await waitTerminalReady(page);
 
 	// One tab, not a second one beside a now-invisible shell.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -237,7 +237,10 @@ of the host.
   closed without deleting associated state), **`project.inspect`** (classify a path) + **`project.init`**
   (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "contains a registered
   spec?" for the Welcome screen — a full-tree walk, so requested only for the shown project,
-  never eagerly for every project) / `workspace.*` / `fs.*` / `git.*` / **`spec.graph`**
+  never eagerly for every project) / `workspace.*` — notably **`workspace.list { projectId,
+  includeDiffStats? }`**, where omitted/true preserves the existing full rows with computed aggregates and
+  `false` returns the same authoritative membership/order without the synchronous per-workspace diff-stat
+  fan-out used nowhere by navigation restoration / `fs.*` / `git.*` / **`spec.graph`**
   (the Specs-viewer whole-graph read, per workspace) / **`todo.*`** — **`list`**/**`add`**/**`update`**/
   **`remove`**, the chat's per-session TODO plan (keyed by `workspaceId` + `sessionId`; `add` tags the
   item `origin:"user"`) / **`terminal.*`** — **`attach`** (idempotent get-or-create keyed by

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -229,7 +229,9 @@ export interface TerminalTabsPush {
 // v42: Central changes are applied through watched runtime generations; restart/recovery/blocked outcomes are
 // removed, `provider.changed` invalidates provider/model reads, and live chats retain their own generation.
 // v43: configured Central status reports the closed proxy-stopped observation and exposes Start proxy.
-export const PROTOCOL_VERSION = 43;
+// v44: `workspace.list.includeDiffStats` can skip only the synchronous per-workspace diff-stat fan-out while
+// preserving complete authoritative membership/order for cold client-local navigation restoration.
+export const PROTOCOL_VERSION = 44;
 
 /**
  * The `server.welcome` push payload (the first message on every WS connect). `protocolVersion` lets a
@@ -596,7 +598,10 @@ export interface WsMethodMap {
 		params: { projectId: string; path: string };
 		result: Workspace;
 	};
-	"workspace.list": { params: { projectId: string }; result: Workspace[] };
+	"workspace.list": {
+		params: { projectId: string; includeDiffStats?: boolean };
+		result: Workspace[];
+	};
 	"workspace.openReview": {
 		params: { workspaceId: string };
 		result: OpenBranchReview | null;

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -127,9 +127,12 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     is never trusted (blocks disclosure *and* arbitrary-URL injection). The **hydration read side** —
     `listSessions(workspaceId, cwd)` (live sessions
     **unioned with on-disk** ones pi persisted under `cwd`, live winning on id → `SessionSummary[]` tagged
-    `live`; before treating that disk list as authoritative it strictly scans every transcript header and
-    verifies pi returned every file, so an unreadable/malformed/skipped file rejects the read rather than
-    masquerading as absent and being tombstoned by reconnect reconciliation) +
+    `live`; before treating the **detached** disk list as authoritative it strictly scans every transcript
+    header and verifies pi returned every file, so an unreadable/malformed/skipped file rejects the read
+    rather than masquerading as absent and being tombstoned by reconnect reconciliation. A registered live
+    session's own exact `SessionManager.getSessionFile()` path is excluded from that disk preflight: its
+    in-memory entry is already authoritative, and pi may truncate/rewrite that path while the host lists,
+    so treating the transient physical state as a detached corrupt chat would blank every chat on reload) +
     `getSessionMessages(sessionId, workspaceId, cwd)` (re-opens a disk session into the manager if
     not live, first resolving any model named by the transcript exactly in the active process runtime and
     rejecting with a closed error when that named model is unavailable—never accepting PI's silent fallback

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, expect, jest, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
 	InMemoryCredentialStore,
 	type Model,
@@ -528,6 +528,34 @@ test("listSessions reports a workspace's live sessions; getSessionMessages retur
 	expect(messages.some((m) => m.role === "assistant")).toBe(true);
 	expect(messages.every((m) => ["user", "assistant", "toolResult"].includes(m.role))).toBe(true);
 	removeSession(s.sessionId);
+});
+
+test("listSessions ignores a live session's transient physical rewrite but stays strict for detached files", async () => {
+	const cwd = tmpCwd("trpi-live-rewrite-");
+	const liveManager = SessionManager.create(cwd);
+	setSessionManagerFactory(() => liveManager);
+	try {
+		const s = await createSession({
+			cwd,
+			workspaceId: "ws-live-rewrite",
+			model: toWireModel(fauxA.getModel()),
+		});
+		const sessionFile = liveManager.getSessionFile();
+		if (!sessionFile) throw new Error("disk-backed live session has no file path");
+		mkdirSync(dirname(sessionFile), { recursive: true });
+		// Model pi's synchronous truncate→rewrite window at its worst point: the registered runtime is still
+		// authoritative, while its exact physical path temporarily has no readable header.
+		writeFileSync(sessionFile, "");
+		expect((await listSessions("ws-live-rewrite", cwd)).map((row) => row.sessionId)).toContain(
+			s.sessionId,
+		);
+
+		removeSession(s.sessionId);
+		// Once detached, the same malformed file is no longer exempt: absence must never be inferred from it.
+		await expect(listSessions("ws-live-rewrite", cwd)).rejects.toThrow("unreadable or malformed");
+	} finally {
+		setSessionManagerFactory(() => SessionManager.inMemory());
+	}
 });
 
 test("disk-reopen: a disposed session is re-listed from disk and re-opened with its transcript (restart survival)", async () => {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -413,7 +413,10 @@ async function readSessionFileIdentity(path: string): Promise<SessionFileIdentit
 }
 
 /** Enumerate every physical transcript in pi's one encoded-cwd directory without swallowing errors. */
-async function scanSessionFiles(cwd: string): Promise<ScannedSessionFile[]> {
+async function scanSessionFiles(
+	cwd: string,
+	excludedPaths: ReadonlySet<string> = new Set(),
+): Promise<ScannedSessionFile[]> {
 	const dir = defaultSessionDirectory(cwd);
 	let names: string[];
 	try {
@@ -428,6 +431,9 @@ async function scanSessionFiles(cwd: string): Promise<ScannedSessionFile[]> {
 	for (const name of names) {
 		if (!name.endsWith(".jsonl")) continue;
 		const path = join(dir, name);
+		// A registered live session is authoritative from memory. Pi can truncate/rewrite its physical file;
+		// observing that tiny window must not turn a healthy live chat into a corrupt detached transcript.
+		if (excludedPaths.has(resolve(path))) continue;
 		try {
 			scanned.push({ path, ok: true, identity: await readSessionFileIdentity(path) });
 		} catch (error) {
@@ -446,8 +452,11 @@ async function scanSessionFiles(cwd: string): Promise<ScannedSessionFile[]> {
  * membership and deletion boundaries that would mean "absent", so preflight every header and verify pi
  * returned every physical file. Only a successful result is authoritative.
  */
-async function listSessionInfosStrict(cwd: string): Promise<SessionInfo[]> {
-	const scanned = await scanSessionFiles(cwd);
+async function listSessionInfosStrict(
+	cwd: string,
+	excludedPaths: ReadonlySet<string> = new Set(),
+): Promise<SessionInfo[]> {
+	const scanned = await scanSessionFiles(cwd, excludedPaths);
 	const broken = scanned.find((file) => !file.ok);
 	if (broken && !broken.ok) throw broken.error;
 	const infos = await SessionManager.list(cwd);
@@ -469,12 +478,15 @@ async function listSessionInfosStrict(cwd: string): Promise<SessionInfo[]> {
 async function listSessionsInternal(workspaceId: string, cwd: string): Promise<SessionSummary[]> {
 	const live: SessionSummary[] = [];
 	const liveIds = new Set<string>();
+	const liveFiles = new Set<string>();
 	for (const [sessionId, entry] of sessions) {
 		if (entry.workspaceId !== workspaceId || isSessionDeleted(sessionId, workspaceId)) continue;
 		live.push(summaryOf(sessionId, entry));
 		liveIds.add(sessionId);
+		const sessionFile = entry.session.sessionManager.getSessionFile();
+		if (sessionFile) liveFiles.add(resolve(sessionFile));
 	}
-	const infos = await listSessionInfosStrict(cwd);
+	const infos = await listSessionInfosStrict(cwd, liveFiles);
 	// One encoded-cwd dir can alias distinct cwds, so disambiguate on the recorded header cwd; live wins.
 	const disk: SessionSummary[] = infos
 		.filter(

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -318,7 +318,10 @@ const handlers: Record<string, Handler> = {
 		const p = params as { projectId: string; path: string };
 		return openExistingWorktree(p.projectId, p.path);
 	},
-	"workspace.list": (params) => listWorkspaces((params as { projectId: string }).projectId),
+	"workspace.list": (params) => {
+		const p = params as { projectId: string; includeDiffStats?: boolean };
+		return listWorkspaces(p.projectId, { includeDiffStats: p.includeDiffStats ?? true });
+	},
 	"workspace.openReview": (params) => {
 		const ws = getWorkspace((params as { workspaceId: string }).workspaceId);
 		return findOpenBranchReview(ws.worktreePath, ws.branch);

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -69,8 +69,12 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   marking the name deliberate so the auto-namer never touches it again — what a user rename and the
   agentic auto-rename want; the host's **provisional naive rename** passes `lock: false` to rename name +
   branch while leaving `renamed` unset, so the settled-turn agentic pass still refines it),
-  `listWorkspaces` (with diff stats), `listWorkspaceRecords` (registry records without per-workspace git
-  diffStats — for read-only paths like history scope mapping that must not block on git spawns),
+  `listWorkspaces(projectId, { includeDiffStats? })` (complete authoritative membership/order after Default
+  ensure + user-owned folder-truth reconciliation; diff stats default **on** for compatibility, while
+  `includeDiffStats: false` skips the per-workspace `git diff --shortstat` fan-out for cold navigation —
+  automatic reload on a shared host must not synchronously diff every worktree), `listWorkspaceRecords`
+  (raw registry records without Default ensure, folder-truth reconciliation, or per-workspace git diffStats —
+  for internal read-only paths like history scope mapping that must not block on git spawns),
   `workspaceDiffStats`, **`setWorkspaceDiffBase(id, ref | null)`** — re-point the ref this workspace's diff is
   measured against (`Workspace.diffBase`), `null` (or the creation base itself, which would be a redundant
   override) clearing it; persists + **broadcasts the updated record** so every client converges on the push,

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -762,3 +762,27 @@ test("ensuring the Default emits created once; listing never writes into the pro
 	expect(readFileSync(join(repo, ".thinkrail", "context", ".gitignore"), "utf8")).toBe("*\n");
 	expect(gitOut(repo, "status", "--porcelain")).not.toContain(".thinkrail");
 });
+
+test("includeDiffStats: false keeps membership/order/Default ensure while skipping the diff-stat fan-out", async () => {
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((e) => events.push(e));
+
+	const ws = await createWorkspace("p1", "Iso");
+	// Commit branch work so the full list demonstrably computes stats the light one skips.
+	writeFileSync(join(ws.worktreePath, "work.txt"), "one\ntwo\n");
+	git(ws.worktreePath, "add", "-A");
+	git(ws.worktreePath, "commit", "-m", "branch work");
+
+	const light = listWorkspaces("p1", { includeDiffStats: false });
+	// Same complete authoritative answer: the ensured Default pinned first, then the worktree.
+	expect(light.map((w) => w.kind ?? "worktree")).toEqual(["default", "worktree"]);
+	expect(events.map((e) => e.kind)).toContain("created"); // the Default ensure still ran
+	// The fan-out was skipped: no row carries a computed aggregate (`diffStats` only ever comes from it).
+	expect(light.every((w) => w.diffStats === undefined)).toBe(true);
+
+	// Omitted (an older client) and explicit `true` both keep the existing full behavior.
+	for (const full of [listWorkspaces("p1"), listWorkspaces("p1", { includeDiffStats: true })]) {
+		expect(full.map((w) => w.id)).toEqual(light.map((w) => w.id));
+		expect(full.find((w) => w.id === ws.id)?.diffStats).toEqual({ added: 2, removed: 0 });
+	}
+});

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -584,7 +584,10 @@ export function setWorkspaceDiffBase(id: string, ref: string | null): Workspace 
 	return ws;
 }
 
-export function listWorkspaces(projectId: string): Workspace[] {
+export function listWorkspaces(
+	projectId: string,
+	opts: { includeDiffStats?: boolean } = {},
+): Workspace[] {
 	// Lazily ensure the built-in Default workspace on every list: find-or-create is idempotent, backfills
 	// projects opened before the feature existed, and self-heals out-of-band state churn (the e2e reset
 	// rewrites workspaces.json mid-run). Unknown project → no ensure, the filter returns [] as before.
@@ -600,6 +603,10 @@ export function listWorkspaces(projectId: string): Workspace[] {
 	const rows = loadWorkspaces().filter((w) => w.projectId === projectId);
 	// Pin the Default workspace first (creation order would put a backfilled one last).
 	rows.sort((a, b) => (a.kind === "default" ? -1 : 0) - (b.kind === "default" ? -1 : 0));
+	// The membership/order above is always the complete authoritative answer; only the per-workspace
+	// diff-stat fan-out (a synchronous `git diff --shortstat` per row) is optional — navigation
+	// restoration opts out so an automatic reload on a shared host never diffs every worktree.
+	if (opts.includeDiffStats === false) return rows;
 	return rows.map((w) => {
 		const stats = diffStats(w);
 		// Omitted, not zeroed, when git couldn't answer (`exactOptionalPropertyTypes`).


### PR DESCRIPTION
## Summary

- add a versioned, backend-relative URL-fragment model for Welcome, Project Home, workspaces, and exact chats
- restore and validate locations from host-owned project/workspace/session state without introducing backend-owned navigation
- make exact-chat hydration race-safe across reloads, reconnects, same-workspace deep links, stale reads, and transient failures
- install `server.welcome` atomically and add protocol v39's lightweight `workspace.list({ includeDiffStats: false })` path for cold navigation
- keep strict detached-session validation while exempting authoritative live-session files from transient pi rewrite windows
- update architecture/module specs and expand unit/e2e coverage for reload, direct links, independent browser tabs, fallbacks, and failure recovery

## Review notes

- browser navigation uses `history.replaceState`; this intentionally does not create per-tab-click browser history yet
- file/diff/doc tabs serialize as the workspace route; only chat tabs have an exact-tab route in this slice
- routes contain backend ids only—no endpoint credentials or backend-global active location
- Electrobun/mobile persistence remains deferred, but reuses the same backend-relative route contract

## Verification

- `bun run check:deps`
- `bun run check:seams`
- `bun run lint` (passes; three existing website CSS specificity warnings remain)
- `bun run typecheck`
- `bun run test`
- `bun run e2e` — all 8 shards / 217 no-agent tests passed

## Screenshots

No static visual delta: this changes URL state and reload/deep-link behavior. A short before/after reload recording would be more representative than screenshots and can be added if useful.
