### PR TITLE
fix(terminal): nudge PTY redraw on reattach so alt-screen TUIs reappear

### DIFF
--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -39,10 +39,30 @@ separate layout snapshot and merely references `tabKey`.
   its process is Theia's `Couldn't attach - can't find terminal with id`).
 - **`attachTerminal` is idempotent get-or-create** — the only way a PTY is born. No separate liveness call, so
   there is no window in which a client holds the only pointer to a running shell.
-- **PTY resizing is change-only.** Each live entry tracks the grid applied at spawn or by the last successful
-  resize. Attach and explicit resize call `IPty.resize` only when that grid changes, and failed calls do not
-  advance the tracked state. Even a same-grid resize can wake the shell through `SIGWINCH`; a redraw emitted
+- **Tracked-grid updates are change-only.** Each live entry tracks the grid applied at spawn or by the last
+  successful resize. Attach and explicit resize advance that grid only when it changes, and failed calls do not
+  advance it. A reattach may still perform a *transient* redraw nudge (below) that leaves the tracked grid
+  untouched. Even a same-grid resize can wake the shell through `SIGWINCH`; a redraw emitted
   after the attach snapshot can overwrite freshly replayed rows.
+- **Reattaching to an unchanged grid still nudges the foreground app** (`nudgePtyRedraw`, `ptyGrid.ts`):
+  `TIOCSWINSZ` to the same size is a kernel no-op — no `SIGWINCH`, so a full-screen alt-screen app (vim,
+  htop, an interactive CLI) left running behind a tab that was switched away and back gets no signal to
+  repaint, and the recorder never captured its alt-screen content to replay in its place (see below) — the
+  tab would otherwise show a frozen pre-alt-screen buffer. `attachTerminal`'s reattach branch resizes to
+  `cols - 1` only when the real resize above was a no-op, forcing a genuine `SIGWINCH`; the restoring
+  resize back to `cols` is **deferred** (`NUDGE_RESTORE_DELAY_MS`, `setTimeout`), not fired back to back
+  with the first. Two `pty.resize()` calls in the same tick are, from the child's perspective, a single
+  observable transition — its own event loop never gets scheduled between them — so an ncurses-style app
+  ends up seeing "same size as before" and does its normal *incremental* refresh (diffing against what it
+  last drew) instead of a full clear-and-redraw; that paints new content over whatever stale/blank buffer
+  the client is currently showing rather than replacing it — visibly garbled, not merely stale, and worse
+  than doing nothing. The deferred restore gives the child a real scheduling opportunity to observe — and
+  fully redraw at — the intermediate size before the second resize lands. The restore checks liveness
+  (`terminals.get(id) === entry`) before firing, since the tab may have closed or respawned in the
+  interval, and it also checks that the tracked grid is still the one it captured: a real resize landing
+  during the delay would otherwise be undone by the restore, leaving the PTY at the old size while the
+  tracked grid says otherwise — and the change-only rule then makes retrying the new size a no-op. This is the same "redraw after the attach snapshot" class of race the bullet above already
+  accepts, deliberately triggered every reattach instead of only incidentally.
 - **Ownership is the host's owner, not the browser page.** Any client may attach; consistent with `history`,
   `todos` and `templates`, which already assume a single-owner host. Consequence: shells survive a reload, a
   closed browser and a different browser.

--- a/packages/server/src/terminal/ptyGrid.test.ts
+++ b/packages/server/src/terminal/ptyGrid.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type PtyGrid, resizePtyIfChanged } from "./ptyGrid";
+import { nudgePtyRedraw, type PtyGrid, resizePtyIfChanged } from "./ptyGrid";
 
 describe("PTY grid", () => {
 	test("same-grid resize is a no-op", () => {
@@ -45,5 +45,89 @@ describe("PTY grid", () => {
 			),
 		).toThrow("resize failed");
 		expect(current).toEqual({ cols: 80, rows: 24 });
+	});
+});
+
+describe("nudgePtyRedraw", () => {
+	test("shrinks the column count immediately; restore is deferred, not immediate", () => {
+		const calls: PtyGrid[] = [];
+		const scheduled: (() => void)[] = [];
+		const current = { cols: 80, rows: 24 };
+
+		nudgePtyRedraw({ resize: (cols, rows) => calls.push({ cols, rows }) }, current, {
+			schedule: (fn, ms) => {
+				expect(ms).toBeGreaterThan(0);
+				scheduled.push(fn);
+			},
+		});
+
+		expect(calls).toEqual([{ cols: 79, rows: 24 }]);
+		expect(current).toEqual({ cols: 80, rows: 24 });
+
+		for (const fn of scheduled) fn();
+		expect(calls).toEqual([
+			{ cols: 79, rows: 24 },
+			{ cols: 80, rows: 24 },
+		]);
+	});
+
+	test("falls back to nudging rows when there is only one column", () => {
+		const calls: PtyGrid[] = [];
+		const scheduled: (() => void)[] = [];
+
+		nudgePtyRedraw(
+			{ resize: (cols, rows) => calls.push({ cols, rows }) },
+			{ cols: 1, rows: 24 },
+			{ schedule: (fn) => scheduled.push(fn) },
+		);
+		for (const fn of scheduled) fn();
+
+		expect(calls).toEqual([
+			{ cols: 1, rows: 23 },
+			{ cols: 1, rows: 24 },
+		]);
+	});
+
+	test("does nothing for a 1x1 grid", () => {
+		const calls: PtyGrid[] = [];
+
+		nudgePtyRedraw(
+			{ resize: (cols, rows) => calls.push({ cols, rows }) },
+			{ cols: 1, rows: 1 },
+			{ schedule: () => calls.push({ cols: -1, rows: -1 }) },
+		);
+
+		expect(calls).toEqual([]);
+	});
+
+	test("skips the restore when a newer resize changed the grid during the delay", () => {
+		const calls: PtyGrid[] = [];
+		const scheduled: (() => void)[] = [];
+		const pty = { resize: (cols: number, rows: number) => calls.push({ cols, rows }) };
+		const current: PtyGrid = { cols: 46, rows: 21 };
+
+		nudgePtyRedraw(pty, current, { schedule: (fn) => scheduled.push(fn) });
+		resizePtyIfChanged(pty, current, { cols: 38, rows: 21 });
+		for (const fn of scheduled) fn();
+
+		expect(calls).toEqual([
+			{ cols: 45, rows: 21 },
+			{ cols: 38, rows: 21 },
+		]);
+		expect(current).toEqual({ cols: 38, rows: 21 });
+	});
+
+	test("skips the restore when the terminal is no longer live", () => {
+		const calls: PtyGrid[] = [];
+		const scheduled: (() => void)[] = [];
+
+		nudgePtyRedraw(
+			{ resize: (cols, rows) => calls.push({ cols, rows }) },
+			{ cols: 80, rows: 24 },
+			{ schedule: (fn) => scheduled.push(fn), isStillLive: () => false },
+		);
+		for (const fn of scheduled) fn();
+
+		expect(calls).toEqual([{ cols: 79, rows: 24 }]);
 	});
 });

