### PR TITLE
fix(ci): make the Windows binary smoke real, not POSIX-shaped

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -19,10 +19,18 @@ GitHub releases. It owns no product code — only workflows, composite actions, 
   see `scripts/check-binary-seams.ts`), unit tests, no-agent e2e, and a **host-target** binary
   build+smoke+**e2e-vs-binary** (`bun run e2e:binary`: the same no-agent suite against the compiled
   artifact, minus the `@dev-seam` fake-login specs — the regression class that only exists inside the
-  binary; ubuntu only by decision, see `task-artifact-verification`). Fast, no provider auth. Gates
-  merges.
+  binary; ubuntu only by decision, see `task-artifact-verification`), **plus a windows-latest binary
+  build+smoke** (`binary-windows`). Fast, no provider auth. Gates merges.
 - **Release** (`nightly.yml` / `stable.yml` → `_release.yml` → `_build.yml`): trusts a green `main` (no
   test gate of its own) and produces published binaries + a GitHub release.
+
+**Why Windows gates PRs and macOS does not.** A release build is all-or-nothing: `release` needs
+`build.result == 'success'`, so one red matrix leg publishes *nothing* — quietly, with no notification, and
+with the other platforms' green artifacts discarded. #255 spent two nightlies and a stable dispatch that
+way on a Windows-only smoke fixture defect (see `module-cli`). Windows is where the host's assumptions
+diverge most (executable resolution, `PATH` shape, `USERPROFILE` vs `HOME`, real-OS trash), and its runner is
+the cheap half of that risk; macOS divergence is narrower (path canonicalization) and its runner minutes are
+dearer, so it stays release-matrix-only. A red release matrix still notifies nobody — an open gap.
 
 ## Channels
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,22 @@ jobs:
           name: playwright-report-binary
           path: playwright-report-binary/
           retention-days: 7
+
+  binary-windows:
+    name: Binary smoke (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - name: Cache bun install
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      # The Windows leg of the artifact smoke (why it gates PRs: .github/SPEC.md). e2e:binary stays ubuntu-only.
+      - run: bun run build:binary
+      - run: bun run smoke:binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,5 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
-      # The Windows leg of the artifact smoke (why it gates PRs: .github/SPEC.md). e2e:binary stays ubuntu-only.
       - run: bun run build:binary
       - run: bun run smoke:binary

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -242,6 +242,13 @@ and `trash`'s **native helper sidecars** (which macOS/Windows must execute from 
     `homedir()` — which pi's `getAgentDir()` uses — reads `USERPROFILE` on Windows and ignores `HOME`.
     Without it the default-agent-dir probe writes into the runner's (or a Windows developer's) real
     `%USERPROFILE%\.pi\agent` instead of the sandbox.
+  - **The two hosts run one at a time**: the default-agent probe boots, asserts and exits before the
+    custom-agent host is spawned. They load the *same* on-disk extension, and a concurrent initial load
+    races on the loader's transpile cache — harmless on POSIX, an EPERM-class failure on Windows, where the
+    loser silently falls back to a runtime without the extension (`prepareInitialRuntime`'s plain-runtime
+    path). A failed *rebuild* keeps the loaded generation, so only the boot load can lose the provider this
+    way — which is why the assertion reports `provider.status`'s `jbcentral` state on failure: `load-failed`
+    names that cause, `absent` names a fixture that never ran.
 
 ## Boundary
 

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -242,6 +242,15 @@ and `trash`'s **native helper sidecars** (which macOS/Windows must execute from 
     `homedir()` — which pi's `getAgentDir()` uses — reads `USERPROFILE` on Windows and ignores `HOME`.
     Without it the default-agent-dir probe writes into the runner's (or a Windows developer's) real
     `%USERPROFILE%\.pi\agent` instead of the sandbox.
+  - **Every spawned host's env is built by `hostEnv`, which drops the inherited case-variants of the keys
+    it overrides.** Windows env names are case-insensitive and the runner's is spelled `Path`, so the
+    familiar `{...process.env, PATH: x}` ships *both* keys and the child reads the inherited one — the host
+    then ran with the machine's real PATH, saw no fake `central`, reported `absent`, and never loaded the
+    extension while the fixture itself was provably fine.
+  - **Both legs require `provider.status`'s `jbcentral` to be `configured`**, not just the model to be
+    present: the artifact sits inside the *default* agent dir, so a leg that only checks `model.list` could
+    in principle pass through pi's own agent-dir discovery instead of the Central-fed absolute path this
+    gate exists to pin. The status read waits out a transient `configuring` (a boot-time watcher event).
   - **The two hosts run one at a time**: the default-agent probe boots, asserts and exits before the
     custom-agent host is spawned. They load the *same* on-disk extension, and a concurrent initial load
     races on the loader's transpile cache — harmless on POSIX, an EPERM-class failure on Windows, where the

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -248,6 +248,10 @@ and `trash`'s **native helper sidecars** (which macOS/Windows must execute from 
 - **Owns:** `src/args.ts` (pure `parseArgs(argv, env) → CliOptions` + `parseSubcommand` + `USAGE`),
   `src/index.ts` (the run-from-source `bootstrap()`: shell env → server → browser open → signal handlers),
   and the binary build + its boot smoke (`scripts/build-binary.ts`, `scripts/smoke-binary.ts`,
+  `scripts/artifactName.ts` — the one place the artifact filename rule lives, including the `.exe` Bun
+  appends for a Windows target, so the build's output path and the smoke's default input cannot disagree
+  the way they did on Windows; the release action re-derives the same name in bash because it is also the
+  published-asset contract, see `module-ci-release`),
   `src/compiled-entry.ts`, `src/web-assets.generated.*`, `src/bundled-extensions.generated.*`,
   `src/runtime-assets.generated.*`),
   `src/version.ts` (the release version stamped in at build time), `src/update.ts` (the `update`

--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -215,15 +215,33 @@ and `trash`'s **native helper sidecars** (which macOS/Windows must execute from 
   because the host stores git's symlink-resolved root — macOS `/var` → `/private/var`, Windows' 8.3 `TEMP`
   — so a fixture written at an unresolved path lands in an encoded session dir the host never scans, and
   the delete then truthfully no-ops while the file stays put), verifies both macOS/Windows helpers were
