### PR TITLE
web: declutter the specs tree rows

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -737,7 +737,7 @@ a project picker, the prompt hero, and the reused
   shape-coded role icon → truncated title → trailing role (`ARCH` / `MODULE` / `SUBMODULE` / `TASK`;
   unknown types degrade compactly). The role is **revealed on row hover/focus**, untruncated, and the
   `aria-label` carries it unconditionally. Titles render through `specDisplayTitle`, which collapses a
-  title's ` — ` to **` · `**. The top-level `goal-and-requirements` row
+  title's ` — ` / ` – ` separator to **` · `**. The top-level `goal-and-requirements` row
   instead carries the exact **`Main spec`** label and distinct root icon; a locally selected file resource's row has a persistent selected
   treatment. **Lifecycle status is not presented at all** — future lint health arrives with a real linter
   feature, not speculative dots or reused status chrome. This remains a restrained hierarchy — no hero,

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -734,9 +734,11 @@ a project picker, the prompt hero, and the reused
   **single click previews** the rendered spec — and whose **double click keeps** it — through the same
   `fs.readFile` → `openTab` flow as `FileTree` (see the Preview tabs bullet; reading down a spec graph is
   the case the reusable slot exists for). Every row stays on one line: indentation → chevron →
-  shape-coded role icon → truncated title → fixed trailing role (`ARCH` / `MODULE` / `SUBMODULE` / `TASK`;
-  unknown types degrade compactly). The top-level `goal-and-requirements` row instead carries the exact
-  **`Main spec`** label and distinct root icon; a locally selected file resource's row has a persistent selected
+  shape-coded role icon → truncated title → trailing role (`ARCH` / `MODULE` / `SUBMODULE` / `TASK`;
+  unknown types degrade compactly). The role is **revealed on row hover/focus**, untruncated, and the
+  `aria-label` carries it unconditionally. Titles render through `specDisplayTitle`, which collapses a
+  title's ` — ` to **` · `**. The top-level `goal-and-requirements` row
+  instead carries the exact **`Main spec`** label and distinct root icon; a locally selected file resource's row has a persistent selected
   treatment. **Lifecycle status is not presented at all** — future lint health arrives with a real linter
   feature, not speculative dots or reused status chrome. This remains a restrained hierarchy — no hero,
   duplicate root, preview pane, or graph canvas. `FileTree` shares the same file gesture model

--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -13,7 +13,13 @@ import { useEffect, useMemo, useState } from "react";
 import { cn } from "../lib";
 import { selectActiveEditorTab, useAppStore } from "../store";
 import { openFileInTab } from "./openTabs";
