### PR TITLE
chat: mid-stream messages — pi-parity queueing, legible send modes, per-row queue editing, hard interrupt

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -1,6 +1,7 @@
 import type {
 	AskUserQuestionResult,
 	PromptHit,
+	QueueLane,
 	SlashCommandInfo,
 	TemplateInfo,
 	ThinkingLevel,
@@ -285,7 +286,11 @@ export default function ChatView({
 		composerRef.current?.refocus();
 	};
 
-	const onSubmit = (text: string, attachments: ChatAttachment[], behavior: SubmitBehavior) => {
+	const performSend = (
+		text: string,
+		attachments: ChatAttachment[],
+		behavior: Exclude<SubmitBehavior, "interrupt">,
+	) => {
 		const queued = behavior !== "send";
 		if (!queued && (text || attachments.length > 0))
 			useAppStore.getState().appendUserMessage(sessionId, text, attachments);
@@ -305,14 +310,39 @@ export default function ChatView({
 			});
 	};
 
+	const onSubmit = (text: string, attachments: ChatAttachment[], behavior: SubmitBehavior) => {
+		if (behavior !== "interrupt") {
+			performSend(text, attachments, behavior);
+			return;
+		}
+		getTransport()
+			.request("session.abort", { sessionId })
+			.then(() => performSend(text, attachments, "send"))
+			.catch((err) => {
+				useAppStore.getState().appendErrorTurn(sessionId, errorText(err));
+				restoreTextToDraft(text);
+			});
+	};
+
+	const removeQueued = (kind: QueueLane, index: number) =>
+		getTransport().request("session.removeQueued", { sessionId, kind, index });
+
+	const onEditQueued = (kind: QueueLane, index: number) =>
+		void removeQueued(kind, index)
+			.then(({ removed }) => {
+				if (removed !== null) restoreTextToDraft(removed);
+			})
+			.catch(() => {});
+
+	const onRemoveQueued = (kind: QueueLane, index: number) =>
+		void removeQueued(kind, index).catch(() => {});
+
 	const restoreQueueToDraft = async (): Promise<void> => {
 		const { steering, followUp } = await getTransport().request("session.clearQueue", {
 			sessionId,
 		});
 		restoreTextToDraft([...steering, ...followUp].join("\n\n"));
 	};
-
-	const onDequeue = () => void restoreQueueToDraft().catch(() => {});
 
 	const onAbort = () => {
 		void restoreQueueToDraft().catch(() => {});
@@ -568,7 +598,7 @@ export default function ChatView({
 							))}
 						</div>
 					) : null}
-					<QueueStrip queue={queue} onDequeue={onDequeue} />
+					<QueueStrip queue={queue} onEdit={onEditQueued} onRemove={onRemoveQueued} />
 					<div className="relative shrink-0">
 						<HistoryOverlay
 							state={historyState}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -34,6 +34,7 @@ import {
 import { ExtUiDialog } from "./ExtUiDialog";
 import { HistoryOverlay } from "./HistoryOverlay";
 import { planGlance } from "./planView";
+import { QueueStrip } from "./QueueStrip";
 import { type ChatRow, deriveRows, rowIndexForTurn } from "./rows";
 import { SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
@@ -133,6 +134,7 @@ export default function ChatView({
 		stats,
 		commands,
 		draft,
+		queue,
 		pendingExtUi,
 		extUiStatus,
 		extUiWidget,
@@ -275,8 +277,17 @@ export default function ChatView({
 			.catch(() => {});
 	};
 
+	const restoreTextToDraft = (text: string) => {
+		if (!text.trim()) return;
+		const current = useAppStore.getState().sessions[sessionId]?.draft ?? "";
+		const combined = [text, current].filter((t) => t.trim()).join("\n\n");
+		useAppStore.getState().setChatDraft(sessionId, combined);
+		composerRef.current?.refocus();
+	};
+
 	const onSubmit = (text: string, attachments: ChatAttachment[], behavior: SubmitBehavior) => {
-		if (text || attachments.length > 0)
+		const queued = behavior !== "send";
+		if (!queued && (text || attachments.length > 0))
 			useAppStore.getState().appendUserMessage(sessionId, text, attachments);
 		const images = attachments.map((a) => a.content);
 		const params = { sessionId, text, ...(images.length > 0 ? { images } : {}) };
@@ -288,10 +299,23 @@ export default function ChatView({
 					: "session.prompt";
 		getTransport()
 			.request(method, params)
-			.catch((err) => useAppStore.getState().appendErrorTurn(sessionId, errorText(err)));
+			.catch((err) => {
+				useAppStore.getState().appendErrorTurn(sessionId, errorText(err));
+				if (queued) restoreTextToDraft(text);
+			});
 	};
 
+	const restoreQueueToDraft = async (): Promise<void> => {
+		const { steering, followUp } = await getTransport().request("session.clearQueue", {
+			sessionId,
+		});
+		restoreTextToDraft([...steering, ...followUp].join("\n\n"));
+	};
+
+	const onDequeue = () => void restoreQueueToDraft().catch(() => {});
+
 	const onAbort = () => {
+		void restoreQueueToDraft().catch(() => {});
 		getTransport()
 			.request("session.abort", { sessionId })
 			.catch(() => {});
@@ -544,6 +568,7 @@ export default function ChatView({
 							))}
 						</div>
 					) : null}
+					<QueueStrip queue={queue} onDequeue={onDequeue} />
 					<div className="relative shrink-0">
 						<HistoryOverlay
 							state={historyState}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -4,7 +4,16 @@ import {
 	type ThinkingLevel,
 	type WireModel,
 } from "@thinkrail/contracts";
-import { ArrowUp, FileIcon, FolderIcon, History, Sparkles, Square, X } from "lucide-react";
+import {
+	ArrowUp,
+	ChevronUp,
+	FileIcon,
+	FolderIcon,
+	History,
+	Sparkles,
+	Square,
+	X,
+} from "lucide-react";
 import {
 	type ClipboardEvent,
 	type DragEvent,
@@ -17,6 +26,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { FileChip } from "./FileChip";
 import { type AttachedImage, fileToAttachedImage } from "./imageAttachment";
 import { ModelSelector } from "./ModelSelector";
@@ -37,7 +47,31 @@ import {
 import { ThinkingSelector } from "./ThinkingSelector";
 import type { ChatAttachment } from "./types";
 
-export type SubmitBehavior = "send" | "steer" | "followUp";
+export type SubmitBehavior = "send" | "steer" | "followUp" | "interrupt";
+
+const STREAMING_SEND_MODES = [
+	{
+		behavior: "steer" as const,
+		name: "Steer",
+		meaning: "delivers at the agent's next step",
+		keys: "Enter",
+		testid: "send-mode-steer",
+	},
+	{
+		behavior: "followUp" as const,
+		name: "Queue",
+		meaning: "runs after the agent finishes",
+		keys: "Cmd/Ctrl+Enter",
+		testid: "send-mode-queue",
+	},
+	{
+		behavior: "interrupt" as const,
+		name: "Interrupt",
+		meaning: "stops the current response and sends now",
+		keys: "Cmd/Ctrl+Shift+Enter",
+		testid: "send-mode-interrupt",
+	},
+];
 
 export interface MentionCandidate {
 	path: string;
@@ -183,6 +217,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const [attachErrors, setAttachErrors] = useState<AttachError[]>([]);
 	const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
 	const [mentionDismissed, setMentionDismissed] = useState(false);
+	const [sendMenuOpen, setSendMenuOpen] = useState(false);
 	const recallIdxRef = useRef<number | null>(null);
 	const [slots, setSlots] = useState<TemplateSlot[] | null>(null);
 	const [slotIdx, setSlotIdx] = useState(0);
@@ -434,6 +469,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			}
 			return;
 		}
+		if (e.key === "Enter" && e.shiftKey && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			submit(isStreaming ? "interrupt" : "send");
+			return;
+		}
 		if (e.key === "Enter" && !e.shiftKey) {
 			e.preventDefault();
 			const behavior: SubmitBehavior = isStreaming
@@ -659,7 +699,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 						rows={4}
 						placeholder={
 							isStreaming
-								? "Enter to steer · Cmd/Ctrl+Enter to queue · @ files · / commands"
+								? "Enter steers at the next step · Cmd/Ctrl+Enter queues for when it finishes"
 								: "Message the agent…  (@ files · / commands · Enter to send)"
 						}
 						className="relative min-h-[108px] w-full resize-none rounded-[var(--radius-sm)] bg-transparent px-md py-sm tr-text-ui text-text-default outline-none placeholder:text-text-muted"
@@ -700,6 +740,45 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							>
 								<Square className="size-3.5" />
 							</button>
+						) : null}
+						{isStreaming ? (
+							<Popover open={sendMenuOpen} onOpenChange={setSendMenuOpen}>
+								<PopoverTrigger asChild>
+									<button
+										type="button"
+										data-testid="send-menu"
+										aria-label="Send options"
+										className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg text-text-default hover:bg-control-bg-hovered"
+									>
+										<ChevronUp className="size-3.5" />
+									</button>
+								</PopoverTrigger>
+								<PopoverContent side="top" align="end" className="w-[320px] p-xs">
+									<div className="flex flex-col gap-2xs">
+										{STREAMING_SEND_MODES.map((mode) => (
+											<button
+												key={mode.behavior}
+												type="button"
+												data-testid={mode.testid}
+												disabled={!canSubmit(value)}
+												onClick={() => {
+													setSendMenuOpen(false);
+													submit(mode.behavior);
+												}}
+												className="flex w-full flex-col gap-2xs rounded-[var(--radius-sm)] px-sm py-xs text-left hover:bg-control-bg-hovered disabled:pointer-events-none disabled:opacity-50"
+											>
+												<span className="flex w-full items-baseline justify-between gap-sm">
+													<span className="text-text-default tr-text-ui">{mode.name}</span>
+													<span className="shrink-0 text-text-muted tr-text-metadata">
+														{mode.keys}
+													</span>
+												</span>
+												<span className="text-text-muted tr-text-metadata">{mode.meaning}</span>
+											</button>
+										))}
+									</div>
+								</PopoverContent>
+							</Popover>
 						) : null}
 						<button
 							type="button"

--- a/apps/web/src/chat/QueueStrip.tsx
+++ b/apps/web/src/chat/QueueStrip.tsx
@@ -1,42 +1,69 @@
-import type { SessionQueueState } from "@thinkrail/contracts";
+import type { QueueLane, SessionQueueState } from "@thinkrail/contracts";
+import { Pencil, X } from "lucide-react";
 
 export function QueueStrip({
 	queue,
-	onDequeue,
+	onEdit,
+	onRemove,
 }: {
 	queue: SessionQueueState;
-	onDequeue: () => void;
+	onEdit: (kind: QueueLane, index: number) => void;
+	onRemove: (kind: QueueLane, index: number) => void;
 }) {
-	const occurrences = new Map<string, number>();
 	const items = [
-		...queue.steering.map((text) => ({ kind: "steering" as const, label: "Steering", text })),
-		...queue.followUp.map((text) => ({ kind: "followUp" as const, label: "Follow-up", text })),
-	].map((item) => {
-		const base = `${item.kind}:${item.text}`;
-		const seen = occurrences.get(base) ?? 0;
-		occurrences.set(base, seen + 1);
-		return { ...item, key: `${base}:${seen}` };
-	});
+		...queue.steering.map((text, index) => ({
+			kind: "steering" as const,
+			index,
+			label: "Steering",
+			hint: "delivers at the agent's next step",
+			text,
+		})),
+		...queue.followUp.map((text, index) => ({
+			kind: "followUp" as const,
+			index,
+			label: "Follow-up",
+			hint: "runs after the agent finishes",
+			text,
+		})),
+	];
 	if (items.length === 0) return null;
 	return (
-		<button
-			type="button"
+		<div
 			data-testid="queue-strip"
-			aria-label="Edit queued messages"
-			onClick={onDequeue}
-			className="flex w-full shrink-0 flex-col gap-2xs border-border-default border-t bg-container-elevated-bg px-md py-xs text-left text-text-muted tr-text-metadata hover:bg-control-bg-hovered hover:text-text-default"
+			className="flex w-full shrink-0 flex-col gap-2xs border-border-default border-t bg-container-elevated-bg px-md py-xs text-text-muted tr-text-metadata"
 		>
 			{items.map((item) => (
-				<span
-					key={item.key}
+				<div
+					key={`${item.kind}:${item.index}`}
 					data-testid="queue-item"
 					data-kind={item.kind}
-					className="w-full truncate"
+					data-index={item.index}
+					title={`${item.text} — ${item.hint}`}
+					className="flex w-full items-center gap-sm"
 				>
-					<span className="text-text-default">{item.label}:</span> {item.text}
-				</span>
+					<span className="min-w-0 flex-1 truncate">
+						<span className="text-text-default">{item.label}:</span> {item.text}
+					</span>
+					<button
+						type="button"
+						data-testid="queue-item-edit"
+						aria-label={`Edit queued message: ${item.text}`}
+						onClick={() => onEdit(item.kind, item.index)}
+						className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-xs)] hover:bg-control-bg-hovered hover:text-text-default"
+					>
+						<Pencil className="size-3" />
+					</button>
+					<button
+						type="button"
+						data-testid="queue-item-remove"
+						aria-label={`Remove queued message: ${item.text}`}
+						onClick={() => onRemove(item.kind, item.index)}
+						className="flex size-5 shrink-0 items-center justify-center rounded-[var(--radius-xs)] hover:bg-control-bg-hovered hover:text-text-default"
+					>
+						<X className="size-3" />
+					</button>
+				</div>
 			))}
-			<span className="w-full truncate opacity-70">↳ click to edit queued messages</span>
-		</button>
+		</div>
 	);
 }

--- a/apps/web/src/chat/QueueStrip.tsx
+++ b/apps/web/src/chat/QueueStrip.tsx
@@ -1,0 +1,42 @@
+import type { SessionQueueState } from "@thinkrail/contracts";
+
+export function QueueStrip({
+	queue,
+	onDequeue,
+}: {
+	queue: SessionQueueState;
+	onDequeue: () => void;
+}) {
+	const occurrences = new Map<string, number>();
+	const items = [
+		...queue.steering.map((text) => ({ kind: "steering" as const, label: "Steering", text })),
+		...queue.followUp.map((text) => ({ kind: "followUp" as const, label: "Follow-up", text })),
+	].map((item) => {
+		const base = `${item.kind}:${item.text}`;
+		const seen = occurrences.get(base) ?? 0;
+		occurrences.set(base, seen + 1);
+		return { ...item, key: `${base}:${seen}` };
+	});
+	if (items.length === 0) return null;
+	return (
+		<button
+			type="button"
+			data-testid="queue-strip"
+			aria-label="Edit queued messages"
+			onClick={onDequeue}
+			className="flex w-full shrink-0 flex-col gap-2xs border-border-default border-t bg-container-elevated-bg px-md py-xs text-left text-text-muted tr-text-metadata hover:bg-control-bg-hovered hover:text-text-default"
+		>
+			{items.map((item) => (
+				<span
+					key={item.key}
+					data-testid="queue-item"
+					data-kind={item.kind}
+					className="w-full truncate"
+				>
+					<span className="text-text-default">{item.label}:</span> {item.text}
+				</span>
+			))}
+			<span className="w-full truncate opacity-70">↳ click to edit queued messages</span>
+		</button>
+	);
+}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -274,20 +274,37 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   skill overrides, + a **Reload** that applies changes to this chat's session via `session.reloadResources`,
   disabled while streaming) or project (`project.skills`, per-project-baseline toggles, no session) — the
   latter reused by `panels` pre-session). All props-driven; behavior detail lives in the components' jsdoc.
-- **Queued messages: the pending strip** (`QueueStrip.tsx`, props-driven: `queue` + `onDequeue`) — the
-  web mirror of pi's interactive-mode pending-messages area. A **streaming send never renders an
+- **Queued messages: the pending strip** (`QueueStrip.tsx`, props-driven: `queue` + `onEdit`/`onRemove`)
+  — the web mirror of pi's interactive-mode pending-messages area. A **streaming send never renders an
   optimistic transcript bubble** (see the store SPEC's echo contract): `ChatView.onSubmit` skips
   `appendUserMessage` for `steer`/`followUp`, and the queued texts render between transcript and
-  composer as one dim clickable strip — a truncated `Steering:`/`Follow-up:` line per message
-  (`queue-strip`/`queue-item` testids, `data-kind`) + an edit hint, sourced from the runtime's `queue`.
-  **Dequeue = click**: `session.clearQueue` returns the texts and `ChatView` prepends them to the draft
-  (queued first, `\n\n`-joined — pi's own restore order); the strip clears via pi's emptying
-  `queue_update`. **Abort restores the queue too** (`onAbort` dequeues first, then `session.abort`) —
-  pi's Escape parity: an aborted run must not silently discard messages the user queued behind it. A
-  **rejected** streaming send likewise restores its text to the draft alongside the `appendErrorTurn`
-  (no bubble holds it anymore). Trade-off, accepted: `queue_update` carries text only, so a queued
-  image attachment shows no chip in the strip; the canonical transcript turn later renders its image
-  blocks with the hydrated-turn fallback labels. E2e: `queue.live.spec.ts` (@agent).
+  composer as dim rows — one truncated `Steering:`/`Follow-up:` line per message (`queue-strip` /
+  `queue-item` testids, `data-kind` + `data-index`; full text + delivery meaning in the row `title`),
+  sourced from the runtime's `queue`. **Each row carries its own edit and remove actions**
+  (`queue-item-edit` / `queue-item-remove`) — both call `session.removeQueued { kind, index }` (rows
+  are position-addressed, matching the wire op); edit additionally prepends the removed text to the
+  draft and refocuses. Per-row actions exist because the original all-or-nothing dequeue (click strip
+  → `clearQueue` → every message merged into one draft blob) proved undiscoverable and lossy in use.
+  **Abort still restores the whole queue** (`onAbort` → `session.clearQueue` → texts prepended
+  `\n\n`-joined, pi's restore order, then `session.abort`) — pi's Escape parity: an aborted run must
+  not silently discard messages queued behind it. A **rejected** streaming send likewise restores its
+  text to the draft alongside the `appendErrorTurn`. Trade-off, accepted: `queue_update` carries text
+  only, so a queued image attachment shows no chip in the strip; the canonical transcript turn later
+  renders its image blocks with the hydrated-turn fallback labels. E2e: `queue.live.spec.ts` (@agent).
+- **Streaming send modes: split send + interrupt** (`Composer`) — steer/queue semantics are pi's loop
+  design (steer = injected at the next turn boundary, after the current assistant message + its tool
+  calls; queue = runs after the agent settles; only abort halts an in-flight response) and proved
+  illegible from key-name hints alone. While streaming the composer therefore self-documents: the
+  placeholder states meanings ("Enter steers at the next step · Cmd/Ctrl+Enter queues for when it
+  finishes") and a **send-options menu** (`send-menu` trigger beside the send button; rows
+  `send-mode-steer` / `send-mode-queue` / `send-mode-interrupt`) names each mode with a one-line
+  meaning + shortcut. Menu rows are **actions** (send the current draft with that mode), never a
+  sticky mode switch — a persistent mode would make the next plain Enter silently obey hidden state.
+  **Interrupt** (`SubmitBehavior: "interrupt"`, Cmd/Ctrl+Shift+Enter while streaming; plain send when
+  idle; Shift+Enter alone stays newline) is the "take my message NOW" gesture pi lacks: `ChatView`
+  awaits `session.abort` (the ack means idle) then performs an ordinary idle send — the partial reply
+  stays in the transcript marked aborted, and messages still queued keep their lanes (they deliver in
+  the run the interrupt starts). Rejection restores the draft like other streaming sends.
 - **History overlay: zoomed preview pane + scope picker** (`HistoryOverlay.tsx`) — `Tab` grows the
   compact single-column overlay into a **two-pane** `zoomed` layout: the existing Prompts/Messages
   sections list stays on the left (~55% width, `data-testid="history-results"` — keyboard nav,

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -274,6 +274,20 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   skill overrides, + a **Reload** that applies changes to this chat's session via `session.reloadResources`,
   disabled while streaming) or project (`project.skills`, per-project-baseline toggles, no session) — the
   latter reused by `panels` pre-session). All props-driven; behavior detail lives in the components' jsdoc.
+- **Queued messages: the pending strip** (`QueueStrip.tsx`, props-driven: `queue` + `onDequeue`) — the
+  web mirror of pi's interactive-mode pending-messages area. A **streaming send never renders an
+  optimistic transcript bubble** (see the store SPEC's echo contract): `ChatView.onSubmit` skips
+  `appendUserMessage` for `steer`/`followUp`, and the queued texts render between transcript and
+  composer as one dim clickable strip — a truncated `Steering:`/`Follow-up:` line per message
+  (`queue-strip`/`queue-item` testids, `data-kind`) + an edit hint, sourced from the runtime's `queue`.
+  **Dequeue = click**: `session.clearQueue` returns the texts and `ChatView` prepends them to the draft
+  (queued first, `\n\n`-joined — pi's own restore order); the strip clears via pi's emptying
+  `queue_update`. **Abort restores the queue too** (`onAbort` dequeues first, then `session.abort`) —
+  pi's Escape parity: an aborted run must not silently discard messages the user queued behind it. A
+  **rejected** streaming send likewise restores its text to the draft alongside the `appendErrorTurn`
+  (no bubble holds it anymore). Trade-off, accepted: `queue_update` carries text only, so a queued
+  image attachment shows no chip in the strip; the canonical transcript turn later renders its image
+  blocks with the hydrated-turn fallback labels. E2e: `queue.live.spec.ts` (@agent).
 - **History overlay: zoomed preview pane + scope picker** (`HistoryOverlay.tsx`) — `Tab` grows the
   compact single-column overlay into a **two-pane** `zoomed` layout: the existing Prompts/Messages
   sections list stays on the left (~55% width, `data-testid="history-results"` — keyboard nav,

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -222,8 +222,15 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   the persisted transcript's final conversational message is current (historical `length` attempts followed
   by later work must not become stale warnings). Hydration is a no-op if a runtime already exists, so a
   live/ahead chat is never clobbered. The
-  pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime. Composer user messages enter
-  optimistically: an equal Pi `message_start` echo is ignored, while Pi's canonical expanded `<skill>`
+  pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime. **Only idle sends enter the transcript
+  optimistically** (`ChatView.onSubmit` → `appendUserMessage`); the last-turn echo dedup below is
+  sufficient precisely because nothing intervenes before the echo. A **streaming send (`steer`/`followUp`)
+  never appends a turn**: its text lives in `queue` (folded verbatim from pi's `queue_update`, seeded from
+  the summary's snapshot at hydration) and the turn lands only via pi's canonical user `message_start` —
+  at its true position, converging live with hydrated. (Mirrors pi's own interactive mode; replaces the
+  optimistic-append-for-everything model whose last-turn dedup missed whenever assistant content landed
+  between the append and the echo — reproduced live as a duplicated, mispositioned queued bubble.)
+  For the idle echo: an equal Pi `message_start` echo is ignored, while Pi's canonical expanded `<skill>`
   echo **replaces** the immediately preceding matching raw `/skill:<name> …` turn in place (same turn id),
   so live and hydrated transcripts both contain one canonical skill invocation; a malformed or mismatched
   block appends normally. **`handlePiEvent(event,

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -205,6 +205,56 @@ test("a host-fired USER message folds into the transcript; the composer's optimi
 	expect(rt("a").turns.filter((t) => t.kind === "user")).toHaveLength(2);
 });
 
+test("queue_update folds pi's queue into the runtime; the canonical echo lands the turn at its true position", () => {
+	const queueUpdate = (steering: string[], followUp: string[]) =>
+		({ type: "queue_update", steering, followUp }) as unknown as PiEvent;
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+	store.handlePiEvent(agentStart, "a");
+	store.handlePiEvent(assistantStart, "a");
+	store.handlePiEvent(assistantText("first reply"), "a");
+
+	store.handlePiEvent(queueUpdate(["course-correct"], ["queued question"]), "a");
+	expect(rt("a").queue).toEqual({ steering: ["course-correct"], followUp: ["queued question"] });
+	expect(rt("a").turns.filter((t) => t.kind === "user")).toHaveLength(0);
+
+	store.handlePiEvent(queueUpdate([], ["queued question"]), "a");
+	store.handlePiEvent(userStart("course-correct"), "a");
+	store.handlePiEvent(queueUpdate([], []), "a");
+	store.handlePiEvent(userStart("queued question"), "a");
+
+	const turns = rt("a").turns;
+	expect(turns.map((t) => t.kind)).toEqual(["assistant", "user", "user"]);
+	expect(rt("a").queue).toEqual({ steering: [], followUp: [] });
+});
+
+test("hydrateSession seeds the queue from the summary snapshot", () => {
+	const store = useAppStore.getState();
+	useAppStore.setState({ activeWorkspaceId: "ws1" });
+	const summary: SessionSummary = {
+		sessionId: "q1",
+		workspaceId: "ws1",
+		title: "Chat",
+		model: null,
+		thinkingLevel: "medium",
+		isStreaming: true,
+		messageCount: 1,
+		updatedAt: 0,
+		live: true,
+		queue: { steering: [], followUp: ["waiting in line"] },
+	};
+	store.hydrateSession(summary, { turns: [], toolResults: {}, askAnswers: {} });
+	expect(rt("q1").queue).toEqual({ steering: [], followUp: ["waiting in line"] });
+
+	const { queue, ...bare } = summary;
+	void queue;
+	store.hydrateSession(
+		{ ...bare, sessionId: "q2" },
+		{ turns: [], toolResults: {}, askAnswers: {} },
+	);
+	expect(rt("q2").queue).toEqual({ steering: [], followUp: [] });
+});
+
 test("Pi's expanded skill echo replaces its matching optimistic slash command in place", () => {
 	const expanded =
 		'<skill name="review" location="/repo/.pi/skills/review/SKILL.md">\nReferences are relative to /repo/.pi/skills/review.\n\n# Review\n\nInspect the diff.\n</skill>\n\nFocus on src/app.ts.';

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -13,6 +13,7 @@ import type {
 	RefreshedModels,
 	ReviewChangedPayload,
 	ReviewSnapshot,
+	SessionQueueState,
 	SessionStats,
 	SessionSummary,
 	SlashCommandInfo,
@@ -267,6 +268,7 @@ export interface SessionRuntime {
 	currentAssistantId: string | null;
 	attemptAssistantId: string | null;
 	isStreaming: boolean;
+	queue: SessionQueueState;
 	model: WireModel | null;
 	thinkingLevel: ThinkingLevel;
 	stats: SessionStats | null;
@@ -278,6 +280,8 @@ export interface SessionRuntime {
 	extUiWidget: Record<string, string[]>;
 }
 
+const EMPTY_QUEUE: SessionQueueState = { steering: [], followUp: [] };
+
 function newRuntime(model: WireModel | null, thinkingLevel: ThinkingLevel): SessionRuntime {
 	return {
 		turns: [],
@@ -286,6 +290,7 @@ function newRuntime(model: WireModel | null, thinkingLevel: ThinkingLevel): Sess
 		currentAssistantId: null,
 		attemptAssistantId: null,
 		isStreaming: false,
+		queue: EMPTY_QUEUE,
 		model,
 		thinkingLevel,
 		stats: null,
@@ -384,6 +389,8 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 	switch (event.type) {
 		case "agent_start":
 			return { ...rt, isStreaming: true, attemptAssistantId: null };
+		case "queue_update":
+			return { ...rt, queue: { steering: event.steering, followUp: event.followUp } };
 		case "message_start": {
 			if (event.message.role === "assistant")
 				return {
@@ -2353,6 +2360,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				toolResults: hydrated.toolResults,
 				askAnswers: hydrated.askAnswers,
 				isStreaming: summary.isStreaming,
+				...(summary.queue ? { queue: summary.queue } : {}),
 				...(hydrated.turnIdByMessageIndex
 					? { turnIdByMessageIndex: hydrated.turnIdByMessageIndex }
 					: {}),

--- a/e2e/queue.live.spec.ts
+++ b/e2e/queue.live.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+
+const COUNT_PROMPT =
+	"Count from 1 to 60, one number per line. No other text, no tools, just the numbers.";
+
+test("Cmd/Ctrl+Enter queues via the pending strip; the follow-up runs after the turn at canonical position; dequeue restores the composer", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(240_000);
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+
+	const input = page.getByTestId("chat-input");
+	const users = page.locator('[data-testid="chat-message"][data-role="user"]');
+	const assistants = page.locator('[data-testid="chat-message"][data-role="assistant"]');
+	const strip = page.getByTestId("queue-strip");
+
+	await input.fill(COUNT_PROMPT);
+	await page.getByTestId("chat-send").click();
+	await expect(input).toHaveAttribute("placeholder", /Cmd\/Ctrl\+Enter to queue/, {
+		timeout: 60_000,
+	});
+
+	await input.fill("Now reply with exactly the single word: QUEUEDOK");
+	await input.press("ControlOrMeta+Enter");
+
+	await expect(input).toHaveValue("");
+	await expect(strip).toBeVisible();
+	await expect(page.getByTestId("queue-item")).toContainText("QUEUEDOK");
+	await expect(page.getByTestId("queue-item")).toHaveAttribute("data-kind", "followUp");
+	await expect(users).toHaveCount(1);
+
+	await expect(assistants.last()).toContainText("QUEUEDOK", { timeout: 120_000 });
+	await expect(strip).toBeHidden();
+	await expect(users).toHaveCount(2);
+	await expect(assistants.first()).toContainText("60");
+
+	const roles = await page
+		.locator('[data-testid="chat-message"]')
+		.evaluateAll((nodes) => nodes.map((node) => node.getAttribute("data-role")));
+	const conversational = roles.filter((role) => role === "user" || role === "assistant");
+	const firstAssistant = conversational.indexOf("assistant");
+	const queuedUser = conversational.indexOf("user", 1);
+	expect(firstAssistant).toBeGreaterThan(0);
+	expect(queuedUser).toBeGreaterThan(firstAssistant);
+
+	await input.fill(COUNT_PROMPT);
+	await input.press("Enter");
+	await expect(users).toHaveCount(3, { timeout: 60_000 });
+	await expect(input).toHaveAttribute("placeholder", /Cmd\/Ctrl\+Enter to queue/, {
+		timeout: 60_000,
+	});
+
+	await input.fill("first queued edit");
+	await input.press("ControlOrMeta+Enter");
+	await input.fill("second queued edit");
+	await input.press("ControlOrMeta+Enter");
+	await expect(page.getByTestId("queue-item")).toHaveCount(2);
+
+	await strip.click();
+	await expect(strip).toBeHidden();
+	await expect(input).toHaveValue("first queued edit\n\nsecond queued edit");
+
+	await page.getByTestId("chat-abort").click();
+	await expect(page.getByTestId("chat-abort")).toBeHidden({ timeout: 60_000 });
+	await expect(users).toHaveCount(3);
+});

--- a/e2e/queue.live.spec.ts
+++ b/e2e/queue.live.spec.ts
@@ -4,10 +4,10 @@ import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fi
 const COUNT_PROMPT =
 	"Count from 1 to 60, one number per line. No other text, no tools, just the numbers.";
 
-test("Cmd/Ctrl+Enter queues via the pending strip; the follow-up runs after the turn at canonical position; dequeue restores the composer", {
+test("queueing: pending strip + canonical order; per-row edit/remove; interrupt aborts and sends now", {
 	tag: "@agent",
 }, async ({ page }) => {
-	test.setTimeout(240_000);
+	test.setTimeout(300_000);
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);
 	await expect(worktreeRows(page).first()).toHaveAttribute("data-active", "true");
@@ -20,7 +20,7 @@ test("Cmd/Ctrl+Enter queues via the pending strip; the follow-up runs after the 
 
 	await input.fill(COUNT_PROMPT);
 	await page.getByTestId("chat-send").click();
-	await expect(input).toHaveAttribute("placeholder", /Cmd\/Ctrl\+Enter to queue/, {
+	await expect(input).toHaveAttribute("placeholder", /Enter steers at the next step/, {
 		timeout: 60_000,
 	});
 
@@ -31,6 +31,7 @@ test("Cmd/Ctrl+Enter queues via the pending strip; the follow-up runs after the 
 	await expect(strip).toBeVisible();
 	await expect(page.getByTestId("queue-item")).toContainText("QUEUEDOK");
 	await expect(page.getByTestId("queue-item")).toHaveAttribute("data-kind", "followUp");
+	await expect(page.getByTestId("send-menu")).toBeVisible();
 	await expect(users).toHaveCount(1);
 
 	await expect(assistants.last()).toContainText("QUEUEDOK", { timeout: 120_000 });
@@ -47,10 +48,12 @@ test("Cmd/Ctrl+Enter queues via the pending strip; the follow-up runs after the 
 	expect(firstAssistant).toBeGreaterThan(0);
 	expect(queuedUser).toBeGreaterThan(firstAssistant);
 
-	await input.fill(COUNT_PROMPT);
+	await input.fill(
+		"Count from 1 to 200, one number per line. No other text, no tools, just the numbers.",
+	);
 	await input.press("Enter");
 	await expect(users).toHaveCount(3, { timeout: 60_000 });
-	await expect(input).toHaveAttribute("placeholder", /Cmd\/Ctrl\+Enter to queue/, {
+	await expect(input).toHaveAttribute("placeholder", /Enter steers at the next step/, {
 		timeout: 60_000,
 	});
 
@@ -60,11 +63,20 @@ test("Cmd/Ctrl+Enter queues via the pending strip; the follow-up runs after the 
 	await input.press("ControlOrMeta+Enter");
 	await expect(page.getByTestId("queue-item")).toHaveCount(2);
 
-	await strip.click();
-	await expect(strip).toBeHidden();
-	await expect(input).toHaveValue("first queued edit\n\nsecond queued edit");
+	await page
+		.locator('[data-testid="queue-item"][data-index="0"]')
+		.getByTestId("queue-item-remove")
+		.click();
+	await expect(page.getByTestId("queue-item")).toHaveCount(1);
+	await expect(page.getByTestId("queue-item")).toContainText("second queued edit");
 
-	await page.getByTestId("chat-abort").click();
+	await page.getByTestId("queue-item-edit").click();
+	await expect(strip).toBeHidden();
+	await expect(input).toHaveValue("second queued edit");
+
+	await input.fill("Now reply with exactly the single word: INTERRUPTOK");
+	await input.press("ControlOrMeta+Shift+Enter");
+	await expect(users).toHaveCount(4, { timeout: 60_000 });
+	await expect(assistants.last()).toContainText("INTERRUPTOK", { timeout: 120_000 });
 	await expect(page.getByTestId("chat-abort")).toBeHidden({ timeout: 60_000 });
-	await expect(users).toHaveCount(3);
 });

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -309,8 +309,11 @@ of the host.
   the pre-session manager) / **`session.reloadResources`** (re-scan skills + rebuild the system prompt for one
   running session; rejected while streaming) /
   `session.*` — `create`/`prompt`/`steer`/`followUp`/**`clearQueue`** (drain pi's steering+followUp
-  queues, returning the texts — the client's dequeue-to-composer; pi itself emits the emptying
-  `queue_update`)/`abort`/`dispose`/**`delete`**/`setModel`/
+  queues, returning the texts — the client's abort-restores-queue path; pi itself emits the emptying
+  `queue_update`)/**`removeQueued`** (`{ kind, index }` → `RemovedQueuedMessage`: drop or extract ONE
+  queued message — the strip rows' edit/remove; position-addressed because pi's queue entries are bare
+  strings with no id, and the host emulates per-item removal over pi's all-or-nothing `clearQueue`, see
+  the server agent SPEC)/`abort`/`dispose`/**`delete`**/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
   read side) / **`layout.get`** (hydrate one workspace snapshot, or `null` before first seeding) /

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -86,6 +86,10 @@ of the host.
     summary's optional **`lastSettlement`** retains the host-observed terminal (`null` = the live run is
     active or settled without an assistant) so reconnect can surface a final failure Pi removed from its rebuilt context; absent
     means this host process has not observed a settlement and the persisted transcript is authoritative.
+    The optional **`queue`** (**`SessionQueueState`**: pi's pending `steering`/`followUp` texts) rides a
+    live summary only when non-empty — the hydration seed for the client's pending strip, since
+    `queue_update` fires only on changes and a client attaching mid-run would otherwise never learn of
+    messages queued before it connected.
     `session.getMessages` returns `{ summary, messages }` (the transcript is
     **`TranscriptMessage[]`** — the pi-canonical `Message` union widened with **`WireCustomMessage`**, a
     type-only mirror of pi-coding-agent's Node-only `CustomMessage`, so extension-injected messages like
@@ -304,7 +308,9 @@ of the host.
   per-skill `decision` + `group` — for a `workspaceId`) / **`project.skills`** (the same, project-scoped, for
   the pre-session manager) / **`session.reloadResources`** (re-scan skills + rebuild the system prompt for one
   running session; rejected while streaming) /
-  `session.*` — `create`/`prompt`/`steer`/`followUp`/`abort`/`dispose`/**`delete`**/`setModel`/
+  `session.*` — `create`/`prompt`/`steer`/`followUp`/**`clearQueue`** (drain pi's steering+followUp
+  queues, returning the texts — the client's dequeue-to-composer; pi itself emits the emptying
+  `queue_update`)/`abort`/`dispose`/**`delete`**/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
   read side) / **`layout.get`** (hydrate one workspace snapshot, or `null` before first seeding) /

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -98,9 +98,16 @@ export interface SessionStats {
 	contextUsage?: ContextUsage;
 }
 
+export type QueueLane = "steering" | "followUp";
+
 export interface SessionQueueState {
 	steering: readonly string[];
 	followUp: readonly string[];
+}
+
+export interface RemovedQueuedMessage {
+	removed: string | null;
+	queue: SessionQueueState;
 }
 
 export interface SessionSummary {

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -98,6 +98,11 @@ export interface SessionStats {
 	contextUsage?: ContextUsage;
 }
 
+export interface SessionQueueState {
+	steering: readonly string[];
+	followUp: readonly string[];
+}
+
 export interface SessionSummary {
 	sessionId: string;
 	workspaceId: string;
@@ -110,6 +115,7 @@ export interface SessionSummary {
 	live: boolean;
 	openTodos?: number;
 	lastSettlement?: AgentSettlement | null;
+	queue?: SessionQueueState;
 }
 
 export type SlashCommandSource = "extension" | "prompt" | "skill";

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -41,7 +41,9 @@ import type {
 	AskUserQuestionResult,
 	ExtUiResponse,
 	ImageContent,
+	QueueLane,
 	RefreshedModels,
+	RemovedQueuedMessage,
 	SessionQueueState,
 	SessionStats,
 	SessionSummary,
@@ -79,7 +81,7 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 47;
+export const PROTOCOL_VERSION = 48;
 
 export interface ServerWelcome {
 	protocolVersion: number;
@@ -152,6 +154,7 @@ export const WS_METHODS = {
 	sessionSteer: "session.steer",
 	sessionFollowUp: "session.followUp",
 	sessionClearQueue: "session.clearQueue",
+	sessionRemoveQueued: "session.removeQueued",
 	sessionAbort: "session.abort",
 	sessionDispose: "session.dispose",
 	sessionDelete: "session.delete",
@@ -376,6 +379,10 @@ export interface WsMethodMap {
 		result: Ack;
 	};
 	"session.clearQueue": { params: { sessionId: string }; result: SessionQueueState };
+	"session.removeQueued": {
+		params: { sessionId: string; kind: QueueLane; index: number };
+		result: RemovedQueuedMessage;
+	};
 	"session.abort": { params: { sessionId: string }; result: Ack };
 	"session.dispose": { params: { sessionId: string }; result: Ack };
 	"session.delete": { params: { workspaceId: string; sessionId: string }; result: Ack };

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -42,6 +42,7 @@ import type {
 	ExtUiResponse,
 	ImageContent,
 	RefreshedModels,
+	SessionQueueState,
 	SessionStats,
 	SessionSummary,
 	SkillCatalogEntry,
@@ -78,7 +79,7 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 46;
+export const PROTOCOL_VERSION = 47;
 
 export interface ServerWelcome {
 	protocolVersion: number;
@@ -150,6 +151,7 @@ export const WS_METHODS = {
 	sessionPrompt: "session.prompt",
 	sessionSteer: "session.steer",
 	sessionFollowUp: "session.followUp",
+	sessionClearQueue: "session.clearQueue",
 	sessionAbort: "session.abort",
 	sessionDispose: "session.dispose",
 	sessionDelete: "session.delete",
@@ -373,6 +375,7 @@ export interface WsMethodMap {
 		params: { sessionId: string; text: string; images?: ImageContent[] };
 		result: Ack;
 	};
+	"session.clearQueue": { params: { sessionId: string }; result: SessionQueueState };
 	"session.abort": { params: { sessionId: string }; result: Ack };
 	"session.dispose": { params: { sessionId: string }; result: Ack };
 	"session.delete": { params: { workspaceId: string; sessionId: string }; result: Ack };

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -105,7 +105,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `estimatedTokensAfter`, never pi's summary, entry id, usage, or extension details. The live entry retains
     that settlement in `SessionSummary.lastSettlement` for reconnect after Pi removed a failed attempt from its rebuilt
     context; a new `agent_start` exposes explicit `null` (no current terminal) so an older persisted failure
-    cannot reappear mid-run, while disk sessions remain transcript-authoritative.
+    cannot reappear mid-run, while disk sessions remain transcript-authoritative. A live summary also
+    carries pi's queue snapshot (`SessionQueueState`, only when non-empty): `queue_update` fires only on
+    changes, so this is the read-side seed that lets a client attaching mid-run render messages queued
+    before it connected.
     New-session and pre-session entrypoints capture the current generation; operations on a live session use
     that session's retained runtime. `abort` remains available as the cancellation control path.
     `prompt`/`steer`/`followUp` (with images) /
@@ -114,7 +117,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     back to `steer`), and pi's `followUp()` only *enqueues* into a queue that a run already in flight
     drains (so on an idle session it falls back to `prompt`, else the message parks forever — the way a
     `review.sendBatch` into a re-attached review chat marked its comments sent to an agent that never
-    saw them) —
+    saw them) / **`clearQueueSession`** (pi's `clearQueue()`, verbatim: drains both queues and returns the
+    texts for the client's dequeue-to-composer; pi emits the emptying `queue_update`, so the host adds no
+    bookkeeping) —
     `setModel` / `setThinkingLevel` / `compact` / `getSessionStats` (+ contextUsage) / `getSessionCommands` /
     `listAvailableModels` / **`clampThinkingForModel`** (pi's `clampThinkingLevel` for a `{model, level}`
     pair — `model.clampThinking`; the host owns it so the pre-session picker, `getDefaultModel`, and a live

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -119,7 +119,15 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `review.sendBatch` into a re-attached review chat marked its comments sent to an agent that never
     saw them) / **`clearQueueSession`** (pi's `clearQueue()`, verbatim: drains both queues and returns the
     texts for the client's dequeue-to-composer; pi emits the emptying `queue_update`, so the host adds no
-    bookkeeping) —
+    bookkeeping) / **`removeQueuedSession(sessionId, kind, index)`** — per-item queue removal, which pi's
+    API lacks (queues are bare string arrays, `clearQueue` is all-or-nothing): drain via `clearQueue()`,
+    drop `lane[index]` (out-of-range → `removed: null`, everything re-queued), re-queue the keepers in
+    order (`steer()`/`followUp()` per lane — each re-queue emits its own `queue_update`, so clients
+    converge by events alone). **No-loss guarantee:** if the run settled during the operation the
+    re-queued keepers would park forever (pi's queues only drain inside a run), so the idle case drains
+    them through the same idle-delivery fallback as `followUpSession` — the first becomes a `prompt`,
+    the rest steer into the run it starts; delivery timing may degrade across that race window, content
+    is never lost (pinned by the idle-fallback unit test) —
     `setModel` / `setThinkingLevel` / `compact` / `getSessionStats` (+ contextUsage) / `getSessionCommands` /
     `listAvailableModels` / **`clampThinkingForModel`** (pi's `clampThinkingLevel` for a `{model, level}`
     pair — `model.clampThinking`; the host owns it so the pre-session picker, `getDefaultModel`, and a live

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -28,11 +28,13 @@ import {
 	listSessions,
 	promptSession,
 	refreshAvailableModels,
+	removeQueuedSession,
 	removeSession,
 	removeWorkspaceSessions,
 	setSessionDeletedPublisher,
 	setSessionManagerFactory,
 	setSessionPublisher,
+	steerSession,
 	toWireModel,
 } from "./agentSessionManager";
 import { configurePiRuntime } from "./piRuntime";
@@ -876,14 +878,27 @@ test("mid-stream followUpSession queues: the summary snapshot carries it, clearQ
 			await new Promise((resolve) => setTimeout(resolve, 20));
 		}
 		await followUpSession(s.sessionId, "queued line");
+		await followUpSession(s.sessionId, "queued line two");
 
 		const summary = (await listSessions("ws-queue", cwd)).find(
 			(row) => row.sessionId === s.sessionId,
 		);
-		expect(summary?.queue).toEqual({ steering: [], followUp: ["queued line"] });
+		expect(summary?.queue).toEqual({
+			steering: [],
+			followUp: ["queued line", "queued line two"],
+		});
 		expect(seen(s.sessionId)).toContain("queue_update");
 
-		expect(clearQueueSession(s.sessionId)).toEqual({ steering: [], followUp: ["queued line"] });
+		expect(await removeQueuedSession(s.sessionId, "followUp", 5)).toEqual({
+			removed: null,
+			queue: { steering: [], followUp: ["queued line", "queued line two"] },
+		});
+		expect(await removeQueuedSession(s.sessionId, "followUp", 0)).toEqual({
+			removed: "queued line",
+			queue: { steering: [], followUp: ["queued line two"] },
+		});
+
+		expect(clearQueueSession(s.sessionId)).toEqual({ steering: [], followUp: ["queued line two"] });
 		expect(clearQueueSession(s.sessionId)).toEqual({ steering: [], followUp: [] });
 
 		await turn;
@@ -893,6 +908,23 @@ test("mid-stream followUpSession queues: the summary snapshot carries it, clearQ
 		setSessionManagerFactory(() => SessionManager.inMemory());
 	}
 }, 20000);
+
+test("removeQueuedSession on an idle session never strands the keepers — they deliver via the idle fallback", async () => {
+	fauxA.setResponses([fauxAssistantMessage("PARKED_DELIVERED")]);
+	const s = await createSession({
+		cwd: tmpCwd("trpi-remove-idle-"),
+		workspaceId: "ws-remove-idle",
+		model: toWireModel(fauxA.getModel()),
+	});
+	await steerSession(s.sessionId, "parked one");
+	await steerSession(s.sessionId, "parked two");
+
+	const result = await removeQueuedSession(s.sessionId, "steering", 0);
+	expect(result.removed).toBe("parked one");
+	expect(result.queue).toEqual({ steering: [], followUp: [] });
+	expect(seen(s.sessionId)).toContain("PARKED_DELIVERED");
+	removeSession(s.sessionId);
+});
 
 test("removeWorkspaceSessions: archives a workspace's live sessions + purges their on-disk transcripts, leaving siblings", async () => {
 	setSessionManagerFactory((cwd) => SessionManager.create(cwd));

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -13,6 +13,7 @@ import type { AgentSettlement, ExtUiRequest } from "@thinkrail/contracts";
 import {
 	buildSessionSettings,
 	clampThinkingForModel,
+	clearQueueSession,
 	createSession,
 	deleteSession,
 	disposeAllSessions,
@@ -849,6 +850,49 @@ test("followUpSession on an IDLE session runs the turn — pi's follow-up queue 
 		setSessionManagerFactory(() => SessionManager.inMemory());
 	}
 });
+
+test("mid-stream followUpSession queues: the summary snapshot carries it, clearQueueSession hands it back", async () => {
+	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
+	const slow = createFauxCore({
+		provider: "fauxq",
+		api: "fauxq",
+		models: [modelDef("fauxq")],
+		tokensPerSecond: 40,
+	});
+	runtime.registerProvider("fauxq", cfg(slow, "fauxq"));
+	try {
+		slow.setResponses([fauxAssistantMessage(`SLOW_TURN ${"word ".repeat(80)}END`)]);
+		const cwd = tmpCwd("trpi-queue-");
+		const s = await createSession({
+			cwd,
+			workspaceId: "ws-queue",
+			model: toWireModel(slow.getModel()),
+		});
+		const turn = promptSession(s.sessionId, "stream slowly");
+		turn.catch(() => {});
+		const deadline = Date.now() + 5000;
+		while (!seen(s.sessionId).includes("message_update")) {
+			if (Date.now() > deadline) throw new Error("first turn never started streaming");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		await followUpSession(s.sessionId, "queued line");
+
+		const summary = (await listSessions("ws-queue", cwd)).find(
+			(row) => row.sessionId === s.sessionId,
+		);
+		expect(summary?.queue).toEqual({ steering: [], followUp: ["queued line"] });
+		expect(seen(s.sessionId)).toContain("queue_update");
+
+		expect(clearQueueSession(s.sessionId)).toEqual({ steering: [], followUp: ["queued line"] });
+		expect(clearQueueSession(s.sessionId)).toEqual({ steering: [], followUp: [] });
+
+		await turn;
+		removeSession(s.sessionId);
+	} finally {
+		runtime.unregisterProvider("fauxq");
+		setSessionManagerFactory(() => SessionManager.inMemory());
+	}
+}, 20000);
 
 test("removeWorkspaceSessions: archives a workspace's live sessions + purges their on-disk transcripts, leaving siblings", async () => {
 	setSessionManagerFactory((cwd) => SessionManager.create(cwd));

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -19,6 +19,7 @@ import type {
 	RefreshedModels,
 	SessionDeletedPayload,
 	SessionEventPayload,
+	SessionQueueState,
 	SessionStats,
 	SessionSummary,
 	SlashCommandInfo,
@@ -283,6 +284,14 @@ function summaryOf(sessionId: string, entry: Entry): SessionSummary {
 		updatedAt: Date.now(),
 		live: true,
 		...(entry.lastSettlement !== undefined ? { lastSettlement: entry.lastSettlement } : {}),
+		...(session.pendingMessageCount > 0
+			? {
+					queue: {
+						steering: [...session.getSteeringMessages()],
+						followUp: [...session.getFollowUpMessages()],
+					},
+				}
+			: {}),
 	};
 }
 
@@ -592,6 +601,10 @@ export async function followUpSession(
 
 export async function compactSession(sessionId: string, instructions?: string): Promise<void> {
 	await mustGet(sessionId).compact(instructions);
+}
+
+export function clearQueueSession(sessionId: string): SessionQueueState {
+	return mustGet(sessionId).clearQueue();
 }
 
 export function abortSession(sessionId: string): Promise<void> {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -16,7 +16,9 @@ import type {
 	AskUserQuestionResult,
 	ImageContent,
 	Model,
+	QueueLane,
 	RefreshedModels,
+	RemovedQueuedMessage,
 	SessionDeletedPayload,
 	SessionEventPayload,
 	SessionQueueState,
@@ -284,14 +286,7 @@ function summaryOf(sessionId: string, entry: Entry): SessionSummary {
 		updatedAt: Date.now(),
 		live: true,
 		...(entry.lastSettlement !== undefined ? { lastSettlement: entry.lastSettlement } : {}),
-		...(session.pendingMessageCount > 0
-			? {
-					queue: {
-						steering: [...session.getSteeringMessages()],
-						followUp: [...session.getFollowUpMessages()],
-					},
-				}
-			: {}),
+		...(session.pendingMessageCount > 0 ? { queue: queueStateOf(session) } : {}),
 	};
 }
 
@@ -603,8 +598,36 @@ export async function compactSession(sessionId: string, instructions?: string): 
 	await mustGet(sessionId).compact(instructions);
 }
 
+function queueStateOf(session: AgentSession): SessionQueueState {
+	return {
+		steering: [...session.getSteeringMessages()],
+		followUp: [...session.getFollowUpMessages()],
+	};
+}
+
 export function clearQueueSession(sessionId: string): SessionQueueState {
 	return mustGet(sessionId).clearQueue();
+}
+
+export async function removeQueuedSession(
+	sessionId: string,
+	kind: QueueLane,
+	index: number,
+): Promise<RemovedQueuedMessage> {
+	const session = mustGet(sessionId);
+	const drained = session.clearQueue();
+	const lane = [...drained[kind]];
+	const removed = index >= 0 && index < lane.length ? (lane.splice(index, 1)[0] ?? null) : null;
+	const keep = { ...drained, [kind]: lane };
+	for (const text of keep.steering) await session.steer(text);
+	for (const text of keep.followUp) await session.followUp(text);
+	if (!session.isStreaming && session.pendingMessageCount > 0) {
+		const parked = session.clearQueue();
+		for (const text of [...parked.steering, ...parked.followUp]) {
+			await followUpSession(sessionId, text);
+		}
+	}
+	return { removed, queue: queueStateOf(session) };
 }
 
 export function abortSession(sessionId: string): Promise<void> {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -7,6 +7,7 @@ import type {
 	ImageContent,
 	LayoutReplaceParams,
 	LoginReply,
+	QueueLane,
 	ReviewAnchor,
 	ReviewComment,
 	ReviewCommentKind,
@@ -43,6 +44,7 @@ import {
 	promptSession,
 	refreshAvailableModels,
 	reloadSessionResources,
+	removeQueuedSession,
 	removeSession,
 	removeWorkspaceSessions,
 	resolveExtUi,
@@ -489,6 +491,10 @@ const handlers: Record<string, Handler> = {
 	},
 	"session.clearQueue": (params) => {
 		return clearQueueSession((params as { sessionId: string }).sessionId);
+	},
+	"session.removeQueued": async (params) => {
+		const p = params as { sessionId: string; kind: QueueLane; index: number };
+		return removeQueuedSession(p.sessionId, p.kind, p.index);
 	},
 	"session.abort": async (params) => {
 		await abortSession((params as { sessionId: string }).sessionId);

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -23,6 +23,7 @@ import {
 	abortSession,
 	answerQuestion,
 	clampThinkingForModel,
+	clearQueueSession,
 	compactSession,
 	createSession,
 	deleteSession,
@@ -485,6 +486,9 @@ const handlers: Record<string, Handler> = {
 		await ackSend(followUpSession(p.sessionId, p.text, p.images));
 		trackSend("follow_up", p.text);
 		return { ok: true } as const;
+	},
+	"session.clearQueue": (params) => {
+		return clearQueueSession((params as { sessionId: string }).sessionId);
 	},
 	"session.abort": async (params) => {
 		await abortSession((params as { sessionId: string }).sessionId);


### PR DESCRIPTION
## Summary

Two stacked changes to how mid-stream messages behave in chat.

### 1. Queued/steered messages: vanilla-pi parity (fixes a live-reproduced defect)

The composer placeholder promises "Cmd/Ctrl+Enter to queue" — queueing worked (pi queues, doesn't interrupt, runs the follow-up after the turn), but a live repro showed the transcript rendering the queued message **twice**, with the optimistic copy **above the reply it didn't prompt**. Root cause: the store's user-echo dedup checked only the last turn, which misses whenever assistant content lands between the optimistic append and pi's canonical echo (followUp drain, steer window, tool calls, first-token latency). Live and reloaded transcripts disagreed.

Fix mirrors vanilla pi's interactive mode:

- A **streaming send (`steer`/`followUp`) no longer appends an optimistic transcript bubble.** The turn lands only via pi's canonical user `message_start` — at its true position, converging live with hydrated. The defect disappears structurally.
- Queued texts render in a **pending strip** above the composer (pi's pending-messages area), folded from pi's `queue_update` event (typed in contracts, previously unconsumed).
- **Abort restores the queue to the composer** (pi's Escape parity); a **rejected** queued send restores its text to the draft.
- **Reconnect snapshot:** live session summaries carry pi's queue (`SessionQueueState`), so a client attaching mid-run renders messages queued before it connected.
- Idle sends keep the optimistic echo + last-turn dedup — sufficient once nothing intervenes before the echo.

### 2. Streaming send-mode legibility + per-row queue management + hard interrupt (field feedback on #1)

- **Split send control while streaming:** a send-options menu names each mode with its meaning and shortcut — *Steer — delivers at the agent's next step (Enter)* / *Queue — runs after the agent finishes (Cmd/Ctrl+Enter)* / *Interrupt — stops the current response and sends now (Cmd/Ctrl+Shift+Enter)*. Rows are actions, never a sticky mode. The placeholder states meanings, not just key names (steer ≠ interrupt was the #1 confusion).
- **Pending strip rows get per-message edit + remove** via the new `session.removeQueued { kind, index }` wire method. pi's queue API is all-or-nothing, so the host emulates per-item removal (clearQueue → re-queue keepers) with a **no-loss idle fallback** (keepers that would park on a settled session deliver via the idle path instead).
- **Hard interrupt:** await `session.abort` (ack = idle), then an ordinary send; the partial reply stays marked aborted.

New wire surface: `session.clearQueue`, `session.removeQueued`, `SessionSummary.queue` (protocol v46 → v48).

Accepted trade-off (recorded in `chat/SPEC.md`): `queue_update` is text-only, so a queued image attachment shows no chip in the strip; its image blocks render when the message lands in the transcript.

Design records: brainstormed task-specs promoted into `apps/web/src/store/SPEC.md` (echo contract), `apps/web/src/chat/SPEC.md` (strip rows, split send, interrupt), `packages/server/src/agent/SPEC.md` + `packages/contracts/SPEC.md` (`clearQueue`/`removeQueued`, queue snapshot).

## Related issues

None — found by reproducing the placeholder's claim, then field-testing the first fix.

## Verification

- Unit: `queue_update` fold + hydration seeding (web store); mid-stream queue snapshot, `clearQueueSession`, `removeQueuedSession` (siblings kept, out-of-range no-op, idle no-loss fallback) against a faux provider (server).
- Permanent `@agent` spec **`e2e/queue.live.spec.ts`** against a real provider: queue mid-stream → strip row appears, first turn uninterrupted, queued turn runs at canonical position, exactly 2 bubbles; row remove + row edit (text back in composer); interrupt aborts and the new reply arrives.
- Full `@agent` suite (`THINKRAIL_E2E_MODEL=openai-codex/gpt-5.4-mini`): 42 passed, 6 failed — **the same 6 fail identically on `origin/main`** with that model (model-sensitivity of specs tuned for the pinned claude default; verified on a detached checkout). No regressions.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e` — 252 passed / 8 shards; agent behavior covered by the `@agent` runs above)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