-  staged from the artifact, and SIGTERM exits 0. CI builds + smokes the binary on every PR (its host
-  target — the generation/bundling/staging logic is platform-independent, but a Linux-only smoke cannot
-  see path-canonicalization or real-OS-trash divergence: those first surface on the release matrix's
-  macOS/Windows runners). What it can't cover without provider auth: the factories registering inside a
+  staged from the artifact, and SIGTERM exits 0. CI builds + smokes the binary on every PR on **ubuntu and
+  windows** (each its host target); macOS binary coverage stays release-matrix-only. The Windows leg is not
+  optional polish: the host reaches that extension only when its Central inspection says *installed and
+  supported*, so the whole assertion is Windows-executable-shaped, and a ubuntu-only smoke let #255 ship a
+  release matrix that failed for two days while publishing nothing (see `module-ci-release`). What it can't cover without provider auth: the factories registering inside a
   live session (that's `e2e:agent` territory, run-from-source). The smoke's **broad-net sibling** is `bun run e2e:binary` (root
   `playwright.binary.config.ts`): the whole no-agent e2e suite executed against this binary — also in CI
   on every PR. And `bun run check:seams` (root `scripts/check-binary-seams.ts`) is the build-time canary
   for the seam class: it fails when a pi bump introduces a new bundler-opaque dynamic import the server's
   `registerBundledRuntime` doesn't statically register.
+- **The smoke's fixtures are host-OS-shaped, not POSIX-shaped.** Every one of them was a Windows failure
+  in a green-on-Linux suite:
+  - The **fake Central CLI is compiled** (`bun build --compile` into `central`/`central.exe`), not written
+    as a `#!/bin/sh` script: the host only feeds the synthetic extension to PI when `inspectJbcentral`
+    resolves *and spawns* a `central` reporting a supported version, and Windows can neither resolve an
+    extensionless file as an executable nor `CreateProcess` a shell script. A `.cmd` shim was rejected —
+    `Bun.spawn` cannot launch a batch file without a `cmd.exe` wrapper, and it splits the fixture per shell
+    dialect. Its argv surface stays the reviewed one: `--version` prints a synthetic `central <semver>`,
+    everything else exits non-zero (so the background `status` probe stays an `unknown` observation).
+  - The **pi-free `PATH` is derived from the live `PATH`** by dropping the entries that hold a `pi`
+    executable, then prepending the fake bin dir — never a hardcoded `/usr/bin:/bin` skeleton, which on
+    Windows leaves the host without `git.exe` or System32 (`project.open` shells out to bare `git`). The
+    smoke still asserts no `pi` is reachable, and additionally that `git` survived the filter.
+  - **`HOME` *and* `USERPROFILE` point at the smoke's temp home** in every spawned host, because
+    `homedir()` — which pi's `getAgentDir()` uses — reads `USERPROFILE` on Windows and ignores `HOME`.
+    Without it the default-agent-dir probe writes into the runner's (or a Windows developer's) real
+    `%USERPROFILE%\.pi\agent` instead of the sandbox.
 
 ## Boundary
 

--- a/apps/cli/scripts/artifactName.ts
+++ b/apps/cli/scripts/artifactName.ts
@@ -1,0 +1,5 @@
+export function binaryArtifactName(target?: string): string {
+	const base = target ? `thinkrail-${target.replace(/^bun-/, "")}` : "thinkrail";
+	const windows = target ? target.includes("windows") : process.platform === "win32";
+	return windows ? `${base}.exe` : base;
+}

--- a/apps/cli/scripts/build-binary.ts
+++ b/apps/cli/scripts/build-binary.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, relative, resolve, sep } from "node:path";
+import { binaryArtifactName } from "./artifactName";
 
 const cliDir = resolve(import.meta.dir, "..");
 const repoRoot = resolve(cliDir, "..", "..");
@@ -105,8 +106,7 @@ function generateRuntimeManifest(): void {
 }
 
 const target = process.argv.find((a) => a.startsWith("--target="))?.slice("--target=".length);
-const outName = target ? `thinkrail-${target.replace(/^bun-/, "")}` : "thinkrail";
-const outFile = join(outDir, outName);
+const outFile = join(outDir, binaryArtifactName(target));
 
 mkdirSync(outDir, { recursive: true });
 generateWebManifest();

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -4,8 +4,11 @@ import { existsSync, globSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } f
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { defaultSessionDirFor, writeFixtureSession } from "@thinkrail/server/history-test-fixtures";
+import { binaryArtifactName } from "./artifactName";
 