-import { buildSpecTree, type SpecTreeNode, specRoleLabel, specRoleTag } from "./specTree";
+import {
+	buildSpecTree,
+	type SpecTreeNode,
+	specDisplayTitle,
+	specRoleLabel,
+	specRoleTag,
+} from "./specTree";
 
 export function SpecsPanel({
 	workspaceId,
@@ -171,12 +177,12 @@ function SpecNodeRow({
 							isActive ? "text-text-default" : "text-text-muted group-hover:text-text-default",
 						)}
 					>
-						{node.title}
+						{specDisplayTitle(node.title)}
 					</span>
 					<span
 						data-testid="spec-role"
 						className={cn(
-							"max-w-16 shrink-0 truncate text-right tr-text-eyebrow",
+							"hidden shrink-0 text-right tr-text-eyebrow group-hover:block group-focus-within:block",
 							isMainSpec || isActive ? "text-primary" : "text-text-subtle",
 						)}
 					>

--- a/apps/web/src/panels/specTree.test.ts
+++ b/apps/web/src/panels/specTree.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { SpecGraphNode } from "@thinkrail/contracts";
-import { buildSpecTree, specRoleLabel, specRoleTag } from "./specTree";
+import { buildSpecTree, specDisplayTitle, specRoleLabel, specRoleTag } from "./specTree";
 
 function node(id: string, over: Partial<SpecGraphNode> = {}): SpecGraphNode {
 	return {
@@ -27,6 +27,17 @@ test("humanizes known and extension-defined spec roles", () => {
 	expect(specRoleTag("architecture-design")).toBe("ARCH");
 	expect(specRoleTag("module-design")).toBe("MODULE");
 	expect(specRoleTag("risk_register")).toBe("RISK REGISTER");
+});
+
+test("renders dashed titles with a compact dot separator", () => {
+	expect(specDisplayTitle("ACP client — spawn, negotiate, translate")).toBe(
+		"ACP client · spawn, negotiate, translate",
+	);
+	expect(specDisplayTitle("meta – the ThinkRail extension namespace")).toBe(
+		"meta · the ThinkRail extension namespace",
+	);
+	expect(specDisplayTitle("browser↔host wire")).toBe("browser↔host wire");
+	expect(specDisplayTitle("e2e/workflows — harness")).toBe("e2e/workflows · harness");
 });
 
 test("nests children under their parent; roots and siblings sort by title", () => {

--- a/apps/web/src/panels/specTree.ts
+++ b/apps/web/src/panels/specTree.ts
@@ -31,6 +31,10 @@ export function specRoleLabel(type: string): string {
 	return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(" ");
 }
 
+export function specDisplayTitle(title: string): string {
+	return title.replace(/\s+[—–]\s+/g, " · ");
+}
+
 export function specRoleTag(type: string): string {
 	return isKnownSpecType(type) ? SPEC_ROLES[type].tag : specRoleLabel(type).toUpperCase();
 }

--- a/e2e/specs-panel.spec.ts
+++ b/e2e/specs-panel.spec.ts
@@ -26,6 +26,7 @@ test("Specs tab renders the worktree's spec tree and opens a spec as an editor t
 	await expect(child).toHaveAttribute("data-spec-role", "MODULE");
 	await expect(child.getByTestId("spec-role")).toBeHidden();
 	await child.hover();
+	await expect(child.getByTestId("spec-role")).toBeVisible();
 	await expect(child.getByTestId("spec-role")).toHaveText("MODULE");
 
 	expect(await child.getAttribute("data-status")).toBeNull();

--- a/e2e/specs-panel.spec.ts
+++ b/e2e/specs-panel.spec.ts
@@ -20,6 +20,7 @@ test("Specs tab renders the worktree's spec tree and opens a spec as an editor t
 	await expect(root).toHaveAttribute("data-spec-role", "Main spec");
 	await expect(root.getByTestId("spec-role")).toBeHidden();
 	await root.hover();
+	await expect(root.getByTestId("spec-role")).toBeVisible();
 	await expect(root.getByTestId("spec-role")).toHaveText("Main spec");
 	await expect(child).toHaveAttribute("data-depth", "1");
 	await expect(child).toHaveAttribute("data-spec-role", "MODULE");

--- a/e2e/specs-panel.spec.ts
+++ b/e2e/specs-panel.spec.ts
@@ -18,10 +18,14 @@ test("Specs tab renders the worktree's spec tree and opens a spec as an editor t
 	await expect(root).toHaveAttribute("data-depth", "0");
 	await expect(root).toHaveAttribute("data-main-spec", "true");
 	await expect(root).toHaveAttribute("data-spec-role", "Main spec");
-	await expect(root).toContainText("Main spec");
+	await expect(root.getByTestId("spec-role")).toBeHidden();
+	await root.hover();
+	await expect(root.getByTestId("spec-role")).toHaveText("Main spec");
 	await expect(child).toHaveAttribute("data-depth", "1");
 	await expect(child).toHaveAttribute("data-spec-role", "MODULE");
-	await expect(child).toContainText("MODULE");
+	await expect(child.getByTestId("spec-role")).toBeHidden();
+	await child.hover();
+	await expect(child.getByTestId("spec-role")).toHaveText("MODULE");
 
 	expect(await child.getAttribute("data-status")).toBeNull();
 	await expect(child).not.toContainText("active");
@@ -72,6 +76,8 @@ test("Specs tab renders the worktree's spec tree and opens a spec as an editor t
 	await expect(submodule).toBeVisible();
 	await expect(submodule).toHaveAttribute("data-depth", "2");
 	await expect(submodule).toHaveAttribute("data-spec-role", "SUBMODULE");
+	await submodule.hover();
+	await expect(submodule.getByTestId("spec-role")).toHaveText("SUBMODULE");
 	const childLeftAfterRefresh = await child.evaluate(
 		(element) => element.getBoundingClientRect().left,
 	);

--- a/e2e/specs-panel.spec.ts
+++ b/e2e/specs-panel.spec.ts
@@ -77,7 +77,9 @@ test("Specs tab renders the worktree's spec tree and opens a spec as an editor t
 	await expect(submodule).toBeVisible();
 	await expect(submodule).toHaveAttribute("data-depth", "2");
 	await expect(submodule).toHaveAttribute("data-spec-role", "SUBMODULE");
+	await expect(submodule.getByTestId("spec-role")).toBeHidden();
 	await submodule.hover();
+	await expect(submodule.getByTestId("spec-role")).toBeVisible();
 	await expect(submodule.getByTestId("spec-role")).toHaveText("SUBMODULE");
 	const childLeftAfterRefresh = await child.evaluate(
 		(element) => element.getBoundingClientRect().left,


### PR DESCRIPTION
The trailing role column repeated down every row and truncated to `SUBMOD…` in the narrow rail; it now appears on row hover/focus only, untruncated, with the role still in each row's aria-label. Spec titles render their name/summary separator as `·` instead of an em dash.

## Summary
Before
<img width="808" height="1280" alt="image" src="https://github.com/user-attachments/assets/5ec12c79-f698-4b2d-93a6-a35c2f61818e" />

After
<img width="954" height="790" alt="image" src="https://github.com/user-attachments/assets/05598a2b-3418-4e7b-9007-145d6efa3527" />


## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
