### PR TITLE
feat(server): add Pino-backed rotated host logging

### DIFF
--- a/apps/cli/SPEC.md
+++ b/apps/cli/SPEC.md
@@ -45,6 +45,10 @@ re-create) the staged asset cache. Otherwise the launch args: `--port` (stable d
 scans upward to the next free port on collision), `--host` (default `localhost`), `--no-open`,
 `--no-analytics` (**per-run mute** for anonymous usage analytics — this run sends nothing; the
 durable switch is the app's Settings → Privacy toggle, see `submodule-server-analytics`),
+`--verbose` (debug-level logging — threaded to `bootHost` as `verbose: true`; the log files under
+`<dataDir>/logs` and their env switch `THINKRAIL_LOG_LEVEL` belong to `submodule-server-log`, whose
+module is that variable's single reader — same pattern as `THINKRAIL_NO_ANALYTICS`, so `dev.ts` honors
+it too),
 `-v`/`--version` (print the baked version and exit), `-h`/`--help`, and one positional `project-dir` (a
 git repo to open as a project on boot, best-effort). Env defaults: `THINKRAIL_PORT` / `THINKRAIL_HOST` /
 `THINKRAIL_STATIC_DIR` (flag > env > default). `THINKRAIL_NO_ANALYTICS` is documented in `--help` but

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -24,6 +24,7 @@ describe("parseArgs", () => {
 			host: DEFAULT_HOST,
 			open: true,
 			noAnalytics: false,
+			verbose: false,
 			staticDir: undefined,
 			projectDir: undefined,
 			help: false,
@@ -35,6 +36,12 @@ describe("parseArgs", () => {
 		expect(parseArgs(["--no-analytics"], {}).noAnalytics).toBe(true);
 		expect(parseArgs([], { THINKRAIL_NO_ANALYTICS: "1" }).noAnalytics).toBe(false);
 		expect(parseArgs([], {}).noAnalytics).toBe(false);
+	});
+
+	test("--verbose turns on debug logging; the env spelling is the log module's job", () => {
+		expect(parseArgs(["--verbose"], {}).verbose).toBe(true);
+		expect(parseArgs([], { THINKRAIL_LOG_LEVEL: "debug" }).verbose).toBe(false);
+		expect(parseArgs([], {}).verbose).toBe(false);
 	});
 
 	test("flags win over env over defaults", () => {

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -6,6 +6,7 @@ export interface CliOptions {
 	host: string;
 	open: boolean;
 	noAnalytics: boolean;
+	verbose: boolean;
 	staticDir: string | undefined;
 	projectDir: string | undefined;
 	help: boolean;
@@ -37,6 +38,8 @@ Options:
   --no-open      Don't open the browser (e.g. headless / remote host).
   --no-analytics Don't send anonymous usage analytics this run (the durable switch
                  lives in the app: Settings → Privacy).
+  --verbose      Debug-level logging (terminal + the rotated log files under
+                 ~/.thinkrail/logs).
   -v, --version  Print the version and exit.
   -h, --help     Show this help.
 
@@ -46,7 +49,8 @@ Arguments:
 Env:
   THINKRAIL_PORT / THINKRAIL_HOST   Defaults for --port / --host.
   THINKRAIL_STATIC_DIR                 Override the built web app served by the host.
-  THINKRAIL_NO_ANALYTICS               Same as --no-analytics (any non-empty value; read by the host).`;
+  THINKRAIL_NO_ANALYTICS               Same as --no-analytics (any non-empty value; read by the host).
+  THINKRAIL_LOG_LEVEL                  Log level: debug|info|warn|error (default info; read by the host).`;
 
 function readFlagValue(arg: string, next: string | undefined): { value: string; consumed: number } {
 	const eq = arg.indexOf("=");
@@ -60,6 +64,7 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 	let host: string | undefined;
 	let open = true;
 	let noAnalytics = false;
+	let verbose = false;
 	let help = false;
 	let version = false;
 	let projectDir: string | undefined;
@@ -70,6 +75,8 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 			open = false;
 		} else if (arg === "--no-analytics") {
 			noAnalytics = true;
+		} else if (arg === "--verbose") {
+			verbose = true;
 		} else if (arg === "-h" || arg === "--help") {
 			help = true;
 		} else if (arg === "-v" || arg === "--version") {
@@ -104,6 +111,7 @@ export function parseArgs(argv: readonly string[], env: ParseEnv = {}): CliOptio
 		host: host ?? env.THINKRAIL_HOST ?? DEFAULT_HOST,
 		open,
 		noAnalytics,
+		verbose,
 		staticDir: env.THINKRAIL_STATIC_DIR,
 		projectDir,
 		help,

--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -59,6 +59,7 @@ async function bootstrap(build: BuildKind): Promise<void> {
 		portMode: "free",
 		staticDir,
 		appVersion: version,
+		...(options.verbose ? { verbose: true } : {}),
 		analytics: {
 			channel,
 			build,

--- a/bun.lock
+++ b/bun.lock
@@ -165,6 +165,9 @@
         "pi-todos": "workspace:*",
         "pi-visualize": "workspace:*",
         "pi-web-access": "0.13.0",
+        "pino": "10.3.1",
+        "pino-pretty": "13.1.3",
+        "pino-roll": "4.0.0",
         "posthog-node": "5.46.1",
         "trash": "10.1.1",
         "typebox": "catalog:",
@@ -599,6 +602,8 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
 
     "@posthog/core": ["@posthog/core@1.45.1", "", { "dependencies": { "@posthog/types": "^1.398.0" } }, "sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA=="],
@@ -969,6 +974,8 @@
 
     "astro": ["astro@7.2.4", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.2", "@astrojs/internal-helpers": "0.10.4", "@astrojs/markdown-satteri": "0.3.7", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "find-process": "^2.1.1", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.3.0", "jsonc-parser": "^3.3.1", "magic-string": "^1.0.0", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.5", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.4" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-+cuLsBns2wwUHI9a10xZMbjrF91m7+QNwqTVeljTx0B8Lf+8h0LgVGjdVIL2FALDKD2I565lczeeS3BFC+KdZg=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
@@ -1022,6 +1029,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
@@ -1125,6 +1134,10 @@
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
     "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -1191,9 +1204,13 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "fast-copy": ["fast-copy@4.0.4", "", {}, "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
@@ -1269,6 +1286,8 @@
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
     "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
@@ -1330,6 +1349,8 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
@@ -1501,6 +1522,8 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
@@ -1542,6 +1565,8 @@
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
     "ohash": ["ohash@2.0.12", "", {}, "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -1607,6 +1632,16 @@
 
     "pinkie-promise": ["pinkie-promise@2.0.1", "", { "dependencies": { "pinkie": "^2.0.0" } }, "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-roll": ["pino-roll@4.0.0", "", { "dependencies": { "date-fns": "^4.1.0", "sonic-boom": "^4.0.1" } }, "sha512-axI1aQaIxXdw1F4OFFli1EDxIrdYNGLowkw/ZoZogX8oCSLHUghzwVVXUS8U+xD/Savwa5IXpiXmsSGKFX/7Sg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
 
     "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
@@ -1627,6 +1662,8 @@
 
     "process-ancestry": ["process-ancestry@0.1.0", "", {}, "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg=="],
 
+    "process-warning": ["process-warning@5.1.0", "", {}, "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw=="],
+
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
@@ -1636,6 +1673,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
@@ -1656,6 +1695,8 @@
     "react-virtuoso": ["react-virtuoso@4.18.7", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -1695,6 +1736,8 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "satteri": ["satteri@0.10.5", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.5", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.10.5", "@bruits/satteri-darwin-x64": "0.10.5", "@bruits/satteri-linux-arm64-gnu": "0.10.5", "@bruits/satteri-linux-arm64-musl": "0.10.5", "@bruits/satteri-linux-x64-gnu": "0.10.5", "@bruits/satteri-linux-x64-musl": "0.10.5", "@bruits/satteri-wasm32-wasi": "0.10.5", "@bruits/satteri-win32-arm64-msvc": "0.10.5", "@bruits/satteri-win32-x64-msvc": "0.10.5" } }, "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ=="],
@@ -1702,6 +1745,8 @@
     "sax": ["sax@1.6.1", "", {}, "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
@@ -1721,9 +1766,13 @@
 
     "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
@@ -1734,6 +1783,8 @@
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
 
@@ -1752,6 +1803,8 @@
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
@@ -2100,6 +2153,8 @@
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "typescript-auto-import-cache/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -51,6 +51,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | --- | --- | --- |
 | `host` | `Bun.serve` HTTP+WS, static SPA, the WS dispatch registry, channel publish | [host/SPEC.md](src/host/SPEC.md) |
 | `persistence` | JSON app state under the data dir, including workspace-layout snapshots | [persistence/SPEC.md](src/persistence/SPEC.md) |
+| `log` | leveled diagnostics → stderr + daily-rotated files under `<dataDir>/logs` (10 MB cap/file, 14-day retention) + the console tee | [log/SPEC.md](src/log/SPEC.md) |
 | `settings` | server-synced app config, including layout preset/default/side-limit settings | [settings/SPEC.md](src/settings/SPEC.md) |
 | `layout` | validated, revisioned, persisted per-workspace workbench snapshots | [layout/SPEC.md](src/layout/SPEC.md) |
 | `projects` | stable known-repo registry: open/recent views + lossless close/reopen (validate, dedupe, slug) | [projects/SPEC.md](src/projects/SPEC.md) |
@@ -80,11 +81,15 @@ the host from env via `bootHost` for dev/e2e.
 
 `host` is the **only composition root** — it wires each feature's handlers into the WS registry.
 
-- `host` → `projects`, `workspaces`, `git`, `github`, `branch-review`, `fs`, `spec`, `todos`, `reviews`, `watch`, `terminal`, `dialog`, `editors`, `agent`, `auth`, `assist`, `settings`, `layout`, `history`, `templates`, `analytics`, `persistence` (`dataDir`, for the crash report)
+- `host` → `projects`, `workspaces`, `git`, `github`, `branch-review`, `fs`, `spec`, `todos`, `reviews`, `watch`, `terminal`, `dialog`, `editors`, `agent`, `auth`, `assist`, `settings`, `layout`, `history`, `templates`, `analytics`, `log`, `persistence` (`dataDir`, for the crash report)
 - `workspaces` → `projects`, `git`, `persistence`
 - `branch-review` → `git`
 - `projects` → `git` (shared runner), `persistence`
 - `git`, `fs`, `spec`, `watch`, `terminal`, `settings`, `layout`, `analytics` → `persistence` (`spec` also → `pi-spec-graph/core`, external; `analytics` also → the pi-ai built-in provider/model catalog + `posthog-node`, external — the identity-bucketing vocabulary and the delivery SDK)
+- `log` → `persistence` (`dataDir`) — and **any feature module (+ `host`) may → `log`**: it is the one
+  cross-cutting edge, like `persistence`, exempt from the never-each-other rule (today: `host`,
+  `agent`, `workspaces`, `watch`, `git`, `todos`, `reviews`, `analytics`). `persistence` never imports
+  `log` (would cycle); `initLogging` is called only from `host`'s `bootHost`
 - `todos` → `workspaces` (worktree path lookup) + `pi-todos/core` (external, value-imported, pi-free)
 - `reviews` → `workspaces` (worktree path lookup), `persistence` (data dir), `git` (the review's baseSha
   resolve, plus the diff range + blob read behind a base-side anchor). The `review.send*` flows are
@@ -95,7 +100,7 @@ the host from env via `bootHost` for dev/e2e.
   `host` installs (`agent.setReviewCommentHandler` → `reviews.resolveCommentFromAgent`)
 - `assist` → `agent` (the one-shot completion primitive)
 - `auth` → `agent` (the current runtime/auth facade plus candidate prepare/activate; one-way, `agent` never imports `auth`)
-- `agent` → (no internal deps — only the pi runtime; auth passes desired opaque Central paths through its public generation seam)
+- `agent` → `log` only (otherwise the pi runtime alone; auth passes desired opaque Central paths through its public generation seam)
 - `persistence`, `dialog`, `github`, `history`, `templates` → (leaves)
 
 Rules: features never import `host`, and never each other except the edges above. The graph is acyclic.

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -52,7 +52,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | --- | --- | --- |
 | `host` | `Bun.serve` HTTP+WS, static SPA, the WS dispatch registry, channel publish | [host/SPEC.md](src/host/SPEC.md) |
 | `persistence` | JSON app state under the data dir, including workspace-layout snapshots | [persistence/SPEC.md](src/persistence/SPEC.md) |
-| `log` | leveled diagnostics → pretty stderr + agent-oriented JSONL under `<dataDir>/logs` (pino-roll daily/10 MB rotation, 14 rotated + active) + the console tee | [log/SPEC.md](src/log/SPEC.md) |
+| `log` | explicit leveled diagnostics → pretty stderr + agent-oriented JSONL under `<dataDir>/logs` (pino-roll daily/10 MB rotation, 14 rotated + active); arbitrary console output stays terminal-only | [log/SPEC.md](src/log/SPEC.md) |
 | `settings` | server-synced app config, including layout preset/default/side-limit settings | [settings/SPEC.md](src/settings/SPEC.md) |
 | `layout` | validated, revisioned, persisted per-workspace workbench snapshots | [layout/SPEC.md](src/layout/SPEC.md) |
 | `projects` | stable known-repo registry: open/recent views + lossless close/reopen (validate, dedupe, slug) | [projects/SPEC.md](src/projects/SPEC.md) |

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -38,7 +38,8 @@ and runs the `pi` agent in-process via `createAgentSession`. Launched in-process
   deliberate second entry that avoids evaluating `host` (Bun-only: `Bun.serve`, `bun-pty`) under the
   node-run e2e worker. Not for `apps/*` use — the web/CLI boundary rules are unchanged.
 - **Allowed deps:** `contracts` (types + WS constants), `shared` (`shellEnv` + the Central adapter), `bun-pty`,
-  `@earendil-works/pi-coding-agent` + `@earendil-works/pi-ai` (runtime), Bun/Node.
+  `@earendil-works/pi-coding-agent` + `@earendil-works/pi-ai` (runtime), `pino` + its pretty/rolling
+  destinations (host diagnostics), Bun/Node.
 - **Forbidden:** importing `web`/`cli`/`desktop`; being bundled into the browser.
 
 ## Internal modules
@@ -51,7 +52,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | --- | --- | --- |
 | `host` | `Bun.serve` HTTP+WS, static SPA, the WS dispatch registry, channel publish | [host/SPEC.md](src/host/SPEC.md) |
 | `persistence` | JSON app state under the data dir, including workspace-layout snapshots | [persistence/SPEC.md](src/persistence/SPEC.md) |
-| `log` | leveled diagnostics → stderr + daily-rotated files under `<dataDir>/logs` (10 MB cap/file, 14-day retention) + the console tee | [log/SPEC.md](src/log/SPEC.md) |
+| `log` | leveled diagnostics → pretty stderr + agent-oriented JSONL under `<dataDir>/logs` (pino-roll daily/10 MB rotation, 14 rotated + active) + the console tee | [log/SPEC.md](src/log/SPEC.md) |
 | `settings` | server-synced app config, including layout preset/default/side-limit settings | [settings/SPEC.md](src/settings/SPEC.md) |
 | `layout` | validated, revisioned, persisted per-workspace workbench snapshots | [layout/SPEC.md](src/layout/SPEC.md) |
 | `projects` | stable known-repo registry: open/recent views + lossless close/reopen (validate, dedupe, slug) | [projects/SPEC.md](src/projects/SPEC.md) |

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,9 @@
 		"pi-todos": "workspace:*",
 		"pi-visualize": "workspace:*",
 		"pi-web-access": "0.13.0",
+		"pino": "10.3.1",
+		"pino-pretty": "13.1.3",
+		"pino-roll": "4.0.0",
 		"posthog-node": "5.46.1",
 		"trash": "10.1.1",
 		"typebox": "catalog:"

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -57,7 +57,7 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     **caller awaits**, because the signal bounds neither pi's unsignalled `forceRefreshAvailability()`
     fan-out after it nor a forced pass queued behind a throttled one — without it one slow provider leaves
     every picker's refresh row spinning. A timed-out caller serves the registry as it stands (reporting
-    `completed: false`) while single-flight keeps tracking the unbounded pass (so it cannot start a second concurrent refresh); failures emit only a closed generic/count `console.warn` (never provider ids or errors) + are swallowed, never the picker's problem; **`PI_OFFLINE`**
+    `completed: false`) while single-flight keeps tracking the unbounded pass (so it cannot start a second concurrent refresh); failures emit only a closed generic/count warn log (never provider ids or errors) + are swallowed, never the picker's problem; **`PI_OFFLINE`**
     (pi's env convention) disables it — resolving as a *completed* pass, since with nothing fetchable the
     registry as it stands is the settled answer; the e2e webServer env and the manager's unit suite set it for
     hermeticity. The **provider-credential surface** over this runtime —
@@ -401,8 +401,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   called with globbing disabled and allowed to throw — never degraded to `unlink`);
   `@stroncium/procfs` (directly pinned solely for the compiled Linux trash parser inclusion seam);
   `contracts` (`PiEvent`/`Model`/`ThinkingLevel`/`ImageContent`/`SessionStats`/`SlashCommandInfo`/`ExtUi*`/
-  `AskUserQuestion*`/`ProviderStatus*`); Node.
-- **Forbidden:** `host`; sibling features (the `cwd` is passed in, not looked up via `persistence`);
+  `AskUserQuestion*`/`ProviderStatus*`); `log` (diagnostics + session-lifecycle debug traces); Node.
+- **Forbidden:** `host`; sibling features other than `log` (the `cwd` is passed in, not looked up via `persistence`);
   Central process/filesystem knowledge—the caller supplies only the desired opaque extension paths for a
   candidate.
 

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -30,6 +30,7 @@ import type {
 	WireModel,
 } from "@thinkrail/contracts";
 import { isTranscriptMessageRole } from "@thinkrail/contracts";
+import { logger } from "../log";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import { buildResourceLoader, toSkillCommands } from "./extensions";
 import {
@@ -44,6 +45,8 @@ import { repairDanglingToolCalls } from "./sessionRepair";
 import type { SkillAdmissionContext } from "./skillAdmission";
 import { trashFile } from "./trash";
 import { cancelExtUiForSession, createWebUiContext, notifyExtUi } from "./webUiContext";
+
+const log = logger("agent");
 
 interface Entry {
 	session: AgentSession;
@@ -250,6 +253,7 @@ async function registerSession(
 ): Promise<CreateSessionResult> {
 	const prepared = await prepareSessionEntry(session, workspaceId, generation);
 	sessions.set(session.sessionId, prepared.entry);
+	log.debug(`session ${session.sessionId} attached (workspace ${workspaceId})`);
 	return prepared.result;
 }
 
@@ -735,6 +739,7 @@ function disposeSession(sessionId: string): void {
 	entry.unsubscribe();
 	entry.session.dispose();
 	sessions.delete(sessionId);
+	log.debug(`session ${sessionId} disposed`);
 }
 
 export function removeSession(sessionId: string): void {

--- a/packages/server/src/agent/piRuntime.ts
+++ b/packages/server/src/agent/piRuntime.ts
@@ -4,6 +4,9 @@ import {
 	getAgentDir,
 	ModelRuntime,
 } from "@earendil-works/pi-coding-agent";
+import { logger } from "../log";
+
+const log = logger("agent");
 
 export interface PiRuntimeGeneration {
 	readonly id: number;
@@ -230,7 +233,7 @@ export function refreshCatalogs(
 function withDeadline(task: Promise<void>): Promise<CatalogRefreshOutcome> {
 	return new Promise<CatalogRefreshOutcome>((resolve) => {
 		const timer = setTimeout(() => {
-			console.warn(
+			log.warn(
 				`model catalog refresh exceeded ${CATALOG_REFRESH_TIMEOUT_MS}ms; serving cached catalogs`,
 			);
 			resolve({ completed: false });
@@ -251,15 +254,15 @@ function runCatalogRefresh(runtime: CatalogRefreshRuntime, force: boolean): Prom
 		.refresh({ allowNetwork: true, force, signal: controller.signal })
 		.then((result) => {
 			if (result.aborted) {
-				console.warn(
+				log.warn(
 					`model catalog refresh timed out after ${CATALOG_REFRESH_TIMEOUT_MS}ms; serving cached catalogs`,
 				);
 			} else if (result.errors.size > 0) {
-				console.warn(`model catalog refresh: ${result.errors.size} provider(s) failed`);
+				log.warn(`model catalog refresh: ${result.errors.size} provider(s) failed`);
 			}
 		})
 		.catch(() => {
-			console.warn("model catalog refresh failed");
+			log.warn("model catalog refresh failed");
 		})
 		.finally(() => clearTimeout(timer));
 }

--- a/packages/server/src/analytics/SPEC.md
+++ b/packages/server/src/analytics/SPEC.md
@@ -69,7 +69,8 @@ PostHog won on free tier, EU residency, and a self-host path).
   `shutdownAnalytics`, `resetAnalyticsForTests`, the event types + bucket helpers, and `BuildKind` — which
   `host/index.ts` re-exports so a launcher can name its own provenance without importing this module
   (the forbidden edge below stays intact).
-- **Allowed deps:** `persistence` (installation record + data dir), `contracts` (types),
+- **Allowed deps:** `persistence` (installation record + data dir), `log` (send failures surface at
+  debug level through the shared logger), `contracts` (types),
   `@earendil-works/pi-ai` (the built-in catalog — server-side value import), `posthog-node` (the
   delivery SDK — value-imported **only** in `sink.ts`), Node `crypto`/`process`.
 - **Forbidden:** importing `host` or any other sibling; being imported by anything but `host` (all

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -1,3 +1,4 @@
+import { logger } from "../log";
 import { ensureInstallation, saveInstallation } from "../persistence";
 import type { AnalyticsEvent, BuildKind } from "./events";
 import { type AnalyticsEnv, environmentMute } from "./mute";
@@ -8,6 +9,8 @@ import {
 	type OutgoingEvent,
 	POSTHOG_PROJECT_KEY,
 } from "./sink";
+
+const log = logger("analytics");
 
 export interface AnalyticsOptions {
 	appVersion?: string;
@@ -139,7 +142,5 @@ function toOutgoingEvent(event: AnalyticsEvent, s: AnalyticsState): OutgoingEven
 }
 
 function debugLog(error: unknown): void {
-	if (process.env.THINKRAIL_ANALYTICS_DEBUG) {
-		console.warn(`analytics failed: ${error instanceof Error ? error.message : error}`);
-	}
+	log.debug(`analytics failed: ${error instanceof Error ? error.message : error}`);
 }

--- a/packages/server/src/analytics/service.ts
+++ b/packages/server/src/analytics/service.ts
@@ -141,6 +141,6 @@ function toOutgoingEvent(event: AnalyticsEvent, s: AnalyticsState): OutgoingEven
 	};
 }
 
-function debugLog(error: unknown): void {
-	log.debug(`analytics failed: ${error instanceof Error ? error.message : error}`);
+function debugLog(_error: unknown): void {
+	log.debug("analytics operation failed");
 }

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -1,4 +1,7 @@
 import { PostHog } from "posthog-node";
+import { logger } from "../log";
+
+const log = logger("analytics");
 
 export interface OutgoingEvent {
 	name: string;
@@ -70,7 +73,5 @@ export function createPostHogSink(options: PostHogSinkOptions): AnalyticsSink {
 }
 
 function debugLog(error: unknown): void {
-	if (process.env.THINKRAIL_ANALYTICS_DEBUG) {
-		console.warn(`analytics send failed: ${error instanceof Error ? error.message : error}`);
-	}
+	log.debug(`analytics send failed: ${error instanceof Error ? error.message : error}`);
 }

--- a/packages/server/src/analytics/sink.ts
+++ b/packages/server/src/analytics/sink.ts
@@ -72,6 +72,6 @@ export function createPostHogSink(options: PostHogSinkOptions): AnalyticsSink {
 	};
 }
 
-function debugLog(error: unknown): void {
-	log.debug(`analytics send failed: ${error instanceof Error ? error.message : error}`);
+function debugLog(_error: unknown): void {
+	log.debug("analytics send failed");
 }

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -138,7 +138,7 @@ ref off the workspace-create critical path.
   `resolveDiffRange`, `changedFileArgs`, `diffBaseRef`, `resolveCommitOid`, `DiffRange`, `isSafeRef`,
   `assertSafeRef`, `listBranches`, `resolveDefaultBranch`, `tryCurrentBranch`, `currentBranch`,
   `canonicalPath`, `prefetchBranch`.
-- **Allowed deps:** `persistence` (workspace + project lookup); `contracts` (`Git*`/`BranchList` types);
+- **Allowed deps:** `persistence` (workspace + project lookup), `log`; `contracts` (`Git*`/`BranchList` types);
   `@thinkrail/shared/codedError` (naming a failure for the wire); Bun (spawn).
 - **Forbidden:** `host`; sibling features.
 

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -9,9 +9,12 @@ import type {
 	GitStatus,
 	Workspace,
 } from "@thinkrail/contracts";
+import { logger } from "../log";
 import { loadProjects, loadWorkspaces } from "../persistence";
 import { changedFileArgs, type DiffRange, diffBaseRef, resolveDiffRange } from "./diffScope";
 import { git, gitAsync } from "./gitExec";
+
+const log = logger("git");
 
 function workspace(workspaceId: string): Workspace {
 	const ws = loadWorkspaces().find((w) => w.id === workspaceId);
@@ -238,7 +241,7 @@ export function readBlobAt(worktreePath: string, ref: string, path: string): str
 	const shown = git(worktreePath, ["show", "--end-of-options", `${ref}:${path}`], { raw: true });
 	if (shown.ok) return shown.out;
 	if (!/does not exist in|exists on disk, but not in/.test(shown.err)) {
-		console.warn(`git show ${ref}:${path} failed: ${shown.err || "unknown error"}`);
+		log.warn(`git show ${ref}:${path} failed: ${shown.err || "unknown error"}`);
 	}
 	return null;
 }

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -241,7 +241,7 @@ export function readBlobAt(worktreePath: string, ref: string, path: string): str
 	const shown = git(worktreePath, ["show", "--end-of-options", `${ref}:${path}`], { raw: true });
 	if (shown.ok) return shown.out;
 	if (!/does not exist in|exists on disk, but not in/.test(shown.err)) {
-		log.warn(`git show ${ref}:${path} failed: ${shown.err || "unknown error"}`);
+		log.warn("git blob read failed");
 	}
 	return null;
 }

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -233,9 +233,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
 
 ## Get right
 
-- Every WS command is debug-traced by **method name only** (`ws <method>` / `ws <method> failed`) —
-  never its params or handler error text, which can reflect credentials and user-supplied values; see
-  `submodule-server-log`'s privacy rule.
+- Every registered WS command is debug-traced by **method name only** (`ws <method>` / `ws <method>
+  failed`); a name absent from the closed handler registry is traced as fixed `ws unknown method` instead.
+  Never trace raw unregistered method names, params, or handler error text, which can reflect credentials
+  and user-supplied values; see `submodule-server-log`'s privacy rule.
 - WS commands return values directly; only events + extension-UI + **`project.updated`** (published from
   the `projects` module's injected publisher) + the workspace lifecycle trio
   (`workspace.created`/`updated`/`removed`, published from the `workspaces` module's injected publisher) +

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -100,7 +100,7 @@ channel fan-out, and the process-boot wrapper both launchers share.
   Never a recovery, and never installed under `NODE_ENV=test` — a unit-test process reports its own
   faults. It renders the throw via the `log` module's `describeError`, so crash reports and log lines
   agree, but keeps its own sync append — the death path must not depend on the logger's state);
-  `boot.ts` (`bootHost` → `initLogging` first — debug level when the launcher passed `verbose`, plus
+  `boot.ts` (`bootHost` → await `initLogging` first — debug level when the launcher passed `verbose`, plus
   the `listening on` info line after `createServer` (see `submodule-server-log`) — then install that
   report, resolve the login-shell PATH, pre-warm the same
   Central watcher/runtime initialization before choosing a port, then await `createServer` (which idempotently enforces the

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -233,9 +233,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
 
 ## Get right
 
-- Every WS command is debug-traced by **method name only** (`ws <method>` / `ws <method> failed: …`) —
-  never its params, which can carry credentials (`provider.loginReply`); see `submodule-server-log`'s
-  privacy rule.
+- Every WS command is debug-traced by **method name only** (`ws <method>` / `ws <method> failed`) —
+  never its params or handler error text, which can reflect credentials and user-supplied values; see
+  `submodule-server-log`'s privacy rule.
 - WS commands return values directly; only events + extension-UI + **`project.updated`** (published from
   the `projects` module's injected publisher) + the workspace lifecycle trio
   (`workspace.created`/`updated`/`removed`, published from the `workspaces` module's injected publisher) +

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -98,7 +98,11 @@ channel fan-out, and the process-boot wrapper both launchers share.
   appended to `<dataDir>/logs/crash.log` and echoed to stderr, then `exit(1)`: in-process pi means such a
   fault is the whole host's, and a launcher started without a terminal otherwise loses its only trace.
   Never a recovery, and never installed under `NODE_ENV=test` — a unit-test process reports its own
-  faults); `boot.ts` (`bootHost` → install that report first, resolve the login-shell PATH, pre-warm the same
+  faults. It renders the throw via the `log` module's `describeError`, so crash reports and log lines
+  agree, but keeps its own sync append — the death path must not depend on the logger's state);
+  `boot.ts` (`bootHost` → `initLogging` first — debug level when the launcher passed `verbose`, plus
+  the `listening on` info line after `createServer` (see `submodule-server-log`) — then install that
+  report, resolve the login-shell PATH, pre-warm the same
   Central watcher/runtime initialization before choosing a port, then await `createServer` (which idempotently enforces the
   bootstrap for every embedder), and
   install SIGINT/SIGTERM handlers that **settle before exit**: `settleSessionsForShutdown()` — abort
@@ -143,7 +147,7 @@ channel fan-out, and the process-boot wrapper both launchers share.
     human-readable name (cheap model), re-checks the workspace (exists, not `renamed`) after the await,
     then calls `renameWorkspace` in the same tick — upgrading the provisional naive name into the final
     name (and its derived branch) and **locking** it (`renamed: true`). Best-effort by contract: every failure path resolves `null` and
-    leaves the flag unset so a later settled turn retries — but a swallowed exception is `console.warn`ed
+    leaves the flag unset so a later settled turn retries — but a swallowed exception is warn-logged
     (a broken rename path must stay distinguishable from "assist had nothing"). Its own per-workspace
     **in-flight set** (independent of the naive one — the two passes can overlap on a short turn) dedupes
     concurrent turns/sessions.
@@ -161,7 +165,7 @@ channel fan-out, and the process-boot wrapper both launchers share.
     external one). So the user never waits
     for the git subprocess + session abort. **Ordering holds:** terminals (sync) and sessions (bg, before
     the reclaim) are down before the dir is deleted, since they hold it as cwd. Best-effort by contract —
-    a failed background teardown is `console.warn`ed, never thrown into the void (nothing awaits it), like
+    a failed background teardown is warn-logged, never thrown into the void (nothing awaits it), like
     the auto-rename tee. **Archive keeps the branch but not the chat:** the git branch stays (code is
     recoverable), yet chat history is purged with the worktree — a deliberate scope choice, not a leak.
 - **Review state is host-composed and serialized per workspace** (`reviewLock.ts`): `review.send*` is
@@ -229,6 +233,9 @@ channel fan-out, and the process-boot wrapper both launchers share.
 
 ## Get right
 
+- Every WS command is debug-traced by **method name only** (`ws <method>` / `ws <method> failed: …`) —
+  never its params, which can carry credentials (`provider.loginReply`); see `submodule-server-log`'s
+  privacy rule.
 - WS commands return values directly; only events + extension-UI + **`project.updated`** (published from
   the `projects` module's injected publisher) + the workspace lifecycle trio
   (`workspace.created`/`updated`/`removed`, published from the `workspaces` module's injected publisher) +

--- a/packages/server/src/host/autoRename.ts
+++ b/packages/server/src/host/autoRename.ts
@@ -1,7 +1,10 @@
 import type { PiEvent, TranscriptMessage, Workspace } from "@thinkrail/contracts";
 import { getSessionMessages } from "../agent";
 import { extractFirstTurn, naiveWorkspaceName, suggestWorkspaceName } from "../assist";
+import { logger } from "../log";
 import { getWorkspace, renameWorkspace } from "../workspaces";
+
+const log = logger("host");
 
 const PRISTINE_BRANCH = /^workspace-\d+$/;
 
@@ -42,7 +45,7 @@ export async function maybeNaiveNameWorkspace(
 		if (!isPristine(workspaceId)) return null;
 		return renameWorkspace(workspaceId, name, { lock: false });
 	} catch (err) {
-		console.warn(
+		log.warn(
 			`workspace naive-rename skipped (${workspaceId}): ${err instanceof Error ? err.message : err}`,
 		);
 		return null;
@@ -90,7 +93,7 @@ export async function maybeAutoRenameWorkspace(
 		if (fresh.renamed) return null;
 		return renameWorkspace(workspaceId, name);
 	} catch (err) {
-		console.warn(
+		log.warn(
 			`workspace auto-rename skipped (${workspaceId}): ${err instanceof Error ? err.message : err}`,
 		);
 		return null;

--- a/packages/server/src/host/autoRename.ts
+++ b/packages/server/src/host/autoRename.ts
@@ -44,10 +44,8 @@ export async function maybeNaiveNameWorkspace(
 
 		if (!isPristine(workspaceId)) return null;
 		return renameWorkspace(workspaceId, name, { lock: false });
-	} catch (err) {
-		log.warn(
-			`workspace naive-rename skipped (${workspaceId}): ${err instanceof Error ? err.message : err}`,
-		);
+	} catch {
+		log.warn(`workspace naive-rename skipped (${workspaceId})`);
 		return null;
 	} finally {
 		naiveInFlight.delete(workspaceId);
@@ -92,10 +90,8 @@ export async function maybeAutoRenameWorkspace(
 		const fresh = getWorkspace(workspaceId);
 		if (fresh.renamed) return null;
 		return renameWorkspace(workspaceId, name);
-	} catch (err) {
-		log.warn(
-			`workspace auto-rename skipped (${workspaceId}): ${err instanceof Error ? err.message : err}`,
-		);
+	} catch {
+		log.warn(`workspace auto-rename skipped (${workspaceId})`);
 		return null;
 	} finally {
 		inFlight.delete(workspaceId);

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -64,6 +64,6 @@ export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
 	process.on("SIGINT", shutdown);
 	process.on("SIGTERM", shutdown);
 
-	log.info(`listening on http://${options.host}:${server.port}`);
+	log.info(`listening on port ${server.port}`);
 	return { server, port: server.port, requested };
 }

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -27,7 +27,7 @@ export interface BootedHost {
 }
 
 export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
-	initLogging({
+	await initLogging({
 		...(options.verbose ? { level: "debug" as const } : {}),
 		...(options.appVersion ? { appVersion: options.appVersion } : {}),
 	});

--- a/packages/server/src/host/boot.ts
+++ b/packages/server/src/host/boot.ts
@@ -3,6 +3,7 @@ import { resolveShellEnv } from "@thinkrail/shared/shellEnv";
 import { settleSessionsForShutdown } from "../agent";
 import { shutdownAnalytics } from "../analytics";
 import { initializeJbcentralRuntime } from "../auth";
+import { initLogging, logger } from "../log";
 import { installCrashLog } from "./crashLog";
 import { type CreateServerOptions, createServer, type RunningServer } from "./server";
 
@@ -14,7 +15,10 @@ export interface BootHostOptions {
 	projectPath?: string;
 	appVersion?: string;
 	analytics?: CreateServerOptions["analytics"];
+	verbose?: boolean;
 }
+
+const log = logger("host");
 
 export interface BootedHost {
 	readonly server: RunningServer;
@@ -23,6 +27,10 @@ export interface BootedHost {
 }
 
 export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
+	initLogging({
+		...(options.verbose ? { level: "debug" as const } : {}),
+		...(options.appVersion ? { appVersion: options.appVersion } : {}),
+	});
 	installCrashLog(options.appVersion);
 	resolveShellEnv();
 	await initializeJbcentralRuntime();
@@ -56,5 +64,6 @@ export async function bootHost(options: BootHostOptions): Promise<BootedHost> {
 	process.on("SIGINT", shutdown);
 	process.on("SIGTERM", shutdown);
 
+	log.info(`listening on http://${options.host}:${server.port}`);
 	return { server, port: server.port, requested };
 }

--- a/packages/server/src/host/crashLog.ts
+++ b/packages/server/src/host/crashLog.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { describeError } from "../log";
 import { dataDir } from "../persistence";
 
 export type CrashKind = "uncaughtException" | "unhandledRejection";
@@ -16,23 +17,7 @@ export function formatCrashRecord(
 	appVersion?: string,
 ): string {
 	const build = appVersion ?? "source";
-	return `[${at.toISOString()}] ${kind} (thinkrail ${build}, up ${Math.round(uptimeSeconds)}s)\n${describe(error)}\n\n`;
-}
-
-function describe(error: unknown): string {
-	try {
-		if (error instanceof Error) {
-			const { stack } = error;
-			return typeof stack === "string" && stack ? stack : `${error.name}: ${error.message}`;
-		}
-		if (typeof error === "string") return `Non-Error thrown: ${error}`;
-		return `Non-Error thrown: ${JSON.stringify(error) ?? String(error)}`;
-	} catch {}
-	try {
-		return `Unrenderable throw: ${String(error)}`;
-	} catch {
-		return `Unrenderable throw (${typeof error})`;
-	}
+	return `[${at.toISOString()}] ${kind} (thinkrail ${build}, up ${Math.round(uptimeSeconds)}s)\n${describeError(error)}\n\n`;
 }
 
 let installed = false;

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Workspace, WorkspaceWatchReadyResult } from "@thinkrail/contracts";
 import { stopAllWatches } from "../watch";
-import { handleRequest } from "./handlers";
+import { handleRequest, requestMethodDiagnostic } from "./handlers";
 
 const CTX = { clientKey: "test-client" };
 
@@ -39,6 +39,13 @@ afterEach(() => {
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("request diagnostics expose only registered method names", async () => {
+	expect(requestMethodDiagnostic("workspace.list")).toBe("workspace.list");
+	expect(requestMethodDiagnostic("secret prompt value")).toBe("unknown method");
+	expect(requestMethodDiagnostic("toString")).toBe("unknown method");
+	await expect(handleRequest("toString", undefined, CTX)).rejects.toThrow("Unknown method");
 });
 
 test("workspace.watchReady waits for startup once, then reports an already-ready watcher", async () => {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -733,12 +733,16 @@ const handlers: Record<string, Handler> = {
 	},
 };
 
+export function requestMethodDiagnostic(method: string): string {
+	return Object.hasOwn(handlers, method) ? method : "unknown method";
+}
+
 export async function handleRequest(
 	method: string,
 	params: unknown,
 	ctx: RequestContext,
 ): Promise<unknown> {
-	const handler = handlers[method];
+	const handler = Object.hasOwn(handlers, method) ? handlers[method] : undefined;
 	if (!handler) throw new Error(`Unknown method: ${method}`);
 	return handler(params, ctx);
 }

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -78,6 +78,7 @@ import {
 	replaceWorkspaceLayout,
 	validateLayoutSettings,
 } from "../layout";
+import { logger } from "../log";
 import {
 	acknowledgeProjectSkills,
 	closeProject,
@@ -151,6 +152,8 @@ import { buildHistoryScope } from "./historyScope";
 import { dropLogin, recordLoginStart } from "./loginAnalytics";
 import { withReviewLock } from "./reviewLock";
 
+const log = logger("host");
+
 export interface RequestContext {
 	clientKey: string;
 }
@@ -162,7 +165,7 @@ async function archiveTeardown(ws: Workspace): Promise<void> {
 		await removeWorkspaceSessions(ws.id, ws.worktreePath);
 		reclaimWorktree(ws);
 	} catch (error) {
-		console.warn(`workspace archive teardown failed for ${ws.id}: ${error}`);
+		log.warn(`workspace archive teardown failed for ${ws.id}: ${error}`);
 	}
 }
 
@@ -188,7 +191,7 @@ function fireReviewPrompt(
 			);
 		})
 		.catch((err) => {
-			console.warn(`review send rollback failed: ${err instanceof Error ? err.message : err}`);
+			log.warn(`review send rollback failed: ${err instanceof Error ? err.message : err}`);
 		});
 }
 
@@ -214,7 +217,7 @@ async function sendToFileChat(
 		};
 	}
 	if (existing) {
-		console.warn(
+		log.warn(
 			`review ${workspaceId}: linked chat ${existing} for ${path} is no longer on disk — starting a new review chat`,
 		);
 	}

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -164,8 +164,8 @@ async function archiveTeardown(ws: Workspace): Promise<void> {
 	try {
 		await removeWorkspaceSessions(ws.id, ws.worktreePath);
 		reclaimWorktree(ws);
-	} catch (error) {
-		log.warn(`workspace archive teardown failed for ${ws.id}: ${error}`);
+	} catch {
+		log.warn(`workspace archive teardown failed for ${ws.id}`);
 	}
 }
 
@@ -190,8 +190,8 @@ function fireReviewPrompt(
 				"error",
 			);
 		})
-		.catch((err) => {
-			log.warn(`review send rollback failed: ${err instanceof Error ? err.message : err}`);
+		.catch(() => {
+			log.warn("review send rollback failed");
 		});
 }
 
@@ -218,7 +218,7 @@ async function sendToFileChat(
 	}
 	if (existing) {
 		log.warn(
-			`review ${workspaceId}: linked chat ${existing} for ${path} is no longer on disk — starting a new review chat`,
+			`review ${workspaceId}: linked chat ${existing} is no longer on disk — starting a new review chat`,
 		);
 	}
 	ensureWorkspaceScratchDir(ws);

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -249,7 +249,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 								return JSON.stringify({ id: requestId, ok: true, result });
 							} catch (err) {
 								const error = err instanceof Error ? err.message : String(err);
-								log.debug(`ws ${method} failed: ${error}`);
+								log.debug(`ws ${method} failed`);
 								const code = errorCodeOf(err);
 								return JSON.stringify({
 									id: requestId,
@@ -443,10 +443,8 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 	if (projectPath) {
 		try {
 			openProject(projectPath);
-		} catch (err) {
-			log.warn(
-				`could not open project ${projectPath}: ${err instanceof Error ? err.message : err}`,
-			);
+		} catch {
+			log.warn("could not open requested project");
 		}
 	}
 

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -36,6 +36,7 @@ import {
 } from "../auth";
 import { resolveWorktreeFile } from "../fs";
 import { normalizeStoredLayoutSettings, setLayoutPublisher } from "../layout";
+import { logger } from "../log";
 import {
 	getProjects,
 	listProjects,
@@ -95,6 +96,8 @@ interface SocketData {
 }
 
 const CLIENT_REPLAY_RETENTION_MS = 60_000;
+
+const log = logger("host");
 
 const isRequestId = (id: unknown): id is string => typeof id === "string";
 
@@ -232,6 +235,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 				const fingerprint = createHash("sha256")
 					.update(JSON.stringify([method, params, sessionId ?? null]))
 					.digest("hex");
+				log.debug(`ws ${method}`);
 				try {
 					const response = await requestReplays.run(
 						ws.data.clientKey,
@@ -245,6 +249,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 								return JSON.stringify({ id: requestId, ok: true, result });
 							} catch (err) {
 								const error = err instanceof Error ? err.message : String(err);
+								log.debug(`ws ${method} failed: ${error}`);
 								const code = errorCodeOf(err);
 								return JSON.stringify({
 									id: requestId,
@@ -439,8 +444,8 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 		try {
 			openProject(projectPath);
 		} catch (err) {
-			console.warn(
-				`Could not open project ${projectPath}: ${err instanceof Error ? err.message : err}`,
+			log.warn(
+				`could not open project ${projectPath}: ${err instanceof Error ? err.message : err}`,
 			);
 		}
 	}

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -69,7 +69,7 @@ import {
 	maybeNaiveNameWorkspace,
 } from "./autoRename";
 import { setFsNudgePublisher } from "./fsNudge";
-import { handleRequest } from "./handlers";
+import { handleRequest, requestMethodDiagnostic } from "./handlers";
 import { trackLoginOutcome } from "./loginAnalytics";
 import { RequestReplayCache } from "./requestReplayCache";
 import { terminalDeliveryForSendStatus } from "./terminalSend";
@@ -230,12 +230,13 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 				}
 				const requestId = req.id;
 				const method = req.method;
+				const methodDiagnostic = requestMethodDiagnostic(method);
 				const params = "params" in req ? req.params : undefined;
 				const sessionId = "sessionId" in req ? req.sessionId : undefined;
 				const fingerprint = createHash("sha256")
 					.update(JSON.stringify([method, params, sessionId ?? null]))
 					.digest("hex");
-				log.debug(`ws ${method}`);
+				log.debug(`ws ${methodDiagnostic}`);
 				try {
 					const response = await requestReplays.run(
 						ws.data.clientKey,
@@ -249,7 +250,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 								return JSON.stringify({ id: requestId, ok: true, result });
 							} catch (err) {
 								const error = err instanceof Error ? err.message : String(err);
-								log.debug(`ws ${method} failed`);
+								log.debug(`ws ${methodDiagnostic} failed`);
 								const code = errorCodeOf(err);
 								return JSON.stringify({
 									id: requestId,

--- a/packages/server/src/log/SPEC.md
+++ b/packages/server/src/log/SPEC.md
@@ -12,9 +12,9 @@ tags: [v1]
 
 The host's diagnostic record: every module logs through `logger(scope)` instead of `console.*`.
 Operators see readable stderr, while the same application records land as structured JSONL under
-`<dataDir>/logs/` so users can send them to ThinkRail for agent-led reproduction and investigation. A
-console tee additionally mirrors `console.*` output from pi / third-party code into the file because pi
-runs in-process and prints its own warnings.
+`<dataDir>/logs/` so users can send them to ThinkRail for agent-led reproduction and investigation.
+Only calls through this module's explicit logger reach durable files; arbitrary pi / extension
+`console.*` arguments remain terminal-only because they can contain prompts, tool data, or credentials.
 
 ## Destinations & rotation
 
@@ -41,19 +41,18 @@ runs in-process and prints its own warnings.
   `THINKRAIL_LOG_LEVEL` (this module is that variable's single reader; an invalid value warns without
   echoing the environment value and falls back to info) > info.
 - Before `initLogging`, `logger(...)` calls echo to stderr only and write no file, so unit tests and
-  library embedders never grow support files or get a patched console implicitly.
+  library embedders never grow support files implicitly.
 - `initLogging` asynchronously opens pino-roll and is awaited first by `host`'s `bootHost` (never by
   `createServer`; process-level logging belongs to the process owner). Repeated calls re-resolve the
   level and concurrent calls await the same one-time opener. Direct in-process streams deliberately avoid `pino.transport()` worker threads and their
   extra-file binary-bundling contract.
 
-## Console tee
+## Console boundary
 
-After the rolling stream opens, `initLogging` patches `console.debug/log/info/warn/error` to call through
-to the original and mirror the formatted arguments into the JSONL file under the `console` scope
-(`log`→info, others 1:1). The mirror uses a file-only Pino logger, so terminal output is not duplicated.
-Because the tee installs only at `bootHost`, the CLI's user-facing `--help`/`update`/`uninstall` output
-never lands in a support file.
+`console.debug/log/info/warn/error` are never patched or copied into durable files. Pi, extensions, and
+third-party packages may put sensitive project data in arbitrary console arguments; no structured
+redactor can make their free text safe. Host diagnostics that belong in support files must instead pass
+through a reviewed `logger(scope)` call with an intentionally bounded message.
 
 ## Failure & privacy boundary
 
@@ -68,11 +67,10 @@ never lands in a support file.
 ## Boundary
 
 - **Owns:** the process-level Pino adapter, level/env resolution, scoped façade, JSONL schema and privacy
-  policy, pino-roll configuration and startup cleanup invocation, pretty stderr, console tee, and the
-  shared `describeError` used by the independent crash report.
+  policy, pino-roll configuration and startup cleanup invocation, pretty stderr, and the shared
+  `describeError` used by the independent crash report.
 - **Public surface (barrel):** `logger`, `Logger`, `LogLevel`, `initLogging`, `InitLoggingOptions`,
   `setLogLevel`, `logsDir`, `describeError`.
-- **Allowed deps:** `persistence` (`dataDir`); `pino`, `pino-pretty`, `pino-roll`; Node
-  `path`/`util`/streams.
+- **Allowed deps:** `persistence` (`dataDir`); `pino`, `pino-pretty`, `pino-roll`; Node path/streams.
 - **Forbidden:** importing any other sibling module or `host`; being imported by `persistence` (the one
   module below it — a `persistence → log` edge would be a cycle).

--- a/packages/server/src/log/SPEC.md
+++ b/packages/server/src/log/SPEC.md
@@ -26,8 +26,10 @@ runs in-process and prints its own warnings.
 - `pino-roll` owns the complete file lifecycle: daily plus 10 MB size rotation, generated suffixes, size
   accounting, restart continuation, and cleanup. The base is `thinkrail.jsonl`; generated names follow
   the installed transport's convention. Fourteen rotated files plus the active file are retained, which
-  bounds ordinary diagnostic storage near 150 MB. Rotation follows the host's local calendar boundary;
-  record timestamps remain UTC ISO strings.
+  bounds ordinary diagnostic storage near 150 MB. The adapter invokes the pinned transport's own cleanup
+  routine once after opening because `pino-roll@4.0.0` otherwise runs it only after an in-process roll;
+  this preserves the bound for restart-heavy, low-volume hosts without duplicating its retention
+  algorithm. Rotation follows the host's local calendar boundary; record timestamps remain UTC ISO strings.
 - The rolling destination writes synchronously so accepted records are not stranded in a worker queue.
   `crash.log` remains a separate synchronous plain-text fatal report owned by `host/crashLog.ts` and is
   outside pino-roll's filename set.
@@ -36,8 +38,8 @@ runs in-process and prints its own warnings.
 
 - `debug | info | warn | error`; default threshold **info**. The threshold gates stderr and file alike.
   Resolution: explicit `initLogging({ level })` (the CLI's `--verbose` → debug) >
-  `THINKRAIL_LOG_LEVEL` (this module is that variable's single reader; an invalid value warns and falls
-  back to info) > info.
+  `THINKRAIL_LOG_LEVEL` (this module is that variable's single reader; an invalid value warns without
+  echoing the environment value and falls back to info) > info.
 - Before `initLogging`, `logger(...)` calls echo to stderr only and write no file, so unit tests and
   library embedders never grow support files or get a patched console implicitly.
 - `initLogging` asynchronously opens pino-roll and is awaited first by `host`'s `bootHost` (never by
@@ -66,8 +68,8 @@ never lands in a support file.
 ## Boundary
 
 - **Owns:** the process-level Pino adapter, level/env resolution, scoped façade, JSONL schema and privacy
-  policy, pino-roll configuration, pretty stderr, console tee, and the shared `describeError` used by the
-  independent crash report.
+  policy, pino-roll configuration and startup cleanup invocation, pretty stderr, console tee, and the
+  shared `describeError` used by the independent crash report.
 - **Public surface (barrel):** `logger`, `Logger`, `LogLevel`, `initLogging`, `InitLoggingOptions`,
   `setLogLevel`, `logsDir`, `describeError`.
 - **Allowed deps:** `persistence` (`dataDir`); `pino`, `pino-pretty`, `pino-roll`; Node

--- a/packages/server/src/log/SPEC.md
+++ b/packages/server/src/log/SPEC.md
@@ -2,7 +2,7 @@
 id: submodule-server-log
 type: submodule-design
 status: active
-title: log — leveled diagnostics to stderr + rotated daily files
+title: log — leveled diagnostics to stderr + rotated support files
 parent: module-server
 depends-on: [submodule-server-persistence]
 tags: [v1]
@@ -10,66 +10,67 @@ tags: [v1]
 
 ## Responsibility
 
-The host's diagnostic record: every module logs through `logger(scope)` instead of `console.*`, and
-each line lands on stderr **and** in a rotated log file under `<dataDir>/logs/` — so a bug report has
-a trace even when the terminal is gone (GUI launch, closed window). A console tee additionally mirrors
-`console.*` output from pi / third-party code into the file, since pi runs in-process and prints its
-own warnings.
+The host's diagnostic record: every module logs through `logger(scope)` instead of `console.*`.
+Operators see readable stderr, while the same application records land as structured JSONL under
+`<dataDir>/logs/` so users can send them to ThinkRail for agent-led reproduction and investigation. A
+console tee additionally mirrors `console.*` output from pi / third-party code into the file because pi
+runs in-process and prints its own warnings.
 
-## File layout & rotation (user-confirmed 2026-01-28)
+## Destinations & rotation
 
-- **Daily files with a 10 MB hard cap per file:** `thinkrail-YYYY-MM-DD.log`; when a file would exceed
-  10 MB the writer moves to `thinkrail-YYYY-MM-DD_1.log`, `_2`, … — append-only, no renames, the
-  newest file has the highest suffix. A single line larger than the cap still lands (in a file of its
-  own) rather than rotating forever.
-- **The day is the UTC day of the line timestamps** (`toISOString()`), so a file's name always matches
-  the stamps inside it — deliberately not the local calendar day, which would disagree with the lines.
-- **Retention: files whose day is older than 14 days are deleted** at open/day-switch (the boundary
-  day is kept). Only `thinkrail-*.log` names are swept — `crash.log` (owned by `host/crashLog.ts`)
-  is never touched.
-- Line format is human-readable text, chosen over JSONL (this log is read by humans in an editor or
-  `tail -f`, not shipped to a pipeline): `<ISO ts> LEVEL [scope] message`, with an error's rendering
-  appended as 2-space-indented lines.
+- Pino owns record serialization. Each JSONL line is an independent schema-versioned record with an ISO
+  timestamp, numeric + textual severity, scope, message, and a structured error when one was supplied.
+  Append-only JSONL is streamable and a truncated final write cannot invalidate earlier records.
+- `pino-pretty` renders application logs to stderr only. Durable files stay as Pino's NDJSON rather than
+  passing through a human-text formatter.
+- `pino-roll` owns the complete file lifecycle: daily plus 10 MB size rotation, generated suffixes, size
+  accounting, restart continuation, and cleanup. The base is `thinkrail.jsonl`; generated names follow
+  the installed transport's convention. Fourteen rotated files plus the active file are retained, which
+  bounds ordinary diagnostic storage near 150 MB. Rotation follows the host's local calendar boundary;
+  record timestamps remain UTC ISO strings.
+- The rolling destination writes synchronously so accepted records are not stranded in a worker queue.
+  `crash.log` remains a separate synchronous plain-text fatal report owned by `host/crashLog.ts` and is
+  outside pino-roll's filename set.
 
-## Levels & the debug switch
+## Levels & initialization
 
-- `debug | info | warn | error`; default threshold **info**. The threshold gates stderr and file
-  alike. Resolution: explicit `initLogging({ level })` (the CLI's `--verbose` → debug) >
-  `THINKRAIL_LOG_LEVEL` (this module is that variable's single reader; an invalid value warns and
-  falls back to info) > info.
-- Before `initLogging`, `logger(...)` calls echo to stderr only (level-gated at the default) and
-  write no file — so unit tests and library embedders never grow log files or a patched console.
-  `initLogging` is called once by `host`'s `bootHost` (never by `createServer` — file logging and the
-  console patch are process-level choices that belong to the process owner); repeated calls only
-  re-resolve the level.
+- `debug | info | warn | error`; default threshold **info**. The threshold gates stderr and file alike.
+  Resolution: explicit `initLogging({ level })` (the CLI's `--verbose` → debug) >
+  `THINKRAIL_LOG_LEVEL` (this module is that variable's single reader; an invalid value warns and falls
+  back to info) > info.
+- Before `initLogging`, `logger(...)` calls echo to stderr only and write no file, so unit tests and
+  library embedders never grow support files or get a patched console implicitly.
+- `initLogging` asynchronously opens pino-roll and is awaited first by `host`'s `bootHost` (never by
+  `createServer`; process-level logging belongs to the process owner). Repeated calls re-resolve the
+  level and concurrent calls await the same one-time opener. Direct in-process streams deliberately avoid `pino.transport()` worker threads and their
+  extra-file binary-bundling contract.
 
 ## Console tee
 
-`initLogging` patches `console.debug/log/info/warn/error` to call through to the original **and**
-mirror the formatted args into the file under the `[console]` scope (`log`→info, others 1:1),
-level-gated like everything else. Terminal-only output is unchanged. Because the tee installs only at
-`bootHost`, the CLI's user-facing output for `--help`/`update`/`uninstall` never lands in a log file.
-The logger's own stderr echo uses `process.stderr.write`, never `console`, so the tee cannot recurse.
+After the rolling stream opens, `initLogging` patches `console.debug/log/info/warn/error` to call through
+to the original and mirror the formatted arguments into the JSONL file under the `console` scope
+(`log`→info, others 1:1). The mirror uses a file-only Pino logger, so terminal output is not duplicated.
+Because the tee installs only at `bootHost`, the CLI's user-facing `--help`/`update`/`uninstall` output
+never lands in a support file.
 
-## Never throw, never leak
+## Failure & privacy boundary
 
-- **Logging must never take the host down:** every file write is try/caught and degrades to
-  stderr-only, silently. The writer tracks bytes itself (one `stat` per file open, not per line).
-- **Privacy rule:** no credential values, no prompt/message contents, no WS payloads — debug traces
-  log command *types* only (a payload can carry an API key, e.g. `provider.loginReply`). The same
-  closed-diagnostics discipline as `submodule-server-analytics`.
+- Logging must never take the host down. Initialization and log calls degrade to direct stderr on failure;
+  every destination error channel is consumed without routing back through the logger.
+- Support files never intentionally contain credentials, authorization headers, cookies, environment
+  values, prompt/message contents, file contents, tool arguments/results, or WS/protocol payloads. Known
+  structured secret fields are removed with Pino redaction as defense in depth; call sites must still
+  follow the closed-diagnostics rule because secrets embedded in free-text messages cannot be redacted
+  structurally. Errors are reduced to type/message/stack rather than copying arbitrary enumerable fields.
 
 ## Boundary
 
-- **Owns:** `logging.ts` — `logger(scope)` → `{ debug, info, warn, error }` (each
-  `(message, error?)`), `initLogging({ level?, appVersion? })` (level resolve + writer + console tee +
-  retention sweep + one boot line naming the logs dir/version/pid/level), `setLogLevel`, `logsDir()`
-  (`<dataDir>/logs`), `describeError` (the shared error renderer — `host/crashLog.ts` uses it too, so
-  crash reports and log lines render a throw identically), and the pure rotation parts
-  (`logFileName`/`parseLogFileName`/`latestLogSequence`/`selectRetentionVictims`/`formatLogLine`/
-  `shouldLog`/`resolveLogLevel` + `LogFileWriter`), pinned by `logging.test.ts`.
+- **Owns:** the process-level Pino adapter, level/env resolution, scoped façade, JSONL schema and privacy
+  policy, pino-roll configuration, pretty stderr, console tee, and the shared `describeError` used by the
+  independent crash report.
 - **Public surface (barrel):** `logger`, `Logger`, `LogLevel`, `initLogging`, `InitLoggingOptions`,
   `setLogLevel`, `logsDir`, `describeError`.
-- **Allowed deps:** `persistence` (`dataDir`); Node `fs`/`path`/`util`.
-- **Forbidden:** importing any other sibling module or `host`; being imported by `persistence` (the
-  one module below it — a `persistence → log` edge would be a cycle).
+- **Allowed deps:** `persistence` (`dataDir`); `pino`, `pino-pretty`, `pino-roll`; Node
+  `path`/`util`/streams.
+- **Forbidden:** importing any other sibling module or `host`; being imported by `persistence` (the one
+  module below it — a `persistence → log` edge would be a cycle).

--- a/packages/server/src/log/SPEC.md
+++ b/packages/server/src/log/SPEC.md
@@ -1,0 +1,75 @@
+---
+id: submodule-server-log
+type: submodule-design
+status: active
+title: log — leveled diagnostics to stderr + rotated daily files
+parent: module-server
+depends-on: [submodule-server-persistence]
+tags: [v1]
+---
+
+## Responsibility
+
+The host's diagnostic record: every module logs through `logger(scope)` instead of `console.*`, and
+each line lands on stderr **and** in a rotated log file under `<dataDir>/logs/` — so a bug report has
+a trace even when the terminal is gone (GUI launch, closed window). A console tee additionally mirrors
+`console.*` output from pi / third-party code into the file, since pi runs in-process and prints its
+own warnings.
+
+## File layout & rotation (user-confirmed 2026-01-28)
+
+- **Daily files with a 10 MB hard cap per file:** `thinkrail-YYYY-MM-DD.log`; when a file would exceed
+  10 MB the writer moves to `thinkrail-YYYY-MM-DD_1.log`, `_2`, … — append-only, no renames, the
+  newest file has the highest suffix. A single line larger than the cap still lands (in a file of its
+  own) rather than rotating forever.
+- **The day is the UTC day of the line timestamps** (`toISOString()`), so a file's name always matches
+  the stamps inside it — deliberately not the local calendar day, which would disagree with the lines.
+- **Retention: files whose day is older than 14 days are deleted** at open/day-switch (the boundary
+  day is kept). Only `thinkrail-*.log` names are swept — `crash.log` (owned by `host/crashLog.ts`)
+  is never touched.
+- Line format is human-readable text, chosen over JSONL (this log is read by humans in an editor or
+  `tail -f`, not shipped to a pipeline): `<ISO ts> LEVEL [scope] message`, with an error's rendering
+  appended as 2-space-indented lines.
+
+## Levels & the debug switch
+
+- `debug | info | warn | error`; default threshold **info**. The threshold gates stderr and file
+  alike. Resolution: explicit `initLogging({ level })` (the CLI's `--verbose` → debug) >
+  `THINKRAIL_LOG_LEVEL` (this module is that variable's single reader; an invalid value warns and
+  falls back to info) > info.
+- Before `initLogging`, `logger(...)` calls echo to stderr only (level-gated at the default) and
+  write no file — so unit tests and library embedders never grow log files or a patched console.
+  `initLogging` is called once by `host`'s `bootHost` (never by `createServer` — file logging and the
+  console patch are process-level choices that belong to the process owner); repeated calls only
+  re-resolve the level.
+
+## Console tee
+
+`initLogging` patches `console.debug/log/info/warn/error` to call through to the original **and**
+mirror the formatted args into the file under the `[console]` scope (`log`→info, others 1:1),
+level-gated like everything else. Terminal-only output is unchanged. Because the tee installs only at
+`bootHost`, the CLI's user-facing output for `--help`/`update`/`uninstall` never lands in a log file.
+The logger's own stderr echo uses `process.stderr.write`, never `console`, so the tee cannot recurse.
+
+## Never throw, never leak
+
+- **Logging must never take the host down:** every file write is try/caught and degrades to
+  stderr-only, silently. The writer tracks bytes itself (one `stat` per file open, not per line).
+- **Privacy rule:** no credential values, no prompt/message contents, no WS payloads — debug traces
+  log command *types* only (a payload can carry an API key, e.g. `provider.loginReply`). The same
+  closed-diagnostics discipline as `submodule-server-analytics`.
+
+## Boundary
+
+- **Owns:** `logging.ts` — `logger(scope)` → `{ debug, info, warn, error }` (each
+  `(message, error?)`), `initLogging({ level?, appVersion? })` (level resolve + writer + console tee +
+  retention sweep + one boot line naming the logs dir/version/pid/level), `setLogLevel`, `logsDir()`
+  (`<dataDir>/logs`), `describeError` (the shared error renderer — `host/crashLog.ts` uses it too, so
+  crash reports and log lines render a throw identically), and the pure rotation parts
+  (`logFileName`/`parseLogFileName`/`latestLogSequence`/`selectRetentionVictims`/`formatLogLine`/
+  `shouldLog`/`resolveLogLevel` + `LogFileWriter`), pinned by `logging.test.ts`.
+- **Public surface (barrel):** `logger`, `Logger`, `LogLevel`, `initLogging`, `InitLoggingOptions`,
+  `setLogLevel`, `logsDir`, `describeError`.
+- **Allowed deps:** `persistence` (`dataDir`); Node `fs`/`path`/`util`.
+- **Forbidden:** importing any other sibling module or `host`; being imported by `persistence` (the
+  one module below it — a `persistence → log` edge would be a cycle).

--- a/packages/server/src/log/SPEC.md
+++ b/packages/server/src/log/SPEC.md
@@ -62,7 +62,9 @@ through a reviewed `logger(scope)` call with an intentionally bounded message.
   values, prompt/message contents, file contents, tool arguments/results, or WS/protocol payloads. Known
   structured secret fields are removed with Pino redaction as defense in depth; call sites must still
   follow the closed-diagnostics rule because secrets embedded in free-text messages cannot be redacted
-  structurally. Errors are reduced to type/message/stack rather than copying arbitrary enumerable fields.
+  structurally. Durable messages may interpolate only closed method names, counts, generated ids, and
+  equivalent bounded metadata — never raw error text or request-derived paths. A callsite that explicitly
+  approves a structured error gets only type/message/stack, never arbitrary enumerable fields.
 
 ## Boundary
 

--- a/packages/server/src/log/index.ts
+++ b/packages/server/src/log/index.ts
@@ -1,0 +1,10 @@
+export {
+	describeError,
+	type InitLoggingOptions,
+	initLogging,
+	type Logger,
+	type LogLevel,
+	logger,
+	logsDir,
+	setLogLevel,
+} from "./logging";

--- a/packages/server/src/log/logging.test.ts
+++ b/packages/server/src/log/logging.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	formatLogLine,
+	LogFileWriter,
+	latestLogSequence,
+	logFileName,
+	parseLogFileName,
+	resolveLogLevel,
+	selectRetentionVictims,
+	shouldLog,
+} from "./logging";
+
+describe("logFileName / parseLogFileName", () => {
+	test("sequence 0 has no suffix, later sequences carry _n", () => {
+		expect(logFileName("2026-01-28", 0)).toBe("thinkrail-2026-01-28.log");
+		expect(logFileName("2026-01-28", 1)).toBe("thinkrail-2026-01-28_1.log");
+		expect(logFileName("2026-01-28", 12)).toBe("thinkrail-2026-01-28_12.log");
+	});
+
+	test("round-trips through parse and rejects foreign files", () => {
+		expect(parseLogFileName("thinkrail-2026-01-28.log")).toEqual({
+			day: "2026-01-28",
+			sequence: 0,
+		});
+		expect(parseLogFileName("thinkrail-2026-01-28_3.log")).toEqual({
+			day: "2026-01-28",
+			sequence: 3,
+		});
+		expect(parseLogFileName("crash.log")).toBeNull();
+		expect(parseLogFileName("thinkrail-notadate.log")).toBeNull();
+	});
+});
+
+describe("latestLogSequence", () => {
+	test("picks the highest sequence for the day, ignoring other days and foreign files", () => {
+		const names = [
+			"crash.log",
+			"thinkrail-2026-01-27_9.log",
+			"thinkrail-2026-01-28.log",
+			"thinkrail-2026-01-28_2.log",
+			"thinkrail-2026-01-28_1.log",
+		];
+		expect(latestLogSequence(names, "2026-01-28")).toBe(2);
+		expect(latestLogSequence(names, "2026-01-27")).toBe(9);
+		expect(latestLogSequence(names, "2026-01-26")).toBeNull();
+	});
+});
+
+describe("selectRetentionVictims", () => {
+	test("deletes files strictly older than the retention window, never crash.log", () => {
+		const names = [
+			"crash.log",
+			"thinkrail-2026-01-13.log",
+			"thinkrail-2026-01-14.log",
+			"thinkrail-2026-01-14_4.log",
+			"thinkrail-2026-01-28.log",
+		];
+		expect(selectRetentionVictims(names, "2026-01-28", 14)).toEqual(["thinkrail-2026-01-13.log"]);
+	});
+});
+
+describe("shouldLog / resolveLogLevel", () => {
+	test("threshold gates lower levels", () => {
+		expect(shouldLog("debug", "info")).toBe(false);
+		expect(shouldLog("info", "info")).toBe(true);
+		expect(shouldLog("error", "warn")).toBe(true);
+		expect(shouldLog("debug", "debug")).toBe(true);
+	});
+
+	test("option beats env beats default; invalid env is reported", () => {
+		expect(resolveLogLevel("debug", "error")).toEqual({ level: "debug", invalidEnv: false });
+		expect(resolveLogLevel(undefined, "warn")).toEqual({ level: "warn", invalidEnv: false });
+		expect(resolveLogLevel(undefined, undefined)).toEqual({ level: "info", invalidEnv: false });
+		expect(resolveLogLevel(undefined, "loud")).toEqual({ level: "info", invalidEnv: true });
+	});
+});
+
+describe("formatLogLine", () => {
+	const at = new Date("2026-01-28T10:03:22.123Z");
+
+	test("renders ts, padded level, scope, message", () => {
+		expect(formatLogLine(at, "info", "host", "listening on http://localhost:24242")).toBe(
+			"2026-01-28T10:03:22.123Z INFO  [host] listening on http://localhost:24242",
+		);
+		expect(formatLogLine(at, "warn", "watch", "watcher failed")).toBe(
+			"2026-01-28T10:03:22.123Z WARN  [watch] watcher failed",
+		);
+	});
+
+	test("appends an indented error rendering", () => {
+		const line = formatLogLine(at, "error", "agent", "prompt failed", new Error("boom"));
+		const [head, ...rest] = line.split("\n");
+		expect(head).toBe("2026-01-28T10:03:22.123Z ERROR [agent] prompt failed");
+		expect(rest.length).toBeGreaterThan(0);
+		expect(rest[0]).toMatch(/^ {2}Error: boom/);
+		expect(rest.every((l) => l.startsWith("  "))).toBe(true);
+	});
+
+	test("renders non-Error values without throwing", () => {
+		expect(formatLogLine(at, "warn", "host", "odd", "just a string")).toContain(
+			"Non-Error thrown: just a string",
+		);
+	});
+});
+
+function tempLogsDir(): string {
+	return mkdtempSync(join(tmpdir(), "thinkrail-log-test-"));
+}
+
+describe("LogFileWriter", () => {
+	test("appends to the day file and rolls to _1, _2 at the byte cap", () => {
+		const dir = tempLogsDir();
+		try {
+			const writer = new LogFileWriter(dir, 64, 14);
+			const at = new Date("2026-01-28T10:00:00.000Z");
+			const line = "x".repeat(30);
+			writer.append(line, at);
+			writer.append(line, at);
+			writer.append(line, at);
+			writer.append(line, at);
+			writer.append(line, at);
+			const names = readdirSync(dir).sort();
+			expect(names).toEqual([
+				"thinkrail-2026-01-28.log",
+				"thinkrail-2026-01-28_1.log",
+				"thinkrail-2026-01-28_2.log",
+			]);
+			expect(readFileSync(join(dir, "thinkrail-2026-01-28.log"), "utf8")).toBe(
+				`${line}\n${line}\n`,
+			);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("a single oversized line still lands (in a file of its own)", () => {
+		const dir = tempLogsDir();
+		try {
+			const writer = new LogFileWriter(dir, 16, 14);
+			const at = new Date("2026-01-28T10:00:00.000Z");
+			writer.append("y".repeat(100), at);
+			writer.append("z", at);
+			const names = readdirSync(dir).sort();
+			expect(names).toEqual(["thinkrail-2026-01-28.log", "thinkrail-2026-01-28_1.log"]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("switches file on day change", () => {
+		const dir = tempLogsDir();
+		try {
+			const writer = new LogFileWriter(dir, 1024, 14);
+			writer.append("today", new Date("2026-01-28T23:59:59.000Z"));
+			writer.append("tomorrow", new Date("2026-01-29T00:00:01.000Z"));
+			expect(readdirSync(dir).sort()).toEqual([
+				"thinkrail-2026-01-28.log",
+				"thinkrail-2026-01-29.log",
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("resumes the highest existing sequence on open and honors its size", () => {
+		const dir = tempLogsDir();
+		try {
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(join(dir, "thinkrail-2026-01-28.log"), "old\n");
+			writeFileSync(join(dir, "thinkrail-2026-01-28_1.log"), "w".repeat(64));
+			const writer = new LogFileWriter(dir, 64, 14);
+			writer.append("fresh", new Date("2026-01-28T12:00:00.000Z"));
+			expect(readdirSync(dir).sort()).toEqual([
+				"thinkrail-2026-01-28.log",
+				"thinkrail-2026-01-28_1.log",
+				"thinkrail-2026-01-28_2.log",
+			]);
+			expect(readFileSync(join(dir, "thinkrail-2026-01-28_2.log"), "utf8")).toBe("fresh\n");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("sweeps files older than retention on open, keeping the boundary day and crash.log", () => {
+		const dir = tempLogsDir();
+		try {
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(join(dir, "thinkrail-2026-01-10.log"), "ancient\n");
+			writeFileSync(join(dir, "thinkrail-2026-01-14.log"), "boundary\n");
+			writeFileSync(join(dir, "crash.log"), "fatal\n");
+			const writer = new LogFileWriter(dir, 1024, 14);
+			writer.append("hello", new Date("2026-01-28T12:00:00.000Z"));
+			expect(readdirSync(dir).sort()).toEqual([
+				"crash.log",
+				"thinkrail-2026-01-14.log",
+				"thinkrail-2026-01-28.log",
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/server/src/log/logging.test.ts
+++ b/packages/server/src/log/logging.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Writable } from "node:stream";
 import pino, { type DestinationStream } from "pino";
 import pretty from "pino-pretty";
 import {
+	cleanManagedLogs,
 	createPinoOptions,
 	createPinoRollOptions,
 	createPrettyOptions,
@@ -11,6 +14,7 @@ import {
 	LOG_FILE_SIZE,
 	LOG_RETENTION_FILES,
 	LOG_SCHEMA_VERSION,
+	LOG_TOTAL_FILES,
 	resolveLogLevel,
 	serializeLogError,
 	shouldLog,
@@ -92,11 +96,36 @@ describe("destinations", () => {
 			dateFormat: "yyyy-MM-dd",
 			file: join("/tmp/logs", "thinkrail.jsonl"),
 			frequency: "daily",
-			limit: { count: LOG_RETENTION_FILES, removeOtherLogFiles: true },
+			limit: { count: LOG_TOTAL_FILES, removeOtherLogFiles: true },
 			mkdir: true,
 			size: LOG_FILE_SIZE,
 			sync: true,
 		});
+	});
+
+	test("enforces the file bound when a new process opens", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "thinkrail-log-retention-"));
+		try {
+			for (let day = 1; day <= LOG_TOTAL_FILES + 2; day += 1) {
+				const date = `2026-08-${String(day).padStart(2, "0")}`;
+				await writeFile(join(directory, `thinkrail.${date}.1.jsonl`), date);
+			}
+			await writeFile(join(directory, "crash.log"), "unrelated");
+			await writeFile(join(directory, "other.jsonl"), "unrelated");
+
+			await cleanManagedLogs(directory);
+
+			const files = await readdir(directory);
+			const managed = files.filter((file) => file.startsWith("thinkrail.")).sort();
+			expect(managed).toHaveLength(LOG_RETENTION_FILES + 1);
+			expect(managed).not.toContain("thinkrail.2026-08-01.1.jsonl");
+			expect(managed).not.toContain("thinkrail.2026-08-02.1.jsonl");
+			expect(managed).toContain("thinkrail.2026-08-17.1.jsonl");
+			expect(files).toContain("crash.log");
+			expect(files).toContain("other.jsonl");
+		} finally {
+			await rm(directory, { force: true, recursive: true });
+		}
 	});
 
 	test("renders readable stderr text", async () => {

--- a/packages/server/src/log/logging.test.ts
+++ b/packages/server/src/log/logging.test.ts
@@ -1,69 +1,36 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Writable } from "node:stream";
+import pino, { type DestinationStream } from "pino";
+import pretty from "pino-pretty";
 import {
-	formatLogLine,
-	LogFileWriter,
-	latestLogSequence,
-	logFileName,
-	parseLogFileName,
+	createPinoOptions,
+	createPinoRollOptions,
+	createPrettyOptions,
+	describeError,
+	LOG_FILE_SIZE,
+	LOG_RETENTION_FILES,
+	LOG_SCHEMA_VERSION,
 	resolveLogLevel,
-	selectRetentionVictims,
+	serializeLogError,
 	shouldLog,
 } from "./logging";
 
-describe("logFileName / parseLogFileName", () => {
-	test("sequence 0 has no suffix, later sequences carry _n", () => {
-		expect(logFileName("2026-01-28", 0)).toBe("thinkrail-2026-01-28.log");
-		expect(logFileName("2026-01-28", 1)).toBe("thinkrail-2026-01-28_1.log");
-		expect(logFileName("2026-01-28", 12)).toBe("thinkrail-2026-01-28_12.log");
-	});
+class StringSink extends Writable {
+	value = "";
 
-	test("round-trips through parse and rejects foreign files", () => {
-		expect(parseLogFileName("thinkrail-2026-01-28.log")).toEqual({
-			day: "2026-01-28",
-			sequence: 0,
-		});
-		expect(parseLogFileName("thinkrail-2026-01-28_3.log")).toEqual({
-			day: "2026-01-28",
-			sequence: 3,
-		});
-		expect(parseLogFileName("crash.log")).toBeNull();
-		expect(parseLogFileName("thinkrail-notadate.log")).toBeNull();
-	});
-});
+	override _write(
+		chunk: string | Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void,
+	): void {
+		this.value += chunk.toString();
+		callback();
+	}
+}
 
-describe("latestLogSequence", () => {
-	test("picks the highest sequence for the day, ignoring other days and foreign files", () => {
-		const names = [
-			"crash.log",
-			"thinkrail-2026-01-27_9.log",
-			"thinkrail-2026-01-28.log",
-			"thinkrail-2026-01-28_2.log",
-			"thinkrail-2026-01-28_1.log",
-		];
-		expect(latestLogSequence(names, "2026-01-28")).toBe(2);
-		expect(latestLogSequence(names, "2026-01-27")).toBe(9);
-		expect(latestLogSequence(names, "2026-01-26")).toBeNull();
-	});
-});
-
-describe("selectRetentionVictims", () => {
-	test("deletes files strictly older than the retention window, never crash.log", () => {
-		const names = [
-			"crash.log",
-			"thinkrail-2026-01-13.log",
-			"thinkrail-2026-01-14.log",
-			"thinkrail-2026-01-14_4.log",
-			"thinkrail-2026-01-28.log",
-		];
-		expect(selectRetentionVictims(names, "2026-01-28", 14)).toEqual(["thinkrail-2026-01-13.log"]);
-	});
-});
-
-describe("shouldLog / resolveLogLevel", () => {
-	test("threshold gates lower levels", () => {
+describe("level resolution", () => {
+	test("gates lower levels", () => {
 		expect(shouldLog("debug", "info")).toBe(false);
 		expect(shouldLog("info", "info")).toBe(true);
 		expect(shouldLog("error", "warn")).toBe(true);
@@ -78,128 +45,88 @@ describe("shouldLog / resolveLogLevel", () => {
 	});
 });
 
-describe("formatLogLine", () => {
-	const at = new Date("2026-01-28T10:03:22.123Z");
+describe("Pino records", () => {
+	test("writes the support schema and a structured error", () => {
+		const lines: string[] = [];
+		const destination: DestinationStream = { write: (line) => lines.push(line) };
+		const log = pino(createPinoOptions("debug"), destination).child({ scope: "agent" });
 
-	test("renders ts, padded level, scope, message", () => {
-		expect(formatLogLine(at, "info", "host", "listening on http://localhost:24242")).toBe(
-			"2026-01-28T10:03:22.123Z INFO  [host] listening on http://localhost:24242",
-		);
-		expect(formatLogLine(at, "warn", "watch", "watcher failed")).toBe(
-			"2026-01-28T10:03:22.123Z WARN  [watch] watcher failed",
-		);
+		log.error({ err: serializeLogError(new Error("boom")) }, "prompt failed");
+
+		const record = JSON.parse(lines[0] as string);
+		expect(record).toMatchObject({
+			err: { message: "boom", type: "Error" },
+			level: 50,
+			levelName: "error",
+			msg: "prompt failed",
+			schemaVersion: LOG_SCHEMA_VERSION,
+			scope: "agent",
+		});
+		expect(record.err.stack).toContain("Error: boom");
+		expect(new Date(record.time).toISOString()).toBe(record.time);
 	});
 
-	test("appends an indented error rendering", () => {
-		const line = formatLogLine(at, "error", "agent", "prompt failed", new Error("boom"));
-		const [head, ...rest] = line.split("\n");
-		expect(head).toBe("2026-01-28T10:03:22.123Z ERROR [agent] prompt failed");
-		expect(rest.length).toBeGreaterThan(0);
-		expect(rest[0]).toMatch(/^ {2}Error: boom/);
-		expect(rest.every((l) => l.startsWith("  "))).toBe(true);
-	});
+	test("removes structured secret fields", () => {
+		const lines: string[] = [];
+		const destination: DestinationStream = { write: (line) => lines.push(line) };
+		const log = pino(createPinoOptions("info"), destination);
 
-	test("renders non-Error values without throwing", () => {
-		expect(formatLogLine(at, "warn", "host", "odd", "just a string")).toContain(
-			"Non-Error thrown: just a string",
+		log.info(
+			{
+				headers: { authorization: "Bearer secret", safe: "kept" },
+				token: "secret",
+			},
+			"redacted",
 		);
+
+		const record = JSON.parse(lines[0] as string);
+		expect(record.token).toBeUndefined();
+		expect(record.headers).toEqual({ safe: "kept" });
+		expect(lines[0]).not.toContain("secret");
 	});
 });
 
-function tempLogsDir(): string {
-	return mkdtempSync(join(tmpdir(), "thinkrail-log-test-"));
-}
-
-describe("LogFileWriter", () => {
-	test("appends to the day file and rolls to _1, _2 at the byte cap", () => {
-		const dir = tempLogsDir();
-		try {
-			const writer = new LogFileWriter(dir, 64, 14);
-			const at = new Date("2026-01-28T10:00:00.000Z");
-			const line = "x".repeat(30);
-			writer.append(line, at);
-			writer.append(line, at);
-			writer.append(line, at);
-			writer.append(line, at);
-			writer.append(line, at);
-			const names = readdirSync(dir).sort();
-			expect(names).toEqual([
-				"thinkrail-2026-01-28.log",
-				"thinkrail-2026-01-28_1.log",
-				"thinkrail-2026-01-28_2.log",
-			]);
-			expect(readFileSync(join(dir, "thinkrail-2026-01-28.log"), "utf8")).toBe(
-				`${line}\n${line}\n`,
-			);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
+describe("destinations", () => {
+	test("configures pino-roll as the file lifecycle owner", () => {
+		expect(createPinoRollOptions("/tmp/logs")).toEqual({
+			dateFormat: "yyyy-MM-dd",
+			file: join("/tmp/logs", "thinkrail.jsonl"),
+			frequency: "daily",
+			limit: { count: LOG_RETENTION_FILES, removeOtherLogFiles: true },
+			mkdir: true,
+			size: LOG_FILE_SIZE,
+			sync: true,
+		});
 	});
 
-	test("a single oversized line still lands (in a file of its own)", () => {
-		const dir = tempLogsDir();
-		try {
-			const writer = new LogFileWriter(dir, 16, 14);
-			const at = new Date("2026-01-28T10:00:00.000Z");
-			writer.append("y".repeat(100), at);
-			writer.append("z", at);
-			const names = readdirSync(dir).sort();
-			expect(names).toEqual(["thinkrail-2026-01-28.log", "thinkrail-2026-01-28_1.log"]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
+	test("renders readable stderr text", async () => {
+		const sink = new StringSink();
+		const prettyStream = pretty(createPrettyOptions(sink));
+		const log = pino(createPinoOptions("info"), prettyStream).child({ scope: "host" });
+
+		log.info("listening");
+		await Bun.sleep(10);
+		prettyStream.end();
+
+		expect(sink.value).toContain("INFO");
+		expect(sink.value).toContain("[host] listening");
+		expect(sink.value).not.toContain("schemaVersion");
+	});
+});
+
+describe("error normalization", () => {
+	test("keeps only the stable Error fields", () => {
+		const error = Object.assign(new Error("boom"), { token: "secret" });
+		const serialized = serializeLogError(error);
+		expect(serialized).toMatchObject({ type: "Error", message: "boom" });
+		expect(serialized).not.toHaveProperty("token");
 	});
 
-	test("switches file on day change", () => {
-		const dir = tempLogsDir();
-		try {
-			const writer = new LogFileWriter(dir, 1024, 14);
-			writer.append("today", new Date("2026-01-28T23:59:59.000Z"));
-			writer.append("tomorrow", new Date("2026-01-29T00:00:01.000Z"));
-			expect(readdirSync(dir).sort()).toEqual([
-				"thinkrail-2026-01-28.log",
-				"thinkrail-2026-01-29.log",
-			]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	test("resumes the highest existing sequence on open and honors its size", () => {
-		const dir = tempLogsDir();
-		try {
-			mkdirSync(dir, { recursive: true });
-			writeFileSync(join(dir, "thinkrail-2026-01-28.log"), "old\n");
-			writeFileSync(join(dir, "thinkrail-2026-01-28_1.log"), "w".repeat(64));
-			const writer = new LogFileWriter(dir, 64, 14);
-			writer.append("fresh", new Date("2026-01-28T12:00:00.000Z"));
-			expect(readdirSync(dir).sort()).toEqual([
-				"thinkrail-2026-01-28.log",
-				"thinkrail-2026-01-28_1.log",
-				"thinkrail-2026-01-28_2.log",
-			]);
-			expect(readFileSync(join(dir, "thinkrail-2026-01-28_2.log"), "utf8")).toBe("fresh\n");
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	test("sweeps files older than retention on open, keeping the boundary day and crash.log", () => {
-		const dir = tempLogsDir();
-		try {
-			mkdirSync(dir, { recursive: true });
-			writeFileSync(join(dir, "thinkrail-2026-01-10.log"), "ancient\n");
-			writeFileSync(join(dir, "thinkrail-2026-01-14.log"), "boundary\n");
-			writeFileSync(join(dir, "crash.log"), "fatal\n");
-			const writer = new LogFileWriter(dir, 1024, 14);
-			writer.append("hello", new Date("2026-01-28T12:00:00.000Z"));
-			expect(readdirSync(dir).sort()).toEqual([
-				"crash.log",
-				"thinkrail-2026-01-14.log",
-				"thinkrail-2026-01-28.log",
-			]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
+	test("renders non-Error throws without throwing", () => {
+		expect(serializeLogError("odd")).toEqual({
+			type: "NonError",
+			message: "Non-Error thrown: odd",
+		});
+		expect(describeError({ reason: "odd" })).toBe('Non-Error thrown: {"reason":"odd"}');
 	});
 });

--- a/packages/server/src/log/logging.ts
+++ b/packages/server/src/log/logging.ts
@@ -1,7 +1,6 @@
 /// <reference path="./pino-roll.d.ts" />
 
 import { join } from "node:path";
-import { format } from "node:util";
 import pino, { type LoggerOptions, type Logger as PinoLogger } from "pino";
 import pretty from "pino-pretty";
 import buildPinoRoll, { type PinoRollOptions, type PinoRollStream } from "pino-roll";
@@ -131,15 +130,12 @@ export function createPinoRollOptions(directory: string): PinoRollOptions {
 
 let currentLevel: LogLevel = "info";
 let applicationLogger: PinoLogger | null = null;
-let consoleFileLogger: PinoLogger | null = null;
 let rollingStream: PinoRollStream | null = null;
 let initialization: Promise<void> | null = null;
-let teeInstalled = false;
 
 export function setLogLevel(level: LogLevel): void {
 	currentLevel = level;
 	if (applicationLogger) applicationLogger.level = level;
-	if (consoleFileLogger) consoleFileLogger.level = level;
 }
 
 function writeDirectStderr(line: string): void {
@@ -183,13 +179,6 @@ function emit(level: LogLevel, scope: string, message: string, error?: unknown):
 	}
 }
 
-function emitFileOnly(level: LogLevel, scope: string, message: string): void {
-	if (!shouldLog(level, currentLevel) || !consoleFileLogger) return;
-	try {
-		writeWithPino(consoleFileLogger, level, scope, message);
-	} catch {}
-}
-
 export interface Logger {
 	debug(message: string, error?: unknown): void;
 	info(message: string, error?: unknown): void;
@@ -204,29 +193,6 @@ export function logger(scope: string): Logger {
 		warn: (message, error?) => emit("warn", scope, message, error),
 		error: (message, error?) => emit("error", scope, message, error),
 	};
-}
-
-const CONSOLE_TEE: ReadonlyArray<readonly ["debug" | "log" | "info" | "warn" | "error", LogLevel]> =
-	[
-		["debug", "debug"],
-		["log", "info"],
-		["info", "info"],
-		["warn", "warn"],
-		["error", "error"],
-	];
-
-function installConsoleTee(): void {
-	if (teeInstalled) return;
-	teeInstalled = true;
-	for (const [method, level] of CONSOLE_TEE) {
-		const original = console[method].bind(console);
-		console[method] = (...args: unknown[]) => {
-			original(...args);
-			try {
-				emitFileOnly(level, "console", format(...args));
-			} catch {}
-		};
-	}
 }
 
 function reportDestinationError(error: unknown): void {
@@ -273,8 +239,6 @@ async function initializeLogging(
 				{ level: "debug", stream: rollingStream },
 			]),
 		);
-		consoleFileLogger = pino(createPinoOptions(currentLevel), rollingStream);
-		installConsoleTee();
 	} catch (error) {
 		reportDestinationError(error);
 	}

--- a/packages/server/src/log/logging.ts
+++ b/packages/server/src/log/logging.ts
@@ -5,6 +5,7 @@ import { format } from "node:util";
 import pino, { type LoggerOptions, type Logger as PinoLogger } from "pino";
 import pretty from "pino-pretty";
 import buildPinoRoll, { type PinoRollOptions, type PinoRollStream } from "pino-roll";
+import { removeOldFiles } from "pino-roll/lib/utils.js";
 import { dataDir } from "../persistence";
 
 export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
@@ -12,6 +13,7 @@ export type LogLevel = (typeof LOG_LEVELS)[number];
 
 export const LOG_SCHEMA_VERSION = 1;
 export const LOG_RETENTION_FILES = 14;
+export const LOG_TOTAL_FILES = LOG_RETENTION_FILES + 1;
 export const LOG_FILE_SIZE = "10m";
 
 const SECRET_PATHS = [
@@ -121,7 +123,7 @@ export function createPinoRollOptions(directory: string): PinoRollOptions {
 		frequency: "daily",
 		size: LOG_FILE_SIZE,
 		dateFormat: "yyyy-MM-dd",
-		limit: { count: LOG_RETENTION_FILES, removeOtherLogFiles: true },
+		limit: { count: LOG_TOTAL_FILES, removeOtherLogFiles: true },
 		mkdir: true,
 		sync: true,
 	};
@@ -231,6 +233,16 @@ function reportDestinationError(error: unknown): void {
 	writeDirectStderr(fallbackLine("error", "log", "logging destination failed", error));
 }
 
+export async function cleanManagedLogs(directory: string): Promise<void> {
+	await removeOldFiles({
+		baseFile: join(directory, "thinkrail"),
+		count: LOG_TOTAL_FILES,
+		dateFormat: "yyyy-MM-dd",
+		extension: "jsonl",
+		removeOtherLogFiles: true,
+	});
+}
+
 export function logsDir(): string {
 	return join(dataDir(), "logs");
 }
@@ -247,6 +259,11 @@ async function initializeLogging(
 	try {
 		rollingStream = await buildPinoRoll(createPinoRollOptions(logsDir()));
 		rollingStream.on("error", reportDestinationError);
+		try {
+			await cleanManagedLogs(logsDir());
+		} catch (error) {
+			reportDestinationError(error);
+		}
 		const prettyStderr = pretty(createPrettyOptions());
 		prettyStderr.on("error", reportDestinationError);
 		applicationLogger = pino(
@@ -264,9 +281,7 @@ async function initializeLogging(
 
 	const log = logger("log");
 	if (invalidEnv) {
-		log.warn(
-			`THINKRAIL_LOG_LEVEL=${process.env.THINKRAIL_LOG_LEVEL} is not a level (debug|info|warn|error); using info`,
-		);
+		log.warn("THINKRAIL_LOG_LEVEL is not a level (debug|info|warn|error); using info");
 	}
 	log.info(
 		`logging to ${logsDir()} (thinkrail ${appVersion ?? "source"}, pid ${process.pid}, level ${currentLevel})`,

--- a/packages/server/src/log/logging.ts
+++ b/packages/server/src/log/logging.ts
@@ -1,16 +1,39 @@
-import { appendFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+/// <reference path="./pino-roll.d.ts" />
+
 import { join } from "node:path";
 import { format } from "node:util";
+import pino, { type LoggerOptions, type Logger as PinoLogger } from "pino";
+import pretty from "pino-pretty";
+import buildPinoRoll, { type PinoRollOptions, type PinoRollStream } from "pino-roll";
 import { dataDir } from "../persistence";
 
 export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
 export type LogLevel = (typeof LOG_LEVELS)[number];
 
-export const MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
-export const LOG_RETENTION_DAYS = 14;
+export const LOG_SCHEMA_VERSION = 1;
+export const LOG_RETENTION_FILES = 14;
+export const LOG_FILE_SIZE = "10m";
 
-const LOG_FILE_RE = /^thinkrail-(\d{4}-\d{2}-\d{2})(?:_(\d+))?\.log$/;
-const DAY_MS = 86_400_000;
+const SECRET_PATHS = [
+	"password",
+	"token",
+	"accessToken",
+	"refreshToken",
+	"apiKey",
+	"api_key",
+	"authorization",
+	"cookie",
+	"headers.authorization",
+	"headers.cookie",
+	"*.password",
+	"*.token",
+	"*.accessToken",
+	"*.refreshToken",
+	"*.apiKey",
+	"*.api_key",
+	"*.authorization",
+	"*.cookie",
+];
 
 export function isLogLevel(value: string): value is LogLevel {
 	return (LOG_LEVELS as readonly string[]).includes(value);
@@ -30,42 +53,6 @@ export function resolveLogLevel(
 	return { level: "info", invalidEnv: true };
 }
 
-export function logDay(at: Date): string {
-	return at.toISOString().slice(0, 10);
-}
-
-export function logFileName(day: string, sequence: number): string {
-	return sequence === 0 ? `thinkrail-${day}.log` : `thinkrail-${day}_${sequence}.log`;
-}
-
-export function parseLogFileName(name: string): { day: string; sequence: number } | null {
-	const match = LOG_FILE_RE.exec(name);
-	if (!match?.[1]) return null;
-	return { day: match[1], sequence: match[2] ? Number(match[2]) : 0 };
-}
-
-export function latestLogSequence(names: readonly string[], day: string): number | null {
-	let latest: number | null = null;
-	for (const name of names) {
-		const parsed = parseLogFileName(name);
-		if (parsed?.day !== day) continue;
-		if (latest === null || parsed.sequence > latest) latest = parsed.sequence;
-	}
-	return latest;
-}
-
-export function selectRetentionVictims(
-	names: readonly string[],
-	today: string,
-	retentionDays: number,
-): string[] {
-	const cutoff = Date.parse(`${today}T00:00:00Z`) - retentionDays * DAY_MS;
-	return names.filter((name) => {
-		const parsed = parseLogFileName(name);
-		return parsed !== null && Date.parse(`${parsed.day}T00:00:00Z`) < cutoff;
-	});
-}
-
 export function describeError(error: unknown): string {
 	try {
 		if (error instanceof Error) {
@@ -82,101 +69,123 @@ export function describeError(error: unknown): string {
 	}
 }
 
-export function formatLogLine(
-	at: Date,
-	level: LogLevel,
-	scope: string,
-	message: string,
-	error?: unknown,
-): string {
-	const base = `${at.toISOString()} ${level.toUpperCase().padEnd(5)} [${scope}] ${message}`;
-	if (error === undefined) return base;
-	const rendered = describeError(error)
-		.split("\n")
-		.map((line) => `  ${line}`)
-		.join("\n");
-	return `${base}\n${rendered}`;
+export interface StructuredLogError {
+	type: string;
+	message: string;
+	stack?: string;
 }
 
-export class LogFileWriter {
-	private day = "";
-	private sequence = 0;
-	private bytes = 0;
-	private opened = false;
-
-	constructor(
-		private readonly dir: string,
-		private readonly maxFileBytes = MAX_LOG_FILE_BYTES,
-		private readonly retentionDays = LOG_RETENTION_DAYS,
-	) {}
-
-	append(line: string, at = new Date()): void {
-		const day = logDay(at);
-		if (!this.opened || day !== this.day) this.open(day);
-		const record = `${line}\n`;
-		const recordBytes = Buffer.byteLength(record);
-		if (this.bytes > 0 && this.bytes + recordBytes > this.maxFileBytes) {
-			this.sequence += 1;
-			this.bytes = 0;
-		}
-		appendFileSync(this.path(), record);
-		this.bytes += recordBytes;
-	}
-
-	path(): string {
-		return join(this.dir, logFileName(this.day, this.sequence));
-	}
-
-	private open(day: string): void {
-		mkdirSync(this.dir, { recursive: true });
-		const names = readdirSync(this.dir);
-		this.day = day;
-		this.sequence = latestLogSequence(names, day) ?? 0;
-		this.bytes = fileSize(this.path());
-		if (this.bytes >= this.maxFileBytes) {
-			this.sequence += 1;
-			this.bytes = 0;
-		}
-		this.opened = true;
-		for (const victim of selectRetentionVictims(names, day, this.retentionDays)) {
-			try {
-				unlinkSync(join(this.dir, victim));
-			} catch {}
-		}
-	}
-}
-
-function fileSize(path: string): number {
+export function serializeLogError(error: unknown): StructuredLogError {
 	try {
-		return statSync(path).size;
-	} catch {
-		return 0;
-	}
+		if (error instanceof Error) {
+			return {
+				type: error.name || "Error",
+				message: error.message,
+				...(typeof error.stack === "string" && error.stack ? { stack: error.stack } : {}),
+			};
+		}
+	} catch {}
+	return { type: "NonError", message: describeError(error) };
+}
+
+export function createPinoOptions(level: LogLevel): LoggerOptions {
+	return {
+		base: { schemaVersion: LOG_SCHEMA_VERSION },
+		formatters: {
+			level: (label, number) => ({ level: number, levelName: label }),
+		},
+		level,
+		redact: { paths: SECRET_PATHS, remove: true },
+		serializers: { err: (error) => error },
+		timestamp: pino.stdTimeFunctions.isoTime,
+	};
+}
+
+type PrettyOptions = NonNullable<Parameters<typeof pretty>[0]>;
+
+export function createPrettyOptions(destination: PrettyOptions["destination"] = 2): PrettyOptions {
+	return {
+		colorize: false,
+		destination,
+		ignore: "pid,hostname,scope,levelName,schemaVersion",
+		messageFormat: "[{scope}] {msg}",
+		singleLine: true,
+		sync: true,
+		translateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss.l'Z'",
+	};
+}
+
+export function createPinoRollOptions(directory: string): PinoRollOptions {
+	return {
+		file: join(directory, "thinkrail.jsonl"),
+		frequency: "daily",
+		size: LOG_FILE_SIZE,
+		dateFormat: "yyyy-MM-dd",
+		limit: { count: LOG_RETENTION_FILES, removeOtherLogFiles: true },
+		mkdir: true,
+		sync: true,
+	};
 }
 
 let currentLevel: LogLevel = "info";
-let writer: LogFileWriter | null = null;
-let initialized = false;
+let applicationLogger: PinoLogger | null = null;
+let consoleFileLogger: PinoLogger | null = null;
+let rollingStream: PinoRollStream | null = null;
+let initialization: Promise<void> | null = null;
 let teeInstalled = false;
 
 export function setLogLevel(level: LogLevel): void {
 	currentLevel = level;
+	if (applicationLogger) applicationLogger.level = level;
+	if (consoleFileLogger) consoleFileLogger.level = level;
 }
 
-function writeToFile(line: string): void {
-	if (!writer) return;
+function writeDirectStderr(line: string): void {
 	try {
-		writer.append(line);
+		process.stderr.write(`${line}\n`);
 	} catch {}
+}
+
+function fallbackLine(level: LogLevel, scope: string, message: string, error?: unknown): string {
+	const line = `${new Date().toISOString()} ${level.toUpperCase()} [${scope}] ${message}`;
+	if (error === undefined) return line;
+	return `${line}\n${describeError(error)
+		.split("\n")
+		.map((part) => `  ${part}`)
+		.join("\n")}`;
+}
+
+function writeWithPino(
+	root: PinoLogger,
+	level: LogLevel,
+	scope: string,
+	message: string,
+	error?: unknown,
+): void {
+	const target = root.child({ scope });
+	const method = target[level].bind(target);
+	if (error === undefined) method(message);
+	else method({ err: serializeLogError(error) }, message);
 }
 
 function emit(level: LogLevel, scope: string, message: string, error?: unknown): void {
 	if (!shouldLog(level, currentLevel)) return;
-	const line = formatLogLine(new Date(), level, scope, message, error);
+	if (!applicationLogger) {
+		writeDirectStderr(fallbackLine(level, scope, message, error));
+		return;
+	}
 	try {
-		process.stderr.write(`${line}\n`);
+		writeWithPino(applicationLogger, level, scope, message, error);
+	} catch {
+		writeDirectStderr(fallbackLine(level, scope, message, error));
+	}
+}
+
+function emitFileOnly(level: LogLevel, scope: string, message: string): void {
+	if (!shouldLog(level, currentLevel) || !consoleFileLogger) return;
+	try {
+		writeWithPino(consoleFileLogger, level, scope, message);
 	} catch {}
-	writeToFile(line);
 }
 
 export interface Logger {
@@ -211,10 +220,15 @@ function installConsoleTee(): void {
 		const original = console[method].bind(console);
 		console[method] = (...args: unknown[]) => {
 			original(...args);
-			if (!shouldLog(level, currentLevel)) return;
-			writeToFile(formatLogLine(new Date(), level, "console", format(...args)));
+			try {
+				emitFileOnly(level, "console", format(...args));
+			} catch {}
 		};
 	}
+}
+
+function reportDestinationError(error: unknown): void {
+	writeDirectStderr(fallbackLine("error", "log", "logging destination failed", error));
 }
 
 export function logsDir(): string {
@@ -226,13 +240,28 @@ export interface InitLoggingOptions {
 	appVersion?: string;
 }
 
-export function initLogging(options: InitLoggingOptions = {}): void {
-	const { level, invalidEnv } = resolveLogLevel(options.level, process.env.THINKRAIL_LOG_LEVEL);
-	setLogLevel(level);
-	if (initialized) return;
-	initialized = true;
-	writer = new LogFileWriter(logsDir());
-	installConsoleTee();
+async function initializeLogging(
+	appVersion: string | undefined,
+	invalidEnv: boolean,
+): Promise<void> {
+	try {
+		rollingStream = await buildPinoRoll(createPinoRollOptions(logsDir()));
+		rollingStream.on("error", reportDestinationError);
+		const prettyStderr = pretty(createPrettyOptions());
+		prettyStderr.on("error", reportDestinationError);
+		applicationLogger = pino(
+			createPinoOptions(currentLevel),
+			pino.multistream([
+				{ level: "debug", stream: prettyStderr },
+				{ level: "debug", stream: rollingStream },
+			]),
+		);
+		consoleFileLogger = pino(createPinoOptions(currentLevel), rollingStream);
+		installConsoleTee();
+	} catch (error) {
+		reportDestinationError(error);
+	}
+
 	const log = logger("log");
 	if (invalidEnv) {
 		log.warn(
@@ -240,6 +269,13 @@ export function initLogging(options: InitLoggingOptions = {}): void {
 		);
 	}
 	log.info(
-		`logging to ${logsDir()} (thinkrail ${options.appVersion ?? "source"}, pid ${process.pid}, level ${level})`,
+		`logging to ${logsDir()} (thinkrail ${appVersion ?? "source"}, pid ${process.pid}, level ${currentLevel})`,
 	);
+}
+
+export async function initLogging(options: InitLoggingOptions = {}): Promise<void> {
+	const { level, invalidEnv } = resolveLogLevel(options.level, process.env.THINKRAIL_LOG_LEVEL);
+	setLogLevel(level);
+	initialization ??= initializeLogging(options.appVersion, invalidEnv);
+	await initialization;
 }

--- a/packages/server/src/log/logging.ts
+++ b/packages/server/src/log/logging.ts
@@ -248,7 +248,7 @@ async function initializeLogging(
 		log.warn("THINKRAIL_LOG_LEVEL is not a level (debug|info|warn|error); using info");
 	}
 	log.info(
-		`logging to ${logsDir()} (thinkrail ${appVersion ?? "source"}, pid ${process.pid}, level ${currentLevel})`,
+		`logging initialized (thinkrail ${appVersion ?? "source"}, pid ${process.pid}, level ${currentLevel})`,
 	);
 }
 

--- a/packages/server/src/log/logging.ts
+++ b/packages/server/src/log/logging.ts
@@ -1,0 +1,245 @@
+import { appendFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { format } from "node:util";
+import { dataDir } from "../persistence";
+
+export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+export const MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
+export const LOG_RETENTION_DAYS = 14;
+
+const LOG_FILE_RE = /^thinkrail-(\d{4}-\d{2}-\d{2})(?:_(\d+))?\.log$/;
+const DAY_MS = 86_400_000;
+
+export function isLogLevel(value: string): value is LogLevel {
+	return (LOG_LEVELS as readonly string[]).includes(value);
+}
+
+export function shouldLog(level: LogLevel, threshold: LogLevel): boolean {
+	return LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(threshold);
+}
+
+export function resolveLogLevel(
+	option: LogLevel | undefined,
+	env: string | undefined,
+): { level: LogLevel; invalidEnv: boolean } {
+	if (option) return { level: option, invalidEnv: false };
+	if (env === undefined || env === "") return { level: "info", invalidEnv: false };
+	if (isLogLevel(env)) return { level: env, invalidEnv: false };
+	return { level: "info", invalidEnv: true };
+}
+
+export function logDay(at: Date): string {
+	return at.toISOString().slice(0, 10);
+}
+
+export function logFileName(day: string, sequence: number): string {
+	return sequence === 0 ? `thinkrail-${day}.log` : `thinkrail-${day}_${sequence}.log`;
+}
+
+export function parseLogFileName(name: string): { day: string; sequence: number } | null {
+	const match = LOG_FILE_RE.exec(name);
+	if (!match?.[1]) return null;
+	return { day: match[1], sequence: match[2] ? Number(match[2]) : 0 };
+}
+
+export function latestLogSequence(names: readonly string[], day: string): number | null {
+	let latest: number | null = null;
+	for (const name of names) {
+		const parsed = parseLogFileName(name);
+		if (parsed?.day !== day) continue;
+		if (latest === null || parsed.sequence > latest) latest = parsed.sequence;
+	}
+	return latest;
+}
+
+export function selectRetentionVictims(
+	names: readonly string[],
+	today: string,
+	retentionDays: number,
+): string[] {
+	const cutoff = Date.parse(`${today}T00:00:00Z`) - retentionDays * DAY_MS;
+	return names.filter((name) => {
+		const parsed = parseLogFileName(name);
+		return parsed !== null && Date.parse(`${parsed.day}T00:00:00Z`) < cutoff;
+	});
+}
+
+export function describeError(error: unknown): string {
+	try {
+		if (error instanceof Error) {
+			const { stack } = error;
+			return typeof stack === "string" && stack ? stack : `${error.name}: ${error.message}`;
+		}
+		if (typeof error === "string") return `Non-Error thrown: ${error}`;
+		return `Non-Error thrown: ${JSON.stringify(error) ?? String(error)}`;
+	} catch {}
+	try {
+		return `Unrenderable throw: ${String(error)}`;
+	} catch {
+		return `Unrenderable throw (${typeof error})`;
+	}
+}
+
+export function formatLogLine(
+	at: Date,
+	level: LogLevel,
+	scope: string,
+	message: string,
+	error?: unknown,
+): string {
+	const base = `${at.toISOString()} ${level.toUpperCase().padEnd(5)} [${scope}] ${message}`;
+	if (error === undefined) return base;
+	const rendered = describeError(error)
+		.split("\n")
+		.map((line) => `  ${line}`)
+		.join("\n");
+	return `${base}\n${rendered}`;
+}
+
+export class LogFileWriter {
+	private day = "";
+	private sequence = 0;
+	private bytes = 0;
+	private opened = false;
+
+	constructor(
+		private readonly dir: string,
+		private readonly maxFileBytes = MAX_LOG_FILE_BYTES,
+		private readonly retentionDays = LOG_RETENTION_DAYS,
+	) {}
+
+	append(line: string, at = new Date()): void {
+		const day = logDay(at);
+		if (!this.opened || day !== this.day) this.open(day);
+		const record = `${line}\n`;
+		const recordBytes = Buffer.byteLength(record);
+		if (this.bytes > 0 && this.bytes + recordBytes > this.maxFileBytes) {
+			this.sequence += 1;
+			this.bytes = 0;
+		}
+		appendFileSync(this.path(), record);
+		this.bytes += recordBytes;
+	}
+
+	path(): string {
+		return join(this.dir, logFileName(this.day, this.sequence));
+	}
+
+	private open(day: string): void {
+		mkdirSync(this.dir, { recursive: true });
+		const names = readdirSync(this.dir);
+		this.day = day;
+		this.sequence = latestLogSequence(names, day) ?? 0;
+		this.bytes = fileSize(this.path());
+		if (this.bytes >= this.maxFileBytes) {
+			this.sequence += 1;
+			this.bytes = 0;
+		}
+		this.opened = true;
+		for (const victim of selectRetentionVictims(names, day, this.retentionDays)) {
+			try {
+				unlinkSync(join(this.dir, victim));
+			} catch {}
+		}
+	}
+}
+
+function fileSize(path: string): number {
+	try {
+		return statSync(path).size;
+	} catch {
+		return 0;
+	}
+}
+
+let currentLevel: LogLevel = "info";
+let writer: LogFileWriter | null = null;
+let initialized = false;
+let teeInstalled = false;
+
+export function setLogLevel(level: LogLevel): void {
+	currentLevel = level;
+}
+
+function writeToFile(line: string): void {
+	if (!writer) return;
+	try {
+		writer.append(line);
+	} catch {}
+}
+
+function emit(level: LogLevel, scope: string, message: string, error?: unknown): void {
+	if (!shouldLog(level, currentLevel)) return;
+	const line = formatLogLine(new Date(), level, scope, message, error);
+	try {
+		process.stderr.write(`${line}\n`);
+	} catch {}
+	writeToFile(line);
+}
+
+export interface Logger {
+	debug(message: string, error?: unknown): void;
+	info(message: string, error?: unknown): void;
+	warn(message: string, error?: unknown): void;
+	error(message: string, error?: unknown): void;
+}
+
+export function logger(scope: string): Logger {
+	return {
+		debug: (message, error?) => emit("debug", scope, message, error),
+		info: (message, error?) => emit("info", scope, message, error),
+		warn: (message, error?) => emit("warn", scope, message, error),
+		error: (message, error?) => emit("error", scope, message, error),
+	};
+}
+
+const CONSOLE_TEE: ReadonlyArray<readonly ["debug" | "log" | "info" | "warn" | "error", LogLevel]> =
+	[
+		["debug", "debug"],
+		["log", "info"],
+		["info", "info"],
+		["warn", "warn"],
+		["error", "error"],
+	];
+
+function installConsoleTee(): void {
+	if (teeInstalled) return;
+	teeInstalled = true;
+	for (const [method, level] of CONSOLE_TEE) {
+		const original = console[method].bind(console);
+		console[method] = (...args: unknown[]) => {
+			original(...args);
+			if (!shouldLog(level, currentLevel)) return;
+			writeToFile(formatLogLine(new Date(), level, "console", format(...args)));
+		};
+	}
+}
+
+export function logsDir(): string {
+	return join(dataDir(), "logs");
+}
+
+export interface InitLoggingOptions {
+	level?: LogLevel;
+	appVersion?: string;
+}
+
+export function initLogging(options: InitLoggingOptions = {}): void {
+	const { level, invalidEnv } = resolveLogLevel(options.level, process.env.THINKRAIL_LOG_LEVEL);
+	setLogLevel(level);
+	if (initialized) return;
+	initialized = true;
+	writer = new LogFileWriter(logsDir());
+	installConsoleTee();
+	const log = logger("log");
+	if (invalidEnv) {
+		log.warn(
+			`THINKRAIL_LOG_LEVEL=${process.env.THINKRAIL_LOG_LEVEL} is not a level (debug|info|warn|error); using info`,
+		);
+	}
+	log.info(
+		`logging to ${logsDir()} (thinkrail ${options.appVersion ?? "source"}, pid ${process.pid}, level ${level})`,
+	);
+}

--- a/packages/server/src/log/pino-roll.d.ts
+++ b/packages/server/src/log/pino-roll.d.ts
@@ -23,3 +23,15 @@ declare module "pino-roll" {
 
 	export default function buildPinoRoll(options: PinoRollOptions): Promise<PinoRollStream>;
 }
+
+declare module "pino-roll/lib/utils.js" {
+	export interface RemoveOldFilesOptions {
+		baseFile: string;
+		count: number;
+		dateFormat?: string;
+		extension?: string;
+		removeOtherLogFiles: true;
+	}
+
+	export function removeOldFiles(options: RemoveOldFilesOptions): Promise<void>;
+}

--- a/packages/server/src/log/pino-roll.d.ts
+++ b/packages/server/src/log/pino-roll.d.ts
@@ -1,0 +1,25 @@
+declare module "pino-roll" {
+	import type { DestinationStream } from "pino";
+
+	export interface PinoRollLimitOptions {
+		count: number;
+		removeOtherLogFiles?: boolean;
+	}
+
+	export interface PinoRollOptions {
+		file: string | (() => string);
+		size?: string | number;
+		frequency?: "daily" | "hourly" | "weekly" | number;
+		dateFormat?: string;
+		limit?: PinoRollLimitOptions;
+		mkdir?: boolean;
+		sync?: boolean;
+	}
+
+	export interface PinoRollStream extends DestinationStream {
+		on(event: "error", listener: (error: Error) => void): this;
+		end(): void;
+	}
+
+	export default function buildPinoRoll(options: PinoRollOptions): Promise<PinoRollStream>;
+}

--- a/packages/server/src/reviews/SPEC.md
+++ b/packages/server/src/reviews/SPEC.md
@@ -139,7 +139,7 @@ lands can still finish its record; archived updates persist without publishing a
   `buildSendPackage`, `removeWorkspaceReviews`, `setReviewPublisher` (+ the pure
   anchoring/render helpers: `reanchor`, `buildTextQuote`, `hashContent`, `lineRangeOf`, `textQuoteOf`,
   `renderPackage`).
-- **Allowed deps:** `contracts` (types), `persistence` (data dir), `workspaces` (worktree path lookup),
+- **Allowed deps:** `contracts` (types), `persistence` (data dir), `log`, `workspaces` (worktree path lookup),
   `git` (the review's `baseSha` resolve, the diff range behind a base anchor's `baseRef`, and blob
   reads for the base side), Node `fs`/`crypto`.
 - **Forbidden:** importing `host`/`agent` or any pi package; publishing except through the seam.

--- a/packages/server/src/reviews/reviews.test.ts
+++ b/packages/server/src/reviews/reviews.test.ts
@@ -26,6 +26,7 @@ import {
 	reanchorWorkspace,
 	removeWorkspaceReviews,
 	resolveCommentFromAgent,
+	reviewReadFailure,
 	reviewSessionKey,
 	rollbackSend,
 	sendableComments,
@@ -430,7 +431,12 @@ test("a DAMAGED review file is refused, never replaced — the comments stay on 
 	const file = join(dataDir, "reviews", `${WS_ID}.json`);
 	const intact = readFileSync(file, "utf8");
 	writeFileSync(file, intact.slice(0, Math.floor(intact.length / 2)));
-	expect(() => getReviewSnapshot(WS_ID)).toThrow(/damaged/);
+	try {
+		getReviewSnapshot(WS_ID);
+		expect.unreachable();
+	} catch (error) {
+		expect(reviewReadFailure(error)).toBe("damaged");
+	}
 	expect(() => clearReview(WS_ID)).toThrow(/damaged/);
 	expect(readFileSync(file, "utf8")).not.toContain('"comments": []');
 	writeFileSync(file, intact);
@@ -442,8 +448,19 @@ test("an unreadable review file fails the read instead of starting an empty revi
 	const file = join(dataDir, "reviews", `${WS_ID}.json`);
 	rmSync(file);
 	mkdirSync(file);
-	expect(() => getReviewSnapshot(WS_ID)).toThrow();
+	try {
+		getReviewSnapshot(WS_ID);
+		expect.unreachable();
+	} catch (error) {
+		expect(reviewReadFailure(error)).toBe("not a file");
+	}
 	expect(statSync(file).isDirectory()).toBe(true);
+});
+
+test("review read diagnostics keep filesystem messages out of their closed classification", () => {
+	const error = Object.assign(new Error("private path"), { code: "EACCES" });
+	expect(reviewReadFailure(error)).toBe("permission denied");
+	expect(reviewReadFailure(new Error("private path"))).toBe("read failure");
 });
 
 test("writes land atomically: a rename, and no temp file left behind", () => {

--- a/packages/server/src/reviews/reviews.ts
+++ b/packages/server/src/reviews/reviews.ts
@@ -19,10 +19,13 @@ import type {
 	ReviewSnapshot,
 } from "@thinkrail/contracts";
 import { diffBaseRef, readBlobAt, resolveCommitOid, resolveDiffRange } from "../git";
+import { logger } from "../log";
 import { dataDir } from "../persistence";
 import { getWorkspace } from "../workspaces";
 import { buildTextQuote, hashContent, lineRangeOf, reanchor, textQuoteOf } from "./anchoring";
 import { renderPackage } from "./packageRender";
+
+const log = logger("reviews");
 
 let publish: (payload: ReviewChangedPayload) => void = () => {};
 export function setReviewPublisher(fn: (payload: ReviewChangedPayload) => void): void {
@@ -114,7 +117,7 @@ function archivedReviewFiles(): string[] {
 				if (review.isFile() && review.name.endsWith(".json")) files.push(join(dir, review.name));
 			}
 		} catch (err) {
-			console.warn(
+			log.warn(
 				`review archive ${workspace.name}: ${err instanceof Error ? err.message : String(err)}`,
 			);
 		}
@@ -441,7 +444,7 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		try {
 			snapshot = load(workspaceId);
 		} catch (err) {
-			console.warn(`review ${workspaceId}: ${err instanceof Error ? err.message : String(err)}`);
+			log.warn(`review ${workspaceId}: ${err instanceof Error ? err.message : String(err)}`);
 			continue;
 		}
 		if (snapshot?.review.status !== "open") continue;
@@ -456,7 +459,7 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		try {
 			snapshot = readSnapshot(file);
 		} catch (err) {
-			console.warn(`review archive ${file}: ${err instanceof Error ? err.message : String(err)}`);
+			log.warn(`review archive ${file}: ${err instanceof Error ? err.message : String(err)}`);
 			continue;
 		}
 		if (snapshot?.review.status !== "closed") continue;

--- a/packages/server/src/reviews/reviews.ts
+++ b/packages/server/src/reviews/reviews.ts
@@ -116,10 +116,8 @@ function archivedReviewFiles(): string[] {
 			for (const review of readdirSync(dir, { withFileTypes: true })) {
 				if (review.isFile() && review.name.endsWith(".json")) files.push(join(dir, review.name));
 			}
-		} catch (err) {
-			log.warn(
-				`review archive ${workspace.name}: ${err instanceof Error ? err.message : String(err)}`,
-			);
+		} catch {
+			log.warn(`review archive could not be listed for workspace ${workspace.name}`);
 		}
 	}
 	return files;
@@ -443,8 +441,8 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		let snapshot: ReviewSnapshot | null = null;
 		try {
 			snapshot = load(workspaceId);
-		} catch (err) {
-			log.warn(`review ${workspaceId}: ${err instanceof Error ? err.message : String(err)}`);
+		} catch {
+			log.warn(`active review could not be read for workspace ${workspaceId}`);
 			continue;
 		}
 		if (snapshot?.review.status !== "open") continue;
@@ -458,8 +456,8 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		let snapshot: ReviewSnapshot | null = null;
 		try {
 			snapshot = readSnapshot(file);
-		} catch (err) {
-			log.warn(`review archive ${file}: ${err instanceof Error ? err.message : String(err)}`);
+		} catch {
+			log.warn("archived review could not be read");
 			continue;
 		}
 		if (snapshot?.review.status !== "closed") continue;

--- a/packages/server/src/reviews/reviews.ts
+++ b/packages/server/src/reviews/reviews.ts
@@ -38,8 +38,11 @@ function reviewsDir(): string {
 
 const SAFE_ID = /^[\w-]+$/;
 
+class InvalidReviewIdError extends Error {}
+class DamagedReviewFileError extends Error {}
+
 function assertSafeId(id: string, kind: "workspace" | "review"): void {
-	if (!SAFE_ID.test(id)) throw new Error(`Invalid ${kind} id: ${id}`);
+	if (!SAFE_ID.test(id)) throw new InvalidReviewIdError(`Invalid ${kind} id: ${id}`);
 }
 
 function reviewFile(workspaceId: string): string {
@@ -72,8 +75,19 @@ function readSnapshot(file: string): ReviewSnapshot | null {
 	try {
 		return JSON.parse(raw) as ReviewSnapshot;
 	} catch {
-		throw new Error(`Review file ${file} is damaged and was left in place — repair or remove it.`);
+		throw new DamagedReviewFileError(
+			`Review file ${file} is damaged and was left in place — repair or remove it.`,
+		);
 	}
+}
+
+export function reviewReadFailure(error: unknown): string {
+	if (error instanceof DamagedReviewFileError) return "damaged";
+	if (error instanceof InvalidReviewIdError) return "invalid id";
+	const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
+	if (code === "EACCES" || code === "EPERM") return "permission denied";
+	if (code === "EISDIR" || code === "ENOTDIR") return "not a file";
+	return "read failure";
 }
 
 function load(workspaceId: string): ReviewSnapshot | null {
@@ -442,7 +456,8 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		try {
 			snapshot = load(workspaceId);
 		} catch (error) {
-			log.warn(`active review could not be read for workspace ${workspaceId}`, error);
+			const target = SAFE_ID.test(workspaceId) ? ` for workspace ${workspaceId}` : "";
+			log.warn(`active review could not be read${target} (${reviewReadFailure(error)})`);
 			continue;
 		}
 		if (snapshot?.review.status !== "open") continue;
@@ -457,7 +472,7 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		try {
 			snapshot = readSnapshot(file);
 		} catch (error) {
-			log.warn("archived review could not be read", error);
+			log.warn(`archived review could not be read (${reviewReadFailure(error)})`);
 			continue;
 		}
 		if (snapshot?.review.status !== "closed") continue;

--- a/packages/server/src/reviews/reviews.ts
+++ b/packages/server/src/reviews/reviews.ts
@@ -441,8 +441,8 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		let snapshot: ReviewSnapshot | null = null;
 		try {
 			snapshot = load(workspaceId);
-		} catch {
-			log.warn(`active review could not be read for workspace ${workspaceId}`);
+		} catch (error) {
+			log.warn(`active review could not be read for workspace ${workspaceId}`, error);
 			continue;
 		}
 		if (snapshot?.review.status !== "open") continue;
@@ -456,8 +456,8 @@ export function resolveCommentFromAgent(commentId: string, note?: string): Revie
 		let snapshot: ReviewSnapshot | null = null;
 		try {
 			snapshot = readSnapshot(file);
-		} catch {
-			log.warn("archived review could not be read");
+		} catch (error) {
+			log.warn("archived review could not be read", error);
 			continue;
 		}
 		if (snapshot?.review.status !== "closed") continue;

--- a/packages/server/src/todos/SPEC.md
+++ b/packages/server/src/todos/SPEC.md
@@ -127,6 +127,6 @@ it resolves immediately when nothing is in flight, and never rejects.
   `gitCommitPaths` — the per-done-item delta commit; `gitHeadSha` — the baseline's head);
   `contracts` (DTOs + `PiEvent` for `isTodoToolEnd`); `@thinkrail/shared/paths` (`WORKSPACE_INTERNAL_DIR`
   — the app-state prefix filtered out of change sets); **`pi-todos/core`** (the pi-free read/write model — a sanctioned host-side
-  value-import of the extension package, the same pattern as `spec` → `pi-spec-graph/core`).
-- **Forbidden:** `host`; sibling features other than `workspaces` + `git`; `pi-todos`' extension entry or
+  value-import of the extension package, the same pattern as `spec` → `pi-spec-graph/core`); `log`.
+- **Forbidden:** `host`; sibling features other than `workspaces` + `git` + `log`; `pi-todos`' extension entry or
   `tools/` (pi-coupled); any pi package.

--- a/packages/server/src/todos/artifacts.ts
+++ b/packages/server/src/todos/artifacts.ts
@@ -2,6 +2,7 @@ import type { PiEvent } from "@thinkrail/contracts";
 import { WORKSPACE_INTERNAL_DIR } from "@thinkrail/shared/paths";
 import { type TodoArtifact, type TodoPlan, TodoStore } from "pi-todos/core";
 import { gitCommitPaths, gitHeadSha, gitStatus } from "../git";
+import { logger } from "../log";
 import { getWorkspace } from "../workspaces";
 import {
 	type Baseline,
@@ -10,6 +11,8 @@ import {
 	readBaselines,
 	writeBaselines,
 } from "./baselines";
+
+const log = logger("todos");
 
 export type CommitWindow = (opts: {
 	title: string;
@@ -67,7 +70,7 @@ function runReconcile(workspaceId: string, sessionId: string): void {
 			() => gitHeadSha(workspaceId),
 		);
 	} catch (err) {
-		console.warn(
+		log.warn(
 			`todo change-artifacts skipped (${workspaceId}/${sessionId}): ${err instanceof Error ? err.message : err}`,
 		);
 	}

--- a/packages/server/src/todos/artifacts.ts
+++ b/packages/server/src/todos/artifacts.ts
@@ -69,10 +69,8 @@ function runReconcile(workspaceId: string, sessionId: string): void {
 				gitCommitPaths(workspaceId, commitMessage(title, sessionId, todoId), paths),
 			() => gitHeadSha(workspaceId),
 		);
-	} catch (err) {
-		log.warn(
-			`todo change-artifacts skipped (${workspaceId}/${sessionId}): ${err instanceof Error ? err.message : err}`,
-		);
+	} catch {
+		log.warn(`todo change-artifacts skipped (${workspaceId}/${sessionId})`);
 	}
 }
 

--- a/packages/server/src/watch/SPEC.md
+++ b/packages/server/src/watch/SPEC.md
@@ -91,10 +91,10 @@ truth) and visible-panel polling (laggy, wasteful over Tailscale).
   deleted+recreated path leaves the old stream silently following a dead inode), **reaps zombie
   watchers** whose workspace record no longer exists (a resurrected path-based stream would keep
   publishing for a forgotten id), and **retries a failed start on the next read** (no sticky failure
-  marker). A watcher that errors mid-flight (ENOSPC, root deleted) is `console.warn`ed and dropped —
+  marker). A watcher that errors mid-flight (ENOSPC, root deleted) is warn-logged and dropped —
   panels fall back to read-on-demand until a later read re-creates it. No idle-stop in V1 (bounded by
   workspaces actually visited plus the capped prewarm tier).
 - **Public surface (barrel):** `ensureWatch`, `stopWatch`, `stopAllWatches`, `setWatchPublisher`,
   `setRepoMetaPublisher`, `setSkillPathClassifier`.
-- **Allowed deps:** `persistence` (workspace lookup); `contracts` (payload type); Bun/Node.
+- **Allowed deps:** `persistence` (workspace lookup), `log`; `contracts` (payload type); Bun/Node.
 - **Forbidden:** `host`; sibling features; any pi package.

--- a/packages/server/src/watch/watch.ts
+++ b/packages/server/src/watch/watch.ts
@@ -5,8 +5,11 @@ import type {
 	WorkspaceSkillChange,
 	WorkspaceWatchReadyResult,
 } from "@thinkrail/contracts";
+import { logger } from "../log";
 import { loadWorkspaces } from "../persistence";
 import { type Coalescer, createCoalescer } from "./coalesce";
+
+const log = logger("watch");
 
 const QUIET_MS = 300;
 const MAX_WAIT_MS = 1000;
@@ -72,14 +75,14 @@ function watchGitDir(
 			scheduleRepoMeta(workspaceId, rootWatcher);
 		});
 		watcher.on("error", (err) => {
-			console.warn(`git metadata watcher for ${workspaceId} failed: ${err}`);
+			log.warn(`git metadata watcher for ${workspaceId} failed: ${err}`);
 			watcher.close();
 			const entry = entries.get(workspaceId);
 			if (entry?.metaWatcher === watcher) entry.metaWatcher = null;
 		});
 		return watcher;
 	} catch (err) {
-		console.warn(`could not watch git metadata for ${workspaceId}: ${err}`);
+		log.warn(`could not watch git metadata for ${workspaceId}: ${err}`);
 		return null;
 	}
 }
@@ -187,7 +190,7 @@ export function ensureWatch(
 			coalescer.add(rel, skillChange);
 		});
 		watcher.on("error", (err) => {
-			console.warn(`worktree watcher for ${workspaceId} failed: ${err}`);
+			log.warn(`worktree watcher for ${workspaceId} failed: ${err}`);
 			stopWatch(workspaceId);
 		});
 		let resolveReady: (result: WorkspaceWatchReadyResult) => void = () => {};
@@ -222,7 +225,7 @@ export function ensureWatch(
 		return ready;
 	} catch (err) {
 		coalescer.dispose();
-		console.warn(`could not watch worktree for ${workspaceId}: ${err}`);
+		log.warn(`could not watch worktree for ${workspaceId}: ${err}`);
 		return startupFallback;
 	}
 }

--- a/packages/server/src/watch/watch.ts
+++ b/packages/server/src/watch/watch.ts
@@ -74,15 +74,15 @@ function watchGitDir(
 		const watcher = watch(gitDir, { recursive: false }, () => {
 			scheduleRepoMeta(workspaceId, rootWatcher);
 		});
-		watcher.on("error", (err) => {
-			log.warn(`git metadata watcher for ${workspaceId} failed: ${err}`);
+		watcher.on("error", () => {
+			log.warn(`git metadata watcher failed for workspace ${workspaceId}`);
 			watcher.close();
 			const entry = entries.get(workspaceId);
 			if (entry?.metaWatcher === watcher) entry.metaWatcher = null;
 		});
 		return watcher;
-	} catch (err) {
-		log.warn(`could not watch git metadata for ${workspaceId}: ${err}`);
+	} catch {
+		log.warn(`could not watch git metadata for workspace ${workspaceId}`);
 		return null;
 	}
 }
@@ -189,8 +189,8 @@ export function ensureWatch(
 							: "none";
 			coalescer.add(rel, skillChange);
 		});
-		watcher.on("error", (err) => {
-			log.warn(`worktree watcher for ${workspaceId} failed: ${err}`);
+		watcher.on("error", () => {
+			log.warn(`worktree watcher failed for workspace ${workspaceId}`);
 			stopWatch(workspaceId);
 		});
 		let resolveReady: (result: WorkspaceWatchReadyResult) => void = () => {};
@@ -223,9 +223,9 @@ export function ensureWatch(
 		const gitDir = resolveExternalGitDir(ws.worktreePath);
 		if (gitDir) entry.metaWatcher = watchGitDir(workspaceId, gitDir, watcher);
 		return ready;
-	} catch (err) {
+	} catch {
 		coalescer.dispose();
-		log.warn(`could not watch worktree for ${workspaceId}: ${err}`);
+		log.warn(`could not watch worktree for workspace ${workspaceId}`);
 		return startupFallback;
 	}
 }

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -163,6 +163,6 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`, `reclaimWorktree`, `removeWorkspace`,
   `workspaceDiffStats`, `getWorkspace`, `renameWorkspace`, `refreshUserOwnedWorkspace`,
   `ensureWorkspaceScratchDir`, `setWorkspacePublisher`, `WorkspaceLifecycleEvent`.
-- **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`; `contracts`;
+- **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`, `log`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -191,7 +191,7 @@ function applyFolderTruth(ws: Workspace, truth: { branch: string; baseBranch: st
 function diffStats(ws: Workspace): DiffStats | undefined {
 	const result = git(ws.worktreePath, changedFileArgs(resolveDiffRange(ws), "--shortstat"));
 	if (!result.ok) {
-		log.warn(`git diff --shortstat failed in ${ws.worktreePath}: ${result.err || "unknown error"}`);
+		log.warn(`git diff --shortstat failed for workspace ${ws.id}`);
 		return undefined;
 	}
 	if (!result.out) return { added: 0, removed: 0 };

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -19,8 +19,11 @@ import {
 	resolveDiffRange,
 	tryCurrentBranch,
 } from "../git";
+import { logger } from "../log";
 import { dataDir, loadProjects, loadWorkspaces, saveWorkspaces } from "../persistence";
 import { getProjects, listProjects } from "../projects";
+
+const log = logger("workspaces");
 
 export type WorkspaceLifecycleEvent =
 	| { kind: "created"; workspace: Workspace }
@@ -188,9 +191,7 @@ function applyFolderTruth(ws: Workspace, truth: { branch: string; baseBranch: st
 function diffStats(ws: Workspace): DiffStats | undefined {
 	const result = git(ws.worktreePath, changedFileArgs(resolveDiffRange(ws), "--shortstat"));
 	if (!result.ok) {
-		console.warn(
-			`git diff --shortstat failed in ${ws.worktreePath}: ${result.err || "unknown error"}`,
-		);
+		log.warn(`git diff --shortstat failed in ${ws.worktreePath}: ${result.err || "unknown error"}`);
 		return undefined;
 	}
 	if (!result.out) return { added: 0, removed: 0 };


### PR DESCRIPTION
## Summary

Add durable host diagnostics so ThinkRail keeps useful logs after the launching terminal is gone. Host-owned diagnostics use a scoped Pino facade; arbitrary pi, extension, and third-party `console.*` arguments stay terminal-only so sensitive project data cannot enter support files.

Durable output is schema-versioned JSONL for agent-led support analysis; terminal output stays human-readable.

## Changes

- Add the bounded `server/log` module backed by direct in-process Pino streams: `pino-pretty` for stderr and `pino-roll` for untouched JSONL files.
- Rotate daily and at 10 MB, retaining 14 rotated files plus the active file; invoke `pino-roll`'s pinned cleanup routine at startup so the bound also holds across low-volume restarts; keep the independent synchronous plain-text `crash.log` fatal path.
- Emit ISO timestamps, numeric and textual levels, scope, message, and normalized structured errors, with Pino field redaction as defense in depth; accept durable records only through explicit `logger(scope)` calls.
- Initialize process-level logging from `bootHost`, share error rendering with the crash log, and add debug traces for registered WS method names (unknown names use a fixed classification) and agent session lifecycle without logging protocol payloads, raw handler errors, or request-derived paths.
- Migrate server diagnostic `console.warn` calls to scoped loggers and route analytics delivery failures through debug logging.
- Add `thinkrail --verbose` plus `THINKRAIL_LOG_LEVEL=debug|info|warn|error` configuration.
- Document the module boundary and dependency edges; replace hand-rolled formatting/rotation tests with schema, redaction, level, pretty-output, roll-configuration, and error-normalization coverage.

## Testing

- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed (669 files)
- `bun run typecheck` — passed (10 packages)
- `bun run test` — passed (698 server tests; all 10 package tasks successful)
- `bun run e2e` — passed (258 no-agent browser tests across all 8 shards)
- `bun run build:binary && bun run smoke:binary` — passed
- `bun run e2e:binary` — passed (254 no-agent browser tests)
