### PR TITLE
fix(shared): invalidate on the Central artifact, not its directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,6 @@ runs `pi` and bridges it to a rich UI; `pi` owns models, skills, compaction, cos
 Canonical specs (read these first):
 - `goal-and-requirements.md` — product goal + V1/V2 scope
 - `architecture.md` — top-level architecture, decisions, invariants
-- `central-integration.md` — the JetBrains AI / Central chain: cross-module state mapping + liveness
 
 ## Module structure & boundaries (top-priority requirement)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ runs `pi` and bridges it to a rich UI; `pi` owns models, skills, compaction, cos
 Canonical specs (read these first):
 - `goal-and-requirements.md` — product goal + V1/V2 scope
 - `architecture.md` — top-level architecture, decisions, invariants
+- `central-integration.md` — the JetBrains AI / Central chain: cross-module state mapping + liveness
 
 ## Module structure & boundaries (top-priority requirement)
 
@@ -62,6 +63,7 @@ PR/Checks.
 
 ```
 goal-and-requirements.md, architecture.md   top-level specs (repo root)
+central-integration.md                      cross-module spec: JetBrains AI via Central
 apps/
   cli/        V1 entrypoint: boot host + open browser   (SPEC.md)
   web/        mobile-first UI client                    (SPEC.md)

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -5,6 +5,7 @@ status: active
 title: panels — feature views
 parent: module-web
 depends-on: [module-contracts]
+references: [central-integration]
 tags: [v1, ui]
 ---
 

--- a/architecture.md
+++ b/architecture.md
@@ -135,17 +135,10 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
     **tmux was rejected** as the persistence layer: an unassumable dependency on Windows, a competing tab
     model, env-propagation breakage, and polling-based capture — for restart survival we have already
     decided not to hold. Detail: [[submodule-server-terminal]].
-13. **Central is an opaque third-party integration, isolated behind one adapter and one artifact.**
-    JetBrains AI models reach ThinkRail through the user's own `central` CLI, not through a provider we
-    configure: the CLI writes a `pi` extension to a single global path and ThinkRail's only coupling to it
-    is that path's existence. Nothing reads the artifact, and no Central-derived text reaches a client —
-    every state the UI sees is a closed enum the host chose. This is the only integration that shells out
-    to a third-party binary which mutates `pi`'s own state directory and injects an opaque extension into a
-    live runtime, so it is also the only one whose behaviour is a *chain* across five modules
-    (`shared` → `auth` → `agent` → `contracts` → `web/panels`) rather than a module boundary. The chain's
-    end-to-end state mapping and its **liveness** obligations are owned by [[central-integration]], because
-    no single module can hold them — a beta livelock proved that two individually-correct module specs can
-    compose into a non-terminating state.
+13. **Central's cross-module lifecycle has one architectural owner.** Its adapter, runtime generation,
+    wire status, and card remain in their bounded modules; the correspondence between those surfaces and
+    their liveness obligations belongs to [[central-integration]]. This keeps feature-specific mechanics in
+    their leaf specs while making a non-terminating composition visible at the architecture layer.
 
 ## Invariants
 

--- a/architecture.md
+++ b/architecture.md
@@ -4,7 +4,7 @@ type: architecture-design
 status: active
 title: ThinkRail — top-level architecture
 parent: goal-and-requirements
-covers: [client-host-split, cli-entrypoint, wire-contract, transport-endpoint, ui-shell-panels, git-worktrees, remote-tailscale, hydrate-then-stream, domain-vs-view-state, shared-workspace-layout, client-local-navigation]
+covers: [client-host-split, cli-entrypoint, wire-contract, transport-endpoint, ui-shell-panels, git-worktrees, remote-tailscale, hydrate-then-stream, domain-vs-view-state, shared-workspace-layout, client-local-navigation, central-integration]
 tags: [v1, architecture]
 ---
 
@@ -135,6 +135,17 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
     **tmux was rejected** as the persistence layer: an unassumable dependency on Windows, a competing tab
     model, env-propagation breakage, and polling-based capture — for restart survival we have already
     decided not to hold. Detail: [[submodule-server-terminal]].
+13. **Central is an opaque third-party integration, isolated behind one adapter and one artifact.**
+    JetBrains AI models reach ThinkRail through the user's own `central` CLI, not through a provider we
+    configure: the CLI writes a `pi` extension to a single global path and ThinkRail's only coupling to it
+    is that path's existence. Nothing reads the artifact, and no Central-derived text reaches a client —
+    every state the UI sees is a closed enum the host chose. This is the only integration that shells out
+    to a third-party binary which mutates `pi`'s own state directory and injects an opaque extension into a
+    live runtime, so it is also the only one whose behaviour is a *chain* across five modules
+    (`shared` → `auth` → `agent` → `contracts` → `web/panels`) rather than a module boundary. The chain's
+    end-to-end state mapping and its **liveness** obligations are owned by [[central-integration]], because
+    no single module can hold them — a beta livelock proved that two individually-correct module specs can
+    compose into a non-terminating state.
 
 ## Invariants
 

--- a/central-integration.md
+++ b/central-integration.md
@@ -49,49 +49,32 @@ Two facts the table encodes that no single module states:
 
 ## Decisions
 
-1. **One artifact is the whole coupling.** `~/.pi/agent/extensions/jetbrains-central.ts`, named identically
-   by the adapter that watches it and the `pi` runtime that loads it. `central add pi` creates it,
-   `central remove pi` deletes it, and existence *is* the configured verdict. ThinkRail never opens, parses,
-   hashes, or copies it. Corollary that makes the first invariant subtle: because existence is the only fact
-   read, an **in-place replacement is invisible to an existence check**, so the watcher — not the poll — is
-   the only thing that can observe one.
-2. **No Central-derived text ever reaches a client.** Every state above is a closed enum the host chose,
-   never a passthrough of what Central printed. The obligation is enforced in three places, each
-   authoritative for its own half: the process surface invokes only reviewed argv and maps only exit success
-   plus a safe postcondition to an outcome ([[module-shared]]); the runtime surface receives the artifact
-   path as the only artifact fact and captures the provider-id allowlist *before* the opaque extension loads
-   ([[submodule-server-agent]]); the wire surface never lets Central-owned providers, credentials, or details
-   become ordinary provider rows ([[submodule-server-auth]], [[module-contracts]]).
+1. **One reviewed artifact joins inspection to runtime loading.** The adapter owns its location, existence
+   verdict, and watcher; the runtime receives only its opaque path. Because configured truth uses existence
+   alone, in-place replacement depends on the watcher rather than the existence poll. The local mechanics
+   remain authoritative in [[module-shared]] and [[submodule-server-agent]].
+2. **No Central-derived text reaches a client.** The process adapter, pre-extension provider allowlist, and
+   closed wire status each enforce one part of that guarantee; their local contracts remain in
+   [[module-shared]], [[submodule-server-agent]], [[submodule-server-auth]], and [[module-contracts]].
 
 ## Invariants
 
-1. **Invalidation is edge-triggered on the artifact, never level-triggered on a directory.** `fs.watch` is
-   per-directory and the watcher re-arms from the nearest existing parent, so the watched directory is
-   routinely an *ancestor* — with Central never installed it is `~/.pi/agent`, `pi`'s entire state directory.
-   Forwarding raw directory events therefore converts unrelated `pi` churn into rebuild demand. Held by
-   [[module-shared]].
-2. **Every path into `configuring` has a bounded exit.** Two paths reach it: an in-flight action (bounded by
-   the adapter's `ACTION_TIMEOUT_MS` / `UPDATE_TIMEOUT_MS`) and an outstanding rebuild
-   (`settledSequence < requestedSequence`). A path with no bound is a stuck card, not a slow one, because
-   the state carries no deadline of its own.
-3. **The rebuild drain settles a requested sequence in bounded time, independent of inbound event rate.**
-   A debounce cannot supply this: it bounds *burst width*, not stream length, so an unbounded event source
-   starves any drain that restarts on every new sequence.
+1. **Watcher invalidations represent possible edges on the reviewed artifact, not directory activity.** The
+   platform event classification and replacement-recovery mechanics belong only to [[module-shared]].
+2. **Every path into `configuring` has a bounded exit.** Actions are bounded by adapter timeouts; an
+   outstanding rebuild exits when the drain settles. The wire state carries no deadline of its own.
+3. **The rebuild drain settles requested state in bounded time, independent of inbound event rate.** A
+   debounce bounds burst width, not stream length, so it cannot provide this guarantee.
 
-**Invariant 3 is currently violated.** `runRebuildDrain` re-reads `requestedSequence` after each
-`preparePiRuntimeGeneration()` and discards the completed build when it changed, so progress requires a
-quiet window of the debounce plus a full runtime build, and nothing bounds how many times it may discard.
-Worse, the activation sits after that guard, so under starvation no generation is adopted at all and the
-host serves the boot-time runtime indefinitely. Latent, not fixed: invariant 1 removed the only known event
-source fast enough to trigger it, and a second such source reproduces it unchanged.
+**Invariant 3 is currently violated and tracked by issue #287.** `runRebuildDrain` discards a completed
+candidate whenever `requestedSequence` changed during preparation, so progress still requires a quiet
+window and activation can starve indefinitely. Artifact-scoped invalidation removes the known source of
+unrelated events but does not change that algorithm.
 
-**Post-mortem.** Both halves of the composition were individually correct. [[module-shared]] said the
-caller debounces events and rechecks existence; [[submodule-server-auth]] said watcher drift schedules a
-rebuild and status is `configuring` until the newest candidate applies. Composed against an endless event
-stream — `pi` rewriting `auth.json.lock` and `models-store.json` at ~23 events/s while idle — the drain
-never settled, `getJbcentralStatus()` pinned `configuring`, and users with no Central installed were told
-ThinkRail "is applying the latest Central configuration" while the host rebuilt the `pi` runtime in a hot
-loop at ~30-45% CPU. No spec was wrong; no spec owned the composition.
+**Post-mortem.** With the artifact directory absent, the watcher fell back to `pi`'s state directory and
+turned unrelated state writes into rebuild requests. The drain's quiet-window assumption kept
+`configuring` active while repeatedly preparing runtimes. Each leaf contract was locally consistent, but
+no spec owned their liveness in composition.
 
 ## Out of scope
 

--- a/central-integration.md
+++ b/central-integration.md
@@ -9,24 +9,22 @@ covers: [central-lifecycle, central-liveness, central-trust-boundary, central-ar
 tags: [v1, providers, central]
 ---
 
-## Why this node exists
+## Drivers
 
-Every other Central concern is already owned by the module that implements it: the process/filesystem
-adapter in [[module-shared]], the status/action orchestration in [[submodule-server-auth]], runtime
-generations in [[submodule-server-agent]], the wire shapes in [[module-contracts]], the card in
-[[submodule-web-panels]]. Those specs are correct and stay authoritative for their own surfaces; this
-node **does not restate them**.
+JetBrains AI models reach ThinkRail through the user's own `central` CLI, which writes a `pi` extension to
+one global path. That makes Central's behaviour a **chain across five modules** rather than a module
+boundary, and two of its properties live only in the chain: the end-to-end state mapping and its liveness.
 
-What no module can own is the **composition**. Central is the only integration where ThinkRail shells out
-to a third-party binary that writes into `pi`'s own state directory and injects an opaque extension into a
-live runtime, so its behaviour is a chain across five modules. Two properties live only in that chain:
-the state mapping end to end (§1) and its **liveness** (§2). Both were unowned, and a beta shipped a
-permanent-`configuring` livelock as a direct result — see §2.
+**Boundary: this node owns the composition and nothing else.** Each module's spec stays authoritative for
+its own surface and is not restated here — the adapter's argv/version/parse contract is
+[[module-shared]], status and action orchestration is [[submodule-server-auth]], runtime generations are
+[[submodule-server-agent]], wire shapes are [[module-contracts]], the card's rendering is
+[[submodule-web-panels]]. A change that only affects one surface updates that leaf, not this file.
 
-## §1 The chain
+## The chain
 
-The single end-to-end mapping. Each column is owned by the module named in its header; this table is the
-only place the *correspondence* is stated.
+The single end-to-end mapping. Each column is owned by the module in its header; this table is the only
+place the *correspondence* between them is stated.
 
 | Disk / CLI truth | `inspectJbcentral` (`shared`) | wire `JbcentralStatus` (`contracts`) | Card (`panels`) |
 | --- | --- | --- | --- |
@@ -49,65 +47,58 @@ Two facts the table encodes that no single module states:
   them; unknown never does. The card turns each into a *replacement* of the primary action rather than an
   annotation, because it must never advertise an action that cannot succeed.
 
-## §2 Liveness
+## Decisions
 
-The chain is a state machine that must always make progress. Three invariants, in dependency order:
+1. **One artifact is the whole coupling.** `~/.pi/agent/extensions/jetbrains-central.ts`, named identically
+   by the adapter that watches it and the `pi` runtime that loads it. `central add pi` creates it,
+   `central remove pi` deletes it, and existence *is* the configured verdict. ThinkRail never opens, parses,
+   hashes, or copies it. Corollary that makes the first invariant subtle: because existence is the only fact
+   read, an **in-place replacement is invisible to an existence check**, so the watcher — not the poll — is
+   the only thing that can observe one.
+2. **No Central-derived text ever reaches a client.** Every state above is a closed enum the host chose,
+   never a passthrough of what Central printed. The obligation is enforced in three places, each
+   authoritative for its own half: the process surface invokes only reviewed argv and maps only exit success
+   plus a safe postcondition to an outcome ([[module-shared]]); the runtime surface receives the artifact
+   path as the only artifact fact and captures the provider-id allowlist *before* the opaque extension loads
+   ([[submodule-server-agent]]); the wire surface never lets Central-owned providers, credentials, or details
+   become ordinary provider rows ([[submodule-server-auth]], [[module-contracts]]).
 
-1. **Invalidation is edge-triggered on the artifact, never level-triggered on a directory.**
-   `fs.watch` is per-directory and the watcher re-arms from the nearest existing parent, so the watched
-   directory is routinely an *ancestor* — with Central never installed it is `~/.pi/agent`, `pi`'s entire
-   state directory. Forwarding raw directory events therefore converts unrelated `pi` churn into rebuild
-   demand. Owned by [[module-shared]].
-2. **Every path into `configuring` has a bounded exit.** Two paths reach it today: an in-flight action
-   (bounded by the adapter's `ACTION_TIMEOUT_MS` / `UPDATE_TIMEOUT_MS`) and an outstanding rebuild
+## Invariants
+
+1. **Invalidation is edge-triggered on the artifact, never level-triggered on a directory.** `fs.watch` is
+   per-directory and the watcher re-arms from the nearest existing parent, so the watched directory is
+   routinely an *ancestor* — with Central never installed it is `~/.pi/agent`, `pi`'s entire state directory.
+   Forwarding raw directory events therefore converts unrelated `pi` churn into rebuild demand. Held by
+   [[module-shared]].
+2. **Every path into `configuring` has a bounded exit.** Two paths reach it: an in-flight action (bounded by
+   the adapter's `ACTION_TIMEOUT_MS` / `UPDATE_TIMEOUT_MS`) and an outstanding rebuild
    (`settledSequence < requestedSequence`). A path with no bound is a stuck card, not a slow one, because
    the state carries no deadline of its own.
 3. **The rebuild drain settles a requested sequence in bounded time, independent of inbound event rate.**
-   Debouncing in the caller cannot supply this: a debounce bounds *burst* width, not stream length, so an
-   unbounded event source starves any drain that restarts on every new sequence.
+   A debounce cannot supply this: it bounds *burst width*, not stream length, so an unbounded event source
+   starves any drain that restarts on every new sequence.
 
-**Known violation of #3.** `runRebuildDrain` re-reads `requestedSequence` after each
-`preparePiRuntimeGeneration()` and restarts when it changed, so any event source faster than one rebuild
-starves it indefinitely. This is currently latent rather than live: #1 removed the only known source fast
-enough to trigger it. It is recorded here as a violated invariant, not a resolved one — a second such
-source reproduces the livelock without any change to #1.
+**Invariant 3 is currently violated.** `runRebuildDrain` re-reads `requestedSequence` after each
+`preparePiRuntimeGeneration()` and discards the completed build when it changed, so progress requires a
+quiet window of the debounce plus a full runtime build, and nothing bounds how many times it may discard.
+Worse, the activation sits after that guard, so under starvation no generation is adopted at all and the
+host serves the boot-time runtime indefinitely. Latent, not fixed: invariant 1 removed the only known event
+source fast enough to trigger it, and a second such source reproduces it unchanged.
 
-**Post-mortem (the beta livelock).** Both halves of the composition were individually correct.
-[[module-shared]] said the caller debounces events and rechecks existence; [[submodule-server-auth]] said
-watcher drift schedules a rebuild and status is `configuring` until the newest candidate applies. Composed
-against an endless event stream — `pi` rewriting `auth.json.lock` and `models-store.json` at ~23 events/s
-while idle — the drain never settled, `getJbcentralStatus()` pinned `configuring`, and users with no
-Central installed were told ThinkRail "is applying the latest Central configuration" while the host
-rebuilt the `pi` runtime in a hot loop at ~30-45% CPU. No spec was wrong; no spec owned the composition.
-That is the gap this node closes.
+**Post-mortem.** Both halves of the composition were individually correct. [[module-shared]] said the
+caller debounces events and rechecks existence; [[submodule-server-auth]] said watcher drift schedules a
+rebuild and status is `configuring` until the newest candidate applies. Composed against an endless event
+stream — `pi` rewriting `auth.json.lock` and `models-store.json` at ~23 events/s while idle — the drain
+never settled, `getJbcentralStatus()` pinned `configuring`, and users with no Central installed were told
+ThinkRail "is applying the latest Central configuration" while the host rebuilt the `pi` runtime in a hot
+loop at ~30-45% CPU. No spec was wrong; no spec owned the composition.
 
-## §3 Trust boundary
+## Out of scope
 
-Central is **opaque**: a third-party binary and a generated extension, neither of which ThinkRail reads.
-The obligations are enforced in three modules and only summarised here — each module's spec is
-authoritative for its own half.
-
-- **Process surface** ([[module-shared]]) — only reviewed argv is invoked; no child output is logged or
-  returned; only exit success plus a safe postcondition maps to a closed outcome. `central status`
-  presentation rows are the sole exception, and even there only positively observed negatives escape.
-- **Runtime surface** ([[submodule-server-agent]]) — the artifact path is the only artifact fact the module
-  receives; the pre-opaque provider-id allowlist is captured *before* the extension loads.
-- **Wire surface** ([[submodule-server-auth]], [[module-contracts]]) — Central-owned provider objects,
-  credentials, and details never become ordinary provider rows or cross the wire; Central is represented
-  only by the dedicated closed lifecycle, never inferred from model URLs.
-
-The composed guarantee: **no Central-derived text ever reaches a client.** Every state in §1 is a closed
-enum the host chose, never a passthrough of what Central printed.
-
-## §4 Artifact contract
-
-One path, `~/.pi/agent/extensions/jetbrains-central.ts`, named identically by the adapter that watches it
-and by the `pi` runtime that loads it. This is the whole coupling between ThinkRail and Central's output —
-`central add pi` creates it, `central remove pi` deletes it, and existence *is* the configured verdict.
-
-ThinkRail never opens, parses, hashes, or copies it. The corollary that makes §2.1 subtle: because
-existence is the only fact read, an **in-place replacement** is invisible to an existence check, so the
-watcher — not the poll — is the only thing that can observe it.
+The adapter's argv set, version policy, status-row parsing, login grace and process timeouts; the card's
+interaction and copy; candidate preparation and generation activation; wire field shapes; boot ordering;
+e2e fixtures. Each stays in its own module spec — listed here only so a reader knows this file is not where
+to change them.
 
 ## Consumed by
 

--- a/central-integration.md
+++ b/central-integration.md
@@ -1,0 +1,115 @@
+---
+id: central-integration
+type: architecture-design
+status: active
+title: JetBrains AI via the Central CLI — cross-module lifecycle
+parent: architecture
+depends-on: [module-shared, submodule-server-auth, submodule-server-agent, module-contracts, submodule-web-panels]
+covers: [central-lifecycle, central-liveness, central-trust-boundary, central-artifact]
+tags: [v1, providers, central]
+---
+
+## Why this node exists
+
+Every other Central concern is already owned by the module that implements it: the process/filesystem
+adapter in [[module-shared]], the status/action orchestration in [[submodule-server-auth]], runtime
+generations in [[submodule-server-agent]], the wire shapes in [[module-contracts]], the card in
+[[submodule-web-panels]]. Those specs are correct and stay authoritative for their own surfaces; this
+node **does not restate them**.
+
+What no module can own is the **composition**. Central is the only integration where ThinkRail shells out
+to a third-party binary that writes into `pi`'s own state directory and injects an opaque extension into a
+live runtime, so its behaviour is a chain across five modules. Two properties live only in that chain:
+the state mapping end to end (§1) and its **liveness** (§2). Both were unowned, and a beta shipped a
+permanent-`configuring` livelock as a direct result — see §2.
+
+## §1 The chain
+
+The single end-to-end mapping. Each column is owned by the module named in its header; this table is the
+only place the *correspondence* is stated.
+
+| Disk / CLI truth | `inspectJbcentral` (`shared`) | wire `JbcentralStatus` (`contracts`) | Card (`panels`) |
+| --- | --- | --- | --- |
+| no `central` resolvable | `absent` | `absent` | host-OS install command + Recheck |
+| version below `MINIMUM_CENTRAL_VERSION` | `outdated` | `outdated` | guided Update |
+| `--version` unparseable | `malformed-version` | `malformed-version` | reinstall guidance, no native action |
+| probe launch/timeout/exit failure | `probe-failed` | `probe-failed` | recheck guidance |
+| binary present, artifact absent | `supported` | `supported` | Connect |
+| binary + artifact present | `supported` + `configured` | `configured` | Connected / Disconnect |
+| …with `Auth` row `not connected` | — (observation) | `signedOut` flag | Sign in *replaces* the primary action |
+| …with `Proxy` row stopped | — (observation) | `proxyStopped` flag | Start proxy *replaces* Disconnect |
+| rebuild outstanding or action in flight | — | `configuring` | spinner, no action offered |
+| candidate runtime failed to load | — | `load-failed` | Retry / Disconnect |
+
+Two facts the table encodes that no single module states:
+
+- **`configuring` and `load-failed` have no inspection counterpart.** They are properties of the host's
+  rebuild machinery, not of the host filesystem, so a reader following only `shared` cannot derive them.
+- **The signed-out and proxy-stopped flags are one-directional.** Only a positively observed negative sets
+  them; unknown never does. The card turns each into a *replacement* of the primary action rather than an
+  annotation, because it must never advertise an action that cannot succeed.
+
+## §2 Liveness
+
+The chain is a state machine that must always make progress. Three invariants, in dependency order:
+
+1. **Invalidation is edge-triggered on the artifact, never level-triggered on a directory.**
+   `fs.watch` is per-directory and the watcher re-arms from the nearest existing parent, so the watched
+   directory is routinely an *ancestor* — with Central never installed it is `~/.pi/agent`, `pi`'s entire
+   state directory. Forwarding raw directory events therefore converts unrelated `pi` churn into rebuild
+   demand. Owned by [[module-shared]].
+2. **Every path into `configuring` has a bounded exit.** Two paths reach it today: an in-flight action
+   (bounded by the adapter's `ACTION_TIMEOUT_MS` / `UPDATE_TIMEOUT_MS`) and an outstanding rebuild
+   (`settledSequence < requestedSequence`). A path with no bound is a stuck card, not a slow one, because
+   the state carries no deadline of its own.
+3. **The rebuild drain settles a requested sequence in bounded time, independent of inbound event rate.**
+   Debouncing in the caller cannot supply this: a debounce bounds *burst* width, not stream length, so an
+   unbounded event source starves any drain that restarts on every new sequence.
+
+**Known violation of #3.** `runRebuildDrain` re-reads `requestedSequence` after each
+`preparePiRuntimeGeneration()` and restarts when it changed, so any event source faster than one rebuild
+starves it indefinitely. This is currently latent rather than live: #1 removed the only known source fast
+enough to trigger it. It is recorded here as a violated invariant, not a resolved one — a second such
+source reproduces the livelock without any change to #1.
+
+**Post-mortem (the beta livelock).** Both halves of the composition were individually correct.
+[[module-shared]] said the caller debounces events and rechecks existence; [[submodule-server-auth]] said
+watcher drift schedules a rebuild and status is `configuring` until the newest candidate applies. Composed
+against an endless event stream — `pi` rewriting `auth.json.lock` and `models-store.json` at ~23 events/s
+while idle — the drain never settled, `getJbcentralStatus()` pinned `configuring`, and users with no
+Central installed were told ThinkRail "is applying the latest Central configuration" while the host
+rebuilt the `pi` runtime in a hot loop at ~30-45% CPU. No spec was wrong; no spec owned the composition.
+That is the gap this node closes.
+
+## §3 Trust boundary
+
+Central is **opaque**: a third-party binary and a generated extension, neither of which ThinkRail reads.
+The obligations are enforced in three modules and only summarised here — each module's spec is
+authoritative for its own half.
+
+- **Process surface** ([[module-shared]]) — only reviewed argv is invoked; no child output is logged or
+  returned; only exit success plus a safe postcondition maps to a closed outcome. `central status`
+  presentation rows are the sole exception, and even there only positively observed negatives escape.
+- **Runtime surface** ([[submodule-server-agent]]) — the artifact path is the only artifact fact the module
+  receives; the pre-opaque provider-id allowlist is captured *before* the extension loads.
+- **Wire surface** ([[submodule-server-auth]], [[module-contracts]]) — Central-owned provider objects,
+  credentials, and details never become ordinary provider rows or cross the wire; Central is represented
+  only by the dedicated closed lifecycle, never inferred from model URLs.
+
+The composed guarantee: **no Central-derived text ever reaches a client.** Every state in §1 is a closed
+enum the host chose, never a passthrough of what Central printed.
+
+## §4 Artifact contract
+
+One path, `~/.pi/agent/extensions/jetbrains-central.ts`, named identically by the adapter that watches it
+and by the `pi` runtime that loads it. This is the whole coupling between ThinkRail and Central's output —
+`central add pi` creates it, `central remove pi` deletes it, and existence *is* the configured verdict.
+
+ThinkRail never opens, parses, hashes, or copies it. The corollary that makes §2.1 subtle: because
+existence is the only fact read, an **in-place replacement** is invisible to an existence check, so the
+watcher — not the poll — is the only thing that can observe it.
+
+## Consumed by
+
+[[module-shared]] · [[submodule-server-auth]] · [[submodule-server-agent]] · [[module-contracts]] ·
+[[submodule-web-panels]] · [[module-cli]] (boot ordering) · [[module-browser-e2e]] (`00-jbcentral*`)

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -5,6 +5,7 @@ status: active
 title: Wire contracts (types-only)
 parent: architecture
 depends-on: []
+references: [central-integration]
 tags: [v1, wire]
 ---
 

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -5,7 +5,7 @@ status: active
 title: agent — in-process pi sessions
 parent: module-server
 depends-on: [module-contracts]
-references: [module-spec-graph]
+references: [module-spec-graph, central-integration]
 tags: [v1, pi]
 ---
 

--- a/packages/server/src/auth/SPEC.md
+++ b/packages/server/src/auth/SPEC.md
@@ -5,7 +5,7 @@ status: active
 title: auth — provider status + in-app login
 parent: module-server
 depends-on: [module-contracts, module-shared]
-references: [submodule-server-agent]
+references: [submodule-server-agent, central-integration]
 tags: [v1, auth, pi]
 ---
 
@@ -28,7 +28,11 @@ ourselves and never surface a credential value over the wire.
     Central is not inferred from model URLs: status combines `shared/jbcentral`'s executable/version/artifact
     postconditions and closed auth/proxy observations with the synchronizer's latest desired/applied generation.
     Watcher drift schedules a rebuild; status is `configuring` until the newest candidate applies and
-    `load-failed` when it cannot apply.
+    `load-failed` when it cannot apply. **`configuring` carries no deadline of its own, so every path into it
+    owes a bounded exit** — an in-flight action is bounded by the adapter's timeouts, an outstanding rebuild
+    by the drain settling. The drain's obligation to settle *independent of inbound event rate*, and its
+    current unmet state, are [[central-integration]] §2; this module must not assume termination it does not
+    enforce.
 
     **The auth/proxy observation is cached, refreshed off the read path, and never polled.** A settled
     `supported` reading serves the cached result immediately and, past `JBCENTRAL_STATUS_TTL_MS`, starts one

--- a/packages/server/src/auth/SPEC.md
+++ b/packages/server/src/auth/SPEC.md
@@ -28,11 +28,8 @@ ourselves and never surface a credential value over the wire.
     Central is not inferred from model URLs: status combines `shared/jbcentral`'s executable/version/artifact
     postconditions and closed auth/proxy observations with the synchronizer's latest desired/applied generation.
     Watcher drift schedules a rebuild; status is `configuring` until the newest candidate applies and
-    `load-failed` when it cannot apply. **`configuring` carries no deadline of its own, so every path into it
-    owes a bounded exit** — an in-flight action is bounded by the adapter's timeouts, an outstanding rebuild
-    by the drain settling. The drain's obligation to settle *independent of inbound event rate*, and its
-    current unmet state, are [[central-integration]] (Invariants); this module must not assume termination it does not
-    enforce.
+    `load-failed` when it cannot apply. The cross-module bounded-exit obligation and the drain's known
+    starvation risk are owned by [[central-integration]] (Invariants).
 
     **The auth/proxy observation is cached, refreshed off the read path, and never polled.** A settled
     `supported` reading serves the cached result immediately and, past `JBCENTRAL_STATUS_TTL_MS`, starts one

--- a/packages/server/src/auth/SPEC.md
+++ b/packages/server/src/auth/SPEC.md
@@ -31,7 +31,7 @@ ourselves and never surface a credential value over the wire.
     `load-failed` when it cannot apply. **`configuring` carries no deadline of its own, so every path into it
     owes a bounded exit** — an in-flight action is bounded by the adapter's timeouts, an outstanding rebuild
     by the drain settling. The drain's obligation to settle *independent of inbound event rate*, and its
-    current unmet state, are [[central-integration]] §2; this module must not assume termination it does not
+    current unmet state, are [[central-integration]] (Invariants); this module must not assume termination it does not
     enforce.
 
     **The auth/proxy observation is cached, refreshed off the read path, and never polled.** A settled

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -142,7 +142,7 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   continuously (~23 events/s while idle), so forwarding raw directory events converts ordinary `pi` churn
   into unbounded rebuild demand — and a debounce in the caller cannot absorb it, because a debounce bounds
   burst width, not stream length. Composed with the caller's rebuild machinery that shipped a beta livelock;
-  the cross-module chain and its liveness obligations are [[central-integration]] §2. Pinned by
+  the cross-module chain and its liveness obligations are [[central-integration]] (Invariants). Pinned by
   `packages/shared/src/jbcentral.test.ts`.
 
   The adapter deliberately has no migration path for the previous unpublished integration: it never reads or

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -122,8 +122,8 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   debounces events and rechecks existence through the ordinary inspection API.
 
   **A directory event is not an artifact event.** `fs.watch` is per-directory, and the re-arm above means the
-  watched directory is routinely an *ancestor* — when Central was never installed, `~/.pi/agent/extensions`
-  does not exist and the watcher lands on `~/.pi/agent`, pi's entire state directory. So invalidation is
+  watched directory is routinely an *ancestor* — when the artifact directory has not been created, the
+  watcher may land on `~/.pi/agent`, pi's entire state directory. So invalidation is
   gated on the artifact itself: an event is forwarded only when it names the artifact entry inside the
   artifact's own directory, and named events from anywhere else (ancestor churn, a sibling extension) at most
   re-arm and re-check existence. Naming the entry — rather than stat-fingerprinting the file — is what keeps
@@ -145,12 +145,8 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   that livelock on any platform that omits filenames, while dropping it on the artifact directory would
   silently strand a stale Central runtime until restart.
 
-  This is load-bearing, not defensive: `pi` itself rewrites `auth.json.lock` and `models-store.json`
-  continuously (~23 events/s while idle), so forwarding raw directory events converts ordinary `pi` churn
-  into unbounded rebuild demand — and a debounce in the caller cannot absorb it, because a debounce bounds
-  burst width, not stream length. Composed with the caller's rebuild machinery that shipped a beta livelock;
-  the cross-module chain and its liveness obligations are [[central-integration]] (Invariants). Pinned by
-  `packages/shared/src/jbcentral.test.ts`.
+  The cross-module liveness obligation and post-mortem live in [[central-integration]]; watcher mechanics are
+  pinned by `packages/shared/src/jbcentral.test.ts`.
 
   The adapter deliberately has no migration path for the previous unpublished integration: it never reads or
   edits `models.json`, `auth.json`, backups, or any unrelated PI state.

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -124,9 +124,18 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   watched directory is routinely an *ancestor* — when Central was never installed, `~/.pi/agent/extensions`
   does not exist and the watcher lands on `~/.pi/agent`, pi's entire state directory. So invalidation is
   gated on the artifact itself: an event is forwarded only when it names the artifact entry inside the
-  artifact's own directory, and any other event (ancestor churn, a sibling extension, an unnamed/error event)
-  at most re-arms and re-checks existence. Naming the entry — rather than stat-fingerprinting the file — is
-  what keeps "replacement" observable without ever reading the generated artifact.
+  artifact's own directory, and named events from anywhere else (ancestor churn, a sibling extension) at most
+  re-arm and re-check existence. Naming the entry — rather than stat-fingerprinting the file — is what keeps
+  "replacement" observable without ever reading the generated artifact.
+
+  **An unnamed event is scoped, not uniformly trusted or dropped.** `fs.watch` may omit the filename, and a
+  watcher error surfaces the same way, so `null` carries no information about *what* changed — only about
+  where we were watching. On the artifact's own directory it is treated as a possible replacement: the handle
+  is closed (it may be the dead watcher behind an error) and the caller is invalidated, because existence is
+  unchanged for an in-place rewrite and the existence poll therefore cannot recover it. From an ancestor it
+  falls back to existence only. That asymmetry is deliberate: trusting `null` from an ancestor would restore
+  the livelock below on any platform that omits filenames, while dropping it on the artifact directory would
+  silently strand a stale Central runtime until restart.
 
   This is load-bearing, not defensive: forwarding raw directory events shipped a beta livelock. pi rewrites
   `auth.json.lock` and `models-store.json` continuously (~23 events/s while idle), each one requested a

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -5,6 +5,7 @@ status: active
 title: Shared server-side utilities
 parent: architecture
 depends-on: []
+references: [central-integration]
 tags: [v1, host]
 ---
 
@@ -134,15 +135,14 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   is closed (it may be the dead watcher behind an error) and the caller is invalidated, because existence is
   unchanged for an in-place rewrite and the existence poll therefore cannot recover it. From an ancestor it
   falls back to existence only. That asymmetry is deliberate: trusting `null` from an ancestor would restore
-  the livelock below on any platform that omits filenames, while dropping it on the artifact directory would
+  that livelock on any platform that omits filenames, while dropping it on the artifact directory would
   silently strand a stale Central runtime until restart.
 
-  This is load-bearing, not defensive: forwarding raw directory events shipped a beta livelock. pi rewrites
-  `auth.json.lock` and `models-store.json` continuously (~23 events/s while idle), each one requested a
-  runtime rebuild, so `settledSequence` never caught `requestedSequence`; `getJbcentralStatus()` pinned
-  `configuring` forever and the card told users with no Central installed that ThinkRail "is applying the
-  latest Central configuration" while the drain rebuilt the pi runtime in a hot loop at ~30% CPU. Debouncing
-  in the caller cannot fix this — the event stream never ends. Pinned by
+  This is load-bearing, not defensive: `pi` itself rewrites `auth.json.lock` and `models-store.json`
+  continuously (~23 events/s while idle), so forwarding raw directory events converts ordinary `pi` churn
+  into unbounded rebuild demand — and a debounce in the caller cannot absorb it, because a debounce bounds
+  burst width, not stream length. Composed with the caller's rebuild machinery that shipped a beta livelock;
+  the cross-module chain and its liveness obligations are [[central-integration]] §2. Pinned by
   `packages/shared/src/jbcentral.test.ts`.
 
   The adapter deliberately has no migration path for the previous unpublished integration: it never reads or

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -129,6 +129,13 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   re-arm and re-check existence. Naming the entry — rather than stat-fingerprinting the file — is what keeps
   "replacement" observable without ever reading the generated artifact.
 
+  **An event is classified against the watcher that emitted it, never the current one.** The watched
+  directory is mutable state that re-arming changes, so a callback already queued by a watcher that has
+  since been closed would otherwise be judged against its successor's directory — reading an ancestor's
+  churn as an artifact replacement, or an artifact event as ancestor churn. Each `arm()` therefore binds its
+  own directory and a monotonic generation into the callback it installs, and closing a handle retires that
+  generation, so a superseded callback is dropped rather than reclassified.
+
   **An unnamed event is scoped, not uniformly trusted or dropped.** `fs.watch` may omit the filename, and a
   watcher error surfaces the same way, so `null` carries no information about *what* changed — only about
   where we were watching. On the artifact's own directory it is treated as a possible replacement: the handle

--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -120,6 +120,22 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   repairs dropped add/remove filesystem events. It never opens or fingerprints the generated file. The caller
   debounces events and rechecks existence through the ordinary inspection API.
 
+  **A directory event is not an artifact event.** `fs.watch` is per-directory, and the re-arm above means the
+  watched directory is routinely an *ancestor* — when Central was never installed, `~/.pi/agent/extensions`
+  does not exist and the watcher lands on `~/.pi/agent`, pi's entire state directory. So invalidation is
+  gated on the artifact itself: an event is forwarded only when it names the artifact entry inside the
+  artifact's own directory, and any other event (ancestor churn, a sibling extension, an unnamed/error event)
+  at most re-arms and re-checks existence. Naming the entry — rather than stat-fingerprinting the file — is
+  what keeps "replacement" observable without ever reading the generated artifact.
+
+  This is load-bearing, not defensive: forwarding raw directory events shipped a beta livelock. pi rewrites
+  `auth.json.lock` and `models-store.json` continuously (~23 events/s while idle), each one requested a
+  runtime rebuild, so `settledSequence` never caught `requestedSequence`; `getJbcentralStatus()` pinned
+  `configuring` forever and the card told users with no Central installed that ThinkRail "is applying the
+  latest Central configuration" while the drain rebuilt the pi runtime in a hot loop at ~30% CPU. Debouncing
+  in the caller cannot fix this — the event stream never ends. Pinned by
+  `packages/shared/src/jbcentral.test.ts`.
+
   The adapter deliberately has no migration path for the previous unpublished integration: it never reads or
   edits `models.json`, `auth.json`, backups, or any unrelated PI state.
 

--- a/packages/shared/src/jbcentral.test.ts
+++ b/packages/shared/src/jbcentral.test.ts
@@ -521,6 +521,37 @@ describe("Central artifact watcher", () => {
 		stop();
 	});
 
+	test("drops a callback from a superseded watcher instead of reclassifying it", async () => {
+		const existing = new Set(["/users/test", "/users/test/.pi", "/users/test/.pi/agent"]);
+		const callbacks = new Map<string, (entry: string | null) => void>();
+		let invalidations = 0;
+		const stop = watchJbcentralArtifact(
+			() => {
+				invalidations += 1;
+			},
+			adapterDeps({
+				exists: (path) => existing.has(path),
+				watchDirectory: (path, callback) => {
+					callbacks.set(path, callback);
+					return { close: () => {} };
+				},
+			}),
+		);
+		const ancestor = callbacks.get("/users/test/.pi/agent");
+		expect(ancestor).toBeDefined();
+
+		existing.add("/users/test/.pi/agent/extensions");
+		ancestor?.("extensions");
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		expect(callbacks.has("/users/test/.pi/agent/extensions")).toBe(true);
+
+		const before = invalidations;
+		ancestor?.(null);
+		ancestor?.("auth.json.lock");
+		expect(invalidations).toBe(before);
+		stop();
+	});
+
 	test("treats an unnamed event on the artifact directory as a possible replacement", async () => {
 		const extensionPath = "/users/test/.pi/agent/extensions/jetbrains-central.ts";
 		const existing = new Set([

--- a/packages/shared/src/jbcentral.test.ts
+++ b/packages/shared/src/jbcentral.test.ts
@@ -410,8 +410,9 @@ ${script}
 
 describe("Central artifact watcher", () => {
 	test("re-arms from the nearest existing parent without reading the artifact", async () => {
+		const extensionPath = "/users/test/.pi/agent/extensions/jetbrains-central.ts";
 		const existing = new Set(["/users/test"]);
-		const callbacks = new Map<string, () => void>();
+		const callbacks = new Map<string, (entry: string | null) => void>();
 		const watched: string[] = [];
 		const closed: string[] = [];
 		let invalidations = 0;
@@ -431,20 +432,92 @@ describe("Central artifact watcher", () => {
 		expect(watched).toEqual(["/users/test"]);
 
 		existing.add("/users/test/.pi");
-		callbacks.get("/users/test")?.();
+		callbacks.get("/users/test")?.(".pi");
 		await new Promise((resolve) => setTimeout(resolve, 5));
 		expect(watched.at(-1)).toBe("/users/test/.pi");
 
 		existing.add("/users/test/.pi/agent/extensions");
-		callbacks.get("/users/test/.pi")?.();
+		callbacks.get("/users/test/.pi")?.("agent");
 		await new Promise((resolve) => setTimeout(resolve, 5));
 		expect(watched.at(-1)).toBe("/users/test/.pi/agent/extensions");
-		expect(invalidations).toBe(2);
 		expect(closed).toEqual(["/users/test", "/users/test/.pi"]);
+		expect(invalidations).toBe(0);
+
+		existing.add(extensionPath);
+		callbacks.get("/users/test/.pi/agent/extensions")?.("jetbrains-central.ts");
+		expect(invalidations).toBe(1);
 
 		stop();
-		callbacks.get("/users/test/.pi/agent/extensions")?.();
+		callbacks.get("/users/test/.pi/agent/extensions")?.("jetbrains-central.ts");
+		expect(invalidations).toBe(1);
+	});
+
+	test("ignores unrelated churn in a watched ancestor of the artifact directory", async () => {
+		const existing = new Set(["/users/test", "/users/test/.pi", "/users/test/.pi/agent"]);
+		const callbacks = new Map<string, (entry: string | null) => void>();
+		let invalidations = 0;
+		const stop = watchJbcentralArtifact(
+			() => {
+				invalidations += 1;
+			},
+			adapterDeps({
+				exists: (path) => existing.has(path),
+				watchDirectory: (path, callback) => {
+					callbacks.set(path, callback);
+					return { close: () => {} };
+				},
+			}),
+		);
+		expect(callbacks.has("/users/test/.pi/agent")).toBe(true);
+
+		for (let index = 0; index < 50; index += 1) {
+			callbacks.get("/users/test/.pi/agent")?.("auth.json.lock");
+			callbacks.get("/users/test/.pi/agent")?.("models-store.json");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(invalidations).toBe(0);
+		stop();
+	});
+
+	test("ignores siblings of the artifact inside the extension directory", async () => {
+		const extensionPath = "/users/test/.pi/agent/extensions/jetbrains-central.ts";
+		const existing = new Set([
+			"/users/test",
+			"/users/test/.pi",
+			"/users/test/.pi/agent",
+			"/users/test/.pi/agent/extensions",
+		]);
+		const callbacks = new Map<string, (entry: string | null) => void>();
+		let invalidations = 0;
+		const stop = watchJbcentralArtifact(
+			() => {
+				invalidations += 1;
+			},
+			adapterDeps({
+				exists: (path) => existing.has(path),
+				watchDirectory: (path, callback) => {
+					callbacks.set(path, callback);
+					return { close: () => {} };
+				},
+			}),
+		);
+		const fire = (entry: string | null): void =>
+			callbacks.get("/users/test/.pi/agent/extensions")?.(entry);
+
+		fire("some-other-extension.ts");
+		expect(invalidations).toBe(0);
+
+		existing.add(extensionPath);
+		fire("jetbrains-central.ts");
+		expect(invalidations).toBe(1);
+
+		fire("jetbrains-central.ts");
 		expect(invalidations).toBe(2);
+
+		existing.delete(extensionPath);
+		fire(null);
+		expect(invalidations).toBe(3);
+		stop();
 	});
 
 	test("repairs a dropped add/remove event by polling artifact existence only", async () => {

--- a/packages/shared/src/jbcentral.test.ts
+++ b/packages/shared/src/jbcentral.test.ts
@@ -473,6 +473,7 @@ describe("Central artifact watcher", () => {
 		for (let index = 0; index < 50; index += 1) {
 			callbacks.get("/users/test/.pi/agent")?.("auth.json.lock");
 			callbacks.get("/users/test/.pi/agent")?.("models-store.json");
+			callbacks.get("/users/test/.pi/agent")?.(null);
 		}
 		await new Promise((resolve) => setTimeout(resolve, 20));
 		expect(invalidations).toBe(0);
@@ -517,6 +518,41 @@ describe("Central artifact watcher", () => {
 		existing.delete(extensionPath);
 		fire(null);
 		expect(invalidations).toBe(3);
+		stop();
+	});
+
+	test("treats an unnamed event on the artifact directory as a possible replacement", async () => {
+		const extensionPath = "/users/test/.pi/agent/extensions/jetbrains-central.ts";
+		const existing = new Set([
+			"/users/test",
+			"/users/test/.pi",
+			"/users/test/.pi/agent",
+			"/users/test/.pi/agent/extensions",
+			extensionPath,
+		]);
+		const callbacks = new Map<string, (entry: string | null) => void>();
+		const closed: string[] = [];
+		let invalidations = 0;
+		const stop = watchJbcentralArtifact(
+			() => {
+				invalidations += 1;
+			},
+			adapterDeps({
+				exists: (path) => existing.has(path),
+				watchDirectory: (path, callback) => {
+					callbacks.set(path, callback);
+					return { close: () => closed.push(path) };
+				},
+			}),
+		);
+
+		callbacks.get("/users/test/.pi/agent/extensions")?.(null);
+		expect(invalidations).toBe(1);
+		expect(closed).toEqual(["/users/test/.pi/agent/extensions"]);
+
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		callbacks.get("/users/test/.pi/agent/extensions")?.("jetbrains-central.ts");
+		expect(invalidations).toBe(2);
 		stop();
 	});
 

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -482,6 +482,7 @@ export function watchJbcentralArtifact(
 	let rearmTimer: ReturnType<typeof setTimeout> | null = null;
 	let pollTimer: ReturnType<typeof setTimeout> | null = null;
 	let artifactExists = pathExists(extensionPath, deps);
+	let watchGeneration = 0;
 
 	const closeHandle = (): void => {
 		try {
@@ -489,6 +490,7 @@ export function watchJbcentralArtifact(
 		} catch {}
 		handle = null;
 		watchedDirectory = null;
+		watchGeneration += 1;
 	};
 
 	const scheduleRearm = (delay = 0): void => {
@@ -515,9 +517,9 @@ export function watchJbcentralArtifact(
 		return true;
 	};
 
-	const handleEntry = (entry: string | null): void => {
-		if (stopped) return;
-		if (watchedDirectory === artifactDirectory) {
+	const handleEntry = (entry: string | null, directory: string, generation: number): void => {
+		if (stopped || generation !== watchGeneration) return;
+		if (directory === artifactDirectory) {
 			if (entry === null) closeHandle();
 			if (entry === null || entry === artifactName) invalidate();
 			return;
@@ -531,8 +533,9 @@ export function watchJbcentralArtifact(
 		const directory = nearestExistingDirectory(extensionPath, deps);
 		if (handle && watchedDirectory === directory) return;
 		closeHandle();
+		const generation = watchGeneration;
 		try {
-			handle = watchDirectory(directory, handleEntry);
+			handle = watchDirectory(directory, (entry) => handleEntry(entry, directory, generation));
 			watchedDirectory = directory;
 		} catch {
 			scheduleRearm(WATCH_RETRY_MS);

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -517,8 +517,9 @@ export function watchJbcentralArtifact(
 
 	const handleEntry = (entry: string | null): void => {
 		if (stopped) return;
-		if (entry !== null && watchedDirectory === artifactDirectory) {
-			if (entry === artifactName) invalidate();
+		if (watchedDirectory === artifactDirectory) {
+			if (entry === null) closeHandle();
+			if (entry === null || entry === artifactName) invalidate();
 			return;
 		}
 		if (syncExistence()) invalidate();

--- a/packages/shared/src/jbcentral.ts
+++ b/packages/shared/src/jbcentral.ts
@@ -1,6 +1,6 @@
 import { existsSync, watch } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import type { JbcentralInstall } from "@thinkrail/contracts";
 
 export type ParseEnv = Record<string, string | undefined>;
@@ -92,7 +92,7 @@ export interface JbcentralAdapterDependencies {
 	exists?: (path: string) => boolean;
 	run?: (request: ProcessRequest) => Promise<ProcessResult>;
 	launchDetached?: (argv: readonly string[]) => LoginHandle | null;
-	watchDirectory?: (path: string, onInvalidate: () => void) => WatchHandle;
+	watchDirectory?: (path: string, onEntry: (entry: string | null) => void) => WatchHandle;
 }
 
 interface SemanticVersion {
@@ -460,9 +460,11 @@ function nearestExistingDirectory(path: string, deps: JbcentralAdapterDependenci
 	return candidate;
 }
 
-function nodeWatchDirectory(path: string, onInvalidate: () => void): WatchHandle {
-	const watcher = watch(path, { persistent: false }, onInvalidate);
-	watcher.on("error", onInvalidate);
+function nodeWatchDirectory(path: string, onEntry: (entry: string | null) => void): WatchHandle {
+	const watcher = watch(path, { persistent: false }, (_event, filename) =>
+		onEntry(typeof filename === "string" ? filename : null),
+	);
+	watcher.on("error", () => onEntry(null));
 	return watcher;
 }
 
@@ -471,6 +473,8 @@ export function watchJbcentralArtifact(
 	deps: JbcentralAdapterDependencies = {},
 ): () => void {
 	const extensionPath = jbcentralExtensionPath(deps);
+	const artifactDirectory = dirname(extensionPath);
+	const artifactName = basename(extensionPath);
 	const watchDirectory = deps.watchDirectory ?? nodeWatchDirectory;
 	let stopped = false;
 	let watchedDirectory: string | null = null;
@@ -504,13 +508,30 @@ export function watchJbcentralArtifact(
 		scheduleRearm();
 	};
 
+	const syncExistence = (): boolean => {
+		const next = pathExists(extensionPath, deps);
+		if (next === artifactExists) return false;
+		artifactExists = next;
+		return true;
+	};
+
+	const handleEntry = (entry: string | null): void => {
+		if (stopped) return;
+		if (entry !== null && watchedDirectory === artifactDirectory) {
+			if (entry === artifactName) invalidate();
+			return;
+		}
+		if (syncExistence()) invalidate();
+		else scheduleRearm();
+	};
+
 	const arm = (): void => {
 		if (stopped) return;
 		const directory = nearestExistingDirectory(extensionPath, deps);
 		if (handle && watchedDirectory === directory) return;
 		closeHandle();
 		try {
-			handle = watchDirectory(directory, invalidate);
+			handle = watchDirectory(directory, handleEntry);
 			watchedDirectory = directory;
 		} catch {
 			scheduleRearm(WATCH_RETRY_MS);
@@ -519,11 +540,7 @@ export function watchJbcentralArtifact(
 
 	const pollExistence = (): void => {
 		if (stopped) return;
-		const nextArtifactExists = pathExists(extensionPath, deps);
-		if (nextArtifactExists !== artifactExists) {
-			artifactExists = nextArtifactExists;
-			invalidate();
-		}
+		if (syncExistence()) invalidate();
 		pollTimer = setTimeout(pollExistence, WATCH_EXISTENCE_POLL_MS);
 		pollTimer.unref?.();
 	};


### PR DESCRIPTION
Fixes #286

## The bug

On a beta host with **Central absent and the artifact directory not yet created**, the JetBrains AI card rendered permanently:

> **ThinkRail is applying the latest Central configuration.**

That is the no-action `configuring` state. The card should instead settle on install guidance.

## Root cause

`watchJbcentralArtifact` forwarded **every** `fs.watch` event in the watched directory as an artifact change. `fs.watch` is per-directory, and the watcher re-arms from the nearest existing parent. When `~/.pi/agent/extensions` is missing, the reporter's watcher landed on **`~/.pi/agent`, pi's entire state directory**.

pi rewrote `auth.json.lock` and `models-store.json` constantly: **68 events in 3s on the idle host**. Each event requested a runtime rebuild, and `runRebuildDrain` discarded its build whenever a newer request arrived during it. The drain never settled, `configuring` never cleared, and the host rebuilt the pi runtime in a hot loop. The beta sat at **45% CPU for 71 minutes**.

Central absence alone is not sufficient: the failure needs the target directory to be missing so the watcher is armed on a noisy ancestor.

## The fix

Invalidate only on a possible edge of the reviewed artifact, not on directory activity. The changed entry name is threaded through the `watchDirectory` seam; ancestor churn and sibling extensions at most re-arm and re-check existence. Naming the entry rather than stat-fingerprinting keeps *replacement* observable without reading the generated file, as the spec requires.

| on the reporter-shaped `~/.pi/agent`, artifact directory absent | before | after |
|---|---|---|
| idle, 3s, zero writes | 68 invalidations | **0** |
| one `models-store.json` write | 26 | **0** |
| artifact add / replace / remove | fires | **fires** |

## Review rounds

Both `jetbrains-air` findings were real; each was reproduced as a failing test before fixing.

- **`a52aab1` — unnamed events.** `fs.watch` may omit the filename, and errors surface the same way, so `null` reached the existence-only path and silently dropped in-place replacements (existence unchanged `true` → `true`, and the poll cannot recover it). `null` is now scoped by *where* the watcher was armed: on the artifact directory it is a possible replacement and closes a possibly-dead handle; from an ancestor it stays existence-only.
- **`a6e74a3` — stale callbacks.** Classification read mutable `watchedDirectory`, so a callback queued by a closed watcher was judged against its successor. Each `arm()` now binds its own directory and monotonic generation; `closeHandle()` retires it, so superseded callbacks are dropped rather than reclassified.

## Spec

`central-integration.md` owns only the end-to-end state correspondence, liveness invariants, and post-mortem that no leaf module can own. Local watcher, runtime, wire, and card mechanics remain in their module specs. `architecture.md` links the cross-module owner, and `AGENTS.md` lists the root node without making it mandatory reading for unrelated work.

## Verification

Full pre-commit gate set, `packages/shared` 29/29, all 15 jbcentral e2e specs, and the full no-agent e2e suite (**254 tests, 4 shards, 0 failures**).

## Follow-up

`runRebuildDrain` still has no progress bound under a sustained stream of legitimate artifact invalidations. That separate algorithmic risk is tracked by #287 rather than widening this focused watcher fix.
