### PR TITLE
fix(chat): Add note appears under each checked option in ask_user_question, multi-select included

### DIFF
--- a/apps/web/src/chat/tools/AskUserQuestionCard.test.ts
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { AskUserQuestionAnswer, AskUserQuestionItem } from "@thinkrail/contracts";
 import {
+	answerSupportsNote,
 	choiceKeyAction,
 	confirmStateFor,
 	createQuestionAttentionClaim,
@@ -14,9 +15,11 @@ import {
 	questionPageForKey,
 	readAskResult,
 	readRecommendation,
+	selectOptionPatch,
 	shouldClaimQuestionFocus,
 	shouldFocusPageTarget,
 	splitRecommended,
+	toggleMultiPatch,
 } from "./AskUserQuestionCard";
 
 const q = (over: Partial<AskUserQuestionItem> = {}): AskUserQuestionItem => ({
@@ -307,6 +310,41 @@ describe("deriveAnswer", () => {
 		});
 	});
 
+	it("multi-select: each checked option's note joins the answer as a labelled line", () => {
+		expect(
+			deriveAnswer(
+				q({
+					multiSelect: true,
+					options: [...q().options, { label: "C (Recommended)", description: "c" }],
+				}),
+				0,
+				state({
+					multi: ["A", "C (Recommended)"],
+					notes: { A: " note a ", B: "unchecked note", "C (Recommended)": "note c" },
+				}),
+			),
+		).toEqual({
+			questionIndex: 0,
+			question: "Which?",
+			kind: "multi",
+			answer: null,
+			selected: ["A", "C (Recommended)"],
+			notes: "A: note a\nC: note c",
+		});
+	});
+
+	it("multi-select: blank notes leave the notes field off entirely", () => {
+		expect(
+			deriveAnswer(q({ multiSelect: true }), 0, state({ multi: ["A"], notes: { A: "   " } })),
+		).toEqual({
+			questionIndex: 0,
+			question: "Which?",
+			kind: "multi",
+			answer: null,
+			selected: ["A"],
+		});
+	});
+
 	it("multi-select: an unchecked 'Other' row keeps its text OUT of the answer", () => {
 		expect(
 			deriveAnswer(
@@ -465,6 +503,51 @@ describe("readRecommendation", () => {
 			recommended: false,
 			reason: undefined,
 		});
+	});
+});
+
+describe("choice patches", () => {
+	it("unchecking the option whose note editor is open closes the editor, keeps the text", () => {
+		const s = state({ multi: ["A", "B"], noteFor: "A", notes: { A: "kept" } });
+		expect(toggleMultiPatch(s, "A", 0)).toEqual({ cursor: 0, multi: ["B"], noteFor: null });
+	});
+	it("unchecking another option leaves the open editor alone", () => {
+		const s = state({ multi: ["A", "B"], noteFor: "A" });
+		expect(toggleMultiPatch(s, "B", 1)).toEqual({ cursor: 1, multi: ["A"] });
+	});
+	it("checking an option never touches noteFor", () => {
+		expect(toggleMultiPatch(state({ multi: [] }), "A", 0)).toEqual({ cursor: 0, multi: ["A"] });
+	});
+	it("selecting a different single-select option closes a stale open editor", () => {
+		const s = state({ option: "A", noteFor: "A", notes: { A: "kept" } });
+		expect(selectOptionPatch(s, "B", 1)).toEqual({
+			cursor: 1,
+			option: "B",
+			customActive: false,
+			noteFor: null,
+		});
+	});
+	it("re-selecting the option that owns the open editor keeps it open", () => {
+		const s = state({ option: "A", noteFor: "A" });
+		expect(selectOptionPatch(s, "A", 0)).toEqual({ cursor: 0, option: "A", customActive: false });
+	});
+});
+
+describe("answerSupportsNote", () => {
+	const base = { questionIndex: 0, question: "Which?" };
+	it("a picked single-select option can carry a note", () => {
+		expect(answerSupportsNote({ ...base, kind: "option", answer: "A" })).toBe(true);
+	});
+	it("a multi answer supports notes only once something is checked", () => {
+		expect(answerSupportsNote({ ...base, kind: "multi", answer: null, selected: ["A"] })).toBe(
+			true,
+		);
+		expect(answerSupportsNote({ ...base, kind: "multi", answer: "typed", selected: [] })).toBe(
+			false,
+		);
+	});
+	it("a custom answer has no option to hang a note on", () => {
+		expect(answerSupportsNote({ ...base, kind: "custom", answer: "mine" })).toBe(false);
 	});
 });
 

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -12,7 +12,7 @@ import {
 	Pencil,
 	SkipForward,
 } from "lucide-react";
-import { type KeyboardEvent, useEffect, useId, useMemo, useRef, useState } from "react";
+import { Fragment, type KeyboardEvent, useEffect, useId, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib";
 import { useAskFocusScope, useAskState } from "../askState";
 import { useChatActions } from "../ChatActions";
@@ -75,7 +75,17 @@ export function deriveAnswer(
 		const valid = state.multi.filter((label) => question.options.some((o) => o.label === label));
 		const custom = state.customActive ? state.customText.trim() : "";
 		if (valid.length === 0 && !custom) return null;
-		return { ...base, kind: "multi", answer: custom || null, selected: valid };
+		const noteLines = valid.flatMap((label) => {
+			const note = state.notes[label]?.trim();
+			return note ? [`${splitRecommended(label).text}: ${note}`] : [];
+		});
+		return {
+			...base,
+			kind: "multi",
+			answer: custom || null,
+			selected: valid,
+			...(noteLines.length > 0 ? { notes: noteLines.join("\n") } : {}),
+		};
 	}
 	if (state.customActive && state.customText.trim()) {
 		return { ...base, kind: "custom", answer: state.customText.trim() };
@@ -102,6 +112,11 @@ export function deriveAnswers(
 	return questions
 		.map((question, index) => deriveAnswer(question, index, states[index] ?? emptyQState()))
 		.filter((answer): answer is AskUserQuestionAnswer => answer != null);
+}
+
+export function answerSupportsNote(answer: AskUserQuestionAnswer): boolean {
+	if (answer.kind === "option") return true;
+	return answer.kind === "multi" && (answer.selected?.length ?? 0) > 0;
 }
 
 export function readAskResult(raw: unknown): AskUserQuestionResult | null {
@@ -162,6 +177,24 @@ export function customTextPatch(text: string): Partial<QState> {
 	return text.trim()
 		? { customText: text, customActive: true, option: null }
 		: { customText: text, customActive: false };
+}
+
+export function selectOptionPatch(state: QState, label: string, cursor: number): Partial<QState> {
+	return {
+		cursor,
+		option: label,
+		customActive: false,
+		...(state.noteFor != null && state.noteFor !== label ? { noteFor: null } : {}),
+	};
+}
+
+export function toggleMultiPatch(state: QState, label: string, cursor: number): Partial<QState> {
+	const removing = state.multi.includes(label);
+	return {
+		cursor,
+		multi: removing ? state.multi.filter((item) => item !== label) : [...state.multi, label],
+		...(removing && state.noteFor === label ? { noteFor: null } : {}),
+	};
 }
 
 export type ConfirmSource = { kind: "choice"; label: string; cursor: number } | { kind: "custom" };
@@ -556,17 +589,8 @@ export function AskUserQuestionCard({
 							question={q}
 							state={state}
 							pageKeys={multipleQuestions}
-							onSelect={(label, cursor) =>
-								patch(idx, { cursor, option: label, customActive: false })
-							}
-							onToggleMulti={(label, cursor) =>
-								patch(idx, {
-									cursor,
-									multi: state.multi.includes(label)
-										? state.multi.filter((item) => item !== label)
-										: [...state.multi, label],
-								})
-							}
+							onSelect={(label, cursor) => patch(idx, selectOptionPatch(state, label, cursor))}
+							onToggleMulti={(label, cursor) => patch(idx, toggleMultiPatch(state, label, cursor))}
 							onCursor={(cursor) => {
 								if (cursor !== state.cursor) patch(idx, { cursor });
 							}}
@@ -575,12 +599,12 @@ export function AskUserQuestionCard({
 							onToggleCustom={() => patch(idx, { customActive: !state.customActive })}
 							onConfirmCustom={confirmCustom}
 							onOpenNote={(label, cursor) =>
-								patch(idx, {
-									cursor,
-									option: label,
-									customActive: false,
-									noteFor: label,
-								})
+								patch(
+									idx,
+									q.multiSelect
+										? { cursor, noteFor: label }
+										: { cursor, option: label, customActive: false, noteFor: label },
+								)
 							}
 							onCloseNote={() => patch(idx, { noteFor: null })}
 							onNote={(label, text) => patch(idx, { notes: { ...state.notes, [label]: text } })}
@@ -593,7 +617,7 @@ export function AskUserQuestionCard({
 							review={onReview}
 							multipleQuestions={multipleQuestions}
 							noteAvailable={
-								!onReview && answers.some((a) => a.questionIndex === idx && a.kind === "option")
+								!onReview && answers.some((a) => a.questionIndex === idx && answerSupportsNote(a))
 							}
 						/>
 						<div className="flex items-center justify-end gap-md">
@@ -796,7 +820,7 @@ function ModeHint({
 			) : (
 				<CircleDot className="size-3.5 shrink-0" />
 			)}
-			<span>↑↓ move incl. Other</span>
+			<span>{multiSelect ? "↑↓ move incl. Other" : "↑↓ move & select"}</span>
 			<span>· Space {multiSelect ? "toggle" : "select"}</span>
 			<span>· Enter confirm</span>
 			<span>· Tab {noteAvailable ? "note/actions" : "actions"}</span>
@@ -843,10 +867,6 @@ function QuestionBody({
 	const cursor = Math.min(Math.max(state.cursor, 0), Math.max(otherIndex - 1, 0));
 	const customOwnsPageFocus =
 		state.customActive && (!question.multiSelect || state.multi.length === 0);
-	const noteIndex = question.multiSelect
-		? -1
-		: question.options.findIndex((option) => option.label === state.option);
-	const noteOption = noteIndex < 0 ? undefined : question.options[noteIndex];
 	const anyPreview = !question.multiSelect && question.options.some((option) => option.preview);
 	const previewSource =
 		question.options.find((option) => option.label === state.option && option.preview) ??
@@ -868,6 +888,12 @@ function QuestionBody({
 		choiceRefs.current[index]?.focus({ preventScroll: true });
 	};
 
+	const moveCursor = (index: number) => {
+		focusChoice(index);
+		const target = question.options[index];
+		if (!question.multiSelect && target) onSelect(target.label, index);
+	};
+
 	const finishNote = (index: number) => {
 		onCloseNote();
 		requestAnimationFrame(() => choiceRefs.current[index]?.focus({ preventScroll: true }));
@@ -882,7 +908,7 @@ function QuestionBody({
 		const action = choiceKeyAction(event.key, index, choiceCount);
 		if (action.type === "none") return;
 		event.preventDefault();
-		if (action.type === "move") focusChoice(action.index);
+		if (action.type === "move") moveCursor(action.index);
 		else if (action.type === "select") {
 			if (question.multiSelect) onToggleMulti(label, index);
 			else onSelect(label, index);
@@ -900,9 +926,9 @@ function QuestionBody({
 			<div className={cn("grid gap-sm", anyPreview && "md:grid-cols-2")}>
 				<div className="flex min-w-0 flex-col gap-sm">
 					<div
-						role="listbox"
-						aria-multiselectable={!!question.multiSelect}
-						aria-label={question.question}
+						{...(question.multiSelect
+							? { role: "group", "aria-label": question.question }
+							: { role: "radiogroup", "aria-label": question.question })}
 						className="flex flex-col gap-sm"
 					>
 						{question.options.map((option, index) => {
@@ -910,71 +936,74 @@ function QuestionBody({
 								? state.multi.includes(option.label)
 								: state.option === option.label;
 							const ownsCursor = index === cursor;
+							const optionText = splitRecommended(option.label).text;
+							const noteText = state.notes[option.label]?.trim();
 							return (
-								<OptionRow
-									key={option.label}
-									buttonRef={(node) => {
-										choiceRefs.current[index] = node;
-									}}
-									label={option.label}
-									description={option.description}
-									recommendedReason={option.recommendedReason}
-									selected={selected}
-									cursor={ownsCursor}
-									pageFocus={ownsCursor && !customOwnsPageFocus}
-									multi={!!question.multiSelect}
-									pageKeys={pageKeys}
-									onFocus={() => onCursor(index)}
-									onKeyDown={(event) => onChoiceKeyDown(event, option.label, index)}
-									onClick={() =>
-										question.multiSelect
-											? onToggleMulti(option.label, index)
-											: onSelect(option.label, index)
-									}
-								/>
+								<Fragment key={option.label}>
+									<OptionRow
+										buttonRef={(node) => {
+											choiceRefs.current[index] = node;
+										}}
+										label={option.label}
+										description={option.description}
+										recommendedReason={option.recommendedReason}
+										selected={selected}
+										cursor={ownsCursor}
+										pageFocus={ownsCursor && !customOwnsPageFocus}
+										multi={!!question.multiSelect}
+										pageKeys={pageKeys}
+										onFocus={() => onCursor(index)}
+										onKeyDown={(event) => onChoiceKeyDown(event, option.label, index)}
+										onClick={() =>
+											question.multiSelect
+												? onToggleMulti(option.label, index)
+												: onSelect(option.label, index)
+										}
+									/>
+									{selected ? (
+										<div className="pl-[calc(1.125rem+var(--spacing-sm))]">
+											{state.noteFor === option.label ? (
+												<textarea
+													ref={noteRef}
+													data-testid="ask-note"
+													aria-label={`Note for ${optionText}`}
+													aria-keyshortcuts="Enter Shift+Enter Escape"
+													rows={2}
+													value={state.notes[option.label] ?? ""}
+													placeholder="Add a note for the model…"
+													onChange={(event) => onNote(option.label, event.target.value)}
+													onKeyDown={(event) => {
+														const action = noteKeyAction(
+															event.key,
+															event.shiftKey,
+															event.nativeEvent.isComposing,
+														);
+														if (action === "none") return;
+														event.stopPropagation();
+														if (action === "consume") return;
+														event.preventDefault();
+														finishNote(index);
+													}}
+													className="w-full resize-none rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-sm py-xs text-text-default tr-text-metadata outline-none focus-visible:border-control-border-active"
+												/>
+											) : (
+												<button
+													type="button"
+													data-testid="ask-note-toggle"
+													aria-label={`${noteText ? "Edit" : "Add"} note for ${optionText}`}
+													onClick={() => openNote(option.label, index)}
+													className="flex items-center gap-xs rounded-[var(--radius-sm)] text-text-muted tr-text-metadata outline-none hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
+												>
+													<Pencil className="size-3" />
+													{noteText ? "Edit note" : "Add note"}
+												</button>
+											)}
+										</div>
+									) : null}
+								</Fragment>
 							);
 						})}
 					</div>
-
-					{noteOption ? (
-						<div className="pl-[calc(1.125rem+var(--spacing-sm))]">
-							{state.noteFor === noteOption.label ? (
-								<textarea
-									ref={noteRef}
-									data-testid="ask-note"
-									aria-label={`Note for ${splitRecommended(noteOption.label).text}`}
-									aria-keyshortcuts="Enter Shift+Enter Escape"
-									rows={2}
-									value={state.notes[noteOption.label] ?? ""}
-									placeholder="Add a note for the model…"
-									onChange={(event) => onNote(noteOption.label, event.target.value)}
-									onKeyDown={(event) => {
-										const action = noteKeyAction(
-											event.key,
-											event.shiftKey,
-											event.nativeEvent.isComposing,
-										);
-										if (action === "none") return;
-										event.stopPropagation();
-										if (action === "consume") return;
-										event.preventDefault();
-										finishNote(noteIndex);
-									}}
-									className="w-full resize-none rounded-[var(--radius-sm)] border border-control-border-default bg-control-bg px-sm py-xs text-text-default tr-text-metadata outline-none focus-visible:border-control-border-active"
-								/>
-							) : (
-								<button
-									type="button"
-									data-testid="ask-note-toggle"
-									onClick={() => openNote(noteOption.label, noteIndex)}
-									className="flex items-center gap-xs rounded-[var(--radius-sm)] text-text-muted tr-text-metadata outline-none hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
-								>
-									<Pencil className="size-3" />
-									{state.notes[noteOption.label]?.trim() ? "Edit note" : "Add note"}
-								</button>
-							)}
-						</div>
-					) : null}
 
 					<OtherOptionRow
 						inputRef={(node) => {
@@ -988,7 +1017,7 @@ function QuestionBody({
 						onText={onCustomText}
 						onMove={(key) => {
 							const action = choiceKeyAction(key, otherIndex, choiceCount);
-							if (action.type === "move") focusChoice(action.index);
+							if (action.type === "move") moveCursor(action.index);
 						}}
 						onConfirm={onConfirmCustom}
 					/>
@@ -1042,8 +1071,9 @@ function OptionRow({
 		<button
 			ref={buttonRef}
 			type="button"
-			role="option"
-			aria-selected={selected}
+			{...(multi
+				? { role: "checkbox", "aria-checked": selected }
+				: { role: "radio", "aria-checked": selected })}
 			aria-keyshortcuts={`ArrowUp ArrowDown Home End Space Enter${pageKeys ? " ArrowLeft ArrowRight" : ""} Shift+Escape`}
 			tabIndex={cursor ? 0 : -1}
 			data-testid="ask-option"

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -120,8 +120,16 @@ registration runs once when the chat module mounts. Unregistered tools fall back
     could only contradict the row on screen — resurrecting multi-select text the user explicitly unchecked, or
     submitting text left over from an earlier edit while the card still paints the option picked after it.
     What is confirmed always matches what is drawn.
-    A selected single-choice note remains an explicit secondary control: Tab reaches Add/Edit note and
-    Enter opens it (the legend only promises `Tab note` once a choice exists to hang one on). In the editor
+    A note remains an explicit secondary control on every **checked choice**: the selected single-select
+    option, or **each checked multi-select option** — one Add/Edit note control per check, rendered
+    **directly beneath its own option row**, appearing the moment the choice is made. (Multi-select notes
+    were missing entirely, and the single-select note had drifted to the bottom of the list where it read
+    as belonging to the last option — both reported as a regression; the contract always allowed notes.)
+    The wire carries **one `notes` string per answer**, so a multi answer joins its per-option notes as
+    `label: note` lines (newline-separated — notes themselves may be multiline). The visible toggle text
+    stays the short Add/Edit note; the option it belongs to is carried by `aria-label`, and adjacency
+    carries it visually. Tab reaches Add/Edit note and Enter opens it (the legend only promises `Tab
+    note` once a choice exists to hang one on — `answerSupportsNote`). In the editor
     Enter finishes and returns focus to the choice, Shift+Enter remains the multiline escape hatch, and
     Escape also returns **without discarding typed text** — **including `Shift+Escape`**, which the open
     editor consumes rather than letting the card's skip gesture throw away the note mid-sentence.
@@ -133,15 +141,29 @@ registration runs once when the chat module mounts. Unregistered tools fall back
     `Shift+Escape` is otherwise the deliberate card-local skip; plain Escape outside a note never declines.
     Tab still reaches
     Other, Skip, and footer actions. A compact visible shortcut legend makes the interaction discoverable,
-    and the choices are a **`listbox` of `option`s with `aria-selected`** — never `aria-pressed`, which
-    announced an exclusive pick as a toggle button and said nothing about the set. Listbox is the pattern
-    whose *keys* these are (a cursor that moves without committing, Space to select, Enter to confirm),
-    where a radiogroup's arrows select as they move; `aria-multiselectable` carries single vs multi, and
-    each row is announced with its position in the choices. It owns **nothing but `option`s** (a `listbox`
-    may only own `option`/`group`; a stray input/textarea/button inside one is skipped by some screen
-    readers and corrupts the announced set), so the **Other row and the note editor are siblings below the
-    list** — hence the note rendering under the list rather than its own row, named by `aria-label` instead
-    of adjacency. Movement is driven by the choice refs, not DOM containment, so the keys are unaffected.
+    and the choices are checked rows with `aria-checked` — never `aria-pressed`, which
+    announced an exclusive pick as a toggle button and said nothing about the set. The container role
+    carries single vs multi (`radiogroup` vs `group` of checkboxes), and
+    each row is announced with its position in the choices. The note controls live **between the rows,
+    each under its checked choice**, because adjacency is what tells the user which choice a note belongs
+    to — the earlier notes-below-the-list layout read as the note belonging to the last option and was
+    reported as a regression. That interleaving is what forced the container role: a `listbox` may own
+    nothing but `option`/`group` (interactive descendants are non-conforming and some ATs flatten or skip
+    them — review finding on the multi-note change; `aria-posinset` only numbers options, it cannot make
+    stray children conforming), so the choices are a **`radiogroup` of `radio` rows (single-select) / a
+    `group` of `checkbox` rows (multi-select)** with `aria-checked`, whose contracts place no constraint
+    on sibling content — the note editor and toggle are ordinary named controls beside them. Each role's
+    keyboard contract is honored, not just its markup (second review finding: a radio whose arrows only
+    move focus exposes the focused row as unchecked while Enter would submit it — the semantic state
+    would contradict both the cursor and the answer): **single-select arrows select as they move** (the
+    APG radio contract; Space also selects, Enter stays the separate confirm), landing on the Other row
+    moves focus without selecting (it is a text field, not a radio), and **multi-select arrows only move**
+    with Space toggling (the checkbox contract). Selection is still never submission — Enter confirms. The **Other row
+    stays a sibling below the rows**. Movement is driven by the choice refs, not DOM containment, so the
+    keys are unaffected.
+    Deselecting a choice whose note editor is open also clears `noteFor` in the same update
+    (`toggleMultiPatch` / `selectOptionPatch`) while keeping the typed note text: a stale `noteFor` would
+    remount the open editor on re-check, stealing a focus action the user never took.
     Bare-letter/number shortcuts and global chords are deliberately absent so
     browser extensions, custom text, and explicit decline stay safe.
   - **Recommended-reason affordance** — a recommended option (label suffix `(Recommended)` **or** a

--- a/e2e/ask-user-question.live.spec.ts
+++ b/e2e/ask-user-question.live.spec.ts
@@ -41,8 +41,6 @@ test("single-select: focus, roving keys, and Enter resolve the tool", {
 
 	await page.keyboard.press("ArrowDown");
 	await expect(options.nth(1)).toBeFocused();
-	await expect(card.locator('[data-testid="ask-option"][data-selected="true"]')).toHaveCount(0);
-	await page.keyboard.press("Space");
 	await expect(options.nth(1)).toHaveAttribute("data-selected", "true");
 	await expect(card.getByTestId("ask-submit")).toBeEnabled();
 
@@ -52,13 +50,15 @@ test("single-select: focus, roving keys, and Enter resolve the tool", {
 	await expect(options.nth(1)).toHaveAttribute("data-selected", "true");
 	await page.keyboard.press("ArrowUp");
 	await expect(options.last()).toBeFocused();
+	await expect(options.last()).toHaveAttribute("data-selected", "true");
 	await expect(card.getByTestId("ask-custom-row")).toHaveAttribute("data-selected", "false");
-	await expect(options.nth(1)).toHaveAttribute("data-selected", "true");
 	await expect(card.getByTestId("ask-submit")).toBeEnabled();
 
 	await page.keyboard.press("Home");
+	await expect(options.first()).toHaveAttribute("data-selected", "true");
 	await page.keyboard.press("ArrowDown");
 	await expect(options.nth(1)).toBeFocused();
+	await expect(options.nth(1)).toHaveAttribute("data-selected", "true");
 	await page.keyboard.press("Enter");
 
 	await expect(page.getByTestId("chat-input")).toBeFocused();
@@ -124,11 +124,36 @@ test("multi-select: several options can be checked and submitted", { tag: "@agen
 	await expect(card.locator('[data-testid="ask-option"][data-selected="true"]')).toHaveCount(0);
 	await expect(card).toBeVisible();
 
+	await expect(card.getByTestId("ask-note-toggle")).toHaveCount(0);
+
 	await page.keyboard.press("Space");
+	await expect(card.getByTestId("ask-note-toggle")).toHaveCount(1);
 	await page.keyboard.press("ArrowDown");
 	await page.keyboard.press("Space");
 	await expect(card.locator('[data-testid="ask-option"][data-selected="true"]')).toHaveCount(2);
 	await expect(card.getByTestId("ask-needs-choice")).toHaveCount(0);
+
+	const labels = (await card.getByTestId("ask-option-label").allTextContents()).map((label) =>
+		label.trim(),
+	);
+	const noteToggles = card.getByTestId("ask-note-toggle");
+	await expect(noteToggles).toHaveCount(2);
+	await expect(noteToggles.nth(0)).toHaveAccessibleName(`Add note for ${labels[0]}`);
+	await expect(noteToggles.nth(1)).toHaveAccessibleName(`Add note for ${labels[1]}`);
+
+	await noteToggles.nth(0).click();
+	const note = card.getByTestId("ask-note");
+	await expect(note).toBeFocused();
+	await page.keyboard.type("e2e-note-alpha");
+	await page.keyboard.press("Enter");
+	await expect(note).toHaveCount(0);
+	await expect(noteToggles.nth(0)).toContainText("Edit note");
+
+	await noteToggles.nth(1).click();
+	await expect(card.getByTestId("ask-note")).toBeFocused();
+	await page.keyboard.type("e2e-note-beta");
+	await page.keyboard.press("Enter");
+	await expect(options.nth(1)).toBeFocused();
 
 	await page.keyboard.press("Enter");
 	const record = answeredRecord(page);
@@ -136,6 +161,8 @@ test("multi-select: several options can be checked and submitted", { tag: "@agen
 	await expect(
 		record.locator('[data-testid="ask-record-option"][data-selected="true"]'),
 	).toHaveCount(2);
+	await expect(record).toContainText(`${labels[0]}: e2e-note-alpha`);
+	await expect(record).toContainText(`${labels[1]}: e2e-note-beta`);
 });
 
 test("multi-select: the free-text row is mandatory and additive — checks + typed text round-trip", {


### PR DESCRIPTION
## Problem

Since #228 the "Add note" control in the ask_user_question card rendered below the
whole option list, visually attaching to the last option instead of the one it
belonged to — and multi-select questions had no note affordance at all, even though
the wire contract (`AskUserQuestionAnswer.notes`) always allowed notes on any answer.

## Fix

- Every checked choice grows its own Add/Edit note directly beneath its row the
  moment it is picked: the selected single-select option, or each checked
  multi-select option.
- A multi answer joins its per-option notes as `label: note` lines into the answer's
  single `notes` string — no protocol change.
- Options pin `aria-posinset`/`aria-setsize` so the interleaved note blocks can't
  corrupt the announced set; each toggle is named for its option via `aria-label`.
  Decision recorded in `apps/web/src/chat/tools/SPEC.md`.

## Testing

- Extended the multi-select `@agent` e2e: per-check toggles, accessible names,
  two-note round-trip into the answered record. All 9 ask e2e specs pass.
- New unit tests: `deriveAnswer` multi notes, `answerSupportsNote`.
- Full no-agent suite green (190 tests); lint/typecheck/deps/seams green.