### PR TITLE
fix(web): make the selected/hover fill visible in High Contrast Light

### DIFF
--- a/apps/web/src/styles/COLOR.md
+++ b/apps/web/src/styles/COLOR.md
@@ -142,18 +142,28 @@ escape hatch, or a second name for a value that already has one.
 - the committed generated files do not match what `colors.json` renders.
 
 `themes/schema.test.ts` additionally pins the **contrast floors**, and those deserve stating here
-because one tier is our judgement rather than the standard's:
+because two of the lines are our judgement rather than the standard's:
 
 - on every RESTING surface (`background`, `content`, `sidebar`, `header`, `elevated`, `input`) text
   meets WCAG AA in full — 4.5 for body and the `text-muted` tier;
 - the deliberately quiet `text-subtle` / `hint` tier remains visible at **3.0** on every resting surface;
-- on the transient HOVER surface the floor is **3.0**, not 4.5.
+- on the transient HOVER surface the floor is **3.0**, not 4.5;
+- the `hover` fill — the palette source of `control-bg-hovered` / `control-bg-selected` — stays
+  **distinguishable from** the surfaces interactive rows sit on: ≥ **1.15** against `background`,
+  `sidebar`, `header`, `elevated`. `content` and `input` are exempt — no hover/selected fill renders
+  on those canvases, and Light ships `hover == content` by design.
 
 WCAG has no "transient state" allowance, so the hover tier is a line we drew deliberately. These themes
 lift the row background toward the text colour on hover, and holding that to 4.5 would have forced a
 theme's signature accent toward a washed-out tint just to survive the hovered row. 3.0 keeps hovered
 text comfortably visible while leaving the themes recognisable.
 Revisit it if strict AA across every state ever becomes a requirement.
