### PR TITLE
web: clearer tab-strip affordances and faster tooltips

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -53,7 +53,7 @@ ThinkRail artwork as the shell logo (compact enough for browser-tab sizes and li
 `main.tsx` is the entry/composition root — it synchronously builds the bundled theme catalog, applies the
 cached first-paint theme hint pre-React, initializes transport + client-local navigation, then wraps `<Shell />` in
 `components/ErrorBoundary` as the last-resort boundary (a crash escaping every region shows a reload
-screen, not a blank root).
+screen, not a blank root) plus the app's single `TooltipProvider`.
 
 **React is one exact, matching `react` + `react-dom` 19.3 canary pin until the first stable release carrying
 upstream fix #34803.** React 19.2's development Performance Tracks retained every
@@ -219,7 +219,8 @@ themselves.
   generator that turns it into CSS is [scripts/SPEC.md](scripts/SPEC.md).
 - **Icons: `@remixicon/react` (Line default, Fill when active/selected). Components: shadcn/ui** (Radix primitives), copy-in under `src/components/ui/`
   and themed with our token utilities (`cn()` in `src/lib/utils.ts`) — never shadcn's default oklch
-  palette. Use these for accessible menus / dialogs / tooltips.
+  palette. Use these for accessible menus / dialogs / tooltips; icon-only controls label themselves with
+  `IconTooltip`, never native `title`.
 
 ## Get right
 

--- a/apps/web/src/chat/HistoryOverlay.tsx
+++ b/apps/web/src/chat/HistoryOverlay.tsx
@@ -12,6 +12,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { IconTooltip } from "@/components/ui/tooltip";
 import { platformShortcutLabel, relativeTime } from "@/lib";
 import {
 	type ChatLocationRequest,
@@ -82,21 +83,22 @@ function DeleteChatButton({
 }) {
 	if (!workspaceId) return null;
 	return (
-		<button
-			type="button"
-			data-testid="history-delete-chat"
-			aria-label="Move chat to trash"
-			title="Move chat to trash"
-			onClick={(event) => {
-				event.stopPropagation();
-				onDeleteChat(workspaceId, sessionId);
-			}}
-			className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-4 text-text-muted opacity-0 transition hover:bg-container-elevated-bg hover:text-feedback-error group-hover:opacity-100 ${
-				isSelected ? "opacity-100" : ""
-			}`}
-		>
-			<Trash2 className="size-14" />
-		</button>
+		<IconTooltip label="Move chat to trash">
+			<button
+				type="button"
+				data-testid="history-delete-chat"
+				aria-label="Move chat to trash"
+				onClick={(event) => {
+					event.stopPropagation();
+					onDeleteChat(workspaceId, sessionId);
+				}}
+				className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-4 text-text-muted opacity-0 transition hover:bg-container-elevated-bg hover:text-feedback-error group-hover:opacity-100 ${
+					isSelected ? "opacity-100" : ""
+				}`}
+			>
+				<Trash2 className="size-14" />
+			</button>
+		</IconTooltip>
 	);
 }
 
@@ -160,21 +162,22 @@ function PromptRow({
 					{SAVE_SHORTCUT_LABEL}
 				</span>
 			) : null}
