### PR TITLE
fix(terminal): stop replaying mouse tracking into restored terminals

### DIFF
--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -78,15 +78,22 @@ separate layout snapshot and merely references `tabKey`.
 - **`closeTerminalTab` checks `busy` and kills in the same synchronous pass.** A separately-asked question
   lets a process started in between die unannounced.
 - Recorder rules: raw bytes (not a serialized grid); never replay resize events; re-emit observed private
-  modes; **never record the alt screen**, tracking it as a *stream* since a switch can split across PTY reads
+  modes **except mouse tracking (1000/1002/1003/1006)** — those belong to a live foreground program, and a TUI
+  that exits without its own `DECRST` leaves the last observed value stuck at `on`, so re-emitting it into a
+  fresh xterm at a bare prompt turns every mouse move into an SGR report the shell echoes back as garbage;
+  **never record the alt screen**, tracking it as a *stream* since a switch can split across PTY reads
   and both screens can appear in one; **never record a mode sequence itself** (replaying `?1049h` would flip
-  the fresh terminal to the alt screen); applied in one write on bind.
+  the fresh terminal to the alt screen); applied in one write on bind. **`restore()` parses what it is handed
+  instead of copying it** — the persisted string is a `snapshot()`, so a verbatim copy moves its mode preamble
+  into the body, where it stops being a re-derivable summary and becomes literal bytes that every later
+  snapshot replays and re-persists: one bad mode then outlives the run that observed it, across restarts.
 - Attach hands back the recording and then **discards** held batcher output — the replay already contains it.
 
 ## Validation
 
 - `outputRecorder.test.ts` — bounds, line/escape-safe trimming, alt-screen exclusion (incl. a switch split
-  across reads and enter+exit in one read), mode restoration.
+  across reads and enter+exit in one read), mode restoration, mouse tracking never restored, and `restore()`
+  keeping mode sequences out of the body (incl. a recording persisted by a host that still replayed them).
 - `outputBatcher.test.ts` — batching, backpressure, truncation, `reset`.
 - `shellBusy.test.ts` — child detection, including that an unanswerable platform reports *not* busy.
 - `terminalManager.test.ts` — attach idempotency (incl. concurrent), takeover, displaced-client rejection,