+
+The distinguishability floor is equally ours: WCAG has no adjacent-fill metric at all. It exists
+because High Contrast Light shipped `hover` at 1.05:1 against its own sidebar — selected
+project/workspace rows were indistinguishable from the panel — while every legibility check stayed
+green. 1.15 is the line that separates a visible selection from an invisible one; every bundled theme
+clears it (the weakest live pair is Light's hover-on-header at 1.154).
 
 `themes/runtime.test.ts` pins application; `themes/shiki.test.ts` pins the syntax-variable map. See [`themes/SPEC.md`](../themes/SPEC.md) for the manifest itself and
 [TYPOGRAPHY.md](./TYPOGRAPHY.md) for the parallel type system.

--- a/apps/web/src/styles/COLOR.md
+++ b/apps/web/src/styles/COLOR.md
@@ -149,9 +149,9 @@ because two of the lines are our judgement rather than the standard's:
 - the deliberately quiet `text-subtle` / `hint` tier remains visible at **3.0** on every resting surface;
 - on the transient HOVER surface the floor is **3.0**, not 4.5;
 - the `hover` fill — the palette source of `control-bg-hovered` / `control-bg-selected` — stays
-  **distinguishable from** the surfaces interactive rows sit on: ≥ **1.15** against `background`,
-  `sidebar`, `header`, `elevated`. `content` and `input` are exempt — no hover/selected fill renders
-  on those canvases, and Light ships `hover == content` by design.
+  **distinguishable from every resting surface**: ≥ **1.15** against all six. No canvas is exempt:
+  interactive fills reach each of them (the content canvas hosts PlanPane's rows and the workbench
+  backdrop's controls; `input` is the resting fill hovered controls swap away from).
 
 WCAG has no "transient state" allowance, so the hover tier is a line we drew deliberately. These themes
 lift the row background toward the text colour on hover, and holding that to 4.5 would have forced a
@@ -162,8 +162,10 @@ Revisit it if strict AA across every state ever becomes a requirement.
 The distinguishability floor is equally ours: WCAG has no adjacent-fill metric at all. It exists
 because High Contrast Light shipped `hover` at 1.05:1 against its own sidebar — selected
 project/workspace rows were indistinguishable from the panel — while every legibility check stayed
-green. 1.15 is the line that separates a visible selection from an invisible one; every bundled theme
-clears it (the weakest live pair is Light's hover-on-header at 1.154).
+green; review of that fix then found Light shipping `hover == content` outright, so PlanPane's
+hovered rows vanished the same way. 1.15 is the line that separates a visible fill from an invisible
+one; every bundled theme clears it on all six surfaces (the weakest live pair is Light's
+hover-on-content at 1.165).
 
 `themes/runtime.test.ts` pins application; `themes/shiki.test.ts` pins the syntax-variable map. See [`themes/SPEC.md`](../themes/SPEC.md) for the manifest itself and
 [TYPOGRAPHY.md](./TYPOGRAPHY.md) for the parallel type system.

--- a/apps/web/src/themes/SPEC.md
+++ b/apps/web/src/themes/SPEC.md
@@ -84,9 +84,9 @@ a theme borrowed from elsewhere keeps its signature colours. `accent` and `succe
 to swallow the primary button's own label. Legibility alone proved insufficient: High Contrast Light
 once shipped its `hover` fill — the palette source of the selected/hovered control roles — at 1.05:1
 against its own sidebar, an invisible selection with every check green, so the suite also pins
-hover-vs-surface **distinguishability** (≥ 1.15 against `background`, `sidebar`, `header`,
-`elevated`; `content`/`input` exempt — no interactive fill sits on those canvases, and Light ships
-`hover == content`). A new manifest that reads poorly fails to merge; see
+hover-vs-surface **distinguishability** (≥ 1.15 against every resting surface — `content` included,
+because PlanPane and the workbench backdrop host hovered controls there, which Light's original
+`hover == content` palette made invisible). A new manifest that reads poorly fails to merge; see
 [`styles/COLOR.md`](../styles/COLOR.md) for the reasoning.
 
 **A `contrast: "high"` manifest is held to AAA (7.0) resting and full AA (4.5) even on hover**, `hint`

--- a/apps/web/src/themes/SPEC.md
+++ b/apps/web/src/themes/SPEC.md
@@ -81,7 +81,12 @@ floor on the transient `hover` surface — the latter being our line rather than
 a theme borrowed from elsewhere keeps its signature colours. `accent` and `success` are exempt from
 `input` alone: neither is ever rendered as text on a control. Separately, `onAccent` must clear AA on
 **both** accent fills (`accent` and `accentHover`), so a theme cannot darken its hover step far enough
-to swallow the primary button's own label. A new manifest that reads poorly fails to merge; see
+to swallow the primary button's own label. Legibility alone proved insufficient: High Contrast Light
+once shipped its `hover` fill — the palette source of the selected/hovered control roles — at 1.05:1
+against its own sidebar, an invisible selection with every check green, so the suite also pins
+hover-vs-surface **distinguishability** (≥ 1.15 against `background`, `sidebar`, `header`,
+`elevated`; `content`/`input` exempt — no interactive fill sits on those canvases, and Light ships
+`hover == content`). A new manifest that reads poorly fails to merge; see
 [`styles/COLOR.md`](../styles/COLOR.md) for the reasoning.
 
 **A `contrast: "high"` manifest is held to AAA (7.0) resting and full AA (4.5) even on hover**, `hint`

--- a/apps/web/src/themes/bundled/high-contrast-light.theme.json
+++ b/apps/web/src/themes/bundled/high-contrast-light.theme.json
@@ -18,7 +18,7 @@
 		"sidebar": "#fafafa",
 		"input": "#f4f4f5",
 		"elevated": "#ffffff",
-		"hover": "#f4f4f5",
+		"hover": "#dcdce0",
 		"border": "#d4d4d8",
 		"borderStrong": "#a1a1aa",
 		"text": "#18181b",

--- a/apps/web/src/themes/bundled/light.theme.json
+++ b/apps/web/src/themes/bundled/light.theme.json
@@ -18,7 +18,7 @@
 		"sidebar": "#fafafa",
 		"input": "#f4f4f5",
 		"elevated": "#ffffff",
-		"hover": "#e4e4e7",
+		"hover": "#d4d4d8",
 		"border": "#e4e4e7",
 		"borderStrong": "#d4d4d8",
 		"text": "#27272a",

--- a/apps/web/src/themes/schema.test.ts
+++ b/apps/web/src/themes/schema.test.ts
@@ -127,12 +127,11 @@ test("the primary control's label stays legible on both its resting and hover fi
 	}
 });
 
-const HOVER_DISTINCTION_SURFACES = ["background", "sidebar", "header", "elevated"] as const;
 const HOVER_DISTINCTION_FLOOR = 1.15;
 
-test("the hover/selected fill stays distinguishable from every surface it sits on", () => {
+test("the hover/selected fill stays distinguishable from every resting surface", () => {
 	for (const theme of bundledThemes()) {
-		for (const surface of HOVER_DISTINCTION_SURFACES) {
+		for (const surface of RESTING) {
 			expect(
 				contrast(theme.colors.hover, theme.colors[surface]),
 				`${theme.id}: hover vs ${surface}`,

--- a/apps/web/src/themes/schema.test.ts
+++ b/apps/web/src/themes/schema.test.ts
@@ -127,6 +127,20 @@ test("the primary control's label stays legible on both its resting and hover fi
 	}
 });
 
+const HOVER_DISTINCTION_SURFACES = ["background", "sidebar", "header", "elevated"] as const;
+const HOVER_DISTINCTION_FLOOR = 1.15;
+
+test("the hover/selected fill stays distinguishable from every surface it sits on", () => {
+	for (const theme of bundledThemes()) {
+		for (const surface of HOVER_DISTINCTION_SURFACES) {
+			expect(
+				contrast(theme.colors.hover, theme.colors[surface]),
+				`${theme.id}: hover vs ${surface}`,
+			).toBeGreaterThanOrEqual(HOVER_DISTINCTION_FLOOR);
+		}
+	}
+});
+
 test("hovered text never drops below the visibility floor", () => {
 	for (const theme of bundledThemes()) {
 		for (const key of Object.keys(FLOORS)) {


### PR DESCRIPTION
Selected rows in High Contrast Light were basically invisible — the \`hover\` fill (source of \`control-bg-selected\`/\`-hovered\`) sat at 1.05:1 against the sidebar and was identical to the input fill. The one theme that exists for contrast had the weakest selection of all four.

- \`hover: #f4f4f5 → #dcdce0\` in the manifest — 1.31–1.37:1 against every surface it sits on, all text floors still pass. One palette value, no component changes.
- New guard in \`schema.test.ts\`: hover must clear 1.15:1 vs \`background\`/\`sidebar\`/\`header\`/\`elevated\` in every theme. This shipped because only text legibility was pinned; now the fill itself can't quietly fade out again.
- Floor + rationale recorded in \`COLOR.md\` / \`themes/SPEC.md\`.

Before / after (workspace selected in the sidebar):

| before | after |
|---|---|
| 1.05:1, can't see it | 1.31:1, clearly reads |

Full e2e ran green (one pre-existing env failure in \`workspace-actions\`, fails on base too).