--- a/packages/server/src/terminal/ptyGrid.ts
+++ b/packages/server/src/terminal/ptyGrid.ts
@@ -14,3 +14,33 @@ export function resizePtyIfChanged(pty: PtyResizer, current: PtyGrid, next: PtyG
 	current.rows = next.rows;
 	return true;
 }
+
+// The restore must stay deferred and grid-checked; see terminal/SPEC.md.
+export const NUDGE_RESTORE_DELAY_MS = 50;
+
+export interface NudgePtyRedrawOptions {
+	isStillLive?: () => boolean;
+	schedule?: (fn: () => void, ms: number) => void;
+}
+
+export function nudgePtyRedraw(
+	pty: PtyResizer,
+	current: PtyGrid,
+	options: NudgePtyRedrawOptions = {},
+): void {
+	const { cols, rows } = current;
+	const schedule = options.schedule ?? ((fn, ms) => setTimeout(fn, ms));
+	const isStillLive = options.isStillLive ?? (() => true);
+	const restore = (): void => {
+		if (!isStillLive()) return;
+		if (current.cols !== cols || current.rows !== rows) return;
+		pty.resize(cols, rows);
+	};
+	if (cols > 1) {
+		pty.resize(cols - 1, rows);
+		schedule(restore, NUDGE_RESTORE_DELAY_MS);
+	} else if (rows > 1) {
+		pty.resize(cols, rows - 1);
+		schedule(restore, NUDGE_RESTORE_DELAY_MS);
+	}
+}

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -21,7 +21,7 @@ import {
 	type TerminalDeliveryResult,
 } from "./outputBatcher";
 import { createOutputRecorder, type OutputRecorder } from "./outputRecorder";
-import { type PtyGrid, resizePtyIfChanged } from "./ptyGrid";
+import { nudgePtyRedraw, type PtyGrid, resizePtyIfChanged } from "./ptyGrid";
 import { terminalShellArgs } from "./shellArgs";
 import { hasChildProcesses } from "./shellBusy";
 
@@ -207,10 +207,16 @@ export function attachTerminal(
 			pushToClient(existing.attachedClient, WS_CHANNELS.terminalDetached, push);
 		}
 		existing.attachedClient = clientKey;
-		if (options.cols !== undefined && options.rows !== undefined) {
-			resizePtyIfChanged(existing.pty, existing.grid, {
-				cols: options.cols,
-				rows: options.rows,
+		const resized =
+			options.cols !== undefined && options.rows !== undefined
+				? resizePtyIfChanged(existing.pty, existing.grid, {
+						cols: options.cols,
+						rows: options.rows,
+					})
+				: false;
+		if (!resized) {
+			nudgePtyRedraw(existing.pty, existing.grid, {
+				isStillLive: () => terminals.get(existingId) === existing,
 			});
 		}
 		const replay = existing.recorder.snapshot();


### PR DESCRIPTION
## Bug
Open `vim` (any full-screen TUI)
<img width="775" height="791" alt="image" src="https://github.com/user-attachments/assets/472d77b7-c168-4cfd-ad8c-35ec4c0755d0" />

Visit another tab, go back to `vim` tab - and there's nothing
<img width="720" height="786" alt="image" src="https://github.com/user-attachments/assets/206f9612-49ef-461d-8eda-7d383148f50f" />

## Summary
- Reattaching to a terminal tab whose grid size didn't change is a no-op resize, so `TIOCSWINSZ` never raises `SIGWINCH` and a foreground full-screen app (vim, htop, an interactive CLI) is left showing the frozen pre-alt-screen buffer — the recorder deliberately never captures alt-screen content to replay in its place.
- `nudgePtyRedraw()` (`packages/server/src/terminal/ptyGrid.ts`) shrinks the column count by one and resizes back when the real resize on attach was a no-op, forcing two genuine `SIGWINCH` deliveries without moving the tracked grid. Wired into `terminalManager.ts`'s reattach branch.

## Test plan
- [x] `bun test packages/server/src/terminal/ptyGrid.test.ts packages/server/src/terminal/terminalManager.test.ts` — 28/28 pass
- [x] `turbo run typecheck` — clean
- [x] `biome check` — clean
- [x] Manually reproduced: opened `claude`/`vim` in a terminal tab, switched to another tab, switched back — TUI now redraws instead of showing a frozen shell prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)