### PR TITLE
fix(web): persist Projects-rail expansion across reloads

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { initNavigation } from "./navigation";
+import { initProjectExpansionPersistence } from "./panels/projectExpansion";
 import { Shell } from "./shell/Shell";
 import { applyTheme, initializeBundledThemes, readThemeHint } from "./themes";
 import { initTransport } from "./transport";
@@ -10,6 +11,7 @@ import { initTransport } from "./transport";
 initializeBundledThemes();
 applyTheme(readThemeHint());
 initTransport();
+initProjectExpansionPersistence();
 initNavigation();
 
 const root = document.getElementById("root");

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -64,9 +64,7 @@ export function ProjectTree() {
 			.catch(() => {});
 	}, []);
 
-	const [expanded, setExpanded] = useState<Set<string>>(
-		() => new Set(selectedProjectId ? [selectedProjectId] : []),
-	);
+	const expandedProjectIds = useAppStore((s) => s.expandedProjectIds);
 	const [dialogProjectId, setDialogProjectId] = useState<string | null>(null);
 	const [existingDialogProjectId, setExistingDialogProjectId] = useState<string | null>(null);
 	const addProjectButtonRef = useRef<HTMLButtonElement>(null);
@@ -102,16 +100,10 @@ export function ProjectTree() {
 
 	const activeProjectId = useAppStore(selectActiveWorkspaceProjectId);
 	useEffect(() => {
-		if (!activeProjectId) return;
-		setExpanded((prev) => {
-			if (prev.has(activeProjectId)) return prev;
-			const next = new Set(prev);
-			next.add(activeProjectId);
-			return next;
-		});
+		if (activeProjectId) useAppStore.getState().expandProject(activeProjectId);
 	}, [activeProjectId]);
 
-	const loadWorkspaces = async (projectId: string) => {
+	const loadWorkspaces = useCallback(async (projectId: string) => {
 		const rows = await getTransport().request("workspace.list", { projectId });
 		const store = useAppStore.getState();
 		store.setWorkspaces(projectId, rows);
@@ -119,11 +111,22 @@ export function ProjectTree() {
 		for (const workspace of rows.slice(0, PREWARM_WORKSPACE_LIMIT)) {
 			void prewarmWorkspaceSkillLoad(workspace.id).catch(() => {});
 		}
-	};
+	}, []);
+
+	const pendingListLoadsRef = useRef(new Set<string>());
+	useEffect(() => {
+		for (const project of projects) {
+			if (!expandedProjectIds[project.id] || workspaces[project.id]) continue;
+			if (pendingListLoadsRef.current.has(project.id)) continue;
+			pendingListLoadsRef.current.add(project.id);
+			void loadWorkspaces(project.id)
+				.catch(() => {})
+				.finally(() => pendingListLoadsRef.current.delete(project.id));
+		}
+	}, [projects, expandedProjectIds, workspaces, loadWorkspaces]);
 
 	const selectProject = async (projectId: string) => {
-		useAppStore.getState().selectProject(projectId);
-		setExpanded((prev) => new Set(prev).add(projectId));
+		useAppStore.getState().selectProject(projectId, { reveal: true });
 		await loadWorkspaces(projectId);
 	};
 
@@ -132,16 +135,10 @@ export function ProjectTree() {
 	};
 
 	const toggleExpand = (projectId: string) => {
-		setExpanded((prev) => {
-			const next = new Set(prev);
-			if (next.has(projectId)) {
-				next.delete(projectId);
-			} else {
-				next.add(projectId);
-				void loadWorkspaces(projectId);
-			}
-			return next;
-		});
+		const store = useAppStore.getState();
+		const willExpand = !store.expandedProjectIds[projectId];
+		store.toggleProjectExpanded(projectId);
+		if (willExpand) void loadWorkspaces(projectId);
 	};
 
 	const { openProject, pickAndOpen, dialogs } = useOpenProject((project) =>
@@ -149,7 +146,7 @@ export function ProjectTree() {
 	);
 
 	const onWorkspaceCreated = async (workspace: Workspace) => {
-		setExpanded((prev) => new Set(prev).add(workspace.projectId));
+		useAppStore.getState().expandProject(workspace.projectId);
 		await loadWorkspaces(workspace.projectId);
 	};
 
@@ -159,8 +156,8 @@ export function ProjectTree() {
 		});
 		const attached = rows.find((candidate) => candidate.id === workspace.id);
 		if (!attached) throw new Error("The attached worktree is missing from the workspace list");
-		setExpanded((prev) => new Set(prev).add(workspace.projectId));
 		const store = useAppStore.getState();
+		store.expandProject(workspace.projectId);
 		store.setWorkspaces(workspace.projectId, rows);
 		store.activateWorkspace(attached);
 	};
@@ -234,7 +231,7 @@ export function ProjectTree() {
 
 			<ul className="flex flex-col">
 				{projects.map((project) => {
-					const isExpanded = expanded.has(project.id);
+					const isExpanded = expandedProjectIds[project.id] === true;
 					const list = workspaces[project.id];
 					return (
 						<li key={project.id}>

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -65,11 +65,21 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   in a capped, evictable pool (server `watch` SPEC), so clicking through many projects in one host lifetime
   reuses that pool instead of accumulating watchers. The list never waits for prewarm, failures stay
   silent and retryable by the eventual chat load, and merely expanding a background project does not prewarm
-  it. The active workspace must also stay visible: when `ProjectTree` mounts with an active workspace, or the
-  active workspace's derived
-  owning project changes or first becomes resolvable, it expands that parent project. A manual collapse
+  it (the prewarm is gated on the *selected* project, so the lazy restored-expansion fetch below keeps this
+  invariant too). **Rail expansion is store-held, per-browser view state**
+  (`store.expandedProjectIds`), not component state: it survives the Project-Home/workspace remount
+  boundary and, via the `projectExpansion` persistence module (localStorage under a host-qualified key,
+  hydrated at boot from `main.tsx`, best-effort writes, untrusted reads), a page reload — the rail
+  looks the same after reloading. Rows whose persisted expansion outlives this client's fetched lists
+  (a fresh reload) fetch their missing `workspace.list` lazily; an already-fetched list is refreshed on
+  an explicit expand gesture, never refetched in a loop. The active workspace must
+  also stay visible: when `ProjectTree` mounts with an active workspace, or the active workspace's derived
+  owning project changes or first becomes resolvable, it expands that parent project — this reveal applies
+  *on top of* the persisted baseline (a persisted collapse never hides the active workspace). A manual collapse
   remains respected while the owning project is unchanged; ordinary `workspace.updated` snapshots and
-  same-project workspace switches do not force it open again. Workspace creation expands its project
+  same-project workspace switches do not force it open again. Navigation restore is neutral: a reload
+  re-selects the routed project without touching expansion (the persisted state *is* the view). Workspace
+  creation expands its project
   explicitly. Selecting or creating a workspace also selects its owning project, keeping project-home and
   active-workspace context coherent even when the create dialog's project picker targets another project.
   **Opening a project lands on that project's Welcome** — deliberately **no auto-enter** into any
@@ -88,7 +98,11 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   on-screen anchor, unlike the Remove popover); `NoticeDialog` is a single-button info modal for failures
   with no yes/no follow-up. The hook returns a `dialogs` node each consumer renders. **Selecting a
   project** (clicking its row — the chevron expands/collapses separately) **deselects any active
-  workspace**, so the shell returns to that project's Welcome — a deliberate "project home" gesture; the
+  workspace**, so the shell returns to that project's Welcome — a deliberate "project home" gesture. Both
+  select-project gestures — the rail row click and adopting a just-opened project (`ProjectTree` *and*
+  `WelcomePanel`) — also **reveal the project's workspaces** (`selectProject(id, { reveal: true })`): a
+  gesture that enters a project promises its workspace list, so opening from the Welcome screen never
+  lands with a collapsed rail row; the
   workspace's shared layout survives on the host, so re-selecting it restores the workbench. That round
   trip unmounts the whole workspace surface, but terminals keep no client-side lifetime to lose: the host owns
   each tab and PTY, and unmounting kills nothing. Several distinct terminals may be visible in different

--- a/apps/web/src/panels/WelcomePanel.tsx
+++ b/apps/web/src/panels/WelcomePanel.tsx
@@ -52,7 +52,7 @@ export function WelcomePanel() {
 	}, [project?.id]);
 
 	const { openProject, pickAndOpen, dialogs } = useOpenProject((opened) =>
-		useAppStore.getState().selectProject(opened.id),
+		useAppStore.getState().selectProject(opened.id, { reveal: true }),
 	);
 
 	const onWorkspaceCreated = async (ws: Workspace) => {

--- a/apps/web/src/panels/projectExpansion.ts
+++ b/apps/web/src/panels/projectExpansion.ts
@@ -1,0 +1,35 @@
+import { STORAGE_PREFIX } from "../constants/branding";
+import { useAppStore } from "../store";
+import { getTransport } from "../transport";
+
+function storageKey(): string {
+	return `${STORAGE_PREFIX}expanded-projects:${getTransport().httpBase()}`;
+}
+
+function readPersistedExpansion(): string[] {
+	try {
+		const raw = localStorage.getItem(storageKey());
+		if (!raw) return [];
+		const parsed = JSON.parse(raw) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((id): id is string => typeof id === "string");
+	} catch {
+		return [];
+	}
+}
+
+function persistExpansion(expanded: Record<string, true>): void {
+	try {
+		localStorage.setItem(storageKey(), JSON.stringify(Object.keys(expanded)));
+	} catch {}
+}
+
+export function initProjectExpansionPersistence(): void {
+	useAppStore.getState().hydrateExpandedProjects(readPersistedExpansion());
+	let previous = useAppStore.getState().expandedProjectIds;
+	useAppStore.subscribe((state) => {
+		if (state.expandedProjectIds === previous) return;
+		previous = state.expandedProjectIds;
+		persistExpansion(previous);
+	});
+}

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -32,9 +32,19 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   remain), while deliberately retaining every workspace layout/attention/resource-render/terminal/session
   map for lossless reopen. Other-client opens never steal navigation, and a background close never moves it.
   All project response call sites use the same updater, so the open and recent copies cannot drift.
-  Explicit local transitions are **`selectMain()`**, **`selectProject(projectId)`**, and
+  Explicit local transitions are **`selectMain()`**, **`selectProject(projectId, opts?)`**, and
   **`activateWorkspace(workspace)`**; each updates its coupled scope ids atomically, and there is no generic
-  active-workspace setter that can split the invariant. Validated route restoration uses
+  active-workspace setter that can split the invariant. **`expandedProjectIds: Record<string, true>`** is the
+  Projects rail's per-browser expansion — store-held (it must survive the rail's remounts and be writable by
+  non-rail gestures) with **`toggleProjectExpanded(projectId)`** (the chevron), **`expandProject(projectId)`**
+  (idempotent reveal: workspace creation / worktree attach / the active-workspace visibility rule), and
+  `selectProject`'s **`{ reveal: true }`** option — the user-gesture variant that enters a project's home and
+  expands its row in one write (rail row click, Welcome-screen open adoption); navigation restore and the
+  workspace-removal fallback call it bare, staying expansion-neutral. Project-snapshot installs prune
+  expansion to the open rail (a closed project's entry drops; identity-stable when unchanged).
+  **`hydrateExpandedProjects(projectIds)`** seeds the set at boot from the `panels/projectExpansion`
+  persistence module — the store itself still touches no storage: that module owns the localStorage
+  mirror (host-qualified key, best-effort writes, untrusted reads) and subscribes to changes. Validated route restoration uses
   **`activateWorkspaceFromRoute(workspace, sessionId?)`**: it applies the same scope ids, advances the
   compatibility workspace navigation tick plus the current destination-group clock, and either installs a
   transient **`routeChatTarget`** stamped with both clocks or clears an older exact target. A workspace-only

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -126,6 +126,7 @@ beforeEach(() => {
 		recentProjects: [],
 		workspaces: {},
 		removedWorkspaceIds: {},
+		expandedProjectIds: {},
 		selectedProjectId: null,
 		activeWorkspaceId: null,
 		activeLogin: null,
@@ -1387,6 +1388,38 @@ test("installProjectSnapshot sorts both projections and repairs navigation after
 	expect(state.activeWorkspaceId).toBeNull();
 	expect(state.workspaces.p2).toEqual([workspace]);
 	expect(state.tabsByWorkspace).toBe(tabs);
+});
+
+test("projects-rail expansion: gestures reveal, restore stays neutral, the chevron toggles", () => {
+	const p1 = project();
+	const p2 = project({ id: "p2", name: "Project two", path: "/projects/two", slug: "project-two" });
+	useAppStore.setState({ projects: [p1, p2], recentProjects: [p1, p2] });
+	const store = useAppStore.getState();
+
+	store.selectProject("p1");
+	expect(useAppStore.getState().expandedProjectIds).toEqual({});
+	store.selectProject("p1", { reveal: true });
+	expect(useAppStore.getState().expandedProjectIds).toEqual({ p1: true });
+	const before = useAppStore.getState().expandedProjectIds;
+	store.expandProject("p1");
+	expect(useAppStore.getState().expandedProjectIds).toBe(before);
+	store.toggleProjectExpanded("p1");
+	expect(useAppStore.getState().expandedProjectIds).toEqual({});
+	store.toggleProjectExpanded("p2");
+	expect(useAppStore.getState().expandedProjectIds).toEqual({ p2: true });
+	useAppStore.getState().applyProjectUpdated({ ...p2, closed: true });
+	expect(useAppStore.getState().expandedProjectIds).toEqual({});
+});
+
+test("hydrateExpandedProjects seeds the persisted mirror; the welcome snapshot prunes to the open rail", () => {
+	const p1 = project();
+	useAppStore.getState().hydrateExpandedProjects(["p1", "stale-closed-project"]);
+	expect(useAppStore.getState().expandedProjectIds).toEqual({
+		p1: true,
+		"stale-closed-project": true,
+	});
+	useAppStore.getState().installWelcomeSnapshot(1, [p1], [p1]);
+	expect(useAppStore.getState().expandedProjectIds).toEqual({ p1: true });
 });
 
 test("applyProjectUpdated closes a background project without moving the current workspace", () => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -586,6 +586,7 @@ interface AppState {
 	recentProjects: Project[];
 	workspaces: Record<string, Workspace[]>;
 	removedWorkspaceIds: Record<string, true>;
+	expandedProjectIds: Record<string, true>;
 	selectedProjectId: string | null;
 	activeWorkspaceId: string | null;
 	routeChatTarget: RouteChatTarget | null;
@@ -651,7 +652,10 @@ interface AppState {
 	updateWorkspace: (workspace: Workspace) => void;
 	removeWorkspace: (projectId: string, workspaceId: string) => void;
 	applyWorkspaceRemoved: (projectId: string, workspaceId: string) => void;
-	selectProject: (projectId: string) => void;
+	selectProject: (projectId: string, opts?: { reveal?: boolean }) => void;
+	toggleProjectExpanded: (projectId: string) => void;
+	expandProject: (projectId: string) => void;
+	hydrateExpandedProjects: (projectIds: readonly string[]) => void;
 	selectMain: () => void;
 	activateWorkspace: (workspace: Pick<Workspace, "id" | "projectId">) => void;
 	activateWorkspaceFromRoute: (
@@ -820,6 +824,25 @@ function upsertProject(projects: Project[], project: Project): Project[] {
 	return projects.some((candidate) => candidate.id === project.id)
 		? projects.map((candidate) => (candidate.id === project.id ? project : candidate))
 		: [...projects, project];
+}
+
+function withExpandedProject(
+	record: Record<string, true>,
+	projectId: string,
+): Record<string, true> {
+	return record[projectId] ? record : { ...record, [projectId]: true };
+}
+
+function pruneExpandedProjects(
+	state: Pick<AppState, "expandedProjectIds">,
+	projects: Project[],
+): Pick<AppState, "expandedProjectIds"> | Record<string, never> {
+	const open = new Set(projects.map((project) => project.id));
+	const kept = Object.keys(state.expandedProjectIds).filter((id) => open.has(id));
+	if (kept.length === Object.keys(state.expandedProjectIds).length) return {};
+	return {
+		expandedProjectIds: Object.fromEntries(kept.map((id) => [id, true as const])),
+	};
 }
 
 function reconcileProjectNavigation(
@@ -1228,6 +1251,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	recentProjects: [],
 	workspaces: {},
 	removedWorkspaceIds: Object.create(null) as Record<string, true>,
+	expandedProjectIds: Object.create(null) as Record<string, true>,
 	selectedProjectId: null,
 	activeWorkspaceId: null,
 	routeChatTarget: null,
@@ -1287,6 +1311,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				recentProjects: sortProjects(recentProjects),
 				...(config ? configPatch(config) : {}),
 				...reconcileProjectNavigation(state, openProjects),
+				...pruneExpandedProjects(state, openProjects),
 				welcomeGeneration: state.welcomeGeneration + 1,
 			};
 		}),
@@ -1297,6 +1322,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				projects: openProjects,
 				recentProjects: sortProjects(recentProjects),
 				...reconcileProjectNavigation(state, openProjects),
+				...pruneExpandedProjects(state, openProjects),
 			};
 		}),
 	applyProjectUpdated: (project) =>
@@ -1309,6 +1335,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				projects,
 				recentProjects: sortProjects(upsertProject(state.recentProjects, project)),
 				...reconcileProjectNavigation(state, projects),
+				...pruneExpandedProjects(state, projects),
 			};
 		}),
 	setWorkspaces: (projectId, workspaces) =>
@@ -1392,7 +1419,29 @@ export const useAppStore = create<AppState>((set, get) => ({
 			toast.info(`Workspace "${name ?? "?"}" was removed`);
 		}
 	},
-	selectProject: (selectedProjectId) => set({ selectedProjectId, activeWorkspaceId: null }),
+	selectProject: (selectedProjectId, opts) =>
+		set((state) => ({
+			selectedProjectId,
+			activeWorkspaceId: null,
+			...(opts?.reveal
+				? { expandedProjectIds: withExpandedProject(state.expandedProjectIds, selectedProjectId) }
+				: {}),
+		})),
+	toggleProjectExpanded: (projectId) =>
+		set((state) => ({
+			expandedProjectIds: state.expandedProjectIds[projectId]
+				? omitKey(state.expandedProjectIds, projectId)
+				: withExpandedProject(state.expandedProjectIds, projectId),
+		})),
+	expandProject: (projectId) =>
+		set((state) => {
+			const expandedProjectIds = withExpandedProject(state.expandedProjectIds, projectId);
+			return expandedProjectIds === state.expandedProjectIds ? {} : { expandedProjectIds };
+		}),
+	hydrateExpandedProjects: (projectIds) =>
+		set(() => ({
+			expandedProjectIds: Object.fromEntries(projectIds.map((id) => [id, true as const])),
+		})),
 	selectMain: () =>
 		set({ selectedProjectId: null, activeWorkspaceId: null, routeChatTarget: null }),
 	activateWorkspace: (workspace) =>

--- a/e2e/auto-open-chats.spec.ts
+++ b/e2e/auto-open-chats.spec.ts
@@ -2,7 +2,12 @@ import { existsSync, mkdirSync, realpathSync, rmSync, utimesSync, writeFileSync 
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { TodoStore } from "pi-todos/core";
-import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import {
+	defaultWorkspaceRow,
+	enterDefaultWorkspace,
+	openFixtureProject,
+	revealFirstProjectWorkspaces,
+} from "./fixtures/app";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
 import { seedWorkspaceSession } from "./fixtures/sessions";
 
@@ -126,7 +131,7 @@ test("trashing a chat converges to a second client", async ({ page, context }) =
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await defaultWorkspaceRow(page2).click();
 	await expect(page2.getByText("shared doomed transcript")).toBeVisible();
 
@@ -174,7 +179,7 @@ test("a client that misses chat deletion while offline reconciles it after recon
 	const page2 = await context2.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await defaultWorkspaceRow(page2).click();
 	await expect(page2.getByText("offline doomed transcript")).toBeVisible();
 

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -126,6 +126,12 @@ export async function enterDefaultWorkspace(page: Page): Promise<void> {
 	await expect(page.getByTestId("center-tabs")).toBeVisible();
 }
 
+export async function revealFirstProjectWorkspaces(page: Page): Promise<void> {
+	const expand = page.getByTestId("project-expand").first();
+	await expect(expand).toBeVisible();
+	if ((await expand.getAttribute("data-expanded")) !== "true") await expand.click();
+}
+
 export function defaultWorkspaceRow(page: Page): Locator {
 	return page.locator('[data-testid="workspace-item"][data-kind="default"]');
 }

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -5,6 +5,7 @@ import {
 	enterDefaultWorkspace,
 	openFixtureProject,
 	pressPlatformShortcut,
+	revealFirstProjectWorkspaces,
 	waitTerminalReady,
 } from "./fixtures/app";
 
@@ -714,7 +715,7 @@ test("remote closures reconcile chat history and cached file reopening", async (
 	const peer = await context.newPage();
 	await peer.goto("/");
 	await expect(peer.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await peer.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(peer);
 	await defaultWorkspaceRow(peer).click();
 	const peerChat = peer.locator('[data-testid="editor-tab"][data-kind="chat"]');
 	await expect(peerChat).toHaveCount(1);
@@ -782,7 +783,7 @@ test("a nonmatching remote revision cancels an active drag and both clients conv
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await defaultWorkspaceRow(page2).getByRole("button").first().click();
 	await expect(page2.getByTestId("center-group")).toHaveCount(1);
 
@@ -816,7 +817,7 @@ test("a nonmatching remote revision cancels an active resize without publishing 
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await defaultWorkspaceRow(page2).getByRole("button").first().click();
 	await expect(page2.getByTestId("right-panel")).toBeVisible();
 

--- a/e2e/multi-tab.live.spec.ts
+++ b/e2e/multi-tab.live.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+import {
+	createWorkspaceViaDialog,
+	openFixtureProject,
+	revealFirstProjectWorkspaces,
+	worktreeRows,
+} from "./fixtures/app";
 
 test("a second tab hydrates the same workspace's chats and then sees live updates", {
 	tag: "@agent",
@@ -22,7 +27,7 @@ test("a second tab hydrates the same workspace's chats and then sees live update
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await worktreeRows(page2).first().click();
 
 	await expect(page2.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1, {

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -4,6 +4,7 @@ import { basename, join } from "node:path";
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
+	defaultWorkspaceRow,
 	openAppFresh,
 	openFixtureProject,
 	stagePlainFolder,
@@ -68,6 +69,27 @@ test("opening a non-git folder offers to initialise a repo, then opens it end-to
 
 	await createWorkspaceViaDialog(page);
 	await expect(worktreeRows(page).first()).toBeVisible();
+});
+
+test("rail expansion is per-browser view state that survives a reload", async ({ page }) => {
+	await openFixtureProject(page);
+	const row = page.getByTestId("project-item").filter({ hasText: "sample-project" });
+	const expand = row.getByTestId("project-expand");
+
+	await expect(expand).toHaveAttribute("data-expanded", "true");
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(expand).toHaveAttribute("data-expanded", "true");
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+
+	await expand.click();
+	await expect(expand).toHaveAttribute("data-expanded", "false");
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(expand).toHaveAttribute("data-expanded", "false");
+	await expect(defaultWorkspaceRow(page)).toHaveCount(0);
 });
 
 test("project context actions stay compact and close/reopen is lossless across clients", async ({

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -92,6 +92,37 @@ test("rail expansion is per-browser view state that survives a reload", async ({
 	await expect(defaultWorkspaceRow(page)).toHaveCount(0);
 });
 
+test("activating a workspace in one project keeps the other project's rail expansion", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	seedSecondRepo();
+	await page.getByTestId("add-project-menu").click();
+	await page.getByTestId("menu-open-project").click();
+
+	const fixtureExpand = page
+		.getByTestId("project-item")
+		.filter({ hasText: "sample-project" })
+		.getByTestId("project-expand");
+	const secondExpand = page
+		.getByTestId("project-item")
+		.filter({ hasText: "second-project" })
+		.getByTestId("project-expand");
+	await expect(secondExpand).toHaveAttribute("data-expanded", "true");
+	await expect(fixtureExpand).toHaveAttribute("data-expanded", "true");
+
+	const fixtureDefaultRow = page
+		.locator("li")
+		.filter({ has: page.getByTestId("project-item").filter({ hasText: "sample-project" }) })
+		.locator('[data-testid="workspace-item"][data-kind="default"]');
+	await fixtureDefaultRow.click();
+	await expect(fixtureDefaultRow).toHaveAttribute("data-active", "true");
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+
+	await expect(secondExpand).toHaveAttribute("data-expanded", "true");
+	await expect(fixtureExpand).toHaveAttribute("data-expanded", "true");
+});
+
 test("project context actions stay compact and close/reopen is lossless across clients", async ({
 	page,
 	context,

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -4,6 +4,7 @@ import {
 	createWorkspaceViaDialog,
 	openFixtureProject,
 	openTerminal,
+	revealFirstProjectWorkspaces,
 	runInTerminal,
 	visibleTerminal,
 	visibleTerminalScreen,
@@ -244,7 +245,7 @@ test("a terminal's output never reaches another client", async ({ page, context 
 
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await worktreeRows(page2).nth(1).click();
 	await waitTerminalReady(page2);
 
@@ -450,7 +451,7 @@ test("a second client takes a terminal over and the first is told", async ({ pag
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await worktreeRows(page2).nth(0).click();
 	await waitTerminalReady(page2);
 
@@ -565,7 +566,7 @@ test("a tab opened or closed in one browser reaches the other", async ({ page, c
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await worktreeRows(page2).nth(0).click();
 	await waitTerminalReady(page2);
 	await expect(page2.getByTestId("terminal-tab")).toHaveCount(1);
@@ -618,7 +619,7 @@ test("a shell that dies during a reclaim is not presented as alive", async ({ pa
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await worktreeRows(page2).nth(0).click();
 	await waitTerminalReady(page2);
 	await expect(visibleTerminal(page)).toHaveAttribute("data-detached", "true");

--- a/e2e/workspace-lifecycle.spec.ts
+++ b/e2e/workspace-lifecycle.spec.ts
@@ -3,6 +3,7 @@ import {
 	createWorkspaceViaDialog,
 	openFixtureProject,
 	openWorkspaceMenu,
+	revealFirstProjectWorkspaces,
 	worktreeRows,
 } from "./fixtures/app";
 
@@ -14,7 +15,7 @@ test("workspace removal propagates — no zombie row in a second tab", async ({ 
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await expect(worktreeRows(page2)).toHaveCount(1);
 	await worktreeRows(page2).first().click();
 	await expect(worktreeRows(page2).first()).toHaveAttribute("data-active", "true");
@@ -35,7 +36,7 @@ test("workspace creation propagates to a second tab's rail", async ({ page, cont
 	const page2 = await context.newPage();
 	await page2.goto("/");
 	await expect(page2.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await page2.getByTestId("project-expand").first().click();
+	await revealFirstProjectWorkspaces(page2);
 	await expect(worktreeRows(page2)).toHaveCount(0);
 
 	await createWorkspaceViaDialog(page);


### PR DESCRIPTION
## Bug

With no workspace selected, expanding a project in the Projects rail and reloading the page lost the expansion — the row rendered collapsed. Expected: the same view after reloading.

Reproduced with browser automation against an isolated instance; a sibling manifestation surfaced while reproducing: opening a project from the **Welcome screen** also landed with its rail row collapsed.

## Root cause

`ProjectTree`'s expansion was component-local `useState`, seeded once at mount from `selectedProjectId`. Nothing survived a reload (navigation restore sets the selection *after* the rail mounts, so even the selected project seeded collapsed), and the Welcome-open path called the raw store `selectProject`, which never expanded.

## Fix

- **`store.expandedProjectIds`** — expansion is now store-held, per-browser view state: `toggleProjectExpanded` (chevron), `expandProject` (idempotent reveal: workspace creation/attach, the active-workspace visibility rule), and `selectProject(id, { reveal: true })` — the user-gesture variant (rail row click, Welcome/Add-project adoption) that enters the project's home and reveals its workspaces in one write. Navigation restore stays expansion-neutral, so the rail restores exactly as left — expanded **or** collapsed. Project-snapshot installs prune expansion to the open rail.
- **`panels/projectExpansion.ts`** (new) — the localStorage mirror (host-qualified key, untrusted reads, best-effort writes), hydrated at boot from `main.tsx`; the store still owns no storage access (its spec'd boundary).
- **`ProjectTree`** lazily fetches `workspace.list` for restored-expanded rows, so they are populated after a reload rather than empty; an explicit expand gesture still refreshes an already-fetched list.
- Specs updated first: `apps/web/src/panels/SPEC.md`, `apps/web/src/store/SPEC.md`.

## Verification

- Browser-verified end-to-end: expand → reload → still expanded (with workspace rows); collapse → reload → still collapsed; Welcome-open lands revealed.
- New store unit tests (gesture reveal / neutral restore / idempotent+identity-stable expand / prune / hydrate) and a new e2e regression test (`e2e/projects.spec.ts` — both expansion and collapse survive a reload).
- The persistence surfaced a real test interaction: second-client e2e pages share their context's localStorage and now load already-expanded, so 12 blind `project-expand` clicks across 6 specs migrated to an idempotent `revealFirstProjectWorkspaces` fixture (a blind click would collapse the row).
- Gates on the rebased branch: `check:deps`, `check:seams`, lint, typecheck, all unit tests, and the complete no-agent e2e suite (**8/8 shards green**). `multi-tab.live.spec.ts` (`@agent`) got the same fixture migration but needs an authenticated pi run.
