### PR TITLE
feat(workflows): shipping-a-pr — bundled PR-lifecycle skill mined from real sessions

### DIFF
--- a/packages/pi-thinkrail-workflow/SPEC.md
+++ b/packages/pi-thinkrail-workflow/SPEC.md
@@ -18,11 +18,13 @@ model *is*; `pi-visualize` is a rendering tool.) It contributes exactly two thin
 
 - **`index.ts`** — an `ExtensionFactory` registering one always-on `before_agent_start` rule that
   points every new piece of work at the root router skill (`choosing-a-workflow`).
-- **`skills/`** — the workflow skill family: the root router, `brainstorming`, and the
-  **setting-up-a-project trio** — the `setting-up-a-project` **dispatcher** routing to
-  `starting-a-new-project` (inception interview → `goal-and-requirements.md`) or
-  `importing-a-codebase` (existing codebase → first spec graph) — plus the authoring checklist. The system's design — concept model, skill roles, meta-rules, the
-  family table, per-skill rationale — lives in [[submodule-workflow-skills]].
+- **`skills/`** — the workflow skill family: the root router that classifies every new piece of
+  work, plus the worker and concept skills reached from it. The **authoritative roster is the
+  family table in [[submodule-workflow-skills]]**, alongside the system's design — concept model,
+  skill roles, meta-rules, per-skill rationale. This spec keeps no roster of its own (a second list
+  would drift — the partial enumeration this bullet replaced had already gone stale, omitting the
+  concept skills) and names an individual skill only where a package-level decision is about it
+  (the root router above; the authoring checklist under Boundary).
 
 The package grows by adding `skills/<name>/` sub-modules (a new tool would go under a `tools/`
 sub-module if one is ever needed); nothing about the layout — or the system's shape — changes to add

--- a/packages/pi-thinkrail-workflow/skills/SPEC.md
+++ b/packages/pi-thinkrail-workflow/skills/SPEC.md
@@ -293,7 +293,14 @@ follows is only the rationale the skill bodies don't state:
   comments blindly" — became its gates and phase docs. One skill rather than five (rule 1): every
   lifecycle ask enters through the same trigger; the phases are internal forks as sibling docs. Its
   done bar (checks green + user told, never "PR opened") and the review-only assets-ref screenshot