-			<button
-				type="button"
-				data-testid="history-save-template"
-				aria-label="Save as template"
-				title={`Save as template (${SAVE_SHORTCUT_LABEL})`}
-				onClick={(e) => {
-					e.stopPropagation();
-					onSaveAsTemplate();
-				}}
-				className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-4 text-text-muted opacity-0 transition hover:bg-container-elevated-bg hover:text-text-default group-hover:opacity-100 ${
-					isSelected ? "opacity-100" : ""
-				}`}
-			>
-				<Save className="size-14" />
-			</button>
+			<IconTooltip label={`Save as template (${SAVE_SHORTCUT_LABEL})`}>
+				<button
+					type="button"
+					data-testid="history-save-template"
+					aria-label="Save as template"
+					onClick={(e) => {
+						e.stopPropagation();
+						onSaveAsTemplate();
+					}}
+					className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-4 text-text-muted opacity-0 transition hover:bg-container-elevated-bg hover:text-text-default group-hover:opacity-100 ${
+						isSelected ? "opacity-100" : ""
+					}`}
+				>
+					<Save className="size-14" />
+				</button>
+			</IconTooltip>
 			{target ? (
 				<>
 					{isSelected ? (
@@ -185,21 +188,22 @@ function PromptRow({
 							⇧⏎
 						</span>
 					) : null}
-					<button
-						type="button"
-						data-testid="history-jump"
-						aria-label="Go to chat"
-						title="⇧⏎ go to chat"
-						onClick={(e) => {
-							e.stopPropagation();
-							onOpenMessage(target);
-						}}
-						className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-4 text-text-muted opacity-0 transition hover:bg-container-elevated-bg hover:text-text-default group-hover:opacity-100 ${
-							isSelected ? "opacity-100" : ""
-						}`}
-					>
-						<CornerUpRight className="size-14" />
-					</button>
+					<IconTooltip label="⇧⏎ go to chat">
+						<button
+							type="button"
+							data-testid="history-jump"
+							aria-label="Go to chat"
+							onClick={(e) => {
+								e.stopPropagation();
+								onOpenMessage(target);
+							}}
+							className={`flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] p-4 text-text-muted opacity-0 transition hover:bg-container-elevated-bg hover:text-text-default group-hover:opacity-100 ${
+								isSelected ? "opacity-100" : ""
+							}`}
+						>
+							<CornerUpRight className="size-14" />
+						</button>
+					</IconTooltip>
 				</>
 			) : null}
 			<DeleteChatButton

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -446,7 +446,7 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   filters; see `packages/server/src/history/SPEC.md`): a user-role hit is always a textual duplicate of
   its own `PromptHit` entry, so the location it used to add moved onto the prompt row instead. Every
   prompt row now renders a go-to-chat icon (`data-testid="history-jump"`, `aria-label="Go to chat"`,
-  `title="⇧⏎ go to chat"`, next to the existing save-as-template icon) **when jumpable** —
+  an `IconTooltip` reading "⇧⏎ go to chat", next to the existing save-as-template icon) **when jumpable** —
   `workspaceId` present and `messageIndex != null` (absent for an unmapped-cwd hit, or a host that
   doesn't populate the prompt's anchor fields). Clicking it, or **`Shift+Enter`** while a prompt row
   is the keyboard selection, routes through the exact same `onOpenMessage` path a message hit's

--- a/apps/web/src/chat/SkillsButton.tsx
+++ b/apps/web/src/chat/SkillsButton.tsx
@@ -1,4 +1,5 @@
 import { RiBookOpenLine as BookOpen } from "@remixicon/react";
+import { IconTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export function SkillsButton({
@@ -13,20 +14,21 @@ export function SkillsButton({
 	className?: string;
 }) {
 	return (
-		<button
-			type="button"
-			data-testid={testId}
-			data-stale={stale ? "true" : undefined}
-			onClick={onOpen}
-			title={stale ? "Skills changed on disk — reload" : "Skills"}
-			className={cn(
-				"flex shrink-0 items-center gap-4 rounded-[var(--radius-sm)] px-8 py-2 text-text-muted tr-text-metadata outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary",
-				className,
-			)}
-		>
-			<BookOpen className="size-14" />
-			Skills
-			{stale ? <span className="size-6 rounded-full bg-feedback-warning" aria-hidden /> : null}
-		</button>
+		<IconTooltip label={stale ? "Skills changed on disk — reload" : "Skills"}>
+			<button
+				type="button"
+				data-testid={testId}
+				data-stale={stale ? "true" : undefined}
+				onClick={onOpen}
+				className={cn(
+					"flex shrink-0 items-center gap-4 rounded-[var(--radius-sm)] px-8 py-2 text-text-muted tr-text-metadata outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary",
+					className,
+				)}
+			>
+				<BookOpen className="size-14" />
+				Skills
+				{stale ? <span className="size-6 rounded-full bg-feedback-warning" aria-hidden /> : null}
+			</button>
+		</IconTooltip>
 	);
 }

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -218,19 +218,18 @@ export function SkillsDialog({
 									? "Available once the current turn finishes"
 									: "Apply to this chat"
 							}
+							wrapTrigger
 						>
-							<span className="flex">
-								<Button
-									size="sm"
-									variant="outline"
-									data-testid="skills-reload"
-									disabled={busy || workspace.streaming}
-									onClick={() => void reload()}
-								>
-									<RefreshCw className="size-14" />
-									Reload
-								</Button>
-							</span>
+							<Button
+								size="sm"
+								variant="outline"
+								data-testid="skills-reload"
+								disabled={busy || workspace.streaming}
+								onClick={() => void reload()}
+							>
+								<RefreshCw className="size-14" />
+								Reload
+							</Button>
 						</IconTooltip>
 					) : null}
 				</div>

--- a/apps/web/src/chat/SkillsDialog.tsx
+++ b/apps/web/src/chat/SkillsDialog.tsx
@@ -7,6 +7,7 @@ import type { Project, SkillCatalogEntry, SkillDecision, Workspace } from "@thin
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { IconTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { toast, useAppStore } from "@/store";
 import { errorText, getTransport, reloadSessionResourcesWithSkillBaseline } from "@/transport";
@@ -211,21 +212,26 @@ export function SkillsDialog({
 				<div className="flex items-center justify-between gap-8 pr-[2rem]">
 					<DialogTitle className="tr-text-ui text-text-default">Skills</DialogTitle>
 					{workspace ? (
-						<Button
-							size="sm"
-							variant="outline"
-							data-testid="skills-reload"
-							disabled={busy || workspace.streaming}
-							title={
+						<IconTooltip
+							label={
 								workspace.streaming
 									? "Available once the current turn finishes"
 									: "Apply to this chat"
 							}
-							onClick={() => void reload()}
 						>
-							<RefreshCw className="size-14" />
-							Reload
-						</Button>
+							<span className="flex">
+								<Button
+									size="sm"
+									variant="outline"
+									data-testid="skills-reload"
+									disabled={busy || workspace.streaming}
+									onClick={() => void reload()}
+								>
+									<RefreshCw className="size-14" />
+									Reload
+								</Button>
+							</span>
+						</IconTooltip>
 					) : null}
 				</div>
 

--- a/apps/web/src/chat/TodoList.tsx
+++ b/apps/web/src/chat/TodoList.tsx
@@ -16,6 +16,7 @@ import {
 } from "@remixicon/react";
 import type { TodoGroupItem, TodoItem, TodoPlan, TodoStatus } from "@thinkrail/contracts";
 import { useState } from "react";
+import { IconTooltip } from "../components/ui/tooltip";
 import { cn } from "../lib";
 import { PlanStatusIcon, SectionLabel } from "./planKit";
 import {
@@ -119,16 +120,17 @@ export function TodoAddRow({
 				className="min-w-0 flex-1 bg-transparent tr-text-ui text-text-default outline-none placeholder:text-text-muted"
 			/>
 			{onOpenPlan ? (
-				<button
-					type="button"
-					data-testid="todo-open-plan"
-					onClick={onOpenPlan}
-					aria-label="Open the plan page"
-					title="Open the plan as a page — review each step's changes"
-					className="flex size-24 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default focus-visible:opacity-100"
-				>
-					<FileText className="size-14" />
-				</button>
+				<IconTooltip label="Open the plan as a page — review each step's changes">
+					<button
+						type="button"
+						data-testid="todo-open-plan"
+						onClick={onOpenPlan}
+						aria-label="Open the plan page"
+						className="flex size-24 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default focus-visible:opacity-100"
+					>
+						<FileText className="size-14" />
+					</button>
+				</IconTooltip>
 			) : null}
 		</div>
 	);
@@ -412,16 +414,19 @@ function TodoRow({
 					<UserRound className="size-14" />
 				</span>
 			) : null}
-			<button
-				type="button"
-				onClick={onRemove}
-				disabled={reviewing}
-				aria-label="Remove"
-				title={reviewing ? "Reviewing… — wait for the review to finish before removing" : "Remove"}
-				className="flex size-24 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-text-muted opacity-0 transition-opacity hover:bg-container-elevated-bg hover:text-feedback-error group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none disabled:opacity-0"
+			<IconTooltip
+				label={reviewing ? "Reviewing… — wait for the review to finish before removing" : "Remove"}
 			>
-				<Trash2 className="size-14" />
-			</button>
+				<button
+					type="button"
+					onClick={onRemove}
+					disabled={reviewing}
+					aria-label="Remove"
+					className="flex size-24 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-text-muted opacity-0 transition-opacity hover:bg-container-elevated-bg hover:text-feedback-error group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none disabled:opacity-0"
+				>
+					<Trash2 className="size-14" />
+				</button>
+			</IconTooltip>
 		</li>
 	);
 }

--- a/apps/web/src/components/ui/SPEC.md
+++ b/apps/web/src/components/ui/SPEC.md
@@ -19,18 +19,27 @@ The shadcn/ui primitives (Radix), copied in and owned here, themed with our desi
   classes), `popover` (with an optional `container` portal target — pass the host Dialog node so a popover
   inside a
   Dialog stays wheel-scrollable under its scroll lock), `command` (cmdk combobox body), `textarea`,
-  `tooltip`, `resizable`, `toast` (Radix Toast primitives — `ToastProvider`/`Toast`/`ToastViewport`/`Title`/
+  `tooltip` (+ the `IconTooltip` convenience; one root `TooltipProvider` sets the delay), `resizable`, `toast` (Radix Toast primitives — `ToastProvider`/`Toast`/`ToastViewport`/`Title`/
   `Description`/`Close` + the `error`/`success`/`info` `toastVariants`; a left accent bar carries severity.
   Presentational only — the store owns the queue; `panels/Toaster` composes these against it).
 - **Public surface:** each primitive imported directly via `@/components/ui/<name>` (no barrel — preserves
   tree-shaking and the shadcn per-primitive convention).
 - **Allowed deps:** Radix (incl. `@radix-ui/react-context-menu`, `@radix-ui/react-popover`,
-  `@radix-ui/react-toast`), `cmdk`, `@remixicon/react`, `lib` (`cn`),
+  `@radix-ui/react-toast`, `@radix-ui/react-tooltip`), `cmdk`, `@remixicon/react`, `lib` (`cn`),
   `class-variance-authority`/`clsx`/`tailwind-merge`.
 - **Forbidden:** `store`/`transport`/`panels`/`shell` (primitives are leaf UI); `server`/`shared`/`pi`;
   shadcn's default oklch palette — themed with our token utilities only.
 
 ## Get right
+
+- **Icon-only controls use `IconTooltip`, never native `title`** — the OS delay is untunable and reads as
+  "no label". `title` stays only where it is not a control label (truncation fallback) or cannot reach the
+  provider (`panels/reviewWidgets`). Keep `aria-label`: the tooltip is the affordance, not the name. A
+  `disabled` trigger emits no pointer events, so wrap it in a plain element that stays interactive.
+- **Never make `IconTooltip` the outer `asChild` over another Radix trigger** — Radix triggers spread
+  incoming props *after* their own `data-state`, so the tooltip's state (`closed`/`instant-open`, never
+  `open`) silently overwrites the popover's or menu's on the shared button, breaking any
+  `data-[state=open]` / `has-[[data-state=open]]` styling. Put a plain span between them.
 
 - **`context-menu` and `dropdown-menu` are one visual menu system** — same tokenized content surface,
   radius/shadow, item/icon spacing, separators, semantic action colors, focus rows, and viewport collision

--- a/apps/web/src/components/ui/SPEC.md
+++ b/apps/web/src/components/ui/SPEC.md
@@ -34,12 +34,14 @@ The shadcn/ui primitives (Radix), copied in and owned here, themed with our desi
 
 - **Icon-only controls use `IconTooltip`, never native `title`** — the OS delay is untunable and reads as
   "no label". `title` stays only where it is not a control label (truncation fallback) or cannot reach the
-  provider (`panels/reviewWidgets`). Keep `aria-label`: the tooltip is the affordance, not the name. A
-  `disabled` trigger emits no pointer events, so wrap it in a plain element that stays interactive.
-- **Never make `IconTooltip` the outer `asChild` over another Radix trigger** — Radix triggers spread
-  incoming props *after* their own `data-state`, so the tooltip's state (`closed`/`instant-open`, never
+  provider (`panels/reviewWidgets`). Keep `aria-label`: the tooltip is the affordance, not the name.
+- **`wrapTrigger` when the child is `disabled` or is itself a Radix trigger.** It renders the tooltip
+  trigger as a plain `flex` span around the child instead of merging onto it. A `disabled` control emits
+  no pointer events, so the tooltip needs an element that stays interactive; and a Radix trigger spreads
+  incoming props *after* its own `data-state`, so a merged tooltip state (`closed`/`instant-open`, never
   `open`) silently overwrites the popover's or menu's on the shared button, breaking any
-  `data-[state=open]` / `has-[[data-state=open]]` styling. Put a plain span between them.
+  `data-[state=open]` / `has-[[data-state=open]]` styling. Never hand-roll that span at the call site —
+  `tooltip.test.tsx` pins both the isolation and the absence of a hand-rolled wrapper.
 
 - **`context-menu` and `dropdown-menu` are one visual menu system** — same tokenized content surface,
   radius/shadow, item/icon spacing, separators, semantic action colors, focus rows, and viewport collision

--- a/apps/web/src/components/ui/tooltip.test.tsx
+++ b/apps/web/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Popover, PopoverTrigger } from "./popover";
+import { IconTooltip, TooltipProvider } from "./tooltip";
+
+function renderTriggerPair(wrapTrigger: boolean): string {
+	return renderToStaticMarkup(
+		<TooltipProvider>
+			<Popover open>
+				<IconTooltip label="Search open tabs" wrapTrigger={wrapTrigger}>
+					<PopoverTrigger data-testid="shared-trigger">Search</PopoverTrigger>
+				</IconTooltip>
+			</Popover>
+		</TooltipProvider>,
+	);
+}
+
+const triggerState = (markup: string) =>
+	markup
+		.match(/<button[^>]*data-testid="shared-trigger"[^>]*>/)?.[0]
+		.match(/data-state="([^"]+)"/)?.[1];
+
+describe("IconTooltip over another Radix trigger", () => {
+	test("wrapTrigger leaves the popover's data-state on the shared button", () => {
+		expect(triggerState(renderTriggerPair(true))).toBe("open");
+	});
+
+	test("merging onto the child is what overwrites it", () => {
+		expect(triggerState(renderTriggerPair(false))).not.toBe("open");
+	});
+});
+
+const SRC = new URL("../..", import.meta.url).pathname;
+
+function sourceFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) {
+			out.push(...sourceFiles(path));
+			continue;
+		}
+		if (/\.tsx$/.test(entry) && !/\.test\.tsx$/.test(entry)) out.push(path);
+	}
+	return out;
+}
+
+test("no call site hand-rolls the wrapper span", () => {
+	const offenders = sourceFiles(SRC).filter((path) =>
+		/<IconTooltip[^>]*>\s*<span className="flex">/.test(readFileSync(path, "utf8")),
+	);
+	expect(offenders.map((path) => path.slice(SRC.length))).toEqual([]);
+});

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -25,4 +25,25 @@ function TooltipContent({
 	);
 }
 
-export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };
+function IconTooltip({
+	label,
+	side,
+	align,
+	children,
+}: {
+	label: React.ReactNode;
+	side?: React.ComponentProps<typeof TooltipPrimitive.Content>["side"];
+	align?: React.ComponentProps<typeof TooltipPrimitive.Content>["align"];
+	children: React.ReactNode;
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>{children}</TooltipTrigger>
+			<TooltipContent {...(side ? { side } : {})} {...(align ? { align } : {})}>
+				{label}
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export { IconTooltip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -29,16 +29,24 @@ function IconTooltip({
 	label,
 	side,
 	align,
+	wrapTrigger,
 	children,
 }: {
 	label: React.ReactNode;
 	side?: React.ComponentProps<typeof TooltipPrimitive.Content>["side"];
 	align?: React.ComponentProps<typeof TooltipPrimitive.Content>["align"];
+	wrapTrigger?: boolean;
 	children: React.ReactNode;
 }) {
 	return (
 		<Tooltip>
-			<TooltipTrigger asChild>{children}</TooltipTrigger>
+			{wrapTrigger ? (
+				<TooltipTrigger asChild>
+					<span className="flex">{children}</span>
+				</TooltipTrigger>
+			) : (
+				<TooltipTrigger asChild>{children}</TooltipTrigger>
+			)}
 			<TooltipContent {...(side ? { side } : {})} {...(align ? { align } : {})}>
 				{label}
 			</TooltipContent>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,7 @@ import "./index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { TooltipProvider } from "./components/ui/tooltip";
 import { initNavigation } from "./navigation";
 import { initProjectExpansionPersistence } from "./panels/projectExpansion";
 import { Shell } from "./shell/Shell";
@@ -19,7 +20,9 @@ if (root) {
 	createRoot(root).render(
 		<StrictMode>
 			<ErrorBoundary label="app">
-				<Shell />
+				<TooltipProvider delayDuration={250} skipDelayDuration={400}>
+					<Shell />
+				</TooltipProvider>
 			</ErrorBoundary>
 		</StrictMode>,
 	);

--- a/apps/web/src/panels/DiffPane.tsx
+++ b/apps/web/src/panels/DiffPane.tsx
@@ -4,6 +4,7 @@ import {
 	RiParagraph as Pilcrow,
 } from "@remixicon/react";
 import { lazy, Suspense, useState } from "react";
+import { IconTooltip } from "@/components/ui/tooltip";
 import { copyText, isMarkdownPath } from "@/lib/utils";
 import type { DiffTab } from "../store";
 import { selectDiffTabTargetRef, useAppStore } from "../store";
@@ -179,21 +180,22 @@ function HeaderIconButton({
 	children: React.ReactNode;
 }) {
 	return (
-		<button
-			type="button"
-			data-testid={testid}
-			data-active={active}
-			aria-pressed={active}
-			aria-label={label}
-			title={label}
-			onClick={onClick}
-			className={`flex size-24 items-center justify-center rounded-[var(--radius-sm)] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary ${
-				active
-					? "bg-container-elevated-bg text-text-default"
-					: "text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-			}`}
-		>
-			{children}
-		</button>
+		<IconTooltip label={label}>
+			<button
+				type="button"
+				data-testid={testid}
+				data-active={active}
+				aria-pressed={active}
+				aria-label={label}
+				onClick={onClick}
+				className={`flex size-24 items-center justify-center rounded-[var(--radius-sm)] outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary ${
+					active
+						? "bg-container-elevated-bg text-text-default"
+						: "text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+				}`}
+			>
+				{children}
+			</button>
+		</IconTooltip>
 	);
 }

--- a/apps/web/src/panels/PlanPane.tsx
+++ b/apps/web/src/panels/PlanPane.tsx
@@ -43,6 +43,7 @@ import {
 } from "../chat/planView";
 import { StatusIcon } from "../chat/TodoList";
 import { useChatTodos } from "../chat/useChatTodos";
+import { IconTooltip } from "../components/ui/tooltip";
 import {
 	selectAgentReviewCommentCount,
 	selectChatTitle,
@@ -80,31 +81,33 @@ function ChangeSetBlock({
 			data-expanded={expanded}
 		>
 			<div className="flex items-center gap-8 px-4">
-				<button
-					type="button"
-					data-testid="plan-change-set-toggle"
-					aria-expanded={expanded}
-					onClick={() => setExpanded((v) => !v)}
-					title={expanded ? "Hide changed files" : "Show changed files"}
-					className="flex min-h-32 min-w-0 items-center gap-4 rounded-[var(--radius-sm)] px-4 py-2 text-left hover:bg-control-bg-hovered"
-				>
-					<Chevron className="size-16 shrink-0 text-text-muted" />
-					<span className="shrink-0 tr-text-metadata text-text-subtle">
-						{count} {count === 1 ? "file" : "files"}
-					</span>
-				</button>
+				<IconTooltip label={expanded ? "Hide changed files" : "Show changed files"}>
+					<button
+						type="button"
+						data-testid="plan-change-set-toggle"
+						aria-expanded={expanded}
+						onClick={() => setExpanded((v) => !v)}
+						className="flex min-h-32 min-w-0 items-center gap-4 rounded-[var(--radius-sm)] px-4 py-2 text-left hover:bg-control-bg-hovered"
+					>
+						<Chevron className="size-16 shrink-0 text-text-muted" />
+						<span className="shrink-0 tr-text-metadata text-text-subtle">
+							{count} {count === 1 ? "file" : "files"}
+						</span>
+					</button>
+				</IconTooltip>
 				{set.kind === "commit" ? (
 					<>
-						<button
-							type="button"
-							data-testid="plan-commit-chip"
-							onClick={() => onOpenCommit(set.sha)}
-							title="Open this step's commit in the Changes panel"
-							className="flex min-h-32 shrink-0 items-center gap-4 rounded-[var(--radius-sm)] px-4 py-2 tr-code-text text-text-subtle hover:bg-control-bg-hovered hover:text-text-default"
-						>
-							<GitCommitHorizontal className="size-14" />
-							{set.sha.slice(0, 7)}
-						</button>
+						<IconTooltip label="Open this step's commit in the Changes panel">
+							<button
+								type="button"
+								data-testid="plan-commit-chip"
+								onClick={() => onOpenCommit(set.sha)}
+								className="flex min-h-32 shrink-0 items-center gap-4 rounded-[var(--radius-sm)] px-4 py-2 tr-code-text text-text-subtle hover:bg-control-bg-hovered hover:text-text-default"
+							>
+								<GitCommitHorizontal className="size-14" />
+								{set.sha.slice(0, 7)}
+							</button>
+						</IconTooltip>
 						<DiffStatBadge added={added} removed={removed} />
 					</>
 				) : null}

--- a/apps/web/src/panels/ProvidersSettings.tsx
+++ b/apps/web/src/panels/ProvidersSettings.tsx
@@ -121,7 +121,6 @@ export function ProvidersSettings() {
 					size="sm"
 					data-testid="providers-refresh"
 					aria-label="Refresh provider status"
-					title="Refresh"
 					disabled={refreshing}
 					onClick={() => void load()}
 				>

--- a/apps/web/src/panels/ReviewPanel.tsx
+++ b/apps/web/src/panels/ReviewPanel.tsx
@@ -130,20 +130,18 @@ export function ReviewPanel({ workspaceId, failed }: { workspaceId: string; fail
 						onConfirm={() => void clearReview()}
 						align="end"
 					>
-						<IconTooltip label="Clear review — archive sent comments">
-							<span className="flex">
-								<PopoverTrigger asChild>
-									<button
-										type="button"
-										data-testid="review-clear"
-										aria-label="Clear review"
-										className="flex shrink-0 items-center gap-4 px-4 tr-text-metadata text-text-subtle hover:text-feedback-error"
-									>
-										<Trash2 className="size-14" />
-										Clear
-									</button>
-								</PopoverTrigger>
-							</span>
+						<IconTooltip label="Clear review — archive sent comments" wrapTrigger>
+							<PopoverTrigger asChild>
+								<button
+									type="button"
+									data-testid="review-clear"
+									aria-label="Clear review"
+									className="flex shrink-0 items-center gap-4 px-4 tr-text-metadata text-text-subtle hover:text-feedback-error"
+								>
+									<Trash2 className="size-14" />
+									Clear
+								</button>
+							</PopoverTrigger>
 						</IconTooltip>
 					</ConfirmPopover>
 				</div>
@@ -428,19 +426,17 @@ function CommentRow({
 			<span className="absolute top-4 right-8 flex items-center gap-4 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
 				{isDraft && (
 					<>
-						<IconTooltip label="Send this comment to the file's review chat">
-							<span className="flex">
-								<button
-									type="button"
-									data-testid="review-comment-send"
-									aria-label="Send this comment to the file's review chat"
-									disabled={sending}
-									onClick={onSend}
-									className="text-text-subtle hover:text-text-default disabled:pointer-events-none"
-								>
-									<Send className="size-14" />
-								</button>
-							</span>
+						<IconTooltip label="Send this comment to the file's review chat" wrapTrigger>
+							<button
+								type="button"
+								data-testid="review-comment-send"
+								aria-label="Send this comment to the file's review chat"
+								disabled={sending}
+								onClick={onSend}
+								className="text-text-subtle hover:text-text-default disabled:pointer-events-none"
+							>
+								<Send className="size-14" />
+							</button>
 						</IconTooltip>
 						<ConfirmPopover
 							open={confirmDelete}
@@ -452,19 +448,17 @@ function CommentRow({
 							onConfirm={() => void removeDraft()}
 							align="end"
 						>
-							<IconTooltip label="Delete draft">
-								<span className="flex">
-									<PopoverTrigger asChild>
-										<button
-											type="button"
-											data-testid="review-comment-delete"
-											aria-label="Delete draft"
-											className="text-text-subtle hover:text-feedback-error"
-										>
-											<Trash2 className="size-14" />
-										</button>
-									</PopoverTrigger>
-								</span>
+							<IconTooltip label="Delete draft" wrapTrigger>
+								<PopoverTrigger asChild>
+									<button
+										type="button"
+										data-testid="review-comment-delete"
+										aria-label="Delete draft"
+										className="text-text-subtle hover:text-feedback-error"
+									>
+										<Trash2 className="size-14" />
+									</button>
+								</PopoverTrigger>
 							</IconTooltip>
 						</ConfirmPopover>
 					</>

--- a/apps/web/src/panels/ReviewPanel.tsx
+++ b/apps/web/src/panels/ReviewPanel.tsx
@@ -11,6 +11,7 @@ import {
 import type { ReviewComment } from "@thinkrail/contracts";
 import { useState } from "react";
 import { PopoverTrigger } from "@/components/ui/popover";
+import { IconTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { PlanStatusIcon, SectionLabel } from "../chat/planKit";
 import { sessionGlance } from "../chat/planView";
@@ -129,18 +130,21 @@ export function ReviewPanel({ workspaceId, failed }: { workspaceId: string; fail
 						onConfirm={() => void clearReview()}
 						align="end"
 					>
-						<PopoverTrigger asChild>
-							<button
-								type="button"
-								data-testid="review-clear"
-								title="Clear review — archive sent comments"
-								aria-label="Clear review"
-								className="flex shrink-0 items-center gap-4 px-4 tr-text-metadata text-text-subtle hover:text-feedback-error"
-							>
-								<Trash2 className="size-14" />
-								Clear
-							</button>
-						</PopoverTrigger>
+						<IconTooltip label="Clear review — archive sent comments">
+							<span className="flex">
+								<PopoverTrigger asChild>
+									<button
+										type="button"
+										data-testid="review-clear"
+										aria-label="Clear review"
+										className="flex shrink-0 items-center gap-4 px-4 tr-text-metadata text-text-subtle hover:text-feedback-error"
+									>
+										<Trash2 className="size-14" />
+										Clear
+									</button>
+								</PopoverTrigger>
+							</span>
+						</IconTooltip>
 					</ConfirmPopover>
 				</div>
 			)}
@@ -189,16 +193,17 @@ export function ReviewPanel({ workspaceId, failed }: { workspaceId: string; fail
 											</span>
 										</button>
 										{finishable && (
-											<button
-												type="button"
-												data-testid="review-file-done"
-												title="Done — finish this file's review"
-												aria-label="Done — finish this file's review"
-												onClick={() => void finishFile(file.path)}
-												className="flex shrink-0 items-center py-4 pr-4 pl-4 text-text-subtle hover:text-feedback-success"
-											>
-												<CheckCircle2 className="size-14" />
-											</button>
+											<IconTooltip label="Done — finish this file's review">
+												<button
+													type="button"
+													data-testid="review-file-done"
+													aria-label="Done — finish this file's review"
+													onClick={() => void finishFile(file.path)}
+													className="flex shrink-0 items-center py-4 pr-4 pl-4 text-text-subtle hover:text-feedback-success"
+												>
+													<CheckCircle2 className="size-14" />
+												</button>
+											</IconTooltip>
 										)}
 									</div>
 									{isOpen && (
@@ -423,16 +428,20 @@ function CommentRow({
 			<span className="absolute top-4 right-8 flex items-center gap-4 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
 				{isDraft && (
 					<>
-						<button
-							type="button"
-							data-testid="review-comment-send"
-							title="Send this comment to the file's review chat"
-							disabled={sending}
-							onClick={onSend}
-							className="text-text-subtle hover:text-text-default"
-						>
-							<Send className="size-14" />
-						</button>
+						<IconTooltip label="Send this comment to the file's review chat">
+							<span className="flex">
+								<button
+									type="button"
+									data-testid="review-comment-send"
+									aria-label="Send this comment to the file's review chat"
+									disabled={sending}
+									onClick={onSend}
+									className="text-text-subtle hover:text-text-default disabled:pointer-events-none"
+								>
+									<Send className="size-14" />
+								</button>
+							</span>
+						</IconTooltip>
 						<ConfirmPopover
 							open={confirmDelete}
 							onOpenChange={setConfirmDelete}
@@ -443,40 +452,48 @@ function CommentRow({
 							onConfirm={() => void removeDraft()}
 							align="end"
 						>
-							<PopoverTrigger asChild>
-								<button
-									type="button"
-									data-testid="review-comment-delete"
-									title="Delete draft"
-									className="text-text-subtle hover:text-feedback-error"
-								>
-									<Trash2 className="size-14" />
-								</button>
-							</PopoverTrigger>
+							<IconTooltip label="Delete draft">
+								<span className="flex">
+									<PopoverTrigger asChild>
+										<button
+											type="button"
+											data-testid="review-comment-delete"
+											aria-label="Delete draft"
+											className="text-text-subtle hover:text-feedback-error"
+										>
+											<Trash2 className="size-14" />
+										</button>
+									</PopoverTrigger>
+								</span>
+							</IconTooltip>
 						</ConfirmPopover>
 					</>
 				)}
 				{comment.sessionId && (
-					<button
-						type="button"
-						data-testid="review-comment-file"
-						title="Show in file"
-						onClick={onNavigate}
-						className="text-text-subtle hover:text-text-default"
-					>
-						<FileText className="size-14" />
-					</button>
+					<IconTooltip label="Show in file">
+						<button
+							type="button"
+							data-testid="review-comment-file"
+							aria-label="Show in file"
+							onClick={onNavigate}
+							className="text-text-subtle hover:text-text-default"
+						>
+							<FileText className="size-14" />
+						</button>
+					</IconTooltip>
 				)}
 				{comment.status === "sent" && (
-					<button
-						type="button"
-						data-testid="review-comment-resolve"
-						title="Mark resolved"
-						onClick={() => void update({ status: "resolved" })}
-						className="text-text-subtle hover:text-feedback-success"
-					>
-						<CheckCircle2 className="size-14" />
-					</button>
+					<IconTooltip label="Mark resolved">
+						<button
+							type="button"
+							data-testid="review-comment-resolve"
+							aria-label="Mark resolved"
+							onClick={() => void update({ status: "resolved" })}
+							className="text-text-subtle hover:text-feedback-success"
+						>
+							<CheckCircle2 className="size-14" />
+						</button>
+					</IconTooltip>
 				)}
 			</span>
 		</div>
@@ -504,15 +521,17 @@ function ResolvedRow({
 			</span>
 			<span className="flex shrink-0 items-center gap-4 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
 				{comment.sessionId && (
-					<button
-						type="button"
-						data-testid="review-comment-chat"
-						title="Open the linked chat"
-						onClick={() => comment.sessionId && onOpenChat(comment.sessionId)}
-						className="text-text-subtle hover:text-text-default"
-					>
-						<MessageSquare className="size-14" />
-					</button>
+					<IconTooltip label="Open the linked chat">
+						<button
+							type="button"
+							data-testid="review-comment-chat"
+							aria-label="Open the linked chat"
+							onClick={() => comment.sessionId && onOpenChat(comment.sessionId)}
+							className="text-text-subtle hover:text-text-default"
+						>
+							<MessageSquare className="size-14" />
+						</button>
+					</IconTooltip>
 				)}
 			</span>
 		</div>

--- a/apps/web/src/panels/ReviewThreadCard.tsx
+++ b/apps/web/src/panels/ReviewThreadCard.tsx
@@ -1,5 +1,6 @@
 import { RiSendPlaneLine as Send, RiDeleteBin6Line as Trash2 } from "@remixicon/react";
 import { useEffect, useRef, useState } from "react";
+import { IconTooltip } from "../components/ui/tooltip";
 import { threadLabel } from "./reviewModel";
 import type { ReviewThreadActions, ReviewThreadData } from "./reviewWidgets";
 
@@ -57,28 +58,34 @@ export function ReviewThreadCard({
 				</span>
 				{thread.status === "draft" && (
 					<span className="review-thread-actions">
-						<button
-							type="button"
-							data-testid="review-thread-send"
-							title="Send this comment to the file's review chat"
-							aria-label="Send this comment to the file's review chat"
-							className="review-thread-action"
-							disabled={busy}
-							onClick={() => run(actions.onSendComment)}
-						>
-							<Send className="size-12" />
-						</button>
-						<button
-							type="button"
-							data-testid="review-thread-delete"
-							title="Delete draft"
-							aria-label="Delete draft"
-							className="review-thread-action"
-							disabled={busy}
-							onClick={() => run(actions.onDeleteComment)}
-						>
-							<Trash2 className="size-12" />
-						</button>
+						<IconTooltip label="Send this comment to the file's review chat">
+							<span className="flex">
+								<button
+									type="button"
+									data-testid="review-thread-send"
+									aria-label="Send this comment to the file's review chat"
+									className="review-thread-action disabled:pointer-events-none"
+									disabled={busy}
+									onClick={() => run(actions.onSendComment)}
+								>
+									<Send className="size-12" />
+								</button>
+							</span>
+						</IconTooltip>
+						<IconTooltip label="Delete draft">
+							<span className="flex">
+								<button
+									type="button"
+									data-testid="review-thread-delete"
+									aria-label="Delete draft"
+									className="review-thread-action disabled:pointer-events-none"
+									disabled={busy}
+									onClick={() => run(actions.onDeleteComment)}
+								>
+									<Trash2 className="size-12" />
+								</button>
+							</span>
+						</IconTooltip>
 					</span>
 				)}
 			</div>

--- a/apps/web/src/panels/ReviewThreadCard.tsx
+++ b/apps/web/src/panels/ReviewThreadCard.tsx
@@ -58,33 +58,29 @@ export function ReviewThreadCard({
 				</span>
 				{thread.status === "draft" && (
 					<span className="review-thread-actions">
-						<IconTooltip label="Send this comment to the file's review chat">
-							<span className="flex">
-								<button
-									type="button"
-									data-testid="review-thread-send"
-									aria-label="Send this comment to the file's review chat"
-									className="review-thread-action disabled:pointer-events-none"
-									disabled={busy}
-									onClick={() => run(actions.onSendComment)}
-								>
-									<Send className="size-12" />
-								</button>
-							</span>
+						<IconTooltip label="Send this comment to the file's review chat" wrapTrigger>
+							<button
+								type="button"
+								data-testid="review-thread-send"
+								aria-label="Send this comment to the file's review chat"
+								className="review-thread-action disabled:pointer-events-none"
+								disabled={busy}
+								onClick={() => run(actions.onSendComment)}
+							>
+								<Send className="size-12" />
+							</button>
 						</IconTooltip>
-						<IconTooltip label="Delete draft">
-							<span className="flex">
-								<button
-									type="button"
-									data-testid="review-thread-delete"
-									aria-label="Delete draft"
-									className="review-thread-action disabled:pointer-events-none"
-									disabled={busy}
-									onClick={() => run(actions.onDeleteComment)}
-								>
-									<Trash2 className="size-12" />
-								</button>
-							</span>
+						<IconTooltip label="Delete draft" wrapTrigger>
+							<button
+								type="button"
+								data-testid="review-thread-delete"
+								aria-label="Delete draft"
+								className="review-thread-action disabled:pointer-events-none"
+								disabled={busy}
+								onClick={() => run(actions.onDeleteComment)}
+							>
+								<Trash2 className="size-12" />
+							</button>
 						</IconTooltip>
 					</span>
 				)}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -729,7 +729,8 @@ own section. The kebab menu (`plan-menu`, a
   preview icon's position/visibility are **imperative DOM (refs + custom properties + `data-visible`),
   never React state**: the markdown components are per-render-typed, so a state flip mid-drag remounts
   the text nodes under the LIVE selection, which Chrome "restores" by flooding whole blocks — a few
-  selected words painted the entire bullet; clicking it opens an **inline
+  selected words painted the entire bullet. Outside React, these widgets cannot reach the root
+  `TooltipProvider`, so their buttons keep native `title`. Clicking it opens an **inline
   composer under the selection** (a view zone: textarea + Save draft / Send now / Esc cancels). In
   Monaco surfaces the same action also sits in the editor's **right-click context menu** ("Comment on
   selection", right after Copy, `Cmd/Ctrl+Shift+M`; `editorHasSelection` precondition) — the «+» and

--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -15,6 +15,7 @@ import {
 	RiStackFill,
 } from "@remixicon/react";
 import { useEffect, useMemo, useState } from "react";
+import { IconTooltip } from "../components/ui/tooltip";
 import { cn } from "../lib";
 import { selectActiveEditorTab, useAppStore } from "../store";
 import { openFileInTab } from "./openTabs";
@@ -74,16 +75,17 @@ export function SpecsPanel({
 		<div className="flex min-h-0 flex-col">
 			{onRefresh ? (
 				<div className="flex h-panel-header-row shrink-0 items-center justify-end border-border-muted border-b px-12">
-					<button
-						type="button"
-						data-testid="specs-refresh"
-						aria-label="Refresh specs"
-						title="Refresh specs"
-						onClick={onRefresh}
-						className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-					>
-						<RefreshCw className="size-14" />
-					</button>
+					<IconTooltip label="Refresh specs">
+						<button
+							type="button"
+							data-testid="specs-refresh"
+							aria-label="Refresh specs"
+							onClick={onRefresh}
+							className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+						>
+							<RefreshCw className="size-14" />
+						</button>
+					</IconTooltip>
 				</div>
 			) : null}
 			{content}

--- a/apps/web/src/panels/TemplatesSettings.tsx
+++ b/apps/web/src/panels/TemplatesSettings.tsx
@@ -11,6 +11,7 @@ import { TemplateEditorDialog } from "@/chat/TemplateEditorDialog";
 import { assembleTemplate } from "@/chat/templateText";
 import { Button } from "@/components/ui/button";
 import { PopoverTrigger } from "@/components/ui/popover";
+import { IconTooltip } from "@/components/ui/tooltip";
 import { toast, useAppStore } from "@/store";
 import { errorText, getTransport } from "@/transport";
 import { ConfirmPopover } from "./ConfirmPopover";
@@ -335,38 +336,43 @@ function TemplateRow({
 				</div>
 				<div className="flex shrink-0 items-center gap-4">
 					{showOpenAsFile ? (
+						<IconTooltip label="Open as file">
+							<button
+								type="button"
+								data-testid="template-open-file"
+								aria-label="Open as file"
+								onClick={openAsFile}
+								className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted transition hover:bg-control-bg-hovered hover:text-text-default"
+							>
+								<FileText className="size-14" />
+							</button>
+						</IconTooltip>
+					) : null}
+					<IconTooltip label="Edit">
 						<button
 							type="button"
-							data-testid="template-open-file"
-							aria-label="Open as file"
-							title="Open as file"
-							onClick={openAsFile}
+							data-testid="template-edit"
+							aria-label="Edit"
+							onClick={onEdit}
 							className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted transition hover:bg-control-bg-hovered hover:text-text-default"
 						>
-							<FileText className="size-14" />
+							<Pencil className="size-14" />
 						</button>
-					) : null}
-					<button
-						type="button"
-						data-testid="template-edit"
-						aria-label="Edit"
-						title="Edit"
-						onClick={onEdit}
-						className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted transition hover:bg-control-bg-hovered hover:text-text-default"
-					>
-						<Pencil className="size-14" />
-					</button>
-					<PopoverTrigger asChild>
-						<button
-							type="button"
-							data-testid="template-delete"
-							aria-label="Delete"
-							title="Delete"
-							className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted transition hover:bg-control-bg-hovered hover:text-feedback-error"
-						>
-							<Trash2 className="size-14" />
-						</button>
-					</PopoverTrigger>
+					</IconTooltip>
+					<IconTooltip label="Delete">
+						<span className="flex">
+							<PopoverTrigger asChild>
+								<button
+									type="button"
+									data-testid="template-delete"
+									aria-label="Delete"
+									className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted transition hover:bg-control-bg-hovered hover:text-feedback-error"
+								>
+									<Trash2 className="size-14" />
+								</button>
+							</PopoverTrigger>
+						</span>
+					</IconTooltip>
 				</div>
 			</div>
 		</ConfirmPopover>

--- a/apps/web/src/panels/TemplatesSettings.tsx
+++ b/apps/web/src/panels/TemplatesSettings.tsx
@@ -359,19 +359,17 @@ function TemplateRow({
 							<Pencil className="size-14" />
 						</button>
 					</IconTooltip>
-					<IconTooltip label="Delete">
-						<span className="flex">
-							<PopoverTrigger asChild>
-								<button
-									type="button"
-									data-testid="template-delete"
-									aria-label="Delete"
-									className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted transition hover:bg-control-bg-hovered hover:text-feedback-error"
-								>
-									<Trash2 className="size-14" />
-								</button>
-							</PopoverTrigger>
-						</span>
+					<IconTooltip label="Delete" wrapTrigger>
+						<PopoverTrigger asChild>
+							<button
+								type="button"
+								data-testid="template-delete"
+								aria-label="Delete"
+								className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted transition hover:bg-control-bg-hovered hover:text-feedback-error"
+							>
+								<Trash2 className="size-14" />
+							</button>
+						</PopoverTrigger>
 					</IconTooltip>
 				</div>
 			</div>

--- a/apps/web/src/panels/TerminalWorkbench.tsx
+++ b/apps/web/src/panels/TerminalWorkbench.tsx
@@ -2,6 +2,7 @@ import { RiAddLine as Plus } from "@remixicon/react";
 import type { TerminalTabsPush } from "@thinkrail/contracts";
 import { WS_CHANNELS } from "@thinkrail/contracts";
 import { lazy, type ReactNode, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { IconTooltip } from "../components/ui/tooltip";
 import type { TerminalTab } from "../store";
 import { isConnectedGeneration, toast, useAppStore } from "../store";
 import { errorText, getTransport } from "../transport";
@@ -61,16 +62,17 @@ export function useTerminalCatalog(workspaceId: string | null): boolean {
 export function TerminalWorkbenchBody({ tab, onAdd }: { tab: TerminalTab; onAdd: () => void }) {
 	return (
 		<div data-testid="terminal-panel" className="relative h-full min-h-0 bg-container-terminal-bg">
-			<button
-				type="button"
-				data-testid="terminal-add"
-				aria-label="New terminal"
-				title="New terminal"
-				onClick={onAdd}
-				className="absolute top-4 right-4 z-10 flex size-20 items-center justify-center rounded-[var(--radius-sm)] bg-container-elevated-bg text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-			>
-				<Plus className="size-14" />
-			</button>
+			<IconTooltip label="New terminal">
+				<button
+					type="button"
+					data-testid="terminal-add"
+					aria-label="New terminal"
+					onClick={onAdd}
+					className="absolute top-4 right-4 z-10 flex size-20 items-center justify-center rounded-[var(--radius-sm)] bg-container-elevated-bg text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+				>
+					<Plus className="size-14" />
+				</button>
+			</IconTooltip>
 			<Suspense fallback={null}>
 				<TerminalInstance
 					tabKey={tab.tabKey}

--- a/apps/web/src/shell/CollapsedPanelRail.tsx
+++ b/apps/web/src/shell/CollapsedPanelRail.tsx
@@ -3,6 +3,7 @@ import {
 	RiLayoutRightLine as PanelRightOpen,
 } from "@remixicon/react";
 import { forwardRef } from "react";
+import { IconTooltip } from "../components/ui/tooltip";
 import { cn, platformShortcutLabel } from "../lib";
 
 type CollapsedPanelRailProps = {
@@ -18,24 +19,28 @@ export const CollapsedPanelRail = forwardRef<HTMLButtonElement, CollapsedPanelRa
 		const shortcut = platformShortcutLabel(shortcutKey);
 		const accessibleLabel = `Open ${label} (${shortcut})`;
 		return (
-			<button
-				ref={ref}
-				type="button"
-				data-testid={`collapsed-${side}-rail`}
-				aria-label={accessibleLabel}
-				title={accessibleLabel}
-				onClick={onOpen}
-				className={cn(
-					"flex h-full w-28 shrink-0 flex-col items-center gap-12 bg-container-sidebar-bg pt-4 text-text-muted outline-none transition-colors",
-					"hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary",
-					side === "left" ? "border-border-default border-r" : "border-border-default border-l",
-				)}
-			>
-				<Icon aria-hidden="true" className="size-14 shrink-0" />
-				<span aria-hidden="true" className="rotate-180 [writing-mode:vertical-rl] tr-text-eyebrow">
-					{label}
-				</span>
-			</button>
+			<IconTooltip label={accessibleLabel}>
+				<button
+					ref={ref}
+					type="button"
+					data-testid={`collapsed-${side}-rail`}
+					aria-label={accessibleLabel}
+					onClick={onOpen}
+					className={cn(
+						"flex h-full w-28 shrink-0 flex-col items-center gap-12 bg-container-sidebar-bg pt-4 text-text-muted outline-none transition-colors",
+						"hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary",
+						side === "left" ? "border-border-default border-r" : "border-border-default border-l",
+					)}
+				>
+					<Icon aria-hidden="true" className="size-14 shrink-0" />
+					<span
+						aria-hidden="true"
+						className="rotate-180 [writing-mode:vertical-rl] tr-text-eyebrow"
+					>
+						{label}
+					</span>
+				</button>
+			</IconTooltip>
 		);
 	},
 );

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -7,6 +7,7 @@ import {
 } from "@remixicon/react";
 import { useEffect, useRef } from "react";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "../components/ui/resizable";
+import { IconTooltip } from "../components/ui/tooltip";
 import { ProjectTree } from "../panels/ProjectTree";
 import { SettingsDialog } from "../panels/SettingsDialog";
 import { Toaster } from "../panels/Toaster";
@@ -154,16 +155,17 @@ export function Shell() {
 							{STATUS_LABEL[status]}
 						</span>
 					</span>
-					<button
-						type="button"
-						data-testid="open-settings"
-						aria-label="Settings"
-						title="Settings"
-						onClick={() => useAppStore.getState().openSettings()}
-						className="flex size-28 items-center justify-center rounded-[var(--radius-sm)] text-text-muted outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
-					>
-						<Settings className="size-16" />
-					</button>
+					<IconTooltip label="Settings">
+						<button
+							type="button"
+							data-testid="open-settings"
+							aria-label="Settings"
+							onClick={() => useAppStore.getState().openSettings()}
+							className="flex size-28 items-center justify-center rounded-[var(--radius-sm)] text-text-muted outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
+						>
+							<Settings className="size-16" />
+						</button>
+					</IconTooltip>
 				</div>
 				<SettingsDialog layoutSettings={<LayoutSettings />} />
 			</header>

--- a/apps/web/src/shell/WorkspaceChatHistory.tsx
+++ b/apps/web/src/shell/WorkspaceChatHistory.tsx
@@ -28,16 +28,14 @@ export function WorkspaceChatHistory({
 	if (closed.length === 0) return null;
 	return (
 		<DropdownMenu>
-			<IconTooltip label="View chat history">
-				<span className="flex">
-					<DropdownMenuTrigger
-						data-testid="chat-history"
-						aria-label="Reopen a closed chat"
-						className="flex w-32 shrink-0 items-center justify-center border-border-default border-l text-text-muted outline-none hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
-					>
-						<History className="size-14" />
-					</DropdownMenuTrigger>
-				</span>
+			<IconTooltip label="View chat history" wrapTrigger>
+				<DropdownMenuTrigger
+					data-testid="chat-history"
+					aria-label="Reopen a closed chat"
+					className="flex w-32 shrink-0 items-center justify-center border-border-default border-l text-text-muted outline-none hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
+				>
+					<History className="size-14" />
+				</DropdownMenuTrigger>
 			</IconTooltip>
 			<DropdownMenuContent align="end" className="min-w-[16rem]">
 				<DropdownMenuLabel>Recently closed</DropdownMenuLabel>

--- a/apps/web/src/shell/WorkspaceChatHistory.tsx
+++ b/apps/web/src/shell/WorkspaceChatHistory.tsx
@@ -11,6 +11,7 @@ import {
 	DropdownMenuLabel,
 	DropdownMenuTrigger,
 } from "../components/ui/dropdown-menu";
+import { IconTooltip } from "../components/ui/tooltip";
 import { relativeTime } from "../lib";
 import { openChatInTab } from "../panels/openChat";
 import { type ClosedChat, toast, useAppStore } from "../store";
@@ -27,14 +28,17 @@ export function WorkspaceChatHistory({
 	if (closed.length === 0) return null;
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger
-				data-testid="chat-history"
-				aria-label="Reopen a closed chat"
-				title="View chat history"
-				className="flex w-32 shrink-0 items-center justify-center border-border-default border-l text-text-muted outline-none hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
-			>
-				<History className="size-14" />
-			</DropdownMenuTrigger>
+			<IconTooltip label="View chat history">
+				<span className="flex">
+					<DropdownMenuTrigger
+						data-testid="chat-history"
+						aria-label="Reopen a closed chat"
+						className="flex w-32 shrink-0 items-center justify-center border-border-default border-l text-text-muted outline-none hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
+					>
+						<History className="size-14" />
+					</DropdownMenuTrigger>
+				</span>
+			</IconTooltip>
 			<DropdownMenuContent align="end" className="min-w-[16rem]">
 				<DropdownMenuLabel>Recently closed</DropdownMenuLabel>
 				{closed.map((chat) => (
@@ -60,28 +64,29 @@ export function WorkspaceChatHistory({
 							</span>
 							<RotateCcw className="size-14 shrink-0 text-text-muted" />
 						</DropdownMenuItem>
-						<DropdownMenuItem
-							data-testid="closed-chat-delete"
-							aria-label={`Move ${chat.title} to trash`}
-							title="Move chat to trash"
-							onSelect={() => {
-								void getTransport()
-									.request("session.delete", { workspaceId, sessionId: chat.sessionId })
-									.then(() => useAppStore.getState().deleteChat(workspaceId, chat.sessionId))
-									.catch((error) => {
-										const state = useAppStore.getState();
-										if (
-											!state.removedWorkspaceIds[workspaceId] &&
-											!state.deletedSessionsByWorkspace[workspaceId]?.[chat.sessionId]
-										) {
-											toast.error(errorText(error), "Couldn't delete the chat");
-										}
-									});
-							}}
-							className="shrink-0 px-4 text-text-muted focus:text-feedback-error"
-						>
-							<Trash2 className="size-14" />
-						</DropdownMenuItem>
+						<IconTooltip label="Move chat to trash">
+							<DropdownMenuItem
+								data-testid="closed-chat-delete"
+								aria-label={`Move ${chat.title} to trash`}
+								onSelect={() => {
+									void getTransport()
+										.request("session.delete", { workspaceId, sessionId: chat.sessionId })
+										.then(() => useAppStore.getState().deleteChat(workspaceId, chat.sessionId))
+										.catch((error) => {
+											const state = useAppStore.getState();
+											if (
+												!state.removedWorkspaceIds[workspaceId] &&
+												!state.deletedSessionsByWorkspace[workspaceId]?.[chat.sessionId]
+											) {
+												toast.error(errorText(error), "Couldn't delete the chat");
+											}
+										});
+								}}
+								className="shrink-0 px-4 text-text-muted focus:text-feedback-error"
+							>
+								<Trash2 className="size-14" />
+							</DropdownMenuItem>
+						</IconTooltip>
 					</DropdownMenuGroup>
 				))}
 			</DropdownMenuContent>

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -20,6 +20,8 @@ import {
 	useState,
 } from "react";
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { DropdownMenuItem } from "../components/ui/dropdown-menu";
+import { IconTooltip } from "../components/ui/tooltip";
 import { type LayoutAttention, layoutResourceIdentity } from "../lib";
 import { ChangesPanel } from "../panels/ChangesPanel";
 import { DiffPane } from "../panels/DiffPane";
@@ -706,18 +708,31 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 				renderCenterActions={(groupId) => (
 					<>
 						<WorkspaceChatHistory workspaceId={workspaceId} targetGroupId={groupId} />
-						<button
-							type="button"
-							data-testid="new-terminal"
-							aria-label="New terminal in this group"
-							title="New terminal in this group"
-							onClick={() => useAppStore.getState().addTerminal(workspaceId, undefined, groupId)}
-							className="flex w-32 shrink-0 items-center justify-center border-border-default border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-						>
-							<SquareTerminal className="size-14" />
-						</button>
+						<IconTooltip label="New terminal in this group">
+							<button
+								type="button"
+								data-testid="new-terminal"
+								aria-label="New terminal in this group"
+								onClick={() => useAppStore.getState().addTerminal(workspaceId, undefined, groupId)}
+								className="flex w-32 shrink-0 items-center justify-center border-border-default border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+							>
+								<SquareTerminal className="size-14" />
+							</button>
+						</IconTooltip>
 					</>
 				)}
+				renderSideMenuActions={(side, groupId) =>
+					side === "right" ? (
+						<DropdownMenuItem
+							data-testid="side-new-terminal"
+							onSelect={() =>
+								useAppStore.getState().addTerminal(workspaceId, undefined, groupId, side)
+							}
+						>
+							New terminal
+						</DropdownMenuItem>
+					) : null
+				}
 				onCommit={commit}
 				onAttentionChange={changeAttention}
 				onUserNavigation={() => useAppStore.getState().noteNavigation(workspaceId)}

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -137,9 +137,20 @@ fixed previous/next controls: wheel, trackpad, touch, roving-keyboard navigation
 searchable keyboard overflow list all scroll the same tab list. Its native scrollbar stays hidden; subtle,
 pointer-transparent edge fades appear only on directions with clipped tabs and update with scroll, resize, and
 tab changes without altering the fixed 32 px strip or tab geometry. Full-height strip actions share that 32 px
-width, keeping search, creation, alignment, and fold controls square. Singleton tool tabs
+width, keeping search, creation, alignment, and fold controls square. A strip control renders only when it
+can act: the searchable overflow list while the tab list overflows its scroller, the fold button while the
+side holds more than one group (or the group is already folded) — folding a lone group buys no space from a
+neighbour. Singleton tool tabs
 (Projects, Specs, Files, Changes, Review) carry no inline close glyph; Close remains in their context menu
 and on the Delete key, while terminals and center resources retain the direct glyph.
+
+Every side strip trails an add-to-this-group menu, so recovery does not depend on discovering the tab
+context menu. It offers app actions injected via `renderSideMenuActions(side, groupId)` (New terminal, right
+side only — the render prop keeps store-bound creation out of this module) above the tools
+`unplacedToolsForSide` reports for **this** side, so the two rails never offer the same tool. The tab context
+menu stays document-wide, being also the recovery path from a center tab. Both read "Show <tool>" — a tool
+may never have been opened. A terminal placed here lands in the group whose menu was used: the action names
+that side as the intent's target area, so no center navigation routing applies.
 
 ## Presets and synchronization
 

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -147,10 +147,12 @@ and on the Delete key, while terminals and center resources retain the direct gl
 Every side strip trails an add-to-this-group menu, so recovery does not depend on discovering the tab
 context menu. It offers app actions injected via `renderSideMenuActions(side, groupId)` (New terminal, right
 side only — the render prop keeps store-bound creation out of this module) above the tools
-`unplacedToolsForSide` reports for **this** side, so the two rails never offer the same tool. The tab context
-menu stays document-wide, being also the recovery path from a center tab. Both read "Show <tool>" — a tool
-may never have been opened. A terminal placed here lands in the group whose menu was used: the action names
-that side as the intent's target area, so no center navigation routing applies.
+`unplacedToolsForSide` reports for **this** side, so the two rails never offer the same tool. A side tab's
+context menu stays document-wide; a center tab's offers no tools at all — they open in the side regions, and
+listing them under a terminal tab put "Show Review" in a menu that is neither where it would open nor
+anything to do with the tab clicked. Both read "Show <tool>" — a tool may never have been opened. A terminal
+placed here lands in the group whose menu was used: the action names that side as the intent's target area,
+so no center navigation routing applies.
 
 ## Presets and synchronization
 

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -23,6 +23,7 @@ import {
 	RiLayoutLeftLine as PanelLeftOpen,
 	RiLayoutRightLine as PanelRightOpen,
 	RiLayout2Line as PanelsTopLeft,
+	RiAddLine as Plus,
 	RiBookOpenFill,
 	RiBookOpenLine,
 	RiChat2Fill,
@@ -37,6 +38,7 @@ import {
 	RiGitPullRequestFill,
 	RiLayout2Fill,
 	RiTerminalBoxFill,
+	RiSearchLine as Search,
 	RiTerminalBoxLine as SquareTerminal,
 	RiCloseLine as X,
 } from "@remixicon/react";
@@ -86,6 +88,7 @@ import {
 	ResizablePanel,
 	ResizablePanelGroup,
 } from "../../components/ui/resizable";
+import { IconTooltip } from "../../components/ui/tooltip";
 import {
 	DOUBLE_CLICK_SETTLE_MS,
 	type LayoutAttention,
@@ -113,7 +116,6 @@ import {
 	isLayoutUnavailable,
 	keepPreview,
 	LAYOUT_LIMITS,
-	LAYOUT_TOOLS,
 	type LayoutGroupLocation,
 	type LayoutMutationResult,
 	type LayoutOperationResult,
@@ -135,6 +137,8 @@ import {
 	showSide,
 	splitCenterGroup,
 	toolTab,
+	unplacedTools,
+	unplacedToolsForSide,
 } from "./model";
 
 export interface LayoutTabFocusRequest {
@@ -160,6 +164,7 @@ export interface WorkbenchProps {
 	renderToolBody: (tool: LayoutToolId) => ReactNode;
 	renderEmptyCenter: (groupId: string) => ReactNode;
 	renderCenterActions: (groupId: string) => ReactNode;
+	renderSideMenuActions: (side: LayoutSide, groupId: string) => ReactNode;
 	onCommit: (document: WorkspaceLayoutDocument) => void;
 	onAttentionChange: (attention: LayoutAttention) => void;
 	onUserNavigation: () => void;
@@ -579,6 +584,7 @@ function TabStrip({
 	const tabRefs = useRef(new Map<string, HTMLButtonElement>());
 	const overflowFocusTarget = useRef<string | null>(null);
 	const [overflowOpen, setOverflowOpen] = useState(false);
+	const overflowing = scrollOverflow.before || scrollOverflow.after;
 	const selectTab = (tabId: string, keep?: boolean) => {
 		selectionEpoch.current += 1;
 		onSelect(tabId, keep);
@@ -604,6 +610,10 @@ function TabStrip({
 		if (selectedId)
 			tabRefs.current.get(selectedId)?.scrollIntoView({ block: "nearest", inline: "nearest" });
 	}, [selectedId]);
+
+	useEffect(() => {
+		if (!overflowing) setOverflowOpen(false);
+	}, [overflowing]);
 
 	const selectAt = (index: number) => {
 		const tab = tabs[index];
@@ -731,47 +741,51 @@ function TabStrip({
 				) : null}
 			</div>
 			{trailing}
-			<Popover open={overflowOpen} onOpenChange={setOverflowOpen}>
-				<PopoverTrigger
-					aria-label="Search open tabs"
-					className="flex w-32 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-				>
-					<MoreHorizontal className="size-14" />
-				</PopoverTrigger>
-				<PopoverContent
-					align="end"
-					className="w-288 p-0"
-					onCloseAutoFocus={(event) => {
-						const targetId = overflowFocusTarget.current;
-						if (!targetId) return;
-						overflowFocusTarget.current = null;
-						event.preventDefault();
-						tabRefs.current.get(targetId)?.focus();
-					}}
-				>
-					<Command>
-						<CommandInput placeholder="Find an open tab…" />
-						<CommandList>
-							<CommandEmpty>No matching tabs.</CommandEmpty>
-							{tabs.map((tab) => (
-								<CommandItem
-									key={tab.id}
-									value={tab.id}
-									keywords={tabSearchKeywords(tab)}
-									onSelect={() => {
-										overflowFocusTarget.current = tab.id;
-										selectTab(tab.id);
-										setOverflowOpen(false);
-									}}
-								>
-									{tabIcon(tab)}
-									<span className="truncate">{layoutTabName(tab)}</span>
-								</CommandItem>
-							))}
-						</CommandList>
-					</Command>
-				</PopoverContent>
-			</Popover>
+			{overflowing ? (
+				<Popover open={overflowOpen} onOpenChange={setOverflowOpen}>
+					<IconTooltip label="Search open tabs">
+						<PopoverTrigger
+							aria-label="Search open tabs"
+							className="flex w-32 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+						>
+							<Search className="size-14" />
+						</PopoverTrigger>
+					</IconTooltip>
+					<PopoverContent
+						align="end"
+						className="w-288 p-0"
+						onCloseAutoFocus={(event) => {
+							const targetId = overflowFocusTarget.current;
+							if (!targetId) return;
+							overflowFocusTarget.current = null;
+							event.preventDefault();
+							tabRefs.current.get(targetId)?.focus();
+						}}
+					>
+						<Command>
+							<CommandInput placeholder="Find an open tab…" />
+							<CommandList>
+								<CommandEmpty>No matching tabs.</CommandEmpty>
+								{tabs.map((tab) => (
+									<CommandItem
+										key={tab.id}
+										value={tab.id}
+										keywords={tabSearchKeywords(tab)}
+										onSelect={() => {
+											overflowFocusTarget.current = tab.id;
+											selectTab(tab.id);
+											setOverflowOpen(false);
+										}}
+									>
+										{tabIcon(tab)}
+										<span className="truncate">{layoutTabName(tab)}</span>
+									</CommandItem>
+								))}
+							</CommandList>
+						</Command>
+					</PopoverContent>
+				</Popover>
+			) : null}
 		</div>
 	);
 }
@@ -876,7 +890,7 @@ function WorkbenchTab({
 		disabled: !acceptsAfter,
 	});
 	const groups = collectAllGroups(document);
-	const missingTools = LAYOUT_TOOLS.filter((tool) => !findPlacedResource(document, toolTab(tool)));
+	const missingTools = unplacedTools(document);
 	const splitReason = (direction: CenterSplitDirection): string | null => {
 		if (location.area !== "center") return "Only center tabs can split the center.";
 		if (tab.kind === "tool") return "Tools stay in a side region.";
@@ -1139,12 +1153,15 @@ function WorkbenchTab({
 						})}
 					</>
 				) : null}
-				{missingTools.length > 0 ? (
+				{/* Tools live in the side regions, and the side strip's own menu offers the missing ones there.
+				    Repeating them under a centre tab put "Show Review" in the menu of a terminal, which is
+				    neither where it would open nor anything to do with the tab clicked. */}
+				{location.area !== "center" && missingTools.length > 0 ? (
 					<>
 						<ContextMenuSeparator />
 						{missingTools.map((tool) => (
 							<ContextMenuItem key={tool} onSelect={() => onRevealTool(tool)}>
-								Restore {toolTab(tool).name}
+								Show {toolTab(tool).name}
 							</ContextMenuItem>
 						))}
 					</>
@@ -1187,6 +1204,7 @@ interface SharedGroupProps {
 	renderTabBody: WorkbenchProps["renderTabBody"];
 	renderTabAdornment: WorkbenchProps["renderTabAdornment"];
 	renderToolBody: WorkbenchProps["renderToolBody"];
+	renderSideMenuActions: WorkbenchProps["renderSideMenuActions"];
 	onAttentionChange: WorkbenchProps["onAttentionChange"];
 	onUserNavigation: WorkbenchProps["onUserNavigation"];
 	onRemoteGestureCanceled: (() => void) | undefined;
@@ -1267,16 +1285,17 @@ function CenterGroupView({
 				trailing={
 					<>
 						{renderCenterActions(group.id)}
-						<button
-							type="button"
-							data-testid="new-chat"
-							aria-label="New chat"
-							title="New chat"
-							onClick={() => onNewChat(group.id)}
-							className="flex w-32 shrink-0 items-center justify-center text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-						>
-							<MessageSquarePlus className="size-14" />
-						</button>
+						<IconTooltip label="New chat">
+							<button
+								type="button"
+								data-testid="new-chat"
+								aria-label="New chat"
+								onClick={() => onNewChat(group.id)}
+								className="flex w-32 shrink-0 items-center justify-center text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+							>
+								<MessageSquarePlus className="size-14" />
+							</button>
+						</IconTooltip>
 					</>
 				}
 			/>
@@ -1439,6 +1458,7 @@ function SideGroupView({
 	side,
 	group,
 	groupIndex,
+	foldable,
 	renderToolBody,
 	onFold,
 	...shared
@@ -1446,6 +1466,7 @@ function SideGroupView({
 	side: LayoutSide;
 	group: LayoutSideGroup;
 	groupIndex: number;
+	foldable: boolean;
 	renderToolBody: WorkbenchProps["renderToolBody"];
 	onFold: () => void;
 }) {
@@ -1531,27 +1552,40 @@ function SideGroupView({
 						onRevealTool={shared.onRevealTool}
 						canFocusAdjacentGroup={shared.canFocusAdjacentGroup}
 						renderTabAdornment={shared.renderTabAdornment}
+						trailing={
+							<SideGroupMenu
+								document={shared.document}
+								side={side}
+								groupId={group.id}
+								renderSideMenuActions={shared.renderSideMenuActions}
+								onRevealTool={shared.onRevealTool}
+							/>
+						}
 					/>
 				</div>
-				<button
-					type="button"
-					data-testid="side-group-fold"
-					aria-label={group.folded ? "Expand group" : "Fold group"}
-					aria-expanded={!group.folded}
-					onClick={onFold}
-					onKeyDown={(event) => {
-						if (event.key !== "Enter" && event.key !== " ") return;
-						event.preventDefault();
-						onFold();
-					}}
-					className="flex w-32 shrink-0 items-center justify-center border-border-muted border-b border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-				>
-					{group.folded ? (
-						<RiExpandVerticalLine className="size-16" />
-					) : (
-						<RiCollapseVerticalLine className="size-16" />
-					)}
-				</button>
+				{foldable ? (
+					<IconTooltip label={group.folded ? "Expand group" : "Fold group"}>
+						<button
+							type="button"
+							data-testid="side-group-fold"
+							aria-label={group.folded ? "Expand group" : "Fold group"}
+							aria-expanded={!group.folded}
+							onClick={onFold}
+							onKeyDown={(event) => {
+								if (event.key !== "Enter" && event.key !== " ") return;
+								event.preventDefault();
+								onFold();
+							}}
+							className="flex w-32 shrink-0 items-center justify-center border-border-muted border-b border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+						>
+							{group.folded ? (
+								<RiExpandVerticalLine className="size-16" />
+							) : (
+								<RiCollapseVerticalLine className="size-16" />
+							)}
+						</button>
+					</IconTooltip>
+				) : null}
 			</div>
 			<div
 				id={groupPanelId(location)}
@@ -1573,6 +1607,52 @@ function SideGroupView({
 			</div>
 			{group.folded ? creationTargets : null}
 		</div>
+	);
+}
+
+function SideGroupMenu({
+	document,
+	side,
+	groupId,
+	renderSideMenuActions,
+	onRevealTool,
+}: {
+	document: WorkspaceLayoutDocument;
+	side: LayoutSide;
+	groupId: string;
+	renderSideMenuActions: WorkbenchProps["renderSideMenuActions"];
+	onRevealTool: (tool: LayoutToolId) => void;
+}) {
+	const missing = unplacedToolsForSide(document, side);
+	const actions = renderSideMenuActions(side, groupId);
+	if (missing.length === 0 && !actions) return null;
+	return (
+		<DropdownMenu>
+			<IconTooltip label="Add to this group">
+				<span className="flex">
+					<DropdownMenuTrigger
+						data-testid="side-group-menu"
+						aria-label="Add to this group"
+						className="flex w-32 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+					>
+						<Plus className="size-16" />
+					</DropdownMenuTrigger>
+				</span>
+			</IconTooltip>
+			<DropdownMenuContent align="end">
+				{actions}
+				{actions && missing.length > 0 ? <DropdownMenuSeparator /> : null}
+				{missing.map((tool) => (
+					<DropdownMenuItem
+						key={tool}
+						data-testid={`show-tool-${tool}`}
+						onSelect={() => onRevealTool(tool)}
+					>
+						Show {toolTab(tool).name}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 
@@ -1656,6 +1736,7 @@ function SideStack({
 								side={side}
 								group={group}
 								groupIndex={index}
+								foldable={region.groups.length > 1 || group.folded}
 								renderToolBody={renderToolBody}
 								onFold={() => {
 									const result = setSideGroupFolded(shared.document, side, group.id, !group.folded);
@@ -2229,20 +2310,23 @@ function HiddenSideRail({
 			data-drop-active={drop.isOver || undefined}
 			className="flex w-28 shrink-0 flex-col items-center border-border-default bg-container-sidebar-bg py-4 first:border-r last:border-l data-[drop-active]:bg-primary-subtle data-[drop-active]:ring-2 data-[drop-active]:ring-inset data-[drop-active]:ring-primary"
 		>
-			<button
-				type="button"
-				aria-label={`Show ${side} side`}
-				title={showEnabled ? `Show ${side} side` : `No ${side} groups to show`}
-				disabled={!showEnabled}
-				onClick={onShow}
-				className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default disabled:text-control-disabled-text disabled:hover:bg-transparent"
-			>
-				{side === "left" ? (
-					<PanelLeftOpen className="size-14" />
-				) : (
-					<PanelRightOpen className="size-14" />
-				)}
-			</button>
+			<IconTooltip label={showEnabled ? `Show ${side} side` : `No ${side} groups to show`}>
+				<span className="flex">
+					<button
+						type="button"
+						aria-label={`Show ${side} side`}
+						disabled={!showEnabled}
+						onClick={onShow}
+						className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default disabled:pointer-events-none disabled:text-control-disabled-text"
+					>
+						{side === "left" ? (
+							<PanelLeftOpen className="size-14" />
+						) : (
+							<PanelRightOpen className="size-14" />
+						)}
+					</button>
+				</span>
+			</IconTooltip>
 		</div>
 	);
 }
@@ -2259,6 +2343,7 @@ export function Workbench({
 	renderToolBody,
 	renderEmptyCenter,
 	renderCenterActions,
+	renderSideMenuActions,
 	onCommit,
 	onAttentionChange,
 	onUserNavigation,
@@ -2809,6 +2894,7 @@ export function Workbench({
 		renderTabBody,
 		renderTabAdornment,
 		renderToolBody,
+		renderSideMenuActions,
 		onAttentionChange,
 		onUserNavigation,
 		onRemoteGestureCanceled,

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -743,7 +743,7 @@ function TabStrip({
 			{trailing}
 			{overflowing ? (
 				<Popover open={overflowOpen} onOpenChange={setOverflowOpen}>
-					<IconTooltip label="Search open tabs">
+					<IconTooltip label="Search open tabs" wrapTrigger>
 						<PopoverTrigger
 							aria-label="Search open tabs"
 							className="flex w-32 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
@@ -1153,9 +1153,6 @@ function WorkbenchTab({
 						})}
 					</>
 				) : null}
-				{/* Tools live in the side regions, and the side strip's own menu offers the missing ones there.
-				    Repeating them under a centre tab put "Show Review" in the menu of a terminal, which is
-				    neither where it would open nor anything to do with the tab clicked. */}
 				{location.area !== "center" && missingTools.length > 0 ? (
 					<>
 						<ContextMenuSeparator />
@@ -1628,16 +1625,14 @@ function SideGroupMenu({
 	if (missing.length === 0 && !actions) return null;
 	return (
 		<DropdownMenu>
-			<IconTooltip label="Add to this group">
-				<span className="flex">
-					<DropdownMenuTrigger
-						data-testid="side-group-menu"
-						aria-label="Add to this group"
-						className="flex w-32 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-					>
-						<Plus className="size-16" />
-					</DropdownMenuTrigger>
-				</span>
+			<IconTooltip label="Add to this group" wrapTrigger>
+				<DropdownMenuTrigger
+					data-testid="side-group-menu"
+					aria-label="Add to this group"
+					className="flex w-32 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+				>
+					<Plus className="size-16" />
+				</DropdownMenuTrigger>
 			</IconTooltip>
 			<DropdownMenuContent align="end">
 				{actions}
@@ -2310,22 +2305,23 @@ function HiddenSideRail({
 			data-drop-active={drop.isOver || undefined}
 			className="flex w-28 shrink-0 flex-col items-center border-border-default bg-container-sidebar-bg py-4 first:border-r last:border-l data-[drop-active]:bg-primary-subtle data-[drop-active]:ring-2 data-[drop-active]:ring-inset data-[drop-active]:ring-primary"
 		>
-			<IconTooltip label={showEnabled ? `Show ${side} side` : `No ${side} groups to show`}>
-				<span className="flex">
-					<button
-						type="button"
-						aria-label={`Show ${side} side`}
-						disabled={!showEnabled}
-						onClick={onShow}
-						className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default disabled:pointer-events-none disabled:text-control-disabled-text"
-					>
-						{side === "left" ? (
-							<PanelLeftOpen className="size-14" />
-						) : (
-							<PanelRightOpen className="size-14" />
-						)}
-					</button>
-				</span>
+			<IconTooltip
+				label={showEnabled ? `Show ${side} side` : `No ${side} groups to show`}
+				wrapTrigger
+			>
+				<button
+					type="button"
+					aria-label={`Show ${side} side`}
+					disabled={!showEnabled}
+					onClick={onShow}
+					className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default disabled:pointer-events-none disabled:text-control-disabled-text"
+				>
+					{side === "left" ? (
+						<PanelLeftOpen className="size-14" />
+					) : (
+						<PanelRightOpen className="size-14" />
+					)}
+				</button>
 			</IconTooltip>
 		</div>
 	);

--- a/apps/web/src/shell/layout/model.test.ts
+++ b/apps/web/src/shell/layout/model.test.ts
@@ -37,6 +37,8 @@ import {
 	showSide,
 	splitCenterGroup,
 	toolTab,
+	unplacedTools,
+	unplacedToolsForSide,
 	validateLayoutDocument,
 	withAvailablePlacementId,
 } from "./model";
@@ -394,6 +396,21 @@ describe("workspace layout model", () => {
 			area: "center",
 			groupId: "center-a",
 		});
+	});
+
+	test("side-scoped tool recovery never offers a tool the other side would receive", () => {
+		let document = baseDocument();
+		document = closeLayoutTab(document, "tool:files").document;
+		document = closeLayoutTab(document, "tool:projects").document;
+
+		expect(unplacedTools(document)).toContain("files");
+		expect(unplacedTools(document)).toContain("projects");
+		expect(unplacedToolsForSide(document, "right")).toContain("files");
+		expect(unplacedToolsForSide(document, "right")).not.toContain("projects");
+		expect(unplacedToolsForSide(document, "left")).toEqual(["projects"]);
+
+		const placedAgain = mutation(revealTool(document, "files", 6)).document;
+		expect(unplacedToolsForSide(placedAgain, "right")).not.toContain("files");
 	});
 
 	test("records singleton restore targets and reveals closed tools unfolded in place", () => {

--- a/apps/web/src/shell/layout/model.ts
+++ b/apps/web/src/shell/layout/model.ts
@@ -375,6 +375,20 @@ export function findPlacedResource(
 	);
 }
 
+export function unplacedTools(document: WorkspaceLayoutDocument): readonly LayoutToolId[] {
+	return LAYOUT_TOOLS.filter((tool) => findPlacedResource(document, toolTab(tool)) === null);
+}
+
+export function unplacedToolsForSide(
+	document: WorkspaceLayoutDocument,
+	side: LayoutSide,
+): readonly LayoutToolId[] {
+	return unplacedTools(document).filter(
+		(tool) =>
+			(document.toolRestoreTargets[tool]?.region ?? LAYOUT_TOOL_DEFAULT_SIDES[tool]) === side,
+	);
+}
+
 function resolvePlacedResource(
 	document: WorkspaceLayoutDocument,
 	tab: LayoutTab,
@@ -844,14 +858,7 @@ export function hideBottom(
 }
 
 export function canShowSide(document: WorkspaceLayoutDocument, side: LayoutSide): boolean {
-	return (
-		document[side].groups.length > 0 ||
-		TOOL_RESTORE_ORDER.some(
-			(tool) =>
-				(document.toolRestoreTargets[tool]?.region ?? LAYOUT_TOOL_DEFAULT_SIDES[tool]) === side &&
-				findPlacedResource(document, toolTab(tool)) === null,
-		)
-	);
+	return document[side].groups.length > 0 || unplacedToolsForSide(document, side).length > 0;
 }
 
 export function showBottom(

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -226,20 +226,28 @@ async function createWorkspaceWithoutOpening(page: Page): Promise<{ id: string; 
 test("full-height panel-header actions stay square", async ({ page }) => {
 	await openDefaultWorkbench(page);
 
-	const controls = [
-		page.getByRole("button", { name: "Search open tabs" }).first(),
-		page.getByTestId("new-chat"),
-		page.getByTestId("new-terminal"),
-		page.getByTestId("side-group-fold").first(),
-		page.getByRole("button", { name: "Bottom panel alignment" }),
-		page.getByTestId("bottom-group-fold"),
-	];
-	for (const control of controls) {
+	const square = async (control: Locator): Promise<void> => {
 		await expect(control).toHaveCSS("width", "32px");
 		const box = await control.boundingBox();
 		if (!box) throw new Error("panel-header control has no bounding box");
 		expect(Math.abs(box.width - box.height)).toBeLessThanOrEqual(1);
-	}
+	};
+
+	const controls = [
+		page.getByTestId("new-chat"),
+		page.getByTestId("new-terminal"),
+		page.getByTestId("side-group-fold").first(),
+		page.getByTestId("side-group-menu").first(),
+		page.getByRole("button", { name: "Bottom panel alignment" }),
+		page.getByTestId("bottom-group-fold"),
+	];
+	for (const control of controls) await square(control);
+
+	await page.getByTestId("tab-files").click();
+	for (const name of ["README.md", "notes.txt", "LINKS.md"])
+		await page.getByTestId("file-node").filter({ hasText: name }).dblclick();
+	await page.setViewportSize({ width: 620, height: 800 });
+	await square(page.getByRole("button", { name: "Search open tabs" }).first());
 });
 
 test("a new workspace starts with one accessible terminal group in a 30% bottom panel", async ({

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -502,6 +502,7 @@ test("keyboard and menu commands reorder, search, recursively split, and collaps
 	await searchTabs.click();
 	await expect(page.getByPlaceholder("Find an open tab…")).toBeVisible();
 	await page.setViewportSize({ width: 1280, height: 720 });
+	await expect(searchTabs).toHaveCount(0);
 	await page.setViewportSize({ width: 620, height: 800 });
 	await expect(searchTabs).toBeVisible();
 	await expect(page.getByPlaceholder("Find an open tab…")).toHaveCount(0);

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -282,6 +282,28 @@ test("dragging outer separators hides both sides and preserves their restore sta
 	await waitTerminalReady(page);
 });
 
+test("the side group menu shows tools for its own side and opens terminals in that group", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	const specsGroup = sideGroups(page, "right").first();
+	await expect(specsGroup.getByTestId("terminal-tab")).toHaveCount(0);
+
+	await specsGroup.getByRole("button", { name: "Add to this group" }).click();
+	await page.getByTestId("side-new-terminal").click();
+	await expect(specsGroup.getByTestId("terminal-tab")).toHaveCount(1);
+	await expect(page.getByTestId("center-tab-strip").getByTestId("terminal-tab")).toHaveCount(0);
+
+	await page.getByTestId("tab-projects").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "Close", exact: true }).click();
+	await page.getByTestId("tab-changes").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "Close", exact: true }).click();
+
+	await specsGroup.getByRole("button", { name: "Add to this group" }).click();
+	await expect(page.getByTestId("show-tool-changes")).toBeVisible();
+	await expect(page.getByTestId("show-tool-projects")).toHaveCount(0);
+});
+
 test("a terminal can move to its own side group; resize, fold, and visibility gate its one body", async ({
 	page,
 }) => {
@@ -289,6 +311,7 @@ test("a terminal can move to its own side group; resize, fold, and visibility ga
 	await pressPlatformShortcut(page, "b");
 	await expect(page.getByTestId("left-layout-rail")).toBeVisible();
 	const terminalTab = page.getByTestId("terminal-tab");
+	await terminalTab.scrollIntoViewIfNeeded();
 	const terminalBox = await terminalTab.boundingBox();
 	if (!terminalBox) throw new Error("terminal tab has no box");
 	await page.mouse.move(
@@ -297,7 +320,7 @@ test("a terminal can move to its own side group; resize, fold, and visibility ga
 	);
 	await page.mouse.down();
 	await page.mouse.move(
-		terminalBox.x + terminalBox.width / 2 + 12,
+		terminalBox.x + terminalBox.width / 2 - 12,
 		terminalBox.y + terminalBox.height / 2 + 8,
 		{ steps: 4 },
 	);
@@ -445,13 +468,13 @@ test("keyboard and menu commands reorder, search, recursively split, and collaps
 	await page.getByRole("menuitem", { name: "Close", exact: true }).click();
 	await expect(page.getByTestId("tab-files")).toHaveCount(0);
 	await page.getByTestId("tab-changes").click({ button: "right" });
-	await page.getByRole("menuitem", { name: "Restore Files" }).click();
+	await page.getByRole("menuitem", { name: "Show Files" }).click();
 	await expect(page.getByTestId("tab-files")).toBeVisible();
 	await page.getByTestId("tab-specs").getByRole("tab").focus();
 	await page.keyboard.press("Delete");
 	await expect(page.getByTestId("tab-specs")).toHaveCount(0);
 	await page.getByTestId("tab-changes").click({ button: "right" });
-	await page.getByRole("menuitem", { name: "Restore Specs" }).click();
+	await page.getByRole("menuitem", { name: "Show Specs" }).click();
 	await expect(page.getByTestId("tab-specs")).toBeVisible();
 
 	await openKeptFiles(page, ["README.md", "notes.txt", "LINKS.md"]);
@@ -462,11 +485,27 @@ test("keyboard and menu commands reorder, search, recursively split, and collaps
 	await expect(tabs.nth(1)).toContainText("README.md");
 
 	const centerStrip = page.getByTestId("center-tab-strip");
-	await centerStrip.getByRole("button", { name: "Search open tabs" }).click();
+	const searchTabs = centerStrip.getByRole("button", { name: "Search open tabs" });
+	await expect(searchTabs).toHaveCount(0);
+
+	await page.setViewportSize({ width: 620, height: 800 });
+	await expect(searchTabs).toBeVisible();
+	await searchTabs.click();
 	await page.getByPlaceholder("Find an open tab…").fill("notes");
 	await page.getByRole("option", { name: /notes\.txt/ }).click();
 	await expect(tabs.filter({ hasText: "notes.txt" })).toHaveAttribute("data-active", "true");
 	await expect(tabs.filter({ hasText: "notes.txt" }).getByRole("tab")).toBeFocused();
+	await page.setViewportSize({ width: 1280, height: 720 });
+	await expect(searchTabs).toHaveCount(0);
+
+	await page.setViewportSize({ width: 620, height: 800 });
+	await searchTabs.click();
+	await expect(page.getByPlaceholder("Find an open tab…")).toBeVisible();
+	await page.setViewportSize({ width: 1280, height: 720 });
+	await page.setViewportSize({ width: 620, height: 800 });
+	await expect(searchTabs).toBeVisible();
+	await expect(page.getByPlaceholder("Find an open tab…")).toHaveCount(0);
+	await page.setViewportSize({ width: 1280, height: 720 });
 
 	await tabs.filter({ hasText: "notes.txt" }).click({ button: "right" });
 	await page.getByRole("menuitem", { name: "Split right" }).click();

--- a/e2e/review.spec.ts
+++ b/e2e/review.spec.ts
@@ -181,6 +181,15 @@ test("selection → icon → inline composer → draft; the tab wears the violet
 	await expect(page.getByTestId("review-comment-revert")).toHaveCount(0);
 	await page.getByTestId("review-comment-delete").click();
 	await expect(page.getByTestId("confirm-popover")).toBeVisible();
+	await page.mouse.move(0, 0);
+	await expect
+		.poll(() =>
+			page.getByTestId("review-comment-delete").evaluate((node) => {
+				const actions = node.closest('[class*="opacity-0"]');
+				return actions ? getComputedStyle(actions).opacity : null;
+			}),
+		)
+		.toBe("1");
 	await page.getByTestId("review-comment-delete-confirm").click();
 	await expect(rows).toHaveCount(0);
 	await expect(page.getByTestId("review-tab-flag")).toHaveCount(0);


### PR DESCRIPTION
- Show custom tooltips for icons with unclear for a new user meaning with less delay because native ones can have uncontrollable and long delay
<img width="183" height="86" alt="image" src="https://github.com/user-attachments/assets/617be55d-f240-4099-8dfb-c34bbc415fd9" />

- Show tab scroll and search controls only while the tabs actually overflow
<img width="314" height="243" alt="image" src="https://github.com/user-attachments/assets/36337053-cbc5-4bd6-b075-512dfbd34940" />

- Show the fold control only while the side holds more than one group
<img width="417" height="814" alt="image" src="https://github.com/user-attachments/assets/16594861-d817-4f85-b0cf-2bde5a87de9a" />


- Offer unplaced tools from a menu on the side strip itself, scoped to that side, not only from a tab's context menu
<img width="398" height="788" alt="image" src="https://github.com/user-attachments/assets/c7b68e7f-b302-4a93-b7a5-d7b3246cf626" />

- Create a terminal from that menu, in the group it was opened from

🤖 Generated with [Claude Code](https://claude.com/claude-code)