-const binary = resolve(process.argv[2] ?? join(import.meta.dir, "..", "dist", "thinkrail"));
+const binary = resolve(
+	process.argv[2] ?? join(import.meta.dir, "..", "dist", binaryArtifactName()),
+);
 if (!existsSync(binary)) {
 	console.error(`binary not found at ${binary} — run \`bun run build:binary\` first.`);
 	process.exit(1);

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -103,6 +103,15 @@ const sandboxEnv = {
 	THINKRAIL_NO_ANALYTICS: "1",
 };
 
+function hostEnv(overrides: Record<string, string>, unset: string[] = []): Record<string, string> {
+	const shadowed = new Set([...Object.keys(overrides), ...unset].map((name) => name.toLowerCase()));
+	const inherited: Record<string, string> = {};
+	for (const [name, value] of Object.entries(process.env)) {
+		if (value !== undefined && !shadowed.has(name.toLowerCase())) inherited[name] = value;
+	}
+	return { ...inherited, ...overrides };
+}
+
 const autoloadDir = join(tmp, "autoload-project");
 const preloadMarker = join(autoloadDir, "preload-ran");
 mkdirSync(autoloadDir, { recursive: true });
@@ -115,11 +124,7 @@ writeFileSync(
 {
 	const subCache = join(tmp, "subcommand-cache");
 	const run = Bun.spawnSync([binary, "uninstall", "--help"], {
-		env: {
-			...process.env,
-			...sandboxEnv,
-			XDG_CACHE_HOME: subCache,
-		},
+		env: hostEnv({ ...sandboxEnv, XDG_CACHE_HOME: subCache }),
 		stdout: "pipe",
 		stderr: "inherit",
 		cwd: autoloadDir,
@@ -161,13 +166,12 @@ if (gitCommit.exitCode !== 0) fail("could not commit the portable-skill smoke pr
 
 const spawnCustomAgentHost = () =>
 	Bun.spawn([binary, "--no-open", "--port", "24262"], {
-		env: {
-			...process.env,
+		env: hostEnv({
 			...sandboxEnv,
 			THINKRAIL_DATA_DIR: dataDir,
 			PI_CODING_AGENT_DIR: agentDir,
 			XDG_CACHE_HOME: cacheDir,
-		},
+		}),
 		stdout: "pipe",
 		stderr: "inherit",
 	});
@@ -244,29 +248,50 @@ function centralFixtureState(): string {
 	});
 }
 
-async function centralStatus(socket: WebSocket): Promise<string> {
+async function centralStatus(socket: WebSocket): Promise<{ state?: string } | null> {
 	try {
 		const report = (await within(
 			rpc(socket, "provider.status", {}),
 			10_000,
 			"provider.status",
-		)) as { jbcentral?: unknown };
-		return JSON.stringify(report.jbcentral ?? null);
+		)) as { jbcentral?: { state?: string } };
+		return report.jbcentral ?? null;
 	} catch (err) {
-		return `unreadable (${err instanceof Error ? err.message : String(err)})`;
+		return { state: `unreadable (${err instanceof Error ? err.message : String(err)})` };
 	}
 }
 
+async function settledCentralStatus(socket: WebSocket): Promise<{ state?: string } | null> {
+	for (let attempt = 0; attempt < 40; attempt += 1) {
+		const status = await centralStatus(socket);
+		if (status?.state !== "configuring") return status;
+		await new Promise((resolve) => setTimeout(resolve, 250));
+	}
+	return await centralStatus(socket);
+}
+
+async function assertExternalExtensionLoaded(
+	socket: WebSocket,
+	agentDirKind: string,
+): Promise<void> {
+	const models = await within(rpc(socket, "model.list", {}), 20_000, `${agentDirKind} model.list`);
+	const status = await settledCentralStatus(socket);
+	if (hasExternalExtensionModel(models) && status?.state === "configured") return;
+	fail(
+		`compiled binary did not load the global external extension with ${agentDirKind} (Central status: ${JSON.stringify(status)}, fixture: ${centralFixtureState()})`,
+	);
+}
+
 async function assertDefaultAgentDirExternalExtension(): Promise<void> {
-	const probeEnv = {
-		...process.env,
-		...sandboxEnv,
-		THINKRAIL_DATA_DIR: join(tmp, "default-agent-data"),
-		XDG_CACHE_HOME: join(tmp, "default-agent-cache"),
-	};
-	delete probeEnv.PI_CODING_AGENT_DIR;
 	const probe = Bun.spawn([binary, "--no-open", "--port", "24312"], {
-		env: probeEnv,
+		env: hostEnv(
+			{
+				...sandboxEnv,
+				THINKRAIL_DATA_DIR: join(tmp, "default-agent-data"),
+				XDG_CACHE_HOME: join(tmp, "default-agent-cache"),
+			},
+			["PI_CODING_AGENT_DIR"],
+		),
 		stdout: "pipe",
 		stderr: "inherit",
 	});
@@ -283,12 +308,7 @@ async function assertDefaultAgentDirExternalExtension(): Promise<void> {
 			"default-agent binary probe did not report a serving URL",
 		);
 		socket = await within(connectRpc(url), 10_000, "default-agent WebSocket connect");
-		const models = await within(rpc(socket, "model.list", {}), 20_000, "default-agent model.list");
-		if (!hasExternalExtensionModel(models)) {
-			fail(
-				`compiled binary did not load the global external extension with the default agent dir (Central status: ${await centralStatus(socket)}, fixture: ${centralFixtureState()})`,
-			);
-		}
+		await assertExternalExtensionLoaded(socket, "the default agent dir");
 		probe.kill("SIGTERM");
 		await within(probe.exited, 15_000, "default-agent probe shutdown");
 	} finally {
@@ -385,16 +405,7 @@ try {
 	}
 
 	rpcSocket = await within(connectRpc(url), 10_000, "WebSocket connect");
-	const externalModels = await within(
-		rpc(rpcSocket, "model.list", {}),
-		20_000,
-		"custom-agent model.list",
-	);
-	if (!hasExternalExtensionModel(externalModels)) {
-		fail(
-			`compiled binary did not load the global external extension with a custom agent dir (Central status: ${await centralStatus(rpcSocket)}, fixture: ${centralFixtureState()})`,
-		);
-	}
+	await assertExternalExtensionLoaded(rpcSocket, "a custom agent dir");
 	const project = (await within(
 		rpc(rpcSocket, "project.open", { path: projectDir }),
 		10_000,

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -159,18 +159,18 @@ const gitCommit = Bun.spawnSync([
 ]);
 if (gitCommit.exitCode !== 0) fail("could not commit the portable-skill smoke project");
 
-const proc = Bun.spawn([binary, "--no-open", "--port", "24262"], {
-	env: {
-		...process.env,
-		...sandboxEnv,
-		THINKRAIL_DATA_DIR: dataDir,
-		PI_CODING_AGENT_DIR: agentDir,
-		XDG_CACHE_HOME: cacheDir,
-	},
-	stdout: "pipe",
-	stderr: "inherit",
-});
-killHost = () => proc.kill("SIGKILL");
+const spawnCustomAgentHost = () =>
+	Bun.spawn([binary, "--no-open", "--port", "24262"], {
+		env: {
+			...process.env,
+			...sandboxEnv,
+			THINKRAIL_DATA_DIR: dataDir,
+			PI_CODING_AGENT_DIR: agentDir,
+			XDG_CACHE_HOME: cacheDir,
+		},
+		stdout: "pipe",
+		stderr: "inherit",
+	});
 
 async function connectRpc(baseUrl: string): Promise<WebSocket> {
 	const socket = new WebSocket(`${baseUrl.replace(/^http/, "ws")}/ws`);
@@ -218,6 +218,32 @@ async function readServedUrlFrom(processHandle: {
 	throw new Error(`stdout closed without a serving URL (output: ${JSON.stringify(buffered)})`);
 }
 
+function hasExternalExtensionModel(models: unknown): boolean {
+	return (
+		Array.isArray(models) &&
+		models.some(
+			(model) =>
+				typeof model === "object" &&
+				model !== null &&
+				(model as { provider?: string; id?: string }).provider === "compiled-external" &&
+				(model as { provider?: string; id?: string }).id === "compiled-external-model",
+		)
+	);
+}
+
+async function centralStatus(socket: WebSocket): Promise<string> {
+	try {
+		const report = (await within(
+			rpc(socket, "provider.status", {}),
+			10_000,
+			"provider.status",
+		)) as { jbcentral?: unknown };
+		return JSON.stringify(report.jbcentral ?? null);
+	} catch (err) {
+		return `unreadable (${err instanceof Error ? err.message : String(err)})`;
+	}
+}
+
 async function assertDefaultAgentDirExternalExtension(): Promise<void> {
 	const probeEnv = {
 		...process.env,
@@ -245,17 +271,10 @@ async function assertDefaultAgentDirExternalExtension(): Promise<void> {
 		);
 		socket = await within(connectRpc(url), 10_000, "default-agent WebSocket connect");
 		const models = await within(rpc(socket, "model.list", {}), 20_000, "default-agent model.list");
-		if (
-			!Array.isArray(models) ||
-			!models.some(
-				(model) =>
-					typeof model === "object" &&
-					model !== null &&
-					(model as { provider?: string; id?: string }).provider === "compiled-external" &&
-					(model as { provider?: string; id?: string }).id === "compiled-external-model",
-			)
-		) {
-			fail("compiled binary did not load the global external extension with the default agent dir");
+		if (!hasExternalExtensionModel(models)) {
+			fail(
+				`compiled binary did not load the global external extension with the default agent dir (Central status: ${await centralStatus(socket)})`,
+			);
 		}
 		probe.kill("SIGTERM");
 		await within(probe.exited, 15_000, "default-agent probe shutdown");
@@ -330,6 +349,8 @@ async function assertOAuthLoginReachesAuthUrl(socket: WebSocket): Promise<void> 
 let rpcSocket: WebSocket | null = null;
 try {
 	await assertDefaultAgentDirExternalExtension();
+	const proc = spawnCustomAgentHost();
+	killHost = () => proc.kill("SIGKILL");
 	const url = await within(
 		Promise.race([
 			readServedUrlFrom(proc),
@@ -356,17 +377,10 @@ try {
 		20_000,
 		"custom-agent model.list",
 	);
-	if (
-		!Array.isArray(externalModels) ||
-		!externalModels.some(
-			(model) =>
-				typeof model === "object" &&
-				model !== null &&
-				(model as { provider?: string; id?: string }).provider === "compiled-external" &&
-				(model as { provider?: string; id?: string }).id === "compiled-external-model",
-		)
-	) {
-		fail("compiled binary did not load the global external extension with a custom agent dir");
+	if (!hasExternalExtensionModel(externalModels)) {
+		fail(
+			`compiled binary did not load the global external extension with a custom agent dir (Central status: ${await centralStatus(rpcSocket)})`,
+		);
 	}
 	const project = (await within(
 		rpc(rpcSocket, "project.open", { path: projectDir }),

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -42,11 +42,20 @@ const fakeBinDir = join(tmp, "no-pi-bin");
 const centralArtifact = join(homeDir, ".pi", "agent", "extensions", "jetbrains-central.ts");
 mkdirSync(fakeBinDir, { recursive: true });
 mkdirSync(dirname(centralArtifact), { recursive: true });
+const centralFakeSource = join(tmp, "central-fake.ts");
+const centralFake = join(fakeBinDir, process.platform === "win32" ? "central.exe" : "central");
 writeFileSync(
-	join(fakeBinDir, "central"),
-	'#!/bin/sh\n[ "$1" = "--version" ] || exit 8\nprintf \'central 1.6.2 (synthetic smoke metadata)\\n\'\n',
-	{ mode: 0o755 },
+	centralFakeSource,
+	`if (process.argv[2] !== "--version") process.exit(8);\nprocess.stdout.write("central 1.6.2 (synthetic smoke metadata)\\n");\n`,
 );
+const compileFake = Bun.spawnSync(
+	[process.execPath, "build", "--compile", centralFakeSource, "--outfile", centralFake],
+	{ cwd: tmp, stdout: "pipe", stderr: "pipe" },
+);
+if (!compileFake.success || !existsSync(centralFake)) {
+	console.error(compileFake.stderr.toString());
+	fail(`could not compile the fake Central CLI at ${centralFake}`);
+}
 writeFileSync(
 	centralArtifact,
 	`const model = {
@@ -69,9 +78,27 @@ export default function syntheticExternalExtension(pi) {
 }
 `,
 );
-const noPiPath = [fakeBinDir, "/usr/bin", "/bin", "/usr/sbin", "/sbin"].join(delimiter);
+const noPiPath = [
+	fakeBinDir,
+	...(process.env.PATH ?? "")
+		.split(delimiter)
+		.filter((entry) => entry.length > 0 && !Bun.which("pi", { PATH: entry })),
+].join(delimiter);
 if (Bun.which("pi", { PATH: noPiPath }))
 	fail("the external-extension smoke PATH unexpectedly contains pi");
+if (!Bun.which("git", { PATH: noPiPath }))
+	fail("dropping every pi directory from PATH also dropped git — move pi out of git's directory");
+
+const sandboxEnv = {
+	HOME: homeDir,
+	USERPROFILE: homeDir,
+	CLAUDE_CONFIG_DIR: join(homeDir, ".claude"),
+	CODEX_HOME: join(homeDir, ".codex"),
+	GEMINI_CLI_HOME: homeDir,
+	PI_OFFLINE: "1",
+	PATH: noPiPath,
+	THINKRAIL_NO_ANALYTICS: "1",
+};
 
 const autoloadDir = join(tmp, "autoload-project");
 const preloadMarker = join(autoloadDir, "preload-ran");
@@ -87,9 +114,8 @@ writeFileSync(
 	const run = Bun.spawnSync([binary, "uninstall", "--help"], {
 		env: {
 			...process.env,
+			...sandboxEnv,
 			XDG_CACHE_HOME: subCache,
-			HOME: homeDir,
-			THINKRAIL_NO_ANALYTICS: "1",
 		},
 		stdout: "pipe",
 		stderr: "inherit",
@@ -133,16 +159,10 @@ if (gitCommit.exitCode !== 0) fail("could not commit the portable-skill smoke pr
 const proc = Bun.spawn([binary, "--no-open", "--port", "24262"], {
 	env: {
 		...process.env,
+		...sandboxEnv,
 		THINKRAIL_DATA_DIR: dataDir,
 		PI_CODING_AGENT_DIR: agentDir,
-		PI_OFFLINE: "1",
 		XDG_CACHE_HOME: cacheDir,
-		HOME: homeDir,
-		CLAUDE_CONFIG_DIR: join(homeDir, ".claude"),
-		CODEX_HOME: join(homeDir, ".codex"),
-		GEMINI_CLI_HOME: homeDir,
-		PATH: noPiPath,
-		THINKRAIL_NO_ANALYTICS: "1",
 	},
 	stdout: "pipe",
 	stderr: "inherit",
@@ -198,15 +218,9 @@ async function readServedUrlFrom(processHandle: {
 async function assertDefaultAgentDirExternalExtension(): Promise<void> {
 	const probeEnv = {
 		...process.env,
+		...sandboxEnv,
 		THINKRAIL_DATA_DIR: join(tmp, "default-agent-data"),
 		XDG_CACHE_HOME: join(tmp, "default-agent-cache"),
-		HOME: homeDir,
-		CLAUDE_CONFIG_DIR: join(homeDir, ".claude"),
-		CODEX_HOME: join(homeDir, ".codex"),
-		GEMINI_CLI_HOME: homeDir,
-		PI_OFFLINE: "1",
-		PATH: noPiPath,
-		THINKRAIL_NO_ANALYTICS: "1",
 	};
 	delete probeEnv.PI_CODING_AGENT_DIR;
 	const probe = Bun.spawn([binary, "--no-open", "--port", "24312"], {

--- a/apps/cli/scripts/smoke-binary.ts
+++ b/apps/cli/scripts/smoke-binary.ts
@@ -231,6 +231,19 @@ function hasExternalExtensionModel(models: unknown): boolean {
 	);
 }
 
+function centralFixtureState(): string {
+	const exe = existsSync(centralFake);
+	const version = exe
+		? Bun.spawnSync([centralFake, "--version"], { stdout: "pipe", stderr: "pipe" })
+		: null;
+	return JSON.stringify({
+		exe,
+		resolved: Bun.which("central", { PATH: noPiPath }),
+		artifact: existsSync(centralArtifact),
+		version: version && { code: version.exitCode, out: version.stdout.toString().trim() },
+	});
+}
+
 async function centralStatus(socket: WebSocket): Promise<string> {
 	try {
 		const report = (await within(
@@ -273,7 +286,7 @@ async function assertDefaultAgentDirExternalExtension(): Promise<void> {
 		const models = await within(rpc(socket, "model.list", {}), 20_000, "default-agent model.list");
 		if (!hasExternalExtensionModel(models)) {
 			fail(
-				`compiled binary did not load the global external extension with the default agent dir (Central status: ${await centralStatus(socket)})`,
+				`compiled binary did not load the global external extension with the default agent dir (Central status: ${await centralStatus(socket)}, fixture: ${centralFixtureState()})`,
 			);
 		}
 		probe.kill("SIGTERM");
@@ -379,7 +392,7 @@ try {
 	);
 	if (!hasExternalExtensionModel(externalModels)) {
 		fail(
-			`compiled binary did not load the global external extension with a custom agent dir (Central status: ${await centralStatus(rpcSocket)})`,
+			`compiled binary did not load the global external extension with a custom agent dir (Central status: ${await centralStatus(rpcSocket)}, fixture: ${centralFixtureState()})`,
 		);
 	}
 	const project = (await within(

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -100,7 +100,10 @@ still valid.
 
 Different worktrees may run concurrently. Two complete E2E invocations in one worktree remain sequential;
 the lane ids are deliberately stable across runs so interrupted state is reclaimed rather than leaked.
-No path may fall back to `~/.thinkrail`, the developer's HOME/config trees, or the real pi agent dir.
+No path may fall back to `~/.thinkrail`, the developer's HOME/config trees, or the real pi agent dir. A
+sandboxed home is handed to the host as **both `HOME` and `USERPROFILE`**: `homedir()` — pi's own home
+resolution — reads `USERPROFILE` on Windows and ignores `HOME`, so `HOME` alone would silently leak a
+Windows lane into the real profile (see `module-shared`).
 
 ## Boundary
 

--- a/e2e/workflows/harness/env.ts
+++ b/e2e/workflows/harness/env.ts
@@ -10,6 +10,7 @@ for (const file of ["auth.json", "models.json", "settings.json"]) {
 }
 
 process.env.HOME = E2E_HOME_DIR;
+process.env.USERPROFILE = E2E_HOME_DIR;
 process.env.CLAUDE_CONFIG_DIR = `${E2E_HOME_DIR}/.claude`;
 process.env.CODEX_HOME = `${E2E_HOME_DIR}/.codex`;
 process.env.GEMINI_CLI_HOME = E2E_HOME_DIR;

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -78,8 +78,8 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   there, not here.)
 - **/jbcentral** — the **single Central process/filesystem boundary**. It resolves Central by absolute path,
   parses a bounded `central --version` result into a compatibility verdict, exposes the
-  global opaque artifact path (`~/.pi/agent/extensions/jetbrains-central.ts`, and the `~/.local/bin/central`
-  fallback) and existence only, and invokes
+  global opaque artifact path (`~/.pi/agent/extensions/jetbrains-central.ts`, and the `~/.local/bin/`
+  installer fallback) and existence only, and invokes
   only the reviewed argv: `status`, `add pi`, `remove pi`, `login`, `update --install`, and
   `proxy start --ensure-updated`. Support is a **minimum version only** (`MINIMUM_CENTRAL_VERSION`,
   `1.4.0` — the first Central release carrying the native PI surface): anything at or above it is supported,
@@ -140,8 +140,14 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
 ## Get right (jbcentral)
 
 - **Detect + invoke Central by absolute path (`resolveJbcentralBin`), never by bare command.** Pass the live
-  `process.env.PATH` to lookup and retain the official `~/.local/bin/central` fallback, because a long-running
-  host must see a just-installed executable without restart.
+  `process.env.PATH` to lookup and retain the official `~/.local/bin` fallback, because a long-running
+  host must see a just-installed executable without restart. **The fallback names the file each OS's
+  installer actually writes** — `central.exe` on Windows, `central` elsewhere (`install.ps1` installs
+  `$HOME\.local\bin\central.exe`) — while the PATH lookup keeps the bare name, since `Bun.which` tries the
+  Windows executable extensions itself and refuses extensionless files there. An extensionless fallback on
+  Windows can never match a real install, which is precisely the case the fallback exists for: Central
+  installed from the in-app guidance while the host is already running with a stale PATH. Its unit test
+  pins the exact path, never an `exists` stub that answers true for everything.
 - **`~` is `USERPROFILE` on Windows and `HOME` everywhere else** — read from the live env, per platform, with
   `homedir()` only as the fallback. This is the *same* home pi resolves for `getAgentDir()`, which is the
   whole point: the adapter and pi must name one artifact. Two rejected forms, both real bugs:

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -78,7 +78,8 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   there, not here.)
 - **/jbcentral** — the **single Central process/filesystem boundary**. It resolves Central by absolute path,
   parses a bounded `central --version` result into a compatibility verdict, exposes the
-  global opaque artifact path (`~/.pi/agent/extensions/jetbrains-central.ts`) and existence only, and invokes
+  global opaque artifact path (`~/.pi/agent/extensions/jetbrains-central.ts`, and the `~/.local/bin/central`
+  fallback) and existence only, and invokes
   only the reviewed argv: `status`, `add pi`, `remove pi`, `login`, `update --install`, and
   `proxy start --ensure-updated`. Support is a **minimum version only** (`MINIMUM_CENTRAL_VERSION`,
   `1.4.0` — the first Central release carrying the native PI surface): anything at or above it is supported,
@@ -141,6 +142,15 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
 - **Detect + invoke Central by absolute path (`resolveJbcentralBin`), never by bare command.** Pass the live
   `process.env.PATH` to lookup and retain the official `~/.local/bin/central` fallback, because a long-running
   host must see a just-installed executable without restart.
+- **`~` is `USERPROFILE` on Windows and `HOME` everywhere else** — read from the live env, per platform, with
+  `homedir()` only as the fallback. This is the *same* home pi resolves for `getAgentDir()`, which is the
+  whole point: the adapter and pi must name one artifact. Two rejected forms, both real bugs:
+  `env.HOME ?? homedir()` (the original) silently loses on Windows, where `HOME` is ignored by pi but *is*
+  set by Git Bash to an MSYS path — Central would be installed and configured and ThinkRail would report
+  `absent`; and plain `homedir()` cannot be redirected in-process under Bun, which resolves it **once at
+  startup** rather than per call (Node re-reads it), so the tests and e2e/smoke hosts that redirect a home
+  would silently read the developer's real one. The platform is an injectable dependency (`platform`), so
+  both branches are pinned by unit tests on any host OS.
 - **Confidential-source-informed, public-surface-only.** Tracked artifacts contain only reviewed argv,
   compatibility bounds, the opaque path, typed outcomes, and independently authored fakes. Never copy or
   paraphrase Central source/output, and never read, parse, hash, snapshot, copy, log, upload, persist elsewhere,

--- a/packages/shared/src/jbcentral.test.ts
+++ b/packages/shared/src/jbcentral.test.ts
@@ -22,7 +22,7 @@ const CENTRAL_BIN = "/opt/central/bin/central";
 
 function adapterDeps(overrides: JbcentralAdapterDependencies = {}): JbcentralAdapterDependencies {
 	return {
-		env: { HOME: "/users/test", PATH: "/opt/central/bin" },
+		env: { HOME: "/users/test", USERPROFILE: "/users/test", PATH: "/opt/central/bin" },
 		which: () => CENTRAL_BIN,
 		exists: () => false,
 		...overrides,
@@ -355,7 +355,7 @@ ${script}
 		);
 		chmodSync(join(binDir, "central"), 0o755);
 		return {
-			env: { HOME: binDir, PATH: binDir },
+			env: { HOME: binDir, USERPROFILE: binDir, PATH: binDir },
 			exists: () => false,
 		};
 	}
@@ -380,7 +380,12 @@ ${script}
 		});
 		rmSync(join(binDir, "central"));
 		expect(
-			(await inspectJbcentral({ env: { HOME: binDir, PATH: binDir }, exists: () => false })).status,
+			(
+				await inspectJbcentral({
+					env: { HOME: binDir, USERPROFILE: binDir, PATH: binDir },
+					exists: () => false,
+				})
+			).status,
 		).toEqual({ state: "absent" });
 	});
 
@@ -477,13 +482,9 @@ describe("Central artifact watcher", () => {
 });
 
 describe("Central paths and install guidance", () => {
-	const originalPath = process.env.PATH;
-	const originalHome = process.env.HOME;
 	let tempHome: string | undefined;
 
 	afterEach(() => {
-		process.env.PATH = originalPath;
-		process.env.HOME = originalHome;
 		if (tempHome) rmSync(tempHome, { recursive: true, force: true });
 		tempHome = undefined;
 	});
@@ -496,7 +497,10 @@ describe("Central paths and install guidance", () => {
 		writeFileSync(central, "#!/bin/sh\n");
 		chmodSync(central, 0o755);
 
-		const deps = { env: { HOME: tempHome, PATH: "" }, which: () => null };
+		const deps = {
+			env: { HOME: tempHome, USERPROFILE: tempHome, PATH: "" },
+			which: () => null,
+		};
 		expect(resolveJbcentralBin(deps)).toBe(central);
 		expect(isJbcentralInstalled(deps)).toBe(true);
 		rmSync(central);
@@ -511,10 +515,23 @@ describe("Central paths and install guidance", () => {
 	});
 
 	test("uses the global extension even with a custom PI agent directory", () => {
-		const env = { HOME: "/home/person", PI_CODING_AGENT_DIR: "/tmp/custom-agent" };
-		expect(jbcentralExtensionPath(env)).toBe(
-			"/home/person/.pi/agent/extensions/jetbrains-central.ts",
+		const env = { HOME: "/home/person", USERPROFILE: "/home/person" };
+		expect(
+			jbcentralExtensionPath({ env: { ...env, PI_CODING_AGENT_DIR: "/tmp/custom-agent" } }),
+		).toBe("/home/person/.pi/agent/extensions/jetbrains-central.ts");
+	});
+
+	test("reads the home PI itself reads: USERPROFILE on Windows, HOME elsewhere", () => {
+		const env = { HOME: "/msys/person", USERPROFILE: "/profile/person" };
+		expect(jbcentralExtensionPath({ env, platform: "win32" })).toBe(
+			join("/profile/person", ".pi", "agent", "extensions", "jetbrains-central.ts"),
 		);
+		expect(jbcentralExtensionPath({ env, platform: "darwin" })).toBe(
+			join("/msys/person", ".pi", "agent", "extensions", "jetbrains-central.ts"),
+		);
+		expect(
+			resolveJbcentralBin({ env, platform: "win32", which: () => null, exists: () => true }),
+		).toBe(join("/profile/person", ".local", "bin", "central"));
 	});
 
 	test("returns official per-OS install plans", () => {

--- a/packages/shared/src/jbcentral.test.ts
+++ b/packages/shared/src/jbcentral.test.ts
@@ -529,9 +529,38 @@ describe("Central paths and install guidance", () => {
 		expect(jbcentralExtensionPath({ env, platform: "darwin" })).toBe(
 			join("/msys/person", ".pi", "agent", "extensions", "jetbrains-central.ts"),
 		);
+	});
+
+	test("the installer fallback is the exact path each OS's installer writes", () => {
+		const env = { HOME: "/msys/person", USERPROFILE: "/profile/person" };
+		const onlyExisting = (existing: string) => (path: string) => path === existing;
+		const windowsInstall = join("/profile/person", ".local", "bin", "central.exe");
+		const posixInstall = join("/msys/person", ".local", "bin", "central");
+
 		expect(
-			resolveJbcentralBin({ env, platform: "win32", which: () => null, exists: () => true }),
-		).toBe(join("/profile/person", ".local", "bin", "central"));
+			resolveJbcentralBin({
+				env,
+				platform: "win32",
+				which: () => null,
+				exists: onlyExisting(windowsInstall),
+			}),
+		).toBe(windowsInstall);
+		expect(
+			resolveJbcentralBin({
+				env,
+				platform: "darwin",
+				which: () => null,
+				exists: onlyExisting(posixInstall),
+			}),
+		).toBe(posixInstall);
+		expect(
+			resolveJbcentralBin({
+				env,
+				platform: "win32",
+				which: () => null,
+				exists: onlyExisting(join("/profile/person", ".local", "bin", "central")),
+			}),
+		).toBeNull();
 	});
 
 	test("returns official per-OS install plans", () => {

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -110,10 +110,17 @@ function pathExists(path: string, deps: JbcentralAdapterDependencies): boolean {
 	return (deps.exists ?? existsSync)(path);
 }
 
+function platformOf(deps: JbcentralAdapterDependencies): NodeJS.Platform {
+	return deps.platform ?? process.platform;
+}
+
 function homeDirectory(deps: JbcentralAdapterDependencies): string {
 	const env = effectiveEnv(deps);
-	const platform = deps.platform ?? process.platform;
-	return (platform === "win32" ? env.USERPROFILE : env.HOME) ?? homedir();
+	return (platformOf(deps) === "win32" ? env.USERPROFILE : env.HOME) ?? homedir();
+}
+
+function centralExecutableName(deps: JbcentralAdapterDependencies): string {
+	return platformOf(deps) === "win32" ? `${CENTRAL_BIN}.exe` : CENTRAL_BIN;
 }
 
 export function jbcentralExtensionPath(deps: JbcentralAdapterDependencies = {}): string {
@@ -127,7 +134,7 @@ export function resolveJbcentralBin(deps: JbcentralAdapterDependencies = {}): st
 	const onPath = which(CENTRAL_BIN, path);
 	if (onPath && isAbsolute(onPath)) return onPath;
 
-	const local = join(homeDirectory(deps), ".local", "bin", CENTRAL_BIN);
+	const local = join(homeDirectory(deps), ".local", "bin", centralExecutableName(deps));
 	return pathExists(local, deps) ? local : null;
 }
 

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -87,6 +87,7 @@ interface LoginHandle {
 
 export interface JbcentralAdapterDependencies {
 	env?: ParseEnv;
+	platform?: NodeJS.Platform;
 	which?: (command: string, path: string) => string | null;
 	exists?: (path: string) => boolean;
 	run?: (request: ProcessRequest) => Promise<ProcessResult>;
@@ -109,8 +110,14 @@ function pathExists(path: string, deps: JbcentralAdapterDependencies): boolean {
 	return (deps.exists ?? existsSync)(path);
 }
 
-export function jbcentralExtensionPath(env: ParseEnv = process.env): string {
-	return join(env.HOME ?? homedir(), ".pi", "agent", "extensions", "jetbrains-central.ts");
+function homeDirectory(deps: JbcentralAdapterDependencies): string {
+	const env = effectiveEnv(deps);
+	const platform = deps.platform ?? process.platform;
+	return (platform === "win32" ? env.USERPROFILE : env.HOME) ?? homedir();
+}
+
+export function jbcentralExtensionPath(deps: JbcentralAdapterDependencies = {}): string {
+	return join(homeDirectory(deps), ".pi", "agent", "extensions", "jetbrains-central.ts");
 }
 
 export function resolveJbcentralBin(deps: JbcentralAdapterDependencies = {}): string | null {
@@ -120,7 +127,7 @@ export function resolveJbcentralBin(deps: JbcentralAdapterDependencies = {}): st
 	const onPath = which(CENTRAL_BIN, path);
 	if (onPath && isAbsolute(onPath)) return onPath;
 
-	const local = join(env.HOME ?? homedir(), ".local", "bin", CENTRAL_BIN);
+	const local = join(homeDirectory(deps), ".local", "bin", CENTRAL_BIN);
 	return pathExists(local, deps) ? local : null;
 }
 
@@ -225,7 +232,7 @@ function processRunner(deps: JbcentralAdapterDependencies) {
 export async function inspectJbcentral(
 	deps: JbcentralAdapterDependencies = {},
 ): Promise<JbcentralInspection> {
-	const extensionPath = jbcentralExtensionPath(effectiveEnv(deps));
+	const extensionPath = jbcentralExtensionPath(deps);
 	const artifactExists = pathExists(extensionPath, deps);
 	const executablePath = resolveJbcentralBin(deps);
 	if (!executablePath) {
@@ -375,7 +382,7 @@ export async function runJbcentralAction(
 	}
 	if (result.exitCode !== 0) return { outcome: "failed", reason: "nonzero-exit" };
 
-	const artifactExists = pathExists(jbcentralExtensionPath(effectiveEnv(deps)), deps);
+	const artifactExists = pathExists(jbcentralExtensionPath(deps), deps);
 	if (action === "add" && !artifactExists) {
 		return { outcome: "failed", reason: "artifact-missing" };
 	}
@@ -456,7 +463,7 @@ export function watchJbcentralArtifact(
 	onInvalidate: () => void,
 	deps: JbcentralAdapterDependencies = {},
 ): () => void {
-	const extensionPath = jbcentralExtensionPath(effectiveEnv(deps));
+	const extensionPath = jbcentralExtensionPath(deps);
 	const watchDirectory = deps.watchDirectory ?? nodeWatchDirectory;
 	let stopped = false;
 	let watchedDirectory: string | null = null;

--- a/playwright.binary.config.ts
+++ b/playwright.binary.config.ts
@@ -89,6 +89,7 @@ export default defineConfig({
 			THINKRAIL_GH_OFFLINE: "1",
 			// Keep cross-agent personal skill aliases away from the developer's real homes/overrides.
 			HOME: E2E_HOME_DIR,
+			USERPROFILE: E2E_HOME_DIR,
 			CLAUDE_CONFIG_DIR: `${E2E_HOME_DIR}/.claude`,
 			CODEX_HOME: `${E2E_HOME_DIR}/.codex`,
 			GEMINI_CLI_HOME: E2E_HOME_DIR,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
 			THINKRAIL_GH_OFFLINE: "1",
 			// Keep cross-agent personal skill aliases away from the developer's real homes/overrides.
 			HOME: E2E_HOME_DIR,
+			USERPROFILE: E2E_HOME_DIR,
 			CLAUDE_CONFIG_DIR: `${E2E_HOME_DIR}/.claude`,
 			CODEX_HOME: `${E2E_HOME_DIR}/.codex`,
 			GEMINI_CLI_HOME: E2E_HOME_DIR,


### PR DESCRIPTION

---

## What the new Windows leg then found (the reason this PR grew)

The gate earned its keep immediately: each fix uncovered the next defect, all of them invisible on
Linux/macOS.

1. **`smoke:binary`'s default binary path was wrong on Windows.** `build:binary` writes `thinkrail.exe`
   (Bun appends the extension for a Windows target) while the smoke defaulted to `dist/thinkrail`. The
   release action never hit it — it passes the resolved path. The name rule now lives once in
   `apps/cli/scripts/artifactName.ts`, used by the build for its output and the smoke for its default.
2. **The two hosts booted concurrently and raced on the extension's transpile cache.** They load the same
   on-disk artifact; on Windows the loser's *initial* load fails and `prepareInitialRuntime` falls back to
   a runtime without the extension. The custom-agent host is now spawned after the probe has asserted and
   exited. (A failed *rebuild* keeps the loaded generation — only the boot load can lose the provider.)
3. **The env overrides did not override.** With the fixture provably healthy (`central.exe` present,
   resolvable, `--version` → exit 0) the host still reported Central `absent`: Windows env names are
   case-insensitive and the runner's PATH is spelled `Path`, so `{...process.env, PATH: noPiPath}` handed
   the child *both* keys and it read the inherited one — the host ran with the machine's real PATH.
   `hostEnv` now drops every inherited case-variant of the keys it overrides or unsets.

Two things made that chain cheap to unwind, and both stay: the failure now reports
`provider.status`'s `jbcentral` state **and** the fixture's own state (exe present? resolvable? what did
`--version` say?), and **both legs require `jbcentral` to be `configured`** rather than just a
`compiled-external` model in `model.list` — the artifact lives inside the *default* agent dir, so that leg
could otherwise pass via pi's own agent-dir discovery instead of the Central-fed absolute path this gate
exists to pin. Verified in both directions locally: green as written, and with a fake that exits non-zero
the smoke fails fast naming `probe-failed / nonzero-exit`.

**All five checks are green, including `Binary smoke (windows)`.**

---

## Review round (rebased onto `main`)

Rebased onto `main` (`9c1aa6e2`) — no conflicts — and addressed all four review findings:

| finding | resolution |
|---|---|
| **Blocking:** Windows job calls `smoke:binary` without the `.exe` path | Already fixed in `e6e0f63f`: the artifact filename rule lives once in `apps/cli/scripts/artifactName.ts`, used by the build's output and the smoke's default input. |
| **Blocking:** serializing the hosts didn't restore the custom-agent load | Root cause found via the diagnostics that commit added, fixed in `96ae7ab7`: the env overrides weren't overriding (Windows env names are case-insensitive; the runner's is `Path`). |
| **Non-blocking:** rationale comment in `ci.yml` duplicates the spec | Removed (`c882835a`) — rationale lives only in `.github/SPEC.md`, per the near-zero-comments invariant. |
| **Blocking:** the `~/.local/bin` fallback probes extensionless `central`, and the new test masked it with `exists: () => true` | **A real defect in this PR** — fixed in `f2b73377`. Verified against the published `install.ps1` (`$installDir = "$HOME\.local\bin"`, `$binName = "$progName.exe"`): the fallback now names what each OS installs (`central.exe` on win32), the PATH lookup keeps the bare name (`Bun.which` handles Windows extensions), and the test pins the exact path per platform plus a null for the extensionless Windows path. |

All five checks green on the current head.