-  default were explicit user decisions (task-spec `task-shipping-a-pr-skill`).
+  default were explicit user decisions (task-spec `task-shipping-a-pr-skill`). Its review hardening
+  (PR #284) converged on one shared discipline instead of per-finding patches — **observed, never
+  assumed**: every finding across three review rounds was the same defect (acting on, or declaring,
+  state not observed at the moment of the action), so the rule lives once in the spine — verify at
+  the point of action, fetch remote state fresh and completely, poll indeterminate answers — and
+  each phase doc instantiates it at its own action points (pre-push re-assertions after
+  tree-mutating steps, body fetched before edit, `UNKNOWN` merge state polled, throwaway cleanup
+  owned by the phase that made the throwaway).
 - **`writing-specs`** carries the family's spec quality bar once — short / honest / on-rails — and is
   the accruing home for the family's rules about specs and the spec graph as they grow. Graph
   *mechanics* (frontmatter, link kinds, the `spec_*` tools) stay with the spec-graph skill

--- a/packages/pi-thinkrail-workflow/skills/SPEC.md
+++ b/packages/pi-thinkrail-workflow/skills/SPEC.md
@@ -292,7 +292,8 @@ follows is only the rationale the skill bodies don't state:
   screenshots for UI changes, "make PR up-to-date", "look at the checks", "do not fix review
   comments blindly" — became its gates and phase docs. One skill rather than five (rule 1): every
   lifecycle ask enters through the same trigger; the phases are internal forks as sibling docs. Its
-  done bar (checks green + user told, never "PR opened") and the review-only assets-ref screenshot
+  done bar (every existing check green + user told, never "PR opened"; a no-CI repo terminates as
+  an explicit "no checks configured", never a silent green) and the review-only assets-ref screenshot
   default were explicit user decisions (task-spec `task-shipping-a-pr-skill`). Its review hardening
   (PR #284) converged on one shared discipline instead of per-finding patches — **observed, never
   assumed**: every finding across three review rounds was the same defect (acting on, or declaring,

--- a/packages/pi-thinkrail-workflow/skills/SPEC.md
+++ b/packages/pi-thinkrail-workflow/skills/SPEC.md
@@ -77,6 +77,7 @@ flowchart LR
   rule([before_agent_start rule]) --> router[root router]
   router --> ps[setting-up-a-project — dispatcher]
   router --> bs[brainstorming]
+  router --> ship[shipping-a-pr]
   card(["/skill:setting-up-a-project card"]) --> ps
   ps --> pn[starting-a-new-project]
   ps --> pim[importing-a-codebase]
@@ -190,6 +191,7 @@ flowchart LR
 | `writing-specs` | concept — the spec quality bar (short / honest / on-rails) for every spec-producing flow | — (reached by name, rule 4) | active; observed by use (2026-07 manual: self-triggered for a spec revision and applied) |
 | `choosing-a-workflow` | router (root) — classification + routing | — (always-on entry, rule 4) | active; all three classifications observed by the routing suite — feature → brainstorming and onboarding → setup family green; the "anything else" row has an observed gap (see Current limitations & gaps) |
 | `writing-workflow-skills` | worker — authoring checklist for adding workflows | — (self-trigger only, rule 4) | active |
+| `shipping-a-pr` | worker — PR lifecycle (create with gates / screenshots / up-to-date sync / checks watch / review comments — phases as sibling docs) | `choosing-a-workflow` (root) + narrow self-trigger | active; unverified by use (rule 14 suspended) |
 
 The family is open and grows from real use; candidates (research/spike, refactor, bug-fix, a composing
 skill in the composer pattern with its stage workers, and **extending an existing spec graph** — the
@@ -285,6 +287,13 @@ follows is only the rationale the skill bodies don't state:
 - **`asking-user-questions`** carries the family's `ask_user_question` norms once: rounds, option
   design, the inference-confirmation pattern, and skip/headless degradation. Callers keep the *when* —
   and say where assumptions get recorded.
+- **`shipping-a-pr`** was mined from the operator's real PR sessions (2026-06→08: 125 scanned, 36
+  with PR work): the recurring asks — verify-then-PR, self-review first, rebase on fresh main,
+  screenshots for UI changes, "make PR up-to-date", "look at the checks", "do not fix review
+  comments blindly" — became its gates and phase docs. One skill rather than five (rule 1): every
+  lifecycle ask enters through the same trigger; the phases are internal forks as sibling docs. Its
+  done bar (checks green + user told, never "PR opened") and the review-only assets-ref screenshot
+  default were explicit user decisions (task-spec `task-shipping-a-pr-skill`).
 - **`writing-specs`** carries the family's spec quality bar once — short / honest / on-rails — and is
   the accruing home for the family's rules about specs and the spec graph as they grow. Graph
   *mechanics* (frontmatter, link kinds, the `spec_*` tools) stay with the spec-graph skill

--- a/packages/pi-thinkrail-workflow/skills/choosing-a-workflow/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/choosing-a-workflow/SKILL.md
@@ -11,12 +11,15 @@ skill alone; read it, don't run it from memory.
 
 ## Classify
 
-Read the request and the workspace, then answer two questions — usually silently, from what is already
+Read the request and the workspace, then answer three questions — usually silently, from what is already
 in front of you:
 
 1. **Is this project onboarding?** No spec graph yet — an empty (or effectively empty) workspace where
    the user brings a raw idea, or an existing codebase being set up / specced for the first time.
-2. **Does the work create or change anything in the project?** A new feature, added functionality, a
+2. **Is this the PR lifecycle?** Finished work shipping as a pull request, or an existing PR being
+   tended — created, brought up to date, given screenshots, its checks watched, its review comments
+   addressed. Fixes that flow from a PR's own review comments belong here, not to feature work.
+3. **Does the work create or change anything in the project?** A new feature, added functionality, a
    behavior change, a nontrivial design decision — anything that alters what the project is or does.
 
 If the route is genuinely ambiguous from the request alone, ask one short clarifying question
@@ -27,6 +30,7 @@ If the route is genuinely ambiguous from the request alone, ask one short clarif
 | Classification | Route |
 |---|---|
 | Project onboarding — no spec graph yet: an empty workspace with a raw idea, or an existing codebase to set up / spec | Read and follow **setting-up-a-project** — a dispatcher that routes on the workspace's state |
+| The PR lifecycle — finished work to ship as a pull request, or an existing PR to tend: create, bring up to date, screenshots, checks, review comments | Read and follow **shipping-a-pr** |
 | The work creates or changes anything in the project — a new feature, added functionality, a behavior change, a nontrivial design decision | Read and follow **brainstorming** — however small it looks; that skill owns the "too small" judgment |
 | Anything else — answering questions, explaining code, running commands or checks, work that changes nothing | **No matching workflow.** Say so in one line (e.g. "No workflow skill covers this; proceeding directly.") and proceed with your own judgment. Never stretch a route to fit — a forced route is worse than none. |
 
@@ -42,6 +46,6 @@ change Y"), route the part that changes the project and handle the rest directly
 
 ## Handoff
 
-This skill ends by naming exactly one of: **setting-up-a-project**, **brainstorming**, or **no matching
-workflow** (proceed with judgment). Adding a workflow to the family adds a row to the table above —
+This skill ends by naming exactly one of: **setting-up-a-project**, **shipping-a-pr**,
+**brainstorming**, or **no matching workflow** (proceed with judgment). Adding a workflow to the family adds a row to the table above —
 see the writing-workflow-skills skill.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
@@ -14,6 +14,22 @@ A PR is **done** when its checks are green and the user has the link plus its cu
 at "PR opened", "pushed", or "comment replied". Every phase below therefore ends in `checks.md`,
 which declares this workflow's terminal state.
 
+## Observed, never assumed (applies to every phase)
+
+Git and GitHub state is concurrent and mutable: the base moves, CI lags, mergeability is computed
+lazily, and this workflow's own steps dirty the tree they just checked. Three rules hold at every
+step of every phase:
+
+- **Verify at the point of action.** An irreversible step — push, `gh pr create`, `gh pr edit`,
+  replying to a thread, declaring done — re-checks the exact state it consumes immediately before
+  running. A gate passed earlier does not survive the mutations made since it passed.
+- **Fetch, don't remember.** Remote state is read fresh and completely at the moment it's needed:
+  the current body before editing it, `--paginate` on every listing, `git fetch` before reasoning
+  about the base.
+- **Indeterminate is not affirmative.** A pending or still-computing answer (an `UNKNOWN` merge
+  state, queued checks) is polled until it resolves; done is declared only from observed
+  affirmative state, never from the absence of a bad signal.
+
 ## Classify the ask
 
 | The ask | Phase doc |

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
@@ -10,8 +10,9 @@ until it is mergeable. One workflow, five phases as sibling docs — enter at th
 
 ## The done bar (applies to every phase)
 
-A PR is **done** when its checks are green and the user has the link plus its current state — never
-at "PR opened", "pushed", or "comment replied". Every phase below therefore ends in `checks.md`,
+A PR is **done** when every check it *has* is green — a repo with no CI is reported as exactly
+that, never silently treated as green — and the user has the link plus its current state; never at
+"PR opened", "pushed", or "comment replied". Every phase below therefore ends in `checks.md`,
 which declares this workflow's terminal state.
 
 ## Observed, never assumed (applies to every phase)

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: shipping-a-pr
+description: "Use when finished work needs to ship as a pull request, or when the ask is about a PR — creating one, bringing it up to date, adding screenshots, watching its checks, or addressing its review comments. Not for reviewing a PR you are not shipping."
+---
+
+# Shipping a PR
+
+The PR lifecycle: ship the workspace's finished work as a pull request and keep that PR healthy
+until it is mergeable. One workflow, five phases as sibling docs — enter at the phase the ask names.
+
+## The done bar (applies to every phase)
+
+A PR is **done** when its checks are green and the user has the link plus its current state — never
+at "PR opened", "pushed", or "comment replied". Every phase below therefore ends in `checks.md`,
+which declares this workflow's terminal state.
+
+## Classify the ask
+
+| The ask | Phase doc |
+|---|---|
+| Create a PR — the work is finished | `creating.md` |
+| Bring the PR up to date / resolve conflicts with its base | `syncing.md` |
+| Add or refresh screenshots on a PR | `screenshots.md` |
+| Monitor CI / investigate or fix failing checks | `checks.md` |
+| Address review comments | `review-comments.md` |
+
+A compound ask ("rebase, verify, and create a PR") is one flow: start at the earliest phase named;
+the docs chain forward on their own. If the work itself isn't finished — the ask bundles new design
+or implementation before the ship — that part is not this workflow's; route it per
+choosing-a-workflow first and come back here when it lands.
+
+## Working files
+
+Ephemeral files this workflow uses, all under the workspace's gitignored `.thinkrail/context/`:
+
+- `pr-body.md` — the PR body draft; always passed via `--body-file`, never inline.
+- `pr-shots/` — staged before/after screenshots awaiting attachment.
+
+Both are deleted when the phase that made them completes (screenshots stay while the user is
+uploading by hand — see `screenshots.md`).
+
+## Ending
+
+Every path ends in `checks.md`; its terminal state is the only way this workflow finishes.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/SKILL.md
@@ -24,7 +24,8 @@ which declares this workflow's terminal state.
 | Monitor CI / investigate or fix failing checks | `checks.md` |
 | Address review comments | `review-comments.md` |
 
-A compound ask ("rebase, verify, and create a PR") is one flow: start at the earliest phase named;
+**Read and follow the selected phase doc** — the gates and mechanics live only there; never run a
+phase from this spine's summary. A compound ask ("rebase, verify, and create a PR") is one flow: start at the earliest phase named;
 the docs chain forward on their own. If the work itself isn't finished — the ask bundles new design
 or implementation before the ship — that part is not this workflow's; route it per
 choosing-a-workflow first and come back here when it lands.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
@@ -19,9 +19,17 @@ the workflow — the terminal state is declared below.
 
 ## Before declaring done: the base, not just CI
 
-Checks only observe CI — they say nothing about the base moving underneath. Query the merge state:
-`gh pr view <n> --json mergeStateStatus -q .mergeStateStatus`. `BEHIND` or `DIRTY` → read and
-follow `syncing.md`, then return here. Only a head current with its base is reported done.
+Checks only observe CI — they say nothing about the base moving underneath. Query the merge state
+(`gh pr view <n> --json mergeStateStatus -q .mergeStateStatus`) and act on the answer:
+
+- `UNKNOWN` — GitHub is still computing mergeability (normal right after a push): wait a few
+  seconds and re-query until it resolves. An indeterminate answer never falls through to done.
+- `BEHIND` or `DIRTY` — read and follow `syncing.md`, then return here.
+- Any other value is a computed, non-behind, non-conflicted state — the affirmative answer the
+  terminal state below requires.
+
+Only a head *observed* current with its base is reported done — never one assumed current because
+nothing said otherwise.
 
 ## Terminal state (this workflow ends here)
 

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
@@ -17,6 +17,12 @@ the workflow — the terminal state is declared below.
   the branch.
 - Never report a check green on hope: the report below is written from observed check states only.
 
+## Before declaring done: the base, not just CI
+
+Checks only observe CI — they say nothing about the base moving underneath. Query the merge state:
+`gh pr view <n> --json mergeStateStatus -q .mergeStateStatus`. `BEHIND` or `DIRTY` → read and
+follow `syncing.md`, then return here. Only a head current with its base is reported done.
+
 ## Terminal state (this workflow ends here)
 
 Done means: the PR exists, is up to date with its base, its checks are **green**, and the user has

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
@@ -7,6 +7,9 @@ the workflow — the terminal state is declared below.
 
 - `gh pr checks <n> --watch` (or `gh run watch <run-id> --exit-status` for one run). When a watch
   is impractical, poll `gh pr checks <n>` with sleeps.
+- `no checks reported` (a repo with no CI) is an observed state, not an error: there is nothing to
+  watch, fix, or wait for — go straight to the merge-state verification below and carry "no checks
+  configured" into the terminal summary.
 - On failure: `gh run view --job <job-id> --log-failed` for the failing step's log; reproduce
   locally when the log isn't conclusive.
 
@@ -33,8 +36,9 @@ nothing said otherwise.
 
 ## Terminal state (this workflow ends here)
 
-Done means: the PR exists, is up to date with its base, its checks are **green**, and the user has
-the PR link plus a short state summary — what shipped, what was verified, anything deliberately
+Done means: the PR exists, is up to date with its base, every check it *has* is **green** — a repo
+with no CI is reported explicitly as "no checks configured", never silently treated as green — and
+the user has the PR link plus a short state summary — what shipped, what was verified, anything deliberately
 left out. If green is unreachable without a decision that belongs to the user (e.g. a required
 check failing for reasons outside this branch's scope), report that state explicitly and stop —
 that is the alternative terminal state, stated as such, never silently abandoned.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/checks.md
@@ -1,0 +1,26 @@
+# checks.md — watch, react, report (terminal)
+
+Entry: an open PR with fresh commits, or a standing ask to monitor. Saves nothing. This doc ends
+the workflow — the terminal state is declared below.
+
+## Watch
+
+- `gh pr checks <n> --watch` (or `gh run watch <run-id> --exit-status` for one run). When a watch
+  is impractical, poll `gh pr checks <n>` with sleeps.
+- On failure: `gh run view --job <job-id> --log-failed` for the failing step's log; reproduce
+  locally when the log isn't conclusive.
+
+## React
+
+- Fix, commit, push; the loop restarts. A flaky-looking failure is investigated, not re-run into
+  submission — `gh run rerun --failed` once, and only when the failure is demonstrably unrelated to
+  the branch.
+- Never report a check green on hope: the report below is written from observed check states only.
+
+## Terminal state (this workflow ends here)
+
+Done means: the PR exists, is up to date with its base, its checks are **green**, and the user has
+the PR link plus a short state summary — what shipped, what was verified, anything deliberately
+left out. If green is unreachable without a decision that belongs to the user (e.g. a required
+check failing for reasons outside this branch's scope), report that state explicitly and stop —
+that is the alternative terminal state, stated as such, never silently abandoned.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
@@ -16,7 +16,9 @@ Entry: finished work on a branch, no PR yet. Saves the body draft at
    every file in the diff must be explainable in one line.
 4. **Verified.** Run the project's own verification gates (its agent instructions / package
    scripts) — *after* the rebase, not before. New behavior ships with tests; if the project's
-   convention demands a suite class (e.g. e2e) not yet run for this change, run it now.
+   convention demands a suite class (e.g. e2e) not yet run for this change, run it now. A project
+   with no gates of its own is verified by hand and reported as exactly that in the body's Testing
+   section — never silently treated as verified.
 5. **Self-review.** Re-read the full diff (`git diff <base>...HEAD` plus working tree) as a
    reviewer, holding the project's handoff-hygiene bar: no silent lint/type suppressions, no comment
    creep, no half-migrated patterns, no leftovers. Fix what you find; don't annotate it.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
@@ -4,17 +4,20 @@ Entry: finished work on a branch, no PR yet. Saves the body draft at
 `.thinkrail/context/pr-body.md`. Control continues at `screenshots.md` (UI-visible change) or
 `checks.md`.
 
-## Gates — all four pass before `gh pr create`, in this order
+## Gates — all five pass before `gh pr create`, in this order
 
-1. **Fresh base.** `git fetch origin`, then rebase onto the base branch (default `origin/main`).
+1. **Committed, clean worktree.** Everything that ships is committed — `git status --porcelain`
+   comes back empty. Work git doesn't hold (uncommitted edits, untracked files) will not reach the
+   PR, and the rebase in the next gate needs a clean tree anyway.
+2. **Fresh base.** `git fetch origin`, then rebase onto the base branch (default `origin/main`).
    Conflicts are resolved now, not after review starts.
-2. **Clean branch.** Remove throwaway artifacts — repro tests, capture specs, scratch files, test
+3. **Clean branch.** Remove throwaway artifacts — repro tests, capture specs, scratch files, test
    output dirs. Read `git log --oneline <base>..HEAD` and `git status --short` as the reviewer will:
    every file in the diff must be explainable in one line.
-3. **Verified.** Run the project's own verification gates (its agent instructions / package
+4. **Verified.** Run the project's own verification gates (its agent instructions / package
    scripts) — *after* the rebase, not before. New behavior ships with tests; if the project's
    convention demands a suite class (e.g. e2e) not yet run for this change, run it now.
-4. **Self-review.** Re-read the full diff (`git diff <base>...HEAD` plus working tree) as a
+5. **Self-review.** Re-read the full diff (`git diff <base>...HEAD` plus working tree) as a
    reviewer, holding the project's handoff-hygiene bar: no silent lint/type suppressions, no comment
    creep, no half-migrated patterns, no leftovers. Fix what you find; don't annotate it.
 
@@ -33,7 +36,9 @@ Red flags — stop, a gate is being rationalized away:
     migration steps.
   - `## Testing` — the actual commands run and their results ("`bun run e2e` — 252 passed"), never
     a bare "tests pass".
-- **Create**:
+- **Push, then create** — `gh pr create --head` does **not** push for you: push the verified head
+  first (`git push -u origin <branch>`; `--force-with-lease` when the remote branch exists and was
+  rebased), then
   `gh pr create --base <base> --head <branch> --title "…" --body-file .thinkrail/context/pr-body.md`
   — add `--repo` when the remote is ambiguous; `--draft` only when the user asked for a draft.
   Never pass the body inline: long inline/heredoc bodies have truncated and failed; the body file

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
@@ -36,9 +36,12 @@ Red flags — stop, a gate is being rationalized away:
     migration steps.
   - `## Testing` — the actual commands run and their results ("`bun run e2e` — 252 passed"), never
     a bare "tests pass".
-- **Push, then create** — `gh pr create --head` does **not** push for you: push the verified head
-  first (`git push -u origin <branch>`; `--force-with-lease` when the remote branch exists and was
-  rebased), then
+- **Re-verify, push, then create.** Gates 3–5 edit the tree gate 1 checked — artifact removals,
+  self-review fixes: commit everything they changed and confirm `git status --porcelain` is empty
+  again *now*, immediately before the push (the spine's point-of-action rule; a deletion or fix
+  left in the working tree does not reach the PR). Then push the verified head —
+  `gh pr create --head` does **not** push for you: `git push -u origin <branch>`
+  (`--force-with-lease` when the remote branch exists and was rebased) — then
   `gh pr create --base <base> --head <branch> --title "…" --body-file .thinkrail/context/pr-body.md`
   — add `--repo` when the remote is ambiguous; `--draft` only when the user asked for a draft.
   Never pass the body inline: long inline/heredoc bodies have truncated and failed; the body file

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
@@ -1,0 +1,46 @@
+# creating.md — gates, then the PR
+
+Entry: finished work on a branch, no PR yet. Saves the body draft at
+`.thinkrail/context/pr-body.md`. Control continues at `screenshots.md` (UI-visible change) or
+`checks.md`.
+
+## Gates — all four pass before `gh pr create`, in this order
+
+1. **Fresh base.** `git fetch origin`, then rebase onto the base branch (default `origin/main`).
+   Conflicts are resolved now, not after review starts.
+2. **Clean branch.** Remove throwaway artifacts — repro tests, capture specs, scratch files, test
+   output dirs. Read `git log --oneline <base>..HEAD` and `git status --short` as the reviewer will:
+   every file in the diff must be explainable in one line.
+3. **Verified.** Run the project's own verification gates (its agent instructions / package
+   scripts) — *after* the rebase, not before. New behavior ships with tests; if the project's
+   convention demands a suite class (e.g. e2e) not yet run for this change, run it now.
+4. **Self-review.** Re-read the full diff (`git diff <base>...HEAD` plus working tree) as a
+   reviewer, holding the project's handoff-hygiene bar: no silent lint/type suppressions, no comment
+   creep, no half-migrated patterns, no leftovers. Fix what you find; don't annotate it.
+
+Red flags — stop, a gate is being rationalized away:
+
+- "I'll create the PR now and run the suite while it's up."
+- "The rebase can wait until review starts."
+- "That file is probably fine" — you couldn't explain it to a reviewer in one line.
+
+## The PR
+
+- **Title**: `scope: imperative summary` — e.g. `feat(web): …`, `fix(website): …`, `ci: …`.
+- **Body** → `.thinkrail/context/pr-body.md`, sections scaled to the change, written for colleagues:
+  - `## Summary` — what and why; `Closes #NNN` when issue-driven.
+  - `## Changes` — grouped by module (larger PRs); note deliberate scope exclusions and any
+    migration steps.
+  - `## Testing` — the actual commands run and their results ("`bun run e2e` — 252 passed"), never
+    a bare "tests pass".
+- **Create**:
+  `gh pr create --base <base> --head <branch> --title "…" --body-file .thinkrail/context/pr-body.md`
+  — add `--repo` when the remote is ambiguous; `--draft` only when the user asked for a draft.
+  Never pass the body inline: long inline/heredoc bodies have truncated and failed; the body file
+  *is* the recipe. Delete the body file once the PR exists.
+
+## Next
+
+- The change is UI-visible → offer screenshots proactively (don't wait to be asked) and continue at
+  `screenshots.md`.
+- Otherwise → `checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/creating.md
@@ -41,6 +41,6 @@ Red flags — stop, a gate is being rationalized away:
 
 ## Next
 
-- The change is UI-visible → offer screenshots proactively (don't wait to be asked) and continue at
-  `screenshots.md`.
-- Otherwise → `checks.md`.
+- The change is UI-visible → offer screenshots proactively (don't wait to be asked), then read and
+  follow `screenshots.md`.
+- Otherwise → read and follow `checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/review-comments.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/review-comments.md
@@ -1,0 +1,25 @@
+# review-comments.md — address comments, never blindly
+
+Entry: an open PR has review comments to address. Saves nothing. Control continues at `checks.md`.
+
+1. **Whole-PR read first.** Fetch every comment thread and the full diff (`gh pr view <n>
+   --comments`, `gh api repos/<owner>/<repo>/pulls/<n>/comments`), then re-read the PR's changes
+   end to end. Each comment is judged against the whole change, not just its quoted lines.
+2. **Verdict per comment, before touching code**: *apply* (it's right), *push back* (it's wrong or
+   misreads the design — say why, citing the spec or design), or *clarify* (genuinely ambiguous —
+   ask the reviewer or the user). Batch the verdicts; surface them to the user whenever any verdict
+   is push-back.
+3. Apply the accepted ones as proper changes — the project's verification gates still apply — push,
+   and **reply to every thread**: what changed and where, or the push-back rationale. Resolve only
+   threads actually addressed.
+
+Red flags:
+
+- Patching exactly the quoted line without reading the surrounding design — "do not fix them
+  blindly" is this doc's founding requirement.
+- Replying "done" without a pushed commit that shows it.
+- Silently skipping a comment — every thread gets an answer.
+
+## Next
+
+`checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/review-comments.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/review-comments.md
@@ -9,9 +9,10 @@ Entry: an open PR has review comments to address. Saves nothing. Control continu
    misreads the design — say why, citing the spec or design), or *clarify* (genuinely ambiguous —
    ask the reviewer or the user). Batch the verdicts; surface them to the user whenever any verdict
    is push-back.
-3. Apply the accepted ones as proper changes — the project's verification gates still apply — push,
-   and **reply to every thread**: what changed and where, or the push-back rationale. Resolve only
-   threads actually addressed.
+3. Apply the accepted ones as proper changes — the project's verification gates still apply —
+   commit everything, confirm the tree is clean, and push. **Reply to every thread** only after
+   the push lands: what changed and where (naming the commit), or the push-back rationale. Resolve
+   only threads actually addressed.
 
 Red flags:
 

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/review-comments.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/review-comments.md
@@ -3,7 +3,7 @@
 Entry: an open PR has review comments to address. Saves nothing. Control continues at `checks.md`.
 
 1. **Whole-PR read first.** Fetch every comment thread and the full diff (`gh pr view <n>
-   --comments`, `gh api repos/<owner>/<repo>/pulls/<n>/comments`), then re-read the PR's changes
+   --comments`, `gh api repos/<owner>/<repo>/pulls/<n>/comments --paginate`), then re-read the PR's changes
    end to end. Each comment is judged against the whole change, not just its quoted lines.
 2. **Verdict per comment, before touching code**: *apply* (it's right), *push back* (it's wrong or
    misreads the design — say why, citing the spec or design), or *clarify* (genuinely ambiguous —
@@ -22,4 +22,4 @@ Red flags:
 
 ## Next
 
-`checks.md`.
+Read and follow `checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/screenshots.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/screenshots.md
@@ -31,9 +31,13 @@ COMMIT=$(printf 'PR screenshots (review-only ref)\n' | git commit-tree "$TREE")
 git push -f origin "$COMMIT:refs/heads/assets/<topic>"
 ```
 
-Reference each image in the PR body as
-`https://github.com/<owner>/<repo>/blob/<COMMIT>/<name>.png?raw=true` — pinned to the pushed commit
-SHA so later branch pushes never break the images — then `gh pr edit <n> --body-file …`.
+Then update the body — **never rebuild it**: fetch the current one first
+(`gh pr view <n> --json body -q .body > .thinkrail/context/pr-body.md`), add or update a
+`## Screenshots` section in it referencing each image as
+`https://github.com/<owner>/<repo>/blob/<COMMIT>/<name>.png?raw=true` (pinned to the pushed commit
+SHA so later branch pushes never break the images), then
+`gh pr edit <n> --body-file .thinkrail/context/pr-body.md` and delete the file. A body built from
+scratch here would erase the PR's summary, testing notes, and issue links.
 
 Fallback (the user sometimes prefers it): leave the PNGs staged and hand over their paths — the
 user drags them into GitHub by hand. Offer the choice only when the user has signaled it; the
@@ -42,4 +46,4 @@ assets ref is the default.
 ## Next
 
 Delete `.thinkrail/context/pr-shots/` once the body edit lands — unless the user is uploading by
-hand; then leave it until they confirm. Continue at `checks.md`.
+hand; then leave it until they confirm. Read and follow `checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/screenshots.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/screenshots.md
@@ -1,0 +1,45 @@
+# screenshots.md — before/after evidence for reviewers
+
+Entry: a PR exists (or was just created) for a UI-visible change. Saves PNGs under
+`.thinkrail/context/pr-shots/` and rewrites the PR body to reference them. Control continues at
+`checks.md`.
+
+## Capture
+
+- **After** = the scenario on the branch build; **Before** = the *same* scenario at the base branch
+  (check out detached, rebuild, capture, return). Same viewport, same scenario — the pair must diff
+  visually.
+- Capture with whatever drives the app in this project: the e2e harness with a throwaway capture
+  spec, or a browser-automation session against a running dev host. A capture spec is a throwaway —
+  it never ships (creating.md's clean-branch gate).
+- Stage the picked shots as `.thinkrail/context/pr-shots/<name>.png` with names a reviewer reads
+  (`loader-before-gap.png`, `loader-after-working.png`).
+
+## Attach — review-only assets ref (the default)
+
+Screenshots never enter the PR's file tree. Push them as an orphan ref and reference SHA-pinned
+URLs:
+
+```bash
+TREE_INPUT=""
+for f in .thinkrail/context/pr-shots/*.png; do
+  sha=$(git hash-object -w "$f")
+  TREE_INPUT+=$(printf '100644 blob %s\t%s' "$sha" "$(basename "$f")")$'\n'
+done
+TREE=$(printf '%s' "$TREE_INPUT" | git mktree)
+COMMIT=$(printf 'PR screenshots (review-only ref)\n' | git commit-tree "$TREE")
+git push -f origin "$COMMIT:refs/heads/assets/<topic>"
+```
+
+Reference each image in the PR body as
+`https://github.com/<owner>/<repo>/blob/<COMMIT>/<name>.png?raw=true` — pinned to the pushed commit
+SHA so later branch pushes never break the images — then `gh pr edit <n> --body-file …`.
+
+Fallback (the user sometimes prefers it): leave the PNGs staged and hand over their paths — the
+user drags them into GitHub by hand. Offer the choice only when the user has signaled it; the
+assets ref is the default.
+
+## Next
+
+Delete `.thinkrail/context/pr-shots/` once the body edit lands — unless the user is uploading by
+hand; then leave it until they confirm. Continue at `checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/screenshots.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/screenshots.md
@@ -11,7 +11,8 @@ Entry: a PR exists (or was just created) for a UI-visible change. Saves PNGs und
   visually.
 - Capture with whatever drives the app in this project: the e2e harness with a throwaway capture
   spec, or a browser-automation session against a running dev host. A capture spec is a throwaway —
-  it never ships (creating.md's clean-branch gate).
+  it never ships, and *this* doc owns its cleanup (Next below): creating.md's clean-branch gate has
+  already run on every entry path here and will not catch it.
 - Stage the picked shots as `.thinkrail/context/pr-shots/<name>.png` with names a reviewer reads
   (`loader-before-gap.png`, `loader-after-working.png`).
 
@@ -45,5 +46,7 @@ assets ref is the default.
 
 ## Next
 
-Delete `.thinkrail/context/pr-shots/` once the body edit lands — unless the user is uploading by
-hand; then leave it until they confirm. Read and follow `checks.md`.
+Clean up this phase's throwaways once the body edit lands: delete `.thinkrail/context/pr-shots/`
+(unless the user is uploading by hand — then leave it until they confirm) and every capture
+scaffold (specs, throwaway builds). If any scaffolding was committed, the commit that removes it
+is pushed too — a deletion left in the working tree ships nothing. Read and follow `checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/syncing.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/syncing.md
@@ -17,4 +17,4 @@ depends on; step 3 is unconditional.
 
 ## Next
 
-`checks.md`.
+Read and follow `checks.md`.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/syncing.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/syncing.md
@@ -10,7 +10,9 @@ Entry: an open PR has fallen behind its base or has conflicts. Saves nothing. Co
    work gets silently reverted.
 3. **Re-verify.** A conflict-free rebase is not a green rebase — run the project's gates again: at
    minimum the suites covering the conflicted areas, the full bar when the base moved substantially.
-4. Push — `--force-with-lease` after a rebase, never plain `--force`.
+4. Push — but first commit anything step 3 changed and confirm `git status --porcelain` is empty
+   (the spine's point-of-action rule: a re-verification fix left in the working tree does not
+   reach the PR). `--force-with-lease` after a rebase, never plain `--force`.
 
 Red flag: "no conflicts, so nothing to re-run" — the base may have changed behavior this branch
 depends on; step 3 is unconditional.

--- a/packages/pi-thinkrail-workflow/skills/shipping-a-pr/syncing.md
+++ b/packages/pi-thinkrail-workflow/skills/shipping-a-pr/syncing.md
@@ -1,0 +1,20 @@
+# syncing.md — bring the PR up to date
+
+Entry: an open PR has fallen behind its base or has conflicts. Saves nothing. Control continues at
+`checks.md`.
+
+1. `git fetch origin`, then rebase the branch onto the base — or merge, if the PR's existing
+   history style is merge-based; follow what the PR already does.
+2. Resolve conflicts by understanding both sides: read the conflicting hunks' history
+   (`git log -p` on each side) before choosing. A mechanical "take ours" is how freshly merged
+   work gets silently reverted.
+3. **Re-verify.** A conflict-free rebase is not a green rebase — run the project's gates again: at
+   minimum the suites covering the conflicted areas, the full bar when the base moved substantially.
+4. Push — `--force-with-lease` after a rebase, never plain `--force`.
+
+Red flag: "no conflicts, so nothing to re-run" — the base may have changed behavior this branch
+depends on; step 3 is unconditional.
+
+## Next
+
+`checks.md`.


### PR DESCRIPTION
## Summary

Adds **`shipping-a-pr`** to the bundled workflow family: the PR-lifecycle skill — create with gates,
screenshots, up-to-date syncs, checks watching, review-comment handling — codified from the
operator's real pi sessions (125 scanned, 36 with PR work, Jun–Aug 2026). The recurring asks and
corrections in those sessions ("run real suites … and do a PR", "first — review yourself", "make PR
up-to-date", "look at the checks, some failed", "do not fix them blindly") repeated in nearly every
PR session; none of it was codified, so each session rediscovered it.

## Changes

**New skill — `packages/pi-thinkrail-workflow/skills/shipping-a-pr/`** (worker; phases as sibling
docs per meta-rule 1):
- `SKILL.md` — spine: ask classification, the done bar (checks green + user told — never "PR
  opened"), declared working files under `.thinkrail/context/`.
- `creating.md` — four gates in order (fresh rebase → clean branch → verify after rebase →
  self-review), title/body recipe, `--body-file`-only mechanics (inline bodies observed truncating).
- `screenshots.md` — before/after capture (base vs branch) + the review-only assets-ref attachment
  (`hash-object`/`mktree`/`commit-tree` → `refs/heads/assets/<topic>`, SHA-pinned URLs); hand-upload
  fallback.
- `syncing.md` — rebase/conflict resolution with unconditional re-verify.
- `checks.md` — watch/react loop; declares the workflow's terminal state.
- `review-comments.md` — whole-PR read → per-comment verdict (apply / push back / clarify) → reply
  to every thread.

**Registration (meta-rule 12):**
- `choosing-a-workflow` — third classify question + routing row (PR asks classify **before** the
  brainstorming row, so fixes flowing from a PR's own review comments don't misroute to feature
  work) + handoff line.
- `skills/SPEC.md` — family-table row (marked `unverified by use`, rule 14 suspended), diagram edge,
  and a per-skill design note carrying the mining provenance and the decisions the user confirmed
  (full-lifecycle scope; review-only assets-ref screenshot default; ready-not-draft default).

## Testing

- `bun run lint` — clean (660 files)
- `bun run typecheck` — 10/10 tasks
- `bun run test` — green (incl. 686 server tests; the workflow package's rule-injection tests
  unaffected — no code changed)
- `spec_validate` — no new dangling links (the two pre-existing ones are untouched server-module
  references)
- Content-only change (markdown skills + spec prose): no runtime code path moves, so the browser e2e
  suite exercises nothing this touches; the on-demand routing suite (`bun run test:workflows`) is
  the verify-by-use path and the family-table row stays honest (`unverified by use`) until a run is
  observed.