--- a/packages/server/src/terminal/outputRecorder.test.ts
+++ b/packages/server/src/terminal/outputRecorder.test.ts
@@ -159,10 +159,19 @@ describe("outputRecorder", () => {
 
 		test("handles several modes set in one sequence", () => {
 			const recorder = createOutputRecorder();
-			recorder.push(`${ESC}[?1000;1006h x`);
+			recorder.push(`${ESC}[?2004;1h x`);
 			const snapshot = recorder.snapshot();
-			expect(snapshot).toContain(`${ESC}[?1000h`);
-			expect(snapshot).toContain(`${ESC}[?1006h`);
+			expect(snapshot).toContain(`${ESC}[?2004h`);
+			expect(snapshot).toContain(`${ESC}[?1h`);
+		});
+
+		test("never restores mouse tracking, which a fresh prompt would echo back as garbage", () => {
+			const recorder = createOutputRecorder();
+			recorder.push(`${ESC}[?1000;1002;1003;1006h x`);
+			const snapshot = recorder.snapshot();
+			for (const mode of [1000, 1002, 1003, 1006]) {
+				expect(snapshot).not.toContain(`${ESC}[?${mode}h`);
+			}
 		});
 
 		test("leaves untouched modes alone rather than asserting xterm's defaults", () => {
@@ -199,6 +208,32 @@ describe("outputRecorder", () => {
 			recorder.push("this run\r\n");
 			const text = body(recorder.snapshot());
 			expect(text.indexOf("previous run")).toBeLessThan(text.indexOf("this run"));
+		});
+
+		test("keeps mode sequences out of the body rather than copying a snapshot verbatim", () => {
+			const recorder = createOutputRecorder();
+			recorder.restore(`${ESC}[0m${ESC}[?2004h$ old prompt\r\n`);
+			expect(body(recorder.snapshot())).not.toContain(`${ESC}[?`);
+			expect(recorder.snapshot()).toContain(`${ESC}[?2004h`);
+		});
+
+		test("a recording persisted by a host that still replayed mouse tracking is scrubbed", () => {
+			const recorder = createOutputRecorder();
+			recorder.restore(`${ESC}[0m${ESC}[?1000h${ESC}[?1006h$ old prompt\r\n`);
+			const snapshot = recorder.snapshot();
+			expect(snapshot).not.toContain(`${ESC}[?1000`);
+			expect(snapshot).not.toContain(`${ESC}[?1006`);
+			expect(snapshot).toContain("old prompt");
+		});
+
+		test("restoring across successive runs never compounds the preamble", () => {
+			const first = createOutputRecorder();
+			first.push(`${ESC}[?2004h$ `);
+			const second = createOutputRecorder();
+			second.restore(first.snapshot());
+			const third = createOutputRecorder();
+			third.restore(second.snapshot());
+			expect(third.snapshot().split(`${ESC}[?2004h`).length - 1).toBe(1);
 		});
 	});
 

--- a/packages/server/src/terminal/outputRecorder.ts
+++ b/packages/server/src/terminal/outputRecorder.ts
@@ -1,13 +1,11 @@
 export const DEFAULT_RECORDER_MAX_CHARS = 64 * 1024;
 
+// Mouse tracking (1000/1002/1003/1006) is deliberately absent — restoring it onto a bare prompt echoes
+// garbage; see SPEC.md.
 const TRACKED_MODES: ReadonlySet<number> = new Set([
 	1, // application cursor keys — arrows send SS3 instead of CSI
 	7, // autowrap
 	25, // cursor visibility
-	1000, // mouse: button events
-	1002, // mouse: drag tracking
-	1003, // mouse: any-motion tracking
-	1006, // mouse: SGR coordinate encoding
 	2004, // bracketed paste
 ]);
 
@@ -100,10 +98,10 @@ export function createOutputRecorder(options: OutputRecorderOptions = {}): Outpu
 		},
 		restore(previous) {
 			if (disposed || maxChars <= 0) return;
-			recorded =
-				previous.length > maxChars
-					? trimToLineStart(previous, previous.length - maxChars)
-					: previous;
+			// Parse, never copy: a verbatim snapshot puts its mode preamble in the body — see SPEC.md.
+			recorded = "";
+			consume(previous);
+			inAltBuffer = false;
 		},
 		dispose() {
 			disposed = true;


### PR DESCRIPTION
## The bug

A restored terminal fills with `35;10;19M`-style noise on every mouse move, with **no TUI running** — just a shell prompt. Once a tab is affected it stays affected across restarts, and a fresh burst appends on every new prompt.

<img width="2000" height="1580" alt="image" src="https://github.com/user-attachments/assets/8a022553-7369-48bc-b929-140c5a5bc2d8" />

Above: a freshly created terminal on `main` where the only thing that happened is `claude` was started and exited. Every subsequent mouse move over the pane appends another burst.

## Why it happens

Those are SGR mouse reports. xterm.js only emits them when mouse tracking is on, and a shell's readline has no idea what they are, so it echoes them back as literal text.

Two independent defects compound:

**1. The recorder restored mouse tracking.** `TRACKED_MODES` included 1000/1002/1003/1006, so `snapshot()` re-emitted the last observed value in its preamble. That is right for the other tracked modes — a replay that omits them leaves the fresh xterm disagreeing with the live shell — but mouse tracking belongs to a live *foreground program*, not to the shell that outlives it. A TUI that exits without its own DECRST (killed, crashed, or simply never pairing the two) leaves the value stuck at `on`, and the replay then hands "mouse tracking on" to a fresh xterm sitting at a bare prompt.

**2. `restore()` copied the persisted string verbatim.** What gets persisted is a `snapshot()` — mode preamble included. Copying it moved that preamble into the *body*, where it stops being a re-derivable summary of observed modes and becomes literal bytes that every later snapshot replays and re-persists.

The second defect is what makes this sticky rather than transient. Once a recording was poisoned, every fresh shell in that tab was told "mouse tracking on" at attach, whether or not a TUI ever ran in it again, and each restart re-saved the poison. Fixing only the first defect would leave already-affected tabs broken indefinitely.

## The fix

- Drop mouse tracking from `TRACKED_MODES`. Any program that wants it enables it on startup, so there is nothing to restore — and unlike the other modes, guessing wrong here corrupts the screen rather than merely disagreeing with it.
- Make `restore()` parse what it is handed through the same path as live output instead of copying it. Mode sequences stay out of the body, and a recording written by an affected host is scrubbed on the way in, so existing broken tabs heal on the next restart.

## Verifying

Before: run `claude` in a terminal tab, exit it, restart the host, then move the mouse over the restored tab.
After: the same sequence produces nothing.

`outputRecorder.test.ts` gains coverage for mouse tracking never being restored, `restore()` keeping mode sequences out of the body, a recording persisted by an affected host being scrubbed, and the preamble not compounding across successive restores. 76 terminal tests pass; lint, typecheck and `check:deps` clean.

## Scope

Recorder-only; no behaviour change to the live PTY stream. There is a related *live-session* variant — a TUI leaving mouse tracking on with no restart involved — that this PR does not address, since detecting it needs a separate signal. Being handled independently.
