### PR TITLE
New feature: add bottom workbench panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Remote/phone access (V2) is over Tailscale; auth stays external (the app carries
 
 **V1 shape (Worktree IDE):** left = projects (git repos) → workspaces (each a `git
 worktree`, own branch/cwd, under `~/.thinkrail/worktrees`); center = a tabbed area of Monaco file tabs
-+ chat tabs; right = an All-files tree + Changes (git diff) + terminals, all scoped to the active
++ chat tabs; right = a Files tree + Changes (git diff) + terminals, all scoped to the active
 worktree. The shell is built **first**, `pi` connected **last**. Deferred to V2: spec-graph viewer,
 PR/Checks.
 

--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -77,7 +77,8 @@ Rules: a panel never imports another panel sideways; nothing imports `shell` (it
 The module set: `transport` / `store` / branded `shell` + its headless `shell/layout` child;
 layout-agnostic Project/File/Specs/Changes/Review renderers; lazy Monaco file/diff bodies and xterm terminal
 bodies; and the `chat` module (`ChatView`, content-block renderers, tool registry, and full Composer). The
-workbench owns strips/groups around those bodies, never the panels themselves.
+workbench owns center and left/right/bottom auxiliary strips/groups around those bodies, never the panels
+themselves.
 
 ## Styling & theming
 

--- a/apps/web/UI-TERMINOLOGY.md
+++ b/apps/web/UI-TERMINOLOGY.md
@@ -330,7 +330,7 @@ leaves a compact restore rail. Side arrangement is workspace-shared; selection a
 
 Every Side Group has a **Group Header**; folding retains that header as a 27px row while its linked
 body stays native-hidden and unmounted. Initial Balanced placement puts Projects on the left, Specs and
-All files in the first right group, then Changes and Review in the second; the default terminal catalog
+Files in the first right group, then Changes and Review in the second; the default terminal catalog
 joins that last group. This is startup behavior, not a fixed hierarchy.
 
 ## Side Tools
@@ -339,7 +339,7 @@ joins that last group. This is startup behavior, not a fixed hierarchy.
 |---|---|---|
 | Projects | `tab-projects`, body `left-nav` | `panels/ProjectTree.tsx`; projects and workspaces |
 | Specs | `tab-specs` | `panels/SpecsPanel.tsx`; read-only spec graph, with `specs-refresh` |
-| All files | `tab-files` | `panels/FileTree.tsx`; worktree file tree |
+| Files | `tab-files` | `panels/FileTree.tsx`; worktree file tree |
 | Changes | `tab-changes` | `panels/ChangesPanel.tsx`; scoped git changes and diff opens |
 | Review | `tab-review` | `panels/ReviewPanel.tsx`; review accordion and send actions |
 
@@ -513,8 +513,8 @@ its alternatives in parentheses.
 **Sides**
 
 - **Left Side**, **Right Side**, **Side Group**, **Hidden-Side Rail**.
-- Singleton tools: **Projects**, **Specs**, **All files**, **Changes**, **Review**.
-- **Specs Panel**, **All Files Panel** (alt: File Tree), **Changes Panel**, **Review Panel**.
+- Singleton tools: **Projects**, **Specs**, **Files**, **Changes**, **Review**.
+- **Specs Panel**, **Files Panel** (alt: File Tree), **Changes Panel**, **Review Panel**.
 - **Changes Header** (no component): **Changes Scope Menu**, **Branch Picker**, **Changes View Toggle**.
 - **Changes List** / **Changes Tree**, **Change-Row Actions**, **Tree Row**, **Diff-Stat Badge**.
 

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -7,6 +7,7 @@ import { menuContentClass, menuItemClass, menuSeparatorClass } from "./menu-styl
 const DropdownMenu = DropdownMenuPrimitive.Root;
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 function DropdownMenuContent({
@@ -34,6 +35,13 @@ function DropdownMenuItem({
 	...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
 	return <DropdownMenuPrimitive.Item className={cn(menuItemClass, className)} {...props} />;
+}
+
+function DropdownMenuRadioItem({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+	return <DropdownMenuPrimitive.RadioItem className={cn(menuItemClass, className)} {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -96,6 +104,8 @@ export {
 	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
 	DropdownMenuSeparator,
 	DropdownMenuSub,
 	DropdownMenuSubContent,

--- a/apps/web/src/lib/layoutAttention.ts
+++ b/apps/web/src/lib/layoutAttention.ts
@@ -1,9 +1,10 @@
 export type WorkbenchSide = "left" | "right";
+export type WorkbenchAuxiliaryRegion = WorkbenchSide | "bottom";
 
 export interface LayoutAttention {
 	selectedByGroup: Record<string, string>;
 	lastFocusedCenterGroupId: string;
-	lastFocusedSideGroupId: Partial<Record<WorkbenchSide, string>>;
+	lastFocusedSideGroupId: Partial<Record<WorkbenchAuxiliaryRegion, string>>;
 	navigationClockByGroup: Record<string, number>;
 }
 

--- a/apps/web/src/navigation/restore.test.ts
+++ b/apps/web/src/navigation/restore.test.ts
@@ -83,7 +83,7 @@ function placeChats(
 	clock?: number,
 ): void {
 	const document: WorkspaceLayoutDocument = {
-		version: 1,
+		version: 2,
 		center: {
 			kind: "group",
 			id: "center",
@@ -96,6 +96,7 @@ function placeChats(
 		},
 		left: { visible: false, width: 0.2, groups: [] },
 		right: { visible: false, width: 0.2, groups: [] },
+		bottom: { visible: false, height: 0.3, alignment: "center", groups: [] },
 		toolRestoreTargets: {},
 	};
 	useAppStore.setState((state) => ({

--- a/apps/web/src/panels/BranchPicker.tsx
+++ b/apps/web/src/panels/BranchPicker.tsx
@@ -61,7 +61,13 @@ export function BranchPicker({
 	);
 
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
+		<Popover
+			open={open}
+			onOpenChange={(nextOpen) => {
+				setOpen(nextOpen);
+				if (nextOpen) onRefresh();
+			}}
+		>
 			<PopoverTrigger data-testid={testid} data-open={open} className={triggerClassName}>
 				<GitBranch className="size-3.5 shrink-0 text-text-muted" />
 				<span className="shrink-0 text-text-muted tr-text-metadata">{label}</span>

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -473,7 +473,7 @@ a project picker, the prompt hero, and the reused
   The shared `ToggleSegment` (List|Tree, Split|Inline, Preview|Source) borrows the same
   `control-bg-selected` fill + `text-default` for its active segment (no bottom marker — a slim toggle,
   not a tab), so "selected" reads the same everywhere and never derives a parallel surface token.
-- The singleton side-tool renderers are **Projects | Specs | All files | Changes | Review**. Their current
+- The singleton side-tool renderers are **Projects | Specs | Files | Changes | Review**. Their current
   location and local selection are supplied by the shell; Review exposes its store-derived pending-draft
   count as tab metadata. A renderer remains the same when its singleton moves to the opposite side.
 - **`ReviewPanel`** is the review sidebar (see [[submodule-server-reviews]] +
@@ -871,7 +871,7 @@ a project picker, the prompt hero, and the reused
 - **Changes: List | Tree.** A header toggle (`store.changesView`, app-wide — persisted in the store, not
   per workspace, so it survives workspace switches) switches the flat **List** and a folder **Tree**
   (`ChangesTree`), both built from the same `git.status` list. The Tree is styled exactly like the
-  All-files tree (shared `TreeRow`); folders **default expanded** (change sets are small), and a
+  Files tree (shared `TreeRow`); folders **default expanded** (change sets are small), and a
   single-directory run is one slash-joined compact row (based on the changed-file tree, regardless of
   unchanged siblings on disk), matching `FileTree`. **Status is shown on the file name, not a letter glyph**
   (the git-decoration convention — `changesModel.statusNameClass`, shared by both views):
@@ -916,7 +916,7 @@ a project picker, the prompt hero, and the reused
   **(1) the wrapper owns the row's highlight** (hover / selected / menu-open), since the band has to span the
   trailing slot too or a row reads as cut off before its own menu — the inner element paints **no** background
   at all (the flat list's button carries no `hover:`/selected class, and `TreeRow` takes
-  `highlight="wrapper"`, its `"self"` default being what the All-files tree wants). Exactly one painter,
+  `highlight="wrapper"`, its `"self"` default being what the Files tree wants). Exactly one painter,
   always: two hide the case where the wrapper stopped painting, which is why the e2e pin compares the *wrapper's*
   computed band against the *inner button's* (transparent) one, not a wrapper against a wrapper;
   **(2) rows *without* a menu reserve the same gutter** (`ROW_MENU_SLOT`, exported from `ChangeRowActions`

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -147,9 +147,10 @@ arrangement (so the mobile shell is an additive layer, not a rewrite).
   `onOpen`/`isActive` by `ChangesPanel`), together with the **diff-tab identity + scope vocabulary**:
   `scopeKey` / `diffTabId(workspaceId, scope, path)` / `diffTabName` / `scopeLabel` and the `splitPath`
   used by both the flat list's path rows and the diff header's path chip. The **branch combobox** is the
-  shared **`BranchPicker`** (searchable, grouped Remote/Local, current pick check-marked, a Refresh that
-  re-lists) — one component for the New-Workspace dialog's *base* branch and the Changes header's *target*
-  branch; the whole state *around* it — the list, `refreshing`, `refresh()` — is the shared
+  shared **`BranchPicker`** (searchable, grouped Remote/Local, current pick check-marked, refreshed on every
+  open with an explicit Refresh control as well) — one component for the New-Workspace dialog's *base* branch
+  and the Changes header's *target* branch; the whole state *around* it — the list, `refreshing`, `refresh()` —
+  is the shared
   **`useBranchList(projectId, onLoaded?)`** (`branches.ts`, over the offline-degrading
   `listBranchesOrEmpty`), so both pickers are identical **by construction**: the list is **keyed to the
   project** (it clears on a project change, and both reads are generation-stamped, so a switch can never

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -242,7 +242,6 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 						const buffered = attemptPrebind.bind(id);
 						if (buffered.truncated) writeTruncation();
 						for (const ev of buffered.frames) writeFrame(ev);
-						useAppStore.getState().settleTerminalAttach(workspaceId, tabKey);
 						setDetached(false);
 						setExited(false);
 						setReady(true);

--- a/apps/web/src/panels/TerminalWorkbench.tsx
+++ b/apps/web/src/panels/TerminalWorkbench.tsx
@@ -49,10 +49,6 @@ export function useTerminalCatalog(workspaceId: string | null): boolean {
 				}
 				state.setWorkspaceTerminals(workspaceId, tabs);
 				setReady(true);
-				const installed = useAppStore.getState();
-				if ((installed.terminalsByWorkspace[workspaceId]?.length ?? 0) === 0) {
-					installed.addTerminal(workspaceId);
-				}
 			})
 			.catch(() => {});
 		return () => {

--- a/apps/web/src/panels/openTabs.test.ts
+++ b/apps/web/src/panels/openTabs.test.ts
@@ -165,7 +165,7 @@ test("an overtaken double click keeps its tab without claiming a newer preview s
 test("a deferred keep refreshes a semantically placed legacy cache without stealing focus", async () => {
 	const placementId = "legacy-diff-placement";
 	const layout: WorkspaceLayoutDocument = {
-		version: 1,
+		version: 2,
 		center: {
 			kind: "split",
 			id: "split",
@@ -190,6 +190,7 @@ test("a deferred keep refreshes a semantically placed legacy cache without steal
 		},
 		left: { visible: false, width: 0.2, groups: [] },
 		right: { visible: false, width: 0.2, groups: [] },
+		bottom: { visible: false, height: 0.3, alignment: "center", groups: [] },
 		toolRestoreTargets: {},
 	};
 	useAppStore.setState({

--- a/apps/web/src/shell/LayoutSettings.tsx
+++ b/apps/web/src/shell/LayoutSettings.tsx
@@ -344,7 +344,7 @@ export function LayoutSettings() {
 						Applies to new groups. Existing over-limit arrangements remain usable and reducible.
 					</p>
 				</div>
-				<div className="grid max-w-lg gap-sm sm:grid-cols-2">
+				<div className="grid max-w-sm gap-sm">
 					<div className="space-y-xs tr-text-metadata text-text-muted">
 						<label htmlFor="layout-side-group-limit">Side groups</label>
 						<div className="flex items-center gap-sm">
@@ -360,6 +360,7 @@ export function LayoutSettings() {
 							/>
 							<button
 								type="button"
+								aria-label="Save side group limit"
 								disabled={
 									!Number.isInteger(Number(sideLimit)) ||
 									Number(sideLimit) < minimumSideLimit ||
@@ -389,6 +390,7 @@ export function LayoutSettings() {
 							/>
 							<button
 								type="button"
+								aria-label="Save bottom group limit"
 								disabled={
 									!Number.isInteger(Number(bottomLimit)) ||
 									Number(bottomLimit) < minimumBottomLimit ||

--- a/apps/web/src/shell/LayoutSettings.tsx
+++ b/apps/web/src/shell/LayoutSettings.tsx
@@ -77,10 +77,7 @@ export function LayoutSettings() {
 	const apply = (preset: LayoutPreset) => {
 		if (!activeWorkspaceId || !document) return;
 		const requiredSideLimit = Math.max(settings.maxSideGroups, minimumSideGroupLimit(preset));
-		const requiredBottomLimit = Math.max(
-			settings.maxBottomGroups,
-			minimumBottomGroupLimit(preset),
-		);
+		const requiredBottomLimit = Math.max(settings.maxBottomGroups, minimumBottomGroupLimit(preset));
 		void (async () => {
 			if (
 				(requiredSideLimit !== settings.maxSideGroups ||
@@ -119,8 +116,8 @@ export function LayoutSettings() {
 			<header>
 				<h2 className="tr-title-section text-text-default">Layout</h2>
 				<p className="mt-xs max-w-[42rem] tr-text-ui text-text-muted">
-					Choose how new workspaces begin, save reusable arrangements, and control auxiliary
-					group density. Existing workspaces change only when you apply a preset.
+					Choose how new workspaces begin, save reusable arrangements, and control auxiliary group
+					density. Existing workspaces change only when you apply a preset.
 				</p>
 			</header>
 
@@ -348,10 +345,11 @@ export function LayoutSettings() {
 					</p>
 				</div>
 				<div className="grid max-w-lg gap-sm sm:grid-cols-2">
-					<label className="space-y-xs tr-text-metadata text-text-muted">
-						<span>Side groups</span>
+					<div className="space-y-xs tr-text-metadata text-text-muted">
+						<label htmlFor="layout-side-group-limit">Side groups</label>
 						<div className="flex items-center gap-sm">
 							<input
+								id="layout-side-group-limit"
 								type="number"
 								min={minimumSideLimit}
 								max={32}
@@ -369,19 +367,18 @@ export function LayoutSettings() {
 									Number(sideLimit) === settings.maxSideGroups ||
 									saving
 								}
-								onClick={() =>
-									void saveSettings({ ...settings, maxSideGroups: Number(sideLimit) })
-								}
+								onClick={() => void saveSettings({ ...settings, maxSideGroups: Number(sideLimit) })}
 								className="rounded-[var(--radius-sm)] border border-border-default px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered disabled:text-control-disabled-text"
 							>
 								Save
 							</button>
 						</div>
-					</label>
-					<label className="space-y-xs tr-text-metadata text-text-muted">
-						<span>Bottom groups</span>
+					</div>
+					<div className="space-y-xs tr-text-metadata text-text-muted">
+						<label htmlFor="layout-bottom-group-limit">Bottom groups</label>
 						<div className="flex items-center gap-sm">
 							<input
+								id="layout-bottom-group-limit"
 								type="number"
 								min={minimumBottomLimit}
 								max={32}
@@ -407,7 +404,7 @@ export function LayoutSettings() {
 								Save
 							</button>
 						</div>
-					</label>
+					</div>
 				</div>
 			</section>
 

--- a/apps/web/src/shell/LayoutSettings.tsx
+++ b/apps/web/src/shell/LayoutSettings.tsx
@@ -13,6 +13,7 @@ import {
 	applyLayoutPreset,
 	BUILTIN_LAYOUT_PRESETS,
 	captureLayoutPreset,
+	minimumBottomGroupLimit,
 	minimumSideGroupLimit,
 	resolveLayoutPreset,
 } from "./layout";
@@ -39,9 +40,11 @@ export function LayoutSettings() {
 	const [name, setName] = useState("");
 	const [renaming, setRenaming] = useState<{ id: string; name: string } | null>(null);
 	const [sideLimit, setSideLimit] = useState(String(settings.maxSideGroups));
+	const [bottomLimit, setBottomLimit] = useState(String(settings.maxBottomGroups));
 	const [applying, setApplying] = useState<LayoutPreset | null>(null);
 	const [saving, setSaving] = useState(false);
 	useEffect(() => setSideLimit(String(settings.maxSideGroups)), [settings.maxSideGroups]);
+	useEffect(() => setBottomLimit(String(settings.maxBottomGroups)), [settings.maxBottomGroups]);
 	const presets = useMemo(
 		() => [
 			...BUILTIN_LAYOUT_PRESETS,
@@ -53,6 +56,10 @@ export function LayoutSettings() {
 	const minimumSideLimit = Math.max(
 		minimumSideGroupLimit(selected),
 		...settings.customPresets.map(minimumSideGroupLimit),
+	);
+	const minimumBottomLimit = Math.max(
+		minimumBottomGroupLimit(selected),
+		...settings.customPresets.map(minimumBottomGroupLimit),
 	);
 
 	const saveSettings = async (next: LayoutSettingsValue): Promise<boolean> => {
@@ -69,11 +76,20 @@ export function LayoutSettings() {
 
 	const apply = (preset: LayoutPreset) => {
 		if (!activeWorkspaceId || !document) return;
-		const requiredLimit = Math.max(settings.maxSideGroups, minimumSideGroupLimit(preset));
+		const requiredSideLimit = Math.max(settings.maxSideGroups, minimumSideGroupLimit(preset));
+		const requiredBottomLimit = Math.max(
+			settings.maxBottomGroups,
+			minimumBottomGroupLimit(preset),
+		);
 		void (async () => {
 			if (
-				requiredLimit !== settings.maxSideGroups &&
-				!(await saveSettings({ ...settings, maxSideGroups: requiredLimit }))
+				(requiredSideLimit !== settings.maxSideGroups ||
+					requiredBottomLimit !== settings.maxBottomGroups) &&
+				!(await saveSettings({
+					...settings,
+					maxSideGroups: requiredSideLimit,
+					maxBottomGroups: requiredBottomLimit,
+				}))
 			) {
 				return;
 			}
@@ -103,8 +119,8 @@ export function LayoutSettings() {
 			<header>
 				<h2 className="tr-title-section text-text-default">Layout</h2>
 				<p className="mt-xs max-w-[42rem] tr-text-ui text-text-muted">
-					Choose how new workspaces begin, save reusable arrangements, and control side-stack
-					density. Existing workspaces change only when you apply a preset.
+					Choose how new workspaces begin, save reusable arrangements, and control auxiliary
+					group density. Existing workspaces change only when you apply a preset.
 				</p>
 			</header>
 
@@ -157,7 +173,8 @@ export function LayoutSettings() {
 											) : null}
 										</div>
 										<p className="mt-0.5 tr-text-metadata text-text-muted">
-											{preset.left.groups.length} left · {preset.right.groups.length} right groups
+											{preset.left.groups.length} left · {preset.right.groups.length} right ·{" "}
+											{preset.bottom.groups.length} bottom groups
 										</p>
 									</div>
 								</div>
@@ -172,6 +189,10 @@ export function LayoutSettings() {
 												maxSideGroups: Math.max(
 													settings.maxSideGroups,
 													minimumSideGroupLimit(preset),
+												),
+												maxBottomGroups: Math.max(
+													settings.maxBottomGroups,
+													minimumBottomGroupLimit(preset),
 												),
 											})
 										}
@@ -242,6 +263,11 @@ export function LayoutSettings() {
 															minimumSideGroupLimit(nextDefault),
 															...customPresets.map(minimumSideGroupLimit),
 														),
+														maxBottomGroups: Math.max(
+															settings.maxBottomGroups,
+															minimumBottomGroupLimit(nextDefault),
+															...customPresets.map(minimumBottomGroupLimit),
+														),
 													});
 												}}
 												className="rounded-[var(--radius-sm)] p-xs text-text-muted hover:bg-feedback-error-subtle hover:text-feedback-error"
@@ -290,10 +316,18 @@ export function LayoutSettings() {
 						onClick={() => {
 							if (!document || !name.trim()) return;
 							const preset = captureLayoutPreset(document, randomId("preset"), name.trim());
-							const requiredLimit = Math.max(settings.maxSideGroups, minimumSideGroupLimit(preset));
+							const requiredSideLimit = Math.max(
+								settings.maxSideGroups,
+								minimumSideGroupLimit(preset),
+							);
+							const requiredBottomLimit = Math.max(
+								settings.maxBottomGroups,
+								minimumBottomGroupLimit(preset),
+							);
 							void saveSettings({
 								...settings,
-								maxSideGroups: requiredLimit,
+								maxSideGroups: requiredSideLimit,
+								maxBottomGroups: requiredBottomLimit,
 								customPresets: [...settings.customPresets, preset],
 							}).then((saved) => {
 								if (saved) setName("");
@@ -308,35 +342,72 @@ export function LayoutSettings() {
 
 			<section className="space-y-sm border-border-default border-t pt-lg">
 				<div>
-					<h3 className="tr-title-section text-text-default">Side group limit</h3>
+					<h3 className="tr-title-section text-text-default">Group limits</h3>
 					<p className="tr-text-metadata text-text-muted">
 						Applies to new groups. Existing over-limit arrangements remain usable and reducible.
 					</p>
 				</div>
-				<div className="flex max-w-xs items-center gap-sm">
-					<input
-						type="number"
-						min={minimumSideLimit}
-						max={32}
-						value={sideLimit}
-						onChange={(event) => setSideLimit(event.target.value)}
-						aria-label="Maximum side groups"
-						className="w-24 rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-sm py-xs tr-text-ui text-text-default outline-none focus:ring-2 focus:ring-primary"
-					/>
-					<button
-						type="button"
-						disabled={
-							!Number.isInteger(Number(sideLimit)) ||
-							Number(sideLimit) < minimumSideLimit ||
-							Number(sideLimit) > 32 ||
-							Number(sideLimit) === settings.maxSideGroups ||
-							saving
-						}
-						onClick={() => void saveSettings({ ...settings, maxSideGroups: Number(sideLimit) })}
-						className="rounded-[var(--radius-sm)] border border-border-default px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered disabled:text-control-disabled-text"
-					>
-						Save limit
-					</button>
+				<div className="grid max-w-lg gap-sm sm:grid-cols-2">
+					<label className="space-y-xs tr-text-metadata text-text-muted">
+						<span>Side groups</span>
+						<div className="flex items-center gap-sm">
+							<input
+								type="number"
+								min={minimumSideLimit}
+								max={32}
+								value={sideLimit}
+								onChange={(event) => setSideLimit(event.target.value)}
+								aria-label="Maximum side groups"
+								className="w-24 rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-sm py-xs tr-text-ui text-text-default outline-none focus:ring-2 focus:ring-primary"
+							/>
+							<button
+								type="button"
+								disabled={
+									!Number.isInteger(Number(sideLimit)) ||
+									Number(sideLimit) < minimumSideLimit ||
+									Number(sideLimit) > 32 ||
+									Number(sideLimit) === settings.maxSideGroups ||
+									saving
+								}
+								onClick={() =>
+									void saveSettings({ ...settings, maxSideGroups: Number(sideLimit) })
+								}
+								className="rounded-[var(--radius-sm)] border border-border-default px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered disabled:text-control-disabled-text"
+							>
+								Save
+							</button>
+						</div>
+					</label>
+					<label className="space-y-xs tr-text-metadata text-text-muted">
+						<span>Bottom groups</span>
+						<div className="flex items-center gap-sm">
+							<input
+								type="number"
+								min={minimumBottomLimit}
+								max={32}
+								value={bottomLimit}
+								onChange={(event) => setBottomLimit(event.target.value)}
+								aria-label="Maximum bottom groups"
+								className="w-24 rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-sm py-xs tr-text-ui text-text-default outline-none focus:ring-2 focus:ring-primary"
+							/>
+							<button
+								type="button"
+								disabled={
+									!Number.isInteger(Number(bottomLimit)) ||
+									Number(bottomLimit) < minimumBottomLimit ||
+									Number(bottomLimit) > 32 ||
+									Number(bottomLimit) === settings.maxBottomGroups ||
+									saving
+								}
+								onClick={() =>
+									void saveSettings({ ...settings, maxBottomGroups: Number(bottomLimit) })
+								}
+								className="rounded-[var(--radius-sm)] border border-border-default px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered disabled:text-control-disabled-text"
+							>
+								Save
+							</button>
+						</div>
+					</label>
 				</div>
 			</section>
 
@@ -346,7 +417,7 @@ export function LayoutSettings() {
 					if (!open) setApplying(null);
 				}}
 				title="Apply this layout?"
-				description="Open files, chats, documents, and terminals are preserved, but their groups and proportions will be rearranged for every client in this workspace. The side-group limit is raised if this preset needs more groups."
+				description="Open files, chats, documents, and terminals are preserved, but their groups and proportions will be rearranged for every client in this workspace. Group limits are raised if this preset needs more groups."
 				confirmLabel="Apply layout"
 				confirmTestId="layout-apply-confirm"
 				onConfirm={() => {

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -19,7 +19,8 @@ must not inherit desktop docking accidentally.
 - **Owns:** `Shell` as the one composition root; the topbar and persistent location context; active-workspace
   versus Project Home/Welcome branching; the single Settings and Toaster mounts; the theme DOM side effect;
   global keyboard chords; the injected Layout settings section (built-ins, custom-preset CRUD, default,
-  apply, and side-group limit); and the integration of `layout/` with store, transport, panel renderers,
+  apply, and independent side/bottom group limits); and the integration of `layout/` with store, transport,
+  panel renderers,
   and region error boundaries.
 - **Public surface:** `Shell`.
 - **Allowed deps:** child `layout`; `panels`; `chat` app-integration hydration/rendering; `store`,
@@ -65,8 +66,9 @@ progressive responsive degradation. A selected project without an active workspa
 No selected project leaves the logo alone.
 
 With an active workspace, `Shell` mounts the synchronized workbench from `layout/`; the workbench owns all
-center/side geometry and visibility. Without one, it mounts the existing Welcome surface beside the
-projects navigator using separate client-local geometry—there is no workspace layout document to mutate.
+center and left/right/bottom auxiliary geometry, alignment, and visibility. Without one, it mounts the
+existing Welcome surface beside the projects navigator using separate client-local geometry—there is no
+workspace layout document to mutate.
 Toasts mount once above both branches.
 
 The shell is also the sole theme side-effect owner: store receives the host-selected opaque theme through
@@ -98,7 +100,10 @@ separate background concern.
 
 Project/file/change/review/chat/terminal views receive only resource identity, visibility, and container
 bounds. Moving a view cannot change its module dependencies or make it inspect the layout tree. A visible
-terminal is mounted through the layout visibility gate; hidden terminal tabs stay unmounted.
+terminal is mounted through the layout visibility gate; hidden terminal tabs stay unmounted while their PTYs
+continue running. After first layout seeding, the parent workbench—not `layoutSync`—creates the one initial
+terminal placement, so synchronization remains resource-lifetime-free. A hidden configured default delays
+PTY attach until the placement becomes visible.
 
 ## Error resilience
 
@@ -116,9 +121,13 @@ workbench command surface rather than imperative feature-panel refs:
 - `Ctrl+R` opens chat history for the locally selected chat, or the workspace's most-recent chat fallback;
 - `Mod+B` toggles the left side; restoring it focuses its last local group/tab or recreates an eligible
   singleton tool from its saved restore target when the side is empty;
-- `Mod+J` does the same for the right side.
+- `Mod+J` does the same for the right side;
+- `Mod+Shift+J` toggles bottom; restoring it focuses last local bottom attention, restores an eligible
+  bottom-targeted singleton, or creates a terminal when structurally empty.
 
-Letter chords match physical `KeyboardEvent.code`, never layout-dependent `key`. Terminal `Ctrl+R` still
-belongs to xterm; the two layout chords remain app-owned there. `Ctrl+Shift+R`, macOS `Cmd+R`, F5, and the
-browser reload control remain untouched. All arrangement operations beyond these shortcuts are exposed by
-the layout command/menu system described in [[submodule-web-shell-layout]].
+Letter chords match physical `KeyboardEvent.code`, never layout-dependent `key`. The three layout chords stay
+app-owned inside xterm, do not repeat, and are suppressed while a modal dialog is open. With no active
+workspace they neither act nor swallow the browser chord. Terminal `Ctrl+R` still belongs to xterm;
+`Ctrl+Shift+R`, macOS `Cmd+R`, F5, and the browser reload control remain untouched. All arrangement operations
+beyond these shortcuts are exposed by the layout command/menu system described in
+[[submodule-web-shell-layout]].

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -102,10 +102,12 @@ Project/file/change/review/chat/terminal views receive only resource identity, v
 bounds. Moving a view cannot change its module dependencies or make it inspect the layout tree. A visible
 terminal is mounted through the layout visibility gate; hidden terminal tabs stay unmounted while their PTYs
 continue running. After first layout seeding, the parent workbench—not `layoutSync`—creates the one initial
-terminal placement, so synchronization remains resource-lifetime-free. Before that intent may commit, the
-parent reserves its client-minted key in the host catalog; the new-workspace seed uses one deterministic key
-inside that workspace, so competing clients reserve and place the same terminal rather than each creating one.
-Reservation is process-free and preserves a hidden configured default across reload and peer reconciliation.
+terminal placement only for an accepted revision-1 version-2 document, so synchronization remains
+resource-lifetime-free and a host migration (floored at revision 2) cannot seed an old workspace. Before that
+intent may commit, the parent reserves its client-minted key in the host catalog; the new-workspace seed uses
+one deterministic key inside that workspace, so competing clients reserve and place the same terminal rather
+than each creating one. Reservation is process-free and preserves a hidden configured default across reload
+and peer reconciliation.
 The placement intent can then retain hidden/folded geometry, and PTY attach still waits until the visibility
 gate mounts it.
 

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -102,8 +102,10 @@ Project/file/change/review/chat/terminal views receive only resource identity, v
 bounds. Moving a view cannot change its module dependencies or make it inspect the layout tree. A visible
 terminal is mounted through the layout visibility gate; hidden terminal tabs stay unmounted while their PTYs
 continue running. After first layout seeding, the parent workbench—not `layoutSync`—creates the one initial
-terminal placement only for an accepted revision-1 version-2 document, so synchronization remains
-resource-lifetime-free and a host migration (floored at revision 2) cannot seed an old workspace. Before that
+terminal placement only when the active host `Workspace` carries `initialTerminalEligible: true` and the
+accepted version-2 document is still at revision 1. The marker scopes eligibility to records created with this
+behavior; revision 1 scopes the attempt to the first layout snapshot, while the migration floor at revision 2
+remains defense in depth for known version-1 layouts. Synchronization stays resource-lifetime-free. Before that
 intent may commit, the parent reserves its client-minted key in the host catalog; the new-workspace seed uses
 one deterministic key inside that workspace, so competing clients reserve and place the same terminal rather
 than each creating one. Reservation is process-free and preserves a hidden configured default across reload

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -107,7 +107,9 @@ resource-lifetime-free and a host migration (floored at revision 2) cannot seed 
 intent may commit, the parent reserves its client-minted key in the host catalog; the new-workspace seed uses
 one deterministic key inside that workspace, so competing clients reserve and place the same terminal rather
 than each creating one. Reservation is process-free and preserves a hidden configured default across reload
-and peer reconciliation.
+and peer reconciliation. A rejected reservation suppresses another automatic attempt within that connection
+only; a later connection generation may retry the deterministic key, while confirmed membership or placement
+ends seeding.
 The placement intent can then retain hidden/folded geometry, and PTY attach still waits until the visibility
 gate mounts it.
 

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -102,8 +102,12 @@ Project/file/change/review/chat/terminal views receive only resource identity, v
 bounds. Moving a view cannot change its module dependencies or make it inspect the layout tree. A visible
 terminal is mounted through the layout visibility gate; hidden terminal tabs stay unmounted while their PTYs
 continue running. After first layout seeding, the parent workbench—not `layoutSync`—creates the one initial
-terminal placement, so synchronization remains resource-lifetime-free. A hidden configured default delays
-PTY attach until the placement becomes visible.
+terminal placement, so synchronization remains resource-lifetime-free. Before that intent may commit, the
+parent reserves its client-minted key in the host catalog; the new-workspace seed uses one deterministic key
+inside that workspace, so competing clients reserve and place the same terminal rather than each creating one.
+Reservation is process-free and preserves a hidden configured default across reload and peer reconciliation.
+The placement intent can then retain hidden/folded geometry, and PTY attach still waits until the visibility
+gate mounts it.
 
 ## Error resilience
 
@@ -127,7 +131,8 @@ workbench command surface rather than imperative feature-panel refs:
 
 Letter chords match physical `KeyboardEvent.code`, never layout-dependent `key`. The three layout chords stay
 app-owned inside xterm, do not repeat, and are suppressed while a modal dialog is open. With no active
-workspace they neither act nor swallow the browser chord. Terminal `Ctrl+R` still belongs to xterm;
+workspace, the right/bottom workbench chords neither act nor swallow the browser chord; the established
+Projects chord remains available. Terminal `Ctrl+R` still belongs to xterm;
 `Ctrl+Shift+R`, macOS `Cmd+R`, F5, and the browser reload control remain untouched. All arrangement operations
 beyond these shortcuts are exposed by the layout command/menu system described in
 [[submodule-web-shell-layout]].

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -70,6 +70,13 @@ export function Shell() {
 							side: "right",
 						});
 					},
+					onBottom: () => {
+						if (!activeWorkspaceId) return;
+						useAppStore.getState().enqueueLayoutIntent({
+							kind: "toggle-bottom",
+							workspaceId: activeWorkspaceId,
+						});
+					},
 				}
 			: {}),
 	});

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -5,7 +5,16 @@ import type {
 	WorkspaceLayoutDocument,
 } from "@thinkrail/contracts";
 import { GitBranch, MessageSquarePlus, SquareTerminal } from "lucide-react";
-import { lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import {
+	lazy,
+	type ReactNode,
+	Suspense,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { type LayoutAttention, layoutResourceIdentity } from "../lib";
 import { ChangesPanel } from "../panels/ChangesPanel";
@@ -155,7 +164,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const reviewDraftCount = useAppStore((state) => selectReviewDraftCount(state, workspaceId));
 	const reviewFlagByPath = useMemo(() => reviewFlags(reviewComments), [reviewComments]);
 	const [focusRequest, setFocusRequest] = useState<LayoutTabFocusRequest | null>(null);
-	const [initialTerminalSeeded, setInitialTerminalSeeded] = useState(false);
+	const attemptedInitialTerminalGeneration = useRef<number | null>(null);
 	const activeReviewedPath = useAppStore((state) => selectActiveReviewedPath(state, workspaceId));
 	const readActiveReviewedPath = useCallback(
 		() => selectActiveReviewedPath(useAppStore.getState(), workspaceId),
@@ -247,7 +256,6 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 
 	useEffect(() => {
 		if (
-			initialTerminalSeeded ||
 			!document ||
 			!attention ||
 			!terminalCatalogReady ||
@@ -260,20 +268,23 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 		const placedTerminal = collectAllGroups(document)
 			.flatMap((group) => group.tabs)
 			.some((tab) => tab.kind === "terminal");
-		if (terminals.length > 0 || placedTerminal) {
-			setInitialTerminalSeeded(true);
+		if (
+			terminals.length > 0 ||
+			placedTerminal ||
+			attemptedInitialTerminalGeneration.current === connectionGeneration
+		) {
 			return;
 		}
 		const preferredId = attention.lastFocusedSideGroupId.bottom;
 		const target =
 			document.bottom.groups.find((group) => group.id === preferredId) ?? document.bottom.groups[0];
-		setInitialTerminalSeeded(true);
+		attemptedInitialTerminalGeneration.current = connectionGeneration;
 		useAppStore
 			.getState()
 			.addTerminal(workspaceId, undefined, target?.id, "bottom", false, INITIAL_TERMINAL_TAB_KEY);
 	}, [
 		attention,
-		initialTerminalSeeded,
+		connectionGeneration,
 		document,
 		layoutRevision,
 		pendingLayoutWrites,

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -153,6 +153,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	);
 	const layoutSettings = useAppStore((state) => state.layoutSettings);
 	const workspace = useAppStore((state) => selectWorkspaceById(state, workspaceId));
+	const initialTerminalEligible = workspace?.initialTerminalEligible === true;
 	const contextProject = useAppStore(selectContextProject);
 	const editorTabs = useAppStore((state) => state.tabsByWorkspace[workspaceId] ?? NO_EDITOR_TABS);
 	const sessions = useAppStore((state) => state.sessions);
@@ -261,6 +262,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 			!terminalCatalogReady ||
 			pendingLayoutWrites > 0 ||
 			status !== "connected" ||
+			!initialTerminalEligible ||
 			layoutRevision !== 1
 		) {
 			return;
@@ -286,6 +288,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 		attention,
 		connectionGeneration,
 		document,
+		initialTerminalEligible,
 		layoutRevision,
 		pendingLayoutWrites,
 		status,

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -81,6 +81,9 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const pendingLayoutWrites = useAppStore(
 		(state) => state.layoutPendingByWorkspace[workspaceId]?.length ?? 0,
 	);
+	const layoutRevision = useAppStore(
+		(state) => state.layoutSnapshotsByWorkspace[workspaceId]?.revision,
+	);
 	const layoutSettings = useAppStore((state) => state.layoutSettings);
 	const workspace = useAppStore((state) => selectWorkspaceById(state, workspaceId));
 	const contextProject = useAppStore(selectContextProject);
@@ -94,6 +97,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const reviewDraftCount = useAppStore((state) => selectReviewDraftCount(state, workspaceId));
 	const reviewFlagByPath = useMemo(() => reviewFlags(reviewComments), [reviewComments]);
 	const [focusRequest, setFocusRequest] = useState<LayoutTabFocusRequest | null>(null);
+	const [initialTerminalSeeded, setInitialTerminalSeeded] = useState(false);
 	const activeReviewedPath = useAppStore((state) => selectActiveReviewedPath(state, workspaceId));
 	const readActiveReviewedPath = useCallback(
 		() => selectActiveReviewedPath(useAppStore.getState(), workspaceId),
@@ -176,8 +180,49 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	useDeletedChatPlacementReconciliation(workspaceId);
 	useLayoutIntentProcessing(workspaceId, commit, changeAttention, setFocusRequest);
 	useWorkspaceChatCatalogReconciliation(workspaceId, commit);
-	const terminals = useTerminalPlacementReconciliation(workspaceId, commit);
+	const { terminals, catalogReady: terminalCatalogReady } = useTerminalPlacementReconciliation(
+		workspaceId,
+		commit,
+	);
 	useChatLocationReconciliation(workspaceId, changeAttention);
+
+	useEffect(() => {
+		if (
+			initialTerminalSeeded ||
+			!document ||
+			!attention ||
+			!terminalCatalogReady ||
+			pendingLayoutWrites > 0 ||
+			status !== "connected" ||
+			layoutRevision !== 1
+		) {
+			return;
+		}
+		const placedTerminal = collectAllGroups(document)
+			.flatMap((group) => group.tabs)
+			.some((tab) => tab.kind === "terminal");
+		if (terminals.length > 0 || placedTerminal) {
+			setInitialTerminalSeeded(true);
+			return;
+		}
+		if (!document.bottom.visible) return;
+		const preferredId = attention.lastFocusedSideGroupId.bottom;
+		const target =
+			document.bottom.groups.find((group) => group.id === preferredId) ?? document.bottom.groups[0];
+		if (!target) return;
+		setInitialTerminalSeeded(true);
+		useAppStore.getState().addTerminal(workspaceId, undefined, target.id, "bottom");
+	}, [
+		attention,
+		initialTerminalSeeded,
+		document,
+		layoutRevision,
+		pendingLayoutWrites,
+		status,
+		terminalCatalogReady,
+		terminals,
+		workspaceId,
+	]);
 
 	useEffect(() => {
 		if (!document || status !== "connected") return;
@@ -352,11 +397,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 								onAdd={() =>
 									useAppStore
 										.getState()
-										.addTerminal(
-											workspaceId,
-											undefined,
-											location?.area === "center" ? location.groupId : undefined,
-										)
+										.addTerminal(workspaceId, undefined, location?.groupId, location?.area)
 								}
 							/>
 						) : (
@@ -486,6 +527,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 				document={document}
 				attention={attention}
 				maxSideGroups={layoutSettings.maxSideGroups}
+				maxBottomGroups={layoutSettings.maxBottomGroups}
 				remoteEpoch={remoteEpoch}
 				{...(focusRequest ? { focusRequest } : {})}
 				renderTabBody={renderTabBody}
@@ -627,6 +669,9 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 						.catch(() => {});
 				}}
 				onNewChat={startChat}
+				onNewTerminal={(groupId, area) =>
+					useAppStore.getState().addTerminal(workspaceId, undefined, groupId, area)
+				}
 				onRemoteGestureCanceled={() =>
 					toast.info("The shared layout changed. Your drag was canceled.")
 				}

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -205,7 +205,6 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 			setInitialTerminalSeeded(true);
 			return;
 		}
-		if (!document.bottom.visible) return;
 		const preferredId = attention.lastFocusedSideGroupId.bottom;
 		const target =
 			document.bottom.groups.find((group) => group.id === preferredId) ?? document.bottom.groups[0];

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -24,6 +24,7 @@ import {
 	isConnectedGeneration,
 	isDefaultWorkspace,
 	isExternalWorkspace,
+	type LayoutIntent,
 	layoutOpenOptionsForNavigation,
 	selectContextProject,
 	selectDiffTabTargetRef,
@@ -63,6 +64,7 @@ const ChatView = lazy(() => import("../chat/ChatView"));
 const PlanPane = lazy(() => import("../panels/PlanPane"));
 
 const NO_EDITOR_TABS: EditorTab[] = [];
+const INITIAL_TERMINAL_TAB_KEY = "thinkrail-initial";
 
 function MissingResource({ label }: { label: string }) {
 	return (
@@ -70,6 +72,62 @@ function MissingResource({ label }: { label: string }) {
 			Restoring {label}…
 		</div>
 	);
+}
+
+function useTerminalReservation(workspaceId: string): void {
+	const status = useAppStore((state) => state.status);
+	const connectionGeneration = useAppStore((state) => state.connectionGeneration);
+	const pendingIntent = useAppStore((state) =>
+		state.layoutIntents.find(
+			(intent): intent is Extract<LayoutIntent, { kind: "place-terminal" }> =>
+				intent.kind === "place-terminal" &&
+				intent.workspaceId === workspaceId &&
+				state.terminalsByWorkspace[workspaceId]?.some(
+					(tab) => tab.tabKey === intent.tabKey && tab.reservationPending,
+				) === true,
+		),
+	);
+
+	useEffect(() => {
+		if (!pendingIntent || status !== "connected" || connectionGeneration === 0) return;
+		let current = true;
+		void getTransport()
+			.request("terminal.reserve", {
+				workspaceId,
+				tabKey: pendingIntent.tabKey,
+				title: pendingIntent.title,
+			})
+			.then(() => {
+				const state = useAppStore.getState();
+				if (
+					!current ||
+					!isConnectedGeneration(state, connectionGeneration) ||
+					state.removedWorkspaceIds[workspaceId]
+				) {
+					return;
+				}
+				state.confirmTerminalReservation(workspaceId, pendingIntent.tabKey);
+			})
+			.catch((error) => {
+				const state = useAppStore.getState();
+				if (
+					!current ||
+					!isConnectedGeneration(state, connectionGeneration) ||
+					state.removedWorkspaceIds[workspaceId]
+				) {
+					return;
+				}
+				const stillPending = state.terminalsByWorkspace[workspaceId]?.some(
+					(tab) => tab.tabKey === pendingIntent.tabKey && tab.reservationPending,
+				);
+				if (!stillPending) return;
+				state.rejectTerminalReservation(workspaceId, pendingIntent.tabKey);
+				toast.error(errorText(error), "Couldn't create the terminal");
+			});
+		return () => {
+			current = false;
+		};
+	}, [connectionGeneration, pendingIntent, status, workspaceId]);
 }
 
 export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
@@ -178,6 +236,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 
 	useLegacySelectionAdapter(workspaceId, activeReviewedPath, readActiveReviewedPath);
 	useDeletedChatPlacementReconciliation(workspaceId);
+	useTerminalReservation(workspaceId);
 	useLayoutIntentProcessing(workspaceId, commit, changeAttention, setFocusRequest);
 	useWorkspaceChatCatalogReconciliation(workspaceId, commit);
 	const { terminals, catalogReady: terminalCatalogReady } = useTerminalPlacementReconciliation(
@@ -208,9 +267,10 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 		const preferredId = attention.lastFocusedSideGroupId.bottom;
 		const target =
 			document.bottom.groups.find((group) => group.id === preferredId) ?? document.bottom.groups[0];
-		if (!target) return;
 		setInitialTerminalSeeded(true);
-		useAppStore.getState().addTerminal(workspaceId, undefined, target.id, "bottom");
+		useAppStore
+			.getState()
+			.addTerminal(workspaceId, undefined, target?.id, "bottom", false, INITIAL_TERMINAL_TAB_KEY);
 	}, [
 		attention,
 		initialTerminalSeeded,

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -130,9 +130,12 @@ roving focus; a folded auxiliary group retains its linked native-hidden tabpanel
 and its named restore control is the group focus endpoint when no tab control is rendered. A local bottom-fold
 transition moves focus onto that restore control and expansion returns it to the selected tab. Separators expose
 orientation and current/min/max values. `Ctrl+F6` visits upper-row groups in visual
-order, then visible bottom groups left-to-right. One-row strips have bounded
-readable tab widths, wheel/trackpad scrolling, previous/next controls, active reveal, and a searchable
-keyboard overflow list.
+order, then visible bottom groups left-to-right. One-row strips have bounded readable tab widths and no
+fixed previous/next controls: wheel, trackpad, touch, roving-keyboard navigation, active reveal, and the
+searchable keyboard overflow list all scroll the same tab list, whose slim horizontal scrollbar appears only
+on hover or focus-within when content overflows without changing the strip's fixed height. Singleton tool tabs
+(Projects, Specs, All files, Changes, Review) carry no inline close glyph; Close remains in their context menu
+and on the Delete key, while terminals and center resources retain the direct glyph.
 
 ## Presets and synchronization
 

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -70,7 +70,9 @@ publishing.
   continues to the workbench bottom; an included side ends above the bottom surface. The hidden restore rail
   follows the same ownership. Alignment composition follows actual browser-local side projection during a
   resize gesture and narrow-width compression, while persisted workbench-wide side ratios remain the durable
-  target and are converted through nested panel groups. A hidden side contributes no phantom width and joins
+  target and are converted through nested panel groups. A separator gesture publishes only the ratio of the
+  side that owns that separator; compression of an untouched neighbor remains browser-local. A hidden side
+  contributes no phantom width and joins
   the span only when shown. Broad left/right targets create groups at every boundary. Empty structural slots
   remain legal for portable terminal layouts and the deliberate process-free New Terminal state. Closing or
   moving a group's final tab removes only that newly vacated group, renormalizes survivors, and auto-hides when
@@ -104,6 +106,8 @@ settlement resolves the resource semantically against the latest document, so a 
 unrelated resource that reused the old opaque placement id is never closed. Any newer tab gesture or center
 navigation suppresses delayed close-focus recovery; structural reconciliation that removes the closing group's
 clock does not impersonate such navigation, so collapsing the final tab in a leaf still restores visible tab focus.
+When closing a populated auxiliary group hides its region while an intentional empty bottom slot survives,
+focus falls back to the last center group rather than targeting the unrendered hidden group.
 
 ## Arrangement and accessibility
 

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -105,11 +105,12 @@ clock does not impersonate such navigation, so collapsing the final tab in a lea
 A tab drag paints exactly one result: strip insertion, whole-group join, legal center half-split, a side
 upper/lower boundary, or a bottom left/right boundary. Expanded tab strips remain join/reorder targets while
 content halves create adjacent groups; folded rails divide their compact axis between the same two targets.
-The user never has to acquire a thin outer edge. Hidden left/right/bottom rails become broad creation targets
-only for an eligible tab within that region's limit. Illegal domains, limits, exact-position no-ops, or
-minimums paint no valid target and commit nothing. Escape, pointer cancellation, outside drop, or a
-superseding remote revision restores the source. Drag moves one tab only—never copies, crosses workspaces, or
-moves a whole group.
+The user never has to acquire a thin outer edge. Hidden left/right rails become broad creation targets for an
+eligible tab within that side's limit. A hidden bottom rail instead reuses the last-focused surviving bottom
+slot, creating one at the trailing boundary only when no slot exists; either drop reveals the region. Illegal
+domains, limits, exact-position no-ops, or minimums paint no valid target and commit nothing. Escape, pointer
+cancellation, outside drop, or a superseding remote revision restores the source. Drag moves one tab
+only—never copies, crosses workspaces, or moves a whole group.
 
 Pointer is never the sole arrangement path. Keyboard controls and the shadcn menu surface cover group/tab
 focus, select/close/keep/reorder/move, directional center splits, absolute and adjacent auxiliary-group
@@ -117,7 +118,8 @@ creation, fold/show/hide/tool restore, bottom alignment, and keyboard separator 
 unavailable reason. A tab can reproduce any interior pointer placement by moving into the destination group
 and invoking New group above/below or left/right. Tab strips implement the WAI-ARIA tabs pattern and visible
 roving focus; a folded auxiliary group retains its linked native-hidden tabpanel while unmounting the body,
-and separators expose orientation and current/min/max values. `Ctrl+F6` visits upper-row groups in visual
+and its named restore control is the group focus endpoint when no tab control is rendered. Separators expose
+orientation and current/min/max values. `Ctrl+F6` visits upper-row groups in visual
 order, then visible bottom groups left-to-right. One-row strips have bounded
 readable tab widths, wheel/trackpad scrolling, previous/next controls, active reveal, and a searchable
 keyboard overflow list.

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -10,15 +10,17 @@ tags: [ui, layout, tabs, drag-and-drop]
 
 ## Responsibility
 
-The shell-owned, headless workbench engine: legal layout mutations, recursive center/side rendering,
-resize and drag geometry, keyboard arrangement commands, and focus recovery for the host-synchronized
-`WorkspaceLayoutDocument`. It renders containers; feature views remain arrangement-agnostic.
+The shell-owned, headless workbench engine: legal layout mutations, recursive center plus left/right/bottom
+auxiliary rendering, resize/alignment and drag geometry, keyboard arrangement commands, and focus recovery
+for the host-synchronized `WorkspaceLayoutDocument`. It renders containers; feature views remain
+arrangement-agnostic.
 
 ## Boundary
 
-- **Owns:** the pure topology/policy operations; semantic minimum and group-limit checks; one-result drag
-  previews; center split and side-stack renderers; tab-strip overflow; ARIA tab/separator behavior; and the
-  visibility gate that mounts a terminal body only while that terminal is selected in a visible group.
+- **Owns:** the pure topology/policy operations; semantic minimum and independent group-limit checks;
+  one-result drag previews; center, side-stack, and bottom-row renderers; bottom span projection; tab-strip
+  overflow; ARIA tab/separator behavior; and the visibility gate that mounts a terminal body only while that
+  terminal is selected in a visible, unfolded group.
 - **Public surface (`index.ts`):** the workbench renderer/controller, pure document mutations and invariant
   validator, built-in preset definitions + instantiate/refill operations, attention-fallback helpers, and
   their web-only types. Callers pass resource/tool render callbacks rather
@@ -37,12 +39,14 @@ commit/error callbacks, current layout settings, and feature renderers. Every st
 one complete document; components never splice the store's group/tab arrays.
 
 The shared document carries topology, stable group/split ids, tab membership/order, per-center-group preview
-identity, side visibility/folds, restore targets, and normalized geometry. A click that may still become a
+identity, auxiliary visibility/folds, bottom alignment, restore targets, and normalized geometry. A click that
+may still become a
 browser `dblclick` waits one shared 250 ms settle window; the upgraded gesture emits only its final keep while
 retaining the leading preview-slot claim, whether content was already cached or required a host read. It never carries selected tabs,
 focus, navigation clocks, pointer drafts, or viewport compression. The browser-local attention overlay keeps
-selection per group plus last focus for center/each side and a zero-initialized clock for every center leaf;
-structural replacement reconciles it to the nearest surviving identity and prunes removed-leaf clocks without
+selection per group plus last focus for center/each auxiliary region and a zero-initialized clock for every
+center leaf;
+structural replacement reconciles it to the nearest surviving identity and prunes removed-group clocks without
 publishing.
 
 ## Layout grammar
@@ -50,22 +54,30 @@ publishing.
 - **Center:** a recursive horizontal/vertical binary tree, maximum four leaves. A split replaces one leaf
   with equal halves. User creation/resize requires each child to remain at least 320 px wide and 180 px high.
   Losing a leaf's final tab removes that leaf and promotes its sibling; one final empty leaf always remains.
-- **Sides:** left/right are ordered vertical stacks. Projects, Specs, All files, Changes, and Review are
-  singleton side-only tools; terminals alone may cross between center and sides. Dragging an outer side
-  separator through its minimum hides that side through the same shared visibility transaction as its
-  keyboard/menu command, retains the last expanded width, and exposes the hidden-side restore rail. During a
-  compatible tab drag, every side group exposes broad upper/lower targets below its tab strip; they create a
-  group immediately before/after that group, including at interior boundaries. Folded rows divide their
-  compact height between the same two targets. Empty groups disappear, and an empty side auto-hides. Expanded bodies have a 120 px
-  normal minimum; independently folded groups occupy 27 px and retain their normalized expanded weights.
-  Closing a singleton keeps its local feature state and restore target; a View/deep-link reveal restores or
-  unfolds it in place and focuses the requested item.
-- **Limits:** the host setting defaults to six groups per side. Existing overages survive; creation is
-  unavailable until the side falls below its limit. Reorder/join/reducing moves remain legal. Center and side
-  domain eligibility, stable-id uniqueness, one canonical placement per resource, and the final-center-leaf
-  invariant are enforced by every mutation.
+- **Auxiliary eligibility:** Projects, Specs, All files, Changes, and Review are singleton auxiliary-only
+  tools; terminals may cross between center and any auxiliary region. Closing a singleton keeps its local
+  feature state and restore target; a View/deep-link reveal restores or unfolds it in place and focuses the
+  requested item.
+- **Left/right:** ordered vertical stacks retain the established behavior. Dragging an outer separator through
+  its minimum hides that side through the shared visibility transaction, retains the last expanded width, and
+  exposes its full-height restore rail. Broad upper/lower targets create groups before/after each row, including
+  folded rows. Empty groups disappear and an empty side auto-hides. Expanded bodies have a 120 px normal
+  minimum; independently folded groups occupy 27 px and retain normalized expanded weights.
+- **Bottom:** ordered left-to-right groups resize on vertical separators. A group may fold to a 27 px-wide
+  vertical rail; the whole region hides to a 27 px-high horizontal restore rail over its selected span. Height
+  starts at 30%, has a 120 px body minimum, and caps at 70%. Alignment is one of center, center+left,
+  center+right, or full workbench; an included hidden side contributes no phantom width and expands the span
+  only when shown. Broad left/right targets create groups at every boundary. Empty structural slots are legal
+  for portable terminal layouts; losing the final placed tab auto-hides, while explicit preset application may
+  deliberately show the New Terminal empty state.
+- **Limits:** left/right share the host setting that defaults to six groups per side; bottom has an independent
+  setting defaulting to three. Both accept 1–32. Existing overages survive; creation is unavailable until the
+  region falls below its limit, while reorder/join/reducing moves remain legal. Domain eligibility, stable-id
+  uniqueness, one canonical placement per resource, normalized geometry, and the final-center-leaf invariant
+  are enforced by every mutation.
 - **Small viewports:** restoring onto less space may compress below operation minimums locally. Content
-  scrolls/clips; the shared topology and ratios are never rewritten merely because this viewport is narrow.
+  scrolls/clips; the shared topology, alignment, and ratios are never rewritten merely because this viewport
+  is narrow.
 
 Ordinary opens target this browser's last-focused surviving center group. Reopening a canonical resource
 selects its existing placement instead of duplicating it and refreshes non-identity metadata such as a chat
@@ -90,38 +102,43 @@ clock does not impersonate such navigation, so collapsing the final tab in a lea
 
 ## Arrangement and accessibility
 
-A tab drag paints exactly one result: strip insertion, whole-group join, legal center half-split, or a side
-group's broad upper/lower before-or-after target. An expanded side tab strip remains the join/reorder target
-while its content halves create groups; a folded row has no content, so its compact upper/lower halves become
-the creation targets during a drag. The user never has to acquire a thin outer edge. A hidden side exposes
-its full-height rail as a creation target only when the tab is side-compatible and the group limit permits it.
-Illegal domains, limits, exact-position no-ops, or minimums paint no valid target and commit nothing. Escape,
-pointer cancellation, outside drop, or a superseding remote revision restores the source. Drag moves one tab
-only—never copies, crosses workspaces, or moves a whole group.
+A tab drag paints exactly one result: strip insertion, whole-group join, legal center half-split, a side
+upper/lower boundary, or a bottom left/right boundary. Expanded tab strips remain join/reorder targets while
+content halves create adjacent groups; folded rails divide their compact axis between the same two targets.
+The user never has to acquire a thin outer edge. Hidden left/right/bottom rails become broad creation targets
+only for an eligible tab within that region's limit. Illegal domains, limits, exact-position no-ops, or
+minimums paint no valid target and commit nothing. Escape, pointer cancellation, outside drop, or a
+superseding remote revision restores the source. Drag moves one tab only—never copies, crosses workspaces, or
+moves a whole group.
 
 Pointer is never the sole arrangement path. Keyboard controls and the shadcn menu surface cover group/tab
-focus, select/close/keep/reorder/move, directional splits, absolute and adjacent side-group creation, side
-fold/show/hide/tool restore, and keyboard separator resize, always with an unavailable reason. A tab can
-reproduce any interior pointer placement by moving into the destination group and invoking New group above
-or New group below. Tab strips implement the WAI-ARIA tabs pattern and
-visible roving focus; a folded side group retains its linked native-hidden tabpanel while unmounting the body,
-and separators expose orientation and current/min/max values. One-row strips have bounded
+focus, select/close/keep/reorder/move, directional center splits, absolute and adjacent auxiliary-group
+creation, fold/show/hide/tool restore, bottom alignment, and keyboard separator resize, always with an
+unavailable reason. A tab can reproduce any interior pointer placement by moving into the destination group
+and invoking New group above/below or left/right. Tab strips implement the WAI-ARIA tabs pattern and visible
+roving focus; a folded auxiliary group retains its linked native-hidden tabpanel while unmounting the body,
+and separators expose orientation and current/min/max values. `Ctrl+F6` visits upper-row groups in visual
+order, then visible bottom groups left-to-right. One-row strips have bounded
 readable tab widths, wheel/trackpad scrolling, previous/next controls, active reveal, and a searchable
 keyboard overflow list.
 
 ## Presets and synchronization
 
-Balanced, Focus, and Review are web-owned portable definitions; custom presets use the same resource-free
-shape. Instantiation fills resources deterministically, prunes unused center leaves, and never imports a
-foreign workspace identity. Selecting, applying, or first-seeding a preset raises the synchronized side-group
-limit first when its topology requires more groups; an existing over-limit document otherwise remains
-grandfathered. Applying a preset preserves resources by flattening center tabs in visual order,
-seeding one per leaf, putting the remainder in the primary leaf, and relocating side terminals through the
-same-side → opposite-side → primary-center fallback without overriding the preset's side visibility.
-Existing singleton-tool placement ids survive relocation, and a newly materialized tool receives a fresh
-placement-only id when its conventional id is already owned by another semantic resource. Singleton tools
-omitted by a custom preset stay deliberately unplaced but receive default/prior-side restore
-targets, so an empty portable preset can never strand the user without a Projects/tool recovery path.
+Balanced, Focus, and Review are web-owned portable definitions with one below-center bottom slot: Balanced
+and Review show it, Focus hides it. Custom presets use the same resource-free shape and capture bottom
+height/alignment/folds/weights plus empty structural slots. Terminal identity and count never enter a preset.
+Instantiation fills resources deterministically, prunes unused center leaves, and never imports a foreign
+workspace identity. Selecting, applying, or first-seeding raises the independent side/bottom limits first
+when topology requires it; existing overages otherwise remain grandfathered.
+
+Applying a bottom-aware preset moves all terminals into its bottom slots: one per group left-to-right, then
+remaining terminals in the first group. With no terminal, a visible slot stays process-free and renders New
+Terminal. Center resources still seed one per leaf with the remainder in the primary leaf. Existing
+singleton-tool placement ids survive relocation, and a newly materialized tool receives a fresh
+placement-only id when its conventional id is already owned by another semantic resource. Omitted singleton
+tools stay deliberately unplaced but receive default/prior auxiliary restore targets, so an empty portable
+preset can never strand the user without a Projects/tool recovery path. Version-1 layouts/custom presets
+normalize to hidden empty bottom without moving a resource.
 
 Pointer drag/resize drafts remain local and emit one snapshot only on drop/pointer-up. A newer accepted
 revision whose mutation id does not match this client's optimistic base cancels the draft, makes release
@@ -132,8 +149,8 @@ advances the accepted revision without cancelling a newer draft begun on that do
 current state and advances the same projection epoch, while this pure module remains unaware of transport,
 persistence, and optimistic queues.
 
-The terminal visibility gate mounts a body only for a terminal locally selected in an expanded visible group.
+The terminal visibility gate mounts a body only for a terminal locally selected in an unfolded visible group.
 Several distinct terminal identities may mount concurrently; the same identity has one body per browser, and
-inactive/folded/hidden terminal tabs never attach. Every center Group Header retains a New terminal command;
-it captures that group in the placement intent, so closing the final terminal body cannot remove the creation
-path and a vanished captured group reroutes to current center focus.
+inactive/folded/hidden terminal tabs never attach. Global New Terminal targets and reveals last bottom focus,
+creating a bottom slot if needed; every center Group Header retains a contextual New terminal command that
+captures that center group. A vanished captured group reroutes through the corresponding current-focus rule.

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -66,8 +66,10 @@ publishing.
 - **Bottom:** ordered left-to-right groups resize on vertical separators. A group may fold to a 27 px-wide
   vertical rail; the whole region hides to a 27 px-high horizontal restore rail over its selected span. Height
   starts at 30%, has a 120 px body minimum, and caps at 70%. Alignment is one of center, center+left,
-  center+right, or full workbench; an included hidden side contributes no phantom width and expands the span
-  only when shown. Broad left/right targets create groups at every boundary. Empty structural slots are legal
+  center+right, or full workbench; its span follows the upper row's actual browser-local side projection during
+  a resize gesture and narrow-width compression, while persisted side-width ratios remain the durable target.
+  An included hidden side contributes no phantom width and expands the span only when shown. Broad left/right
+  targets create groups at every boundary. Empty structural slots are legal
   for portable terminal layouts; losing the final placed tab auto-hides, while explicit preset application may
   deliberately show the New Terminal empty state.
 - **Limits:** left/right share the host setting that defaults to six groups per side; bottom has an independent
@@ -76,8 +78,8 @@ publishing.
   uniqueness, one canonical placement per resource, normalized geometry, and the final-center-leaf invariant
   are enforced by every mutation.
 - **Small viewports:** restoring onto less space may compress below operation minimums locally. Content
-  scrolls/clips; the shared topology, alignment, and ratios are never rewritten merely because this viewport
-  is narrow.
+  scrolls/clips; bottom alignment projects from those actual compressed side spans, while the shared topology,
+  alignment choice, and ratios are never rewritten merely because this viewport is narrow.
 
 Ordinary opens target this browser's last-focused surviving center group. Reopening a canonical resource
 selects its existing placement instead of duplicating it and refreshes non-identity metadata such as a chat
@@ -143,7 +145,9 @@ tools stay deliberately unplaced but receive default/prior auxiliary restore tar
 preset can never strand the user without a Projects/tool recovery path. Version-1 layouts/custom presets
 normalize to hidden empty bottom without moving a resource.
 
-Pointer drag/resize drafts remain local and emit one snapshot only on drop/pointer-up. A newer accepted
+Pointer drag/resize drafts remain local and emit one snapshot only on drop/pointer-up. The bottom row follows
+an outer side-resize draft from the panel group's live projection without publishing that transient geometry.
+A newer accepted
 revision whose mutation id does not match this client's optimistic base cancels the draft, makes release
 inert, and lets the parent explain the cancellation; the same projection epoch invalidates a pending
 preview-click settle timer before it can publish from the replaced document. A matching acknowledgement

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -134,8 +134,9 @@ transition moves focus onto that restore control and expansion returns it to the
 orientation and current/min/max values. `Ctrl+F6` visits upper-row groups in visual
 order, then visible bottom groups left-to-right. One-row strips have bounded readable tab widths and no
 fixed previous/next controls: wheel, trackpad, touch, roving-keyboard navigation, active reveal, and the
-searchable keyboard overflow list all scroll the same tab list, whose slim horizontal scrollbar appears only
-on hover or focus-within when content overflows without changing the strip's fixed height. Singleton tool tabs
+searchable keyboard overflow list all scroll the same tab list. Its native scrollbar stays hidden; subtle,
+pointer-transparent edge fades appear only on directions with clipped tabs and update with scroll, resize, and
+tab changes without altering the fixed 28 px strip or tab geometry. Singleton tool tabs
 (Projects, Specs, Files, Changes, Review) carry no inline close glyph; Close remains in their context menu
 and on the Delete key, while terminals and center resources retain the direct glyph.
 

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -18,9 +18,9 @@ arrangement-agnostic.
 ## Boundary
 
 - **Owns:** the pure topology/policy operations; semantic minimum and independent group-limit checks;
-  one-result drag previews; center, side-stack, and bottom-row renderers; bottom span projection; tab-strip
-  overflow; ARIA tab/separator behavior; and the visibility gate that mounts a terminal body only while that
-  terminal is selected in a visible, unfolded group.
+  one-result drag previews; center/side/bottom renderers; alignment-owned nested workbench composition and
+  side-width projection; tab-strip overflow; ARIA tab/separator behavior; and the visibility gate that mounts
+  a terminal body only while that terminal is selected in a visible, unfolded group.
 - **Public surface (`index.ts`):** the workbench renderer/controller, pure document mutations and invariant
   validator, built-in preset definitions + instantiate/refill operations, attention-fallback helpers, and
   their web-only types. Callers pass resource/tool render callbacks rather
@@ -66,12 +66,15 @@ publishing.
 - **Bottom:** ordered left-to-right groups resize on vertical separators. A group may fold to a 27 px-wide
   vertical rail; the whole region hides to a 27 px-high horizontal restore rail over its selected span. Height
   starts at 30%, has a 120 px body minimum, and caps at 70%. Alignment is one of center, center+left,
-  center+right, or full workbench; its span follows the upper row's actual browser-local side projection during
-  a resize gesture and narrow-width compression, while persisted side-width ratios remain the durable target.
-  An included hidden side contributes no phantom width and expands the span only when shown. Broad left/right
-  targets create groups at every boundary. Empty structural slots are legal
-  for portable terminal layouts; losing the final placed tab auto-hides, while explicit preset application may
-  deliberately show the New Terminal empty state.
+  center+right, or full workbench. A side excluded from that span owns its lower corner and its real stack
+  continues to the workbench bottom; an included side ends above the bottom surface. The hidden restore rail
+  follows the same ownership. Alignment composition follows actual browser-local side projection during a
+  resize gesture and narrow-width compression, while persisted workbench-wide side ratios remain the durable
+  target and are converted through nested panel groups. A hidden side contributes no phantom width and joins
+  the span only when shown. Broad left/right targets create groups at every boundary. Empty structural slots
+  remain legal for portable terminal layouts and the deliberate process-free New Terminal state. Closing or
+  moving a group's final tab removes only that newly vacated group, renormalizes survivors, and auto-hides when
+  no populated group remains.
 - **Limits:** left/right share the host setting that defaults to six groups per side; bottom has an independent
   setting defaulting to three. Both accept 1–32. Existing overages survive; creation is unavailable until the
   region falls below its limit, while reorder/join/reducing moves remain legal. Domain eligibility, stable-id
@@ -145,9 +148,9 @@ tools stay deliberately unplaced but receive default/prior auxiliary restore tar
 preset can never strand the user without a Projects/tool recovery path. Version-1 layouts/custom presets
 normalize to hidden empty bottom without moving a resource.
 
-Pointer drag/resize drafts remain local and emit one snapshot only on drop/pointer-up. The bottom row follows
-an outer side-resize draft from the panel group's live projection without publishing that transient geometry.
-A newer accepted
+Pointer drag/resize drafts remain local and emit one snapshot only on drop/pointer-up. Nested outer and
+aligned-row groups project active side-resize drafts through one browser-local workbench-wide coordinate
+space without publishing that transient geometry. A newer accepted
 revision whose mutation id does not match this client's optimistic base cancels the draft, makes release
 inert, and lets the parent explain the cancellation; the same projection epoch invalidates a pending
 preview-click settle timer before it can publish from the replaced document. A matching acknowledgement

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -118,7 +118,8 @@ creation, fold/show/hide/tool restore, bottom alignment, and keyboard separator 
 unavailable reason. A tab can reproduce any interior pointer placement by moving into the destination group
 and invoking New group above/below or left/right. Tab strips implement the WAI-ARIA tabs pattern and visible
 roving focus; a folded auxiliary group retains its linked native-hidden tabpanel while unmounting the body,
-and its named restore control is the group focus endpoint when no tab control is rendered. Separators expose
+and its named restore control is the group focus endpoint when no tab control is rendered. A local bottom-fold
+transition moves focus onto that restore control and expansion returns it to the selected tab. Separators expose
 orientation and current/min/max values. `Ctrl+F6` visits upper-row groups in visual
 order, then visible bottom groups left-to-right. One-row strips have bounded
 readable tab widths, wheel/trackpad scrolling, previous/next controls, active reveal, and a searchable

--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -47,14 +47,16 @@ focus, navigation clocks, pointer drafts, or viewport compression. The browser-l
 selection per group plus last focus for center/each auxiliary region and a zero-initialized clock for every
 center leaf;
 structural replacement reconciles it to the nearest surviving identity and prunes removed-group clocks without
-publishing.
+publishing. A tab's stored `name` is non-identity metadata. Singleton tool names resolve from the current
+web-owned catalog at presentation time, so a vocabulary update reaches old snapshots without spending a
+shared-layout revision merely to rewrite display copy.
 
 ## Layout grammar
 
 - **Center:** a recursive horizontal/vertical binary tree, maximum four leaves. A split replaces one leaf
   with equal halves. User creation/resize requires each child to remain at least 320 px wide and 180 px high.
   Losing a leaf's final tab removes that leaf and promotes its sibling; one final empty leaf always remains.
-- **Auxiliary eligibility:** Projects, Specs, All files, Changes, and Review are singleton auxiliary-only
+- **Auxiliary eligibility:** Projects, Specs, Files, Changes, and Review are singleton auxiliary-only
   tools; terminals may cross between center and any auxiliary region. Closing a singleton keeps its local
   feature state and restore target; a View/deep-link reveal restores or unfolds it in place and focuses the
   requested item.
@@ -134,7 +136,7 @@ order, then visible bottom groups left-to-right. One-row strips have bounded rea
 fixed previous/next controls: wheel, trackpad, touch, roving-keyboard navigation, active reveal, and the
 searchable keyboard overflow list all scroll the same tab list, whose slim horizontal scrollbar appears only
 on hover or focus-within when content overflows without changing the strip's fixed height. Singleton tool tabs
-(Projects, Specs, All files, Changes, Review) carry no inline close glyph; Close remains in their context menu
+(Projects, Specs, Files, Changes, Review) carry no inline close glyph; Close remains in their context menu
 and on the Delete key, while terminals and center resources retain the direct glyph.
 
 ## Presets and synchronization

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -29,7 +29,6 @@ import {
 	Check,
 	ChevronDown,
 	ChevronLeft,
-	ChevronRight,
 	File,
 	GitCompareArrows,
 	ListTodo,
@@ -551,19 +550,11 @@ function TabStrip({
 			data-drop-active={groupDrop.isOver || undefined}
 			className="relative flex h-panel-header-row shrink-0 items-stretch border-border-default border-b bg-container-workspace-bg data-[drop-active]:bg-primary-subtle"
 		>
-			<button
-				type="button"
-				aria-label="Scroll tabs left"
-				onClick={() => scroller.current?.scrollBy({ left: -180, behavior: "smooth" })}
-				className="flex w-6 shrink-0 items-center justify-center border-border-muted border-r text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-			>
-				<ChevronLeft className="size-3.5" />
-			</button>
 			<div
 				ref={scroller}
 				role="tablist"
 				aria-label={`${location.area} group tabs`}
-				className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-width:none]"
+				className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-color:transparent_transparent] [scrollbar-width:thin] supports-[selector(::-webkit-scrollbar)]:[scrollbar-width:auto] [&::-webkit-scrollbar]:!h-0.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent hover:[scrollbar-color:var(--color-border-default)_transparent] hover:[&::-webkit-scrollbar-thumb]:bg-border-default focus-within:[scrollbar-color:var(--color-border-default)_transparent] focus-within:[&::-webkit-scrollbar-thumb]:bg-border-default"
 				onWheel={(event) => {
 					if (!scroller.current || Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
 					scroller.current.scrollLeft += event.deltaY;
@@ -639,14 +630,6 @@ function TabStrip({
 				) : null}
 			</div>
 			{trailing}
-			<button
-				type="button"
-				aria-label="Scroll tabs right"
-				onClick={() => scroller.current?.scrollBy({ left: 180, behavior: "smooth" })}
-				className="flex w-6 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-			>
-				<ChevronRight className="size-3.5" />
-			</button>
 			<Popover open={overflowOpen} onOpenChange={setOverflowOpen}>
 				<PopoverTrigger
 					aria-label="Search open tabs"
@@ -880,22 +863,24 @@ function WorkbenchTab({
 						onClick={selectFromClick}
 						onDoubleClick={selectFromDoubleClick}
 						onKeyDown={onKeyDown}
-						className="flex min-w-0 flex-1 items-center gap-xs py-xs pl-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+						className={`flex min-w-0 flex-1 items-center gap-xs py-xs pl-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary ${tab.kind === "tool" ? "pr-sm" : ""}`}
 					>
 						{tabIcon(tab)}
 						<span className={`truncate ${preview ? "italic" : ""}`}>{tab.name}</span>
 						{renderTabAdornment(tab)}
 					</button>
-					<button
-						type="button"
-						tabIndex={-1}
-						data-testid={tab.kind === "terminal" ? "terminal-tab-close" : "editor-tab-close"}
-						aria-label={`Close ${tab.name}`}
-						onClick={onClose}
-						className="mr-xs rounded-[var(--radius-sm)] p-0.5 opacity-0 hover:bg-control-bg-hovered group-hover:opacity-100 focus:opacity-100"
-					>
-						<X className="size-3.5" />
-					</button>
+					{tab.kind !== "tool" ? (
+						<button
+							type="button"
+							tabIndex={-1}
+							data-testid={tab.kind === "terminal" ? "terminal-tab-close" : "editor-tab-close"}
+							aria-label={`Close ${tab.name}`}
+							onClick={onClose}
+							className="mr-xs rounded-[var(--radius-sm)] p-0.5 opacity-0 hover:bg-control-bg-hovered group-hover:opacity-100 focus:opacity-100"
+						>
+							<X className="size-3.5" />
+						</button>
+					) : null}
 				</div>
 			</ContextMenuTrigger>
 			<ContextMenuContent>

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -170,10 +170,10 @@ interface DragData {
 	tab: LayoutTab;
 }
 
-function sameSizes(first: readonly number[], second: readonly number[]): boolean {
+function sameSizes(first: readonly number[], second: readonly number[], tolerance = 0.15): boolean {
 	return (
 		first.length === second.length &&
-		first.every((value, index) => Math.abs(value - (second[index] ?? 0)) < 0.15)
+		first.every((value, index) => Math.abs(value - (second[index] ?? 0)) < tolerance)
 	);
 }
 
@@ -1985,63 +1985,57 @@ function BottomStack({
 
 function BottomAlignedRow({
 	document,
-	leftVisible,
-	rightVisible,
+	projectedLeft,
+	projectedRight,
 	children,
 }: {
 	document: WorkspaceLayoutDocument;
-	leftVisible: boolean;
-	rightVisible: boolean;
+	projectedLeft: number;
+	projectedRight: number;
 	children: ReactNode;
 }) {
-	const left = leftVisible ? document.left.width * 100 : 0;
-	const right = rightVisible ? document.right.width * 100 : 0;
-	const center = 100 - left - right;
 	const start =
 		document.bottom.alignment === "center" || document.bottom.alignment === "center-right"
-			? left
+			? projectedLeft
 			: 0;
 	const end =
 		document.bottom.alignment === "center" || document.bottom.alignment === "center-left"
-			? right
+			? projectedRight
 			: 0;
-	const body = Math.max(Number.EPSILON, center + left + right - start - end);
+	const body = Math.max(Number.EPSILON, 100 - start - end);
+	const layout = useMemo(
+		() => [...(start > 0 ? [start] : []), body, ...(end > 0 ? [end] : [])],
+		[body, end, start],
+	);
+	const groupRef = useRef<ImperativePanelGroupHandle>(null);
+	useEffect(() => {
+		const group = groupRef.current;
+		if (group && !sameSizes(group.getLayout(), layout, 0.01)) group.setLayout(layout);
+	}, [layout]);
 	return (
 		<ResizablePanelGroup
-			key={tupleKey("bottom-alignment", document.bottom.alignment, String(left), String(right))}
+			ref={groupRef}
+			key={tupleKey(
+				"bottom-alignment",
+				document.bottom.alignment,
+				String(start > 0),
+				String(end > 0),
+			)}
 			direction="horizontal"
 			data-testid="bottom-aligned-row"
 			data-alignment={document.bottom.alignment}
 			className="min-h-0 min-w-0"
 		>
 			{start > 0 ? (
-				<ResizablePanel
-					id="bottom-start-spacer"
-					order={1}
-					defaultSize={start}
-					minSize={start}
-					maxSize={start}
-				>
+				<ResizablePanel id="bottom-start-spacer" order={1} defaultSize={start}>
 					<div aria-hidden="true" className="h-full bg-container-workspace-bg" />
 				</ResizablePanel>
 			) : null}
-			<ResizablePanel
-				id="bottom-aligned-body"
-				order={2}
-				defaultSize={body}
-				minSize={body}
-				maxSize={body}
-			>
+			<ResizablePanel id="bottom-aligned-body" order={2} defaultSize={body}>
 				{children}
 			</ResizablePanel>
 			{end > 0 ? (
-				<ResizablePanel
-					id="bottom-end-spacer"
-					order={3}
-					defaultSize={end}
-					minSize={end}
-					maxSize={end}
-				>
+				<ResizablePanel id="bottom-end-spacer" order={3} defaultSize={end}>
 					<div aria-hidden="true" className="h-full bg-container-workspace-bg" />
 				</ResizablePanel>
 			) : null}
@@ -2465,6 +2459,11 @@ export function Workbench({
 		],
 		[document.left.width, document.right.width, leftVisible, rightVisible],
 	);
+	const [projectedOuter, setProjectedOuter] = useState<readonly number[]>(outerCurrent);
+	const activeProjection =
+		projectedOuter.length === outerCurrent.length ? projectedOuter : outerCurrent;
+	const projectedLeft = leftVisible ? (activeProjection[0] ?? 0) : 0;
+	const projectedRight = rightVisible ? (activeProjection.at(-1) ?? 0) : 0;
 	const outerGroupRef = useRef<ImperativePanelGroupHandle>(null);
 	useEffect(() => {
 		const group = outerGroupRef.current;
@@ -2500,6 +2499,13 @@ export function Workbench({
 			apply(result);
 		},
 		onRemoteGestureCanceled,
+	);
+	const projectOuterLayout = useCallback(
+		(sizes: number[]) => {
+			setProjectedOuter((current) => (sameSizes(current, sizes, 0.01) ? current : [...sizes]));
+			outerResize.onLayout(sizes);
+		},
+		[outerResize.onLayout],
 	);
 	const bottomVisible = document.bottom.visible && document.bottom.groups.length > 0;
 	const hiddenBottomTargetGroupId =
@@ -2658,7 +2664,7 @@ export function Workbench({
 				String(remoteEpoch),
 			)}
 			direction="horizontal"
-			onLayout={outerResize.onLayout}
+			onLayout={projectOuterLayout}
 			className="h-full min-h-0 min-w-0 flex-1"
 		>
 			{leftVisible ? (
@@ -2816,8 +2822,8 @@ export function Workbench({
 							>
 								<BottomAlignedRow
 									document={document}
-									leftVisible={leftVisible}
-									rightVisible={rightVisible}
+									projectedLeft={projectedLeft}
+									projectedRight={projectedRight}
 								>
 									<BottomStack
 										remoteEpoch={remoteEpoch}
@@ -2834,8 +2840,8 @@ export function Workbench({
 							<div className="h-7 shrink-0">
 								<BottomAlignedRow
 									document={document}
-									leftVisible={leftVisible}
-									rightVisible={rightVisible}
+									projectedLeft={projectedLeft}
+									projectedRight={projectedRight}
 								>
 									<HiddenBottomRail
 										onShow={showBottomRegion}

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -58,6 +58,15 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "../../components/ui/context-menu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../../components/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "../../components/ui/popover";
 import {
 	type ImperativePanelGroupHandle,
@@ -1574,42 +1583,35 @@ function BottomAlignmentMenu({
 	onHide: () => void;
 }) {
 	return (
-		<Popover>
-			<PopoverTrigger
+		<DropdownMenu>
+			<DropdownMenuTrigger
 				aria-label="Bottom panel alignment"
 				title={`Bottom panel alignment: ${BOTTOM_ALIGNMENT_LABELS[alignment]}`}
 				className="flex w-7 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
 			>
 				<MoreHorizontal className="size-4" />
-			</PopoverTrigger>
-			<PopoverContent align="end" className="w-56 p-xs">
-				<div className="space-y-0.5" role="menu" aria-label="Bottom panel alignment">
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-56">
+				<DropdownMenuRadioGroup
+					value={alignment}
+					onValueChange={(value) => onChange(value as LayoutBottomAlignment)}
+				>
 					{(Object.keys(BOTTOM_ALIGNMENT_LABELS) as LayoutBottomAlignment[]).map((value) => (
-						<button
+						<DropdownMenuRadioItem
 							key={value}
-							type="button"
-							role="menuitemradio"
-							aria-checked={alignment === value}
+							value={value}
 							data-testid={`bottom-align-${value}`}
-							onClick={() => onChange(value)}
-							className="flex w-full items-center justify-between rounded-[var(--radius-sm)] px-sm py-xs text-left tr-text-ui text-text-default hover:bg-control-bg-hovered"
+							className="justify-between"
 						>
 							<span>{BOTTOM_ALIGNMENT_LABELS[value]}</span>
-							{alignment === value ? <Check className="size-3.5 text-primary" /> : null}
-						</button>
+							{alignment === value ? <Check className="text-primary" /> : null}
+						</DropdownMenuRadioItem>
 					))}
-					<div className="my-xs border-border-default border-t" />
-					<button
-						type="button"
-						role="menuitem"
-						onClick={onHide}
-						className="w-full rounded-[var(--radius-sm)] px-sm py-xs text-left tr-text-ui text-text-default hover:bg-control-bg-hovered"
-					>
-						Hide bottom panel
-					</button>
-				</div>
-			</PopoverContent>
-		</Popover>
+				</DropdownMenuRadioGroup>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem onSelect={onHide}>Hide bottom panel</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 
@@ -1917,7 +1919,14 @@ function BottomStack({
 							group.id,
 							!group.folded,
 						);
-						if (!isLayoutUnavailable(result)) shared.onApply(result);
+						if (isLayoutUnavailable(result)) return;
+						const selectedId = readLayoutSelection(shared.attention, group.id);
+						const selected = group.tabs.find((tab) => tab.id === selectedId) ?? group.tabs[0];
+						shared.onApply({
+							...result,
+							focusGroupId: group.id,
+							...(group.folded && selected ? { focusTabId: selected.id } : {}),
+						});
 					};
 					return (
 						<PanelWithHandle

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -314,6 +314,51 @@ function useElementSize(): {
 	return { ref, ...size };
 }
 
+interface HorizontalOverflow {
+	before: boolean;
+	after: boolean;
+}
+
+function useHorizontalOverflow(ref: React.RefObject<HTMLDivElement | null>): HorizontalOverflow {
+	const [overflow, setOverflow] = useState<HorizontalOverflow>({ before: false, after: false });
+	const update = useCallback(() => {
+		const element = ref.current;
+		if (!element) return;
+		const maximum = Math.max(0, element.scrollWidth - element.clientWidth);
+		const next = {
+			before: element.scrollLeft > 1,
+			after: element.scrollLeft < maximum - 1,
+		};
+		setOverflow((current) =>
+			current.before === next.before && current.after === next.after ? current : next,
+		);
+	}, [ref]);
+
+	useEffect(() => {
+		const element = ref.current;
+		if (!element) return;
+		const frame = requestAnimationFrame(update);
+		element.addEventListener("scroll", update, { passive: true });
+		const resize = new ResizeObserver(update);
+		resize.observe(element);
+		const mutations = new MutationObserver(update);
+		mutations.observe(element, {
+			attributes: true,
+			characterData: true,
+			childList: true,
+			subtree: true,
+		});
+		return () => {
+			cancelAnimationFrame(frame);
+			element.removeEventListener("scroll", update);
+			resize.disconnect();
+			mutations.disconnect();
+		};
+	}, [ref, update]);
+
+	return overflow;
+}
+
 function tabSearchKeywords(tab: LayoutTab): string[] {
 	const name = layoutTabName(tab);
 	switch (tab.kind) {
@@ -499,6 +544,7 @@ function TabStrip({
 	trailing,
 }: TabStripProps) {
 	const scroller = useRef<HTMLDivElement>(null);
+	const scrollOverflow = useHorizontalOverflow(scroller);
 	const tabRefs = useRef(new Map<string, HTMLButtonElement>());
 	const overflowFocusTarget = useRef<string | null>(null);
 	const [overflowOpen, setOverflowOpen] = useState(false);
@@ -552,82 +598,104 @@ function TabStrip({
 			data-drop-active={groupDrop.isOver || undefined}
 			className="relative flex h-panel-header-row shrink-0 items-stretch border-border-default border-b bg-container-workspace-bg data-[drop-active]:bg-primary-subtle"
 		>
-			<div
-				ref={scroller}
-				role="tablist"
-				aria-label={`${location.area} group tabs`}
-				className="flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-color:transparent_transparent] [scrollbar-width:thin] supports-[selector(::-webkit-scrollbar)]:[scrollbar-width:auto] [&::-webkit-scrollbar]:!h-0.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent [&::-webkit-scrollbar-track]:bg-transparent hover:[scrollbar-color:var(--color-border-default)_transparent] hover:[&::-webkit-scrollbar-thumb]:bg-border-default focus-within:[scrollbar-color:var(--color-border-default)_transparent] focus-within:[&::-webkit-scrollbar-thumb]:bg-border-default"
-				onWheel={(event) => {
-					if (!scroller.current || Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
-					scroller.current.scrollLeft += event.deltaY;
-				}}
-			>
-				{tabs.map((tab, index) => (
-					<WorkbenchTab
-						key={tab.id}
-						tab={tab}
-						index={index}
-						location={location}
-						attention={attention}
-						selectionEpoch={selectionEpoch}
-						active={tab.id === selectedId}
-						preview={tab.id === previewId}
-						document={document}
-						maxSideGroups={maxSideGroups}
-						maxBottomGroups={maxBottomGroups}
-						register={(node) => {
-							if (node) tabRefs.current.set(tab.id, node);
-							else tabRefs.current.delete(tab.id);
-						}}
-						onSelect={selectTab}
-						onClose={() => closeTab(tab)}
-						onApply={applyResult}
-						onFocusAdjacentGroup={onFocusAdjacentGroup}
-						onHideSide={onHideSide}
-						onRevealTool={onRevealTool}
-						canFocusAdjacentGroup={canFocusAdjacentGroup}
-						renderTabAdornment={renderTabAdornment}
-						draggingTab={draggingTab}
-						panelId={panelId}
-						{...(splitGeometry ? { splitGeometry } : {})}
-						onKeyDown={(event) => {
-							if (event.altKey && event.shiftKey && event.key === "ArrowLeft") {
-								event.preventDefault();
-								if (index > 0) {
-									const moved = moveTabToGroup(document, tab, location, index - 1);
-									if (!isLayoutUnavailable(moved)) applyResult(moved);
+			<div className="relative min-w-0 flex-1 overflow-hidden">
+				<div
+					ref={scroller}
+					role="tablist"
+					aria-label={`${location.area} group tabs`}
+					className="flex h-full w-full min-w-0 items-stretch overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+					onWheel={(event) => {
+						if (!scroller.current || Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+						scroller.current.scrollLeft += event.deltaY;
+					}}
+				>
+					{tabs.map((tab, index) => (
+						<WorkbenchTab
+							key={tab.id}
+							tab={tab}
+							index={index}
+							location={location}
+							attention={attention}
+							selectionEpoch={selectionEpoch}
+							active={tab.id === selectedId}
+							preview={tab.id === previewId}
+							document={document}
+							maxSideGroups={maxSideGroups}
+							maxBottomGroups={maxBottomGroups}
+							register={(node) => {
+								if (node) tabRefs.current.set(tab.id, node);
+								else tabRefs.current.delete(tab.id);
+							}}
+							onSelect={selectTab}
+							onClose={() => closeTab(tab)}
+							onApply={applyResult}
+							onFocusAdjacentGroup={onFocusAdjacentGroup}
+							onHideSide={onHideSide}
+							onRevealTool={onRevealTool}
+							canFocusAdjacentGroup={canFocusAdjacentGroup}
+							renderTabAdornment={renderTabAdornment}
+							draggingTab={draggingTab}
+							panelId={panelId}
+							{...(splitGeometry ? { splitGeometry } : {})}
+							onKeyDown={(event) => {
+								if (event.altKey && event.shiftKey && event.key === "ArrowLeft") {
+									event.preventDefault();
+									if (index > 0) {
+										const moved = moveTabToGroup(document, tab, location, index - 1);
+										if (!isLayoutUnavailable(moved)) applyResult(moved);
+									}
+								} else if (event.altKey && event.shiftKey && event.key === "ArrowRight") {
+									event.preventDefault();
+									if (index < tabs.length - 1) {
+										const moved = moveTabToGroup(document, tab, location, index + 1);
+										if (!isLayoutUnavailable(moved)) applyResult(moved);
+									}
+								} else if (event.key === "ArrowLeft") {
+									event.preventDefault();
+									selectAt(index === 0 ? tabs.length - 1 : index - 1);
+								} else if (event.key === "ArrowRight") {
+									event.preventDefault();
+									selectAt(index === tabs.length - 1 ? 0 : index + 1);
+								} else if (event.key === "Home") {
+									event.preventDefault();
+									selectAt(0);
+								} else if (event.key === "End") {
+									event.preventDefault();
+									selectAt(tabs.length - 1);
+								} else if (event.key === "Delete") {
+									event.preventDefault();
+									closeTab(tab);
 								}
-							} else if (event.altKey && event.shiftKey && event.key === "ArrowRight") {
-								event.preventDefault();
-								if (index < tabs.length - 1) {
-									const moved = moveTabToGroup(document, tab, location, index + 1);
-									if (!isLayoutUnavailable(moved)) applyResult(moved);
-								}
-							} else if (event.key === "ArrowLeft") {
-								event.preventDefault();
-								selectAt(index === 0 ? tabs.length - 1 : index - 1);
-							} else if (event.key === "ArrowRight") {
-								event.preventDefault();
-								selectAt(index === tabs.length - 1 ? 0 : index + 1);
-							} else if (event.key === "Home") {
-								event.preventDefault();
-								selectAt(0);
-							} else if (event.key === "End") {
-								event.preventDefault();
-								selectAt(tabs.length - 1);
-							} else if (event.key === "Delete") {
-								event.preventDefault();
-								closeTab(tab);
-							}
-						}}
+							}}
+						/>
+					))}
+					{acceptsAppend ? (
+						<DropZone
+							id={tupleKey(
+								"dnd-insert",
+								location.area,
+								location.groupId,
+								String(tabs.length),
+								"end",
+							)}
+							target={{ kind: "insert", location, index: tabs.length }}
+							label="Insert at end"
+							className="relative h-full w-5 shrink-0"
+						/>
+					) : null}
+				</div>
+				{scrollOverflow.before ? (
+					<div
+						aria-hidden="true"
+						data-testid="tab-overflow-before"
+						className="pointer-events-none absolute inset-y-0 left-0 z-20 w-lg bg-[linear-gradient(to_right,var(--color-container-workspace-bg),transparent)]"
 					/>
-				))}
-				{acceptsAppend ? (
-					<DropZone
-						id={tupleKey("dnd-insert", location.area, location.groupId, String(tabs.length), "end")}
-						target={{ kind: "insert", location, index: tabs.length }}
-						label="Insert at end"
-						className="relative h-full w-5 shrink-0"
+				) : null}
+				{scrollOverflow.after ? (
+					<div
+						aria-hidden="true"
+						data-testid="tab-overflow-after"
+						className="pointer-events-none absolute inset-y-0 right-0 z-20 w-lg bg-[linear-gradient(to_left,var(--color-container-workspace-bg),transparent)]"
 					/>
 				) : null}
 			</div>

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -177,6 +177,10 @@ function sameSizes(first: readonly number[], second: readonly number[], toleranc
 	);
 }
 
+function isResizeArrowKey(key: string): boolean {
+	return ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(key);
+}
+
 function useCommittedSizes(
 	current: readonly number[],
 	remoteEpoch: number,
@@ -258,7 +262,7 @@ function useCommittedSizes(
 		[cancelStaleGesture, flush],
 	);
 	const onKeyboard = useCallback((event: { key: string }) => {
-		if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) return;
+		if (!isResizeArrowKey(event.key)) return;
 		startEpoch.current = epoch.current;
 		keyboard.current = true;
 	}, []);
@@ -267,6 +271,28 @@ function useCommittedSizes(
 		pending.current = null;
 	}, []);
 	return { onLayout, onDragging, onKeyboard, onKeyboardEnd };
+}
+
+function bindSideResize(
+	side: LayoutSide,
+	resize: ReturnType<typeof useCommittedSizes>,
+	activeSide: { current: LayoutSide | null },
+) {
+	return {
+		onDragging: (active: boolean) => {
+			if (active) activeSide.current = side;
+			resize.onDragging(active);
+			if (!active && activeSide.current === side) activeSide.current = null;
+		},
+		onKeyboard: (event: { key: string }) => {
+			if (isResizeArrowKey(event.key)) activeSide.current = side;
+			resize.onKeyboard(event);
+		},
+		onKeyboardEnd: () => {
+			resize.onKeyboardEnd();
+			if (activeSide.current === side) activeSide.current = null;
+		},
+	};
 }
 
 function useElementSize(): {
@@ -2281,7 +2307,12 @@ export function Workbench({
 						const countsAsNavigation =
 							(wasSelectedAtRequest || closeControlHadFocusAtRequest) && !navigationWasOvertaken;
 						let focusLocation: LayoutGroupLocation | null = null;
-						if (countsAsNavigation && location && location.area !== "center") {
+						if (
+							countsAsNavigation &&
+							location &&
+							location.area !== "center" &&
+							acceptedDocument[location.area].visible
+						) {
 							const sideGroupId = nextAttention.lastFocusedSideGroupId[location.area];
 							if (sideGroupId) focusLocation = { area: location.area, groupId: sideGroupId };
 						}
@@ -2449,6 +2480,7 @@ export function Workbench({
 	});
 	const projectedAlignedWidth =
 		alignedProjection.topology === outerTopology ? alignedProjection.width : alignedWidthCurrent;
+	const activeSideResize = useRef<LayoutSide | null>(null);
 	const commitSideSizes = useCallback(
 		(entries: ReadonlyArray<readonly [LayoutSide, number]>) => {
 			let next = document;
@@ -2478,12 +2510,13 @@ export function Workbench({
 		outerCurrent,
 		remoteEpoch,
 		(sizes) => {
-			const entries: Array<readonly [LayoutSide, number]> = [];
-			if (leftOwnsBottomCorner) entries.push(["left", sizes[0] ?? globalLeftCurrent]);
-			if (rightOwnsBottomCorner) {
-				entries.push(["right", sizes.at(-1) ?? globalRightCurrent]);
+			const side = activeSideResize.current;
+			if (side === "left" && leftOwnsBottomCorner) {
+				commitSideSizes([["left", sizes[0] ?? globalLeftCurrent]]);
 			}
-			commitSideSizes(entries);
+			if (side === "right" && rightOwnsBottomCorner) {
+				commitSideSizes([["right", sizes.at(-1) ?? globalRightCurrent]]);
+			}
 		},
 		onRemoteGestureCanceled,
 	);
@@ -2531,17 +2564,20 @@ export function Workbench({
 		alignedRowCurrent,
 		remoteEpoch,
 		(sizes) => {
-			const entries: Array<readonly [LayoutSide, number]> = [];
-			if (leftInAlignedRow) {
-				entries.push(["left", ((sizes[0] ?? 0) * projectedAlignedWidth) / 100]);
+			const side = activeSideResize.current;
+			if (side === "left" && leftInAlignedRow) {
+				commitSideSizes([["left", ((sizes[0] ?? 0) * projectedAlignedWidth) / 100]]);
 			}
-			if (rightInAlignedRow) {
-				entries.push(["right", ((sizes.at(-1) ?? 0) * projectedAlignedWidth) / 100]);
+			if (side === "right" && rightInAlignedRow) {
+				commitSideSizes([["right", ((sizes.at(-1) ?? 0) * projectedAlignedWidth) / 100]]);
 			}
-			commitSideSizes(entries);
 		},
 		onRemoteGestureCanceled,
 	);
+	const outerLeftResize = bindSideResize("left", outerResize, activeSideResize);
+	const outerRightResize = bindSideResize("right", outerResize, activeSideResize);
+	const alignedLeftResize = bindSideResize("left", alignedRowResize, activeSideResize);
+	const alignedRightResize = bindSideResize("right", alignedRowResize, activeSideResize);
 	const bottomVisible = document.bottom.visible && document.bottom.groups.length > 0;
 	const hiddenBottomTargetGroupId =
 		document.bottom.groups.find((group) => group.id === attention.lastFocusedSideGroupId.bottom)
@@ -2746,9 +2782,9 @@ export function Workbench({
 					<ResizableHandle
 						direction="horizontal"
 						data-testid="resize-left"
-						onDragging={alignedRowResize.onDragging}
-						onKeyDownCapture={alignedRowResize.onKeyboard}
-						onKeyUpCapture={alignedRowResize.onKeyboardEnd}
+						onDragging={alignedLeftResize.onDragging}
+						onKeyDownCapture={alignedLeftResize.onKeyboard}
+						onKeyUpCapture={alignedLeftResize.onKeyboardEnd}
 					/>
 				</>
 			) : null}
@@ -2765,9 +2801,9 @@ export function Workbench({
 					<ResizableHandle
 						direction="horizontal"
 						data-testid="resize-right"
-						onDragging={alignedRowResize.onDragging}
-						onKeyDownCapture={alignedRowResize.onKeyboard}
-						onKeyUpCapture={alignedRowResize.onKeyboardEnd}
+						onDragging={alignedRightResize.onDragging}
+						onKeyDownCapture={alignedRightResize.onKeyboard}
+						onKeyUpCapture={alignedRightResize.onKeyboardEnd}
 					/>
 					<ResizablePanel
 						id="layout-right"
@@ -2869,9 +2905,9 @@ export function Workbench({
 					<ResizableHandle
 						direction="horizontal"
 						data-testid="resize-left"
-						onDragging={outerResize.onDragging}
-						onKeyDownCapture={outerResize.onKeyboard}
-						onKeyUpCapture={outerResize.onKeyboardEnd}
+						onDragging={outerLeftResize.onDragging}
+						onKeyDownCapture={outerLeftResize.onKeyboard}
+						onKeyUpCapture={outerLeftResize.onKeyboardEnd}
 					/>
 				</>
 			) : null}
@@ -2888,9 +2924,9 @@ export function Workbench({
 					<ResizableHandle
 						direction="horizontal"
 						data-testid="resize-right"
-						onDragging={outerResize.onDragging}
-						onKeyDownCapture={outerResize.onKeyboard}
-						onKeyUpCapture={outerResize.onKeyboardEnd}
+						onDragging={outerRightResize.onDragging}
+						onKeyDownCapture={outerRightResize.onKeyboard}
+						onKeyUpCapture={outerRightResize.onKeyboardEnd}
 					/>
 					<ResizablePanel
 						id="layout-right"

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -490,9 +490,11 @@ function TabStrip({
 	const compatibilityTestId =
 		location.area === "center"
 			? "center-tab-strip"
-			: tabs.some((tab) => tab.kind === "tool" && tab.tool === "specs")
-				? "right-tab-strip"
-				: "workbench-tab-strip";
+			: location.area === "bottom"
+				? "bottom-tab-strip"
+				: tabs.some((tab) => tab.kind === "tool" && tab.tool === "specs")
+					? "right-tab-strip"
+					: "workbench-tab-strip";
 	return (
 		<div
 			ref={groupDrop.setNodeRef}
@@ -1015,7 +1017,7 @@ function WorkbenchTab({
 				<ContextMenuSeparator />
 				{location.area !== "center" ? (
 					<ContextMenuItem onSelect={() => onHideSide(location.area)}>
-						Hide {location.area} region
+						{location.area === "bottom" ? "Hide bottom panel" : `Hide ${location.area} side`}
 					</ContextMenuItem>
 				) : null}
 				<ContextMenuItem
@@ -1673,6 +1675,7 @@ function BottomGroupView({
 			id={groupDomId(location)}
 			data-testid="bottom-group"
 			data-group-id={group.id}
+			data-folded="false"
 			tabIndex={-1}
 			aria-label={selected ? `Bottom group: ${selected.name}` : "Empty bottom group"}
 			className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-container-sidebar-bg outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
@@ -1980,6 +1983,8 @@ function BottomAlignedRow({
 		<ResizablePanelGroup
 			key={tupleKey("bottom-alignment", document.bottom.alignment, String(left), String(right))}
 			direction="horizontal"
+			data-testid="bottom-aligned-row"
+			data-alignment={document.bottom.alignment}
 			className="min-h-0 min-w-0"
 		>
 			{start > 0 ? (
@@ -2102,22 +2107,18 @@ function HiddenSideRail({
 	onShow,
 	dropEnabled,
 	showEnabled,
-	targetGroupId,
 	targetIndex,
 }: {
 	side: LayoutSide;
 	onShow: () => void;
 	dropEnabled: boolean;
 	showEnabled: boolean;
-	targetGroupId: string | undefined;
 	targetIndex: number;
 }) {
 	const drop = useDroppable({
 		id: tupleKey("dnd-hidden-side-edge", side),
 		data: {
-			target: targetGroupId
-				? ({ kind: "group", location: { area: side, groupId: targetGroupId } } satisfies DropTarget)
-				: ({ kind: "auxiliary-edge", region: side, index: targetIndex } satisfies DropTarget),
+			target: { kind: "auxiliary-edge", region: side, index: targetIndex } satisfies DropTarget,
 		},
 		disabled: !dropEnabled,
 	});
@@ -2432,12 +2433,6 @@ export function Workbench({
 
 	const leftVisible = document.left.visible && document.left.groups.length > 0;
 	const rightVisible = document.right.visible && document.right.groups.length > 0;
-	const hiddenLeftTargetGroupId =
-		document.left.groups.find((group) => group.id === attention.lastFocusedSideGroupId.left)?.id ??
-		document.left.groups[0]?.id;
-	const hiddenRightTargetGroupId =
-		document.right.groups.find((group) => group.id === attention.lastFocusedSideGroupId.right)
-			?.id ?? document.right.groups[0]?.id;
 	const visibleSideMinimums = (leftVisible ? 8 : 0) + (rightVisible ? 8 : 0);
 	const centerMinimumPercent = Math.min(
 		Math.max(10, 100 - visibleSideMinimums),
@@ -2758,16 +2753,14 @@ export function Workbench({
 						dropEnabled={
 							!!draggingTab &&
 							canPlaceLayoutTab(draggingTab, "left") &&
-							(hiddenLeftTargetGroupId !== undefined ||
-								canCreateSideGroup(
-									document,
-									"left",
-									draggingTab,
-									maxSideGroups,
-									document.left.groups.length,
-								))
+							canCreateSideGroup(
+								document,
+								"left",
+								draggingTab,
+								maxSideGroups,
+								document.left.groups.length,
+							)
 						}
-						targetGroupId={hiddenLeftTargetGroupId}
 						targetIndex={document.left.groups.length}
 					/>
 				) : null}
@@ -2852,16 +2845,14 @@ export function Workbench({
 						dropEnabled={
 							!!draggingTab &&
 							canPlaceLayoutTab(draggingTab, "right") &&
-							(hiddenRightTargetGroupId !== undefined ||
-								canCreateSideGroup(
-									document,
-									"right",
-									draggingTab,
-									maxSideGroups,
-									document.right.groups.length,
-								))
+							canCreateSideGroup(
+								document,
+								"right",
+								draggingTab,
+								maxSideGroups,
+								document.right.groups.length,
+							)
 						}
-						targetGroupId={hiddenRightTargetGroupId}
 						targetIndex={document.right.groups.length}
 					/>
 				) : null}

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -328,6 +328,13 @@ function groupDomId(location: LayoutGroupLocation): string {
 	return encodedElementId("layout-group", location.area, location.groupId);
 }
 
+function focusLayoutRequest(request: LayoutTabFocusRequest): void {
+	const tab = request.tabId
+		? globalThis.document.getElementById(tabDomId(request.location, request.tabId))
+		: null;
+	(tab ?? globalThis.document.getElementById(groupDomId(request.location)))?.focus();
+}
+
 function navigationClockSnapshot(attention: LayoutAttention): string {
 	return JSON.stringify(
 		Object.keys(attention.navigationClockByGroup)
@@ -339,28 +346,33 @@ function navigationClockSnapshot(attention: LayoutAttention): string {
 function visibleFocusableGroups(document: WorkspaceLayoutDocument): Array<{
 	location: LayoutGroupLocation;
 	tabs: LayoutTab[];
+	tabControlsRendered: boolean;
 }> {
 	return [
 		...(document.left.visible
 			? document.left.groups.map((group) => ({
 					location: { area: "left" as const, groupId: group.id },
 					tabs: group.tabs,
+					tabControlsRendered: true,
 				}))
 			: []),
 		...collectCenterGroups(document.center).map((group) => ({
 			location: { area: "center" as const, groupId: group.id },
 			tabs: group.tabs,
+			tabControlsRendered: true,
 		})),
 		...(document.right.visible
 			? document.right.groups.map((group) => ({
 					location: { area: "right" as const, groupId: group.id },
 					tabs: group.tabs,
+					tabControlsRendered: true,
 				}))
 			: []),
 		...(document.bottom.visible
 			? document.bottom.groups.map((group) => ({
 					location: { area: "bottom" as const, groupId: group.id },
 					tabs: group.tabs,
+					tabControlsRendered: !group.folded,
 				}))
 			: []),
 	];
@@ -1788,6 +1800,8 @@ function BottomFoldedGroup({
 	const selectedId = readLayoutSelection(shared.attention, group.id);
 	const selected = group.tabs.find((tab) => tab.id === selectedId) ?? group.tabs[0];
 	const location: LayoutGroupLocation = { area: "bottom", groupId: group.id };
+	const restoreId = groupDomId(location);
+	const panelId = groupPanelId(location);
 	const drop = useDroppable({
 		id: tupleKey("dnd-bottom-folded", group.id),
 		data: { target: { kind: "group", location } satisfies DropTarget },
@@ -1800,6 +1814,7 @@ function BottomFoldedGroup({
 			data-group-id={group.id}
 			data-folded="true"
 			data-drop-active={drop.isOver || undefined}
+			aria-label={selected ? `Folded bottom group: ${selected.name}` : "Folded empty bottom group"}
 			className="relative flex h-full items-stretch overflow-hidden border-border-default border-r bg-container-sidebar-bg data-[drop-active]:bg-primary-subtle"
 		>
 			<div className="flex min-h-0 w-full flex-col">
@@ -1811,9 +1826,11 @@ function BottomFoldedGroup({
 					/>
 				) : null}
 				<button
+					id={restoreId}
 					type="button"
 					data-testid="bottom-group-restore"
 					aria-label={`Expand bottom group${selected ? ` ${selected.name}` : ""}`}
+					aria-controls={panelId}
 					aria-expanded="false"
 					onClick={onExpand}
 					className="flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
@@ -1822,6 +1839,7 @@ function BottomFoldedGroup({
 						{selected?.name ?? "Empty group"}
 					</span>
 				</button>
+				<div id={panelId} role="tabpanel" aria-labelledby={restoreId} hidden />
 			</div>
 			<BottomCreationTargets group={group} groupIndex={groupIndex} shared={shared} />
 		</section>
@@ -2192,23 +2210,13 @@ export function Workbench({
 
 	useEffect(() => {
 		if (!focusRequest) return;
-		const frame = requestAnimationFrame(() => {
-			const id = focusRequest.tabId
-				? tabDomId(focusRequest.location, focusRequest.tabId)
-				: groupDomId(focusRequest.location);
-			globalThis.document.getElementById(id)?.focus();
-		});
+		const frame = requestAnimationFrame(() => focusLayoutRequest(focusRequest));
 		return () => cancelAnimationFrame(frame);
 	}, [focusRequest]);
 
 	useEffect(() => {
 		if (!localFocusRequest) return;
-		const frame = requestAnimationFrame(() => {
-			const id = localFocusRequest.tabId
-				? tabDomId(localFocusRequest.location, localFocusRequest.tabId)
-				: groupDomId(localFocusRequest.location);
-			globalThis.document.getElementById(id)?.focus();
-		});
+		const frame = requestAnimationFrame(() => focusLayoutRequest(localFocusRequest));
 		return () => cancelAnimationFrame(frame);
 	}, [localFocusRequest]);
 
@@ -2546,7 +2554,7 @@ export function Workbench({
 				setLocalFocusRequest({
 					key: createLayoutId("focus-group"),
 					location: target.location,
-					tabId: selected.id,
+					...(target.tabControlsRendered ? { tabId: selected.id } : {}),
 				});
 				return;
 			}
@@ -2814,23 +2822,31 @@ export function Workbench({
 					) : (
 						<>
 							<div className="min-h-0 min-w-0 flex-1">{mainRow}</div>
-							<HiddenBottomRail
-								onShow={showBottomRegion}
-								dropEnabled={
-									!!draggingTab &&
-									canPlaceLayoutTab(draggingTab, "bottom") &&
-									(hiddenBottomTargetGroupId !== undefined ||
-										canCreateAuxiliaryGroup(
-											document,
-											"bottom",
-											draggingTab,
-											maxBottomGroups,
-											document.bottom.groups.length,
-										))
-								}
-								targetGroupId={hiddenBottomTargetGroupId}
-								targetIndex={document.bottom.groups.length}
-							/>
+							<div className="h-7 shrink-0">
+								<BottomAlignedRow
+									document={document}
+									leftVisible={leftVisible}
+									rightVisible={rightVisible}
+								>
+									<HiddenBottomRail
+										onShow={showBottomRegion}
+										dropEnabled={
+											!!draggingTab &&
+											canPlaceLayoutTab(draggingTab, "bottom") &&
+											(hiddenBottomTargetGroupId !== undefined ||
+												canCreateAuxiliaryGroup(
+													document,
+													"bottom",
+													draggingTab,
+													maxBottomGroups,
+													document.bottom.groups.length,
+												))
+										}
+										targetGroupId={hiddenBottomTargetGroupId}
+										targetIndex={document.bottom.groups.length}
+									/>
+								</BottomAlignedRow>
+							</div>
 						</>
 					)}
 				</div>

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -105,6 +105,7 @@ import {
 	type LayoutMutationResult,
 	type LayoutOperationResult,
 	type LayoutSide,
+	layoutTabName,
 	moveTabToGroup,
 	reconcileAttention,
 	resizeAuxiliaryGroups,
@@ -314,18 +315,19 @@ function useElementSize(): {
 }
 
 function tabSearchKeywords(tab: LayoutTab): string[] {
+	const name = layoutTabName(tab);
 	switch (tab.kind) {
 		case "file":
 		case "diff":
-			return [tab.name, tab.kind, tab.path];
+			return [name, tab.kind, tab.path];
 		case "chat":
-			return [tab.name, tab.kind, tab.sessionId];
+			return [name, tab.kind, tab.sessionId];
 		case "document":
-			return [tab.name, tab.kind, tab.sourceId, tab.docPath];
+			return [name, tab.kind, tab.sourceId, tab.docPath];
 		case "terminal":
-			return [tab.name, tab.kind, tab.tabKey];
+			return [name, tab.kind, tab.tabKey];
 		case "tool":
-			return [tab.name, tab.kind, tab.tool];
+			return [name, tab.kind, tab.tool];
 	}
 }
 
@@ -664,7 +666,7 @@ function TabStrip({
 									}}
 								>
 									{tabIcon(tab)}
-									<span className="truncate">{tab.name}</span>
+									<span className="truncate">{layoutTabName(tab)}</span>
 								</CommandItem>
 							))}
 						</CommandList>
@@ -802,6 +804,7 @@ function WorkbenchTab({
 		? document[currentAuxiliary].groups.findIndex((group) => group.id === location.groupId)
 		: -1;
 	const currentAuxiliaryLimit = currentAuxiliary === "bottom" ? maxBottomGroups : maxSideGroups;
+	const name = layoutTabName(tab);
 
 	const move = (target: LayoutGroupLocation, targetIndex?: number) => {
 		const result = moveTabToGroup(document, tab, target, targetIndex);
@@ -837,14 +840,14 @@ function WorkbenchTab({
 					<div
 						ref={before.setNodeRef}
 						aria-hidden="true"
-						data-drop-label={acceptsBefore ? `Insert before ${tab.name}` : undefined}
+						data-drop-label={acceptsBefore ? `Insert before ${name}` : undefined}
 						data-drop-active={before.isOver || undefined}
 						className="pointer-events-none absolute inset-y-0 left-0 z-10 w-1/2 border-primary data-[drop-active]:border-l-2"
 					/>
 					<div
 						ref={after.setNodeRef}
 						aria-hidden="true"
-						data-drop-label={acceptsAfter ? `Insert after ${tab.name}` : undefined}
+						data-drop-label={acceptsAfter ? `Insert after ${name}` : undefined}
 						data-drop-active={after.isOver || undefined}
 						className="pointer-events-none absolute inset-y-0 right-0 z-10 w-1/2 border-primary data-[drop-active]:border-r-2"
 					/>
@@ -859,14 +862,14 @@ function WorkbenchTab({
 						data-layout-tab-id={tab.id}
 						tabIndex={active ? 0 : -1}
 						{...drag.listeners}
-						title={preview ? "Preview — double-click to keep" : tab.name}
+						title={preview ? "Preview — double-click to keep" : name}
 						onClick={selectFromClick}
 						onDoubleClick={selectFromDoubleClick}
 						onKeyDown={onKeyDown}
 						className={`flex min-w-0 flex-1 items-center gap-xs py-xs pl-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary ${tab.kind === "tool" ? "pr-sm" : ""}`}
 					>
 						{tabIcon(tab)}
-						<span className={`truncate ${preview ? "italic" : ""}`}>{tab.name}</span>
+						<span className={`truncate ${preview ? "italic" : ""}`}>{name}</span>
 						{renderTabAdornment(tab)}
 					</button>
 					{tab.kind !== "tool" ? (
@@ -874,7 +877,7 @@ function WorkbenchTab({
 							type="button"
 							tabIndex={-1}
 							data-testid={tab.kind === "terminal" ? "terminal-tab-close" : "editor-tab-close"}
-							aria-label={`Close ${tab.name}`}
+							aria-label={`Close ${name}`}
 							onClick={onClose}
 							className="mr-xs rounded-[var(--radius-sm)] p-0.5 opacity-0 hover:bg-control-bg-hovered group-hover:opacity-100 focus:opacity-100"
 						>
@@ -1695,6 +1698,7 @@ function BottomGroupView({
 	const location: LayoutGroupLocation = { area: "bottom", groupId: group.id };
 	const selectedId = readLayoutSelection(shared.attention, group.id);
 	const selected = group.tabs.find((tab) => tab.id === selectedId) ?? group.tabs[0];
+	const selectedName = selected ? layoutTabName(selected) : undefined;
 	return (
 		<section
 			id={groupDomId(location)}
@@ -1702,7 +1706,7 @@ function BottomGroupView({
 			data-group-id={group.id}
 			data-folded="false"
 			tabIndex={-1}
-			aria-label={selected ? `Bottom group: ${selected.name}` : "Empty bottom group"}
+			aria-label={selectedName ? `Bottom group: ${selectedName}` : "Empty bottom group"}
 			className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-container-sidebar-bg outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
 			onFocusCapture={() => {
 				if (selected) {
@@ -1812,6 +1816,7 @@ function BottomFoldedGroup({
 }) {
 	const selectedId = readLayoutSelection(shared.attention, group.id);
 	const selected = group.tabs.find((tab) => tab.id === selectedId) ?? group.tabs[0];
+	const selectedName = selected ? layoutTabName(selected) : undefined;
 	const location: LayoutGroupLocation = { area: "bottom", groupId: group.id };
 	const restoreId = groupDomId(location);
 	const panelId = groupPanelId(location);
@@ -1827,7 +1832,9 @@ function BottomFoldedGroup({
 			data-group-id={group.id}
 			data-folded="true"
 			data-drop-active={drop.isOver || undefined}
-			aria-label={selected ? `Folded bottom group: ${selected.name}` : "Folded empty bottom group"}
+			aria-label={
+				selectedName ? `Folded bottom group: ${selectedName}` : "Folded empty bottom group"
+			}
 			className="relative flex h-full items-stretch overflow-hidden border-border-default border-r bg-container-sidebar-bg data-[drop-active]:bg-primary-subtle"
 		>
 			<div className="flex min-h-0 w-full flex-col">
@@ -1842,14 +1849,14 @@ function BottomFoldedGroup({
 					id={restoreId}
 					type="button"
 					data-testid="bottom-group-restore"
-					aria-label={`Expand bottom group${selected ? ` ${selected.name}` : ""}`}
+					aria-label={`Expand bottom group${selectedName ? ` ${selectedName}` : ""}`}
 					aria-controls={panelId}
 					aria-expanded="false"
 					onClick={onExpand}
 					className="flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
 				>
 					<span className="truncate [writing-mode:vertical-rl]">
-						{selected?.name ?? "Empty group"}
+						{selectedName ?? "Empty group"}
 					</span>
 				</button>
 				<div id={panelId} role="tabpanel" aria-labelledby={restoreId} hidden />
@@ -3001,7 +3008,7 @@ export function Workbench({
 				{draggingTab ? (
 					<div className="flex max-w-56 items-center gap-xs rounded-[var(--radius-sm)] border border-primary bg-container-elevated-bg px-sm py-xs tr-text-ui text-text-default shadow-lg">
 						{tabIcon(draggingTab)}
-						<span className="truncate">{draggingTab.name}</span>
+						<span className="truncate">{layoutTabName(draggingTab)}</span>
 					</div>
 				) : null}
 			</DragOverlay>

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -1985,61 +1985,19 @@ function BottomStack({
 
 function BottomAlignedRow({
 	document,
-	projectedLeft,
-	projectedRight,
 	children,
 }: {
 	document: WorkspaceLayoutDocument;
-	projectedLeft: number;
-	projectedRight: number;
 	children: ReactNode;
 }) {
-	const start =
-		document.bottom.alignment === "center" || document.bottom.alignment === "center-right"
-			? projectedLeft
-			: 0;
-	const end =
-		document.bottom.alignment === "center" || document.bottom.alignment === "center-left"
-			? projectedRight
-			: 0;
-	const body = Math.max(Number.EPSILON, 100 - start - end);
-	const layout = useMemo(
-		() => [...(start > 0 ? [start] : []), body, ...(end > 0 ? [end] : [])],
-		[body, end, start],
-	);
-	const groupRef = useRef<ImperativePanelGroupHandle>(null);
-	useEffect(() => {
-		const group = groupRef.current;
-		if (group && !sameSizes(group.getLayout(), layout, 0.01)) group.setLayout(layout);
-	}, [layout]);
 	return (
-		<ResizablePanelGroup
-			ref={groupRef}
-			key={tupleKey(
-				"bottom-alignment",
-				document.bottom.alignment,
-				String(start > 0),
-				String(end > 0),
-			)}
-			direction="horizontal"
+		<div
 			data-testid="bottom-aligned-row"
 			data-alignment={document.bottom.alignment}
-			className="min-h-0 min-w-0"
+			className="h-full min-h-0 min-w-0"
 		>
-			{start > 0 ? (
-				<ResizablePanel id="bottom-start-spacer" order={1} defaultSize={start}>
-					<div aria-hidden="true" className="h-full bg-container-workspace-bg" />
-				</ResizablePanel>
-			) : null}
-			<ResizablePanel id="bottom-aligned-body" order={2} defaultSize={body}>
-				{children}
-			</ResizablePanel>
-			{end > 0 ? (
-				<ResizablePanel id="bottom-end-spacer" order={3} defaultSize={end}>
-					<div aria-hidden="true" className="h-full bg-container-workspace-bg" />
-				</ResizablePanel>
-			) : null}
-		</ResizablePanelGroup>
+			{children}
+		</div>
 	);
 }
 
@@ -2449,44 +2407,55 @@ export function Workbench({
 		Math.max(10, 100 - visibleSideMinimums),
 		workbenchWidth > 0 ? (LAYOUT_LIMITS.minCenterWidth / workbenchWidth) * 100 : 10,
 	);
+	const leftOwnsBottomCorner =
+		leftVisible &&
+		document.bottom.alignment !== "center-left" &&
+		document.bottom.alignment !== "full";
+	const rightOwnsBottomCorner =
+		rightVisible &&
+		document.bottom.alignment !== "center-right" &&
+		document.bottom.alignment !== "full";
+	const leftInAlignedRow = leftVisible && !leftOwnsBottomCorner;
+	const rightInAlignedRow = rightVisible && !rightOwnsBottomCorner;
+	const globalLeftCurrent = leftVisible ? document.left.width * 100 : 0;
+	const globalRightCurrent = rightVisible ? document.right.width * 100 : 0;
+	const alignedWidthCurrent =
+		100 -
+		(leftOwnsBottomCorner ? globalLeftCurrent : 0) -
+		(rightOwnsBottomCorner ? globalRightCurrent : 0);
 	const outerCurrent = useMemo(
 		() => [
-			...(leftVisible ? [document.left.width * 100] : []),
-			100 -
-				(leftVisible ? document.left.width * 100 : 0) -
-				(rightVisible ? document.right.width * 100 : 0),
-			...(rightVisible ? [document.right.width * 100] : []),
+			...(leftOwnsBottomCorner ? [globalLeftCurrent] : []),
+			alignedWidthCurrent,
+			...(rightOwnsBottomCorner ? [globalRightCurrent] : []),
 		],
-		[document.left.width, document.right.width, leftVisible, rightVisible],
+		[
+			alignedWidthCurrent,
+			globalLeftCurrent,
+			globalRightCurrent,
+			leftOwnsBottomCorner,
+			rightOwnsBottomCorner,
+		],
 	);
-	const [projectedOuter, setProjectedOuter] = useState<readonly number[]>(outerCurrent);
-	const activeProjection =
-		projectedOuter.length === outerCurrent.length ? projectedOuter : outerCurrent;
-	const projectedLeft = leftVisible ? (activeProjection[0] ?? 0) : 0;
-	const projectedRight = rightVisible ? (activeProjection.at(-1) ?? 0) : 0;
-	const outerGroupRef = useRef<ImperativePanelGroupHandle>(null);
-	useEffect(() => {
-		const group = outerGroupRef.current;
-		if (group && !sameSizes(group.getLayout(), outerCurrent)) group.setLayout(outerCurrent);
-	}, [outerCurrent]);
-	const outerResize = useCommittedSizes(
-		outerCurrent,
-		remoteEpoch,
-		(sizes) => {
-			let index = 0;
+	const outerTopology = tupleKey(
+		"outer-workbench",
+		String(leftOwnsBottomCorner),
+		String(rightOwnsBottomCorner),
+		String(remoteEpoch),
+	);
+	const [alignedProjection, setAlignedProjection] = useState({
+		topology: outerTopology,
+		width: alignedWidthCurrent,
+	});
+	const projectedAlignedWidth =
+		alignedProjection.topology === outerTopology ? alignedProjection.width : alignedWidthCurrent;
+	const commitSideSizes = useCallback(
+		(entries: ReadonlyArray<readonly [LayoutSide, number]>) => {
 			let next = document;
 			const collapsedSides: LayoutSide[] = [];
-			if (leftVisible) {
-				const size = sizes[index] ?? outerCurrent[index] ?? 18;
-				if (size <= Number.EPSILON) collapsedSides.push("left");
-				else next = resizeSideRegion(next, "left", size / 100);
-				index += 1;
-			}
-			index += 1;
-			if (rightVisible) {
-				const size = sizes[index] ?? outerCurrent[index] ?? 28;
-				if (size <= Number.EPSILON) collapsedSides.push("right");
-				else next = resizeSideRegion(next, "right", size / 100);
+			for (const [side, size] of entries) {
+				if (size <= Number.EPSILON) collapsedSides.push(side);
+				else next = resizeSideRegion(next, side, size / 100);
 			}
 			if (collapsedSides.length === 0) {
 				if (next !== document) onCommit(next);
@@ -2498,14 +2467,80 @@ export function Workbench({
 			}
 			apply(result);
 		},
+		[apply, document, onCommit],
+	);
+	const outerGroupRef = useRef<ImperativePanelGroupHandle>(null);
+	useEffect(() => {
+		const group = outerGroupRef.current;
+		if (group && !sameSizes(group.getLayout(), outerCurrent)) group.setLayout(outerCurrent);
+	}, [outerCurrent]);
+	const outerResize = useCommittedSizes(
+		outerCurrent,
+		remoteEpoch,
+		(sizes) => {
+			const entries: Array<readonly [LayoutSide, number]> = [];
+			if (leftOwnsBottomCorner) entries.push(["left", sizes[0] ?? globalLeftCurrent]);
+			if (rightOwnsBottomCorner) {
+				entries.push(["right", sizes.at(-1) ?? globalRightCurrent]);
+			}
+			commitSideSizes(entries);
+		},
 		onRemoteGestureCanceled,
 	);
 	const projectOuterLayout = useCallback(
 		(sizes: number[]) => {
-			setProjectedOuter((current) => (sameSizes(current, sizes, 0.01) ? current : [...sizes]));
+			const alignedIndex = leftOwnsBottomCorner ? 1 : 0;
+			const width = sizes[alignedIndex] ?? alignedWidthCurrent;
+			setAlignedProjection((current) =>
+				current.topology === outerTopology && Math.abs(current.width - width) < 0.01
+					? current
+					: { topology: outerTopology, width },
+			);
 			outerResize.onLayout(sizes);
 		},
-		[outerResize.onLayout],
+		[alignedWidthCurrent, leftOwnsBottomCorner, outerResize.onLayout, outerTopology],
+	);
+	const alignedRowCurrent = useMemo(() => {
+		const widths = [
+			...(leftInAlignedRow ? [globalLeftCurrent] : []),
+			Math.max(
+				Number.EPSILON,
+				projectedAlignedWidth -
+					(leftInAlignedRow ? globalLeftCurrent : 0) -
+					(rightInAlignedRow ? globalRightCurrent : 0),
+			),
+			...(rightInAlignedRow ? [globalRightCurrent] : []),
+		];
+		const total = widths.reduce((sum, width) => sum + width, 0);
+		return widths.map((width) => (width / total) * 100);
+	}, [
+		globalLeftCurrent,
+		globalRightCurrent,
+		leftInAlignedRow,
+		projectedAlignedWidth,
+		rightInAlignedRow,
+	]);
+	const alignedRowGroupRef = useRef<ImperativePanelGroupHandle>(null);
+	useEffect(() => {
+		const group = alignedRowGroupRef.current;
+		if (group && !sameSizes(group.getLayout(), alignedRowCurrent, 0.01)) {
+			group.setLayout(alignedRowCurrent);
+		}
+	}, [alignedRowCurrent]);
+	const alignedRowResize = useCommittedSizes(
+		alignedRowCurrent,
+		remoteEpoch,
+		(sizes) => {
+			const entries: Array<readonly [LayoutSide, number]> = [];
+			if (leftInAlignedRow) {
+				entries.push(["left", ((sizes[0] ?? 0) * projectedAlignedWidth) / 100]);
+			}
+			if (rightInAlignedRow) {
+				entries.push(["right", ((sizes.at(-1) ?? 0) * projectedAlignedWidth) / 100]);
+			}
+			commitSideSizes(entries);
+		},
+		onRemoteGestureCanceled,
 	);
 	const bottomVisible = document.bottom.visible && document.bottom.groups.length > 0;
 	const hiddenBottomTargetGroupId =
@@ -2654,20 +2689,172 @@ export function Workbench({
 		onRevealTool: revealMissingTool,
 		canFocusAdjacentGroup,
 	};
-	const mainRow = (
+	const alignedWidth = Math.max(Number.EPSILON, projectedAlignedWidth);
+	const alignedSideMinimum = Math.min(100, (8 / alignedWidth) * 100);
+	const alignedCenterMinimum = Math.min(100, (centerMinimumPercent / alignedWidth) * 100);
+	const alignedColumnMinimum = Math.min(
+		100,
+		centerMinimumPercent + (leftInAlignedRow ? 8 : 0) + (rightInAlignedRow ? 8 : 0),
+	);
+	const sideStack = (side: LayoutSide) => (
+		<SideStack
+			side={side}
+			region={document[side]}
+			remoteEpoch={remoteEpoch}
+			onCommit={onCommit}
+			{...shared}
+		/>
+	);
+	const centerView = (
+		<main data-testid="center-tabs" className="h-full min-h-0 min-w-0">
+			<CenterNodeView
+				node={document.center}
+				remoteEpoch={remoteEpoch}
+				onCommit={onCommit}
+				onNewChat={onNewChat}
+				renderEmptyCenter={renderEmptyCenter}
+				renderCenterActions={renderCenterActions}
+				{...shared}
+			/>
+		</main>
+	);
+	const alignedTopRow = (
 		<ResizablePanelGroup
-			ref={outerGroupRef}
+			ref={alignedRowGroupRef}
 			key={tupleKey(
-				"outer-workbench",
-				String(leftVisible),
-				String(rightVisible),
+				"aligned-workbench-row",
+				String(leftInAlignedRow),
+				String(rightInAlignedRow),
 				String(remoteEpoch),
 			)}
+			direction="horizontal"
+			onLayout={alignedRowResize.onLayout}
+			className="h-full min-h-0 min-w-0"
+		>
+			{leftInAlignedRow ? (
+				<>
+					<ResizablePanel
+						id="layout-left"
+						order={1}
+						defaultSize={alignedRowCurrent[0]}
+						minSize={alignedSideMinimum}
+						collapsedSize={0}
+						collapsible
+					>
+						{sideStack("left")}
+					</ResizablePanel>
+					<ResizableHandle
+						direction="horizontal"
+						data-testid="resize-left"
+						onDragging={alignedRowResize.onDragging}
+						onKeyDownCapture={alignedRowResize.onKeyboard}
+						onKeyUpCapture={alignedRowResize.onKeyboardEnd}
+					/>
+				</>
+			) : null}
+			<ResizablePanel
+				id="layout-center"
+				order={2}
+				defaultSize={alignedRowCurrent[leftInAlignedRow ? 1 : 0]}
+				minSize={alignedCenterMinimum}
+			>
+				{centerView}
+			</ResizablePanel>
+			{rightInAlignedRow ? (
+				<>
+					<ResizableHandle
+						direction="horizontal"
+						data-testid="resize-right"
+						onDragging={alignedRowResize.onDragging}
+						onKeyDownCapture={alignedRowResize.onKeyboard}
+						onKeyUpCapture={alignedRowResize.onKeyboardEnd}
+					/>
+					<ResizablePanel
+						id="layout-right"
+						order={3}
+						defaultSize={alignedRowCurrent[alignedRowCurrent.length - 1]}
+						minSize={alignedSideMinimum}
+						collapsedSize={0}
+						collapsible
+					>
+						{sideStack("right")}
+					</ResizablePanel>
+				</>
+			) : null}
+		</ResizablePanelGroup>
+	);
+	const alignedColumn = bottomVisible ? (
+		<ResizablePanelGroup
+			ref={bottomGroupRef}
+			key={tupleKey("workbench-bottom", String(remoteEpoch))}
+			direction="vertical"
+			onLayout={bottomResize.onLayout}
+			className="min-h-0 min-w-0 flex-1"
+		>
+			<ResizablePanel id="layout-main-row" order={1} defaultSize={bottomCurrent[0]} minSize={30}>
+				{alignedTopRow}
+			</ResizablePanel>
+			<ResizableHandle
+				direction="vertical"
+				data-testid="resize-bottom"
+				onDragging={bottomResize.onDragging}
+				onKeyDownCapture={bottomResize.onKeyboard}
+				onKeyUpCapture={bottomResize.onKeyboardEnd}
+			/>
+			<ResizablePanel
+				id="layout-bottom"
+				order={2}
+				defaultSize={bottomCurrent[1]}
+				minSize={bottomMinimumPercent}
+				maxSize={LAYOUT_LIMITS.maxBottomHeight * 100}
+				collapsedSize={0}
+				collapsible
+			>
+				<BottomAlignedRow document={document}>
+					<BottomStack
+						remoteEpoch={remoteEpoch}
+						onCommit={onCommit}
+						onNewTerminal={onNewTerminal}
+						{...shared}
+					/>
+				</BottomAlignedRow>
+			</ResizablePanel>
+		</ResizablePanelGroup>
+	) : (
+		<div className="flex h-full min-h-0 min-w-0 flex-col">
+			<div className="min-h-0 min-w-0 flex-1">{alignedTopRow}</div>
+			<div className="h-7 shrink-0">
+				<BottomAlignedRow document={document}>
+					<HiddenBottomRail
+						onShow={showBottomRegion}
+						dropEnabled={
+							!!draggingTab &&
+							canPlaceLayoutTab(draggingTab, "bottom") &&
+							(hiddenBottomTargetGroupId !== undefined ||
+								canCreateAuxiliaryGroup(
+									document,
+									"bottom",
+									draggingTab,
+									maxBottomGroups,
+									document.bottom.groups.length,
+								))
+						}
+						targetGroupId={hiddenBottomTargetGroupId}
+						targetIndex={document.bottom.groups.length}
+					/>
+				</BottomAlignedRow>
+			</div>
+		</div>
+	);
+	const workbenchColumns = (
+		<ResizablePanelGroup
+			ref={outerGroupRef}
+			key={outerTopology}
 			direction="horizontal"
 			onLayout={projectOuterLayout}
 			className="h-full min-h-0 min-w-0 flex-1"
 		>
-			{leftVisible ? (
+			{leftOwnsBottomCorner ? (
 				<>
 					<ResizablePanel
 						id="layout-left"
@@ -2677,13 +2864,7 @@ export function Workbench({
 						collapsedSize={0}
 						collapsible
 					>
-						<SideStack
-							side="left"
-							region={document.left}
-							remoteEpoch={remoteEpoch}
-							onCommit={onCommit}
-							{...shared}
-						/>
+						{sideStack("left")}
 					</ResizablePanel>
 					<ResizableHandle
 						direction="horizontal"
@@ -2695,24 +2876,14 @@ export function Workbench({
 				</>
 			) : null}
 			<ResizablePanel
-				id="layout-center"
+				id="layout-aligned-column"
 				order={2}
-				defaultSize={outerCurrent[leftVisible ? 1 : 0]}
-				minSize={centerMinimumPercent}
+				defaultSize={outerCurrent[leftOwnsBottomCorner ? 1 : 0]}
+				minSize={alignedColumnMinimum}
 			>
-				<main data-testid="center-tabs" className="h-full min-h-0 min-w-0">
-					<CenterNodeView
-						node={document.center}
-						remoteEpoch={remoteEpoch}
-						onCommit={onCommit}
-						onNewChat={onNewChat}
-						renderEmptyCenter={renderEmptyCenter}
-						renderCenterActions={renderCenterActions}
-						{...shared}
-					/>
-				</main>
+				{alignedColumn}
 			</ResizablePanel>
-			{rightVisible ? (
+			{rightOwnsBottomCorner ? (
 				<>
 					<ResizableHandle
 						direction="horizontal"
@@ -2729,13 +2900,7 @@ export function Workbench({
 						collapsedSize={0}
 						collapsible
 					>
-						<SideStack
-							side="right"
-							region={document.right}
-							remoteEpoch={remoteEpoch}
-							onCommit={onCommit}
-							{...shared}
-						/>
+						{sideStack("right")}
 					</ResizablePanel>
 				</>
 			) : null}
@@ -2787,84 +2952,7 @@ export function Workbench({
 						targetIndex={document.left.groups.length}
 					/>
 				) : null}
-				<div className="flex min-h-0 min-w-0 flex-1 flex-col">
-					{bottomVisible ? (
-						<ResizablePanelGroup
-							ref={bottomGroupRef}
-							key={tupleKey("workbench-bottom", String(remoteEpoch))}
-							direction="vertical"
-							onLayout={bottomResize.onLayout}
-							className="min-h-0 min-w-0 flex-1"
-						>
-							<ResizablePanel
-								id="layout-main-row"
-								order={1}
-								defaultSize={bottomCurrent[0]}
-								minSize={30}
-							>
-								{mainRow}
-							</ResizablePanel>
-							<ResizableHandle
-								direction="vertical"
-								data-testid="resize-bottom"
-								onDragging={bottomResize.onDragging}
-								onKeyDownCapture={bottomResize.onKeyboard}
-								onKeyUpCapture={bottomResize.onKeyboardEnd}
-							/>
-							<ResizablePanel
-								id="layout-bottom"
-								order={2}
-								defaultSize={bottomCurrent[1]}
-								minSize={bottomMinimumPercent}
-								maxSize={LAYOUT_LIMITS.maxBottomHeight * 100}
-								collapsedSize={0}
-								collapsible
-							>
-								<BottomAlignedRow
-									document={document}
-									projectedLeft={projectedLeft}
-									projectedRight={projectedRight}
-								>
-									<BottomStack
-										remoteEpoch={remoteEpoch}
-										onCommit={onCommit}
-										onNewTerminal={onNewTerminal}
-										{...shared}
-									/>
-								</BottomAlignedRow>
-							</ResizablePanel>
-						</ResizablePanelGroup>
-					) : (
-						<>
-							<div className="min-h-0 min-w-0 flex-1">{mainRow}</div>
-							<div className="h-7 shrink-0">
-								<BottomAlignedRow
-									document={document}
-									projectedLeft={projectedLeft}
-									projectedRight={projectedRight}
-								>
-									<HiddenBottomRail
-										onShow={showBottomRegion}
-										dropEnabled={
-											!!draggingTab &&
-											canPlaceLayoutTab(draggingTab, "bottom") &&
-											(hiddenBottomTargetGroupId !== undefined ||
-												canCreateAuxiliaryGroup(
-													document,
-													"bottom",
-													draggingTab,
-													maxBottomGroups,
-													document.bottom.groups.length,
-												))
-										}
-										targetGroupId={hiddenBottomTargetGroupId}
-										targetIndex={document.bottom.groups.length}
-									/>
-								</BottomAlignedRow>
-							</div>
-						</>
-					)}
-				</div>
+				{workbenchColumns}
 				{!rightVisible ? (
 					<HiddenSideRail
 						side="right"

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -12,6 +12,9 @@ import {
 	useSensors,
 } from "@dnd-kit/core";
 import type {
+	LayoutAuxiliaryRegion,
+	LayoutBottomAlignment,
+	LayoutBottomGroup,
 	LayoutCenterGroup,
 	LayoutCenterNode,
 	LayoutCenterSplit,
@@ -23,6 +26,7 @@ import type {
 	WorkspaceLayoutDocument,
 } from "@thinkrail/contracts";
 import {
+	Check,
 	ChevronDown,
 	ChevronLeft,
 	ChevronRight,
@@ -32,6 +36,7 @@ import {
 	MessageSquare,
 	MessageSquarePlus,
 	MoreHorizontal,
+	PanelBottomOpen,
 	PanelLeftOpen,
 	PanelRightOpen,
 	PanelsTopLeft,
@@ -69,17 +74,20 @@ import {
 } from "../../lib";
 import {
 	type CenterSplitDirection,
+	canCreateAuxiliaryGroup,
 	canCreateSideGroup,
 	canPlaceLayoutTab,
 	canShowSide,
 	closePlacedResource,
 	collectAllGroups,
 	collectCenterGroups,
+	createAuxiliaryGroup,
 	createLayoutId,
-	createSideGroup,
+	findAuxiliaryGroup,
 	findCenterGroup,
 	findPlacedResource,
 	findTabLocation,
+	hideBottom,
 	hideSide,
 	isLayoutUnavailable,
 	keepPreview,
@@ -91,12 +99,17 @@ import {
 	type LayoutSide,
 	moveTabToGroup,
 	reconcileAttention,
+	resizeAuxiliaryGroups,
+	resizeBottomRegion,
 	resizeCenterSplit,
 	resizeSideGroups,
 	resizeSideRegion,
 	revealTool,
 	selectTab,
+	setAuxiliaryGroupFolded,
+	setBottomAlignment,
 	setSideGroupFolded,
+	showBottom,
 	showSide,
 	splitCenterGroup,
 	toolTab,
@@ -117,6 +130,7 @@ export interface WorkbenchProps {
 	document: WorkspaceLayoutDocument;
 	attention: LayoutAttention;
 	maxSideGroups: number;
+	maxBottomGroups: number;
 	remoteEpoch: number;
 	focusRequest?: LayoutTabFocusRequest;
 	renderTabBody: (tab: LayoutCenterTab | Extract<LayoutSideTab, { kind: "terminal" }>) => ReactNode;
@@ -133,6 +147,7 @@ export interface WorkbenchProps {
 		prepare: (latestDocument?: WorkspaceLayoutDocument) => PreparedLayoutClose,
 	) => void;
 	onNewChat: (groupId: string) => void;
+	onNewTerminal: (groupId: string, area: "center" | LayoutAuxiliaryRegion) => void;
 	onRemoteGestureCanceled?: () => void;
 }
 
@@ -140,7 +155,7 @@ type DropTarget =
 	| { kind: "group"; location: LayoutGroupLocation }
 	| { kind: "insert"; location: LayoutGroupLocation; index: number }
 	| { kind: "split"; groupId: string; direction: CenterSplitDirection }
-	| { kind: "side-edge"; side: LayoutSide; index: number };
+	| { kind: "auxiliary-edge"; region: LayoutAuxiliaryRegion; index: number };
 
 interface DragData {
 	tab: LayoutTab;
@@ -342,6 +357,12 @@ function visibleFocusableGroups(document: WorkspaceLayoutDocument): Array<{
 					tabs: group.tabs,
 				}))
 			: []),
+		...(document.bottom.visible
+			? document.bottom.groups.map((group) => ({
+					location: { area: "bottom" as const, groupId: group.id },
+					tabs: group.tabs,
+				}))
+			: []),
 	];
 }
 
@@ -393,12 +414,13 @@ interface TabStripProps {
 	selectedId?: string | undefined;
 	previewId?: string | undefined;
 	maxSideGroups: number;
+	maxBottomGroups: number;
 	draggingTab: LayoutTab | null;
 	onSelect: (tabId: string, keep?: boolean) => void;
 	onClose: (tab: LayoutTab) => void;
 	onApply: (result: LayoutMutationResult) => void;
 	onFocusAdjacentGroup: (delta: -1 | 1, fromGroupId?: string) => void;
-	onHideSide: (side: LayoutSide) => void;
+	onHideSide: (region: LayoutAuxiliaryRegion) => void;
 	onRevealTool: (tool: LayoutToolId) => void;
 	canFocusAdjacentGroup: boolean;
 	renderTabAdornment: WorkbenchProps["renderTabAdornment"];
@@ -415,6 +437,7 @@ function TabStrip({
 	selectedId,
 	previewId,
 	maxSideGroups,
+	maxBottomGroups,
 	draggingTab,
 	onSelect,
 	onClose,
@@ -509,6 +532,7 @@ function TabStrip({
 						preview={tab.id === previewId}
 						document={document}
 						maxSideGroups={maxSideGroups}
+						maxBottomGroups={maxBottomGroups}
 						register={(node) => {
 							if (node) tabRefs.current.set(tab.id, node);
 							else tabRefs.current.delete(tab.id);
@@ -629,12 +653,13 @@ interface WorkbenchTabProps {
 	preview: boolean;
 	document: WorkspaceLayoutDocument;
 	maxSideGroups: number;
+	maxBottomGroups: number;
 	register: (node: HTMLButtonElement | null) => void;
 	onSelect: (tabId: string, keep?: boolean) => void;
 	onClose: () => void;
 	onApply: (result: LayoutMutationResult) => void;
 	onFocusAdjacentGroup: (delta: -1 | 1, fromGroupId?: string) => void;
-	onHideSide: (side: LayoutSide) => void;
+	onHideSide: (region: LayoutAuxiliaryRegion) => void;
 	onRevealTool: (tool: LayoutToolId) => void;
 	canFocusAdjacentGroup: boolean;
 	renderTabAdornment: WorkbenchProps["renderTabAdornment"];
@@ -654,6 +679,7 @@ function WorkbenchTab({
 	preview,
 	document,
 	maxSideGroups,
+	maxBottomGroups,
 	register,
 	onSelect,
 	onClose,
@@ -739,10 +765,11 @@ function WorkbenchTab({
 				? tab.kind !== "tool"
 				: tab.kind === "tool"),
 	);
-	const currentSide = location.area === "center" ? null : location.area;
-	const currentSideGroupIndex = currentSide
-		? document[currentSide].groups.findIndex((group) => group.id === location.groupId)
+	const currentAuxiliary = location.area === "center" ? null : location.area;
+	const currentAuxiliaryGroupIndex = currentAuxiliary
+		? document[currentAuxiliary].groups.findIndex((group) => group.id === location.groupId)
 		: -1;
+	const currentAuxiliaryLimit = currentAuxiliary === "bottom" ? maxBottomGroups : maxSideGroups;
 
 	const move = (target: LayoutGroupLocation, targetIndex?: number) => {
 		const result = moveTabToGroup(document, tab, target, targetIndex);
@@ -879,41 +906,54 @@ function WorkbenchTab({
 						Move to {group.location.area} group {group.location.groupId.slice(-4)}
 					</ContextMenuItem>
 				))}
-				{currentSide &&
-				currentSideGroupIndex >= 0 &&
+				{currentAuxiliary &&
+				currentAuxiliaryGroupIndex >= 0 &&
 				(tab.kind === "terminal" || tab.kind === "tool") ? (
 					<>
 						<ContextMenuSeparator />
-						{(["above", "below"] as const).map((position) => {
-							const insertAt = currentSideGroupIndex + (position === "below" ? 1 : 0);
-							const countAvailable = canCreateSideGroup(document, currentSide, tab, maxSideGroups);
-							const available = canCreateSideGroup(
+						{(["before", "after"] as const).map((position) => {
+							const insertAt = currentAuxiliaryGroupIndex + (position === "after" ? 1 : 0);
+							const countAvailable = canCreateAuxiliaryGroup(
 								document,
-								currentSide,
+								currentAuxiliary,
 								tab,
-								maxSideGroups,
+								currentAuxiliaryLimit,
+							);
+							const available = canCreateAuxiliaryGroup(
+								document,
+								currentAuxiliary,
+								tab,
+								currentAuxiliaryLimit,
 								insertAt,
 							);
 							const unavailable = countAvailable
 								? "already at this position"
-								: `limited to ${maxSideGroups}`;
+								: `limited to ${currentAuxiliaryLimit}`;
+							const positionLabel =
+								currentAuxiliary === "bottom"
+									? position === "before"
+										? "left"
+										: "right"
+									: position === "before"
+										? "above"
+										: "below";
 							return (
 								<ContextMenuItem
 									key={position}
 									disabled={!available}
 									title={available ? undefined : unavailable}
 									onSelect={() => {
-										const result = createSideGroup(
+										const result = createAuxiliaryGroup(
 											document,
-											currentSide,
+											currentAuxiliary,
 											tab,
 											insertAt,
-											maxSideGroups,
+											currentAuxiliaryLimit,
 										);
 										if (!isLayoutUnavailable(result)) onApply(result);
 									}}
 								>
-									New group {position}
+									New group {positionLabel}
 									{available ? "" : ` — ${unavailable}`}
 								</ContextMenuItem>
 							);
@@ -923,54 +963,39 @@ function WorkbenchTab({
 				{tab.kind === "terminal" || tab.kind === "tool" ? (
 					<>
 						<ContextMenuSeparator />
-						{(["left", "right"] as const).map((side) => {
-							const countAvailable = canCreateSideGroup(document, side, tab, maxSideGroups);
-							const topAvailable = canCreateSideGroup(document, side, tab, maxSideGroups, 0);
-							const bottomIndex = document[side].groups.length;
-							const bottomAvailable = canCreateSideGroup(
-								document,
-								side,
-								tab,
-								maxSideGroups,
-								bottomIndex,
-							);
-							const unavailableSuffix = (available: boolean, edge: "top" | "bottom") =>
-								available
-									? null
-									: countAvailable
-										? `already at ${edge}`
-										: `limited to ${maxSideGroups}`;
-							const topUnavailable = unavailableSuffix(topAvailable, "top");
-							const bottomUnavailable = unavailableSuffix(bottomAvailable, "bottom");
+						{(["left", "right", "bottom"] as const).map((region) => {
+							const limit = region === "bottom" ? maxBottomGroups : maxSideGroups;
+							const countAvailable = canCreateAuxiliaryGroup(document, region, tab, limit);
+							const startAvailable = canCreateAuxiliaryGroup(document, region, tab, limit, 0);
+							const endIndex = document[region].groups.length;
+							const endAvailable = canCreateAuxiliaryGroup(document, region, tab, limit, endIndex);
+							const unavailableSuffix = (available: boolean, edge: "start" | "end") =>
+								available ? null : countAvailable ? `already at ${edge}` : `limited to ${limit}`;
+							const startUnavailable = unavailableSuffix(startAvailable, "start");
+							const endUnavailable = unavailableSuffix(endAvailable, "end");
 							return (
-								<Fragment key={side}>
+								<Fragment key={region}>
 									<ContextMenuItem
-										disabled={!topAvailable}
-										title={topUnavailable ?? undefined}
+										disabled={!startAvailable}
+										title={startUnavailable ?? undefined}
 										onSelect={() => {
-											const result = createSideGroup(document, side, tab, 0, maxSideGroups);
+											const result = createAuxiliaryGroup(document, region, tab, 0, limit);
 											if (!isLayoutUnavailable(result)) onApply(result);
 										}}
 									>
-										New {side} group at top
-										{topUnavailable ? ` — ${topUnavailable}` : ""}
+										New {region} group at {region === "bottom" ? "left" : "top"}
+										{startUnavailable ? ` — ${startUnavailable}` : ""}
 									</ContextMenuItem>
 									<ContextMenuItem
-										disabled={!bottomAvailable}
-										title={bottomUnavailable ?? undefined}
+										disabled={!endAvailable}
+										title={endUnavailable ?? undefined}
 										onSelect={() => {
-											const result = createSideGroup(
-												document,
-												side,
-												tab,
-												bottomIndex,
-												maxSideGroups,
-											);
+											const result = createAuxiliaryGroup(document, region, tab, endIndex, limit);
 											if (!isLayoutUnavailable(result)) onApply(result);
 										}}
 									>
-										New {side} group
-										{bottomUnavailable ? ` — ${bottomUnavailable}` : ""}
+										New {region} group at {region === "bottom" ? "right" : "bottom"}
+										{endUnavailable ? ` — ${endUnavailable}` : ""}
 									</ContextMenuItem>
 								</Fragment>
 							);
@@ -990,7 +1015,7 @@ function WorkbenchTab({
 				<ContextMenuSeparator />
 				{location.area !== "center" ? (
 					<ContextMenuItem onSelect={() => onHideSide(location.area)}>
-						Hide {location.area} side
+						Hide {location.area} region
 					</ContextMenuItem>
 				) : null}
 				<ContextMenuItem
@@ -1020,16 +1045,18 @@ interface SharedGroupProps {
 	attention: LayoutAttention;
 	selectionEpoch: React.MutableRefObject<number>;
 	maxSideGroups: number;
+	maxBottomGroups: number;
 	draggingTab: LayoutTab | null;
 	renderTabBody: WorkbenchProps["renderTabBody"];
 	renderTabAdornment: WorkbenchProps["renderTabAdornment"];
+	renderToolBody: WorkbenchProps["renderToolBody"];
 	onAttentionChange: WorkbenchProps["onAttentionChange"];
 	onUserNavigation: WorkbenchProps["onUserNavigation"];
 	onRemoteGestureCanceled: (() => void) | undefined;
 	onApply: (result: LayoutMutationResult) => void;
 	onClose: (tab: LayoutTab) => void;
 	onFocusAdjacentGroup: (delta: -1 | 1, fromGroupId?: string) => void;
-	onHideSide: (side: LayoutSide) => void;
+	onHideSide: (region: LayoutAuxiliaryRegion) => void;
 	onRevealTool: (tool: LayoutToolId) => void;
 	canFocusAdjacentGroup: boolean;
 }
@@ -1089,6 +1116,7 @@ function CenterGroupView({
 				selectedId={selected?.id}
 				previewId={group.previewTabId}
 				maxSideGroups={shared.maxSideGroups}
+				maxBottomGroups={shared.maxBottomGroups}
 				draggingTab={shared.draggingTab}
 				splitGeometry={splitGeometry}
 				onSelect={applySelect}
@@ -1313,7 +1341,7 @@ function SideGroupView({
 				{canCreateAbove ? (
 					<DropZone
 						id={tupleKey("dnd-side-group", side, group.id, "above")}
-						target={{ kind: "side-edge", side, index: groupIndex }}
+						target={{ kind: "auxiliary-edge", region: side, index: groupIndex }}
 						label={`Create ${side} group above`}
 						className="absolute inset-x-1 top-1 bottom-1/2"
 					/>
@@ -1321,7 +1349,7 @@ function SideGroupView({
 				{canCreateBelow ? (
 					<DropZone
 						id={tupleKey("dnd-side-group", side, group.id, "below")}
-						target={{ kind: "side-edge", side, index: groupIndex + 1 }}
+						target={{ kind: "auxiliary-edge", region: side, index: groupIndex + 1 }}
 						label={`Create ${side} group below`}
 						className="absolute inset-x-1 top-1/2 bottom-1"
 					/>
@@ -1354,6 +1382,7 @@ function SideGroupView({
 						tabs={group.tabs}
 						selectedId={selected?.id}
 						maxSideGroups={shared.maxSideGroups}
+						maxBottomGroups={shared.maxBottomGroups}
 						draggingTab={group.folded ? null : shared.draggingTab}
 						onSelect={(tabId) =>
 							shared.onAttentionChange(selectTab(shared.attention, location, tabId))
@@ -1514,9 +1543,528 @@ function SideStack({
 	);
 }
 
+const BOTTOM_ALIGNMENT_LABELS: Record<LayoutBottomAlignment, string> = {
+	center: "Below center",
+	"center-left": "Below center and left",
+	"center-right": "Below center and right",
+	full: "Full width",
+};
+
+function BottomAlignmentMenu({
+	alignment,
+	onChange,
+	onHide,
+}: {
+	alignment: LayoutBottomAlignment;
+	onChange: (alignment: LayoutBottomAlignment) => void;
+	onHide: () => void;
+}) {
+	return (
+		<Popover>
+			<PopoverTrigger
+				aria-label="Bottom panel alignment"
+				title={`Bottom panel alignment: ${BOTTOM_ALIGNMENT_LABELS[alignment]}`}
+				className="flex w-7 shrink-0 items-center justify-center border-border-muted border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+			>
+				<MoreHorizontal className="size-4" />
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-56 p-xs">
+				<div className="space-y-0.5" role="menu" aria-label="Bottom panel alignment">
+					{(Object.keys(BOTTOM_ALIGNMENT_LABELS) as LayoutBottomAlignment[]).map((value) => (
+						<button
+							key={value}
+							type="button"
+							role="menuitemradio"
+							aria-checked={alignment === value}
+							data-testid={`bottom-align-${value}`}
+							onClick={() => onChange(value)}
+							className="flex w-full items-center justify-between rounded-[var(--radius-sm)] px-sm py-xs text-left tr-text-ui text-text-default hover:bg-control-bg-hovered"
+						>
+							<span>{BOTTOM_ALIGNMENT_LABELS[value]}</span>
+							{alignment === value ? <Check className="size-3.5 text-primary" /> : null}
+						</button>
+					))}
+					<div className="my-xs border-border-default border-t" />
+					<button
+						type="button"
+						role="menuitem"
+						onClick={onHide}
+						className="w-full rounded-[var(--radius-sm)] px-sm py-xs text-left tr-text-ui text-text-default hover:bg-control-bg-hovered"
+					>
+						Hide bottom panel
+					</button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function BottomCreationTargets({
+	group,
+	groupIndex,
+	shared,
+}: {
+	group: LayoutBottomGroup;
+	groupIndex: number;
+	shared: SharedGroupProps;
+}) {
+	const tab =
+		shared.draggingTab?.kind === "tool" || shared.draggingTab?.kind === "terminal"
+			? shared.draggingTab
+			: null;
+	const canCreateLeft = Boolean(
+		tab &&
+			canCreateAuxiliaryGroup(shared.document, "bottom", tab, shared.maxBottomGroups, groupIndex),
+	);
+	const canCreateRight = Boolean(
+		tab &&
+			canCreateAuxiliaryGroup(
+				shared.document,
+				"bottom",
+				tab,
+				shared.maxBottomGroups,
+				groupIndex + 1,
+			),
+	);
+	if (!canCreateLeft && !canCreateRight) return null;
+	return (
+		<div className="pointer-events-none absolute inset-0 z-30">
+			{canCreateLeft ? (
+				<DropZone
+					id={tupleKey("dnd-bottom-group", group.id, "left")}
+					target={{ kind: "auxiliary-edge", region: "bottom", index: groupIndex }}
+					label="Create bottom group to the left"
+					className="absolute inset-y-1 left-1 right-1/2"
+				/>
+			) : null}
+			{canCreateRight ? (
+				<DropZone
+					id={tupleKey("dnd-bottom-group", group.id, "right")}
+					target={{ kind: "auxiliary-edge", region: "bottom", index: groupIndex + 1 }}
+					label="Create bottom group to the right"
+					className="absolute inset-y-1 left-1/2 right-1"
+				/>
+			) : null}
+		</div>
+	);
+}
+
+function BottomGroupView({
+	group,
+	groupIndex,
+	showAlignmentMenu,
+	onFold,
+	onNewTerminal,
+	onAlignmentChange,
+	...shared
+}: SharedGroupProps & {
+	group: LayoutBottomGroup;
+	groupIndex: number;
+	showAlignmentMenu: boolean;
+	onFold: () => void;
+	onNewTerminal: () => void;
+	onAlignmentChange: (alignment: LayoutBottomAlignment) => void;
+}) {
+	const location: LayoutGroupLocation = { area: "bottom", groupId: group.id };
+	const selectedId = readLayoutSelection(shared.attention, group.id);
+	const selected = group.tabs.find((tab) => tab.id === selectedId) ?? group.tabs[0];
+	return (
+		<section
+			id={groupDomId(location)}
+			data-testid="bottom-group"
+			data-group-id={group.id}
+			tabIndex={-1}
+			aria-label={selected ? `Bottom group: ${selected.name}` : "Empty bottom group"}
+			className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-container-sidebar-bg outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+			onFocusCapture={() => {
+				if (selected) {
+					shared.onAttentionChange(selectTab(shared.attention, location, selected.id, false));
+					return;
+				}
+				shared.onAttentionChange({
+					...shared.attention,
+					lastFocusedSideGroupId: Object.assign(
+						Object.create(null),
+						shared.attention.lastFocusedSideGroupId,
+						{ bottom: group.id },
+					),
+				});
+			}}
+		>
+			<div className="flex h-panel-header-row shrink-0 items-stretch">
+				<div className="min-w-0 flex-1">
+					<TabStrip
+						document={shared.document}
+						attention={shared.attention}
+						selectionEpoch={shared.selectionEpoch}
+						location={location}
+						tabs={group.tabs}
+						selectedId={selected?.id}
+						maxSideGroups={shared.maxSideGroups}
+						maxBottomGroups={shared.maxBottomGroups}
+						draggingTab={shared.draggingTab}
+						onSelect={(tabId) =>
+							shared.onAttentionChange(selectTab(shared.attention, location, tabId))
+						}
+						onClose={shared.onClose}
+						onApply={shared.onApply}
+						onFocusAdjacentGroup={shared.onFocusAdjacentGroup}
+						onHideSide={shared.onHideSide}
+						onRevealTool={shared.onRevealTool}
+						canFocusAdjacentGroup={shared.canFocusAdjacentGroup}
+						renderTabAdornment={shared.renderTabAdornment}
+						trailing={
+							showAlignmentMenu ? (
+								<BottomAlignmentMenu
+									alignment={shared.document.bottom.alignment}
+									onChange={onAlignmentChange}
+									onHide={() => shared.onHideSide("bottom")}
+								/>
+							) : null
+						}
+					/>
+				</div>
+				<button
+					type="button"
+					data-testid="bottom-group-fold"
+					aria-label="Fold bottom group"
+					aria-expanded="true"
+					onClick={onFold}
+					className="flex w-7 shrink-0 items-center justify-center border-border-muted border-b border-l text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+				>
+					<ChevronLeft className="size-3.5" />
+				</button>
+			</div>
+			<div
+				id={groupPanelId(location)}
+				role="tabpanel"
+				aria-labelledby={selected ? tabDomId(location, selected.id) : undefined}
+				className="relative min-h-0 flex-1 overflow-auto"
+			>
+				{selected ? (
+					<Fragment key={selected.id}>
+						{selected.kind === "tool"
+							? shared.renderToolBody(selected.tool)
+							: selected.kind === "terminal"
+								? shared.renderTabBody(selected)
+								: null}
+					</Fragment>
+				) : (
+					<div className="flex h-full items-center justify-center p-md">
+						<button
+							type="button"
+							data-testid="bottom-new-terminal"
+							onClick={onNewTerminal}
+							className="flex items-center gap-xs rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-md py-xs tr-text-ui text-text-default hover:bg-control-bg-hovered"
+						>
+							<SquareTerminal className="size-4" /> New terminal
+						</button>
+					</div>
+				)}
+				<BottomCreationTargets group={group} groupIndex={groupIndex} shared={shared} />
+			</div>
+		</section>
+	);
+}
+
+function BottomFoldedGroup({
+	group,
+	groupIndex,
+	showAlignmentMenu,
+	onExpand,
+	onAlignmentChange,
+	shared,
+}: {
+	group: LayoutBottomGroup;
+	groupIndex: number;
+	showAlignmentMenu: boolean;
+	onExpand: () => void;
+	onAlignmentChange: (alignment: LayoutBottomAlignment) => void;
+	shared: SharedGroupProps;
+}) {
+	const selectedId = readLayoutSelection(shared.attention, group.id);
+	const selected = group.tabs.find((tab) => tab.id === selectedId) ?? group.tabs[0];
+	const location: LayoutGroupLocation = { area: "bottom", groupId: group.id };
+	const drop = useDroppable({
+		id: tupleKey("dnd-bottom-folded", group.id),
+		data: { target: { kind: "group", location } satisfies DropTarget },
+		disabled: !shared.draggingTab || !canPlaceLayoutTab(shared.draggingTab, "bottom"),
+	});
+	return (
+		<section
+			ref={drop.setNodeRef}
+			data-testid="bottom-group"
+			data-group-id={group.id}
+			data-folded="true"
+			data-drop-active={drop.isOver || undefined}
+			className="relative flex h-full items-stretch overflow-hidden border-border-default border-r bg-container-sidebar-bg data-[drop-active]:bg-primary-subtle"
+		>
+			<div className="flex min-h-0 w-full flex-col">
+				{showAlignmentMenu ? (
+					<BottomAlignmentMenu
+						alignment={shared.document.bottom.alignment}
+						onChange={onAlignmentChange}
+						onHide={() => shared.onHideSide("bottom")}
+					/>
+				) : null}
+				<button
+					type="button"
+					data-testid="bottom-group-restore"
+					aria-label={`Expand bottom group${selected ? ` ${selected.name}` : ""}`}
+					aria-expanded="false"
+					onClick={onExpand}
+					className="flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+				>
+					<span className="truncate [writing-mode:vertical-rl]">
+						{selected?.name ?? "Empty group"}
+					</span>
+				</button>
+			</div>
+			<BottomCreationTargets group={group} groupIndex={groupIndex} shared={shared} />
+		</section>
+	);
+}
+
+function BottomStack({
+	remoteEpoch,
+	onCommit,
+	onNewTerminal,
+	...shared
+}: SharedGroupProps & {
+	remoteEpoch: number;
+	onCommit: WorkbenchProps["onCommit"];
+	onNewTerminal: WorkbenchProps["onNewTerminal"];
+}) {
+	const size = useElementSize();
+	const region = shared.document.bottom;
+	const alignmentMenuGroupId =
+		region.groups.find((group) => !group.folded)?.id ?? region.groups[0]?.id;
+	const commitAlignment = (alignment: LayoutBottomAlignment) => {
+		const next = setBottomAlignment(shared.document, alignment);
+		if (next !== shared.document) onCommit(next);
+	};
+	const total = region.groups.reduce((sum, group) => sum + group.weight, 0) || 1;
+	const current = region.groups.map((group) => (group.weight / total) * 100);
+	const resize = useCommittedSizes(
+		current,
+		remoteEpoch,
+		(sizes) => {
+			const next = resizeAuxiliaryGroups(shared.document, "bottom", sizes);
+			if (next !== shared.document) onCommit(next);
+		},
+		shared.onRemoteGestureCanceled,
+	);
+	const foldedCount = region.groups.filter((group) => group.folded).length;
+	const expandedCount = region.groups.length - foldedCount;
+	const roomForMinimums =
+		size.width >=
+		foldedCount * LAYOUT_LIMITS.foldedBottomWidth +
+			expandedCount * LAYOUT_LIMITS.minBottomGroupWidth;
+	const equalShare = 100 / Math.max(1, region.groups.length);
+	const requestedFoldedPercent =
+		size.width > 0 ? (LAYOUT_LIMITS.foldedBottomWidth / size.width) * 100 : 4;
+	const foldedPercent = roomForMinimums
+		? requestedFoldedPercent
+		: Math.min(requestedFoldedPercent, equalShare);
+	const expandedMinimum =
+		roomForMinimums && size.width > 0
+			? (LAYOUT_LIMITS.minBottomGroupWidth / size.width) * 100
+			: Math.min(4, equalShare);
+	const foldedSpacerPercent = Math.max(0, 100 - foldedCount * foldedPercent);
+	return (
+		<aside
+			ref={size.ref}
+			aria-label="Bottom workbench"
+			data-testid="bottom-panel"
+			className="relative h-full min-h-0 min-w-0 overflow-hidden"
+		>
+			<ResizablePanelGroup
+				key={tupleKey(
+					"bottom-stack",
+					String(remoteEpoch),
+					...region.groups.flatMap((group) => [group.id, String(group.folded)]),
+				)}
+				direction="horizontal"
+				onLayout={(sizes) => resize.onLayout(sizes.slice(0, region.groups.length))}
+			>
+				{region.groups.map((group, index) => {
+					const sizePercent = group.folded ? foldedPercent : current[index];
+					const fold = () => {
+						const result = setAuxiliaryGroupFolded(
+							shared.document,
+							"bottom",
+							group.id,
+							!group.folded,
+						);
+						if (!isLayoutUnavailable(result)) shared.onApply(result);
+					};
+					return (
+						<PanelWithHandle
+							key={tupleKey("bottom-group", group.id)}
+							id={tupleKey("bottom-stack-panel", group.id)}
+							order={index + 1}
+							defaultSize={sizePercent}
+							minSize={group.folded ? foldedPercent : expandedMinimum}
+							maxSize={group.folded ? foldedPercent : 100}
+							showHandle={index < region.groups.length - 1}
+							handleDirection="horizontal"
+							handleTestId="bottom-group-resize"
+							handleDisabled={!roomForMinimums || expandedCount < 2}
+							onDragging={resize.onDragging}
+							onKeyboard={resize.onKeyboard}
+							onKeyboardEnd={resize.onKeyboardEnd}
+						>
+							{group.folded ? (
+								<BottomFoldedGroup
+									group={group}
+									groupIndex={index}
+									showAlignmentMenu={group.id === alignmentMenuGroupId}
+									onExpand={fold}
+									onAlignmentChange={commitAlignment}
+									shared={shared}
+								/>
+							) : (
+								<BottomGroupView
+									group={group}
+									groupIndex={index}
+									showAlignmentMenu={group.id === alignmentMenuGroupId}
+									onFold={fold}
+									onNewTerminal={() => onNewTerminal(group.id, "bottom")}
+									onAlignmentChange={commitAlignment}
+									{...shared}
+								/>
+							)}
+						</PanelWithHandle>
+					);
+				})}
+				{expandedCount === 0 && foldedSpacerPercent > 0 ? (
+					<ResizablePanel
+						id="bottom-folded-spacer"
+						order={region.groups.length + 1}
+						defaultSize={foldedSpacerPercent}
+						minSize={foldedSpacerPercent}
+						maxSize={foldedSpacerPercent}
+					>
+						<div aria-hidden="true" className="h-full" />
+					</ResizablePanel>
+				) : null}
+			</ResizablePanelGroup>
+		</aside>
+	);
+}
+
+function BottomAlignedRow({
+	document,
+	leftVisible,
+	rightVisible,
+	children,
+}: {
+	document: WorkspaceLayoutDocument;
+	leftVisible: boolean;
+	rightVisible: boolean;
+	children: ReactNode;
+}) {
+	const left = leftVisible ? document.left.width * 100 : 0;
+	const right = rightVisible ? document.right.width * 100 : 0;
+	const center = 100 - left - right;
+	const start =
+		document.bottom.alignment === "center" || document.bottom.alignment === "center-right"
+			? left
+			: 0;
+	const end =
+		document.bottom.alignment === "center" || document.bottom.alignment === "center-left"
+			? right
+			: 0;
+	const body = Math.max(Number.EPSILON, center + left + right - start - end);
+	return (
+		<ResizablePanelGroup
+			key={tupleKey("bottom-alignment", document.bottom.alignment, String(left), String(right))}
+			direction="horizontal"
+			className="min-h-0 min-w-0"
+		>
+			{start > 0 ? (
+				<ResizablePanel
+					id="bottom-start-spacer"
+					order={1}
+					defaultSize={start}
+					minSize={start}
+					maxSize={start}
+				>
+					<div aria-hidden="true" className="h-full bg-container-workspace-bg" />
+				</ResizablePanel>
+			) : null}
+			<ResizablePanel
+				id="bottom-aligned-body"
+				order={2}
+				defaultSize={body}
+				minSize={body}
+				maxSize={body}
+			>
+				{children}
+			</ResizablePanel>
+			{end > 0 ? (
+				<ResizablePanel
+					id="bottom-end-spacer"
+					order={3}
+					defaultSize={end}
+					minSize={end}
+					maxSize={end}
+				>
+					<div aria-hidden="true" className="h-full bg-container-workspace-bg" />
+				</ResizablePanel>
+			) : null}
+		</ResizablePanelGroup>
+	);
+}
+
+function HiddenBottomRail({
+	onShow,
+	dropEnabled,
+	targetGroupId,
+	targetIndex,
+}: {
+	onShow: () => void;
+	dropEnabled: boolean;
+	targetGroupId: string | undefined;
+	targetIndex: number;
+}) {
+	const drop = useDroppable({
+		id: "dnd-hidden-bottom-edge",
+		data: {
+			target: targetGroupId
+				? ({
+						kind: "group",
+						location: { area: "bottom", groupId: targetGroupId },
+					} satisfies DropTarget)
+				: ({ kind: "auxiliary-edge", region: "bottom", index: targetIndex } satisfies DropTarget),
+		},
+		disabled: !dropEnabled,
+	});
+	return (
+		<div
+			ref={drop.setNodeRef}
+			data-testid="bottom-layout-rail"
+			data-drop-label={dropEnabled ? "Create group in hidden bottom region" : undefined}
+			data-drop-active={drop.isOver || undefined}
+			className="flex h-7 shrink-0 items-center justify-center border-border-default border-t bg-container-sidebar-bg data-[drop-active]:bg-primary-subtle data-[drop-active]:ring-2 data-[drop-active]:ring-inset data-[drop-active]:ring-primary"
+		>
+			<button
+				type="button"
+				aria-label="Show bottom panel"
+				title="Show bottom panel (Mod+Shift+J)"
+				onClick={onShow}
+				className="flex h-6 items-center gap-xs rounded-[var(--radius-sm)] px-sm tr-text-metadata text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
+			>
+				<PanelBottomOpen className="size-4" /> Bottom
+			</button>
+		</div>
+	);
+}
+
 function PanelWithHandle({
 	children,
 	showHandle,
+	handleDirection = "vertical",
 	handleTestId,
 	handleDisabled,
 	onDragging,
@@ -1525,6 +2073,7 @@ function PanelWithHandle({
 	...panelProps
 }: React.ComponentProps<typeof ResizablePanel> & {
 	showHandle: boolean;
+	handleDirection?: "horizontal" | "vertical";
 	handleTestId: string;
 	handleDisabled: boolean;
 	onDragging: (active: boolean) => void;
@@ -1536,7 +2085,7 @@ function PanelWithHandle({
 			<ResizablePanel {...panelProps}>{children}</ResizablePanel>
 			{showHandle ? (
 				<ResizableHandle
-					direction="vertical"
+					direction={handleDirection}
 					data-testid={handleTestId}
 					disabled={handleDisabled}
 					onDragging={onDragging}
@@ -1553,17 +2102,23 @@ function HiddenSideRail({
 	onShow,
 	dropEnabled,
 	showEnabled,
+	targetGroupId,
 	targetIndex,
 }: {
 	side: LayoutSide;
 	onShow: () => void;
 	dropEnabled: boolean;
 	showEnabled: boolean;
+	targetGroupId: string | undefined;
 	targetIndex: number;
 }) {
 	const drop = useDroppable({
 		id: tupleKey("dnd-hidden-side-edge", side),
-		data: { target: { kind: "side-edge", side, index: targetIndex } satisfies DropTarget },
+		data: {
+			target: targetGroupId
+				? ({ kind: "group", location: { area: side, groupId: targetGroupId } } satisfies DropTarget)
+				: ({ kind: "auxiliary-edge", region: side, index: targetIndex } satisfies DropTarget),
+		},
 		disabled: !dropEnabled,
 	});
 	return (
@@ -1596,6 +2151,7 @@ export function Workbench({
 	document,
 	attention,
 	maxSideGroups,
+	maxBottomGroups,
 	remoteEpoch,
 	focusRequest,
 	renderTabBody,
@@ -1609,6 +2165,7 @@ export function Workbench({
 	readNavigationTick,
 	onRequestClose,
 	onNewChat,
+	onNewTerminal,
 	onRemoteGestureCanceled,
 }: WorkbenchProps) {
 	const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
@@ -1619,7 +2176,7 @@ export function Workbench({
 		selectionRemoteEpoch.current = remoteEpoch;
 		tabSelectionEpoch.current += 1;
 	}
-	const { ref: workbenchRef, width: workbenchWidth } = useElementSize();
+	const { ref: workbenchRef, width: workbenchWidth, height: workbenchHeight } = useElementSize();
 	const [focusAfterClose, setFocusAfterClose] = useState<{
 		closedTab: LayoutTab;
 		fallbackDomId: string;
@@ -1677,12 +2234,19 @@ export function Workbench({
 		(result: LayoutMutationResult) => {
 			updateAttentionForResult(result);
 			onCommit(result.document);
-			if (result.focusGroupId) {
+			const focusGroupId = result.focusGroupId;
+			if (focusGroupId) {
 				const location = result.focusTabId
 					? findTabLocation(result.document, result.focusTabId)
-					: findCenterGroup(result.document.center, result.focusGroupId)
-						? ({ area: "center", groupId: result.focusGroupId } as const)
-						: null;
+					: findCenterGroup(result.document.center, focusGroupId)
+						? ({ area: "center", groupId: focusGroupId } as const)
+						: ((["left", "right", "bottom"] as const)
+								.map((area) =>
+									findAuxiliaryGroup(result.document, area, focusGroupId)
+										? ({ area, groupId: focusGroupId } as const)
+										: null,
+								)
+								.find((candidate) => candidate !== null) ?? null);
 				if (location) {
 					setLocalFocusRequest({
 						key: createLayoutId("focus"),
@@ -1850,11 +2414,17 @@ export function Workbench({
 						? { reason: "Tools stay in a side region." }
 						: splitCenterGroup(document, target.groupId, target.direction, tab);
 				break;
-			case "side-edge":
+			case "auxiliary-edge":
 				result =
 					tab.kind === "terminal" || tab.kind === "tool"
-						? createSideGroup(document, target.side, tab, target.index, maxSideGroups)
-						: { reason: "That tab type cannot move to a side region." };
+						? createAuxiliaryGroup(
+								document,
+								target.region,
+								tab,
+								target.index,
+								target.region === "bottom" ? maxBottomGroups : maxSideGroups,
+							)
+						: { reason: "That tab type cannot move to an auxiliary region." };
 				break;
 		}
 		if (!isLayoutUnavailable(result)) apply(result);
@@ -1862,6 +2432,12 @@ export function Workbench({
 
 	const leftVisible = document.left.visible && document.left.groups.length > 0;
 	const rightVisible = document.right.visible && document.right.groups.length > 0;
+	const hiddenLeftTargetGroupId =
+		document.left.groups.find((group) => group.id === attention.lastFocusedSideGroupId.left)?.id ??
+		document.left.groups[0]?.id;
+	const hiddenRightTargetGroupId =
+		document.right.groups.find((group) => group.id === attention.lastFocusedSideGroupId.right)
+			?.id ?? document.right.groups[0]?.id;
 	const visibleSideMinimums = (leftVisible ? 8 : 0) + (rightVisible ? 8 : 0);
 	const centerMinimumPercent = Math.min(
 		Math.max(10, 100 - visibleSideMinimums),
@@ -1913,6 +2489,40 @@ export function Workbench({
 		},
 		onRemoteGestureCanceled,
 	);
+	const bottomVisible = document.bottom.visible && document.bottom.groups.length > 0;
+	const hiddenBottomTargetGroupId =
+		document.bottom.groups.find((group) => group.id === attention.lastFocusedSideGroupId.bottom)
+			?.id ?? document.bottom.groups.at(-1)?.id;
+	const bottomCurrent = useMemo(
+		() => [(1 - document.bottom.height) * 100, document.bottom.height * 100],
+		[document.bottom.height],
+	);
+	const bottomGroupRef = useRef<ImperativePanelGroupHandle>(null);
+	useEffect(() => {
+		const group = bottomGroupRef.current;
+		if (group && !sameSizes(group.getLayout(), bottomCurrent)) group.setLayout(bottomCurrent);
+	}, [bottomCurrent]);
+	const bottomResize = useCommittedSizes(
+		bottomCurrent,
+		remoteEpoch,
+		(sizes) => {
+			const bottomSize = sizes[1] ?? bottomCurrent[1] ?? 30;
+			if (bottomSize <= Number.EPSILON) {
+				apply(hideBottom(document, attentionRef.current));
+				return;
+			}
+			const next = resizeBottomRegion(document, bottomSize / 100);
+			if (next !== document) onCommit(next);
+		},
+		onRemoteGestureCanceled,
+	);
+	const bottomMinimumPercent = Math.min(
+		LAYOUT_LIMITS.maxBottomHeight * 100,
+		workbenchHeight > 0
+			? ((LAYOUT_LIMITS.minBottomBodyHeight + LAYOUT_LIMITS.foldedSideHeight) / workbenchHeight) *
+					100
+			: 10,
+	);
 	const focusableGroups = useMemo(() => visibleFocusableGroups(document), [document]);
 	const focusAdjacentGroup = useCallback(
 		(delta: -1 | 1, fromGroupId?: string) => {
@@ -1945,7 +2555,21 @@ export function Workbench({
 				});
 				return;
 			}
-			if (target.location.area !== "center") return;
+			if (target.location.area !== "center") {
+				onAttentionChange({
+					...currentAttention,
+					lastFocusedSideGroupId: Object.assign(
+						Object.create(null),
+						currentAttention.lastFocusedSideGroupId,
+						{ [target.location.area]: target.location.groupId },
+					),
+				});
+				setLocalFocusRequest({
+					key: createLayoutId("focus-group"),
+					location: target.location,
+				});
+				return;
+			}
 			const nextAttention = {
 				...currentAttention,
 				lastFocusedCenterGroupId: target.location.groupId,
@@ -1968,24 +2592,40 @@ export function Workbench({
 	);
 	const canFocusAdjacentGroup = focusableGroups.length > 1;
 	const hideSideRegion = useCallback(
-		(side: LayoutSide) => apply(hideSide(document, side, attentionRef.current)),
+		(region: LayoutAuxiliaryRegion) =>
+			apply(
+				region === "bottom"
+					? hideBottom(document, attentionRef.current)
+					: hideSide(document, region, attentionRef.current),
+			),
 		[apply, document],
 	);
+	const showBottomRegion = useCallback(() => {
+		const shown = showBottom(document, maxSideGroups, maxBottomGroups, attentionRef.current);
+		if (isLayoutUnavailable(shown)) return;
+		apply(shown);
+		if (shown.document.bottom.groups.every((group) => group.tabs.length === 0)) {
+			const groupId = shown.focusGroupId ?? shown.document.bottom.groups[0]?.id;
+			if (groupId) onNewTerminal(groupId, "bottom");
+		}
+	}, [apply, document, maxBottomGroups, maxSideGroups, onNewTerminal]);
 	const revealMissingTool = useCallback(
 		(tool: LayoutToolId) => {
-			const result = revealTool(document, tool, maxSideGroups);
+			const result = revealTool(document, tool, maxSideGroups, maxBottomGroups);
 			if (!isLayoutUnavailable(result)) apply(result);
 		},
-		[apply, document, maxSideGroups],
+		[apply, document, maxBottomGroups, maxSideGroups],
 	);
 	const shared: SharedGroupProps = {
 		document,
 		attention,
 		selectionEpoch: tabSelectionEpoch,
 		maxSideGroups,
+		maxBottomGroups,
 		draggingTab,
 		renderTabBody,
 		renderTabAdornment,
+		renderToolBody,
 		onAttentionChange,
 		onUserNavigation,
 		onRemoteGestureCanceled,
@@ -1996,6 +2636,93 @@ export function Workbench({
 		onRevealTool: revealMissingTool,
 		canFocusAdjacentGroup,
 	};
+	const mainRow = (
+		<ResizablePanelGroup
+			ref={outerGroupRef}
+			key={tupleKey(
+				"outer-workbench",
+				String(leftVisible),
+				String(rightVisible),
+				String(remoteEpoch),
+			)}
+			direction="horizontal"
+			onLayout={outerResize.onLayout}
+			className="h-full min-h-0 min-w-0 flex-1"
+		>
+			{leftVisible ? (
+				<>
+					<ResizablePanel
+						id="layout-left"
+						order={1}
+						defaultSize={outerCurrent[0]}
+						minSize={8}
+						collapsedSize={0}
+						collapsible
+					>
+						<SideStack
+							side="left"
+							region={document.left}
+							remoteEpoch={remoteEpoch}
+							onCommit={onCommit}
+							{...shared}
+						/>
+					</ResizablePanel>
+					<ResizableHandle
+						direction="horizontal"
+						data-testid="resize-left"
+						onDragging={outerResize.onDragging}
+						onKeyDownCapture={outerResize.onKeyboard}
+						onKeyUpCapture={outerResize.onKeyboardEnd}
+					/>
+				</>
+			) : null}
+			<ResizablePanel
+				id="layout-center"
+				order={2}
+				defaultSize={outerCurrent[leftVisible ? 1 : 0]}
+				minSize={centerMinimumPercent}
+			>
+				<main data-testid="center-tabs" className="h-full min-h-0 min-w-0">
+					<CenterNodeView
+						node={document.center}
+						remoteEpoch={remoteEpoch}
+						onCommit={onCommit}
+						onNewChat={onNewChat}
+						renderEmptyCenter={renderEmptyCenter}
+						renderCenterActions={renderCenterActions}
+						{...shared}
+					/>
+				</main>
+			</ResizablePanel>
+			{rightVisible ? (
+				<>
+					<ResizableHandle
+						direction="horizontal"
+						data-testid="resize-right"
+						onDragging={outerResize.onDragging}
+						onKeyDownCapture={outerResize.onKeyboard}
+						onKeyUpCapture={outerResize.onKeyboardEnd}
+					/>
+					<ResizablePanel
+						id="layout-right"
+						order={3}
+						defaultSize={outerCurrent[outerCurrent.length - 1]}
+						minSize={8}
+						collapsedSize={0}
+						collapsible
+					>
+						<SideStack
+							side="right"
+							region={document.right}
+							remoteEpoch={remoteEpoch}
+							onCommit={onCommit}
+							{...shared}
+						/>
+					</ResizablePanel>
+				</>
+			) : null}
+		</ResizablePanelGroup>
+	);
 
 	return (
 		<DndContext
@@ -2031,104 +2758,89 @@ export function Workbench({
 						dropEnabled={
 							!!draggingTab &&
 							canPlaceLayoutTab(draggingTab, "left") &&
-							canCreateSideGroup(
-								document,
-								"left",
-								draggingTab,
-								maxSideGroups,
-								document.left.groups.length,
-							)
+							(hiddenLeftTargetGroupId !== undefined ||
+								canCreateSideGroup(
+									document,
+									"left",
+									draggingTab,
+									maxSideGroups,
+									document.left.groups.length,
+								))
 						}
+						targetGroupId={hiddenLeftTargetGroupId}
 						targetIndex={document.left.groups.length}
 					/>
 				) : null}
-				<ResizablePanelGroup
-					ref={outerGroupRef}
-					key={tupleKey(
-						"outer-workbench",
-						String(leftVisible),
-						String(rightVisible),
-						String(remoteEpoch),
-					)}
-					direction="horizontal"
-					onLayout={outerResize.onLayout}
-					className="min-h-0 min-w-0 flex-1"
-				>
-					{leftVisible ? (
-						<>
+				<div className="flex min-h-0 min-w-0 flex-1 flex-col">
+					{bottomVisible ? (
+						<ResizablePanelGroup
+							ref={bottomGroupRef}
+							key={tupleKey("workbench-bottom", String(remoteEpoch))}
+							direction="vertical"
+							onLayout={bottomResize.onLayout}
+							className="min-h-0 min-w-0 flex-1"
+						>
 							<ResizablePanel
-								id="layout-left"
+								id="layout-main-row"
 								order={1}
-								defaultSize={outerCurrent[0]}
-								minSize={8}
-								collapsedSize={0}
-								collapsible
+								defaultSize={bottomCurrent[0]}
+								minSize={30}
 							>
-								<SideStack
-									side="left"
-									region={document.left}
-									remoteEpoch={remoteEpoch}
-									renderToolBody={renderToolBody}
-									onCommit={onCommit}
-									{...shared}
-								/>
+								{mainRow}
 							</ResizablePanel>
 							<ResizableHandle
-								direction="horizontal"
-								data-testid="resize-left"
-								onDragging={outerResize.onDragging}
-								onKeyDownCapture={outerResize.onKeyboard}
-								onKeyUpCapture={outerResize.onKeyboardEnd}
-							/>
-						</>
-					) : null}
-					<ResizablePanel
-						id="layout-center"
-						order={2}
-						defaultSize={outerCurrent[leftVisible ? 1 : 0]}
-						minSize={centerMinimumPercent}
-					>
-						<main data-testid="center-tabs" className="h-full min-h-0 min-w-0">
-							<CenterNodeView
-								node={document.center}
-								remoteEpoch={remoteEpoch}
-								onCommit={onCommit}
-								onNewChat={onNewChat}
-								renderEmptyCenter={renderEmptyCenter}
-								renderCenterActions={renderCenterActions}
-								{...shared}
-							/>
-						</main>
-					</ResizablePanel>
-					{rightVisible ? (
-						<>
-							<ResizableHandle
-								direction="horizontal"
-								data-testid="resize-right"
-								onDragging={outerResize.onDragging}
-								onKeyDownCapture={outerResize.onKeyboard}
-								onKeyUpCapture={outerResize.onKeyboardEnd}
+								direction="vertical"
+								data-testid="resize-bottom"
+								onDragging={bottomResize.onDragging}
+								onKeyDownCapture={bottomResize.onKeyboard}
+								onKeyUpCapture={bottomResize.onKeyboardEnd}
 							/>
 							<ResizablePanel
-								id="layout-right"
-								order={3}
-								defaultSize={outerCurrent[outerCurrent.length - 1]}
-								minSize={8}
+								id="layout-bottom"
+								order={2}
+								defaultSize={bottomCurrent[1]}
+								minSize={bottomMinimumPercent}
+								maxSize={LAYOUT_LIMITS.maxBottomHeight * 100}
 								collapsedSize={0}
 								collapsible
 							>
-								<SideStack
-									side="right"
-									region={document.right}
-									remoteEpoch={remoteEpoch}
-									renderToolBody={renderToolBody}
-									onCommit={onCommit}
-									{...shared}
-								/>
+								<BottomAlignedRow
+									document={document}
+									leftVisible={leftVisible}
+									rightVisible={rightVisible}
+								>
+									<BottomStack
+										remoteEpoch={remoteEpoch}
+										onCommit={onCommit}
+										onNewTerminal={onNewTerminal}
+										{...shared}
+									/>
+								</BottomAlignedRow>
 							</ResizablePanel>
+						</ResizablePanelGroup>
+					) : (
+						<>
+							<div className="min-h-0 min-w-0 flex-1">{mainRow}</div>
+							<HiddenBottomRail
+								onShow={showBottomRegion}
+								dropEnabled={
+									!!draggingTab &&
+									canPlaceLayoutTab(draggingTab, "bottom") &&
+									(hiddenBottomTargetGroupId !== undefined ||
+										canCreateAuxiliaryGroup(
+											document,
+											"bottom",
+											draggingTab,
+											maxBottomGroups,
+											document.bottom.groups.length,
+										))
+								}
+								targetGroupId={hiddenBottomTargetGroupId}
+								targetIndex={document.bottom.groups.length}
+							/>
 						</>
-					) : null}
-				</ResizablePanelGroup>
+					)}
+				</div>
 				{!rightVisible ? (
 					<HiddenSideRail
 						side="right"
@@ -2140,14 +2852,16 @@ export function Workbench({
 						dropEnabled={
 							!!draggingTab &&
 							canPlaceLayoutTab(draggingTab, "right") &&
-							canCreateSideGroup(
-								document,
-								"right",
-								draggingTab,
-								maxSideGroups,
-								document.right.groups.length,
-							)
+							(hiddenRightTargetGroupId !== undefined ||
+								canCreateSideGroup(
+									document,
+									"right",
+									draggingTab,
+									maxSideGroups,
+									document.right.groups.length,
+								))
 						}
+						targetGroupId={hiddenRightTargetGroupId}
 						targetIndex={document.right.groups.length}
 					/>
 				) : null}

--- a/apps/web/src/shell/layout/model.test.ts
+++ b/apps/web/src/shell/layout/model.test.ts
@@ -11,6 +11,7 @@ import {
 	closePlacedResource,
 	collectAllGroups,
 	collectCenterGroups,
+	createAuxiliaryGroup,
 	createSideGroup,
 	findTabLocation,
 	hideSide,
@@ -20,10 +21,14 @@ import {
 	openCenterTab,
 	reconcileAttention,
 	removeSessionLayoutTabs,
+	resizeAuxiliaryGroups,
+	resizeBottomRegion,
 	resizeSideGroups,
 	resizeSideRegion,
 	revealTool,
 	selectTab,
+	setAuxiliaryGroupFolded,
+	setBottomAlignment,
 	setSideGroupFolded,
 	setSideVisibility,
 	showSide,
@@ -48,7 +53,7 @@ const file = (id: string): LayoutCenterTab => ({
 
 function baseDocument(tabs: LayoutCenterTab[] = []): WorkspaceLayoutDocument {
 	return {
-		version: 1,
+		version: 2,
 		center: { kind: "group", id: "center-a", tabs },
 		left: {
 			visible: true,
@@ -60,6 +65,7 @@ function baseDocument(tabs: LayoutCenterTab[] = []): WorkspaceLayoutDocument {
 			width: 0.28,
 			groups: [{ id: "right-a", weight: 1, folded: false, tabs: [toolTab("files")] }],
 		},
+		bottom: { visible: false, height: 0.3, alignment: "center", groups: [] },
 		toolRestoreTargets: {},
 	};
 }
@@ -204,6 +210,51 @@ describe("workspace layout model", () => {
 		expect(findTabLocation(document, "terminal:canonical-alias")).toBeNull();
 	});
 
+	test("bottom groups accept auxiliary tabs, preserve empty slots, and use independent geometry", () => {
+		const terminal: LayoutTerminalTab = {
+			kind: "terminal",
+			id: "terminal:bottom",
+			name: "Bottom terminal",
+			tabKey: "bottom",
+		};
+		let document = baseDocument([file("one"), terminal]);
+		document = mutation(createAuxiliaryGroup(document, "bottom", terminal, 0, 1)).document;
+		expect(findTabLocation(document, terminal.id)).toEqual({
+			area: "bottom",
+			groupId: document.bottom.groups[0]?.id,
+		});
+		expect(document.bottom.visible).toBe(true);
+		expect(isLayoutUnavailable(createAuxiliaryGroup(document, "bottom", toolTab("changes"), 1, 1))).toBe(
+			true,
+		);
+		document = mutation(createAuxiliaryGroup(document, "bottom", toolTab("changes"), 1, 2)).document;
+		expect(document.bottom.groups).toHaveLength(2);
+		expect(isLayoutUnavailable(moveTabToGroup(document, file("one"), {
+			area: "bottom",
+			groupId: document.bottom.groups[0]?.id ?? "missing",
+		}))).toBe(true);
+		const firstGroupId = document.bottom.groups[0]?.id;
+		if (!firstGroupId) throw new Error("missing first bottom group");
+		document = mutation(setAuxiliaryGroupFolded(document, "bottom", firstGroupId, true)).document;
+		document = resizeAuxiliaryGroups(document, "bottom", [5, 95]);
+		expect(document.bottom.groups.map((group) => group.weight)).toEqual([0.5, 0.5]);
+		document = setBottomAlignment(document, "full");
+		document = resizeBottomRegion(document, 0.9);
+		expect(document.bottom.alignment).toBe("full");
+		expect(document.bottom.height).toBe(0.7);
+		document = closeLayoutTab(document, terminal.id).document;
+		expect(document.bottom.groups[0]?.tabs).toEqual([]);
+		expect(document.bottom.visible).toBe(true);
+		document = closeLayoutTab(document, "tool:changes").document;
+		expect(document.bottom.groups).toHaveLength(2);
+		expect(document.bottom.visible).toBe(false);
+		expect(document.toolRestoreTargets.changes?.region).toBe("bottom");
+		const revealed = mutation(revealTool(document, "changes", 6, 2));
+		expect(findTabLocation(revealed.document, revealed.focusTabId ?? "missing")?.area).toBe("bottom");
+		expect(revealed.document.bottom.visible).toBe(true);
+		expect(validateLayoutDocument(revealed.document, 6, 2)).toEqual([]);
+	});
+
 	test("rejects no-op moves and preserves identity when a missing tab is closed", () => {
 		const document = baseDocument([file("one"), file("two")]);
 		const noChange = moveTabToGroup(
@@ -256,7 +307,7 @@ describe("workspace layout model", () => {
 		expect(document.right.groups).toHaveLength(0);
 		expect(document.right.visible).toBe(false);
 		expect(document.toolRestoreTargets.files).toEqual({
-			side: "right",
+			region: "right",
 			groupId: "right-a",
 			index: 0,
 		});
@@ -429,6 +480,31 @@ describe("workspace layout model", () => {
 		expect(passivelySelected.navigationClockByGroup["center-a"]).toBe(7);
 	});
 
+	test("attention tracks bottom selection and last focus without affecting center navigation", () => {
+		const document = baseDocument([file("one")]);
+		document.bottom = {
+			visible: true,
+			height: 0.3,
+			alignment: "center",
+			groups: [
+				{
+					id: "bottom-a",
+					weight: 1,
+					folded: false,
+					tabs: [
+						{ kind: "terminal", id: "terminal:t1", name: "Terminal", tabKey: "t1" },
+					],
+				},
+			],
+		};
+		const initial = reconcileAttention(document, undefined);
+		const selected = selectTab(initial, { area: "bottom", groupId: "bottom-a" }, "terminal:t1");
+		expect(selected.selectedByGroup["bottom-a"]).toBe("terminal:t1");
+		expect(selected.lastFocusedSideGroupId.bottom).toBe("bottom-a");
+		expect(selected.lastFocusedCenterGroupId).toBe("center-a");
+		expect(selected.navigationClockByGroup["center-a"]).toBe(0);
+	});
+
 	test("attention reconciliation treats opaque group ids as data, not object prototype keys", () => {
 		const document = baseDocument([file("one")]);
 		document.center.id = "__proto__";
@@ -472,7 +548,23 @@ describe("workspace layout model", () => {
 		]);
 	});
 
-	test("preset application preserves resources and falls terminals back to center when sides are empty", () => {
+	test("built-in presets carry the approved bottom topology", () => {
+		const balanced = BUILTIN_LAYOUT_PRESETS.find((preset) => preset.id === "balanced");
+		const focus = BUILTIN_LAYOUT_PRESETS.find((preset) => preset.id === "focus");
+		const review = BUILTIN_LAYOUT_PRESETS.find((preset) => preset.id === "review");
+		expect(balanced?.bottom).toMatchObject({
+			visible: true,
+			height: 0.3,
+			alignment: "center",
+		});
+		expect(balanced?.bottom.groups).toHaveLength(1);
+		expect(focus?.bottom.visible).toBe(false);
+		expect(focus?.bottom.groups).toHaveLength(1);
+		expect(review?.bottom).toMatchObject({ visible: true, alignment: "center" });
+		expect(review?.bottom.groups).toHaveLength(1);
+	});
+
+	test("preset application preserves resources and routes every terminal through bottom slots", () => {
 		const terminal: LayoutTerminalTab = {
 			kind: "terminal",
 			id: "terminal:t1",
@@ -492,34 +584,37 @@ describe("workspace layout model", () => {
 				groupId: "right-a",
 			}),
 		).document;
-		const emptyPreset = {
+		const bottomPreset = {
 			id: "empty-sides",
 			name: "Empty sides",
 			center: { kind: "group" as const, id: "only" },
 			left: { visible: false, width: 0.2, groups: [] },
 			right: { visible: false, width: 0.2, groups: [] },
+			bottom: {
+				visible: true,
+				height: 0.3,
+				alignment: "center" as const,
+				groups: [{ id: "bottom-slot", weight: 1, folded: false, tools: [] }],
+			},
 		};
 		const seeded = instantiateLayoutPreset({
-			...emptyPreset,
+			...bottomPreset,
 			center: { kind: "group", id: "x".repeat(200) },
 		});
 		expect(seeded.center.id.length).toBeLessThanOrEqual(200);
-		expect(validateLayoutDocument(seeded, 6)).toEqual([]);
+		expect(validateLayoutDocument(seeded, 6, 3)).toEqual([]);
 		expect(canShowSide(seeded, "left")).toBe(true);
 		expect(canShowSide(seeded, "right")).toBe(true);
-		const applied = applyLayoutPreset(source, emptyPreset);
-		expect(validateLayoutDocument(applied, 6)).toEqual([]);
-		expect(
-			collectCenterGroups(applied.center)[0]
-				?.tabs.map((tab) => tab.id)
-				.sort(),
-		).toEqual(["one", "terminal:t1"]);
+		const applied = applyLayoutPreset(source, bottomPreset);
+		expect(validateLayoutDocument(applied, 6, 3)).toEqual([]);
+		expect(collectCenterGroups(applied.center)[0]?.tabs.map((tab) => tab.id)).toEqual(["one"]);
+		expect(applied.bottom.groups[0]?.tabs.map((tab) => tab.id)).toEqual(["terminal:t1"]);
 		expect(applied.toolRestoreTargets).toEqual({
-			projects: { side: "left", index: 0 },
-			specs: { side: "right", index: 0 },
-			files: { side: "right", index: 0 },
-			changes: { side: "right", index: 2 },
-			review: { side: "right", index: 3 },
+			projects: { region: "left", index: 0 },
+			specs: { region: "right", index: 0 },
+			files: { region: "right", index: 0 },
+			changes: { region: "right", index: 2 },
+			review: { region: "right", index: 3 },
 		});
 		expect(canShowSide(applied, "left")).toBe(true);
 		expect(
@@ -531,8 +626,9 @@ describe("workspace layout model", () => {
 		const focused = applyLayoutPreset(source, focus);
 		expect(focused.left.visible).toBe(false);
 		expect(focused.right.visible).toBe(false);
+		expect(focused.bottom.visible).toBe(false);
 		expect(
-			focused.right.groups.flatMap((group) => group.tabs).some((tab) => tab.id === "terminal:t1"),
+			focused.bottom.groups.flatMap((group) => group.tabs).some((tab) => tab.id === "terminal:t1"),
 		).toBe(true);
 		expect(
 			focused.right.groups
@@ -549,7 +645,7 @@ describe("workspace layout model", () => {
 			tabKey: "collision",
 		};
 		const collisionApplied = applyLayoutPreset(baseDocument([collidingTerminal]), balanced);
-		expect(validateLayoutDocument(collisionApplied, 6)).toEqual([]);
+		expect(validateLayoutDocument(collisionApplied, 6, 3)).toEqual([]);
 		expect(
 			collisionApplied.right.groups
 				.flatMap((group) => group.tabs)
@@ -557,18 +653,61 @@ describe("workspace layout model", () => {
 		).not.toBe("tool:review");
 	});
 
-	test("portable capture drops terminal-only groups without leaving an impossible visible side", () => {
-		const terminalOnly = baseDocument();
-		terminalOnly.right.groups = [
-			{
-				id: "terminal-only",
-				weight: 1,
-				folded: false,
-				tabs: [{ kind: "terminal", id: "terminal:t1", name: "Terminal", tabKey: "t1" }],
+	test("preset terminal distribution is one per bottom group before extras join the first", () => {
+		const document = baseDocument(
+			["one", "two", "three"].map((tabKey) => ({
+				kind: "terminal" as const,
+				id: `terminal:${tabKey}`,
+				name: tabKey,
+				tabKey,
+			})),
+		);
+		const preset = {
+			...BUILTIN_LAYOUT_PRESETS[0],
+			bottom: {
+				visible: true,
+				height: 0.4,
+				alignment: "full" as const,
+				groups: [
+					{ id: "bottom-one", weight: 0.6, folded: false, tools: [] },
+					{ id: "bottom-two", weight: 0.4, folded: true, tools: [] },
+				],
 			},
+		};
+		const applied = applyLayoutPreset(document, preset);
+		expect(applied.bottom.groups.map((group) => group.tabs.map((tab) => tab.id))).toEqual([
+			["terminal:one", "terminal:three"],
+			["terminal:two"],
+		]);
+		expect(applied.bottom).toMatchObject({ visible: true, height: 0.4, alignment: "full" });
+	});
+
+	test("portable capture drops side terminal-only groups but retains empty bottom structure", () => {
+		const terminalOnly = baseDocument();
+		const terminal = { kind: "terminal" as const, id: "terminal:t1", name: "Terminal", tabKey: "t1" };
+		terminalOnly.right.groups = [
+			{ id: "terminal-only", weight: 1, folded: false, tabs: [terminal] },
 		];
+		terminalOnly.bottom = {
+			visible: true,
+			height: 0.44,
+			alignment: "center-right",
+			groups: [
+				{ id: "bottom-one", weight: 0.4, folded: false, tabs: [terminal] },
+				{ id: "bottom-two", weight: 0.6, folded: true, tabs: [] },
+			],
+		};
 		const preset = captureLayoutPreset(terminalOnly, "portable", "Portable");
 		expect(preset.right).toEqual({ visible: false, width: 0.28, groups: [] });
+		expect(preset.bottom).toEqual({
+			visible: true,
+			height: 0.44,
+			alignment: "center-right",
+			groups: [
+				{ id: "bottom-one", weight: 0.4, folded: false, tools: [] },
+				{ id: "bottom-two", weight: 0.6, folded: true, tools: [] },
+			],
+		});
 
 		terminalOnly.right.groups.unshift({
 			id: "tool-group",

--- a/apps/web/src/shell/layout/model.test.ts
+++ b/apps/web/src/shell/layout/model.test.ts
@@ -18,6 +18,7 @@ import {
 	hideSide,
 	isLayoutUnavailable,
 	type LayoutOperationResult,
+	layoutTabName,
 	moveTabToGroup,
 	openCenterTab,
 	reconcileAttention,
@@ -78,6 +79,13 @@ function mutation<T extends { document: WorkspaceLayoutDocument } | { reason: st
 }
 
 describe("workspace layout model", () => {
+	test("canonical tool labels override stale persisted display copy", () => {
+		const legacyFiles = { ...toolTab("files"), name: "All files" };
+		expect(toolTab("files").name).toBe("Files");
+		expect(layoutTabName(legacyFiles)).toBe("Files");
+		expect(layoutTabName(file("one"))).toBe("one.ts");
+	});
+
 	test("opens one canonical tab and keeps preview promotion one-way", () => {
 		let document = baseDocument();
 		document = mutation(openCenterTab(document, file("one"), "center-a", "preview")).document;

--- a/apps/web/src/shell/layout/model.test.ts
+++ b/apps/web/src/shell/layout/model.test.ts
@@ -251,10 +251,12 @@ describe("workspace layout model", () => {
 		expect(document.bottom.alignment).toBe("full");
 		expect(document.bottom.height).toBe(0.7);
 		document = closeLayoutTab(document, terminal.id).document;
-		expect(document.bottom.groups[0]?.tabs).toEqual([]);
+		expect(document.bottom.groups).toHaveLength(1);
+		expect(document.bottom.groups[0]?.tabs).toEqual([toolTab("changes")]);
+		expect(document.bottom.groups[0]?.weight).toBe(1);
 		expect(document.bottom.visible).toBe(true);
 		document = closeLayoutTab(document, "tool:changes").document;
-		expect(document.bottom.groups).toHaveLength(2);
+		expect(document.bottom.groups).toEqual([]);
 		expect(document.bottom.visible).toBe(false);
 		expect(document.toolRestoreTargets.changes?.region).toBe("bottom");
 		const revealed = mutation(revealTool(document, "changes", 6, 2));
@@ -263,6 +265,64 @@ describe("workspace layout model", () => {
 		);
 		expect(revealed.document.bottom.visible).toBe(true);
 		expect(validateLayoutDocument(revealed.document, 6, 2)).toEqual([]);
+	});
+
+	test("bottom removal drops only the group newly vacated by its final tab", () => {
+		const terminal: LayoutTerminalTab = {
+			kind: "terminal",
+			id: "terminal:bottom",
+			name: "Bottom terminal",
+			tabKey: "bottom",
+		};
+		const document = baseDocument([file("one")]);
+		document.bottom = {
+			visible: true,
+			height: 0.3,
+			alignment: "center",
+			groups: [
+				{ id: "deliberate-empty", weight: 0.25, folded: false, tabs: [] },
+				{ id: "vacated", weight: 0.75, folded: false, tabs: [terminal] },
+			],
+		};
+
+		const closed = closeLayoutTab(document, terminal.id).document;
+
+		expect(closed.bottom.groups).toEqual([
+			{ id: "deliberate-empty", weight: 1, folded: false, tabs: [] },
+		]);
+		expect(closed.bottom.visible).toBe(false);
+	});
+
+	test("moving a bottom group's final tab removes its source group", () => {
+		const terminal: LayoutTerminalTab = {
+			kind: "terminal",
+			id: "terminal:bottom",
+			name: "Bottom terminal",
+			tabKey: "bottom",
+		};
+		const document = baseDocument([file("one")]);
+		document.bottom = {
+			visible: true,
+			height: 0.3,
+			alignment: "center",
+			groups: [
+				{ id: "source", weight: 0.4, folded: false, tabs: [terminal] },
+				{ id: "destination", weight: 0.6, folded: false, tabs: [toolTab("changes")] },
+			],
+		};
+
+		const moved = mutation(
+			moveTabToGroup(document, terminal, { area: "bottom", groupId: "destination" }),
+		).document;
+
+		expect(moved.bottom.groups).toEqual([
+			{
+				id: "destination",
+				weight: 1,
+				folded: false,
+				tabs: [toolTab("changes"), terminal],
+			},
+		]);
 	});
 
 	test("bottom hide and show preserve focus, restore tools, and seed a process-free slot", () => {

--- a/apps/web/src/shell/layout/model.test.ts
+++ b/apps/web/src/shell/layout/model.test.ts
@@ -14,6 +14,7 @@ import {
 	createAuxiliaryGroup,
 	createSideGroup,
 	findTabLocation,
+	hideBottom,
 	hideSide,
 	isLayoutUnavailable,
 	type LayoutOperationResult,
@@ -31,6 +32,7 @@ import {
 	setBottomAlignment,
 	setSideGroupFolded,
 	setSideVisibility,
+	showBottom,
 	showSide,
 	splitCenterGroup,
 	toolTab,
@@ -224,15 +226,21 @@ describe("workspace layout model", () => {
 			groupId: document.bottom.groups[0]?.id,
 		});
 		expect(document.bottom.visible).toBe(true);
-		expect(isLayoutUnavailable(createAuxiliaryGroup(document, "bottom", toolTab("changes"), 1, 1))).toBe(
-			true,
-		);
-		document = mutation(createAuxiliaryGroup(document, "bottom", toolTab("changes"), 1, 2)).document;
+		expect(
+			isLayoutUnavailable(createAuxiliaryGroup(document, "bottom", toolTab("changes"), 1, 1)),
+		).toBe(true);
+		document = mutation(
+			createAuxiliaryGroup(document, "bottom", toolTab("changes"), 1, 2),
+		).document;
 		expect(document.bottom.groups).toHaveLength(2);
-		expect(isLayoutUnavailable(moveTabToGroup(document, file("one"), {
-			area: "bottom",
-			groupId: document.bottom.groups[0]?.id ?? "missing",
-		}))).toBe(true);
+		expect(
+			isLayoutUnavailable(
+				moveTabToGroup(document, file("one"), {
+					area: "bottom",
+					groupId: document.bottom.groups[0]?.id ?? "missing",
+				}),
+			),
+		).toBe(true);
 		const firstGroupId = document.bottom.groups[0]?.id;
 		if (!firstGroupId) throw new Error("missing first bottom group");
 		document = mutation(setAuxiliaryGroupFolded(document, "bottom", firstGroupId, true)).document;
@@ -250,9 +258,29 @@ describe("workspace layout model", () => {
 		expect(document.bottom.visible).toBe(false);
 		expect(document.toolRestoreTargets.changes?.region).toBe("bottom");
 		const revealed = mutation(revealTool(document, "changes", 6, 2));
-		expect(findTabLocation(revealed.document, revealed.focusTabId ?? "missing")?.area).toBe("bottom");
+		expect(findTabLocation(revealed.document, revealed.focusTabId ?? "missing")?.area).toBe(
+			"bottom",
+		);
 		expect(revealed.document.bottom.visible).toBe(true);
 		expect(validateLayoutDocument(revealed.document, 6, 2)).toEqual([]);
+	});
+
+	test("bottom hide and show preserve focus, restore tools, and seed a process-free slot", () => {
+		const empty = baseDocument([file("one")]);
+		const shown = mutation(showBottom(empty, 6, 3));
+		expect(shown.document.bottom.visible).toBe(true);
+		expect(shown.document.bottom.groups).toHaveLength(1);
+		expect(shown.document.bottom.groups[0]?.tabs).toEqual([]);
+		const attention = reconcileAttention(shown.document, undefined);
+		const hidden = hideBottom(shown.document, attention);
+		expect(hidden.document.bottom.visible).toBe(false);
+		expect(hidden.focusGroupId).toBe("center-a");
+
+		const restorable = baseDocument();
+		restorable.toolRestoreTargets.changes = { region: "bottom", index: 0 };
+		const restored = mutation(showBottom(restorable, 6, 3));
+		expect(findTabLocation(restored.document, "tool:changes")?.area).toBe("bottom");
+		expect(restored.document.bottom.visible).toBe(true);
 	});
 
 	test("rejects no-op moves and preserves identity when a missing tab is closed", () => {
@@ -491,9 +519,7 @@ describe("workspace layout model", () => {
 					id: "bottom-a",
 					weight: 1,
 					folded: false,
-					tabs: [
-						{ kind: "terminal", id: "terminal:t1", name: "Terminal", tabKey: "t1" },
-					],
+					tabs: [{ kind: "terminal", id: "terminal:t1", name: "Terminal", tabKey: "t1" }],
 				},
 			],
 		};
@@ -684,7 +710,12 @@ describe("workspace layout model", () => {
 
 	test("portable capture drops side terminal-only groups but retains empty bottom structure", () => {
 		const terminalOnly = baseDocument();
-		const terminal = { kind: "terminal" as const, id: "terminal:t1", name: "Terminal", tabKey: "t1" };
+		const terminal = {
+			kind: "terminal" as const,
+			id: "terminal:t1",
+			name: "Terminal",
+			tabKey: "t1",
+		};
 		terminalOnly.right.groups = [
 			{ id: "terminal-only", weight: 1, folded: false, tabs: [terminal] },
 		];

--- a/apps/web/src/shell/layout/model.test.ts
+++ b/apps/web/src/shell/layout/model.test.ts
@@ -679,6 +679,31 @@ describe("workspace layout model", () => {
 		).not.toBe("tool:review");
 	});
 
+	test("a slotless hidden preset stays slotless until it has terminals to preserve", () => {
+		const preset = {
+			...BUILTIN_LAYOUT_PRESETS[0],
+			bottom: {
+				visible: false,
+				height: 0.3,
+				alignment: "center" as const,
+				groups: [],
+			},
+		};
+		const withoutTerminal = applyLayoutPreset(baseDocument([file("one")]), preset);
+		expect(withoutTerminal.bottom.groups).toEqual([]);
+
+		const terminal = {
+			kind: "terminal" as const,
+			id: "terminal:one",
+			name: "Terminal",
+			tabKey: "one",
+		};
+		const withTerminal = applyLayoutPreset(baseDocument([terminal]), preset);
+		expect(withTerminal.bottom).toMatchObject({ visible: false });
+		expect(withTerminal.bottom.groups).toHaveLength(1);
+		expect(withTerminal.bottom.groups[0]?.tabs).toEqual([terminal]);
+	});
+
 	test("preset terminal distribution is one per bottom group before extras join the first", () => {
 		const document = baseDocument(
 			["one", "two", "three"].map((tabKey) => ({
@@ -842,6 +867,14 @@ describe("workspace layout model", () => {
 				expect(validateLayoutDocument(document, 6)).toEqual([]);
 			}
 		}
+	});
+
+	test("validator rejects a visible bottom region without a structural slot", () => {
+		const document = baseDocument([file("one")]);
+		document.bottom.visible = true;
+		expect(validateLayoutDocument(document, 6, 3)).toContain(
+			"Visible bottom region requires a group.",
+		);
 	});
 
 	test("validator catches duplicate placement and illegal side content", () => {

--- a/apps/web/src/shell/layout/model.ts
+++ b/apps/web/src/shell/layout/model.ts
@@ -715,10 +715,7 @@ export function createAuxiliaryGroup(
 	);
 	const movedWeight = removesSourceGroup ? sourceGroup.weight : undefined;
 	const removed = removeTabEverywhere(document, movingTab.id);
-	const retained =
-		region === "bottom" && removesSourceGroup
-			? removed.bottom.groups.filter((group) => group.id !== sourceGroup.id)
-			: removed[region].groups;
+	const retained = removed[region].groups;
 	const retainedTotal = retained.reduce((sum, group) => sum + group.weight, 0);
 	const groups = retained.map((group) => ({
 		...group,

--- a/apps/web/src/shell/layout/model.ts
+++ b/apps/web/src/shell/layout/model.ts
@@ -1332,6 +1332,9 @@ export function validateLayoutDocument(
 	) {
 		errors.push("Invalid bottom alignment.");
 	}
+	if (bottom.visible && bottom.groups.length === 0) {
+		errors.push("Visible bottom region requires a group.");
+	}
 	if (bottom.groups.length > maxBottomGroups) errors.push("Too many bottom groups.");
 	if (bottom.groups.length > LAYOUT_LIMITS.maxSideGroupsSafety) {
 		errors.push("Unsafe bottom group count.");

--- a/apps/web/src/shell/layout/model.ts
+++ b/apps/web/src/shell/layout/model.ts
@@ -296,10 +296,14 @@ function removeTabFromSide(region: LayoutSideRegion, tabId: string): LayoutSideR
 
 function removeTabFromBottom(region: LayoutBottomRegion, tabId: string): LayoutBottomRegion {
 	if (!region.groups.some((group) => group.tabs.some((tab) => tab.id === tabId))) return region;
-	const groups = region.groups.map((group) => ({
-		...group,
-		tabs: group.tabs.filter((tab) => tab.id !== tabId),
-	}));
+	const remaining = region.groups.flatMap((group) => {
+		if (!group.tabs.some((tab) => tab.id === tabId)) return [group];
+		const tabs = group.tabs.filter((tab) => tab.id !== tabId);
+		return tabs.length > 0 ? [{ ...group, tabs }] : [];
+	});
+	const total = remaining.reduce((sum, group) => sum + group.weight, 0);
+	const groups =
+		total > 0 ? remaining.map((group) => ({ ...group, weight: group.weight / total })) : remaining;
 	return {
 		...region,
 		visible: region.visible && groups.some((group) => group.tabs.length > 0),

--- a/apps/web/src/shell/layout/model.ts
+++ b/apps/web/src/shell/layout/model.ts
@@ -82,15 +82,20 @@ export const LAYOUT_TOOL_DEFAULT_SIDES: Record<LayoutToolId, LayoutSide> = {
 	review: "right",
 };
 
+const LAYOUT_TOOL_NAMES: Record<LayoutToolId, string> = {
+	projects: "Projects",
+	specs: "Specs",
+	files: "Files",
+	changes: "Changes",
+	review: "Review",
+};
+
+export function layoutTabName(tab: LayoutTab): string {
+	return tab.kind === "tool" ? LAYOUT_TOOL_NAMES[tab.tool] : tab.name;
+}
+
 export function toolTab(tool: LayoutToolId): LayoutSideTab {
-	const names: Record<LayoutToolId, string> = {
-		projects: "Projects",
-		specs: "Specs",
-		files: "All files",
-		changes: "Changes",
-		review: "Review",
-	};
-	return { kind: "tool", id: `tool:${tool}`, name: names[tool], tool };
+	return { kind: "tool", id: `tool:${tool}`, name: LAYOUT_TOOL_NAMES[tool], tool };
 }
 
 export function collectCenterGroups(node: LayoutCenterNode): LayoutCenterGroup[] {

--- a/apps/web/src/shell/layout/model.ts
+++ b/apps/web/src/shell/layout/model.ts
@@ -1,4 +1,7 @@
 import type {
+	LayoutAuxiliaryRegion,
+	LayoutBottomAlignment,
+	LayoutBottomRegion,
 	LayoutCenterGroup,
 	LayoutCenterNode,
 	LayoutCenterSplit,
@@ -26,14 +29,19 @@ export const LAYOUT_LIMITS = {
 	minCenterWidth: 320,
 	minCenterHeight: 180,
 	minSideBodyHeight: 120,
+	minBottomBodyHeight: 120,
 	foldedSideHeight: 27,
+	foldedBottomWidth: 27,
+	initialBottomHeight: 0.3,
+	maxBottomHeight: 0.7,
 } as const;
 
 export type LayoutSide = "left" | "right";
+export type LayoutAuxiliary = LayoutAuxiliaryRegion;
 export type CenterSplitDirection = "left" | "right" | "up" | "down";
 export type LayoutGroupLocation =
 	| { area: "center"; groupId: string }
-	| { area: LayoutSide; groupId: string };
+	| { area: LayoutAuxiliaryRegion; groupId: string };
 
 export type { LayoutAttention } from "../../lib";
 
@@ -110,6 +118,11 @@ export function collectAllGroups(document: WorkspaceLayoutDocument): Array<{
 			tabs: group.tabs,
 			folded: group.folded,
 		})),
+		...document.bottom.groups.map((group) => ({
+			location: { area: "bottom" as const, groupId: group.id },
+			tabs: group.tabs,
+			folded: group.folded,
+		})),
 	];
 }
 
@@ -147,12 +160,20 @@ export function findCenterGroup(node: LayoutCenterNode, groupId: string): Layout
 	return findCenterGroup(node.children[0], groupId) ?? findCenterGroup(node.children[1], groupId);
 }
 
+export function findAuxiliaryGroup(
+	document: WorkspaceLayoutDocument,
+	region: LayoutAuxiliaryRegion,
+	groupId: string,
+): LayoutSideGroup | null {
+	return document[region].groups.find((group) => group.id === groupId) ?? null;
+}
+
 export function findSideGroup(
 	document: WorkspaceLayoutDocument,
 	side: LayoutSide,
 	groupId: string,
 ): LayoutSideGroup | null {
-	return document[side].groups.find((group) => group.id === groupId) ?? null;
+	return findAuxiliaryGroup(document, side, groupId);
 }
 
 export function primaryCenterGroupId(document: WorkspaceLayoutDocument): string {
@@ -272,6 +293,19 @@ function removeTabFromSide(region: LayoutSideRegion, tabId: string): LayoutSideR
 	return { ...region, visible: groups.length > 0 && region.visible, groups };
 }
 
+function removeTabFromBottom(region: LayoutBottomRegion, tabId: string): LayoutBottomRegion {
+	if (!region.groups.some((group) => group.tabs.some((tab) => tab.id === tabId))) return region;
+	const groups = region.groups.map((group) => ({
+		...group,
+		tabs: group.tabs.filter((tab) => tab.id !== tabId),
+	}));
+	return {
+		...region,
+		visible: region.visible && groups.some((group) => group.tabs.length > 0),
+		groups,
+	};
+}
+
 function removeTabEverywhere(
 	document: WorkspaceLayoutDocument,
 	tabId: string,
@@ -282,6 +316,7 @@ function removeTabEverywhere(
 		center: centerResult.node,
 		left: removeTabFromSide(document.left, tabId),
 		right: removeTabFromSide(document.right, tabId),
+		bottom: removeTabFromBottom(document.bottom, tabId),
 	};
 }
 
@@ -297,7 +332,7 @@ function replacePlacedCenterTab(
 	if (replacement.kind !== "terminal") {
 		return center === document.center ? document : { ...document, center };
 	}
-	const replaceInSide = (region: LayoutSideRegion): LayoutSideRegion => {
+	const replaceInAuxiliary = <T extends LayoutSideRegion | LayoutBottomRegion>(region: T): T => {
 		let changed = false;
 		const groups = region.groups.map((group) => {
 			const index = group.tabs.findIndex((tab) => tab.id === tabId);
@@ -305,13 +340,17 @@ function replacePlacedCenterTab(
 			changed = true;
 			return { ...group, tabs: group.tabs.with(index, replacement) };
 		});
-		return changed ? { ...region, groups } : region;
+		return changed ? ({ ...region, groups } as T) : region;
 	};
-	const left = replaceInSide(document.left);
-	const right = replaceInSide(document.right);
-	return center === document.center && left === document.left && right === document.right
+	const left = replaceInAuxiliary(document.left);
+	const right = replaceInAuxiliary(document.right);
+	const bottom = replaceInAuxiliary(document.bottom);
+	return center === document.center &&
+		left === document.left &&
+		right === document.right &&
+		bottom === document.bottom
 		? document
-		: { ...document, center, left, right };
+		: { ...document, center, left, right, bottom };
 }
 
 export function findPlacedResource(
@@ -415,20 +454,27 @@ export function closeLayoutTab(
 	if (tab.kind !== "tool" || location.area === "center") {
 		return { document: removeTabEverywhere(document, tabId) };
 	}
-	const group = findSideGroup(document, location.area, location.groupId);
+	const group = findAuxiliaryGroup(document, location.area, location.groupId);
 	const index = group?.tabs.findIndex((candidate) => candidate.id === tabId) ?? 0;
 	return {
 		document: {
 			...removeTabEverywhere(document, tabId),
 			toolRestoreTargets: {
 				...document.toolRestoreTargets,
-				[tab.tool]: { side: location.area, groupId: location.groupId, index: Math.max(0, index) },
+				[tab.tool]: {
+					region: location.area,
+					groupId: location.groupId,
+					index: Math.max(0, index),
+				},
 			},
 		},
 	};
 }
 
-export function canPlaceLayoutTab(tab: LayoutTab, area: "center" | LayoutSide): boolean {
+export function canPlaceLayoutTab(
+	tab: LayoutTab,
+	area: "center" | LayoutAuxiliaryRegion,
+): boolean {
 	if (area === "center") return tab.kind !== "tool";
 	return tab.kind === "tool" || tab.kind === "terminal";
 }
@@ -449,7 +495,7 @@ export function moveTabToGroup(
 		const current =
 			target.area === "center"
 				? findCenterGroup(document.center, target.groupId)
-				: findSideGroup(document, target.area, target.groupId);
+				: findAuxiliaryGroup(document, target.area, target.groupId);
 		if (!current) return { reason: "The destination group no longer exists." };
 		const tabs = current.tabs.filter((candidate) => candidate.id !== movingTab.id);
 		const insertion = Math.max(0, Math.min(index ?? tabs.length, tabs.length));
@@ -566,6 +612,7 @@ export function splitCenterGroup(
 					),
 					left: removeTabFromSide(document.left, placedTab.id),
 					right: removeTabFromSide(document.right, placedTab.id),
+					bottom: removeTabFromBottom(document.bottom, placedTab.id),
 				}
 			: removeTabEverywhere(document, placedTab.id);
 	const current = findCenterGroup(cleaned.center, groupId);
@@ -601,18 +648,18 @@ function sideGroupInsertionIndex(
 	return removesSourceGroup && sourceGroupIndex < boundary ? boundary - 1 : boundary;
 }
 
-export function canCreateSideGroup(
+export function canCreateAuxiliaryGroup(
 	document: WorkspaceLayoutDocument,
-	side: LayoutSide,
+	region: LayoutAuxiliaryRegion,
 	tab: LayoutTab,
 	maxGroups: number,
 	insertAt?: number,
 ): boolean {
-	const groups = document[side].groups;
+	const groups = document[region].groups;
 	const currentCount = groups.length;
 	const source = findTabLocation(document, tab.id);
 	const sourceGroupIndex =
-		source?.area === side ? groups.findIndex((group) => group.id === source.groupId) : -1;
+		source?.area === region ? groups.findIndex((group) => group.id === source.groupId) : -1;
 	const sourceGroup = sourceGroupIndex >= 0 ? groups[sourceGroupIndex] : undefined;
 	const removesSourceGroup = sourceGroup?.tabs.length === 1;
 	if (currentCount - (removesSourceGroup ? 1 : 0) + 1 > Math.max(maxGroups, currentCount)) {
@@ -624,9 +671,19 @@ export function canCreateSideGroup(
 	);
 }
 
-export function createSideGroup(
+export function canCreateSideGroup(
 	document: WorkspaceLayoutDocument,
 	side: LayoutSide,
+	tab: LayoutTab,
+	maxGroups: number,
+	insertAt?: number,
+): boolean {
+	return canCreateAuxiliaryGroup(document, side, tab, maxGroups, insertAt);
+}
+
+export function createAuxiliaryGroup(
+	document: WorkspaceLayoutDocument,
+	region: LayoutAuxiliaryRegion,
 	tab: LayoutSideTab,
 	insertAt: number,
 	maxGroups: number,
@@ -635,32 +692,41 @@ export function createSideGroup(
 	if (resolved.conflictingId) return { reason: "That tab id belongs to another resource." };
 	const placedTab = resolved.placed;
 	const movingTab = placedTab?.kind === "tool" || placedTab?.kind === "terminal" ? placedTab : tab;
-	if (!canCreateSideGroup(document, side, movingTab, maxGroups)) {
-		return { reason: `This side is limited to ${maxGroups} groups.` };
+	if (!canCreateAuxiliaryGroup(document, region, movingTab, maxGroups)) {
+		return { reason: `This region is limited to ${maxGroups} groups.` };
 	}
-	if (!canCreateSideGroup(document, side, movingTab, maxGroups, insertAt)) {
+	if (!canCreateAuxiliaryGroup(document, region, movingTab, maxGroups, insertAt)) {
 		return { reason: "That tab is already at this position." };
 	}
 	const source = findTabLocation(document, movingTab.id);
 	const sourceGroupIndex =
-		source?.area === side
-			? document[side].groups.findIndex((group) => group.id === source.groupId)
+		source?.area === region
+			? document[region].groups.findIndex((group) => group.id === source.groupId)
 			: -1;
-	const sourceGroup = sourceGroupIndex >= 0 ? document[side].groups[sourceGroupIndex] : undefined;
+	const sourceGroup =
+		sourceGroupIndex >= 0 ? document[region].groups[sourceGroupIndex] : undefined;
 	const removesSourceGroup = sourceGroup?.tabs.length === 1;
 	const insertionIndex = sideGroupInsertionIndex(
-		document[side].groups.length,
+		document[region].groups.length,
 		sourceGroupIndex,
 		removesSourceGroup,
 		insertAt,
 	);
 	const movedWeight = removesSourceGroup ? sourceGroup.weight : undefined;
-	const without = removeTabEverywhere(document, movingTab.id);
-	const groups = [...without[side].groups];
+	const removed = removeTabEverywhere(document, movingTab.id);
+	const retained =
+		region === "bottom" && removesSourceGroup
+			? removed.bottom.groups.filter((group) => group.id !== sourceGroup.id)
+			: removed[region].groups;
+	const retainedTotal = retained.reduce((sum, group) => sum + group.weight, 0);
+	const groups = retained.map((group) => ({
+		...group,
+		weight: retainedTotal > 0 ? group.weight / retainedTotal : group.weight,
+	}));
 	const newWeight = movedWeight ?? 1 / (groups.length + 1);
 	const retainedWeight = 1 - newWeight;
 	const group: LayoutSideGroup = {
-		id: createLayoutId(`${side}-group`),
+		id: createLayoutId(`${region}-group`),
 		weight: newWeight,
 		folded: false,
 		tabs: [movingTab],
@@ -671,9 +737,41 @@ export function createSideGroup(
 	}
 	groups.splice(Math.max(0, Math.min(insertionIndex, groups.length)), 0, group);
 	return {
-		document: { ...without, [side]: { ...without[side], visible: true, groups } },
+		document: { ...removed, [region]: { ...removed[region], visible: true, groups } },
 		focusGroupId: group.id,
 		focusTabId: movingTab.id,
+	};
+}
+
+export function createSideGroup(
+	document: WorkspaceLayoutDocument,
+	side: LayoutSide,
+	tab: LayoutSideTab,
+	insertAt: number,
+	maxGroups: number,
+): LayoutOperationResult {
+	return createAuxiliaryGroup(document, side, tab, insertAt, maxGroups);
+}
+
+export function setAuxiliaryGroupFolded(
+	document: WorkspaceLayoutDocument,
+	region: LayoutAuxiliaryRegion,
+	groupId: string,
+	folded: boolean,
+): LayoutOperationResult {
+	if (!document[region].groups.some((group) => group.id === groupId)) {
+		return { reason: "The auxiliary group no longer exists." };
+	}
+	return {
+		document: {
+			...document,
+			[region]: {
+				...document[region],
+				groups: document[region].groups.map((group) =>
+					group.id === groupId ? { ...group, folded } : group,
+				),
+			},
+		},
 	};
 }
 
@@ -683,20 +781,7 @@ export function setSideGroupFolded(
 	groupId: string,
 	folded: boolean,
 ): LayoutOperationResult {
-	if (!document[side].groups.some((group) => group.id === groupId)) {
-		return { reason: "The side group no longer exists." };
-	}
-	return {
-		document: {
-			...document,
-			[side]: {
-				...document[side],
-				groups: document[side].groups.map((group) =>
-					group.id === groupId ? { ...group, folded } : group,
-				),
-			},
-		},
-	};
+	return setAuxiliaryGroupFolded(document, side, groupId, folded);
 }
 
 export function setSideVisibility(
@@ -734,7 +819,7 @@ export function canShowSide(document: WorkspaceLayoutDocument, side: LayoutSide)
 		document[side].groups.length > 0 ||
 		TOOL_RESTORE_ORDER.some(
 			(tool) =>
-				(document.toolRestoreTargets[tool]?.side ?? LAYOUT_TOOL_DEFAULT_SIDES[tool]) === side &&
+				(document.toolRestoreTargets[tool]?.region ?? LAYOUT_TOOL_DEFAULT_SIDES[tool]) === side &&
 				findPlacedResource(document, toolTab(tool)) === null,
 		)
 	);
@@ -762,7 +847,7 @@ export function showSide(
 	const tool =
 		TOOL_RESTORE_ORDER.find(
 			(candidate) =>
-				document.toolRestoreTargets[candidate]?.side === side &&
+				document.toolRestoreTargets[candidate]?.region === side &&
 				!findPlacedResource(document, toolTab(candidate)),
 		) ??
 		TOOL_RESTORE_ORDER.find(
@@ -777,6 +862,7 @@ export function revealTool(
 	document: WorkspaceLayoutDocument,
 	tool: LayoutToolId,
 	maxSideGroups: number,
+	maxBottomGroups = 3,
 ): LayoutOperationResult {
 	const requestedTab = withAvailablePlacementId(document, toolTab(tool));
 	const placedTab = resolvePlacedResource(document, requestedTab).placed;
@@ -803,8 +889,8 @@ export function revealTool(
 		};
 	}
 	const restore = document.toolRestoreTargets[tool];
-	const side: LayoutSide = restore?.side ?? LAYOUT_TOOL_DEFAULT_SIDES[tool];
-	const groups = document[side].groups;
+	const region: LayoutAuxiliaryRegion = restore?.region ?? LAYOUT_TOOL_DEFAULT_SIDES[tool];
+	const groups = document[region].groups;
 	const restoreGroup = restore?.groupId
 		? groups.find((group) => group.id === restore.groupId)
 		: undefined;
@@ -814,8 +900,8 @@ export function revealTool(
 		return {
 			document: {
 				...document,
-				[side]: {
-					...document[side],
+				[region]: {
+					...document[region],
 					visible: true,
 					groups: groups.map((group) =>
 						group.id === restoreGroup.id ? { ...group, folded: false, tabs } : group,
@@ -826,14 +912,15 @@ export function revealTool(
 			focusTabId: requestedTab.id,
 		};
 	}
-	if (groups.length > 0 && groups.length >= maxSideGroups) {
+	const maxGroups = region === "bottom" ? maxBottomGroups : maxSideGroups;
+	if (groups.length > 0 && groups.length >= maxGroups) {
 		const group = groups[0];
-		if (!group) return { reason: "There is no side group available for this tool." };
+		if (!group) return { reason: "There is no auxiliary group available for this tool." };
 		return moveTabToGroup(
 			{
 				...document,
-				[side]: {
-					...document[side],
+				[region]: {
+					...document[region],
 					visible: true,
 					groups: groups.map((candidate) =>
 						candidate.id === group.id ? { ...candidate, folded: false } : candidate,
@@ -841,10 +928,10 @@ export function revealTool(
 				},
 			},
 			requestedTab,
-			{ area: side, groupId: group.id },
+			{ area: region, groupId: group.id },
 		);
 	}
-	return createSideGroup(document, side, requestedTab, groups.length, maxSideGroups);
+	return createAuxiliaryGroup(document, region, requestedTab, groups.length, maxGroups);
 }
 
 export function resizeSideRegion(
@@ -863,12 +950,30 @@ export function resizeSideRegion(
 	return { ...document, [side]: { ...document[side], width: normalized } };
 }
 
-export function resizeSideGroups(
+export function resizeBottomRegion(
 	document: WorkspaceLayoutDocument,
-	side: LayoutSide,
+	height: number,
+): WorkspaceLayoutDocument {
+	const requested = Number.isFinite(height) ? height : document.bottom.height;
+	const normalized = Math.max(Number.MIN_VALUE, Math.min(LAYOUT_LIMITS.maxBottomHeight, requested));
+	if (Math.abs(normalized - document.bottom.height) < 1e-9) return document;
+	return { ...document, bottom: { ...document.bottom, height: normalized } };
+}
+
+export function setBottomAlignment(
+	document: WorkspaceLayoutDocument,
+	alignment: LayoutBottomAlignment,
+): WorkspaceLayoutDocument {
+	if (document.bottom.alignment === alignment) return document;
+	return { ...document, bottom: { ...document.bottom, alignment } };
+}
+
+export function resizeAuxiliaryGroups(
+	document: WorkspaceLayoutDocument,
+	region: LayoutAuxiliaryRegion,
 	weights: readonly number[],
 ): WorkspaceLayoutDocument {
-	const groups = document[side].groups;
+	const groups = document[region].groups;
 	if (weights.length !== groups.length) return document;
 	const expanded = groups.flatMap((group, index) => (group.folded ? [] : [index]));
 	if (expanded.length === 0) return document;
@@ -890,11 +995,19 @@ export function resizeSideGroups(
 	if (nextGroups.every((group, index) => group === groups[index])) return document;
 	return {
 		...document,
-		[side]: {
-			...document[side],
+		[region]: {
+			...document[region],
 			groups: nextGroups,
 		},
 	};
+}
+
+export function resizeSideGroups(
+	document: WorkspaceLayoutDocument,
+	side: LayoutSide,
+	weights: readonly number[],
+): WorkspaceLayoutDocument {
+	return resizeAuxiliaryGroups(document, side, weights);
 }
 
 export function closePlacedResource(
@@ -976,20 +1089,22 @@ export function reconcileAttention(
 		(oldCenterIndex >= 0
 			? centerGroups[Math.min(oldCenterIndex, centerGroups.length - 1)]
 			: centerGroups[0]);
-	const lastFocusedSideGroupId = Object.create(null) as Partial<Record<LayoutSide, string>>;
-	for (const side of ["left", "right"] as const) {
-		const sideGroups = groups.filter((group) => group.location.area === side);
-		const previousSide = previous?.lastFocusedSideGroupId[side];
-		const oldSideGroups = oldGroups.filter((group) => group.location.area === side);
-		const oldSideIndex = oldSideGroups.findIndex(
-			(group) => group.location.groupId === previousSide,
+	const lastFocusedSideGroupId = Object.create(null) as Partial<
+		Record<LayoutAuxiliaryRegion, string>
+	>;
+	for (const region of ["left", "right", "bottom"] as const) {
+		const auxiliaryGroups = groups.filter((group) => group.location.area === region);
+		const previousGroup = previous?.lastFocusedSideGroupId[region];
+		const oldAuxiliaryGroups = oldGroups.filter((group) => group.location.area === region);
+		const oldGroupIndex = oldAuxiliaryGroups.findIndex(
+			(group) => group.location.groupId === previousGroup,
 		);
 		const group =
-			sideGroups.find((candidate) => candidate.location.groupId === previousSide) ??
-			(oldSideIndex >= 0
-				? sideGroups[Math.min(oldSideIndex, sideGroups.length - 1)]
-				: sideGroups[0]);
-		if (group) lastFocusedSideGroupId[side] = group.location.groupId;
+			auxiliaryGroups.find((candidate) => candidate.location.groupId === previousGroup) ??
+			(oldGroupIndex >= 0
+				? auxiliaryGroups[Math.min(oldGroupIndex, auxiliaryGroups.length - 1)]
+				: auxiliaryGroups[0]);
+		if (group) lastFocusedSideGroupId[region] = group.location.groupId;
 	}
 	const navigationClockByGroup = Object.assign(
 		Object.create(null),
@@ -1039,7 +1154,7 @@ export function selectTab(
 				? attention.lastFocusedSideGroupId
 				: (Object.assign(Object.create(null), attention.lastFocusedSideGroupId, {
 						[location.area]: location.groupId,
-					}) as Partial<Record<LayoutSide, string>>),
+					}) as Partial<Record<LayoutAuxiliaryRegion, string>>),
 		navigationClockByGroup:
 			location.area === "center" && countNavigation
 				? (Object.assign(Object.create(null), attention.navigationClockByGroup, {
@@ -1052,15 +1167,16 @@ export function selectTab(
 export function validateLayoutDocument(
 	document: WorkspaceLayoutDocument,
 	maxSideGroups: number,
+	maxBottomGroups = 3,
 ): string[] {
 	const errors: string[] = [];
-	if (document.version !== 1) errors.push("Unsupported layout version.");
+	if (document.version !== 2) errors.push("Unsupported layout version.");
 	const groupIds = new Set<string>();
 	const tabIds = new Set<string>();
 	const resourceKeys = new Set<string>();
 	const toolIds = new Set<LayoutToolId>();
 	let tabCount = 0;
-	const trackTab = (tab: LayoutTab, area: "center" | LayoutSide): void => {
+	const trackTab = (tab: LayoutTab, area: "center" | LayoutAuxiliaryRegion): void => {
 		tabCount += 1;
 		if (!canPlaceLayoutTab(tab, area)) errors.push(`Illegal ${area} tab: ${tab.id}`);
 		if (tabIds.has(tab.id)) errors.push(`Duplicate tab placement: ${tab.id}`);
@@ -1124,6 +1240,38 @@ export function validateLayoutDocument(
 			if (group.tabs.length === 0) errors.push(`Empty side group: ${group.id}`);
 			for (const tab of group.tabs) trackTab(tab, side);
 		}
+	}
+	const bottom = document.bottom;
+	if (
+		!Number.isFinite(bottom.height) ||
+		bottom.height <= 0 ||
+		bottom.height > LAYOUT_LIMITS.maxBottomHeight
+	) {
+		errors.push("Invalid bottom height.");
+	}
+	if (
+		bottom.alignment !== "center" &&
+		bottom.alignment !== "center-left" &&
+		bottom.alignment !== "center-right" &&
+		bottom.alignment !== "full"
+	) {
+		errors.push("Invalid bottom alignment.");
+	}
+	if (bottom.groups.length > maxBottomGroups) errors.push("Too many bottom groups.");
+	if (bottom.groups.length > LAYOUT_LIMITS.maxSideGroupsSafety) {
+		errors.push("Unsafe bottom group count.");
+	}
+	const bottomWeightTotal = bottom.groups.reduce((sum, group) => sum + group.weight, 0);
+	if (bottom.groups.length > 0 && Math.abs(bottomWeightTotal - 1) > 1e-6) {
+		errors.push("Invalid normalized bottom group weights.");
+	}
+	for (const group of bottom.groups) {
+		if (groupIds.has(group.id)) errors.push(`Duplicate group id: ${group.id}`);
+		groupIds.add(group.id);
+		if (!Number.isFinite(group.weight) || group.weight <= 0) {
+			errors.push(`Invalid group weight: ${group.id}`);
+		}
+		for (const tab of group.tabs) trackTab(tab, "bottom");
 	}
 	if (document.left.width + document.right.width >= 1) {
 		errors.push("Side widths leave no center region.");

--- a/apps/web/src/shell/layout/model.ts
+++ b/apps/web/src/shell/layout/model.ts
@@ -30,6 +30,7 @@ export const LAYOUT_LIMITS = {
 	minCenterHeight: 180,
 	minSideBodyHeight: 120,
 	minBottomBodyHeight: 120,
+	minBottomGroupWidth: 160,
 	foldedSideHeight: 27,
 	foldedBottomWidth: 27,
 	initialBottomHeight: 0.3,
@@ -471,10 +472,7 @@ export function closeLayoutTab(
 	};
 }
 
-export function canPlaceLayoutTab(
-	tab: LayoutTab,
-	area: "center" | LayoutAuxiliaryRegion,
-): boolean {
+export function canPlaceLayoutTab(tab: LayoutTab, area: "center" | LayoutAuxiliaryRegion): boolean {
 	if (area === "center") return tab.kind !== "tool";
 	return tab.kind === "tool" || tab.kind === "terminal";
 }
@@ -703,8 +701,7 @@ export function createAuxiliaryGroup(
 		source?.area === region
 			? document[region].groups.findIndex((group) => group.id === source.groupId)
 			: -1;
-	const sourceGroup =
-		sourceGroupIndex >= 0 ? document[region].groups[sourceGroupIndex] : undefined;
+	const sourceGroup = sourceGroupIndex >= 0 ? document[region].groups[sourceGroupIndex] : undefined;
 	const removesSourceGroup = sourceGroup?.tabs.length === 1;
 	const insertionIndex = sideGroupInsertionIndex(
 		document[region].groups.length,
@@ -794,6 +791,15 @@ export function setSideVisibility(
 	return { ...document, [side]: { ...document[side], visible: nextVisible } };
 }
 
+export function setBottomVisibility(
+	document: WorkspaceLayoutDocument,
+	visible: boolean,
+): WorkspaceLayoutDocument {
+	const nextVisible = visible && document.bottom.groups.length > 0;
+	if (document.bottom.visible === nextVisible) return document;
+	return { ...document, bottom: { ...document.bottom, visible: nextVisible } };
+}
+
 const TOOL_RESTORE_ORDER = LAYOUT_TOOLS;
 
 export function hideSide(
@@ -814,6 +820,23 @@ export function hideSide(
 	};
 }
 
+export function hideBottom(
+	document: WorkspaceLayoutDocument,
+	attention: LayoutAttention,
+): LayoutMutationResult {
+	const center =
+		findCenterGroup(document.center, attention.lastFocusedCenterGroupId) ??
+		findCenterGroup(document.center, primaryCenterGroupId(document));
+	const selected =
+		center?.tabs.find((tab) => tab.id === readLayoutSelection(attention, center.id)) ??
+		center?.tabs[0];
+	return {
+		document: setBottomVisibility(document, false),
+		...(center ? { focusGroupId: center.id } : {}),
+		...(selected ? { focusTabId: selected.id } : {}),
+	};
+}
+
 export function canShowSide(document: WorkspaceLayoutDocument, side: LayoutSide): boolean {
 	return (
 		document[side].groups.length > 0 ||
@@ -823,6 +846,58 @@ export function canShowSide(document: WorkspaceLayoutDocument, side: LayoutSide)
 				findPlacedResource(document, toolTab(tool)) === null,
 		)
 	);
+}
+
+export function showBottom(
+	document: WorkspaceLayoutDocument,
+	maxSideGroups: number,
+	maxBottomGroups: number,
+	attention?: LayoutAttention,
+): LayoutOperationResult {
+	const populated = document.bottom.groups.some((group) => group.tabs.length > 0);
+	if (populated) {
+		const shown = setBottomVisibility(document, true);
+		const preferredId = attention?.lastFocusedSideGroupId.bottom;
+		const group =
+			shown.bottom.groups.find((candidate) => candidate.id === preferredId) ??
+			shown.bottom.groups.find((candidate) => candidate.tabs.length > 0) ??
+			shown.bottom.groups[0];
+		if (!group) return { document: shown };
+		const selectedId = attention ? readLayoutSelection(attention, group.id) : undefined;
+		const tab = group.tabs.find((candidate) => candidate.id === selectedId) ?? group.tabs[0];
+		return {
+			document: shown,
+			focusGroupId: group.id,
+			...(tab ? { focusTabId: tab.id } : {}),
+		};
+	}
+	const tool = TOOL_RESTORE_ORDER.find(
+		(candidate) =>
+			document.toolRestoreTargets[candidate]?.region === "bottom" &&
+			!findPlacedResource(document, toolTab(candidate)),
+	);
+	if (tool) return revealTool(document, tool, maxSideGroups, maxBottomGroups);
+	if (document.bottom.groups.length > 0) {
+		const shown = setBottomVisibility(document, true);
+		const preferredId = attention?.lastFocusedSideGroupId.bottom;
+		const group =
+			shown.bottom.groups.find((candidate) => candidate.id === preferredId) ??
+			shown.bottom.groups[0];
+		return { document: shown, ...(group ? { focusGroupId: group.id } : {}) };
+	}
+	const group: LayoutSideGroup = {
+		id: createLayoutId("bottom-group"),
+		weight: 1,
+		folded: false,
+		tabs: [],
+	};
+	return {
+		document: {
+			...document,
+			bottom: { ...document.bottom, visible: true, groups: [group] },
+		},
+		focusGroupId: group.id,
+	};
 }
 
 export function showSide(

--- a/apps/web/src/shell/layout/presets.ts
+++ b/apps/web/src/shell/layout/presets.ts
@@ -1,7 +1,9 @@
 import {
 	DEFAULT_CONFIG,
+	type LayoutBottomRegion,
 	type LayoutCenterTab,
 	type LayoutPreset,
+	type LayoutPresetBottomRegion,
 	type LayoutPresetCenterNode,
 	type LayoutPresetSideRegion,
 	type LayoutSideGroup,
@@ -11,6 +13,7 @@ import {
 	type WorkspaceLayoutDocument,
 } from "@thinkrail/contracts";
 import {
+	collectAllGroups,
 	collectCenterGroups,
 	createLayoutId,
 	LAYOUT_TOOL_DEFAULT_SIDES,
@@ -32,23 +35,33 @@ const split = (
 	children: [first, second],
 });
 
+const weightedGroups = (
+	groups: Array<{ id: string; tools: LayoutToolId[]; weight?: number; folded?: boolean }>,
+) => {
+	const total = groups.reduce((sum, candidate) => sum + (candidate.weight ?? 1), 0);
+	return groups.map((candidate) => ({
+		id: candidate.id,
+		weight: (candidate.weight ?? 1) / total,
+		folded: candidate.folded ?? false,
+		tools: candidate.tools,
+	}));
+};
+
 const side = (
 	visible: boolean,
 	width: number,
 	groups: Array<{ id: string; tools: LayoutToolId[]; weight?: number; folded?: boolean }>,
-): LayoutPresetSideRegion => {
-	const total = groups.reduce((sum, candidate) => sum + (candidate.weight ?? 1), 0);
-	return {
-		visible,
-		width,
-		groups: groups.map((candidate) => ({
-			id: candidate.id,
-			weight: (candidate.weight ?? 1) / total,
-			folded: candidate.folded ?? false,
-			tools: candidate.tools,
-		})),
-	};
-};
+): LayoutPresetSideRegion => ({ visible, width, groups: weightedGroups(groups) });
+
+const bottom = (
+	visible: boolean,
+	groups: Array<{ id: string; tools: LayoutToolId[]; weight?: number; folded?: boolean }>,
+): LayoutPresetBottomRegion => ({
+	visible,
+	height: 0.3,
+	alignment: "center",
+	groups: weightedGroups(groups),
+});
 
 export const BUILTIN_LAYOUT_PRESETS: readonly LayoutPreset[] = [
 	{
@@ -65,6 +78,7 @@ export const BUILTIN_LAYOUT_PRESETS: readonly LayoutPreset[] = [
 			{ id: "balanced-right-top", tools: ["specs", "files"], weight: 1.25 },
 			{ id: "balanced-right-bottom", tools: ["changes", "review"] },
 		]),
+		bottom: bottom(true, [{ id: "balanced-bottom", tools: [] }]),
 	},
 	{
 		id: "focus",
@@ -74,6 +88,7 @@ export const BUILTIN_LAYOUT_PRESETS: readonly LayoutPreset[] = [
 		right: side(false, 0.26, [
 			{ id: "focus-right", tools: ["specs", "files", "changes", "review"] },
 		]),
+		bottom: bottom(false, [{ id: "focus-bottom", tools: [] }]),
 	},
 	{
 		id: "review",
@@ -84,11 +99,16 @@ export const BUILTIN_LAYOUT_PRESETS: readonly LayoutPreset[] = [
 			{ id: "review-right-main", tools: ["changes", "review"], weight: 1.4 },
 			{ id: "review-right-reference", tools: ["specs", "files"] },
 		]),
+		bottom: bottom(true, [{ id: "review-bottom", tools: [] }]),
 	},
 ] as const;
 
 export function minimumSideGroupLimit(preset: LayoutPreset): number {
 	return Math.max(1, preset.left.groups.length, preset.right.groups.length);
+}
+
+export function minimumBottomGroupLimit(preset: LayoutPreset): number {
+	return Math.max(1, preset.bottom.groups.length);
 }
 
 export function resolveLayoutPreset(
@@ -106,7 +126,7 @@ export function resolveLayoutPreset(
 function defaultRestoreTarget(tool: LayoutToolId) {
 	const side = LAYOUT_TOOL_DEFAULT_SIDES[tool];
 	return {
-		side,
+		region: side,
 		index: LAYOUT_TOOLS.filter(
 			(candidate) => LAYOUT_TOOL_DEFAULT_SIDES[candidate] === side,
 		).indexOf(tool),
@@ -117,7 +137,9 @@ function restoreTargetsForPreset(
 	preset: LayoutPreset,
 ): WorkspaceLayoutDocument["toolRestoreTargets"] {
 	const placed = new Set(
-		[...preset.left.groups, ...preset.right.groups].flatMap((group) => group.tools),
+		[...preset.left.groups, ...preset.right.groups, ...preset.bottom.groups].flatMap(
+			(group) => group.tools,
+		),
 	);
 	return Object.fromEntries(
 		LAYOUT_TOOLS.filter((tool) => !placed.has(tool)).map((tool) => [
@@ -141,12 +163,32 @@ function instantiateSide(
 	return { visible: region.visible && groups.length > 0, width: region.width, groups };
 }
 
+function instantiateBottom(
+	region: LayoutPresetBottomRegion,
+	resolveTool: (tool: LayoutToolId) => ReturnType<typeof toolTab> = toolTab,
+): LayoutBottomRegion {
+	const weightTotal = region.groups.reduce((sum, candidate) => sum + candidate.weight, 0);
+	const groups = region.groups.map((candidate) => ({
+		id: createLayoutId("bottom"),
+		weight: candidate.weight / weightTotal,
+		folded: candidate.folded,
+		tabs: candidate.tools.map(resolveTool),
+	}));
+	return {
+		visible: region.visible && groups.length > 0,
+		height: region.height,
+		alignment: region.alignment,
+		groups,
+	};
+}
+
 export function instantiateLayoutPreset(preset: LayoutPreset): WorkspaceLayoutDocument {
 	return {
-		version: 1,
+		version: 2,
 		center: { kind: "group", id: createLayoutId("center"), tabs: [] },
 		left: instantiateSide(preset.left),
 		right: instantiateSide(preset.right),
+		bottom: instantiateBottom(preset.bottom),
 		toolRestoreTargets: restoreTargetsForPreset(preset),
 	};
 }
@@ -155,10 +197,10 @@ function flattenCenterTabs(document: WorkspaceLayoutDocument): LayoutCenterTab[]
 	return collectCenterGroups(document.center).flatMap((candidate) => candidate.tabs);
 }
 
-function flattenSideTerminals(region: LayoutSideRegion): LayoutTerminalTab[] {
-	return region.groups.flatMap((candidate) =>
-		candidate.tabs.filter((tab): tab is LayoutTerminalTab => tab.kind === "terminal"),
-	);
+function flattenTerminals(document: WorkspaceLayoutDocument): LayoutTerminalTab[] {
+	return collectAllGroups(document)
+		.flatMap((group) => group.tabs)
+		.filter((tab): tab is LayoutTerminalTab => tab.kind === "terminal");
 }
 
 function presetLeafCount(node: LayoutPresetCenterNode): number {
@@ -191,38 +233,43 @@ function fillPresetCenter(
 	};
 }
 
-function putTerminalsInExistingSide(
-	region: LayoutSideRegion,
+function putTerminalsInBottom(
+	region: LayoutBottomRegion,
 	terminals: LayoutTerminalTab[],
-): { region: LayoutSideRegion; remaining: LayoutTerminalTab[] } {
-	if (terminals.length === 0 || region.groups.length === 0) return { region, remaining: terminals };
-	return {
-		region: {
-			...region,
-			groups: region.groups.map((group, index) =>
-				index === 0 ? { ...group, tabs: [...group.tabs, ...terminals] } : group,
-			),
-		},
-		remaining: [],
-	};
+): LayoutBottomRegion {
+	const seeded =
+		region.groups.length > 0
+			? region.groups
+			: [{ id: createLayoutId("bottom"), weight: 1, folded: false, tabs: [] }];
+	const groups = seeded.map((group, index) => ({
+		...group,
+		tabs: [...group.tabs, ...(terminals[index] ? [terminals[index]] : [])],
+	}));
+	if (groups[0] && terminals.length > groups.length) {
+		groups[0] = { ...groups[0], tabs: [...groups[0].tabs, ...terminals.slice(groups.length)] };
+	}
+	return { ...region, groups };
 }
 
 function restoreTargetsForOmittedTools(
 	document: WorkspaceLayoutDocument,
 	left: LayoutSideRegion,
 	right: LayoutSideRegion,
+	bottomRegion: LayoutBottomRegion,
 ): WorkspaceLayoutDocument["toolRestoreTargets"] {
 	const placed = new Set(
-		[...left.groups, ...right.groups]
+		[...left.groups, ...right.groups, ...bottomRegion.groups]
 			.flatMap((group) => group.tabs)
 			.filter((tab) => tab.kind === "tool")
 			.map((tab) => tab.tool),
 	);
 	const targets = { ...document.toolRestoreTargets };
-	for (const side of ["left", "right"] as const) {
-		for (const group of document[side].groups) {
+	for (const region of ["left", "right", "bottom"] as const) {
+		for (const group of document[region].groups) {
 			group.tabs.forEach((tab, index) => {
-				if (tab.kind === "tool" && !placed.has(tab.tool)) targets[tab.tool] = { side, index };
+				if (tab.kind === "tool" && !placed.has(tab.tool)) {
+					targets[tab.tool] = { region, index };
+				}
 			});
 		}
 	}
@@ -233,23 +280,11 @@ function restoreTargetsForOmittedTools(
 	return targets;
 }
 
-function putTerminalsInPrimaryCenter(
-	center: WorkspaceLayoutDocument["center"],
-	terminals: LayoutTerminalTab[],
-): WorkspaceLayoutDocument["center"] {
-	if (terminals.length === 0) return center;
-	if (center.kind === "group") return { ...center, tabs: [...center.tabs, ...terminals] };
-	return {
-		...center,
-		children: [putTerminalsInPrimaryCenter(center.children[0], terminals), center.children[1]],
-	};
-}
-
 export function applyLayoutPreset(
 	document: WorkspaceLayoutDocument,
 	preset: LayoutPreset,
 ): WorkspaceLayoutDocument {
-	const centerTabs = flattenCenterTabs(document);
+	const centerTabs = flattenCenterTabs(document).filter((tab) => tab.kind !== "terminal");
 	const leafCount = presetLeafCount(preset.center);
 	const buckets = Array.from({ length: leafCount }, () => [] as LayoutCenterTab[]);
 	for (let index = 0; index < centerTabs.length; index += 1) {
@@ -260,21 +295,14 @@ export function applyLayoutPreset(
 	}
 	const filled = fillPresetCenter(preset.center, buckets, { value: 0 });
 	const fallback = { kind: "group" as const, id: createLayoutId("center"), tabs: [] };
-	let center = filled ?? fallback;
+	const center = filled ?? fallback;
+	const allTabs = collectAllGroups(document).flatMap((group) => group.tabs);
 	const existingTools = new Map(
-		[...document.left.groups, ...document.right.groups]
-			.flatMap((group) => group.tabs)
+		allTabs
 			.filter((tab) => tab.kind === "tool")
 			.map((tab) => [tab.tool, tab] as const),
 	);
-	const claimedIds = new Set(
-		[
-			...flattenCenterTabs(document),
-			...flattenSideTerminals(document.left),
-			...flattenSideTerminals(document.right),
-			...existingTools.values(),
-		].map((tab) => tab.id),
-	);
+	const claimedIds = new Set(allTabs.map((tab) => tab.id));
 	const resolveTool = (tool: LayoutToolId): ReturnType<typeof toolTab> => {
 		const existing = existingTools.get(tool);
 		if (existing) {
@@ -291,28 +319,19 @@ export function applyLayoutPreset(
 		claimedIds.add(id);
 		return { ...canonical, id };
 	};
-	let left = instantiateSide(preset.left, resolveTool);
-	let right = instantiateSide(preset.right, resolveTool);
-	const leftTerminals = flattenSideTerminals(document.left);
-	const rightTerminals = flattenSideTerminals(document.right);
-	const leftSameSide = putTerminalsInExistingSide(left, leftTerminals);
-	left = leftSameSide.region;
-	const rightSameSide = putTerminalsInExistingSide(right, rightTerminals);
-	right = rightSameSide.region;
-	const leftOpposite = putTerminalsInExistingSide(right, leftSameSide.remaining);
-	right = leftOpposite.region;
-	const rightOpposite = putTerminalsInExistingSide(left, rightSameSide.remaining);
-	left = rightOpposite.region;
-	center = putTerminalsInPrimaryCenter(center, [
-		...leftOpposite.remaining,
-		...rightOpposite.remaining,
-	]);
+	const left = instantiateSide(preset.left, resolveTool);
+	const right = instantiateSide(preset.right, resolveTool);
+	const bottomRegion = putTerminalsInBottom(
+		instantiateBottom(preset.bottom, resolveTool),
+		flattenTerminals(document),
+	);
 	return {
-		version: 1,
+		version: 2,
 		center,
 		left,
 		right,
-		toolRestoreTargets: restoreTargetsForOmittedTools(document, left, right),
+		bottom: bottomRegion,
+		toolRestoreTargets: restoreTargetsForOmittedTools(document, left, right, bottomRegion),
 	};
 }
 
@@ -347,11 +366,26 @@ export function captureLayoutPreset(
 		}));
 		return { visible: region.visible && groups.length > 0, width: region.width, groups };
 	};
+	const portableBottom = (region: LayoutBottomRegion): LayoutPresetBottomRegion => {
+		const total = region.groups.reduce((sum, candidate) => sum + candidate.weight, 0);
+		return {
+			visible: region.visible && region.groups.length > 0,
+			height: region.height,
+			alignment: region.alignment,
+			groups: region.groups.map((candidate) => ({
+				id: candidate.id,
+				weight: candidate.weight / total,
+				folded: candidate.folded,
+				tools: candidate.tabs.filter((tab) => tab.kind === "tool").map((tab) => tab.tool),
+			})),
+		};
+	};
 	return {
 		id,
 		name,
 		center: center(document.center),
 		left: portableSide(document.left),
 		right: portableSide(document.right),
+		bottom: portableBottom(document.bottom),
 	};
 }

--- a/apps/web/src/shell/layout/presets.ts
+++ b/apps/web/src/shell/layout/presets.ts
@@ -298,9 +298,7 @@ export function applyLayoutPreset(
 	const center = filled ?? fallback;
 	const allTabs = collectAllGroups(document).flatMap((group) => group.tabs);
 	const existingTools = new Map(
-		allTabs
-			.filter((tab) => tab.kind === "tool")
-			.map((tab) => [tab.tool, tab] as const),
+		allTabs.filter((tab) => tab.kind === "tool").map((tab) => [tab.tool, tab] as const),
 	);
 	const claimedIds = new Set(allTabs.map((tab) => tab.id));
 	const resolveTool = (tool: LayoutToolId): ReturnType<typeof toolTab> => {

--- a/apps/web/src/shell/layout/presets.ts
+++ b/apps/web/src/shell/layout/presets.ts
@@ -237,6 +237,7 @@ function putTerminalsInBottom(
 	region: LayoutBottomRegion,
 	terminals: LayoutTerminalTab[],
 ): LayoutBottomRegion {
+	if (region.groups.length === 0 && terminals.length === 0) return region;
 	const seeded =
 		region.groups.length > 0
 			? region.groups

--- a/apps/web/src/shell/layoutIntents/SPEC.md
+++ b/apps/web/src/shell/layoutIntents/SPEC.md
@@ -27,6 +27,9 @@ transaction plus the corresponding device-local attention/focus transition.
 An intent is consumed only after confirming that its captured store document and attention are still current.
 Deferred chat/history work retains its request-time navigation stamp so a late completion cannot steal focus.
 A global terminal placement resolves to last surviving bottom focus, reveals or creates its bottom slot, and
-selects it; a contextual group id still wins. Bottom show/toggle uses the same consume-once transaction as
+selects it; a contextual group id still wins. The parent-reserved new-workspace intent is the explicit
+non-activating exception: it uses its captured/preferred bottom slot, creates one when none survives, and
+retains that region's visibility and existing fold state. Bottom show/toggle uses the same consume-once
+transaction as
 left/right, including eligible singleton restoration before terminal creation and non-bottom focus recovery
 on hide.

--- a/apps/web/src/shell/layoutIntents/SPEC.md
+++ b/apps/web/src/shell/layoutIntents/SPEC.md
@@ -15,8 +15,8 @@ transaction plus the corresponding device-local attention/focus transition.
 ## Boundary
 
 - **Owns:** stale document/attention identity guards; consume-once intent handling; destination and navigation
-  arbitration; open/select/close/tool/terminal/toggle dispatch; accepted attention/focus calculation; and
-  issuing at most one complete-document commit for the result.
+  arbitration; open/select/close/tool/terminal/auxiliary-toggle dispatch; accepted attention/focus
+  calculation; and issuing at most one complete-document commit for the result.
 - **Public surface (`index.ts`):** the workspace intent-processing hook and its narrow callback types.
 - **External deps:** contracts layout types; store intent, attention, and navigation APIs; transport error
   normalization; React.
@@ -26,3 +26,7 @@ transaction plus the corresponding device-local attention/focus transition.
 
 An intent is consumed only after confirming that its captured store document and attention are still current.
 Deferred chat/history work retains its request-time navigation stamp so a late completion cannot steal focus.
+A global terminal placement resolves to last surviving bottom focus, reveals or creates its bottom slot, and
+selects it; a contextual group id still wins. Bottom show/toggle uses the same consume-once transaction as
+left/right, including eligible singleton restoration before terminal creation and non-bottom focus recovery
+on hide.

--- a/apps/web/src/shell/layoutIntents/layoutIntents.test.ts
+++ b/apps/web/src/shell/layoutIntents/layoutIntents.test.ts
@@ -51,6 +51,42 @@ describe("terminal intent routing", () => {
 		expect(result.document.bottom.groups[1]?.folded).toBe(false);
 	});
 
+	test("a reserved hidden default keeps its captured bottom geometry and does not request focus", () => {
+		const result = placeTerminalForIntent(
+			document(),
+			attention,
+			terminal,
+			{ area: "bottom", groupId: "bottom-two" },
+			limits,
+			false,
+		);
+		if ("reason" in result) throw new Error(result.reason);
+		expect(findTabLocation(result.document, terminal.id)).toEqual({
+			area: "bottom",
+			groupId: "bottom-two",
+		});
+		expect(result.document.bottom.visible).toBe(false);
+		expect(result.document.bottom.groups[1]?.folded).toBe(true);
+		expect(result.focusGroupId).toBeUndefined();
+		expect(result.focusTabId).toBeUndefined();
+
+		const withoutSlot = document();
+		withoutSlot.bottom.groups = [];
+		const created = placeTerminalForIntent(
+			withoutSlot,
+			attention,
+			terminal,
+			undefined,
+			limits,
+			false,
+		);
+		if ("reason" in created) throw new Error(created.reason);
+		expect(created.document.bottom.visible).toBe(false);
+		expect(created.document.bottom.groups).toHaveLength(1);
+		expect(findTabLocation(created.document, terminal.id)?.area).toBe("bottom");
+		expect(created.focusGroupId).toBeUndefined();
+	});
+
 	test("global creation makes a bottom slot while an explicit center target stays center", () => {
 		const empty = document();
 		empty.bottom.groups = [];

--- a/apps/web/src/shell/layoutIntents/layoutIntents.test.ts
+++ b/apps/web/src/shell/layoutIntents/layoutIntents.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import type { LayoutTerminalTab, WorkspaceLayoutDocument } from "@thinkrail/contracts";
+import type { LayoutAttention } from "../../lib";
+import { findTabLocation } from "../layout";
+import { placeTerminalForIntent } from "./layoutIntents";
+
+function document(): WorkspaceLayoutDocument {
+	return {
+		version: 2,
+		center: { kind: "group", id: "center", tabs: [] },
+		left: { visible: false, width: 0.18, groups: [] },
+		right: { visible: false, width: 0.28, groups: [] },
+		bottom: {
+			visible: false,
+			height: 0.3,
+			alignment: "center",
+			groups: [
+				{ id: "bottom-one", weight: 0.5, folded: false, tabs: [] },
+				{ id: "bottom-two", weight: 0.5, folded: true, tabs: [] },
+			],
+		},
+		toolRestoreTargets: {},
+	};
+}
+
+const attention: LayoutAttention = {
+	selectedByGroup: {},
+	lastFocusedCenterGroupId: "center",
+	lastFocusedSideGroupId: { bottom: "bottom-two" },
+	navigationClockByGroup: { center: 0 },
+};
+
+const terminal: LayoutTerminalTab = {
+	kind: "terminal",
+	id: "terminal:new",
+	name: "Terminal 1",
+	tabKey: "new",
+};
+
+const limits = { maxSideGroups: 6, maxBottomGroups: 3 } as const;
+
+describe("terminal intent routing", () => {
+	test("global creation uses and reveals the last-focused surviving bottom group", () => {
+		const result = placeTerminalForIntent(document(), attention, terminal, undefined, limits);
+		if ("reason" in result) throw new Error(result.reason);
+		expect(findTabLocation(result.document, terminal.id)).toEqual({
+			area: "bottom",
+			groupId: "bottom-two",
+		});
+		expect(result.document.bottom.visible).toBe(true);
+		expect(result.document.bottom.groups[1]?.folded).toBe(false);
+	});
+
+	test("global creation makes a bottom slot while an explicit center target stays center", () => {
+		const empty = document();
+		empty.bottom.groups = [];
+		const created = placeTerminalForIntent(empty, attention, terminal, undefined, limits);
+		if ("reason" in created) throw new Error(created.reason);
+		expect(findTabLocation(created.document, terminal.id)?.area).toBe("bottom");
+		expect(created.document.bottom.groups).toHaveLength(1);
+
+		const centered = placeTerminalForIntent(
+			document(),
+			attention,
+			terminal,
+			{ area: "center", groupId: "center" },
+			limits,
+		);
+		if ("reason" in centered) throw new Error(centered.reason);
+		expect(findTabLocation(centered.document, terminal.id)?.area).toBe("center");
+	});
+});

--- a/apps/web/src/shell/layoutIntents/layoutIntents.ts
+++ b/apps/web/src/shell/layoutIntents/layoutIntents.ts
@@ -1,4 +1,8 @@
-import type { LayoutCenterTab, WorkspaceLayoutDocument } from "@thinkrail/contracts";
+import type {
+	LayoutCenterTab,
+	LayoutTerminalTab,
+	WorkspaceLayoutDocument,
+} from "@thinkrail/contracts";
 import { useEffect } from "react";
 import type { LayoutAttention } from "../../lib";
 import {
@@ -13,13 +17,18 @@ import { currentChatDestination, hydrateChatResource } from "../chatReconciliati
 import {
 	closeLayoutTab,
 	collectAllGroups,
+	createAuxiliaryGroup,
+	findAuxiliaryGroup,
 	findCenterGroup,
 	findLayoutTab,
 	findPlacedResource,
 	findTabLocation,
+	hideBottom,
 	hideSide,
 	isLayoutUnavailable,
 	keepPreview,
+	type LayoutGroupLocation,
+	type LayoutOperationResult,
 	type LayoutTabFocusRequest,
 	moveTabToGroup,
 	openCenterTab,
@@ -28,11 +37,66 @@ import {
 	removeSessionLayoutTabs,
 	revealTool,
 	selectTab,
-	setSideGroupFolded,
+	setAuxiliaryGroupFolded,
+	showBottom,
 	showSide,
 	withAvailablePlacementId,
 } from "../layout";
 import { terminalLayoutId } from "../terminalReconciliation";
+
+export function placeTerminalForIntent(
+	document: WorkspaceLayoutDocument,
+	attention: LayoutAttention,
+	tab: LayoutTerminalTab,
+	target: LayoutGroupLocation | undefined,
+	limits: { maxSideGroups: number; maxBottomGroups: number },
+): LayoutOperationResult {
+	if (target?.area === "center") {
+		const groupId =
+			findCenterGroup(document.center, target.groupId)?.id ??
+			findCenterGroup(document.center, attention.lastFocusedCenterGroupId)?.id ??
+			primaryCenterGroupId(document);
+		return moveTabToGroup(document, tab, { area: "center", groupId });
+	}
+	if (target && findAuxiliaryGroup(document, target.area, target.groupId)) {
+		const moved = moveTabToGroup(document, tab, target);
+		if (isLayoutUnavailable(moved)) return moved;
+		const unfolded = setAuxiliaryGroupFolded(moved.document, target.area, target.groupId, false);
+		if (isLayoutUnavailable(unfolded)) return moved;
+		return {
+			...moved,
+			document: {
+				...unfolded.document,
+				[target.area]: { ...unfolded.document[target.area], visible: true },
+			},
+		};
+	}
+	const preferredId = attention.lastFocusedSideGroupId.bottom;
+	const bottomGroup =
+		document.bottom.groups.find((group) => group.id === preferredId) ??
+		document.bottom.groups.at(-1);
+	if (bottomGroup) {
+		const moved = moveTabToGroup(document, tab, {
+			area: "bottom",
+			groupId: bottomGroup.id,
+		});
+		if (isLayoutUnavailable(moved)) return moved;
+		return {
+			...moved,
+			document: {
+				...moved.document,
+				bottom: {
+					...moved.document.bottom,
+					visible: true,
+					groups: moved.document.bottom.groups.map((group) =>
+						group.id === bottomGroup.id ? { ...group, folded: false } : group,
+					),
+				},
+			},
+		};
+	}
+	return createAuxiliaryGroup(document, "bottom", tab, 0, limits.maxBottomGroups);
+}
 
 export function toLayoutTab(tab: EditorTab): LayoutCenterTab | null {
 	switch (tab.kind) {
@@ -82,6 +146,7 @@ export function useLayoutIntentProcessing(
 		(state) => state.layoutIntents.find((intent) => intent.workspaceId === workspaceId) ?? null,
 	);
 	const maxSideGroups = useAppStore((state) => state.layoutSettings.maxSideGroups);
+	const maxBottomGroups = useAppStore((state) => state.layoutSettings.maxBottomGroups);
 
 	useEffect(() => {
 		if (!layoutIntent || !document || !attention) return;
@@ -117,6 +182,7 @@ export function useLayoutIntentProcessing(
 		let result:
 			| { document: WorkspaceLayoutDocument; focusGroupId?: string; focusTabId?: string }
 			| undefined;
+		let terminalTargetAfterCommit: string | undefined;
 		switch (layoutIntent.kind) {
 			case "open": {
 				const cacheTab = toLayoutTab(layoutIntent.tab);
@@ -253,7 +319,7 @@ export function useLayoutIntentProcessing(
 				break;
 			}
 			case "reveal-tool": {
-				const revealed = revealTool(document, layoutIntent.tool, maxSideGroups);
+				const revealed = revealTool(document, layoutIntent.tool, maxSideGroups, maxBottomGroups);
 				if (!isLayoutUnavailable(revealed)) result = revealed;
 				break;
 			}
@@ -267,35 +333,19 @@ export function useLayoutIntentProcessing(
 					name: layoutIntent.title,
 					tabKey: layoutIntent.tabKey,
 				});
-				const requestedGroupId = currentRouting?.targetGroupId ?? layoutIntent.targetGroupId;
-				const requestedGroup = requestedGroupId
-					? findCenterGroup(document.center, requestedGroupId)
-					: null;
-				if (requestedGroupId) {
-					const groupId =
-						requestedGroup?.id ??
-						findCenterGroup(document.center, attention.lastFocusedCenterGroupId)?.id ??
-						primaryCenterGroupId(document);
-					const moved = moveTabToGroup(document, tab, { area: "center", groupId });
-					if (!isLayoutUnavailable(moved)) result = moved;
-					break;
-				}
-				const target = document.right.groups.at(-1);
-				if (target) {
-					const moved = moveTabToGroup(document, tab, { area: "right", groupId: target.id });
-					if (!isLayoutUnavailable(moved)) {
-						const unfolded = setSideGroupFolded(moved.document, "right", target.id, false);
-						result = isLayoutUnavailable(unfolded)
-							? moved
-							: { ...moved, document: unfolded.document };
-					}
-				} else {
-					const moved = moveTabToGroup(document, tab, {
-						area: "center",
-						groupId: attention.lastFocusedCenterGroupId,
-					});
-					if (!isLayoutUnavailable(moved)) result = moved;
-				}
+				const routedCenterGroupId = currentRouting?.targetGroupId;
+				const requestedGroupId = routedCenterGroupId ?? layoutIntent.targetGroupId;
+				const requestedArea = routedCenterGroupId
+					? "center"
+					: (layoutIntent.targetArea ?? "center");
+				const target = requestedGroupId
+					? { area: requestedArea, groupId: requestedGroupId }
+					: undefined;
+				const placed = placeTerminalForIntent(document, attention, tab, target, {
+					maxSideGroups,
+					maxBottomGroups,
+				});
+				if (!isLayoutUnavailable(placed)) result = placed;
 				break;
 			}
 			case "close-terminal": {
@@ -331,6 +381,19 @@ export function useLayoutIntentProcessing(
 					if (!isLayoutUnavailable(shown)) result = shown;
 				}
 				break;
+			case "toggle-bottom":
+				if (document.bottom.visible) {
+					result = hideBottom(document, attention);
+				} else {
+					const shown = showBottom(document, maxSideGroups, maxBottomGroups, attention);
+					if (!isLayoutUnavailable(shown)) {
+						result = shown;
+						if (shown.document.bottom.groups.every((group) => group.tabs.length === 0)) {
+							terminalTargetAfterCommit = shown.focusGroupId ?? shown.document.bottom.groups[0]?.id;
+						}
+					}
+				}
+				break;
 		}
 		if (!result) return;
 		let nextAttention = reconcileAttention(result.document, attention, document);
@@ -341,11 +404,18 @@ export function useLayoutIntentProcessing(
 					? currentRouting?.activate !== false
 					: true;
 		if (activateResult && result.focusGroupId) {
+			const focusGroupId = result.focusGroupId;
 			const location = result.focusTabId
 				? findTabLocation(result.document, result.focusTabId)
-				: findCenterGroup(result.document.center, result.focusGroupId)
-					? ({ area: "center", groupId: result.focusGroupId } as const)
-					: null;
+				: findCenterGroup(result.document.center, focusGroupId)
+					? ({ area: "center", groupId: focusGroupId } as const)
+					: ((["left", "right", "bottom"] as const)
+							.map((area) =>
+								findAuxiliaryGroup(result.document, area, focusGroupId)
+									? ({ area, groupId: focusGroupId } as const)
+									: null,
+							)
+							.find((candidate) => candidate !== null) ?? null);
 			if (location) {
 				if (result.focusTabId) {
 					nextAttention = selectTab(
@@ -367,12 +437,18 @@ export function useLayoutIntentProcessing(
 		}
 		changeAttention(nextAttention);
 		if (result.document !== document) commit(result.document);
+		if (terminalTargetAfterCommit) {
+			useAppStore
+				.getState()
+				.addTerminal(workspaceId, undefined, terminalTargetAfterCommit, "bottom");
+		}
 	}, [
 		attention,
 		changeAttention,
 		commit,
 		document,
 		layoutIntent,
+		maxBottomGroups,
 		maxSideGroups,
 		requestFocus,
 		workspaceId,

--- a/apps/web/src/shell/layoutIntents/layoutIntents.ts
+++ b/apps/web/src/shell/layoutIntents/layoutIntents.ts
@@ -44,32 +44,58 @@ import {
 } from "../layout";
 import { terminalLayoutId } from "../terminalReconciliation";
 
+function preservePassiveAuxiliaryPlacement(
+	original: WorkspaceLayoutDocument,
+	moved: { document: WorkspaceLayoutDocument },
+	location: Exclude<LayoutGroupLocation, { area: "center" }>,
+): LayoutOperationResult {
+	const previousGroup = findAuxiliaryGroup(original, location.area, location.groupId);
+	return {
+		document: {
+			...moved.document,
+			[location.area]: {
+				...moved.document[location.area],
+				visible: original[location.area].visible,
+				groups: moved.document[location.area].groups.map((group) =>
+					group.id === previousGroup?.id ? { ...group, folded: previousGroup.folded } : group,
+				),
+			},
+		},
+	};
+}
+
 export function placeTerminalForIntent(
 	document: WorkspaceLayoutDocument,
 	attention: LayoutAttention,
 	tab: LayoutTerminalTab,
 	target: LayoutGroupLocation | undefined,
 	limits: { maxSideGroups: number; maxBottomGroups: number },
+	reveal = true,
 ): LayoutOperationResult {
 	if (target?.area === "center") {
 		const groupId =
 			findCenterGroup(document.center, target.groupId)?.id ??
 			findCenterGroup(document.center, attention.lastFocusedCenterGroupId)?.id ??
 			primaryCenterGroupId(document);
-		return moveTabToGroup(document, tab, { area: "center", groupId });
+		const moved = moveTabToGroup(document, tab, { area: "center", groupId });
+		return !reveal && !isLayoutUnavailable(moved) ? { document: moved.document } : moved;
 	}
-	if (target && findAuxiliaryGroup(document, target.area, target.groupId)) {
-		const moved = moveTabToGroup(document, tab, target);
-		if (isLayoutUnavailable(moved)) return moved;
-		const unfolded = setAuxiliaryGroupFolded(moved.document, target.area, target.groupId, false);
-		if (isLayoutUnavailable(unfolded)) return moved;
-		return {
-			...moved,
-			document: {
-				...unfolded.document,
-				[target.area]: { ...unfolded.document[target.area], visible: true },
-			},
-		};
+	if (target) {
+		const targetGroup = findAuxiliaryGroup(document, target.area, target.groupId);
+		if (targetGroup) {
+			const moved = moveTabToGroup(document, tab, target);
+			if (isLayoutUnavailable(moved)) return moved;
+			if (!reveal) return preservePassiveAuxiliaryPlacement(document, moved, target);
+			const unfolded = setAuxiliaryGroupFolded(moved.document, target.area, target.groupId, false);
+			if (isLayoutUnavailable(unfolded)) return moved;
+			return {
+				...moved,
+				document: {
+					...unfolded.document,
+					[target.area]: { ...unfolded.document[target.area], visible: true },
+				},
+			};
+		}
 	}
 	const preferredId = attention.lastFocusedSideGroupId.bottom;
 	const bottomGroup =
@@ -81,6 +107,12 @@ export function placeTerminalForIntent(
 			groupId: bottomGroup.id,
 		});
 		if (isLayoutUnavailable(moved)) return moved;
+		if (!reveal) {
+			return preservePassiveAuxiliaryPlacement(document, moved, {
+				area: "bottom",
+				groupId: bottomGroup.id,
+			});
+		}
 		return {
 			...moved,
 			document: {
@@ -95,7 +127,14 @@ export function placeTerminalForIntent(
 			},
 		};
 	}
-	return createAuxiliaryGroup(document, "bottom", tab, 0, limits.maxBottomGroups);
+	const created = createAuxiliaryGroup(document, "bottom", tab, 0, limits.maxBottomGroups);
+	if (reveal || isLayoutUnavailable(created)) return created;
+	return {
+		document: {
+			...created.document,
+			bottom: { ...created.document.bottom, visible: document.bottom.visible },
+		},
+	};
 }
 
 export function toLayoutTab(tab: EditorTab): LayoutCenterTab | null {
@@ -147,6 +186,14 @@ export function useLayoutIntentProcessing(
 	);
 	const maxSideGroups = useAppStore((state) => state.layoutSettings.maxSideGroups);
 	const maxBottomGroups = useAppStore((state) => state.layoutSettings.maxBottomGroups);
+	const terminalReservationPending = useAppStore((state) => {
+		if (layoutIntent?.kind !== "place-terminal") return false;
+		return (
+			state.terminalsByWorkspace[workspaceId]?.some(
+				(tab) => tab.tabKey === layoutIntent.tabKey && tab.reservationPending,
+			) ?? false
+		);
+	});
 
 	useEffect(() => {
 		if (!layoutIntent || !document || !attention) return;
@@ -157,6 +204,7 @@ export function useLayoutIntentProcessing(
 		) {
 			return;
 		}
+		if (layoutIntent.kind === "place-terminal" && terminalReservationPending) return;
 		if (
 			layoutIntent.kind === "select" &&
 			layoutIntent.historyRequestId !== undefined &&
@@ -341,10 +389,17 @@ export function useLayoutIntentProcessing(
 				const target = requestedGroupId
 					? { area: requestedArea, groupId: requestedGroupId }
 					: undefined;
-				const placed = placeTerminalForIntent(document, attention, tab, target, {
-					maxSideGroups,
-					maxBottomGroups,
-				});
+				const placed = placeTerminalForIntent(
+					document,
+					attention,
+					tab,
+					target,
+					{
+						maxSideGroups,
+						maxBottomGroups,
+					},
+					layoutIntent.reveal !== false,
+				);
 				if (!isLayoutUnavailable(placed)) result = placed;
 				break;
 			}
@@ -451,6 +506,7 @@ export function useLayoutIntentProcessing(
 		maxBottomGroups,
 		maxSideGroups,
 		requestFocus,
+		terminalReservationPending,
 		workspaceId,
 	]);
 }

--- a/apps/web/src/shell/layoutSync/layoutSync.test.ts
+++ b/apps/web/src/shell/layoutSync/layoutSync.test.ts
@@ -15,7 +15,7 @@ import {
 
 function document(tabId: string): WorkspaceLayoutDocument {
 	return {
-		version: 1,
+		version: 2,
 		center: {
 			kind: "group",
 			id: "center",
@@ -23,6 +23,7 @@ function document(tabId: string): WorkspaceLayoutDocument {
 		},
 		left: { visible: false, width: 0.18, groups: [] },
 		right: { visible: false, width: 0.28, groups: [] },
+		bottom: { visible: false, height: 0.3, alignment: "center", groups: [] },
 		toolRestoreTargets: {},
 	};
 }

--- a/apps/web/src/shell/layoutSync/layoutSync.ts
+++ b/apps/web/src/shell/layoutSync/layoutSync.ts
@@ -11,6 +11,7 @@ import { errorText, getTransport } from "../../transport";
 import {
 	createLayoutId,
 	instantiateLayoutPreset,
+	minimumBottomGroupLimit,
 	minimumSideGroupLimit,
 	reconcileAttention,
 	resolveLayoutPreset,
@@ -90,7 +91,9 @@ function loadAttention(workspaceId: string): LayoutAttention | undefined {
 		if (
 			Object.values(selectedByGroup).some((entry) => typeof entry !== "string") ||
 			Object.entries(lastFocusedSideGroupId).some(
-				([side, entry]) => (side !== "left" && side !== "right") || typeof entry !== "string",
+				([region, entry]) =>
+					(region !== "left" && region !== "right" && region !== "bottom") ||
+					typeof entry !== "string",
 			) ||
 			Object.values(navigationClockByGroup).some(
 				(entry) => !Number.isSafeInteger(entry) || Number(entry) < 0,
@@ -105,7 +108,7 @@ function loadAttention(workspaceId: string): LayoutAttention | undefined {
 			>,
 			lastFocusedCenterGroupId: value.lastFocusedCenterGroupId,
 			lastFocusedSideGroupId: Object.assign(Object.create(null), lastFocusedSideGroupId) as Partial<
-				Record<"left" | "right", string>
+				Record<"left" | "right" | "bottom", string>
 			>,
 			navigationClockByGroup: Object.assign(Object.create(null), navigationClockByGroup) as Record<
 				string,
@@ -265,10 +268,20 @@ export function hydrateWorkspaceLayout(workspaceId: string): Promise<WorkspaceLa
 			}
 			const settings = currentState.layoutSettings;
 			const preset = resolveLayoutPreset(settings.defaultPresetId, settings.customPresets);
-			const requiredLimit = minimumSideGroupLimit(preset);
-			if (requiredLimit > settings.maxSideGroups) {
+			const requiredSideLimit = minimumSideGroupLimit(preset);
+			const requiredBottomLimit = minimumBottomGroupLimit(preset);
+			if (
+				requiredSideLimit > settings.maxSideGroups ||
+				requiredBottomLimit > settings.maxBottomGroups
+			) {
 				await getTransport().request("settings.update", {
-					config: { layout: { ...settings, maxSideGroups: requiredLimit } },
+					config: {
+						layout: {
+							...settings,
+							maxSideGroups: Math.max(settings.maxSideGroups, requiredSideLimit),
+							maxBottomGroups: Math.max(settings.maxBottomGroups, requiredBottomLimit),
+						},
+					},
 				});
 				const afterSettings = useAppStore.getState();
 				if (afterSettings.removedWorkspaceIds[workspaceId]) {

--- a/apps/web/src/shell/terminalReconciliation/SPEC.md
+++ b/apps/web/src/shell/terminalReconciliation/SPEC.md
@@ -25,5 +25,7 @@ and browser-local attention separate from placement.
   restored terminal, direct WS calls, panel rendering, server/shared/pi imports, or treating layout references
   as terminal existence proof.
 
-New attach-pending terminals continue through their explicit placement intents. Remote/catalog restoration
-preserves side visibility and never steals attention.
+New attach-pending terminals continue through their explicit placement intents. A catalog terminal with no
+placement passively restores into the last available bottom group (creating a hidden slot within the bottom
+limit when needed), preserving bottom visibility and never stealing attention. Existing placed terminals,
+including version-1 center/side placements, never move merely because bottom now exists.

--- a/apps/web/src/shell/terminalReconciliation/SPEC.md
+++ b/apps/web/src/shell/terminalReconciliation/SPEC.md
@@ -25,7 +25,8 @@ and browser-local attention separate from placement.
   restored terminal, direct WS calls, panel rendering, server/shared/pi imports, or treating layout references
   as terminal existence proof.
 
-New attach-pending terminals continue through their explicit placement intents. A catalog terminal with no
+New reservation-pending terminals remain behind their explicit placement intents until the host catalog
+confirms them. A catalog terminal with no
 placement passively restores into the last available bottom group (creating a hidden slot within the bottom
 limit when needed), preserving bottom visibility and never stealing attention. Existing placed terminals,
 including version-1 center/side placements, never move merely because bottom now exists.

--- a/apps/web/src/shell/terminalReconciliation/terminalReconciliation.test.ts
+++ b/apps/web/src/shell/terminalReconciliation/terminalReconciliation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import type { LayoutTerminalTab, WorkspaceLayoutDocument } from "@thinkrail/contracts";
+import type { LayoutAttention } from "../../lib";
+import { findTabLocation, toolTab } from "../layout";
+import { placeRecoveredTerminal } from "./terminalReconciliation";
+
+function document(): WorkspaceLayoutDocument {
+	return {
+		version: 2,
+		center: { kind: "group", id: "center", tabs: [] },
+		left: { visible: false, width: 0.18, groups: [] },
+		right: { visible: false, width: 0.28, groups: [] },
+		bottom: {
+			visible: false,
+			height: 0.3,
+			alignment: "center",
+			groups: [
+				{ id: "bottom-one", weight: 0.5, folded: false, tabs: [] },
+				{ id: "bottom-two", weight: 0.5, folded: false, tabs: [toolTab("changes")] },
+			],
+		},
+		toolRestoreTargets: {},
+	};
+}
+
+const attention: LayoutAttention = {
+	selectedByGroup: {},
+	lastFocusedCenterGroupId: "center",
+	lastFocusedSideGroupId: { bottom: "bottom-two" },
+	navigationClockByGroup: { center: 0 },
+};
+
+const terminal: LayoutTerminalTab = {
+	kind: "terminal",
+	id: "terminal:recovered",
+	name: "Recovered",
+	tabKey: "recovered",
+};
+
+describe("recovered terminal placement", () => {
+	test("uses the last-focused surviving bottom group without revealing the region", () => {
+		const result = placeRecoveredTerminal(document(), attention, terminal, 3);
+		expect(findTabLocation(result.document, terminal.id)).toEqual({
+			area: "bottom",
+			groupId: "bottom-two",
+		});
+		expect(result.document.bottom.visible).toBe(false);
+		expect(result.focusGroupId).toBeUndefined();
+	});
+
+	test("creates one hidden structural slot when bottom has no groups", () => {
+		const empty = document();
+		empty.bottom.groups = [];
+		const result = placeRecoveredTerminal(empty, attention, terminal, 1);
+		expect(result.document.bottom.groups).toHaveLength(1);
+		expect(result.document.bottom.groups[0]?.tabs).toEqual([terminal]);
+		expect(result.document.bottom.visible).toBe(false);
+	});
+});

--- a/apps/web/src/shell/terminalReconciliation/terminalReconciliation.ts
+++ b/apps/web/src/shell/terminalReconciliation/terminalReconciliation.ts
@@ -1,10 +1,12 @@
-import type { WorkspaceLayoutDocument } from "@thinkrail/contracts";
+import type { LayoutTerminalTab, WorkspaceLayoutDocument } from "@thinkrail/contracts";
 import { useEffect, useRef } from "react";
+import type { LayoutAttention } from "../../lib";
 import { useTerminalCatalog } from "../../panels/TerminalWorkbench";
 import { type TerminalTab, useAppStore } from "../../store";
 import {
 	closeLayoutTab,
 	collectAllGroups,
+	createAuxiliaryGroup,
 	isLayoutUnavailable,
 	moveTabToGroup,
 	openCenterTab,
@@ -18,10 +20,33 @@ export function terminalLayoutId(tabKey: string): string {
 	return `terminal:${tabKey}`;
 }
 
+export function placeRecoveredTerminal(
+	document: WorkspaceLayoutDocument,
+	attention: LayoutAttention | undefined,
+	tab: LayoutTerminalTab,
+	maxBottomGroups: number,
+): { document: WorkspaceLayoutDocument } {
+	const preferredId = attention?.lastFocusedSideGroupId.bottom;
+	const target =
+		document.bottom.groups.find((group) => group.id === preferredId) ??
+		document.bottom.groups.at(-1);
+	const visible = document.bottom.visible;
+	const placed = target
+		? moveTabToGroup(document, tab, { area: "bottom", groupId: target.id })
+		: createAuxiliaryGroup(document, "bottom", tab, 0, maxBottomGroups);
+	if (isLayoutUnavailable(placed)) return { document };
+	return {
+		document: {
+			...placed.document,
+			bottom: { ...placed.document.bottom, visible },
+		},
+	};
+}
+
 export function useTerminalPlacementReconciliation(
 	workspaceId: string,
 	commit: (document: WorkspaceLayoutDocument) => void,
-): readonly TerminalTab[] {
+): { terminals: readonly TerminalTab[]; catalogReady: boolean } {
 	const document = useAppStore((state) => state.layoutDocumentsByWorkspace[workspaceId]);
 	const status = useAppStore((state) => state.status);
 	const connectionGeneration = useAppStore((state) => state.connectionGeneration);
@@ -31,6 +56,8 @@ export function useTerminalPlacementReconciliation(
 	const pendingLayoutWrites = useAppStore(
 		(state) => state.layoutPendingByWorkspace[workspaceId]?.length ?? 0,
 	);
+	const attention = useAppStore((state) => state.layoutAttentionByWorkspace[workspaceId]);
+	const maxBottomGroups = useAppStore((state) => state.layoutSettings.maxBottomGroups);
 	const terminals = useAppStore((state) => state.terminalsByWorkspace[workspaceId] ?? NO_TERMINALS);
 	const terminalCatalogReady = useTerminalCatalog(workspaceId);
 	const reconciledTerminalCatalog = useRef<{
@@ -90,23 +117,7 @@ export function useTerminalPlacementReconciliation(
 				name: terminal.title,
 				tabKey: terminal.tabKey,
 			});
-			const target = next.right.groups.at(-1);
-			if (target) {
-				const visible = next.right.visible;
-				const moved = moveTabToGroup(next, tab, { area: "right", groupId: target.id });
-				if (!isLayoutUnavailable(moved)) {
-					next = {
-						...moved.document,
-						right: { ...moved.document.right, visible },
-					};
-				}
-			} else {
-				const moved = moveTabToGroup(next, tab, {
-					area: "center",
-					groupId: primaryCenterGroupId(next),
-				});
-				if (!isLayoutUnavailable(moved)) next = moved.document;
-			}
+			next = placeRecoveredTerminal(next, attention, tab, maxBottomGroups).document;
 		}
 		if (next !== document) {
 			commit(next);
@@ -114,10 +125,12 @@ export function useTerminalPlacementReconciliation(
 		}
 		if (attemptedCatalog) reconciledTerminalCatalog.current = attemptedCatalog;
 	}, [
+		attention,
 		commit,
 		connectionGeneration,
 		document,
 		layoutIntent,
+		maxBottomGroups,
 		pendingLayoutWrites,
 		status,
 		terminalCatalogReady,
@@ -125,5 +138,5 @@ export function useTerminalPlacementReconciliation(
 		workspaceId,
 	]);
 
-	return terminals;
+	return { terminals, catalogReady: terminalCatalogReady };
 }

--- a/apps/web/src/shell/terminalReconciliation/terminalReconciliation.ts
+++ b/apps/web/src/shell/terminalReconciliation/terminalReconciliation.ts
@@ -109,7 +109,7 @@ export function useTerminalPlacementReconciliation(
 			if (!isLayoutUnavailable(refreshed)) next = refreshed.document;
 		}
 		const placed = new Set(placedTabs.map((tab) => tab.tabKey));
-		const missing = terminals.filter((tab) => !tab.attachPending && !placed.has(tab.tabKey));
+		const missing = terminals.filter((tab) => !tab.reservationPending && !placed.has(tab.tabKey));
 		for (const terminal of missing) {
 			const tab = withAvailablePlacementId(next, {
 				kind: "terminal" as const,

--- a/apps/web/src/shell/useGlobalHotkeys.test.ts
+++ b/apps/web/src/shell/useGlobalHotkeys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { panelHotkeyCommand } from "./useGlobalHotkeys";
+
+const key = (
+	code: string,
+	overrides: Partial<{
+		ctrlKey: boolean;
+		metaKey: boolean;
+		altKey: boolean;
+		shiftKey: boolean;
+	}> = {},
+) => ({
+	code,
+	ctrlKey: true,
+	metaKey: false,
+	altKey: false,
+	shiftKey: false,
+	...overrides,
+});
+
+const all = { projects: true, workspace: true, bottom: true } as const;
+
+describe("panel hotkey routing", () => {
+	test("keeps the existing physical-key chords and adds Mod+Shift+J for bottom", () => {
+		expect(panelHotkeyCommand(key("KeyB"), all, false, "Linux")).toBe("projects");
+		expect(panelHotkeyCommand(key("KeyJ"), all, false, "Linux")).toBe("workspace");
+		expect(panelHotkeyCommand(key("KeyJ", { shiftKey: true }), all, false, "Linux")).toBe("bottom");
+		expect(
+			panelHotkeyCommand(
+				key("KeyJ", { ctrlKey: false, metaKey: true, shiftKey: true }),
+				all,
+				false,
+				"MacIntel",
+			),
+		).toBe("bottom");
+		expect(panelHotkeyCommand(key("KeyK", { shiftKey: true }), all, false, "Linux")).toBeNull();
+	});
+
+	test("does not claim unavailable workspace commands or any panel chord behind a modal", () => {
+		expect(
+			panelHotkeyCommand(
+				key("KeyJ", { shiftKey: true }),
+				{ projects: true, workspace: false, bottom: false },
+				false,
+				"Linux",
+			),
+		).toBeNull();
+		expect(panelHotkeyCommand(key("KeyB"), all, true, "Linux")).toBeNull();
+		expect(panelHotkeyCommand(key("KeyJ"), all, true, "Linux")).toBeNull();
+		expect(panelHotkeyCommand(key("KeyJ", { shiftKey: true }), all, true, "Linux")).toBeNull();
+	});
+});

--- a/apps/web/src/shell/useGlobalHotkeys.ts
+++ b/apps/web/src/shell/useGlobalHotkeys.ts
@@ -7,7 +7,34 @@ const TERMINAL_ROOT_SELECTOR = ".xterm";
 type GlobalHotkeyActions = {
 	onProjects: () => void;
 	onWorkspace?: () => void;
+	onBottom?: () => void;
 };
+
+type PanelHotkeyCommand = "projects" | "workspace" | "bottom";
+
+type PanelHotkeyAvailability = Record<PanelHotkeyCommand, boolean>;
+
+type PanelHotkeyEvent = Pick<KeyboardEvent, "altKey" | "code" | "ctrlKey" | "metaKey" | "shiftKey">;
+
+export function panelHotkeyCommand(
+	event: PanelHotkeyEvent,
+	available: PanelHotkeyAvailability,
+	modalOpen: boolean,
+	platform?: string,
+): PanelHotkeyCommand | null {
+	if (modalOpen || event.altKey || !hasPlatformModifier(event, platform)) return null;
+	if (!event.shiftKey && event.code === "KeyB" && available.projects) return "projects";
+	if (!event.shiftKey && event.code === "KeyJ" && available.workspace) return "workspace";
+	if (event.shiftKey && event.code === "KeyJ" && available.bottom) return "bottom";
+	return null;
+}
+
+function hasOpenModal(): boolean {
+	return (
+		globalThis.document.querySelector('[aria-modal="true"], [role="dialog"][data-state="open"]') !==
+		null
+	);
+}
 
 function isInTerminal(target: EventTarget | null): boolean {
 	return target instanceof Element && target.closest(TERMINAL_ROOT_SELECTOR) !== null;
@@ -19,17 +46,22 @@ export function useGlobalHotkeys(actions: GlobalHotkeyActions): void {
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
-			const isPanelCommand =
-				!event.altKey &&
-				!event.shiftKey &&
-				hasPlatformModifier(event) &&
-				(event.code === "KeyB" || event.code === "KeyJ");
-			if (isPanelCommand) {
+			const command = panelHotkeyCommand(
+				event,
+				{
+					projects: true,
+					workspace: actionsRef.current.onWorkspace !== undefined,
+					bottom: actionsRef.current.onBottom !== undefined,
+				},
+				hasOpenModal(),
+			);
+			if (command) {
 				event.preventDefault();
 				event.stopPropagation();
 				if (!event.repeat) {
-					if (event.code === "KeyB") actionsRef.current.onProjects();
-					else actionsRef.current.onWorkspace?.();
+					if (command === "projects") actionsRef.current.onProjects();
+					else if (command === "workspace") actionsRef.current.onWorkspace?.();
+					else actionsRef.current.onBottom?.();
 				}
 				return;
 			}

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -117,7 +117,8 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   enter the layout.
 
   **Device-local layout attention** is separate: selected tab per stable group, last-focused center group,
-  last-focused group per side, and per-group navigation clocks keyed by host/workspace. Selection/focus
+  last-focused group per auxiliary region (left/right/bottom), and per-group navigation clocks keyed by
+  host/workspace. Selection/focus
   mutations never alter or publish
   the shared document. Installing a structural snapshot reconciles attention deterministically to the nearest
   surviving tab/group. Navigation clocks advance at request time for every local focus-changing open and
@@ -145,10 +146,11 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   **`terminalsByWorkspace` remains a mirror of terminal domain state, never placement authority.** The host
   owns terminal existence and keys shells by `(workspaceId, tabKey)`; the layout snapshot merely references a
   tab key at one eligible location. `setWorkspaceTerminals` adopts `terminal.list` / `terminal.tabs`, retaining
-  an omitted local tab only while its own attach is genuinely in flight. `addTerminal` mints a durable key
-  and may attach a captured center-group destination to its placement intent (it never edits topology itself),
-  so Group Header creation still works with no terminal body mounted; attach registers the key host-side and
-  consumes any initial command only for a newly created shell. Confirmed
+  an omitted local tab only while its own attach is genuinely in flight. `addTerminal` mints a durable key and
+  emits one placement intent (it never edits topology itself): a captured group destination preserves
+  contextual Group Header creation, while an uncaptured request resolves to bottom. The initial-workspace
+  request may establish a hidden placement without attaching; attach registers the key host-side only when
+  the visibility gate mounts it and consumes any initial command only for a newly created shell. Confirmed
   close removes the domain tab and queues a resource-removal intent; the shell layout integration prunes
   every stale placement through the next whole-document commit. A stale layout reference never reattaches or
   recreates an absent catalog entry. There is no workspace-global

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -146,11 +146,15 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   **`terminalsByWorkspace` remains a mirror of terminal domain state, never placement authority.** The host
   owns terminal existence and keys shells by `(workspaceId, tabKey)`; the layout snapshot merely references a
   tab key at one eligible location. `setWorkspaceTerminals` adopts `terminal.list` / `terminal.tabs`, retaining
-  an omitted local tab only while its own attach is genuinely in flight. `addTerminal` mints a durable key and
-  emits one placement intent (it never edits topology itself): a captured group destination preserves
-  contextual Group Header creation, while an uncaptured request resolves to bottom. The initial-workspace
-  request may establish a hidden placement without attaching; attach registers the key host-side only when
-  the visibility gate mounts it and consumes any initial command only for a newly created shell. Confirmed
+  an omitted local tab only while its host-catalog reservation is in flight. `addTerminal` mints a durable key
+  and emits one placement intent (it never edits topology itself): a captured group destination preserves
+  contextual Group Header creation, while an uncaptured request resolves to bottom. An optional caller key
+  makes the one first-workspace seed idempotent across clients; duplicate local requests for that key are a
+  no-op. The parent shell reserves that key without a process before intent consumption. The initial-workspace
+  request may then establish a hidden placement without revealing, unfolding, or attaching it; attach waits for
+  the visibility gate and
+  consumes any initial command only for a newly created shell. A failed same-generation reservation atomically
+  rejects both the pending mirror and its placement intent. Confirmed
   close removes the domain tab and queues a resource-removal intent; the shell layout integration prunes
   every stale placement through the next whole-document commit. A stale layout reference never reattaches or
   recreates an absent catalog entry. There is no workspace-global
@@ -421,7 +425,8 @@ branch's review — a commit sha means nothing in another worktree — and dropp
   identities from its supplied document + local attention, while host attachment remains exclusive per terminal),
   `selectActiveWorkspaceProjectId`, `selectHistoryTarget` + `HistoryTarget` (the shell's `Ctrl+R` routing
   target: the locally selected chat resource, or the workspace's newest chat otherwise),
-  `selectContextProject`, `selectAttentionCenterTab` (the selected resource in local last center focus),
+  `selectContextProject`, the layout placement selectors (recursive center plus left/right/bottom auxiliary
+  groups), `selectAttentionCenterTab` (the selected resource in local last center focus),
   `selectCurrentRouteChatTarget` (exact-chat intent only while its workspace and stamped navigation remain
   current), `selectSkillsStale`, **`selectDiffScope` + `BRANCH_SCOPE`** (what a workspace's
   Changes panel is diffing, defaulting to the shared branch-scope constant), **`selectDiffBaseRef`** (the ref

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -3035,6 +3035,26 @@ test("terminal creation can capture a center-group destination without creating 
 	expect(state.navTickByWorkspace.w1).toBe(1);
 });
 
+test("terminal creation can target bottom without advancing center navigation", () => {
+	const attention = {
+		selectedByGroup: {},
+		lastFocusedCenterGroupId: "center-a",
+		lastFocusedSideGroupId: { bottom: "bottom-a" },
+		navigationClockByGroup: { "center-a": 2 },
+	};
+	useAppStore.setState({ layoutAttentionByWorkspace: { w1: attention } });
+	useAppStore.getState().addTerminal("w1", undefined, "bottom-b", "bottom");
+	const state = useAppStore.getState();
+	expect(state.layoutIntents[0]).toMatchObject({
+		kind: "place-terminal",
+		workspaceId: "w1",
+		targetGroupId: "bottom-b",
+		targetArea: "bottom",
+	});
+	expect(state.layoutAttentionByWorkspace.w1).toBe(attention);
+	expect(state.navTickByWorkspace.w1).toBeUndefined();
+});
+
 test("catalog authority falls with the list it describes — only an awaited refresh sets it", () => {
 	const s = () => useAppStore.getState();
 	const listed = [{ id: "opus-5", name: "opus-5", provider: "anthropic" }] as WireModel[];

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -95,6 +95,12 @@ const assistantText = (text: string) =>
 			partial: { role: "assistant", content: [{ type: "text", text }] },
 		},
 	}) as unknown as PiEvent;
+const emptyBottomRegion = (): WorkspaceLayoutDocument["bottom"] => ({
+	visible: false,
+	height: 0.3,
+	alignment: "center",
+	groups: [],
+});
 
 beforeEach(() => {
 	useAppStore.setState({
@@ -834,7 +840,7 @@ test("setTitle refreshes shared chat metadata without requesting activation", ()
 		layoutIntents: [],
 		layoutDocumentsByWorkspace: {
 			ws1: {
-				version: 1,
+				version: 2,
 				center: {
 					kind: "group",
 					id: "center",
@@ -842,6 +848,7 @@ test("setTitle refreshes shared chat metadata without requesting activation", ()
 				},
 				left: { visible: false, width: 0.2, groups: [] },
 				right: { visible: false, width: 0.2, groups: [] },
+				bottom: emptyBottomRegion(),
 				toolRestoreTargets: {},
 			},
 		},
@@ -899,10 +906,11 @@ test("setTitle cannot restore a cache whose structural close is already accepted
 		layoutIntents: [],
 		layoutDocumentsByWorkspace: {
 			ws1: {
-				version: 1,
+				version: 2,
 				center: { kind: "group", id: "center", tabs: [] },
 				left: { visible: false, width: 0.2, groups: [] },
 				right: { visible: false, width: 0.2, groups: [] },
+				bottom: emptyBottomRegion(),
 				toolRestoreTargets: {},
 			},
 		},
@@ -1845,10 +1853,11 @@ test("applyWorkspaceRemoved drops the row, clears its tabs, and returns the acti
 	expect(s.reviewFocusRequest).toBeNull();
 
 	const lateDocument: WorkspaceLayoutDocument = {
-		version: 1,
+		version: 2,
 		center: { kind: "group", id: "center", tabs: [] },
 		left: { visible: false, width: 0.2, groups: [] },
 		right: { visible: false, width: 0.2, groups: [] },
+		bottom: emptyBottomRegion(),
 		toolRestoreTargets: {},
 	};
 	s.installLayoutSnapshot({ workspaceId: "w1", revision: 1, document: lateDocument });
@@ -2677,10 +2686,11 @@ test("a preview open replaces the previous preview tab at its index (the strip n
 
 test("hydrated per-group previews never evict one another from the render cache", () => {
 	const document: WorkspaceLayoutDocument = {
-		version: 1,
+		version: 2,
 		center: { kind: "group", id: "center-a", tabs: [] },
 		left: { visible: false, width: 0.18, groups: [] },
 		right: { visible: false, width: 0.28, groups: [] },
+		bottom: emptyBottomRegion(),
 		toolRestoreTargets: {},
 	};
 	useAppStore.setState({ layoutDocumentsByWorkspace: { ws1: document } });
@@ -2874,7 +2884,7 @@ test("history selection resolves a cache alias to its stable shared placement id
 		layoutIntents: [],
 		layoutDocumentsByWorkspace: {
 			ws1: {
-				version: 1,
+				version: 2,
 				center: {
 					kind: "group",
 					id: "history-group",
@@ -2889,6 +2899,7 @@ test("history selection resolves a cache alias to its stable shared placement id
 				},
 				left: { visible: false, width: 0.2, groups: [] },
 				right: { visible: false, width: 0.2, groups: [] },
+				bottom: emptyBottomRegion(),
 				toolRestoreTargets: {},
 			},
 		},
@@ -2929,7 +2940,7 @@ test("history selection never uses a colliding cache id as shared placement iden
 		tabsByWorkspace: { ws1: [{ ...chat, id: collidingId }] },
 		layoutDocumentsByWorkspace: {
 			ws1: {
-				version: 1,
+				version: 2,
 				center: {
 					kind: "split",
 					id: "history-split",
@@ -2946,6 +2957,7 @@ test("history selection never uses a colliding cache id as shared placement iden
 				},
 				left: { visible: false, width: 0.2, groups: [] },
 				right: { visible: false, width: 0.2, groups: [] },
+				bottom: emptyBottomRegion(),
 				toolRestoreTargets: {},
 			},
 		},
@@ -3053,6 +3065,51 @@ test("terminal creation can target bottom without advancing center navigation", 
 	});
 	expect(state.layoutAttentionByWorkspace.w1).toBe(attention);
 	expect(state.navTickByWorkspace.w1).toBeUndefined();
+});
+
+test("the host catalog confirms a reservation while retaining its one-shot command", () => {
+	useAppStore.getState().addTerminal("w1", "code .", "bottom-a", "bottom");
+	const pending = useAppStore.getState().terminalsByWorkspace.w1?.[0];
+	if (!pending) throw new Error("missing pending terminal");
+	expect(pending.reservationPending).toBe(true);
+
+	useAppStore
+		.getState()
+		.setWorkspaceTerminals("w1", [{ tabKey: pending.tabKey, title: "Host title" }]);
+	expect(useAppStore.getState().terminalsByWorkspace.w1).toEqual([
+		{
+			tabKey: pending.tabKey,
+			workspaceId: "w1",
+			title: "Host title",
+			initialCommand: "code .",
+		},
+	]);
+	expect(useAppStore.getState().layoutIntents).toHaveLength(1);
+});
+
+test("hidden terminal seeding stays non-activating, idempotent, and atomically rejectable", () => {
+	useAppStore
+		.getState()
+		.addTerminal("w1", undefined, "bottom-a", "bottom", false, "initial-terminal");
+	useAppStore
+		.getState()
+		.addTerminal("w1", undefined, "bottom-a", "bottom", false, "initial-terminal");
+	const pending = useAppStore.getState().terminalsByWorkspace.w1?.[0];
+	if (!pending) throw new Error("missing pending terminal");
+	expect(useAppStore.getState().terminalsByWorkspace.w1).toHaveLength(1);
+	expect(useAppStore.getState().layoutIntents).toHaveLength(1);
+	expect(useAppStore.getState().layoutIntents[0]).toMatchObject({
+		kind: "place-terminal",
+		workspaceId: "w1",
+		tabKey: pending.tabKey,
+		targetGroupId: "bottom-a",
+		targetArea: "bottom",
+		reveal: false,
+	});
+
+	useAppStore.getState().rejectTerminalReservation("w1", pending.tabKey);
+	expect(useAppStore.getState().terminalsByWorkspace.w1).toEqual([]);
+	expect(useAppStore.getState().layoutIntents).toEqual([]);
 });
 
 test("catalog authority falls with the list it describes — only an awaited refresh sets it", () => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -3,6 +3,7 @@ import type {
 	AskUserQuestionResult,
 	ExtUiRequest,
 	GitDiffScope,
+	LayoutAuxiliaryRegion,
 	LayoutChangedPayload,
 	LayoutSettings,
 	LayoutToolId,
@@ -205,12 +206,14 @@ export type LayoutIntent =
 			tabKey: string;
 			title: string;
 			targetGroupId?: string;
+			targetArea?: "center" | LayoutAuxiliaryRegion;
 			navigation?: CenterNavigationStamp | null;
 			countNavigation?: boolean;
 	  }
 	| { id: string; kind: "close-terminal"; workspaceId: string; tabKey: string }
 	| { id: string; kind: "select-terminal"; workspaceId: string; tabKey: string }
-	| { id: string; kind: "toggle-side"; workspaceId: string; side: "left" | "right" };
+	| { id: string; kind: "toggle-side"; workspaceId: string; side: "left" | "right" }
+	| { id: string; kind: "toggle-bottom"; workspaceId: string };
 export type LayoutIntentInput = LayoutIntent extends infer Intent
 	? Intent extends { id: string }
 		? Omit<Intent, "id">
@@ -730,7 +733,12 @@ interface AppState {
 		loadedTarget: string,
 	) => void;
 	clearWorkspaceTabs: (workspaceId: string) => void;
-	addTerminal: (workspaceId: string, initialCommand?: string, targetGroupId?: string) => void;
+	addTerminal: (
+		workspaceId: string,
+		initialCommand?: string,
+		targetGroupId?: string,
+		targetArea?: "center" | LayoutAuxiliaryRegion,
+	) => void;
 	setWorkspaceTerminals: (workspaceId: string, tabs: TerminalTabInfo[]) => void;
 	settleTerminalAttach: (workspaceId: string, tabKey: string) => void;
 	consumeTerminalInitialCommand: (workspaceId: string, tabKey: string) => void;
@@ -1975,13 +1983,14 @@ export const useAppStore = create<AppState>((set, get) => ({
 				skillsSyncedTickBySession,
 			};
 		}),
-	addTerminal: (workspaceId, initialCommand, targetGroupId) =>
+	addTerminal: (workspaceId, initialCommand, targetGroupId, targetArea = "center") =>
 		set((s) => {
 			if (s.removedWorkspaceIds[workspaceId]) return {};
 			const list = s.terminalsByWorkspace[workspaceId] ?? [];
-			const navigation = targetGroupId
-				? advanceCenterNavigation(s, workspaceId, targetGroupId)
-				: null;
+			const navigation =
+				targetGroupId && targetArea === "center"
+					? advanceCenterNavigation(s, workspaceId, targetGroupId)
+					: null;
 			const tabKey = randomId("terminal");
 			const tab: TerminalTab = {
 				tabKey,
@@ -1997,7 +2006,13 @@ export const useAppStore = create<AppState>((set, get) => ({
 					workspaceId,
 					tabKey,
 					title: tab.title,
-					...(targetGroupId ? { targetGroupId, navigation: navigation?.stamp ?? null } : {}),
+					...(targetGroupId
+						? {
+								targetGroupId,
+								...(targetArea !== "center" ? { targetArea } : {}),
+								...(targetArea === "center" ? { navigation: navigation?.stamp ?? null } : {}),
+							}
+						: {}),
 				}),
 				terminalsByWorkspace: { ...s.terminalsByWorkspace, [workspaceId]: [...list, tab] },
 				activeTerminalByWorkspace: { ...s.activeTerminalByWorkspace, [workspaceId]: tabKey },

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -207,6 +207,7 @@ export type LayoutIntent =
 			title: string;
 			targetGroupId?: string;
 			targetArea?: "center" | LayoutAuxiliaryRegion;
+			reveal?: false;
 			navigation?: CenterNavigationStamp | null;
 			countNavigation?: boolean;
 	  }
@@ -245,7 +246,7 @@ export interface TerminalTab {
 	workspaceId: string;
 	title: string;
 	initialCommand?: string;
-	attachPending?: true;
+	reservationPending?: true;
 }
 
 export interface ClosedChat {
@@ -738,9 +739,12 @@ interface AppState {
 		initialCommand?: string,
 		targetGroupId?: string,
 		targetArea?: "center" | LayoutAuxiliaryRegion,
+		reveal?: boolean,
+		requestedTabKey?: string,
 	) => void;
 	setWorkspaceTerminals: (workspaceId: string, tabs: TerminalTabInfo[]) => void;
-	settleTerminalAttach: (workspaceId: string, tabKey: string) => void;
+	confirmTerminalReservation: (workspaceId: string, tabKey: string) => void;
+	rejectTerminalReservation: (workspaceId: string, tabKey: string) => void;
 	consumeTerminalInitialCommand: (workspaceId: string, tabKey: string) => void;
 	closeTerminalTab: (workspaceId: string, tabKey: string, syncLayout?: boolean) => void;
 	setActiveTerminalTab: (workspaceId: string, tabKey: string, syncLayout?: boolean) => void;
@@ -1983,20 +1987,28 @@ export const useAppStore = create<AppState>((set, get) => ({
 				skillsSyncedTickBySession,
 			};
 		}),
-	addTerminal: (workspaceId, initialCommand, targetGroupId, targetArea = "center") =>
+	addTerminal: (
+		workspaceId,
+		initialCommand,
+		targetGroupId,
+		targetArea = "center",
+		reveal = true,
+		requestedTabKey,
+	) =>
 		set((s) => {
 			if (s.removedWorkspaceIds[workspaceId]) return {};
 			const list = s.terminalsByWorkspace[workspaceId] ?? [];
+			const tabKey = requestedTabKey ?? randomId("terminal");
+			if (list.some((tab) => tab.tabKey === tabKey)) return {};
 			const navigation =
 				targetGroupId && targetArea === "center"
 					? advanceCenterNavigation(s, workspaceId, targetGroupId)
 					: null;
-			const tabKey = randomId("terminal");
 			const tab: TerminalTab = {
 				tabKey,
 				workspaceId,
 				title: nextTerminalTitle(list),
-				attachPending: true,
+				reservationPending: true,
 				...(initialCommand ? { initialCommand } : {}),
 			};
 			return {
@@ -2013,6 +2025,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 								...(targetArea === "center" ? { navigation: navigation?.stamp ?? null } : {}),
 							}
 						: {}),
+					...(reveal ? {} : { reveal: false as const }),
 				}),
 				terminalsByWorkspace: { ...s.terminalsByWorkspace, [workspaceId]: [...list, tab] },
 				activeTerminalByWorkspace: { ...s.activeTerminalByWorkspace, [workspaceId]: tabKey },
@@ -2023,7 +2036,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 			if (s.removedWorkspaceIds[workspaceId]) return {};
 			const local = s.terminalsByWorkspace[workspaceId] ?? [];
 			const known = new Set(tabs.map((tab) => tab.tabKey));
-			const pending = local.filter((tab) => !known.has(tab.tabKey) && tab.attachPending);
+			const pending = local.filter((tab) => !known.has(tab.tabKey) && tab.reservationPending);
 			const merged: TerminalTab[] = [
 				...tabs.map((tab) => {
 					const existing = local.find((candidate) => candidate.tabKey === tab.tabKey);
@@ -2046,20 +2059,41 @@ export const useAppStore = create<AppState>((set, get) => ({
 				},
 			};
 		}),
-	settleTerminalAttach: (workspaceId, tabKey) =>
+	confirmTerminalReservation: (workspaceId, tabKey) =>
 		set((s) => {
 			if (s.removedWorkspaceIds[workspaceId]) return {};
 			const list = s.terminalsByWorkspace[workspaceId] ?? [];
-			if (!list.some((t) => t.tabKey === tabKey && t.attachPending)) return s;
+			if (!list.some((tab) => tab.tabKey === tabKey && tab.reservationPending)) return s;
 			return {
 				terminalsByWorkspace: {
 					...s.terminalsByWorkspace,
-					[workspaceId]: list.map(({ attachPending, ...rest }) =>
+					[workspaceId]: list.map(({ reservationPending, ...rest }) =>
 						rest.tabKey === tabKey
 							? rest
-							: { ...rest, ...(attachPending ? { attachPending } : {}) },
+							: { ...rest, ...(reservationPending ? { reservationPending } : {}) },
 					),
 				},
+			};
+		}),
+	rejectTerminalReservation: (workspaceId, tabKey) =>
+		set((s) => {
+			if (s.removedWorkspaceIds[workspaceId]) return {};
+			const list = s.terminalsByWorkspace[workspaceId] ?? [];
+			if (!list.some((tab) => tab.tabKey === tabKey && tab.reservationPending)) return s;
+			const terminals = list.filter((tab) => tab.tabKey !== tabKey);
+			const active = s.activeTerminalByWorkspace[workspaceId] ?? null;
+			return {
+				terminalsByWorkspace: { ...s.terminalsByWorkspace, [workspaceId]: terminals },
+				activeTerminalByWorkspace: {
+					...s.activeTerminalByWorkspace,
+					[workspaceId]: active === tabKey ? (terminals.at(-1)?.tabKey ?? null) : active,
+				},
+				layoutIntents: s.layoutIntents.filter(
+					(intent) =>
+						intent.kind !== "place-terminal" ||
+						intent.workspaceId !== workspaceId ||
+						intent.tabKey !== tabKey,
+				),
 			};
 		}),
 	consumeTerminalInitialCommand: (workspaceId, tabKey) =>

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -56,9 +56,9 @@ test("workspace kind predicates distinguish managed and user-owned checkouts", (
 	expect(isUserOwnedWorkspace(external)).toBe(true);
 });
 
-test("layout placement lookup traverses recursive center and side groups", () => {
+test("layout placement lookup traverses recursive center and every auxiliary region", () => {
 	const layout: WorkspaceLayoutDocument = {
-		version: 1,
+		version: 2,
 		center: {
 			kind: "split",
 			id: "split",
@@ -83,6 +83,26 @@ test("layout placement lookup traverses recursive center and side groups", () =>
 					weight: 1,
 					folded: false,
 					tabs: [{ kind: "tool", id: "tool:files", name: "Files", tool: "files" }],
+				},
+			],
+		},
+		bottom: {
+			visible: true,
+			height: 0.3,
+			alignment: "center",
+			groups: [
+				{
+					id: "bottom",
+					weight: 1,
+					folded: false,
+					tabs: [
+						{
+							kind: "terminal",
+							id: "bottom-terminal",
+							name: "Terminal 1",
+							tabKey: "terminal-1",
+						},
+					],
 				},
 			],
 		},
@@ -118,6 +138,18 @@ test("layout placement lookup traverses recursive center and side groups", () =>
 		groupId: "b",
 	});
 	expect(selectLayoutTabPlaced(state, "ws", "tool:files")).toBe(true);
+	expect(selectLayoutTabPlacement(state, "ws", "bottom-terminal")).toEqual({
+		area: "bottom",
+		groupId: "bottom",
+	});
+	expect(
+		selectLayoutResourcePlacement(state, "ws", {
+			kind: "terminal",
+			id: "another-placement-id",
+			name: "Terminal",
+			tabKey: "terminal-1",
+		}),
+	).toMatchObject({ area: "bottom", groupId: "bottom", tabId: "bottom-terminal" });
 	expect(selectLayoutTabPlaced(state, "ws", "missing")).toBe(false);
 	expect(selectAttentionCenterTab(state, "ws")?.id).toBe("legacy-file-placement");
 	const cachedResource = state.tabsByWorkspace.ws[0];
@@ -136,7 +168,7 @@ test("layout placement lookup traverses recursive center and side groups", () =>
 
 test("registered documents participate in legacy selection readiness", () => {
 	const layout: WorkspaceLayoutDocument = {
-		version: 1,
+		version: 2,
 		center: {
 			kind: "group",
 			id: "center",
@@ -153,6 +185,7 @@ test("registered documents participate in legacy selection readiness", () => {
 		},
 		left: { visible: false, width: 0.2, groups: [] },
 		right: { visible: false, width: 0.2, groups: [] },
+		bottom: { visible: false, height: 0.3, alignment: "center", groups: [] },
 		toolRestoreTargets: {},
 	};
 	const state = {

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,5 +1,6 @@
 import type {
 	GitDiffScope,
+	LayoutAuxiliaryRegion,
 	LayoutCenterTab,
 	LayoutTab,
 	Project,
@@ -53,7 +54,7 @@ interface ProjectContextState extends ActiveWorkspaceState {
 }
 
 export interface LayoutTabPlacement {
-	area: "center" | "left" | "right";
+	area: "center" | LayoutAuxiliaryRegion;
 	groupId: string;
 }
 
@@ -73,10 +74,10 @@ function findLayoutPlacement(
 	};
 	const center = findCenter(document.center);
 	if (center) return center;
-	for (const side of ["left", "right"] as const) {
-		for (const group of document[side].groups) {
+	for (const region of ["left", "right", "bottom"] as const) {
+		for (const group of document[region].groups) {
 			const tab = group.tabs.find(matches);
-			if (tab) return { area: side, groupId: group.id, tabId: tab.id, tab };
+			if (tab) return { area: region, groupId: group.id, tabId: tab.id, tab };
 		}
 	}
 	return null;

--- a/apps/website/SPEC.md
+++ b/apps/website/SPEC.md
@@ -68,7 +68,7 @@ binary.
   parameterized: `website` on the landing, `blog` on blog pages, each with the matching
   `workspace/<name> · from main` branch label), the left project rail, the right files rail +
   terminal, the status bar, and the `main.ts` script import; the center column is its default slot
-  and the right rail's All-files rows its `filetree` slot. The left rail carries the site's real
+  and the right rail's Files rows its `filetree` slot. The left rail carries the site's real
   navigation as child rows of the `website` workspace — **Landing** (`/`) and **Blog** (`/blog/`,
   selected on the index and on every article) as links, **Docs** disabled with a `Coming soon` chip
   (no tooltip — the tag carries the state) — while the remaining mock rows keep the
@@ -257,7 +257,7 @@ The `/blog` subsite is a typed Astro content collection over Markdown posts in `
   rule — deliberately *not* the `.file-section` class, whose typography cascade would fight the blog
   content styles). Opening an article replaces the index in that same central area. **No tab strip on
   blog pages** (the landing keeps its section tabs; page-level Landing/Blog tabs were explicitly
-  rejected for now). The right rail's All-files list shows the published articles (current one
+  rejected for now). The right rail's Files list shows the published articles (current one
   active); the terminal keeps its static install transcript — `main.ts` guards make every
   landing-only enhancement inert (no sections → no scroll-spy, no picker → no terminal replay).
   Post cards are whole-card links that signal hover on the border alone (no underline, no movement)

--- a/apps/website/src/components/IdeShell.astro
+++ b/apps/website/src/components/IdeShell.astro
@@ -302,7 +302,7 @@ const { workspace, nav, skipHref } = Astro.props;
 		<aside class="rail-right" id="rail-right" aria-label="Files and terminal">
 			<div class="rail-tabs" data-mock-hint="Want the real thing?" data-mock-label="Files and terminal tabs — a static mock">
 				<span class="rail-tab dim" title="In the app: the worktree's spec graph">Specs</span>
-				<span class="rail-tab active">All files</span>
+				<span class="rail-tab active">Files</span>
 				<span class="rail-tab dim" title="In the app: the live git diff">Changes</span>
 				<span class="rail-tab dim" title="In the app: run hooks">Hooks</span>
 			</div>

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -193,7 +193,7 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 							<p>The VS Code editor engine: syntax everywhere, rendered markdown with a source toggle, file tabs per workspace.</p>
 						</div>
 						<div class="feature-card">
-							<h3><svg class="i" aria-hidden="true"><use href="#i-folder-tree" /></svg> All-files tree</h3>
+							<h3><svg class="i" aria-hidden="true"><use href="#i-folder-tree" /></svg> Files tree</h3>
 							<p>The active worktree at a glance — like the rail on the right of this very page.</p>
 						</div>
 						<div class="feature-card">

--- a/architecture.md
+++ b/architecture.md
@@ -131,7 +131,9 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
     mouse reporting and OSC 8 working.
 
 12. **A shell belongs to a tab, and the host owns the mapping.** Terminals are keyed by
-    `(workspaceId, tabKey)` and reached through one idempotent `terminal.attach`; the client keeps no
+    `(workspaceId, tabKey)`; `terminal.reserve` may durably establish the catalog tab without a process, while
+    one idempotent `terminal.attach` remains the only way its PTY is born. This separation lets a synchronized
+    hidden default placement survive reload and another client without starting a shell. The client keeps no
     tab→shell pointer of its own. Shells are **owner-scoped**, matching `history`/`todos`/`templates`, so
     they survive a reload, a closed browser and a different browser — attach is exclusive, and taking a tab
     over notifies the displaced client. Lifetime is bounded by reference (no tab → no shell) plus the host

--- a/architecture.md
+++ b/architecture.md
@@ -92,8 +92,10 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    bottom explicitly and migrates known version-1 documents to hidden/empty bottom without moving a resource;
    a generic region map was rejected as an unnecessary rewrite of stable side contracts, while a separate
    bottom snapshot would make cross-region moves non-atomic. A migrated snapshot is reported at revision 2
-   or later, keeping revision 1 exclusive to a newly created version-2 layout so default-terminal seeding can
-   never mistake an old workspace for a new one. Valid full snapshots converge by monotonic revision, but
+   or later, so revision 1 identifies a first persisted version-2 layout—but not the age of its workspace.
+   Default-terminal seeding additionally requires the host-owned `Workspace.initialTerminalEligible` marker,
+   written only when a workspace record is first created; legacy records are never backfilled. Valid full
+   snapshots converge by monotonic revision, but
    replacement is optimistic-concurrency guarded: a client names its exact accepted revision
    (or create-only absence), and a stale full replacement conflicts with the current snapshot instead of
    making the last arrival win. Left/right/bottom visibility, folds, extents, and bottom alignment are

--- a/architecture.md
+++ b/architecture.md
@@ -91,8 +91,10 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    tab order, preview identities, folds/visibility, and normalized geometry. Layout schema version 2 adds
    bottom explicitly and migrates known version-1 documents to hidden/empty bottom without moving a resource;
    a generic region map was rejected as an unnecessary rewrite of stable side contracts, while a separate
-   bottom snapshot would make cross-region moves non-atomic. Valid full snapshots converge by monotonic
-   revision, but replacement is optimistic-concurrency guarded: a client names its exact accepted revision
+   bottom snapshot would make cross-region moves non-atomic. A migrated snapshot is reported at revision 2
+   or later, keeping revision 1 exclusive to a newly created version-2 layout so default-terminal seeding can
+   never mistake an old workspace for a new one. Valid full snapshots converge by monotonic revision, but
+   replacement is optimistic-concurrency guarded: a client names its exact accepted revision
    (or create-only absence), and a stale full replacement conflicts with the current snapshot instead of
    making the last arrival win. Left/right/bottom visibility, folds, extents, and bottom alignment are
    structural; this remains placement only, never resource lifetime. *Attention and drafts* — selected tab per

--- a/architecture.md
+++ b/architecture.md
@@ -134,9 +134,10 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
 
 12. **A shell belongs to a tab, and the host owns the mapping.** Terminals are keyed by
     `(workspaceId, tabKey)`; `terminal.reserve` may durably establish the catalog tab without a process, while
-    one idempotent `terminal.attach` remains the only way its PTY is born. This separation lets a synchronized
-    hidden default placement survive reload and another client without starting a shell. The client keeps no
-    tab→shell pointer of its own. Shells are **owner-scoped**, matching `history`/`todos`/`templates`, so
+    one idempotent `terminal.attach` remains the only way its PTY is born. Reservation persists before
+    publishing membership and rolls back its in-memory insertion if persistence fails. This separation lets a
+    synchronized hidden default placement survive reload and another client without starting a shell. The
+    client keeps no tab→shell pointer of its own. Shells are **owner-scoped**, matching `history`/`todos`/`templates`, so
     they survive a reload, a closed browser and a different browser — attach is exclusive, and taking a tab
     over notifies the displaced client. Lifetime is bounded by reference (no tab → no shell) plus the host
     process, **not** by timers: no idle culling, no abandoned-client reap. A host restart cannot preserve

--- a/architecture.md
+++ b/architecture.md
@@ -56,10 +56,11 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
    is keyed by backend profile so ids from one host are never interpreted against another.
 5. **UI = panels + shell.** Layout-agnostic, store-driven panels (project→workspace nav, file tree,
    Monaco editor, changes/diff, workspace-local review, terminal, chat, composer) never know their
-   arrangement. The desktop shell owns a host-synchronized IDE workbench: a recursively split center plus
-   vertically stacked side groups, with terminal tabs eligible in either domain. A future mobile shell may
-   project the same panels differently; desktop docking does not define that projection. Detail:
-   [[submodule-web-shell-layout]].
+   arrangement. The desktop shell owns one host-synchronized IDE workbench: a recursively split center plus
+   auxiliary groups in vertical left/right stacks and a horizontally grouped bottom region with synchronized
+   height/alignment. Singleton tools move among auxiliary regions; terminals may also occupy center, with new
+   workspaces defaulting one terminal to bottom. A future mobile shell may project the same panels differently;
+   desktop docking does not define that projection. Detail: [[submodule-web-shell-layout]].
 6. **Workspaces are git worktrees (V1).** project (git repo) → workspace (`git worktree` on its own
    branch/cwd, under `~/.thinkrail/worktrees`) → {chats, files, terminals}. **Two deliberate
    exceptions, both `kind`-marked on the wire and both *user-owned* — never renamed or reclaimed by
@@ -86,12 +87,16 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
 9. **Domain state, shared placement, and local attention.** *Domain* state — projects, workspaces,
    **sessions + their transcripts**, terminals, git — is backend-owned, shared, and persistent; every
    client hydrates it from the host. Workspace **placement state is deliberately shared too**: one
-   versioned host document owns center/side topology, open resource references, tab order, preview
-   identities, folds/visibility, and normalized geometry. Valid full snapshots converge by monotonic
+   versioned host document owns center plus left/right/bottom auxiliary topology, open resource references,
+   tab order, preview identities, folds/visibility, and normalized geometry. Layout schema version 2 adds
+   bottom explicitly and migrates known version-1 documents to hidden/empty bottom without moving a resource;
+   a generic region map was rejected as an unnecessary rewrite of stable side contracts, while a separate
+   bottom snapshot would make cross-region moves non-atomic. Valid full snapshots converge by monotonic
    revision, but replacement is optimistic-concurrency guarded: a client names its exact accepted revision
    (or create-only absence), and a stale full replacement conflicts with the current snapshot instead of
-   making the last arrival win. That is placement only, never resource lifetime. *Attention and
-   drafts* — selected tab per group, last-focused group, uncommitted pointer/resize drafts, composer drafts — remain
+   making the last arrival win. Left/right/bottom visibility, folds, extents, and bottom alignment are
+   structural; this remains placement only, never resource lifetime. *Attention and drafts* — selected tab per
+   group, last-focused group, uncommitted pointer/resize drafts, composer drafts — remain
    per-client (ephemeral or local reload persistence), so one browser cannot steal another's focus. The active
    client location is likewise local: one backend-relative route names main / Project Home / workspace / exact
    chat; web stores it in a versioned fragment, while later native shells persist it per backend profile and

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -92,8 +92,9 @@ one indistinguishable card.
 
 The bottom-workbench scenarios exercise the integrated layout-v2 path rather than only the pure model: first
 seeding and process-free hidden reservation, transactional-failure retry after reconnect, reload survival
-before attach, all four alignments, live alignment during side resizing and narrow-width compression,
-independent height/group resizing, 27 px folding with `Ctrl+F6` restore focus, modal-aware visibility chords,
+before attach, all four alignments with real side-stack ownership of excluded lower corners, live alignment
+during side resizing and narrow-width compression, vacated bottom-group cleanup, independent height/group
+resizing, 27 px folding with `Ctrl+F6` restore focus, modal-aware visibility chords,
 PTY continuity while hidden, peer synchronization, and version-1 migration without terminal creation.
 
 ## Isolation contract

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -93,8 +93,9 @@ one indistinguishable card.
 The bottom-workbench scenarios exercise the integrated layout-v2 path rather than only the pure model: first
 seeding and process-free hidden reservation, transactional-failure retry after reconnect, reload survival
 before attach, all four alignments with real side-stack ownership of excluded lower corners, live alignment
-during side resizing and narrow-width compression, vacated bottom-group cleanup, independent height/group
-resizing, 27 px folding with `Ctrl+F6` restore focus, modal-aware visibility chords,
+during side resizing and narrow-width compression, pointer/keyboard persistence of only the separator-owned
+side ratio, vacated bottom-group cleanup with center-focus recovery beside a surviving empty slot, independent
+height/group resizing, 27 px folding with `Ctrl+F6` restore focus, modal-aware visibility chords,
 PTY continuity while hidden, peer synchronization, and version-1 migration without terminal creation.
 
 ## Isolation contract

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -91,8 +91,9 @@ scenarios are a finding, not a defect: they are how the suite shows two distinct
 one indistinguishable card.
 
 The bottom-workbench scenarios exercise the integrated layout-v2 path rather than only the pure model: first
-seeding and process-free hidden reservation, transactional-failure retry after reconnect, reload survival
-before attach, all four alignments with real side-stack ownership of excluded lower corners, live alignment
+seeding and process-free hidden reservation, a legacy layoutless workspace without the host creation marker
+remaining terminal-free, transactional-failure retry after reconnect, reload survival before attach, all four
+alignments with real side-stack ownership of excluded lower corners, live alignment
 during side resizing and narrow-width compression, pointer/keyboard persistence of only the separator-owned
 side ratio, vacated bottom-group cleanup with center-focus recovery beside a surviving empty slot, independent
 height/group resizing, 27 px folding with `Ctrl+F6` restore focus, modal-aware visibility chords,

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -90,11 +90,20 @@ assertion — a state that only a picture would catch is a missing `data-testid`
 scenarios are a finding, not a defect: they are how the suite shows two distinct host situations rendering
 one indistinguishable card.
 
+The bottom-workbench scenarios exercise the integrated layout-v2 path rather than only the pure model: first
+seeding and process-free hidden reservation, reload survival before attach, all four alignments, independent
+height/group resizing, 27 px folding with `Ctrl+F6` restore focus, local narrow-viewport compression,
+modal-aware visibility chords, PTY continuity while hidden, peer synchronization, and version-1 migration
+without terminal creation.
+
 ## Isolation contract
 
 Every concurrent lane derives a distinct data dir, HOME, pi-agent dir, fixture repository, binary cache,
 restart artifacts, picker/editor/provider control files, host/restart/binary ports, and Central fixture
-artifacts. Port allocation remains stable and collision-safe across worktrees: the registry claim distinguishes
+artifacts. The lane's fake executable directory lives under `.bun/bin`: this intentionally marks the injected,
+hermetic host `PATH` as complete to `resolveShellEnv()`, preventing login-shell repair from replacing the
+Central/editor stubs with developer-machine executables. Port allocation remains stable and collision-safe
+across worktrees: the registry claim distinguishes
 a lane's logical key while checking staleness against the real worktree path. Legacy plain-path claims are
 still valid.
 

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -91,10 +91,10 @@ scenarios are a finding, not a defect: they are how the suite shows two distinct
 one indistinguishable card.
 
 The bottom-workbench scenarios exercise the integrated layout-v2 path rather than only the pure model: first
-seeding and process-free hidden reservation, reload survival before attach, all four alignments, independent
-height/group resizing, 27 px folding with `Ctrl+F6` restore focus, local narrow-viewport compression,
-modal-aware visibility chords, PTY continuity while hidden, peer synchronization, and version-1 migration
-without terminal creation.
+seeding and process-free hidden reservation, transactional-failure retry after reconnect, reload survival
+before attach, all four alignments, live alignment during side resizing and narrow-width compression,
+independent height/group resizing, 27 px folding with `Ctrl+F6` restore focus, modal-aware visibility chords,
+PTY continuity while hidden, peer synchronization, and version-1 migration without terminal creation.
 
 ## Isolation contract
 

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -288,6 +288,23 @@ test("bottom height, all alignments, and keyboard resizing persist across reload
 	const left = page.getByTestId("left-stack");
 	const right = page.getByTestId("right-stack");
 	await expectHorizontalSpan(bottom, center, center);
+	const alignmentButton = page.getByRole("button", { name: "Bottom panel alignment" });
+	await alignmentButton.focus();
+	await page.keyboard.press("Enter");
+	await expect(
+		page.getByRole("menuitemradio", { name: "Below center", exact: true }),
+	).toBeFocused();
+	await page.keyboard.press("ArrowDown");
+	await expect(
+		page.getByRole("menuitemradio", { name: "Below center and left", exact: true }),
+	).toBeFocused();
+	await page.keyboard.press("Enter");
+	await waitForLayoutSettled(page);
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute(
+		"data-alignment",
+		"center-left",
+	);
+	await setBottomAlignment(page, "Below center");
 	const before = await size(bottom, "height");
 	const handle = page.getByTestId("resize-bottom");
 	const handleBox = await handle.boundingBox();
@@ -358,6 +375,7 @@ test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and en
 
 	await first.getByTestId("bottom-group-fold").click();
 	await expect(first).toHaveAttribute("data-folded", "true");
+	await expect(first.getByTestId("bottom-group-restore")).toBeFocused();
 	expect(await size(first, "width")).toBeCloseTo(27, 0);
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
 	await second.getByRole("tab", { name: "Changes" }).focus();
@@ -365,6 +383,7 @@ test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and en
 	await expect(first.getByTestId("bottom-group-restore")).toBeFocused();
 	await page.keyboard.press("Space");
 	await expect(first).toHaveAttribute("data-folded", "false");
+	await expect(first.getByRole("tab", { name: "Terminal 1" })).toBeFocused();
 	await waitTerminalReady(page);
 
 	await page.getByTestId("tab-files").click({ button: "right" });
@@ -472,7 +491,7 @@ test("a stored version-1 layout migrates with its tools untouched and no termina
 		join(directory, `${fileId}.json`),
 		`${JSON.stringify({
 			workspaceId: workspace.id,
-			revision: 7,
+			revision: 1,
 			document: {
 				version: 1,
 				center: { kind: "group", id: "legacy-center", tabs: [] },
@@ -527,7 +546,7 @@ test("a stored version-1 layout migrates with its tools untouched and no termina
 		revision: number;
 		document: { version: number; bottom: { visible: boolean; groups: unknown[] } };
 	}>(page, "layout.get", { workspaceId: workspace.id });
-	expect(migrated.revision).toBe(7);
+	expect(migrated.revision).toBe(2);
 	expect(migrated.document.version).toBe(2);
 	expect(migrated.document.bottom).toMatchObject({ visible: false, groups: [] });
 
@@ -538,7 +557,7 @@ test("a stored version-1 layout migrates with its tools untouched and no termina
 		revision: number;
 		document: { bottom: { visible: boolean; groups: unknown[] } };
 	}>(page, "layout.get", { workspaceId: workspace.id });
-	expect(installed.revision).toBeGreaterThanOrEqual(7);
+	expect(installed.revision).toBeGreaterThanOrEqual(2);
 	expect(installed.document.bottom).toMatchObject({ visible: false, groups: [] });
 	await expect(page.getByTestId("left-nav")).toContainText("Projects");
 	await expect(page.getByTestId("right-stack")).toContainText("Specs");

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -60,6 +60,23 @@ async function expectHorizontalSpan(surface: Locator, start: Locator, end: Locat
 		.toBeLessThan(4);
 }
 
+async function expectVerticalSpan(surface: Locator, start: Locator, end: Locator): Promise<void> {
+	await expect
+		.poll(async () => {
+			const [surfaceBox, startBox, endBox] = await Promise.all([
+				surface.boundingBox(),
+				start.boundingBox(),
+				end.boundingBox(),
+			]);
+			if (!surfaceBox || !startBox || !endBox) return Number.POSITIVE_INFINITY;
+			return Math.max(
+				Math.abs(surfaceBox.y - startBox.y),
+				Math.abs(surfaceBox.y + surfaceBox.height - (endBox.y + endBox.height)),
+			);
+		})
+		.toBeLessThan(4);
+}
+
 async function dragHandle(page: Page, handle: Locator, x: number, y: number): Promise<void> {
 	const box = await handle.boundingBox();
 	if (!box) throw new Error("resize handle has no bounding box");
@@ -425,6 +442,48 @@ test("bottom height, all alignments, and keyboard resizing persist across reload
 	await expectHorizontalSpan(page.getByTestId("bottom-panel"), left, center);
 });
 
+test("bottom alignments give excluded lower corners to the actual side panels", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	const workbench = page.getByTestId("workbench");
+	const center = page.getByTestId("center-tabs");
+	const left = page.getByTestId("left-stack");
+	const right = page.getByTestId("right-stack");
+
+	const cases = [
+		{ name: "Below center", leftOwnsCorner: true, rightOwnsCorner: true },
+		{ name: "Below center and left", leftOwnsCorner: false, rightOwnsCorner: true },
+		{ name: "Below center and right", leftOwnsCorner: true, rightOwnsCorner: false },
+		{ name: "Full width", leftOwnsCorner: false, rightOwnsCorner: false },
+	];
+	for (const alignment of cases) {
+		await setBottomAlignment(page, alignment.name);
+		await expectVerticalSpan(
+			left,
+			alignment.leftOwnsCorner ? workbench : center,
+			alignment.leftOwnsCorner ? workbench : center,
+		);
+		await expectVerticalSpan(
+			right,
+			alignment.rightOwnsCorner ? workbench : center,
+			alignment.rightOwnsCorner ? workbench : center,
+		);
+		await pressPlatformShortcut(page, "Shift+j");
+		await expectVerticalSpan(
+			left,
+			alignment.leftOwnsCorner ? workbench : center,
+			alignment.leftOwnsCorner ? workbench : center,
+		);
+		await expectVerticalSpan(
+			right,
+			alignment.rightOwnsCorner ? workbench : center,
+			alignment.rightOwnsCorner ? workbench : center,
+		);
+		await pressPlatformShortcut(page, "Shift+j");
+	}
+});
+
 test("bottom alignments follow locally compressed side geometry at narrow widths", async ({
 	page,
 }) => {
@@ -482,6 +541,16 @@ test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and en
 	await expect(bottomGroups(page)).toHaveCount(2);
 	await expect(bottomGroups(page).nth(0)).toContainText("Terminal 1");
 	await expect(bottomGroups(page).nth(1)).toContainText("Changes");
+
+	await page.getByTestId("tab-changes").click({ button: "right" });
+	await page.getByRole("menuitem", { name: /Move to bottom group/ }).click();
+	await waitForLayoutSettled(page);
+	await expect(bottomGroups(page)).toHaveCount(1);
+	await expect(bottomGroups(page).nth(0)).toContainText("Terminal 1");
+	await expect(bottomGroups(page).nth(0)).toContainText("Changes");
+	await page.getByTestId("tab-changes").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "New bottom group at right", exact: true }).click();
+	await expect(bottomGroups(page)).toHaveCount(2);
 
 	const first = bottomGroups(page).nth(0);
 	const second = bottomGroups(page).nth(1);

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -722,7 +722,7 @@ test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and en
 	await page.getByTestId("tab-files").click({ button: "right" });
 	await page.getByRole("menuitem", { name: "New bottom group at left", exact: true }).click();
 	await expect(bottomGroups(page)).toHaveCount(3);
-	await expect(bottomGroups(page).nth(0)).toContainText("All files");
+	await expect(bottomGroups(page).nth(0)).toContainText("Files");
 	await page.getByTestId("tab-specs").click({ button: "right" });
 	await expect(
 		page.getByRole("menuitem", { name: /New bottom group at left — limited to 3/ }),
@@ -894,6 +894,8 @@ test("a stored version-1 layout migrates with its tools untouched and no termina
 	expect(installed.document.bottom).toMatchObject({ visible: false, groups: [] });
 	await expect(page.getByTestId("left-nav")).toContainText("Projects");
 	await expect(page.getByTestId("right-stack")).toContainText("Specs");
+	await expect(page.getByTestId("tab-files")).toContainText("Files");
+	await expect(page.getByTestId("tab-files")).not.toContainText("All files");
 	await expect(page.getByTestId("right-stack")).toContainText("Changes");
 	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(0);

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import type { WorkspaceLayoutSnapshot } from "@thinkrail/contracts";
@@ -324,6 +324,36 @@ test("a hidden default reserves one synchronized terminal placement without atta
 	await page.getByRole("button", { name: "Show bottom panel" }).click();
 	await waitTerminalReady(page);
 	await expect(bottomGroups(page).getByTestId("terminal-tab")).toHaveCount(1);
+});
+
+test("a legacy layoutless workspace does not gain a default terminal", async ({ page }) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceWithoutOpening(page);
+	const workspaceFile = join(E2E_DATA_DIR, "workspaces.json");
+	const records = JSON.parse(readFileSync(workspaceFile, "utf8")) as Array<Record<string, unknown>>;
+	const legacyRecord = records.find((candidate) => candidate.id === workspace.id);
+	if (!legacyRecord) throw new Error("created workspace record is missing");
+	delete legacyRecord.initialTerminalEligible;
+	writeFileSync(workspaceFile, `${JSON.stringify(records, null, "\t")}\n`);
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await revealFirstProjectWorkspaces(page);
+	const workspaceRow = page.getByTestId("workspace-item").filter({ hasText: workspace.name });
+	await expect(workspaceRow).toBeVisible();
+	await workspaceRow.getByRole("button").first().click();
+	await expect(page.getByTestId("workspace-workbench")).toHaveAttribute(
+		"data-layout-status",
+		"settled",
+	);
+	await expect(page.getByTestId("bottom-new-terminal")).toBeVisible();
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(0);
+	const catalog = await requestOverWire<{ tabs: Array<{ tabKey: string }> }>(
+		page,
+		"terminal.list",
+		{ workspaceId: workspace.id },
+	);
+	expect(catalog.tabs).toEqual([]);
 });
 
 test("a failed default reservation retries after reconnect without duplicating the terminal", async ({

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -43,18 +43,18 @@ async function size(locator: Locator, axis: "height" | "width"): Promise<number>
 	return box[axis];
 }
 
-async function expectBottomSpan(page: Page, start: Locator, end: Locator): Promise<void> {
+async function expectHorizontalSpan(surface: Locator, start: Locator, end: Locator): Promise<void> {
 	await expect
 		.poll(async () => {
-			const [bottomBox, startBox, endBox] = await Promise.all([
-				page.getByTestId("bottom-panel").boundingBox(),
+			const [surfaceBox, startBox, endBox] = await Promise.all([
+				surface.boundingBox(),
 				start.boundingBox(),
 				end.boundingBox(),
 			]);
-			if (!bottomBox || !startBox || !endBox) return Number.POSITIVE_INFINITY;
+			if (!surfaceBox || !startBox || !endBox) return Number.POSITIVE_INFINITY;
 			return Math.max(
-				Math.abs(bottomBox.x - startBox.x),
-				Math.abs(bottomBox.x + bottomBox.width - (endBox.x + endBox.width)),
+				Math.abs(surfaceBox.x - startBox.x),
+				Math.abs(surfaceBox.x + surfaceBox.width - (endBox.x + endBox.width)),
 			);
 		})
 		.toBeLessThan(4);
@@ -76,6 +76,7 @@ function bottomGroups(page: Page): Locator {
 async function setBottomAlignment(page: Page, name: string): Promise<void> {
 	await page.getByRole("button", { name: "Bottom panel alignment" }).click();
 	await page.getByRole("menuitemradio", { name, exact: true }).click();
+	await waitForLayoutSettled(page);
 }
 
 async function requestOverWire<T>(
@@ -176,6 +177,80 @@ test("a new workspace starts with one accessible terminal group in a 30% bottom 
 	await expect(page.getByTestId("tab-changes").getByRole("tab")).toBeFocused();
 });
 
+test("a hidden default reserves one synchronized terminal placement without attaching until shown", async ({
+	page,
+	context,
+}) => {
+	await openDefaultWorkbench(page);
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-layout").click();
+	const focusPreset = page.getByTestId("layout-preset").filter({ hasText: "Focus" });
+	await focusPreset.getByRole("button", { name: "Set default" }).click();
+	await expect(focusPreset.getByText("Default", { exact: true })).toBeVisible();
+	await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+
+	const workspace = await createWorkspaceWithoutOpening(page);
+	const peer = await context.newPage();
+	await peer.goto("/");
+	await expect(peer.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await revealFirstProjectWorkspaces(peer);
+	const workspaceRow = page.getByTestId("workspace-item").filter({ hasText: workspace.name });
+	const peerWorkspaceRow = peer.getByTestId("workspace-item").filter({ hasText: workspace.name });
+	await expect(workspaceRow).toBeVisible();
+	await expect(peerWorkspaceRow).toBeVisible();
+	await Promise.all([
+		workspaceRow.getByRole("button").first().click(),
+		peerWorkspaceRow.getByRole("button").first().click(),
+	]);
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(peer.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
+	await expect(peer.getByTestId("terminal-instance")).toHaveCount(0);
+	await expect
+		.poll(async () => {
+			const [layout, catalog] = await Promise.all([
+				requestOverWire<{
+					document: {
+						bottom: {
+							visible: boolean;
+							groups: Array<{ tabs: Array<{ kind: string; tabKey?: string }> }>;
+						};
+					};
+				}>(page, "layout.get", { workspaceId: workspace.id }),
+				requestOverWire<{ tabs: Array<{ tabKey: string }> }>(page, "terminal.list", {
+					workspaceId: workspace.id,
+				}),
+			]);
+			const placements = layout.document.bottom.groups
+				.flatMap((group) => group.tabs)
+				.filter((tab) => tab.kind === "terminal");
+			return {
+				visible: layout.document.bottom.visible,
+				placementCount: placements.length,
+				catalogCount: catalog.tabs.length,
+				sameKey:
+					typeof placements[0]?.tabKey === "string" &&
+					placements[0]?.tabKey === catalog.tabs[0]?.tabKey,
+			};
+		})
+		.toEqual({ visible: false, placementCount: 1, catalogCount: 1, sameKey: true });
+
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-layout").click();
+	const balancedPreset = page.getByTestId("layout-preset").filter({ hasText: "Balanced" });
+	await balancedPreset.getByRole("button", { name: "Set default" }).click();
+	await expect(balancedPreset.getByText("Default", { exact: true })).toBeVisible();
+	await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+	await peer.close();
+
+	await page.reload();
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
+	await page.getByRole("button", { name: "Show bottom panel" }).click();
+	await waitTerminalReady(page);
+	await expect(bottomGroups(page).getByTestId("terminal-tab")).toHaveCount(1);
+});
+
 test("Mod+Shift+J works from xterm, preserves its PTY through hide and reload, and is modal-aware", async ({
 	page,
 }) => {
@@ -212,7 +287,7 @@ test("bottom height, all alignments, and keyboard resizing persist across reload
 	const center = page.getByTestId("center-tabs");
 	const left = page.getByTestId("left-stack");
 	const right = page.getByTestId("right-stack");
-	await expectBottomSpan(page, center, center);
+	await expectHorizontalSpan(bottom, center, center);
 	const before = await size(bottom, "height");
 	const handle = page.getByTestId("resize-bottom");
 	const handleBox = await handle.boundingBox();
@@ -226,16 +301,16 @@ test("bottom height, all alignments, and keyboard resizing persist across reload
 		"data-alignment",
 		"center-left",
 	);
-	await expectBottomSpan(page, left, center);
+	await expectHorizontalSpan(bottom, left, center);
 	await setBottomAlignment(page, "Below center and right");
 	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute(
 		"data-alignment",
 		"center-right",
 	);
-	await expectBottomSpan(page, center, right);
+	await expectHorizontalSpan(bottom, center, right);
 	await setBottomAlignment(page, "Full width");
 	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "full");
-	await expectBottomSpan(page, left, right);
+	await expectHorizontalSpan(bottom, left, right);
 	await setBottomAlignment(page, "Below center and left");
 
 	await reloadDefaultWorkbench(page);
@@ -254,6 +329,11 @@ test("bottom height, all alignments, and keyboard resizing persist across reload
 	await expect
 		.poll(() => size(page.getByTestId("bottom-panel"), "height"))
 		.toBeGreaterThan(keyboardBefore);
+
+	await pressPlatformShortcut(page, "Shift+j");
+	await expectHorizontalSpan(page.getByTestId("bottom-layout-rail"), left, center);
+	await pressPlatformShortcut(page, "Shift+j");
+	await expectHorizontalSpan(page.getByTestId("bottom-panel"), left, center);
 });
 
 test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and enforce their own limit", async ({
@@ -267,6 +347,7 @@ test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and en
 	await expect(bottomGroups(page).nth(1)).toContainText("Changes");
 
 	const first = bottomGroups(page).nth(0);
+	const second = bottomGroups(page).nth(1);
 	const firstBefore = await size(first, "width");
 	const groupHandle = page.getByTestId("bottom-group-resize");
 	await expect(groupHandle).toHaveAttribute("aria-orientation", "vertical");
@@ -279,7 +360,9 @@ test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and en
 	await expect(first).toHaveAttribute("data-folded", "true");
 	expect(await size(first, "width")).toBeCloseTo(27, 0);
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
-	await first.getByTestId("bottom-group-restore").focus();
+	await second.getByRole("tab", { name: "Changes" }).focus();
+	await page.keyboard.press("Control+Shift+F6");
+	await expect(first.getByTestId("bottom-group-restore")).toBeFocused();
 	await page.keyboard.press("Space");
 	await expect(first).toHaveAttribute("data-folded", "false");
 	await waitTerminalReady(page);
@@ -463,6 +546,12 @@ test("a stored version-1 layout migrates with its tools untouched and no termina
 	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(0);
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
+	const emptyCatalog = await requestOverWire<{ tabs: Array<{ tabKey: string }> }>(
+		page,
+		"terminal.list",
+		{ workspaceId: workspace.id },
+	);
+	expect(emptyCatalog.tabs).toEqual([]);
 
 	await page.getByRole("button", { name: "Show bottom panel" }).click();
 	await expect(bottomGroups(page)).toHaveCount(1);

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Locator, type Page, test } from "@playwright/test";
+import type { WorkspaceLayoutSnapshot } from "@thinkrail/contracts";
 import {
 	defaultWorkspaceRow,
 	enterDefaultWorkspace,
@@ -127,6 +128,63 @@ async function requestOverWire<T>(
 		},
 		{ requestMethod: method, requestParams: params },
 	) as Promise<T>;
+}
+
+function activeWorkspaceId(page: Page): string {
+	const encodedWorkspaceId = new URL(page.url()).hash.match(/\/workspaces\/([^/]+)/)?.[1];
+	if (!encodedWorkspaceId) throw new Error("active workspace route is missing");
+	return decodeURIComponent(encodedWorkspaceId);
+}
+
+async function readActiveSideWidths(page: Page): Promise<{ left: number; right: number }> {
+	const snapshot = await requestOverWire<WorkspaceLayoutSnapshot>(page, "layout.get", {
+		workspaceId: activeWorkspaceId(page),
+	});
+	return { left: snapshot.document.left.width, right: snapshot.document.right.width };
+}
+
+async function readLocalSideWidths(page: Page): Promise<{ left: number; right: number }> {
+	const [workbench, left, right] = await Promise.all([
+		page.getByTestId("workbench").boundingBox(),
+		page.getByTestId("left-stack").boundingBox(),
+		page.getByTestId("right-stack").boundingBox(),
+	]);
+	if (!workbench || !left || !right) throw new Error("visible workbench sides are missing");
+	return { left: left.width / workbench.width, right: right.width / workbench.width };
+}
+
+async function replaceActiveSideWidths(page: Page, left: number, right: number): Promise<void> {
+	const workspaceId = activeWorkspaceId(page);
+	const snapshot = await requestOverWire<WorkspaceLayoutSnapshot>(page, "layout.get", {
+		workspaceId,
+	});
+	const result = await requestOverWire<{ status: "accepted" | "conflict" }>(
+		page,
+		"layout.replace",
+		{
+			workspaceId,
+			mutationId: `bottom-side-widths-${Date.now()}-${Math.random()}`,
+			expectedRevision: snapshot.revision,
+			document: {
+				...snapshot.document,
+				left: { ...snapshot.document.left, width: left },
+				right: { ...snapshot.document.right, width: right },
+			},
+		},
+	);
+	expect(result.status).toBe("accepted");
+	await expect
+		.poll(async () => {
+			const widths = await readActiveSideWidths(page);
+			return Math.max(Math.abs(widths.left - left), Math.abs(widths.right - right));
+		})
+		.toBeLessThan(1e-8);
+	await expect
+		.poll(async () => {
+			const widths = await readLocalSideWidths(page);
+			return Math.max(Math.abs(widths.left - left), Math.abs(widths.right - right));
+		})
+		.toBeLessThan(0.005);
 }
 
 async function createWorkspaceWithoutOpening(page: Page): Promise<{ id: string; name: string }> {
@@ -500,6 +558,92 @@ test("bottom alignments follow locally compressed side geometry at narrow widths
 	await expectHorizontalSpan(bottom, left, center);
 	await setBottomAlignment(page, "Below center and right");
 	await expectHorizontalSpan(bottom, center, right);
+});
+
+test("narrow side resizing persists only the side whose separator moved", async ({ page }) => {
+	await openDefaultWorkbench(page);
+	const cases = [
+		{ alignment: "Full width", side: "left", input: "pointer" },
+		{ alignment: "Full width", side: "right", input: "keyboard" },
+		{ alignment: "Below center", side: "left", input: "keyboard" },
+		{ alignment: "Below center", side: "right", input: "pointer" },
+	] as const;
+	for (const scenario of cases) {
+		await page.setViewportSize({ width: 1200, height: 844 });
+		await setBottomAlignment(page, scenario.alignment);
+		await replaceActiveSideWidths(page, 0.18, 0.28);
+		const durableBefore = await readActiveSideWidths(page);
+		await page.setViewportSize({ width: 500, height: 844 });
+		await expect
+			.poll(async () => {
+				const local = await readLocalSideWidths(page);
+				return Math.max(
+					Math.abs(local.left - durableBefore.left),
+					Math.abs(local.right - durableBefore.right),
+				);
+			})
+			.toBeGreaterThan(0.005);
+		const untouched = scenario.side === "left" ? "right" : "left";
+		const handle = page.getByTestId(`resize-${scenario.side}`);
+		if (scenario.input === "keyboard") {
+			await handle.focus();
+			await page.keyboard.press(scenario.side === "left" ? "ArrowLeft" : "ArrowRight");
+		} else {
+			const handleBox = await handle.boundingBox();
+			if (!handleBox) throw new Error(`${scenario.side} resize handle has no bounding box`);
+			await dragHandle(
+				page,
+				handle,
+				handleBox.x + (scenario.side === "left" ? -20 : 20),
+				handleBox.y,
+			);
+		}
+		await expect
+			.poll(async () =>
+				Math.abs((await readActiveSideWidths(page))[scenario.side] - durableBefore[scenario.side]),
+			)
+			.toBeGreaterThan(0.001);
+		const durableAfter = await readActiveSideWidths(page);
+		expect(durableAfter[untouched]).toBeCloseTo(durableBefore[untouched], 8);
+	}
+});
+
+test("closing the final populated bottom group focuses center when an empty slot survives", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	const workspaceId = activeWorkspaceId(page);
+	const snapshot = await requestOverWire<WorkspaceLayoutSnapshot>(page, "layout.get", {
+		workspaceId,
+	});
+	const replaced = await requestOverWire<{ status: "accepted" | "conflict" }>(
+		page,
+		"layout.replace",
+		{
+			workspaceId,
+			mutationId: `bottom-empty-focus-${Date.now()}`,
+			expectedRevision: snapshot.revision,
+			document: {
+				...snapshot.document,
+				bottom: {
+					...snapshot.document.bottom,
+					groups: [
+						{ id: "e2e-intentional-empty", weight: 0.5, folded: false, tabs: [] },
+						...snapshot.document.bottom.groups.map((group) => ({
+							...group,
+							weight: 0.5 / snapshot.document.bottom.groups.length,
+						})),
+					],
+				},
+			},
+		},
+	);
+	expect(replaced.status).toBe("accepted");
+	await expect(bottomGroups(page)).toHaveCount(2);
+
+	await page.getByTestId("terminal-tab-close").click();
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("center-group")).toBeFocused();
 });
 
 test("bottom alignments follow side geometry while a resize gesture is in progress", async ({

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -1,0 +1,471 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import {
+	defaultWorkspaceRow,
+	enterDefaultWorkspace,
+	openFixtureProject,
+	pressPlatformShortcut,
+	revealFirstProjectWorkspaces,
+	runInTerminal,
+	visibleTerminal,
+	visibleTerminalScreen,
+	waitTerminalReady,
+} from "./fixtures/app";
+import { E2E_DATA_DIR } from "./fixtures/paths";
+
+async function openDefaultWorkbench(page: Page): Promise<void> {
+	await openFixtureProject(page);
+	await enterDefaultWorkspace(page);
+	await waitTerminalReady(page);
+	await expect(page.getByTestId("workspace-workbench")).toHaveAttribute(
+		"data-layout-status",
+		"settled",
+	);
+}
+
+async function reloadDefaultWorkbench(page: Page): Promise<void> {
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(page.getByTestId("center-tabs")).toBeVisible();
+}
+
+async function waitForLayoutSettled(page: Page): Promise<void> {
+	await expect(page.getByTestId("workspace-workbench")).toHaveAttribute(
+		"data-layout-status",
+		"settled",
+	);
+}
+
+async function size(locator: Locator, axis: "height" | "width"): Promise<number> {
+	const box = await locator.boundingBox();
+	if (!box) throw new Error("element has no bounding box");
+	return box[axis];
+}
+
+async function expectBottomSpan(page: Page, start: Locator, end: Locator): Promise<void> {
+	await expect
+		.poll(async () => {
+			const [bottomBox, startBox, endBox] = await Promise.all([
+				page.getByTestId("bottom-panel").boundingBox(),
+				start.boundingBox(),
+				end.boundingBox(),
+			]);
+			if (!bottomBox || !startBox || !endBox) return Number.POSITIVE_INFINITY;
+			return Math.max(
+				Math.abs(bottomBox.x - startBox.x),
+				Math.abs(bottomBox.x + bottomBox.width - (endBox.x + endBox.width)),
+			);
+		})
+		.toBeLessThan(4);
+}
+
+async function dragHandle(page: Page, handle: Locator, x: number, y: number): Promise<void> {
+	const box = await handle.boundingBox();
+	if (!box) throw new Error("resize handle has no bounding box");
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(x, y, { steps: 12 });
+	await page.mouse.up();
+}
+
+function bottomGroups(page: Page): Locator {
+	return page.getByTestId("bottom-group");
+}
+
+async function setBottomAlignment(page: Page, name: string): Promise<void> {
+	await page.getByRole("button", { name: "Bottom panel alignment" }).click();
+	await page.getByRole("menuitemradio", { name, exact: true }).click();
+}
+
+async function requestOverWire<T>(
+	page: Page,
+	method: string,
+	params: Record<string, unknown>,
+): Promise<T> {
+	return page.evaluate(
+		async ({ requestMethod, requestParams }) => {
+			const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+			const socket = new WebSocket(`${protocol}//${location.host}/ws`);
+			await new Promise<void>((resolve) => {
+				socket.onopen = () => resolve();
+			});
+			const id = `bottom_${Math.random()}`;
+			const result = await new Promise<unknown>((resolve, reject) => {
+				socket.addEventListener("message", (event: MessageEvent<string>) => {
+					const message = JSON.parse(event.data) as {
+						id?: string;
+						result?: unknown;
+						error?: { message?: string };
+					};
+					if (message.id !== id) return;
+					if (message.error) reject(new Error(message.error.message ?? "request failed"));
+					else resolve(message.result);
+				});
+				socket.send(JSON.stringify({ id, method: requestMethod, params: requestParams }));
+			});
+			socket.close();
+			return result;
+		},
+		{ requestMethod: method, requestParams: params },
+	) as Promise<T>;
+}
+
+async function createWorkspaceWithoutOpening(page: Page): Promise<{ id: string; name: string }> {
+	return page.evaluate(async () => {
+		const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+		const socket = new WebSocket(`${protocol}//${location.host}/ws`);
+		await new Promise<void>((resolve) => {
+			socket.onopen = () => resolve();
+		});
+		const request = <T>(method: string, params: unknown) =>
+			new Promise<T>((resolve, reject) => {
+				const id = `bottom_${Math.random()}`;
+				const listener = (event: MessageEvent<string>) => {
+					const message = JSON.parse(event.data) as {
+						id?: string;
+						result?: T;
+						error?: { message?: string };
+					};
+					if (message.id !== id) return;
+					socket.removeEventListener("message", listener);
+					if (message.error) reject(new Error(message.error.message ?? "request failed"));
+					else resolve(message.result as T);
+				};
+				socket.addEventListener("message", listener);
+				socket.send(JSON.stringify({ id, method, params }));
+			});
+		const projects = await request<{ id: string }[]>("project.list", {});
+		const project = projects[0];
+		if (!project) throw new Error("fixture project is not open");
+		const workspace = await request<{ id: string; name: string }>("workspace.create", {
+			projectId: project.id,
+			name: `legacy-layout-${Date.now()}`,
+		});
+		socket.close();
+		return workspace;
+	});
+}
+
+test("a new workspace starts with one accessible terminal group in a 30% bottom panel", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+
+	const workbench = page.getByTestId("workbench");
+	const bottom = page.getByTestId("bottom-panel");
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "center");
+	await expect(bottomGroups(page)).toHaveCount(1);
+	await expect(bottomGroups(page).getByTestId("terminal-tab")).toHaveCount(1);
+	await expect(bottom.getByRole("tablist")).toHaveCount(1);
+	const terminalTab = bottom.getByRole("tab", { name: /Terminal 1/ });
+	await expect(terminalTab).toHaveAttribute("aria-selected", "true");
+	const terminalTabId = await terminalTab.getAttribute("id");
+	if (!terminalTabId) throw new Error("bottom terminal tab has no id");
+	await expect(bottom.getByRole("tabpanel")).toHaveAttribute("aria-labelledby", terminalTabId);
+	await expect(page.getByTestId("resize-bottom")).toHaveAttribute("role", "separator");
+	await expect(page.getByTestId("resize-bottom")).toHaveAttribute("aria-orientation", "horizontal");
+	await expect
+		.poll(async () => (await size(bottom, "height")) / (await size(workbench, "height")))
+		.toBeCloseTo(0.3, 1);
+
+	await page.getByTestId("tab-changes").getByRole("tab").focus();
+	await page.keyboard.press("Control+F6");
+	await expect(bottom.getByRole("tab", { name: /Terminal 1/ })).toBeFocused();
+	await page.keyboard.press("Control+Shift+F6");
+	await expect(page.getByTestId("tab-changes").getByRole("tab")).toBeFocused();
+});
+
+test("Mod+Shift+J works from xterm, preserves its PTY through hide and reload, and is modal-aware", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	const marker = "bottom-panel-running-marker";
+	await runInTerminal(page, `printf '${marker}\\n'`);
+	await expect(visibleTerminalScreen(page)).toContainText(marker);
+
+	await visibleTerminal(page).locator(".xterm-helper-textarea").focus();
+	await pressPlatformShortcut(page, "Shift+j");
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
+
+	await reloadDefaultWorkbench(page);
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await pressPlatformShortcut(page, "Shift+j");
+	await waitTerminalReady(page);
+	await expect(visibleTerminalScreen(page)).toContainText(marker);
+
+	await page.getByTestId("open-settings").click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await pressPlatformShortcut(page, "Shift+j");
+	await expect(page.getByTestId("bottom-panel")).toBeVisible();
+	await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
+	await pressPlatformShortcut(page, "Shift+j");
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+});
+
+test("bottom height, all alignments, and keyboard resizing persist across reload", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	const bottom = page.getByTestId("bottom-panel");
+	const center = page.getByTestId("center-tabs");
+	const left = page.getByTestId("left-stack");
+	const right = page.getByTestId("right-stack");
+	await expectBottomSpan(page, center, center);
+	const before = await size(bottom, "height");
+	const handle = page.getByTestId("resize-bottom");
+	const handleBox = await handle.boundingBox();
+	if (!handleBox) throw new Error("bottom resize handle has no bounding box");
+	await dragHandle(page, handle, handleBox.x, handleBox.y - 90);
+	await expect.poll(() => size(bottom, "height")).toBeGreaterThan(before + 55);
+	const resized = await size(bottom, "height");
+
+	await setBottomAlignment(page, "Below center and left");
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute(
+		"data-alignment",
+		"center-left",
+	);
+	await expectBottomSpan(page, left, center);
+	await setBottomAlignment(page, "Below center and right");
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute(
+		"data-alignment",
+		"center-right",
+	);
+	await expectBottomSpan(page, center, right);
+	await setBottomAlignment(page, "Full width");
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "full");
+	await expectBottomSpan(page, left, right);
+	await setBottomAlignment(page, "Below center and left");
+
+	await reloadDefaultWorkbench(page);
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute(
+		"data-alignment",
+		"center-left",
+	);
+	await expect
+		.poll(async () => Math.abs((await size(page.getByTestId("bottom-panel"), "height")) - resized))
+		.toBeLessThan(24);
+
+	const persistedHandle = page.getByTestId("resize-bottom");
+	const keyboardBefore = await size(page.getByTestId("bottom-panel"), "height");
+	await persistedHandle.focus();
+	await page.keyboard.press("ArrowUp");
+	await expect
+		.poll(() => size(page.getByTestId("bottom-panel"), "height"))
+		.toBeGreaterThan(keyboardBefore);
+});
+
+test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and enforce their own limit", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	await page.getByTestId("tab-changes").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "New bottom group at right", exact: true }).click();
+	await expect(bottomGroups(page)).toHaveCount(2);
+	await expect(bottomGroups(page).nth(0)).toContainText("Terminal 1");
+	await expect(bottomGroups(page).nth(1)).toContainText("Changes");
+
+	const first = bottomGroups(page).nth(0);
+	const firstBefore = await size(first, "width");
+	const groupHandle = page.getByTestId("bottom-group-resize");
+	await expect(groupHandle).toHaveAttribute("aria-orientation", "vertical");
+	const groupHandleBox = await groupHandle.boundingBox();
+	if (!groupHandleBox) throw new Error("bottom group resize handle has no bounding box");
+	await dragHandle(page, groupHandle, groupHandleBox.x + 90, groupHandleBox.y);
+	await expect.poll(() => size(first, "width")).toBeGreaterThan(firstBefore + 50);
+
+	await first.getByTestId("bottom-group-fold").click();
+	await expect(first).toHaveAttribute("data-folded", "true");
+	expect(await size(first, "width")).toBeCloseTo(27, 0);
+	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
+	await first.getByTestId("bottom-group-restore").focus();
+	await page.keyboard.press("Space");
+	await expect(first).toHaveAttribute("data-folded", "false");
+	await waitTerminalReady(page);
+
+	await page.getByTestId("tab-files").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "New bottom group at left", exact: true }).click();
+	await expect(bottomGroups(page)).toHaveCount(3);
+	await expect(bottomGroups(page).nth(0)).toContainText("All files");
+	await page.getByTestId("tab-specs").click({ button: "right" });
+	await expect(
+		page.getByRole("menuitem", { name: /New bottom group at left — limited to 3/ }),
+	).toBeDisabled();
+	await expect(
+		page.getByRole("menuitem", { name: /New bottom group at right — limited to 3/ }),
+	).toBeDisabled();
+});
+
+test("a narrow viewport locally compresses bottom groups without rewriting their topology", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	await page.getByTestId("tab-changes").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "New bottom group at right", exact: true }).click();
+	await waitForLayoutSettled(page);
+	await page.getByTestId("tab-files").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "New bottom group at right", exact: true }).click();
+	await waitForLayoutSettled(page);
+	await expect(bottomGroups(page)).toHaveCount(3);
+	const groupIds = await bottomGroups(page).evaluateAll((groups) =>
+		groups.map((group) => group.getAttribute("data-group-id")),
+	);
+	await setBottomAlignment(page, "Full width");
+	await waitForLayoutSettled(page);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect(bottomGroups(page)).toHaveCount(3);
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "full");
+	const rowBox = await page.getByTestId("bottom-aligned-row").boundingBox();
+	if (!rowBox) throw new Error("bottom row has no bounding box");
+	for (const group of await bottomGroups(page).all()) {
+		const groupBox = await group.boundingBox();
+		if (!groupBox) throw new Error("bottom group has no bounding box");
+		expect(groupBox.width).toBeGreaterThan(0);
+		expect(groupBox.x).toBeGreaterThanOrEqual(rowBox.x - 1);
+		expect(groupBox.x + groupBox.width).toBeLessThanOrEqual(rowBox.x + rowBox.width + 1);
+	}
+	expect(
+		await bottomGroups(page).evaluateAll((groups) => groups.map((group) => group.dataset.folded)),
+	).toEqual(["false", "false", "false"]);
+	await expect
+		.poll(() =>
+			bottomGroups(page).evaluateAll((groups) =>
+				groups.map((group) => group.getAttribute("data-group-id")),
+			),
+		)
+		.toEqual(groupIds);
+
+	await reloadDefaultWorkbench(page);
+	await expect(bottomGroups(page)).toHaveCount(3);
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "full");
+	await expect
+		.poll(() =>
+			bottomGroups(page).evaluateAll((groups) =>
+				groups.map((group) => group.getAttribute("data-group-id")),
+			),
+		)
+		.toEqual(groupIds);
+});
+
+test("bottom visibility and alignment synchronize across clients while reload keeps the topology", async ({
+	page,
+	context,
+}) => {
+	await openDefaultWorkbench(page);
+	const peer = await context.newPage();
+	await peer.goto("/");
+	await expect(peer.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await revealFirstProjectWorkspaces(peer);
+	await defaultWorkspaceRow(peer).getByRole("button").first().click();
+	await expect(peer.getByTestId("bottom-panel")).toBeVisible();
+
+	await setBottomAlignment(page, "Full width");
+	await expect(peer.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "full");
+	await pressPlatformShortcut(page, "Shift+j");
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(peer.getByTestId("bottom-layout-rail")).toBeVisible();
+
+	await pressPlatformShortcut(peer, "Shift+j");
+	await expect(page.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "full");
+	await expect(peer.getByTestId("bottom-panel")).toBeVisible();
+	await peer.reload();
+	await expect(peer.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "full");
+	await peer.close();
+});
+
+test("a stored version-1 layout migrates with its tools untouched and no terminal process started", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceWithoutOpening(page);
+	const fileId = /^[A-Za-z0-9_-]+$/.test(workspace.id)
+		? workspace.id
+		: `~${Buffer.from(workspace.id).toString("base64url")}`;
+	const directory = join(E2E_DATA_DIR, "layouts");
+	mkdirSync(directory, { recursive: true });
+	writeFileSync(
+		join(directory, `${fileId}.json`),
+		`${JSON.stringify({
+			workspaceId: workspace.id,
+			revision: 7,
+			document: {
+				version: 1,
+				center: { kind: "group", id: "legacy-center", tabs: [] },
+				left: {
+					visible: true,
+					width: 0.18,
+					groups: [
+						{
+							id: "legacy-left",
+							weight: 1,
+							folded: false,
+							tabs: [
+								{
+									kind: "tool",
+									id: "tool:projects",
+									name: "Projects",
+									tool: "projects",
+								},
+							],
+						},
+					],
+				},
+				right: {
+					visible: true,
+					width: 0.28,
+					groups: [
+						{
+							id: "legacy-right-top",
+							weight: 0.5,
+							folded: false,
+							tabs: [
+								{ kind: "tool", id: "tool:specs", name: "Specs", tool: "specs" },
+								{ kind: "tool", id: "tool:files", name: "All files", tool: "files" },
+							],
+						},
+						{
+							id: "legacy-right-bottom",
+							weight: 0.5,
+							folded: false,
+							tabs: [
+								{ kind: "tool", id: "tool:changes", name: "Changes", tool: "changes" },
+								{ kind: "tool", id: "tool:review", name: "Review", tool: "review" },
+							],
+						},
+					],
+				},
+				toolRestoreTargets: { changes: { side: "right", index: 1 } },
+			},
+		})}\n`,
+	);
+	const migrated = await requestOverWire<{
+		revision: number;
+		document: { version: number; bottom: { visible: boolean; groups: unknown[] } };
+	}>(page, "layout.get", { workspaceId: workspace.id });
+	expect(migrated.revision).toBe(7);
+	expect(migrated.document.version).toBe(2);
+	expect(migrated.document.bottom).toMatchObject({ visible: false, groups: [] });
+
+	const workspaceRow = page.getByTestId("workspace-item").filter({ hasText: workspace.name });
+	await expect(workspaceRow).toBeVisible();
+	await workspaceRow.getByRole("button").first().click();
+	const installed = await requestOverWire<{
+		revision: number;
+		document: { bottom: { visible: boolean; groups: unknown[] } };
+	}>(page, "layout.get", { workspaceId: workspace.id });
+	expect(installed.revision).toBeGreaterThanOrEqual(7);
+	expect(installed.document.bottom).toMatchObject({ visible: false, groups: [] });
+	await expect(page.getByTestId("left-nav")).toContainText("Projects");
+	await expect(page.getByTestId("right-stack")).toContainText("Specs");
+	await expect(page.getByTestId("right-stack")).toContainText("Changes");
+	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(0);
+	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
+
+	await page.getByRole("button", { name: "Show bottom panel" }).click();
+	await expect(bottomGroups(page)).toHaveCount(1);
+	await waitTerminalReady(page);
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
+});

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import {
@@ -251,6 +251,78 @@ test("a hidden default reserves one synchronized terminal placement without atta
 	await expect(bottomGroups(page).getByTestId("terminal-tab")).toHaveCount(1);
 });
 
+test("a failed default reservation retries after reconnect without duplicating the terminal", async ({
+	page,
+	context,
+}) => {
+	await page.addInitScript(() => {
+		const NativeWebSocket = window.WebSocket;
+		const sockets = new Set<WebSocket>();
+		Object.defineProperty(window, "__thinkrailBottomSockets", {
+			configurable: true,
+			value: sockets,
+		});
+		class TrackedWebSocket extends NativeWebSocket {
+			constructor(url: string | URL, protocols?: string | string[]) {
+				super(url, protocols);
+				sockets.add(this);
+				this.addEventListener("close", () => sockets.delete(this));
+			}
+		}
+		window.WebSocket = TrackedWebSocket;
+	});
+	await page.reload();
+	await openDefaultWorkbench(page);
+	const workspace = await createWorkspaceWithoutOpening(page);
+	const terminalFile = join(E2E_DATA_DIR, "terminals.json");
+	const savedTerminalFile = join(E2E_DATA_DIR, "terminals.before-bottom-retry.json");
+	if (!existsSync(terminalFile)) throw new Error("terminal catalog fixture was not persisted");
+	if (existsSync(savedTerminalFile)) rmSync(savedTerminalFile, { recursive: true, force: true });
+	await waitForLayoutSettled(page);
+	const workspaceRow = page.getByTestId("workspace-item").filter({ hasText: workspace.name });
+	try {
+		renameSync(terminalFile, savedTerminalFile);
+		mkdirSync(terminalFile);
+		await workspaceRow.getByRole("button").first().click();
+		await expect(
+			page.getByTestId("toast").getByText("Couldn't create the terminal", { exact: true }),
+		).toBeVisible();
+		await expect(page.getByTestId("terminal-tab")).toHaveCount(0);
+		const failedCatalog = await requestOverWire<{ tabs: Array<{ tabKey: string }> }>(
+			page,
+			"terminal.list",
+			{ workspaceId: workspace.id },
+		);
+		expect(failedCatalog.tabs).toEqual([]);
+	} finally {
+		rmSync(terminalFile, { recursive: true, force: true });
+		if (existsSync(savedTerminalFile)) renameSync(savedTerminalFile, terminalFile);
+	}
+
+	await context.setOffline(true);
+	await page.evaluate(() => {
+		const sockets = Object.getOwnPropertyDescriptor(window, "__thinkrailBottomSockets")?.value;
+		if (!(sockets instanceof Set)) return;
+		for (const socket of sockets) {
+			if (socket instanceof WebSocket) socket.close();
+		}
+	});
+	await expect(page.getByTestId("connection-status")).toHaveAttribute(
+		"data-status",
+		"disconnected",
+	);
+	await context.setOffline(false);
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await waitTerminalReady(page);
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
+	const recoveredCatalog = await requestOverWire<{ tabs: Array<{ tabKey: string }> }>(
+		page,
+		"terminal.list",
+		{ workspaceId: workspace.id },
+	);
+	expect(recoveredCatalog.tabs).toHaveLength(1);
+});
+
 test("Mod+Shift+J works from xterm, preserves its PTY through hide and reload, and is modal-aware", async ({
 	page,
 }) => {
@@ -351,6 +423,54 @@ test("bottom height, all alignments, and keyboard resizing persist across reload
 	await expectHorizontalSpan(page.getByTestId("bottom-layout-rail"), left, center);
 	await pressPlatformShortcut(page, "Shift+j");
 	await expectHorizontalSpan(page.getByTestId("bottom-panel"), left, center);
+});
+
+test("bottom alignments follow locally compressed side geometry at narrow widths", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	await page.setViewportSize({ width: 390, height: 844 });
+	const bottom = page.getByTestId("bottom-panel");
+	const center = page.getByTestId("center-tabs");
+	const left = page.getByTestId("left-stack");
+	const right = page.getByTestId("right-stack");
+
+	await setBottomAlignment(page, "Below center");
+	await expectHorizontalSpan(bottom, center, center);
+	await setBottomAlignment(page, "Below center and left");
+	await expectHorizontalSpan(bottom, left, center);
+	await setBottomAlignment(page, "Below center and right");
+	await expectHorizontalSpan(bottom, center, right);
+});
+
+test("bottom alignments follow side geometry while a resize gesture is in progress", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	const bottom = page.getByTestId("bottom-panel");
+	const center = page.getByTestId("center-tabs");
+	const left = page.getByTestId("left-stack");
+	const right = page.getByTestId("right-stack");
+	const handle = page.getByTestId("resize-left");
+	const cases: Array<{ name: string; start: Locator; end: Locator; offset: number }> = [
+		{ name: "Below center", start: center, end: center, offset: 60 },
+		{ name: "Below center and left", start: left, end: center, offset: -50 },
+		{ name: "Below center and right", start: center, end: right, offset: 50 },
+	];
+
+	for (const alignment of cases) {
+		await setBottomAlignment(page, alignment.name);
+		const handleBox = await handle.boundingBox();
+		if (!handleBox) throw new Error("left resize handle has no bounding box");
+		const x = handleBox.x + handleBox.width / 2;
+		const y = handleBox.y + handleBox.height / 2;
+		await page.mouse.move(x, y);
+		await page.mouse.down();
+		await page.mouse.move(x + alignment.offset, y, { steps: 8 });
+		await expectHorizontalSpan(bottom, alignment.start, alignment.end);
+		await page.mouse.up();
+		await waitForLayoutSettled(page);
+	}
 });
 
 test("bottom groups arrange left-to-right, resize, fold to 27px, restore, and enforce their own limit", async ({

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
 
-test("shows files and compacts single-directory runs in the All-files tree", async ({ page }) => {
+test("shows files and compacts single-directory runs in the Files tree", async ({ page }) => {
 	await openFixtureProject(page);
 
 	const workspace = await createWorkspaceViaDialog(page);

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -209,7 +209,10 @@ export async function waitTerminalReady(page: Page): Promise<void> {
 }
 
 export async function openTerminal(page: Page): Promise<void> {
+	const tabs = page.getByTestId("terminal-tab");
+	const previousCount = await tabs.count();
 	await page.getByTestId("terminal-add").click();
+	await expect(tabs).toHaveCount(previousCount + 1);
 	await waitTerminalReady(page);
 }
 

--- a/e2e/fixtures/paths.ts
+++ b/e2e/fixtures/paths.ts
@@ -57,7 +57,7 @@ export const E2E_DATA_DIR = join(tmpdir(), `thinkrail-e2e-${E2E_STATE_KEY}`);
 
 export const E2E_HOME_DIR = join(E2E_DATA_DIR, "home");
 
-export const E2E_FAKE_BIN_DIR = join(E2E_DATA_DIR, "bin");
+export const E2E_FAKE_BIN_DIR = join(E2E_DATA_DIR, ".bun", "bin");
 
 export const E2E_CENTRAL_EXTENSION_SOURCE = join(E2E_DATA_DIR, "synthetic-central-extension.ts");
 export const E2E_CENTRAL_BAD_EXTENSION_SOURCE = join(

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -36,11 +36,14 @@ async function openSeededClosedChat(page: Page, messages: SeededMessages) {
 	await expect(closedChat).toBeVisible();
 	await closedChat.click();
 
-	const userMessageCount = messages.filter((message) => message.role === "user").length;
-	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(
-		userMessageCount,
-		{ timeout: 20_000 },
-	);
+	const latestUserMessage = messages.filter((message) => message.role === "user").at(-1);
+	if (latestUserMessage) {
+		await expect(
+			page
+				.locator('[data-testid="chat-message"][data-role="user"]')
+				.filter({ hasText: latestUserMessage.text }),
+		).toBeVisible({ timeout: 20_000 });
+	}
 	const input = page.getByTestId("chat-input");
 	await expect(input).toBeVisible();
 	return input;

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -42,6 +42,10 @@ async function height(locator: Locator): Promise<number> {
 	return box.height;
 }
 
+async function scrollbarColor(locator: Locator): Promise<string> {
+	return locator.evaluate((element) => getComputedStyle(element).scrollbarColor);
+}
+
 async function dragHandle(page: Page, handle: Locator, x: number, y: number): Promise<void> {
 	const box = await handle.boundingBox();
 	if (!box) throw new Error("resize handle has no bounding box");
@@ -104,6 +108,7 @@ test("workbench strips and feature toolbars keep one-row geometry with ARIA tabs
 	for (const strip of [centerStrip, rightStrip, bottomStrip]) {
 		await expect(strip).toHaveCSS("height", "28px");
 		await expect(strip.getByRole("tablist")).toHaveCount(1);
+		await expect(strip.getByRole("button", { name: /^Scroll tabs (left|right)$/ })).toHaveCount(0);
 		const active = strip.locator('[role="tab"][aria-selected="true"]');
 		await expect(active).toHaveCount(1);
 		const panelId = await active.getAttribute("aria-controls");
@@ -116,11 +121,65 @@ test("workbench strips and feature toolbars keep one-row geometry with ARIA tabs
 	const centerScroller = centerStrip.getByRole("tablist");
 	await expect(centerScroller).toHaveCSS("overflow-x", "auto");
 	await expect(centerScroller).toHaveCSS("overflow-y", "hidden");
+	for (const tool of ["projects", "specs", "files", "changes", "review"]) {
+		await expect(
+			page.getByTestId(`tab-${tool}`).getByRole("button", { name: /^Close / }),
+		).toHaveCount(0);
+	}
+	await expect(centerStrip.getByTestId("editor-tab-close")).toHaveCount(1);
+	await expect(bottomStrip.getByTestId("terminal-tab-close")).toHaveCount(1);
 
 	await page.getByTestId("tab-changes").click();
 	await expect(page.getByTestId("chat-toolbar")).toHaveCSS("height", "28px");
 	await expect(page.getByTestId("chat-toolbar")).toHaveCSS("overflow-x", "clip");
 	await expect(page.getByTestId("changes-view-toggle")).toHaveCSS("height", "28px");
+});
+
+test("overflow uses a focus-revealed scrollbar and keyboard navigation reveals the active tab", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 800, height: 720 });
+	await openDefaultWorkbench(page);
+	await openKeptFiles(page, [
+		"README.md",
+		"notes.txt",
+		"ALERTS.md",
+		"DIAGRAM.md",
+		"LARGE.md",
+		"LINKS.md",
+	]);
+	const strip = page.getByTestId("center-tab-strip");
+	const tablist = strip.getByRole("tablist");
+	await expect
+		.poll(() => tablist.evaluate((element) => element.scrollWidth > element.clientWidth))
+		.toBe(true);
+
+	const outside = page.getByTestId("open-settings");
+	await outside.hover();
+	await outside.focus();
+	const idleColor = await scrollbarColor(tablist);
+	await tablist.hover();
+	await expect.poll(() => scrollbarColor(tablist)).not.toBe(idleColor);
+	await expect
+		.poll(() =>
+			tablist.evaluate((element) => getComputedStyle(element, "::-webkit-scrollbar").height),
+		)
+		.toBe("2px");
+
+	await outside.hover();
+	await strip.getByRole("tab", { name: /README\.md/ }).focus();
+	await expect.poll(() => scrollbarColor(tablist)).not.toBe(idleColor);
+	await page.keyboard.press("End");
+	const last = strip.getByRole("tab", { name: /LINKS\.md/ });
+	await expect(last).toBeFocused();
+	await expect
+		.poll(async () => {
+			const [listBox, tabBox] = await Promise.all([tablist.boundingBox(), last.boundingBox()]);
+			if (!listBox || !tabBox) return false;
+			return tabBox.x >= listBox.x && tabBox.x + tabBox.width <= listBox.x + listBox.width + 1;
+		})
+		.toBe(true);
+	await expect(strip).toHaveCSS("height", "28px");
 });
 
 test("ARIA tabs use roving keyboard focus, recover after close, and expose keyboard separators", async ({
@@ -383,6 +442,12 @@ test("keyboard and menu commands reorder, search, recursively split, and collaps
 	await page.getByTestId("tab-changes").click({ button: "right" });
 	await page.getByRole("menuitem", { name: "Restore All files" }).click();
 	await expect(page.getByTestId("tab-files")).toBeVisible();
+	await page.getByTestId("tab-specs").getByRole("tab").focus();
+	await page.keyboard.press("Delete");
+	await expect(page.getByTestId("tab-specs")).toHaveCount(0);
+	await page.getByTestId("tab-changes").click({ button: "right" });
+	await page.getByRole("menuitem", { name: "Restore Specs" }).click();
+	await expect(page.getByTestId("tab-specs")).toBeVisible();
 
 	await openKeptFiles(page, ["README.md", "notes.txt", "LINKS.md"]);
 	const tabs = page.getByTestId("editor-tab");

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -126,6 +126,8 @@ test("workbench strips and feature toolbars keep one-row geometry with ARIA tabs
 			page.getByTestId(`tab-${tool}`).getByRole("button", { name: /^Close / }),
 		).toHaveCount(0);
 	}
+	await expect(page.getByTestId("tab-files")).toContainText("Files");
+	await expect(page.getByTestId("tab-files")).not.toContainText("All files");
 	await expect(centerStrip.getByTestId("editor-tab-close")).toHaveCount(1);
 	await expect(bottomStrip.getByTestId("terminal-tab-close")).toHaveCount(1);
 
@@ -440,7 +442,7 @@ test("keyboard and menu commands reorder, search, recursively split, and collaps
 	await page.getByRole("menuitem", { name: "Close", exact: true }).click();
 	await expect(page.getByTestId("tab-files")).toHaveCount(0);
 	await page.getByTestId("tab-changes").click({ button: "right" });
-	await page.getByRole("menuitem", { name: "Restore All files" }).click();
+	await page.getByRole("menuitem", { name: "Restore Files" }).click();
 	await expect(page.getByTestId("tab-files")).toBeVisible();
 	await page.getByTestId("tab-specs").getByRole("tab").focus();
 	await page.keyboard.press("Delete");

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -100,7 +100,8 @@ test("workbench strips and feature toolbars keep one-row geometry with ARIA tabs
 
 	const centerStrip = page.getByTestId("center-tab-strip");
 	const rightStrip = page.getByTestId("right-tab-strip");
-	for (const strip of [centerStrip, rightStrip]) {
+	const bottomStrip = page.getByTestId("bottom-tab-strip");
+	for (const strip of [centerStrip, rightStrip, bottomStrip]) {
 		await expect(strip).toHaveCSS("height", "28px");
 		await expect(strip.getByRole("tablist")).toHaveCount(1);
 		const active = strip.locator('[role="tab"][aria-selected="true"]');
@@ -155,6 +156,13 @@ test("ARIA tabs use roving keyboard focus, recover after close, and expose keybo
 	await separator.focus();
 	await page.keyboard.press("ArrowLeft");
 	await expect.poll(() => width(page.getByTestId("right-stack"))).not.toBeCloseTo(before, 0);
+
+	const bottomSeparator = page.getByTestId("resize-bottom");
+	await expect(bottomSeparator).toHaveAttribute("role", "separator");
+	await expect(bottomSeparator).toHaveAttribute("aria-orientation", "horizontal");
+	await expect(bottomSeparator).toHaveAttribute("aria-valuemin", /\d+/);
+	await expect(bottomSeparator).toHaveAttribute("aria-valuemax", /\d+/);
+	await expect(bottomSeparator).toHaveAttribute("aria-valuenow", /\d+/);
 });
 
 test("outer side widths publish on pointer-up and restore after reload", async ({ page }) => {
@@ -246,7 +254,7 @@ test("a terminal can move to its own side group; resize, fold, and visibility ga
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(1);
 	await page.getByTestId("terminal-tab").click({ button: "right" });
 	await expect(
-		page.getByRole("menuitem", { name: "New left group — already at bottom" }),
+		page.getByRole("menuitem", { name: "New left group at bottom — already at end" }),
 	).toBeDisabled();
 	await expect(page.getByRole("menuitem", { name: "New left group at top" })).toBeEnabled();
 	await page.keyboard.press("Escape");
@@ -282,7 +290,7 @@ test("a terminal can move to its own side group; resize, fold, and visibility ga
 	await waitTerminalReady(page);
 
 	await page.getByTestId("tab-files").click({ button: "right" });
-	await page.getByRole("menuitem", { name: "New left group", exact: true }).click();
+	await page.getByRole("menuitem", { name: "New left group at bottom", exact: true }).click();
 	await expect(sideGroups(page, "left")).toHaveCount(3);
 	await expect(page.getByTestId("tab-files")).toHaveCount(1);
 });
@@ -333,7 +341,7 @@ test("side groups expose broad per-panel above and below split targets", async (
 	await expect(groups.nth(2)).toHaveAttribute("data-folded", "true");
 });
 
-test("Mod+B and Mod+J hide and restore synchronized sides, including after reload", async ({
+test("Mod+B and Mod+J hide and restore synchronized sides without affecting bottom", async ({
 	page,
 }) => {
 	await openDefaultWorkbench(page);
@@ -345,7 +353,8 @@ test("Mod+B and Mod+J hide and restore synchronized sides, including after reloa
 	await pressPlatformShortcut(page, "j");
 	await expect(page.getByTestId("right-layout-rail")).toBeVisible();
 	await expect(page.getByTestId("right-stack")).toHaveCount(0);
-	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
+	await expect(page.getByTestId("terminal-instance")).toHaveCount(1);
+	await waitForLayoutSettled(page);
 
 	await reloadDefaultWorkbench(page);
 	await expect(page.getByTestId("left-layout-rail")).toBeVisible();
@@ -591,6 +600,8 @@ test("applying the Review preset preserves resources and installs its vertical c
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
 	await expect(sideGroups(page, "left")).toHaveCount(1);
 	await expect(sideGroups(page, "right")).toHaveCount(2);
+	await expect(page.getByTestId("bottom-group")).toHaveCount(1);
+	await expect(page.getByTestId("bottom-group")).toContainText("Terminal 1");
 	await page.keyboard.press("Escape");
 	await expect(page.getByRole("heading", { name: "Layout" })).toBeHidden();
 	await expect
@@ -606,7 +617,7 @@ test("applying the Review preset preserves resources and installs its vertical c
 	);
 });
 
-test("custom presets and the side-group limit round-trip through synchronized Layout settings", async ({
+test("custom presets and independent group limits round-trip through synchronized Layout settings", async ({
 	page,
 }) => {
 	await openDefaultWorkbench(page);
@@ -627,9 +638,15 @@ test("custom presets and the side-group limit round-trip through synchronized La
 
 	const sideLimit = page.getByRole("spinbutton", { name: "Maximum side groups" });
 	await sideLimit.fill("7");
-	await page.getByRole("button", { name: "Save limit" }).click();
+	await page.getByRole("button", { name: "Save side group limit" }).click();
 	await expect(sideLimit).toHaveValue("7");
-	await expect(page.getByRole("button", { name: "Save limit" })).toBeDisabled();
+	await expect(page.getByRole("button", { name: "Save side group limit" })).toBeDisabled();
+
+	const bottomLimit = page.getByRole("spinbutton", { name: "Maximum bottom groups" });
+	await bottomLimit.fill("4");
+	await page.getByRole("button", { name: "Save bottom group limit" }).click();
+	await expect(bottomLimit).toHaveValue("4");
+	await expect(page.getByRole("button", { name: "Save bottom group limit" })).toBeDisabled();
 
 	await custom.getByRole("button", { name: "Delete My renamed workbench" }).click();
 	await expect(custom).toHaveCount(0);
@@ -647,11 +664,11 @@ test("an accepted side-group overage is grandfathered without allowing further g
 	await page.getByTestId("settings-nav-layout").click();
 	let sideLimit = page.getByRole("spinbutton", { name: "Maximum side groups" });
 	await sideLimit.fill("3");
-	await page.getByRole("button", { name: "Save limit" }).click();
+	await page.getByRole("button", { name: "Save side group limit" }).click();
 	await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
 
 	await page.getByTestId("terminal-tab").click({ button: "right" });
-	await page.getByRole("menuitem", { name: "New right group", exact: true }).click();
+	await page.getByRole("menuitem", { name: "New right group at bottom", exact: true }).click();
 	await expect(sideGroups(page, "right")).toHaveCount(3);
 
 	await createWorkspaceViaDialog(page);
@@ -659,7 +676,7 @@ test("an accepted side-group overage is grandfathered without allowing further g
 	await page.getByTestId("settings-nav-layout").click();
 	sideLimit = page.getByRole("spinbutton", { name: "Maximum side groups" });
 	await sideLimit.fill("2");
-	await page.getByRole("button", { name: "Save limit" }).click();
+	await page.getByRole("button", { name: "Save side group limit" }).click();
 	await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
 
 	await defaultWorkspaceRow(page).getByRole("button").first().click();
@@ -667,12 +684,12 @@ test("an accepted side-group overage is grandfathered without allowing further g
 	await expect(sideGroups(page, "right")).toHaveCount(3);
 	await page.getByTestId("tab-files").click({ button: "right" });
 	await expect(page.getByRole("menuitem", { name: /^New right group at top/ })).toBeDisabled();
-	await expect(page.getByRole("menuitem", { name: /^New right group(?: —|$)/ })).toBeDisabled();
+	await expect(page.getByRole("menuitem", { name: /^New right group at bottom/ })).toBeDisabled();
 	await page.keyboard.press("Escape");
 
 	await page.getByTestId("terminal-tab").click({ button: "right" });
 	await expect(
-		page.getByRole("menuitem", { name: "New right group — already at bottom" }),
+		page.getByRole("menuitem", { name: "New right group at bottom — already at end" }),
 	).toBeDisabled();
 	await expect(page.getByRole("menuitem", { name: "New right group at top" })).toBeEnabled();
 	await page.getByRole("menuitem", { name: "New right group at top" }).click();
@@ -691,6 +708,7 @@ test("a narrow viewport compresses locally without rewriting recursive topology"
 	await page.setViewportSize({ width: 390, height: 844 });
 	await expect(page.getByTestId("workbench")).toBeVisible();
 	await expect(page.getByTestId("center-group")).toHaveCount(2);
+	await expect(page.getByTestId("bottom-group")).toHaveCount(1);
 	const bounds = await page.getByTestId("workbench").boundingBox();
 	if (!bounds) throw new Error("workbench has no box");
 	expect(bounds.x).toBeGreaterThanOrEqual(0);

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -42,10 +42,6 @@ async function height(locator: Locator): Promise<number> {
 	return box.height;
 }
 
-async function scrollbarColor(locator: Locator): Promise<string> {
-	return locator.evaluate((element) => getComputedStyle(element).scrollbarColor);
-}
-
 async function dragHandle(page: Page, handle: Locator, x: number, y: number): Promise<void> {
 	const box = await handle.boundingBox();
 	if (!box) throw new Error("resize handle has no bounding box");
@@ -137,9 +133,7 @@ test("workbench strips and feature toolbars keep one-row geometry with ARIA tabs
 	await expect(page.getByTestId("changes-view-toggle")).toHaveCSS("height", "28px");
 });
 
-test("overflow uses a focus-revealed scrollbar and keyboard navigation reveals the active tab", async ({
-	page,
-}) => {
+test("overflow uses directional fades without changing tab-strip geometry", async ({ page }) => {
 	await page.setViewportSize({ width: 800, height: 720 });
 	await openDefaultWorkbench(page);
 	await openKeptFiles(page, [
@@ -155,25 +149,33 @@ test("overflow uses a focus-revealed scrollbar and keyboard navigation reveals t
 	await expect
 		.poll(() => tablist.evaluate((element) => element.scrollWidth > element.clientWidth))
 		.toBe(true);
-
-	const outside = page.getByTestId("open-settings");
-	await outside.hover();
-	await outside.focus();
-	const idleColor = await scrollbarColor(tablist);
-	await tablist.hover();
-	await expect.poll(() => scrollbarColor(tablist)).not.toBe(idleColor);
+	await expect(tablist).toHaveCSS("scrollbar-width", "none");
 	await expect
 		.poll(() =>
-			tablist.evaluate((element) => getComputedStyle(element, "::-webkit-scrollbar").height),
+			tablist.evaluate((element) => getComputedStyle(element, "::-webkit-scrollbar").display),
 		)
-		.toBe("2px");
+		.toBe("none");
+	await expect(strip).toHaveCSS("height", "28px");
+	await expect.poll(() => height(strip.getByRole("tab").first())).toBeCloseTo(28, 1);
 
-	await outside.hover();
+	await tablist.evaluate((element) => {
+		element.scrollLeft = 0;
+	});
+	await expect(strip.getByTestId("tab-overflow-before")).toHaveCount(0);
+	await expect(strip.getByTestId("tab-overflow-after")).toHaveCount(1);
+
+	await tablist.evaluate((element) => {
+		element.scrollLeft = (element.scrollWidth - element.clientWidth) / 2;
+	});
+	await expect(strip.getByTestId("tab-overflow-before")).toHaveCount(1);
+	await expect(strip.getByTestId("tab-overflow-after")).toHaveCount(1);
+
 	await strip.getByRole("tab", { name: /README\.md/ }).focus();
-	await expect.poll(() => scrollbarColor(tablist)).not.toBe(idleColor);
 	await page.keyboard.press("End");
 	const last = strip.getByRole("tab", { name: /LINKS\.md/ });
 	await expect(last).toBeFocused();
+	await expect(strip.getByTestId("tab-overflow-before")).toHaveCount(1);
+	await expect(strip.getByTestId("tab-overflow-after")).toHaveCount(0);
 	await expect
 		.poll(async () => {
 			const [listBox, tabBox] = await Promise.all([tablist.boundingBox(), last.boundingBox()]);
@@ -182,6 +184,7 @@ test("overflow uses a focus-revealed scrollbar and keyboard navigation reveals t
 		})
 		.toBe(true);
 	await expect(strip).toHaveCSS("height", "28px");
+	await expect.poll(() => height(last)).toBeCloseTo(28, 1);
 });
 
 test("ARIA tabs use roving keyboard focus, recover after close, and expose keyboard separators", async ({

--- a/e2e/live-refresh.spec.ts
+++ b/e2e/live-refresh.spec.ts
@@ -7,7 +7,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const fsExpect = expect.configure({ timeout: 10_000 });
 
-test("worktree changes on disk appear live in Specs, All files, Changes, and an open file tab", async ({
+test("worktree changes on disk appear live in Specs, Files, Changes, and an open file tab", async ({
 	page,
 }) => {
 	await openFixtureProject(page);

--- a/e2e/reload-navigation.spec.ts
+++ b/e2e/reload-navigation.spec.ts
@@ -132,10 +132,10 @@ test("missing chat, workspace, and project fall back to the nearest valid locati
 	await coldOpen(page, `#/v1/projects/${projectId}/workspaces/${workspace.id}/chats/gone`);
 	await expect(activeWorktreeRow(page)).toHaveCount(1);
 	await expect(chatTabs(page).first()).toBeVisible();
+	await expect.poll(() => currentHash(page)).not.toContain("/chats/gone");
 	await expect
 		.poll(() => currentHash(page))
 		.toContain(`#/v1/projects/${projectId}/workspaces/${workspace.id}`);
-	expect(await currentHash(page)).not.toContain("/chats/gone");
 
 	await coldOpen(page, `#/v1/projects/${projectId}/workspaces/gone`);
 	await expect(page.getByTestId("welcome")).toBeVisible();

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -571,7 +571,7 @@ test("a tab opened or closed in one browser reaches the other", async ({ page, c
 	await waitTerminalReady(page2);
 	await expect(page2.getByTestId("terminal-tab")).toHaveCount(1);
 
-	await page2.getByTestId("terminal-add").click();
+	await openTerminal(page2);
 	await expect(page2.getByTestId("terminal-tab")).toHaveCount(2);
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(2);
 

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -270,7 +270,7 @@ test("a tab says so when its shell exits", async ({ page }) => {
 	await runInTerminal(page, "exit");
 
 	await expect(visibleTerminal(page)).toHaveAttribute("data-exited", "true");
-	await expect(visibleTerminalScreen(page)).toContainText("[process exited]");
+	await expect(visibleTerminalScreen(page)).toContainText(/\[process exited(?: with code \d+)?\]/);
 });
 
 test("Ctrl+C still interrupts while an input method is active", async ({ page }) => {

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -143,7 +143,7 @@ test("selected workspace tabs keep their surface and edge marker in high contras
 	const strips = [
 		page.getByTestId("center-tab-strip"),
 		page.getByTestId("right-tab-strip"),
-		page.getByTestId("workbench-tab-strip").filter({ has: page.getByTestId("terminal-tab") }),
+		page.getByTestId("bottom-tab-strip").filter({ has: page.getByTestId("terminal-tab") }),
 	];
 	for (const strip of strips) {
 		await expect(strip.getByRole("tablist")).toHaveCount(1);

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -30,10 +30,11 @@ The shell is built first, `pi` connected last:
   newcomers aren't lost in the worktree model, and any **existing worktree** the user attaches in place
   from the project menu (ThinkRail uses its cwd, never touches its checkout).
 - **Desktop workbench**: a recursively splittable center for files, diffs, registered documents, chats, and terminals,
-  bounded to four visible groups; Projects / Specs / All files / Changes / Review live in movable,
-  independently foldable vertical side groups. Terminal tabs may move between center and sides. Each
-  workspace's structural layout is host-persisted and shared across clients, while active selection/focus
-  remains local so clients do not steal one another's attention.
+  bounded to four visible groups; Projects / Specs / All files / Changes / Review and terminals may occupy
+  movable auxiliary groups—vertical stacks at left/right and a horizontally grouped, alignable bottom panel.
+  New workspaces place one terminal in that bottom panel by default. Each workspace's structural layout is
+  host-persisted and shared across clients, while active selection/focus remains local so clients do not steal
+  one another's attention.
 - A workspace-local **Review** surface for the current worktree: GitHub-style anchored file/diff drafts
   are collected without starting the agent, then sent as structured context into per-file `pi` chats;
   sent records persist and the agent can resolve them. This is local review, not PR-provider integration.

--- a/goal-and-requirements.md
+++ b/goal-and-requirements.md
@@ -30,7 +30,7 @@ The shell is built first, `pi` connected last:
   newcomers aren't lost in the worktree model, and any **existing worktree** the user attaches in place
   from the project menu (ThinkRail uses its cwd, never touches its checkout).
 - **Desktop workbench**: a recursively splittable center for files, diffs, registered documents, chats, and terminals,
-  bounded to four visible groups; Projects / Specs / All files / Changes / Review and terminals may occupy
+  bounded to four visible groups; Projects / Specs / Files / Changes / Review and terminals may occupy
   movable auxiliary groups—vertical stacks at left/right and a horizontally grouped, alignable bottom panel.
   New workspaces place one terminal in that bottom panel by default. Each workspace's structural layout is
   host-persisted and shared across clients, while active selection/focus remains local so clients do not steal

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -186,8 +186,9 @@ of the host.
   the **theme/config selection** — **`ThemeId`** is an open string on the wire, because the host persists
   an opaque selection while the independently shipped web client owns the available manifest catalog;
   **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, layout }` — an extensible bag; `layout` is the
-  **`LayoutSettings`** selection (`defaultPresetId`, named portable `customPresets`, and
-  `maxSideGroups`, default 6); `analyticsEnabled` is the anonymous-usage-analytics switch, default `true`
+  **`LayoutSettings`** selection (`defaultPresetId`, named portable `customPresets`, `maxSideGroups`
+  defaulting to 6, and independent `maxBottomGroups` defaulting to 3); `analyticsEnabled` is the
+  anonymous-usage-analytics switch, default `true`
   — it is the **only** analytics fact on the wire:
   the installation id stays server-side by design, see `submodule-server-analytics`) carries it with the
   **`DEFAULT_CONFIG`** fallback
@@ -236,17 +237,20 @@ of the host.
   what `template.list` returns; deliberately body-free so a listing never ships every file's full text),
   and **`Template`** (`TemplateInfo` + full `content` — frontmatter + body — the by-name
   `template.get`/`template.save` shape);
-  **workbench layout DTOs** — a versioned **`WorkspaceLayoutDocument`** (stable center split/group and
-  side/group/tab references, normalized geometry, preview identities, folds/visibility, and singleton-tool
-  restore targets; explicitly no active/focused tab; virtual-document references name a registered resolver
-  and durable source identity, never inline client-only content), **`WorkspaceLayoutSnapshot`**
+  **workbench layout DTOs** — version-2 **`WorkspaceLayoutDocument`** (stable recursive center plus
+  left/right auxiliary stacks and a bottom auxiliary row; group/tab references, normalized side widths and
+  bottom height, bottom alignment, preview identities, folds/visibility, and singleton-tool restore targets;
+  explicitly no active/focused tab; virtual-document references name a registered resolver and durable source
+  identity, never inline client-only content), **`WorkspaceLayoutSnapshot`**
   (`workspaceId` +
   monotonic `revision` + document), **`LayoutReplaceParams`** (complete document + client-generated
   `mutationId` + explicit `expectedRevision`, where `null` is create-only and a number is exact
   replace-only), **`LayoutReplaceResult`** (discriminated accepted payload or conflict carrying the current
   snapshot, including `null`), **`LayoutChangedPayload`** (snapshot + echoed origin `mutationId`), and
-  portable **`LayoutPreset`** / **`LayoutSettings`**. The mutation id is correlation metadata, not the
-  concurrency token or durable document state. A tab `id` is an opaque stable placement key—including for singleton tools—not semantic identity;
+  portable **`LayoutPreset`** / **`LayoutSettings`**. Presets carry resource-free bottom group slots, so a
+  terminal-only group survives capture without carrying terminal identity/count. The mutation id is
+  correlation metadata, not the concurrency token or durable document state. A tab `id` is an opaque stable
+  placement key—including for singleton tools—not semantic identity;
   the kind-specific path/scope/session/source/tabKey/tool fields define the resource and prevent aliases from
   duplicating it. Resource references carry placement identity only; their domain DTO remains authoritative
   for lifetime.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -140,7 +140,9 @@ of the host.
   project folder itself as a workspace, exactly one per project, pinned first in `workspace.list`,
   non-removable and non-renamable server-side; **`kind: "external"`** marks an explicitly attached,
   user-owned worktree ThinkRail may forget but must never rename or reclaim; absent = a ThinkRail-managed
-  worktree workspace — an explicit wire field, never an id convention),
+  worktree workspace; optional literal **`initialTerminalEligible: true`** is the host-owned creation marker
+  carried only by newly persisted workspace records, while absence is the backward-compatible legacy value
+  that forbids automatic default-terminal seeding — explicit wire fields, never id conventions),
   **`OpenBranchReview`** (the optional open review reference for the active branch: PR vs MR + number; no status/actions),
   **`ExistingWorktreeCandidate`** (a `workspace.listExisting` row: absolute `path` + `branch`, or a
   `detached` row the chooser disables), `Session` (chat tab),

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -264,9 +264,10 @@ of the host.
   fan-out used nowhere by navigation restoration / `fs.*` / `git.*` / **`spec.graph`**
   (the Specs-viewer whole-graph read, per workspace) / **`todo.*`** — **`list`**/**`add`**/**`update`**/
   **`remove`**, the chat's per-session TODO plan (keyed by `workspaceId` + `sessionId`; `add` tags the
-  item `origin:"user"`) / **`terminal.*`** — **`attach`** (idempotent get-or-create keyed by
-  `(workspaceId, tabKey)`, returning `created` + the `replay` to repaint; the only way a PTY is born, and it
-  replaced `create`+`alive`) / **`list`** (the host owns the tab list) / `write` / `resize` /
+  item `origin:"user"`) / **`terminal.*`** — **`reserve`** (idempotently establishes a host-catalog tab
+  without starting its PTY) / **`attach`** (idempotent get-or-create keyed by `(workspaceId, tabKey)`,
+  returning `created` + the `replay` to repaint; the only way a PTY is born, and it replaced
+  `create`+`alive`) / **`list`** (the host owns the tab list) / `write` / `resize` /
   **`close`** (by `tabKey`, refusing a busy shell unless `force`) / `model.list` + **`model.refresh`** (awaits the host's
   single-flighted catalog refresh and returns **`RefreshedModels`** — the post-refresh list plus
   **`complete`**, whether that pass settled inside the host's capped wait, since only a settled list is

--- a/packages/contracts/src/domain.test.ts
+++ b/packages/contracts/src/domain.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	ACCEPTED_IMAGE_TYPES,
 	base64EncodedLength,
+	DEFAULT_CONFIG,
 	IMAGE_MAX_BASE64_BYTES,
 	isRetriedAttempt,
 	REQUEST_IMAGE_BASE64_BUDGET,
@@ -36,6 +37,12 @@ describe("isRetriedAttempt", () => {
 	test("an intervening toolResult breaks adjacency — pi's _prepareRetry re-runs the turn directly, so anything between the two means this was not a retry", () => {
 		const toolResult = { role: "toolResult" };
 		expect(isRetriedAttempt([userMsg, failed, toolResult, ok], 1)).toBe(false);
+	});
+});
+
+describe("layout defaults", () => {
+	test("bottom groups have an independent default limit", () => {
+		expect(DEFAULT_CONFIG.layout.maxBottomGroups).toBe(3);
 	});
 });
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -328,8 +328,9 @@ export type LayoutCenterTab =
 	| LayoutChatTab
 	| LayoutDocumentTab
 	| LayoutTerminalTab;
-export type LayoutSideTab = LayoutToolTab | LayoutTerminalTab;
-export type LayoutTab = LayoutCenterTab | LayoutSideTab;
+export type LayoutAuxiliaryTab = LayoutToolTab | LayoutTerminalTab;
+export type LayoutSideTab = LayoutAuxiliaryTab;
+export type LayoutTab = LayoutCenterTab | LayoutAuxiliaryTab;
 
 export interface LayoutCenterGroup {
 	kind: "group";
@@ -352,7 +353,7 @@ export interface LayoutSideGroup {
 	id: string;
 	weight: number;
 	folded: boolean;
-	tabs: LayoutSideTab[];
+	tabs: LayoutAuxiliaryTab[];
 }
 
 export interface LayoutSideRegion {
@@ -361,17 +362,36 @@ export interface LayoutSideRegion {
 	groups: LayoutSideGroup[];
 }
 
+export type LayoutBottomAlignment = "center" | "center-left" | "center-right" | "full";
+
+export interface LayoutBottomGroup {
+	id: string;
+	weight: number;
+	folded: boolean;
+	tabs: LayoutAuxiliaryTab[];
+}
+
+export interface LayoutBottomRegion {
+	visible: boolean;
+	height: number;
+	alignment: LayoutBottomAlignment;
+	groups: LayoutBottomGroup[];
+}
+
+export type LayoutAuxiliaryRegion = "left" | "right" | "bottom";
+
 export interface LayoutToolRestoreTarget {
-	side: "left" | "right";
+	region: LayoutAuxiliaryRegion;
 	groupId?: string;
 	index: number;
 }
 
 export interface WorkspaceLayoutDocument {
-	version: 1;
+	version: 2;
 	center: LayoutCenterNode;
 	left: LayoutSideRegion;
 	right: LayoutSideRegion;
+	bottom: LayoutBottomRegion;
 	toolRestoreTargets: Partial<Record<LayoutToolId, LayoutToolRestoreTarget>>;
 }
 
@@ -422,18 +442,34 @@ export interface LayoutPresetSideRegion {
 	groups: LayoutPresetSideGroup[];
 }
 
+export interface LayoutPresetBottomGroup {
+	id: string;
+	weight: number;
+	folded: boolean;
+	tools: LayoutToolId[];
+}
+
+export interface LayoutPresetBottomRegion {
+	visible: boolean;
+	height: number;
+	alignment: LayoutBottomAlignment;
+	groups: LayoutPresetBottomGroup[];
+}
+
 export interface LayoutPreset {
 	id: string;
 	name: string;
 	center: LayoutPresetCenterNode;
 	left: LayoutPresetSideRegion;
 	right: LayoutPresetSideRegion;
+	bottom: LayoutPresetBottomRegion;
 }
 
 export interface LayoutSettings {
 	defaultPresetId: string;
 	customPresets: LayoutPreset[];
 	maxSideGroups: number;
+	maxBottomGroups: number;
 }
 
 export interface AppConfig {
@@ -453,6 +489,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 		defaultPresetId: "balanced",
 		customPresets: [],
 		maxSideGroups: 6,
+		maxBottomGroups: 3,
 	},
 };
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -30,6 +30,7 @@ export interface Workspace {
 	baseBranch: string;
 	diffBase?: string;
 	renamed?: boolean;
+	initialTerminalEligible?: true;
 	diffStats?: DiffStats;
 	skillOverrides?: Record<string, "on" | "off">;
 }

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -81,7 +81,7 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 49;
+export const PROTOCOL_VERSION = 50;
 
 export interface ServerWelcome {
 	protocolVersion: number;

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -141,6 +141,7 @@ export const WS_METHODS = {
 	gitStatus: "git.status",
 	gitDiffFile: "git.diffFile",
 	gitListCommits: "git.listCommits",
+	terminalReserve: "terminal.reserve",
 	terminalAttach: "terminal.attach",
 	terminalList: "terminal.list",
 	terminalWrite: "terminal.write",
@@ -345,6 +346,10 @@ export interface WsMethodMap {
 		result: { original: string; modified: string };
 	};
 	"git.listCommits": { params: { workspaceId: string }; result: { commits: GitCommit[] } };
+	"terminal.reserve": {
+		params: { workspaceId: string; tabKey: string; title: string };
+		result: { tab: TerminalTabInfo };
+	};
 	"terminal.attach": {
 		params: { workspaceId: string; tabKey: string; title?: string; cols?: number; rows?: number };
 		result: { id: string; created: boolean; replay?: string };

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -81,7 +81,7 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 48;
+export const PROTOCOL_VERSION = 49;
 
 export interface ServerWelcome {
 	protocolVersion: number;

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -51,7 +51,7 @@ internals**. The edges between them are owned here (see the dependency graph), n
 | --- | --- | --- |
 | `host` | `Bun.serve` HTTP+WS, static SPA, the WS dispatch registry, channel publish | [host/SPEC.md](src/host/SPEC.md) |
 | `persistence` | JSON app state under the data dir, including workspace-layout snapshots | [persistence/SPEC.md](src/persistence/SPEC.md) |
-| `settings` | server-synced app config, including layout preset/default/side-limit settings | [settings/SPEC.md](src/settings/SPEC.md) |
+| `settings` | server-synced app config, including layout presets/default and independent side/bottom limits | [settings/SPEC.md](src/settings/SPEC.md) |
 | `layout` | validated, revisioned, persisted per-workspace workbench snapshots | [layout/SPEC.md](src/layout/SPEC.md) |
 | `projects` | stable known-repo registry: open/recent views + lossless close/reopen (validate, dedupe, slug) | [projects/SPEC.md](src/projects/SPEC.md) |
 | `workspaces` | workspaces = `git worktree`s on their own branch | [workspaces/SPEC.md](src/workspaces/SPEC.md) |
@@ -110,8 +110,9 @@ own never import `host` either: they expose a **publisher-injection seam** (`set
 analytics + `provider.changed` invalidation publishers) that `host` installs at `createServer` — so
 channel/analytics wiring lives only in
 `host`.
-For layout writes, `host` passes `settings.getConfig().layout.maxSideGroups` into the `layout` validator;
-for layout-setting writes it runs the complete nested value through `layout.validateLayoutSettings` before calling `settings`.
+For layout writes, `host` passes the current side + bottom group-limit policy from
+`settings.getConfig().layout` into the `layout` validator; for layout-setting writes it runs the complete
+nested value through `layout.validateLayoutSettings` before calling `settings`.
 Neither sibling imports the other.
 `history` stays registry-free (never imports `projects`/`workspaces`); `host` injects the scope filter
 + labels from the registries at the handler layer (`history.search` handler). `templates` stays

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -119,6 +119,7 @@ import {
 	closeTerminalTab,
 	closeWorkspaceTerminals,
 	listTerminals,
+	reserveTerminal,
 	resizeTerminal,
 	writeTerminal,
 } from "../terminal";
@@ -352,6 +353,11 @@ const handlers: Record<string, Handler> = {
 		return gitDiffFile(p.workspaceId, p.path, p.scope);
 	},
 	"git.listCommits": (params) => listCommits((params as { workspaceId: string }).workspaceId),
+	"terminal.reserve": (params) => {
+		const p = params as { workspaceId: string; tabKey: string; title: string };
+		getWorkspace(p.workspaceId);
+		return { tab: reserveTerminal(p.workspaceId, p.tabKey, p.title) };
+	},
 	"terminal.attach": (params, ctx) => {
 		const p = params as {
 			workspaceId: string;

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -603,7 +603,8 @@ const handlers: Record<string, Handler> = {
 	"layout.replace": (params) => {
 		const replacement = params as LayoutReplaceParams;
 		getWorkspace(replacement.workspaceId);
-		return replaceWorkspaceLayout(replacement, getConfig().layout.maxSideGroups);
+		const { maxSideGroups, maxBottomGroups } = getConfig().layout;
+		return replaceWorkspaceLayout(replacement, { maxSideGroups, maxBottomGroups });
 	},
 	"settings.update": (params) => {
 		const config = (params as { config: Partial<AppConfig> }).config;

--- a/packages/server/src/layout/SPEC.md
+++ b/packages/server/src/layout/SPEC.md
@@ -36,9 +36,10 @@ replace, and broadcast complete documents.
 `layout.get` returns `null` for an uninitialized workspace; the compatible web client owns built-in preset
 instantiation and commits the first document through the normal replace path. A persisted version-1 document
 migrates to version 2 with a hidden, empty below-center bottom region, preserving every existing placement,
-side geometry, and process lifetime. Migration floors the reported snapshot revision at 2; revision 1 remains
-an unambiguous fresh-version-2 marker for the web's one-time default-terminal seed. A bottom-less custom
-preset normalizes the same way. An unknown future
+side geometry, and process lifetime. Migration floors the reported snapshot revision at 2. Revision 1
+identifies a first persisted version-2 document, not whether its workspace is new; the web combines it with
+`Workspace.initialTerminalEligible`, which is owned by the workspace registry, for one-time default-terminal
+seeding. A bottom-less custom preset normalizes the same way. An unknown future
 version is preserved and may fall back to a compatible last-known-good copy, but an older host never
 overwrites it implicitly. Persisted settings normalization isolates malformed custom presets and, when the
 selected custom preset is lost, restores the contracts default preset **and both default group capacities** so

--- a/packages/server/src/layout/SPEC.md
+++ b/packages/server/src/layout/SPEC.md
@@ -10,8 +10,9 @@ tags: [layout, persistence, wire]
 
 ## Responsibility
 
-The host authority for one versioned structural workbench-layout snapshot per workspace: validate, hydrate,
-atomically persist, monotonically revision, replace, and broadcast complete documents.
+The host authority for one versioned structural workbench-layout snapshot per workspace: validate and migrate
+the recursive center plus left/right/bottom auxiliary regions, atomically persist, monotonically revision,
+replace, and broadcast complete documents.
 
 ## Boundary
 
@@ -24,7 +25,8 @@ atomically persist, monotonically revision, replace, and broadcast complete docu
 - **Public surface (`index.ts`):** read/replace operations, document + portable-preset validators, pure
   persisted-layout-settings normalization, publisher injection, persistence/recovery hooks, and a test
   reset seam. `host`
-  supplies the current side-group policy from `settings`; layout does not import that sibling.
+  supplies the current independent side/bottom group-limit policy from `settings`; layout does not import that
+  sibling.
 - **External deps:** `@thinkrail/contracts` only. Internal sibling edges are declared in the server parent
   spec.
 - **Forbidden:** importing host or web; rendering/layout projection; owning file/session/terminal lifetime;
@@ -32,22 +34,26 @@ atomically persist, monotonically revision, replace, and broadcast complete docu
   malformed/unknown-schema documents.
 
 `layout.get` returns `null` for an uninitialized workspace; the compatible web client owns built-in preset
-instantiation and commits the first document through the normal replace path. Known persisted versions
-migrate before use. An unknown future version is preserved and may fall back to a compatible last-known-good
-copy, but an older host never overwrites it implicitly. Persisted settings normalization isolates malformed
-custom presets and, when the selected custom preset is lost, restores the contracts default preset **and its
-default side-group capacity** so the fallback cannot become structurally inapplicable.
+instantiation and commits the first document through the normal replace path. A persisted version-1 document
+migrates to version 2 with a hidden, empty below-center bottom region, preserving every existing placement,
+side geometry, and process lifetime. A bottom-less custom preset normalizes the same way. An unknown future
+version is preserved and may fall back to a compatible last-known-good copy, but an older host never
+overwrites it implicitly. Persisted settings normalization isolates malformed custom presets and, when the
+selected custom preset is lost, restores the contracts default preset **and both default group capacities** so
+the fallback cannot become structurally inapplicable.
 
 A replacement is accepted only when `expectedRevision` matches the current snapshot inside the serialized
 workspace queue: `null` matches absence only, and a number matches that exact revision only. A mismatch
 returns a typed conflict carrying the current snapshot (including `null`) and does not validate/persist the
 stale document, increment the revision, or broadcast. `mutationId` remains correlation metadata only.
-Configured side limits use `max(limit, acceptedCount)` per side, so grandfathered overages survive but cannot
-increase. On acceptance the module assigns the next revision, persists before broadcasting, and cancels
-queued writes when workspace cleanup wins the race. It enforces one final empty center leaf, normalized split/side weights,
-outer side widths that leave a center region, canonical worktree-relative POSIX file/diff/document paths
-(backslashes, absolute paths, and Windows drive-absolute forms are rejected), opaque placement ids (including
-singleton-tool ids), and one semantic placement per resource; it never mutates a
-document merely because a client viewport is smaller. Resource validation is syntactic and policy-based;
+Configured limits use `max(limit, acceptedCount)`: one shared left/right limit plus an independent bottom
+limit, so grandfathered overages survive but cannot increase. On acceptance the module assigns the next
+revision, persists before broadcasting, and cancels queued writes when workspace cleanup wins the race. It
+enforces one final empty center leaf; normalized split, side, and bottom weights; outer side widths that leave
+a center region; bottom height within its normalized contract; a closed alignment enum; non-empty side groups
+versus intentionally legal empty bottom slots; canonical worktree-relative POSIX file/diff/document paths
+(backslashes, absolute paths, and Windows drive-absolute forms are rejected); opaque placement ids (including
+singleton-tool ids); and one semantic placement per resource. It never mutates a document merely because a
+client viewport is smaller. Resource validation is syntactic and policy-based;
 layout does not dereference sibling domain registries. References are placement only, and
 their domain modules remain the existence/lifetime authorities.

--- a/packages/server/src/layout/SPEC.md
+++ b/packages/server/src/layout/SPEC.md
@@ -36,7 +36,9 @@ replace, and broadcast complete documents.
 `layout.get` returns `null` for an uninitialized workspace; the compatible web client owns built-in preset
 instantiation and commits the first document through the normal replace path. A persisted version-1 document
 migrates to version 2 with a hidden, empty below-center bottom region, preserving every existing placement,
-side geometry, and process lifetime. A bottom-less custom preset normalizes the same way. An unknown future
+side geometry, and process lifetime. Migration floors the reported snapshot revision at 2; revision 1 remains
+an unambiguous fresh-version-2 marker for the web's one-time default-terminal seed. A bottom-less custom
+preset normalizes the same way. An unknown future
 version is preserved and may fall back to a compatible last-known-good copy, but an older host never
 overwrites it implicitly. Persisted settings normalization isolates malformed custom presets and, when the
 selected custom preset is lost, restores the contracts default preset **and both default group capacities** so

--- a/packages/server/src/layout/layout.test.ts
+++ b/packages/server/src/layout/layout.test.ts
@@ -212,7 +212,9 @@ describe("workspace layout validation", () => {
 				{ kind: "group", id: "empty-b", tabs: [] },
 			],
 		};
-		expect(() => validateWorkspaceLayout(emptyLeaves, LIMITS)).toThrow("Only one empty center group");
+		expect(() => validateWorkspaceLayout(emptyLeaves, LIMITS)).toThrow(
+			"Only one empty center group",
+		);
 
 		const badGeometry = document();
 		const rightGroup = badGeometry.right.groups[0];
@@ -227,7 +229,9 @@ describe("workspace layout validation", () => {
 
 	test("enforces byte-accurate budgets and rejects unserializable values", () => {
 		const byteHeavy = { ...document(), padding: "界".repeat(180_000) };
-		expect(() => validateWorkspaceLayout(byteHeavy, LIMITS)).toThrow("Layout snapshot is too large");
+		expect(() => validateWorkspaceLayout(byteHeavy, LIMITS)).toThrow(
+			"Layout snapshot is too large",
+		);
 		expect(() => validateWorkspaceLayout({ ...document(), padding: 1n }, LIMITS)).toThrow(
 			"Layout snapshot is too large",
 		);

--- a/packages/server/src/layout/layout.test.ts
+++ b/packages/server/src/layout/layout.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
+	LayoutBottomGroup,
 	LayoutChangedPayload,
 	LayoutPreset,
 	LayoutReplaceResult,
@@ -25,10 +26,11 @@ import {
 
 let dataDir: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+const LIMITS = { maxSideGroups: 6, maxBottomGroups: 3 } as const;
 
 function document(name = "README.md"): WorkspaceLayoutDocument {
 	return {
-		version: 1,
+		version: 2,
 		center: {
 			kind: "group",
 			id: "center",
@@ -58,8 +60,20 @@ function document(name = "README.md"): WorkspaceLayoutDocument {
 				},
 			],
 		},
+		bottom: {
+			visible: true,
+			height: 0.3,
+			alignment: "center",
+			groups: [{ id: "bottom", weight: 1, folded: false, tabs: [] }],
+		},
 		toolRestoreTargets: {},
 	};
+}
+
+function legacyDocument(name = "README.md") {
+	const current = document(name);
+	const { bottom: _bottom, ...legacy } = current;
+	return { ...legacy, version: 1 };
 }
 
 function preset(id: string): LayoutPreset {
@@ -76,6 +90,12 @@ function preset(id: string): LayoutPreset {
 				{ id: `${id}-two`, weight: 1 / 3, folded: false, tools: ["changes"] },
 				{ id: `${id}-three`, weight: 1 / 3, folded: false, tools: ["review"] },
 			],
+		},
+		bottom: {
+			visible: true,
+			height: 0.3,
+			alignment: "center",
+			groups: [{ id: `${id}-bottom`, weight: 1, folded: false, tools: [] }],
 		},
 	};
 }
@@ -96,12 +116,12 @@ afterEach(() => {
 
 describe("workspace layout validation", () => {
 	test("accepts the protocol document and rejects unknown or browser-only fields", () => {
-		expect(validateWorkspaceLayout(document(), 6)).toEqual(document());
+		expect(validateWorkspaceLayout(document(), LIMITS)).toEqual(document());
 		const withInlineContent = structuredClone(document()) as WorkspaceLayoutDocument & {
 			content?: string;
 		};
 		withInlineContent.content = "not legal shared state";
-		expect(() => validateWorkspaceLayout(withInlineContent, 6)).toThrow("unknown field");
+		expect(() => validateWorkspaceLayout(withInlineContent, LIMITS)).toThrow("unknown field");
 
 		const virtual = document();
 		if (virtual.center.kind !== "group") throw new Error("expected group");
@@ -116,23 +136,44 @@ describe("workspace layout validation", () => {
 				content: "inline markdown",
 			} as never,
 		];
-		expect(() => validateWorkspaceLayout(virtual, 6)).toThrow("unknown field");
+		expect(() => validateWorkspaceLayout(virtual, LIMITS)).toThrow("unknown field");
 		delete (virtual.center.tabs[0] as { content?: string }).content;
 		(virtual.center.tabs[0] as { docPath: string }).docPath = "../TODO.md";
-		expect(() => validateWorkspaceLayout(virtual, 6)).toThrow("Invalid virtual document");
+		expect(() => validateWorkspaceLayout(virtual, LIMITS)).toThrow("Invalid virtual document");
 
 		const chatPreview = document();
 		if (chatPreview.center.kind !== "group") throw new Error("expected group");
 		chatPreview.center.tabs = [{ kind: "chat", id: "chat", name: "Chat", sessionId: "session" }];
 		chatPreview.center.previewTabId = "chat";
-		expect(() => validateWorkspaceLayout(chatPreview, 6)).toThrow("invalid preview");
+		expect(() => validateWorkspaceLayout(chatPreview, LIMITS)).toThrow("invalid preview");
 
 		const unsafeRestore = document();
 		unsafeRestore.toolRestoreTargets.files = {
-			side: "right",
+			region: "right",
 			index: Number.MAX_SAFE_INTEGER + 1,
 		};
-		expect(() => validateWorkspaceLayout(unsafeRestore, 6)).toThrow("Invalid restore target");
+		expect(() => validateWorkspaceLayout(unsafeRestore, LIMITS)).toThrow("Invalid restore target");
+	});
+
+	test("accepts process-free bottom slots and rejects malformed bottom geometry or content", () => {
+		expect(validateWorkspaceLayout(document(), LIMITS)).toEqual(document());
+
+		const badAlignment = structuredClone(document());
+		badAlignment.bottom.alignment = "floating" as never;
+		expect(() => validateWorkspaceLayout(badAlignment, LIMITS)).toThrow("Malformed bottom region");
+
+		const badHeight = structuredClone(document());
+		badHeight.bottom.height = 0.8;
+		expect(() => validateWorkspaceLayout(badHeight, LIMITS)).toThrow("Invalid bottom height");
+
+		const illegalTab = structuredClone(document());
+		illegalTab.bottom.groups[0]?.tabs.push({
+			kind: "file",
+			id: "bottom-file",
+			name: "README",
+			path: "README.md",
+		} as never);
+		expect(() => validateWorkspaceLayout(illegalTab, LIMITS)).toThrow("Invalid file tab");
 	});
 
 	test("rejects noncanonical resource paths and more than one empty center leaf", () => {
@@ -144,21 +185,21 @@ describe("workspace layout validation", () => {
 			name: "README alias",
 			path: "./README.md",
 		});
-		expect(() => validateWorkspaceLayout(pathAlias, 6)).toThrow("Invalid file tab");
+		expect(() => validateWorkspaceLayout(pathAlias, LIMITS)).toThrow("Invalid file tab");
 		pathAlias.center.tabs[1] = {
 			kind: "file",
 			id: "file:alias",
 			name: "README alias",
 			path: "folder\\README.md",
 		};
-		expect(() => validateWorkspaceLayout(pathAlias, 6)).toThrow("Invalid file tab");
+		expect(() => validateWorkspaceLayout(pathAlias, LIMITS)).toThrow("Invalid file tab");
 		pathAlias.center.tabs[1] = {
 			kind: "file",
 			id: "file:alias",
 			name: "README alias",
 			path: "C:/outside/README.md",
 		};
-		expect(() => validateWorkspaceLayout(pathAlias, 6)).toThrow("Invalid file tab");
+		expect(() => validateWorkspaceLayout(pathAlias, LIMITS)).toThrow("Invalid file tab");
 
 		const emptyLeaves = document();
 		emptyLeaves.center = {
@@ -171,23 +212,23 @@ describe("workspace layout validation", () => {
 				{ kind: "group", id: "empty-b", tabs: [] },
 			],
 		};
-		expect(() => validateWorkspaceLayout(emptyLeaves, 6)).toThrow("Only one empty center group");
+		expect(() => validateWorkspaceLayout(emptyLeaves, LIMITS)).toThrow("Only one empty center group");
 
 		const badGeometry = document();
 		const rightGroup = badGeometry.right.groups[0];
 		if (!rightGroup) throw new Error("missing right group fixture");
 		rightGroup.weight = 2;
-		expect(() => validateWorkspaceLayout(badGeometry, 6)).toThrow("not normalized");
+		expect(() => validateWorkspaceLayout(badGeometry, LIMITS)).toThrow("not normalized");
 		rightGroup.weight = 1;
 		badGeometry.left.width = 0.7;
 		badGeometry.right.width = 0.4;
-		expect(() => validateWorkspaceLayout(badGeometry, 6)).toThrow("no center region");
+		expect(() => validateWorkspaceLayout(badGeometry, LIMITS)).toThrow("no center region");
 	});
 
 	test("enforces byte-accurate budgets and rejects unserializable values", () => {
 		const byteHeavy = { ...document(), padding: "界".repeat(180_000) };
-		expect(() => validateWorkspaceLayout(byteHeavy, 6)).toThrow("Layout snapshot is too large");
-		expect(() => validateWorkspaceLayout({ ...document(), padding: 1n }, 6)).toThrow(
+		expect(() => validateWorkspaceLayout(byteHeavy, LIMITS)).toThrow("Layout snapshot is too large");
+		expect(() => validateWorkspaceLayout({ ...document(), padding: 1n }, LIMITS)).toThrow(
 			"Layout snapshot is too large",
 		);
 		expect(() =>
@@ -195,6 +236,7 @@ describe("workspace layout validation", () => {
 				defaultPresetId: "界".repeat(180_000),
 				customPresets: [],
 				maxSideGroups: 6,
+				maxBottomGroups: 3,
 			}),
 		).toThrow("Layout settings are too large");
 	});
@@ -206,7 +248,7 @@ describe("workspace layout validation", () => {
 		const files = filesGroup.tabs[0];
 		if (files?.kind !== "tool") throw new Error("missing tool fixture");
 		filesGroup.tabs[0] = { ...files, id: "legacy-files-placement" };
-		expect(validateWorkspaceLayout(opaque, 6)).toEqual(opaque);
+		expect(validateWorkspaceLayout(opaque, LIMITS)).toEqual(opaque);
 
 		const collision = document();
 		if (collision.center.kind !== "group") throw new Error("expected group");
@@ -216,7 +258,7 @@ describe("workspace layout validation", () => {
 			name: "Terminal",
 			tabKey: "collision",
 		});
-		expect(validateWorkspaceLayout(collision, 6)).toEqual(collision);
+		expect(validateWorkspaceLayout(collision, LIMITS)).toEqual(collision);
 	});
 
 	test("rejects one canonical resource smuggled under two placement ids", () => {
@@ -234,7 +276,7 @@ describe("workspace layout validation", () => {
 			name: "Terminal alias",
 			tabKey: "shared-terminal",
 		});
-		expect(() => validateWorkspaceLayout(duplicate, 6)).toThrow(
+		expect(() => validateWorkspaceLayout(duplicate, LIMITS)).toThrow(
 			"Duplicate canonical resource: terminal shared-terminal",
 		);
 
@@ -256,7 +298,7 @@ describe("workspace layout validation", () => {
 				scope: { kind: "commit", sha: "y" },
 			},
 		);
-		expect(() => validateWorkspaceLayout(delimiterSafe, 6)).not.toThrow();
+		expect(() => validateWorkspaceLayout(delimiterSafe, LIMITS)).not.toThrow();
 	});
 
 	test("grandfathers only the currently accepted side overage", () => {
@@ -279,10 +321,31 @@ describe("workspace layout validation", () => {
 			weight: 1 / 7,
 		}));
 		const sameCount = structuredClone(current);
-		expect(validateWorkspaceLayout(sameCount, 6, current)).toEqual(sameCount);
+		expect(validateWorkspaceLayout(sameCount, LIMITS, current)).toEqual(sameCount);
 		const increased = structuredClone(current);
 		increased.right.groups.push({ ...makeGroup(7), weight: 1 / 7 });
-		expect(() => validateWorkspaceLayout(increased, 6, current)).toThrow("group limit");
+		expect(() => validateWorkspaceLayout(increased, LIMITS, current)).toThrow("group limit");
+	});
+
+	test("grandfathers bottom overages independently from side limits", () => {
+		const current = document();
+		const makeGroup = (index: number): LayoutBottomGroup => ({
+			id: `bottom-${index}`,
+			weight: 0.25,
+			folded: false,
+			tabs: [],
+		});
+		current.bottom.groups = Array.from({ length: 4 }, (_, index) => makeGroup(index));
+		const sameCount = structuredClone(current);
+		expect(validateWorkspaceLayout(sameCount, LIMITS, current)).toEqual(sameCount);
+		const increased = structuredClone(current);
+		increased.bottom.groups = [
+			...increased.bottom.groups.map((group) => ({ ...group, weight: 0.2 })),
+			{ id: "bottom-4", weight: 0.2, folded: false, tabs: [] },
+		];
+		expect(() => validateWorkspaceLayout(increased, LIMITS, current)).toThrow(
+			"bottom region exceeds its group limit",
+		);
 	});
 
 	test("rejects unnormalized portable preset geometry", () => {
@@ -312,36 +375,67 @@ describe("workspace layout validation", () => {
 			defaultPresetId: "future-built-in",
 			customPresets: [valid, valid, { id: "broken" } as never],
 			maxSideGroups: 1,
+			maxBottomGroups: 1,
 		});
 		expect(normalized).toEqual({
 			defaultPresetId: "future-built-in",
 			customPresets: [valid],
 			maxSideGroups: 3,
+			maxBottomGroups: 1,
 		});
 
 		const selectedInvalid: LayoutSettings = {
 			defaultPresetId: "broken",
 			customPresets: [{ id: "broken" } as never],
 			maxSideGroups: 1,
+			maxBottomGroups: 1,
 		};
 		expect(normalizeStoredLayoutSettings(selectedInvalid)).toEqual({
 			defaultPresetId: "balanced",
 			customPresets: [],
 			maxSideGroups: 6,
+			maxBottomGroups: 3,
 		});
 
 		const capped = normalizeStoredLayoutSettings({
 			defaultPresetId: "balanced",
 			customPresets: Array.from({ length: 40 }, (_, index) => preset(`custom-${index}`)),
 			maxSideGroups: 6,
+			maxBottomGroups: 3,
 		});
 		expect(capped.customPresets).toHaveLength(32);
 	});
 
+	test("migrates bottom-less custom presets to a hidden empty bottom slot", () => {
+		const { bottom: _bottom, ...current } = preset("legacy-custom");
+		const normalized = normalizeStoredLayoutSettings({
+			defaultPresetId: "legacy-custom",
+			customPresets: [current as never],
+			maxSideGroups: 6,
+			maxBottomGroups: 3,
+		});
+		expect(normalized.customPresets[0]?.bottom).toEqual({
+			visible: false,
+			height: 0.3,
+			alignment: "center",
+			groups: [],
+		});
+	});
+
 	test("validates layout settings as one complete strict nested value", () => {
 		expect(
-			validateLayoutSettings({ defaultPresetId: "balanced", customPresets: [], maxSideGroups: 6 }),
-		).toEqual({ defaultPresetId: "balanced", customPresets: [], maxSideGroups: 6 });
+			validateLayoutSettings({
+				defaultPresetId: "balanced",
+				customPresets: [],
+				maxSideGroups: 6,
+				maxBottomGroups: 3,
+			}),
+		).toEqual({
+			defaultPresetId: "balanced",
+			customPresets: [],
+			maxSideGroups: 6,
+			maxBottomGroups: 3,
+		});
 		expect(() => validateLayoutSettings({ defaultPresetId: "balanced", maxSideGroups: 6 })).toThrow(
 			"Invalid layout settings",
 		);
@@ -350,6 +444,7 @@ describe("workspace layout validation", () => {
 				defaultPresetId: "balanced",
 				customPresets: [],
 				maxSideGroups: 6,
+				maxBottomGroups: 3,
 				extra: true,
 			}),
 		).toThrow("unknown field");
@@ -371,6 +466,30 @@ describe("workspace layout persistence and ordering", () => {
 		return result.payload;
 	}
 
+	test("migrates a stored version-1 layout without moving resources or showing bottom", () => {
+		const directory = join(dataDir, "layouts");
+		mkdirSync(directory, { recursive: true });
+		const legacy = legacyDocument();
+		legacy.toolRestoreTargets = { changes: { side: "right", index: 1 } } as never;
+		writeFileSync(
+			join(directory, "ws.json"),
+			JSON.stringify({ workspaceId: "ws", revision: 7, document: legacy }),
+		);
+
+		const migrated = getWorkspaceLayout("ws");
+		expect(migrated?.revision).toBe(7);
+		expect(migrated?.document).toEqual({
+			...document(),
+			bottom: {
+				visible: false,
+				height: 0.3,
+				alignment: "center",
+				groups: [],
+			},
+			toolRestoreTargets: { changes: { region: "right", index: 1 } },
+		});
+	});
+
 	test("serializes dependent writes with the revision produced by their predecessor", async () => {
 		const seen: LayoutChangedPayload[] = [];
 		setLayoutPublisher((payload) => seen.push(payload));
@@ -381,7 +500,7 @@ describe("workspace layout persistence and ordering", () => {
 				expectedRevision: null,
 				document: document("first.ts"),
 			},
-			6,
+			LIMITS,
 		);
 		const second = replaceWorkspaceLayout(
 			{
@@ -390,7 +509,7 @@ describe("workspace layout persistence and ordering", () => {
 				expectedRevision: 1,
 				document: document("second.ts"),
 			},
-			6,
+			LIMITS,
 		);
 		const payloads = (await Promise.all([first, second])).map(accepted);
 		expect(payloads.map((payload) => payload.snapshot.revision)).toEqual([1, 2]);
@@ -414,7 +533,7 @@ describe("workspace layout persistence and ordering", () => {
 					expectedRevision: null,
 					document: document("seed.ts"),
 				},
-				6,
+				LIMITS,
 			),
 		);
 		const seen: LayoutChangedPayload[] = [];
@@ -428,7 +547,7 @@ describe("workspace layout persistence and ordering", () => {
 					expectedRevision: 1,
 					document: document("client-a.ts"),
 				},
-				6,
+				LIMITS,
 			),
 			replaceWorkspaceLayout(
 				{
@@ -437,7 +556,7 @@ describe("workspace layout persistence and ordering", () => {
 					expectedRevision: 1,
 					document: document("client-b.ts"),
 				},
-				6,
+				LIMITS,
 			),
 		]);
 
@@ -482,7 +601,7 @@ describe("workspace layout persistence and ordering", () => {
 					expectedRevision: 0,
 					document: document("stale.ts"),
 				},
-				6,
+				LIMITS,
 			),
 		).resolves.toEqual({ status: "conflict", current: null });
 		expect(getWorkspaceLayout("ws")).toBeNull();
@@ -495,7 +614,7 @@ describe("workspace layout persistence and ordering", () => {
 				expectedRevision: null,
 				document: document("created.ts"),
 			},
-			6,
+			LIMITS,
 		);
 		expect(accepted(created).snapshot.revision).toBe(1);
 	});
@@ -504,7 +623,7 @@ describe("workspace layout persistence and ordering", () => {
 		const workspaceId = "../legacy workspace";
 		await replaceWorkspaceLayout(
 			{ workspaceId, mutationId: "safe-path", expectedRevision: null, document: document() },
-			6,
+			LIMITS,
 		);
 		resetLayoutsForTests();
 		expect(getWorkspaceLayout(workspaceId)?.workspaceId).toBe(workspaceId);
@@ -522,7 +641,7 @@ describe("workspace layout persistence and ordering", () => {
 				expectedRevision: null,
 				document: document("first.ts"),
 			},
-			6,
+			LIMITS,
 		);
 		await replaceWorkspaceLayout(
 			{
@@ -531,7 +650,7 @@ describe("workspace layout persistence and ordering", () => {
 				expectedRevision: 1,
 				document: document("second.ts"),
 			},
-			6,
+			LIMITS,
 		);
 		writeFileSync(join(dataDir, "layouts", "ws.json"), "{broken");
 		resetLayoutsForTests();
@@ -562,7 +681,7 @@ describe("workspace layout persistence and ordering", () => {
 					expectedRevision: 4,
 					document: document("overwrite.ts"),
 				},
-				6,
+				LIMITS,
 			),
 		).rejects.toThrow("read-only");
 		const primary = JSON.parse(readFileSync(join(directory, "ws.json"), "utf8"));
@@ -572,7 +691,7 @@ describe("workspace layout persistence and ordering", () => {
 	test("a workspace removal cancels a queued write before it can resurrect persistence", async () => {
 		const pending = replaceWorkspaceLayout(
 			{ workspaceId: "ws", mutationId: "racing", expectedRevision: null, document: document() },
-			6,
+			LIMITS,
 		);
 		removeWorkspaceLayout("ws");
 		await expect(pending).rejects.toThrow("removed before the write completed");
@@ -582,7 +701,7 @@ describe("workspace layout persistence and ordering", () => {
 	test("removes primary, backup, and cache with the workspace", async () => {
 		await replaceWorkspaceLayout(
 			{ workspaceId: "ws", mutationId: "first", expectedRevision: null, document: document() },
-			6,
+			LIMITS,
 		);
 		removeWorkspaceLayout("ws");
 		expect(getWorkspaceLayout("ws")).toBeNull();

--- a/packages/server/src/layout/layout.test.ts
+++ b/packages/server/src/layout/layout.test.ts
@@ -500,6 +500,17 @@ describe("workspace layout persistence and ordering", () => {
 		});
 	});
 
+	test("keeps a revision-one version-1 migration distinct from a fresh version-2 layout", () => {
+		const directory = join(dataDir, "layouts");
+		mkdirSync(directory, { recursive: true });
+		writeFileSync(
+			join(directory, "ws.json"),
+			JSON.stringify({ workspaceId: "ws", revision: 1, document: legacyDocument() }),
+		);
+
+		expect(getWorkspaceLayout("ws")?.revision).toBe(2);
+	});
+
 	test("serializes dependent writes with the revision produced by their predecessor", async () => {
 		const seen: LayoutChangedPayload[] = [];
 		setLayoutPublisher((payload) => seen.push(payload));

--- a/packages/server/src/layout/layout.test.ts
+++ b/packages/server/src/layout/layout.test.ts
@@ -56,7 +56,7 @@ function document(name = "README.md"): WorkspaceLayoutDocument {
 					id: "right",
 					weight: 1,
 					folded: false,
-					tabs: [{ kind: "tool", id: "tool:files", name: "All files", tool: "files" }],
+					tabs: [{ kind: "tool", id: "tool:files", name: "Files", tool: "files" }],
 				},
 			],
 		},

--- a/packages/server/src/layout/layout.test.ts
+++ b/packages/server/src/layout/layout.test.ts
@@ -166,6 +166,12 @@ describe("workspace layout validation", () => {
 		badHeight.bottom.height = 0.8;
 		expect(() => validateWorkspaceLayout(badHeight, LIMITS)).toThrow("Invalid bottom height");
 
+		const visibleWithoutSlot = structuredClone(document());
+		visibleWithoutSlot.bottom.groups = [];
+		expect(() => validateWorkspaceLayout(visibleWithoutSlot, LIMITS)).toThrow(
+			"Visible bottom region requires a group",
+		);
+
 		const illegalTab = structuredClone(document());
 		illegalTab.bottom.groups[0]?.tabs.push({
 			kind: "file",

--- a/packages/server/src/layout/layout.ts
+++ b/packages/server/src/layout/layout.ts
@@ -22,6 +22,13 @@ const MAX_CENTER_GROUPS = 4;
 const MAX_DEPTH = 8;
 const MAX_TABS = 256;
 const MAX_SIDE_GROUPS_SAFETY = 32;
+const MAX_BOTTOM_HEIGHT = 0.7;
+const DEFAULT_BOTTOM = {
+	visible: false,
+	height: 0.3,
+	alignment: "center",
+	groups: [],
+} as const;
 const MAX_CUSTOM_PRESETS = 32;
 const MAX_NAME_LENGTH = 200;
 const MAX_TAB_NAME_LENGTH = 1000;
@@ -44,6 +51,38 @@ function record(value: unknown): Record<string, unknown> | null {
 	return value !== null && typeof value === "object" && !Array.isArray(value)
 		? (value as Record<string, unknown>)
 		: null;
+}
+
+type LayoutGroupLimits = Pick<LayoutSettings, "maxSideGroups" | "maxBottomGroups">;
+
+function migrateRestoreTargets(value: unknown): unknown {
+	const targets = record(value);
+	if (!targets) return value;
+	return Object.fromEntries(
+		Object.entries(targets).map(([tool, raw]) => {
+			const target = record(raw);
+			if (!target || !("side" in target) || "region" in target) return [tool, raw];
+			const { side, ...rest } = target;
+			return [tool, { ...rest, region: side }];
+		}),
+	);
+}
+
+function migrateWorkspaceDocument(value: unknown): unknown {
+	const document = record(value);
+	if (document?.version !== 1) return value;
+	return {
+		...document,
+		version: 2,
+		bottom: structuredClone(DEFAULT_BOTTOM),
+		toolRestoreTargets: migrateRestoreTargets(document.toolRestoreTargets),
+	};
+}
+
+function migrateStoredPreset(value: unknown): unknown {
+	const preset = record(value);
+	if (!preset || preset.bottom !== undefined) return value;
+	return { ...preset, bottom: structuredClone(DEFAULT_BOTTOM) };
 }
 
 function nonEmptyString(value: unknown, max = MAX_NAME_LENGTH): value is string {
@@ -365,6 +404,54 @@ function validateSide(
 	}
 }
 
+function validateBottom(
+	value: unknown,
+	currentCount: number,
+	configuredLimit: number,
+	state: ValidationState,
+): void {
+	const region = record(value);
+	if (
+		!region ||
+		typeof region.visible !== "boolean" ||
+		!positive(region.height) ||
+		(region.alignment !== "center" &&
+			region.alignment !== "center-left" &&
+			region.alignment !== "center-right" &&
+			region.alignment !== "full") ||
+		!Array.isArray(region.groups)
+	) {
+		state.errors.push("Malformed bottom region");
+		return;
+	}
+	validateKeys(region, ["visible", "height", "alignment", "groups"], "Bottom region", state);
+	if (Number(region.height) > MAX_BOTTOM_HEIGHT) state.errors.push("Invalid bottom height");
+	const allowed = Math.max(configuredLimit, currentCount);
+	if (region.groups.length > allowed) state.errors.push("bottom region exceeds its group limit");
+	if (region.groups.length > MAX_SIDE_GROUPS_SAFETY) {
+		state.errors.push("bottom region exceeds the safety limit");
+	}
+	let weightTotal = 0;
+	for (const valueGroup of region.groups) {
+		const group = record(valueGroup);
+		if (!group || !addId(state, group.id, "Bottom group")) continue;
+		validateKeys(group, ["id", "weight", "folded", "tabs"], `Bottom group ${group.id}`, state);
+		if (
+			!positive(group.weight) ||
+			typeof group.folded !== "boolean" ||
+			!Array.isArray(group.tabs)
+		) {
+			state.errors.push(`Malformed bottom group: ${group.id}`);
+			continue;
+		}
+		weightTotal += Number(group.weight);
+		for (const tab of group.tabs) validateTab(tab, "side", state);
+	}
+	if (region.groups.length > 0 && Math.abs(weightTotal - 1) > 1e-6) {
+		state.errors.push("Bottom group weights are not normalized");
+	}
+}
+
 function validateRestoreTargets(value: unknown, state: ValidationState): void {
 	const targets = record(value);
 	if (!targets) {
@@ -377,10 +464,12 @@ function validateRestoreTargets(value: unknown, state: ValidationState): void {
 			continue;
 		}
 		const target = record(raw);
-		if (target) validateKeys(target, ["side", "groupId", "index"], `Restore target ${tool}`, state);
+		if (target) {
+			validateKeys(target, ["region", "groupId", "index"], `Restore target ${tool}`, state);
+		}
 		if (
 			!target ||
-			(target.side !== "left" && target.side !== "right") ||
+			(target.region !== "left" && target.region !== "right" && target.region !== "bottom") ||
 			!Number.isSafeInteger(target.index) ||
 			Number(target.index) < 0 ||
 			Number(target.index) > MAX_TABS ||
@@ -393,12 +482,12 @@ function validateRestoreTargets(value: unknown, state: ValidationState): void {
 
 export function validateWorkspaceLayout(
 	value: unknown,
-	configuredLimit: number,
+	limits: LayoutGroupLimits,
 	current?: WorkspaceLayoutDocument,
 ): WorkspaceLayoutDocument {
 	if (exceedsLayoutBudget(value)) throw new Error("Layout snapshot is too large");
 	const document = record(value);
-	if (document?.version !== 1) throw new Error("Unsupported layout schema version");
+	if (document?.version !== 2) throw new Error("Unsupported layout schema version");
 	const state: ValidationState = {
 		errors: [],
 		ids: new Set(),
@@ -411,13 +500,31 @@ export function validateWorkspaceLayout(
 	};
 	validateKeys(
 		document,
-		["version", "center", "left", "right", "toolRestoreTargets"],
+		["version", "center", "left", "right", "bottom", "toolRestoreTargets"],
 		"Layout document",
 		state,
 	);
 	validateCenter(document.center, 1, state);
-	validateSide(document.left, "left", current?.left.groups.length ?? 0, configuredLimit, state);
-	validateSide(document.right, "right", current?.right.groups.length ?? 0, configuredLimit, state);
+	validateSide(
+		document.left,
+		"left",
+		current?.left.groups.length ?? 0,
+		limits.maxSideGroups,
+		state,
+	);
+	validateSide(
+		document.right,
+		"right",
+		current?.right.groups.length ?? 0,
+		limits.maxSideGroups,
+		state,
+	);
+	validateBottom(
+		document.bottom,
+		current?.bottom.groups.length ?? 0,
+		limits.maxBottomGroups,
+		state,
+	);
 	const left = record(document.left);
 	const right = record(document.right);
 	if (
@@ -478,7 +585,7 @@ export function validateLayoutPreset(value: unknown): LayoutPreset {
 	if (!preset || !nonEmptyString(preset.id, 200) || !nonEmptyString(preset.name, MAX_NAME_LENGTH)) {
 		throw new Error("Malformed layout preset");
 	}
-	assertKeys(preset, ["id", "name", "center", "left", "right"], "Layout preset");
+	assertKeys(preset, ["id", "name", "center", "left", "right", "bottom"], "Layout preset");
 	const ids = new Set<string>();
 	if (validatePresetCenter(preset.center, 1, ids) > MAX_CENTER_GROUPS) {
 		throw new Error("Preset has too many center groups");
@@ -527,6 +634,52 @@ export function validateLayoutPreset(value: unknown): LayoutPreset {
 			throw new Error(`Preset ${side} side group weights are not normalized`);
 		}
 	}
+	const bottom = record(preset.bottom);
+	if (
+		!bottom ||
+		typeof bottom.visible !== "boolean" ||
+		!positive(bottom.height) ||
+		Number(bottom.height) > MAX_BOTTOM_HEIGHT ||
+		(bottom.alignment !== "center" &&
+			bottom.alignment !== "center-left" &&
+			bottom.alignment !== "center-right" &&
+			bottom.alignment !== "full") ||
+		!Array.isArray(bottom.groups)
+	) {
+		throw new Error("Malformed preset bottom region");
+	}
+	assertKeys(bottom, ["visible", "height", "alignment", "groups"], "Preset bottom region");
+	if (bottom.visible && bottom.groups.length === 0) {
+		throw new Error("Preset bottom region cannot be visible without a group");
+	}
+	if (bottom.groups.length > MAX_SIDE_GROUPS_SAFETY) {
+		throw new Error("Preset has too many bottom groups");
+	}
+	let bottomWeightTotal = 0;
+	for (const rawGroup of bottom.groups) {
+		const group = record(rawGroup);
+		if (
+			!group ||
+			!nonEmptyString(group.id, 200) ||
+			!positive(group.weight) ||
+			typeof group.folded !== "boolean" ||
+			!Array.isArray(group.tools) ||
+			!group.tools.every((tool) => typeof tool === "string" && TOOL_IDS.has(tool as LayoutToolId))
+		) {
+			throw new Error("Malformed preset bottom group");
+		}
+		assertKeys(group, ["id", "weight", "folded", "tools"], "Preset bottom group");
+		bottomWeightTotal += Number(group.weight);
+		if (ids.has(group.id)) throw new Error(`Duplicate preset id: ${group.id}`);
+		ids.add(group.id);
+		for (const tool of group.tools) {
+			if (tools.has(String(tool))) throw new Error(`Duplicate preset singleton tool: ${tool}`);
+			tools.add(String(tool));
+		}
+	}
+	if (bottom.groups.length > 0 && Math.abs(bottomWeightTotal - 1) > 1e-6) {
+		throw new Error("Preset bottom group weights are not normalized");
+	}
 	const left = record(preset.left);
 	const right = record(preset.right);
 	if (
@@ -546,9 +699,10 @@ export function normalizeStoredLayoutSettings(current: LayoutSettings): LayoutSe
 		(candidate) => record(candidate)?.id === current.defaultPresetId,
 	);
 	let maxSideGroups = current.maxSideGroups;
+	let maxBottomGroups = current.maxBottomGroups ?? DEFAULT_CONFIG.layout.maxBottomGroups;
 	for (const candidate of current.customPresets.slice(0, MAX_CUSTOM_PRESETS)) {
 		try {
-			const preset = validateLayoutPreset(candidate);
+			const preset = validateLayoutPreset(migrateStoredPreset(candidate));
 			if (seen.has(preset.id)) continue;
 			seen.add(preset.id);
 			customPresets.push(preset);
@@ -557,6 +711,7 @@ export function normalizeStoredLayoutSettings(current: LayoutSettings): LayoutSe
 				preset.left.groups.length,
 				preset.right.groups.length,
 			);
+			maxBottomGroups = Math.max(maxBottomGroups, preset.bottom.groups.length);
 		} catch {}
 	}
 	const selectedCustomSurvived = customPresets.some(
@@ -571,6 +726,9 @@ export function normalizeStoredLayoutSettings(current: LayoutSettings): LayoutSe
 		maxSideGroups: fellBackToDefault
 			? Math.max(maxSideGroups, DEFAULT_CONFIG.layout.maxSideGroups)
 			: maxSideGroups,
+		maxBottomGroups: fellBackToDefault
+			? Math.max(maxBottomGroups, DEFAULT_CONFIG.layout.maxBottomGroups)
+			: maxBottomGroups,
 	};
 }
 
@@ -583,12 +741,19 @@ export function validateLayoutSettings(value: unknown): LayoutSettings {
 		!Number.isInteger(settings.maxSideGroups) ||
 		Number(settings.maxSideGroups) < 1 ||
 		Number(settings.maxSideGroups) > MAX_SIDE_GROUPS_SAFETY ||
+		!Number.isInteger(settings.maxBottomGroups) ||
+		Number(settings.maxBottomGroups) < 1 ||
+		Number(settings.maxBottomGroups) > MAX_SIDE_GROUPS_SAFETY ||
 		!Array.isArray(settings.customPresets) ||
 		settings.customPresets.length > MAX_CUSTOM_PRESETS
 	) {
 		throw new Error("Invalid layout settings");
 	}
-	assertKeys(settings, ["defaultPresetId", "customPresets", "maxSideGroups"], "Layout settings");
+	assertKeys(
+		settings,
+		["defaultPresetId", "customPresets", "maxSideGroups", "maxBottomGroups"],
+		"Layout settings",
+	);
 	for (const rawPreset of settings.customPresets) {
 		const preset = validateLayoutPreset(rawPreset);
 		if (
@@ -596,6 +761,9 @@ export function validateLayoutSettings(value: unknown): LayoutSettings {
 			preset.right.groups.length > Number(settings.maxSideGroups)
 		) {
 			throw new Error("Custom preset exceeds the configured side-group limit");
+		}
+		if (preset.bottom.groups.length > Number(settings.maxBottomGroups)) {
+			throw new Error("Custom preset exceeds the configured bottom-group limit");
 		}
 	}
 	const ids = settings.customPresets.map((preset) => preset.id);
@@ -615,7 +783,10 @@ function parseSnapshot(value: unknown, workspaceId: string): WorkspaceLayoutSnap
 		return null;
 	}
 	try {
-		const document = validateWorkspaceLayout(snapshot.document, MAX_SIDE_GROUPS_SAFETY);
+		const document = validateWorkspaceLayout(migrateWorkspaceDocument(snapshot.document), {
+			maxSideGroups: MAX_SIDE_GROUPS_SAFETY,
+			maxBottomGroups: MAX_SIDE_GROUPS_SAFETY,
+		});
 		return { workspaceId, revision: Number(snapshot.revision), document };
 	} catch {
 		return null;
@@ -625,7 +796,7 @@ function parseSnapshot(value: unknown, workspaceId: string): WorkspaceLayoutSnap
 function hasFutureLayoutVersion(value: unknown): boolean {
 	const snapshot = record(value);
 	const document = record(snapshot?.document);
-	return typeof document?.version === "number" && document.version > 1;
+	return typeof document?.version === "number" && document.version > 2;
 }
 
 export function getWorkspaceLayout(workspaceId: string): WorkspaceLayoutSnapshot | null {
@@ -651,7 +822,7 @@ export function getWorkspaceLayout(workspaceId: string): WorkspaceLayoutSnapshot
 
 export function replaceWorkspaceLayout(
 	params: LayoutReplaceParams,
-	configuredLimit: number,
+	limits: LayoutGroupLimits,
 ): Promise<LayoutReplaceResult> {
 	if (!nonEmptyString(params.mutationId, 200))
 		return Promise.reject(new Error("Invalid layout mutation id"));
@@ -678,7 +849,7 @@ export function replaceWorkspaceLayout(
 			if (futureProtected.has(params.workspaceId)) {
 				throw new Error("Workspace layout is read-only because it was written by a newer host");
 			}
-			const document = validateWorkspaceLayout(params.document, configuredLimit, current?.document);
+			const document = validateWorkspaceLayout(params.document, limits, current?.document);
 			if ((current?.revision ?? 0) >= Number.MAX_SAFE_INTEGER) {
 				throw new Error("Workspace layout revision limit reached");
 			}

--- a/packages/server/src/layout/layout.ts
+++ b/packages/server/src/layout/layout.ts
@@ -425,6 +425,9 @@ function validateBottom(
 		return;
 	}
 	validateKeys(region, ["visible", "height", "alignment", "groups"], "Bottom region", state);
+	if (region.visible && region.groups.length === 0) {
+		state.errors.push("Visible bottom region requires a group");
+	}
 	if (Number(region.height) > MAX_BOTTOM_HEIGHT) state.errors.push("Invalid bottom height");
 	const allowed = Math.max(configuredLimit, currentCount);
 	if (region.groups.length > allowed) state.errors.push("bottom region exceeds its group limit");

--- a/packages/server/src/layout/layout.ts
+++ b/packages/server/src/layout/layout.ts
@@ -23,6 +23,7 @@ const MAX_DEPTH = 8;
 const MAX_TABS = 256;
 const MAX_SIDE_GROUPS_SAFETY = 32;
 const MAX_BOTTOM_HEIGHT = 0.7;
+const MIGRATED_LAYOUT_REVISION_FLOOR = 2;
 const DEFAULT_BOTTOM = {
 	visible: false,
 	height: 0.3,
@@ -786,11 +787,15 @@ function parseSnapshot(value: unknown, workspaceId: string): WorkspaceLayoutSnap
 		return null;
 	}
 	try {
+		const migratedFromVersionOne = record(snapshot.document)?.version === 1;
 		const document = validateWorkspaceLayout(migrateWorkspaceDocument(snapshot.document), {
 			maxSideGroups: MAX_SIDE_GROUPS_SAFETY,
 			maxBottomGroups: MAX_SIDE_GROUPS_SAFETY,
 		});
-		return { workspaceId, revision: Number(snapshot.revision), document };
+		const revision = migratedFromVersionOne
+			? Math.max(Number(snapshot.revision), MIGRATED_LAYOUT_REVISION_FLOOR)
+			: Number(snapshot.revision);
+		return { workspaceId, revision, document };
 	} catch {
 		return null;
 	}

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -17,8 +17,8 @@ and the install identity — as JSON under the data dir.
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
   `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, `loadConfig`/`saveConfig`
-  (`config.json`, fieldwise-normalized over `DEFAULT_CONFIG`—including nested layout settings—so a missing
-  file or key degrades cleanly, while unknown top-level extension fields survive known-field updates),
+  (`config.json`, fieldwise-normalized over `DEFAULT_CONFIG`—including both nested layout group limits—so a
+  missing file or key degrades cleanly, while unknown top-level extension fields survive known-field updates),
   `loadWorkspaceLayout`/`loadWorkspaceLayoutBackup`/`saveWorkspaceLayout`/`removeWorkspaceLayout`
   (versioned full snapshots in traversal-safe workspace-keyed filenames; atomic replacement with a
   last-known-good copy so a torn/corrupt write cannot blank a workspace; complete cleanup when its

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -95,6 +95,13 @@ export function loadConfig(): AppConfig {
 				layoutValue.maxSideGroups <= 32
 					? layoutValue.maxSideGroups
 					: DEFAULT_CONFIG.layout.maxSideGroups,
+			maxBottomGroups:
+				typeof layoutValue.maxBottomGroups === "number" &&
+				Number.isInteger(layoutValue.maxBottomGroups) &&
+				layoutValue.maxBottomGroups >= 1 &&
+				layoutValue.maxBottomGroups <= 32
+					? layoutValue.maxBottomGroups
+					: DEFAULT_CONFIG.layout.maxBottomGroups,
 		},
 	};
 }

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -11,7 +11,8 @@ tags: [v1]
 ## Responsibility
 
 The server-synced app config — OUR settings (an opaque theme selection, the analytics switch, terminal
-replay budget, and workbench default/custom presets + side-group limit), an extensible `AppConfig` bag.
+replay budget, and workbench default/custom presets + independent side/bottom group limits), an extensible
+`AppConfig` bag.
 Reads/merges/persists it and fans changes out to every client,
 so a preference set on one client follows the user to the others (architecture #9: shared domain state). The
 web client owns the available theme manifests; settings stores only the selected string id.
@@ -40,7 +41,7 @@ web client owns the available theme manifests; settings stores only the selected
 - `settings.update` remains a top-level partial merge; a supplied `layout` field is a complete validated
   `LayoutSettings` replacement, never a nested partial that could drop catalog/default/limit siblings.
 - Layout preset payloads are portable structure/tool placement only; settings never accepts workspace
-  resource identities in a preset. `host` runs custom payloads through `layout`'s portable-preset validator
-  before calling settings, preserving sibling boundaries without duplicating the parser. Built-in definitions
-  may evolve with the independently shipped UI, while the host preserves the selected opaque id and custom
-  payloads.
+  resource identities in a preset. Empty bottom groups are structural terminal slots, not terminal identity or
+  count. `host` runs custom payloads through `layout`'s portable-preset validator before calling settings,
+  preserving sibling boundaries without duplicating the parser. Built-in definitions may evolve with the
+  independently shipped UI, while the host preserves the selected opaque id and custom payloads.

--- a/packages/server/src/settings/settings.test.ts
+++ b/packages/server/src/settings/settings.test.ts
@@ -74,6 +74,7 @@ test("loadConfig normalizes nested layout fields independently", () => {
 				defaultPresetId: "review",
 				customPresets: "corrupt",
 				maxSideGroups: 0,
+				maxBottomGroups: 33,
 			},
 		}),
 	);
@@ -85,6 +86,7 @@ test("loadConfig normalizes nested layout fields independently", () => {
 			defaultPresetId: "review",
 			customPresets: [],
 			maxSideGroups: DEFAULT_CONFIG.layout.maxSideGroups,
+			maxBottomGroups: DEFAULT_CONFIG.layout.maxBottomGroups,
 		},
 	});
 });

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -21,9 +21,10 @@ separate layout snapshot and merely references `tabKey`.
   `(workspaceId, tabKey)`; batched output on `terminal.data` plus `terminal.exit` / `terminal.detached`
   (addressed) and `terminal.tabs` (broadcast), via injected publishers; the bounded per-terminal output
   recorder replayed on attach.
-- **Public surface (barrel):** `attachTerminal`, `listTerminals`, `writeTerminal`, `resizeTerminal`,
-  `closeTerminalTab`, `resumeClientTerminals`, `closeWorkspaceTerminals`, `persistTerminalSessions`,
-  `reviveTerminalSessions`, `closeAllTerminals`, `resetTerminalState` (test seam), `setTerminalPublisher`,
+- **Public surface (barrel):** `reserveTerminal`, `attachTerminal`, `listTerminals`, `writeTerminal`,
+  `resizeTerminal`, `closeTerminalTab`, `resumeClientTerminals`, `closeWorkspaceTerminals`,
+  `persistTerminalSessions`, `reviveTerminalSessions`, `closeAllTerminals`, `resetTerminalState` (test seam),
+  `setTerminalPublisher`,
   `setTerminalTabsPublisher`;
   the `TerminalDeliveryResult` type shared with the host publisher adapter.
 - **Allowed deps:** `persistence`, `contracts` (`WS_CHANNELS`), `bun-pty`, `process.env`.
@@ -37,8 +38,10 @@ separate layout snapshot and merely references `tabKey`.
 - **A shell is keyed by `(workspaceId, tabKey)`**, never by a socket, a client, or a component. `tabKey` is
   durable and client-supplied; PTY ids are per-run and **never persisted** (attaching to an id that outlived
   its process is Theia's `Couldn't attach - can't find terminal with id`).
-- **`attachTerminal` is idempotent get-or-create** — the only way a PTY is born. No separate liveness call, so
-  there is no window in which a client holds the only pointer to a running shell.
+- **Catalog reservation and PTY attachment are separate.** `reserveTerminal` idempotently persists and
+  broadcasts a client-minted tab identity without spawning. `attachTerminal` remains idempotent
+  get-or-create and the only way a PTY is born. This is not a liveness split: a client still never holds the
+  only pointer to a running shell.
 - **Tracked-grid updates are change-only.** Each live entry tracks the grid applied at spawn or by the last
   successful resize. Attach and explicit resize advance that grid only when it changes, and failed calls do not
   advance it. A reattach may still perform a *transient* redraw nudge (below) that leaves the tracked grid
@@ -76,8 +79,8 @@ separate layout snapshot and merely references `tabKey`.
   first keystroke is what stops a tab looking live while nothing happens. The client also guards the reverse
   order with an attach generation, so a stale attach response can never clear a newer detach.
 - **Output stays addressed**, never broadcast — a frame only ever reaches a client that attached. The tab
-  *catalog* is the exception: which terminals exist is shared domain state (architecture #9), so every change
-  fans out on `terminal.tabs` as an idempotent per-workspace snapshot.
+  *catalog* is the exception: which terminals exist is shared domain state (architecture #12), so every
+  reservation or removal fans out on `terminal.tabs` as an idempotent per-workspace snapshot.
 - **A shell dies from exactly five causes:** tab closed, workspace archived, natural exit, host stop, orphan
   sweep on attach. Unmounting a view kills nothing.
 - **No idle culling.** Terminal "activity" can only mean last PTY I/O, so a quiet long-running command would be
@@ -116,7 +119,7 @@ separate layout snapshot and merely references `tabKey`.
   keeping mode sequences out of the body (incl. a recording persisted by a host that still replayed them).
 - `outputBatcher.test.ts` — batching, backpressure, truncation, `reset`.
 - `shellBusy.test.ts` — child detection, including that an unanswerable platform reports *not* busy.
-- `terminalManager.test.ts` — attach idempotency (incl. concurrent), takeover, displaced-client rejection,
-  tab-list broadcast, close/busy, revive.
+- `terminalManager.test.ts` — reservation without spawn, attach idempotency (incl. concurrent), takeover,
+  displaced-client rejection, tab-list broadcast, close/busy, revive.
 - `e2e/terminals.spec.ts` — the rapid re-entry regression, reload survival, second-client takeover,
   cross-client tab convergence.

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -38,10 +38,15 @@ separate layout snapshot and merely references `tabKey`.
 - **A shell is keyed by `(workspaceId, tabKey)`**, never by a socket, a client, or a component. `tabKey` is
   durable and client-supplied; PTY ids are per-run and **never persisted** (attaching to an id that outlived
   its process is Theia's `Couldn't attach - can't find terminal with id`).
-- **Catalog reservation and PTY attachment are separate.** `reserveTerminal` idempotently persists and
-  broadcasts a client-minted tab identity without spawning. `attachTerminal` remains idempotent
-  get-or-create and the only way a PTY is born. This is not a liveness split: a client still never holds the
-  only pointer to a running shell.
+- **Catalog reservation and PTY attachment are separate.** `reserveTerminal` idempotently records a
+  client-minted tab identity without spawning. A new reservation is transactional: validate and insert,
+  persist the complete catalog, then publish membership; persistence failure removes the in-memory insertion
+  and publishes nothing. `attachTerminal` remains idempotent get-or-create and the only way a PTY is born.
+  This is not a liveness split: a client still never holds the only pointer to a running shell.
+- **Durable terminal identities are bounded.** A workspace catalog holds at most 256 tabs; a key is non-empty
+  and at most 500 characters, and a title is non-empty and at most 1000 characters. Reservation and new attach
+  share those checks. Revival truncates oversized catalogs, drops invalid keys, and repairs invalid titles
+  before exposing host-authoritative membership.
 - **Tracked-grid updates are change-only.** Each live entry tracks the grid applied at spawn or by the last
   successful resize. Attach and explicit resize advance that grid only when it changes, and failed calls do not
   advance it. A reattach may still perform a *transient* redraw nudge (below) that leaves the tracked grid
@@ -119,7 +124,8 @@ separate layout snapshot and merely references `tabKey`.
   keeping mode sequences out of the body (incl. a recording persisted by a host that still replayed them).
 - `outputBatcher.test.ts` — batching, backpressure, truncation, `reset`.
 - `shellBusy.test.ts` — child detection, including that an unanswerable platform reports *not* busy.
-- `terminalManager.test.ts` — reservation without spawn, attach idempotency (incl. concurrent), takeover,
-  displaced-client rejection, tab-list broadcast, close/busy, revive.
+- `terminalManager.test.ts` — transactional durable reservation without spawn, catalog bounds, attach
+  idempotency (incl. concurrent), takeover, displaced-client rejection, tab-list broadcast, close/busy,
+  revive.
 - `e2e/terminals.spec.ts` — the rapid re-entry regression, reload survival, second-client takeover,
   cross-client tab convergence.

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Workspace } from "@thinkrail/contracts";
-import { saveWorkspaces } from "../persistence";
+import { saveTerminalSessions, saveWorkspaces } from "../persistence";
 import {
 	attachTerminal,
 	closeTerminalTab,
@@ -117,12 +117,66 @@ test("reserving a tab persists catalog membership without starting its shell", (
 	});
 	expect(listTerminals(WS)).toEqual([{ tabKey: "tab-a", title: "Reserved" }]);
 	expect(seen).toEqual([{ workspaceId: WS, tabs: [{ tabKey: "tab-a", title: "Reserved" }] }]);
+	expect(attachTerminal(WS, "tab-a", "client-1").created).toBe(true);
 
-	persistTerminalSessions();
 	resetTerminalState();
 	reviveTerminalSessions();
 	expect(listTerminals(WS)).toEqual([{ tabKey: "tab-a", title: "Reserved" }]);
-	expect(attachTerminal(WS, "tab-a", "client-1").created).toBe(true);
+});
+
+test("a failed reservation persistence rolls back without publishing membership", () => {
+	const seen: unknown[] = [];
+	setTerminalTabsPublisher((workspaceId, tabs) => seen.push({ workspaceId, tabs }));
+	mkdirSync(join(dataDir, "terminals.json"));
+
+	expect(() => reserveTerminal(WS, "tab-a", "Reserved")).toThrow();
+	expect(listTerminals(WS)).toEqual([]);
+	expect(seen).toEqual([]);
+});
+
+test("reservations and attachments reject malformed or excessive catalog entries", () => {
+	expect(() => reserveTerminal(WS, "", "Terminal")).toThrow("Invalid terminal tab key");
+	expect(() => reserveTerminal(WS, "x".repeat(501), "Terminal")).toThrow(
+		"Invalid terminal tab key",
+	);
+	expect(() => reserveTerminal(WS, "tab-a", "")).toThrow("Invalid terminal title");
+	expect(() => reserveTerminal(WS, "tab-a", "x".repeat(1001))).toThrow("Invalid terminal title");
+	expect(() => attachTerminal(WS, "", "client-1")).toThrow("Invalid terminal tab key");
+	expect(() => attachTerminal(WS, "tab-a", "client-1", { title: "" })).toThrow(
+		"Invalid terminal title",
+	);
+	for (let index = 0; index < 256; index += 1) {
+		reserveTerminal(WS, `tab-${index}`, `Terminal ${index}`);
+	}
+	expect(() => reserveTerminal(WS, "tab-over-limit", "Terminal")).toThrow(
+		"Terminal tabs are limited to 256 per workspace",
+	);
+	expect(() => attachTerminal(WS, "tab-over-limit", "client-1")).toThrow(
+		"Terminal tabs are limited to 256 per workspace",
+	);
+});
+
+test("revival bounds the catalog and sanitizes durable identities", () => {
+	saveTerminalSessions({
+		[WS]: [
+			{ tabKey: "", title: "Dropped" },
+			{ tabKey: "x".repeat(501), title: "Dropped" },
+			{ tabKey: "kept", title: "" },
+		],
+	});
+	reviveTerminalSessions();
+	expect(listTerminals(WS)).toEqual([{ tabKey: "kept", title: "Terminal" }]);
+
+	resetTerminalState();
+	saveTerminalSessions({
+		[WS]: Array.from({ length: 300 }, (_, index) => ({
+			tabKey: `tab-${index}`,
+			title: `Terminal ${index}`,
+		})),
+	});
+	reviveTerminalSessions();
+	expect(listTerminals(WS)).toHaveLength(256);
+	expect(listTerminals(WS).at(-1)?.tabKey).toBe("tab-255");
 });
 
 test("the tab list is the host's, in creation order", () => {

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -10,6 +10,7 @@ import {
 	closeWorkspaceTerminals,
 	listTerminals,
 	persistTerminalSessions,
+	reserveTerminal,
 	resetTerminalState,
 	resizeTerminal,
 	reviveTerminalSessions,
@@ -100,6 +101,28 @@ test("re-attaching as the same client does not announce a takeover", () => {
 	attachTerminal(WS, "tab-a", "client-1");
 
 	expect(pushed.filter((frame) => frame.channel === "terminal.detached")).toHaveLength(0);
+});
+
+test("reserving a tab persists catalog membership without starting its shell", () => {
+	const seen: unknown[] = [];
+	setTerminalTabsPublisher((workspaceId, tabs) => seen.push({ workspaceId, tabs }));
+
+	expect(reserveTerminal(WS, "tab-a", "Reserved")).toEqual({
+		tabKey: "tab-a",
+		title: "Reserved",
+	});
+	expect(reserveTerminal(WS, "tab-a", "Ignored rename")).toEqual({
+		tabKey: "tab-a",
+		title: "Reserved",
+	});
+	expect(listTerminals(WS)).toEqual([{ tabKey: "tab-a", title: "Reserved" }]);
+	expect(seen).toEqual([{ workspaceId: WS, tabs: [{ tabKey: "tab-a", title: "Reserved" }] }]);
+
+	persistTerminalSessions();
+	resetTerminalState();
+	reviveTerminalSessions();
+	expect(listTerminals(WS)).toEqual([{ tabKey: "tab-a", title: "Reserved" }]);
+	expect(attachTerminal(WS, "tab-a", "client-1").created).toBe(true);
 });
 
 test("the tab list is the host's, in creation order", () => {

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -179,6 +179,20 @@ function spawnForTab(
 	return { id, entry };
 }
 
+export function reserveTerminal(
+	workspaceId: string,
+	tabKey: string,
+	title: string,
+): TerminalTabInfo {
+	const tabs = tabsFor(workspaceId);
+	const existing = tabs.find((tab) => tab.tabKey === tabKey);
+	if (existing) return { tabKey: existing.tabKey, title: existing.title };
+	const tab = { tabKey, title };
+	tabs.push(tab);
+	membershipChanged(workspaceId);
+	return tab;
+}
+
 export interface AttachResult {
 	id: string;
 	created: boolean;

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -47,6 +47,9 @@ const OUTPUT_BATCH = {
 	maxBatchChars: 32_768,
 	maxPendingChars: 1_048_576,
 } as const;
+const MAX_TERMINAL_TABS_PER_WORKSPACE = 256;
+const MAX_TERMINAL_TAB_KEY_LENGTH = 500;
+const MAX_TERMINAL_TITLE_LENGTH = 1000;
 
 const terminals = new Map<string, TerminalEntry>();
 const ptyByTab = new Map<string, string>();
@@ -107,6 +110,32 @@ function tabsFor(workspaceId: string): TabRecord[] {
 		tabsByWorkspace.set(workspaceId, tabs);
 	}
 	return tabs;
+}
+
+function isValidTerminalTabKey(value: unknown): value is string {
+	return (
+		typeof value === "string" && value.length > 0 && value.length <= MAX_TERMINAL_TAB_KEY_LENGTH
+	);
+}
+
+function assertTerminalTabKey(tabKey: string): void {
+	if (!isValidTerminalTabKey(tabKey)) throw new Error("Invalid terminal tab key");
+}
+
+function isValidTerminalTitle(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0 && value.length <= MAX_TERMINAL_TITLE_LENGTH;
+}
+
+function assertTerminalTitle(title: string): void {
+	if (!isValidTerminalTitle(title)) throw new Error("Invalid terminal title");
+}
+
+function assertTerminalCatalogCapacity(tabs: readonly TabRecord[]): void {
+	if (tabs.length >= MAX_TERMINAL_TABS_PER_WORKSPACE) {
+		throw new Error(
+			`Terminal tabs are limited to ${MAX_TERMINAL_TABS_PER_WORKSPACE} per workspace`,
+		);
+	}
 }
 
 function spawnForTab(
@@ -184,12 +213,22 @@ export function reserveTerminal(
 	tabKey: string,
 	title: string,
 ): TerminalTabInfo {
+	assertTerminalTabKey(tabKey);
+	assertTerminalTitle(title);
 	const tabs = tabsFor(workspaceId);
 	const existing = tabs.find((tab) => tab.tabKey === tabKey);
 	if (existing) return { tabKey: existing.tabKey, title: existing.title };
+	assertTerminalCatalogCapacity(tabs);
 	const tab = { tabKey, title };
 	tabs.push(tab);
-	membershipChanged(workspaceId);
+	try {
+		persistTerminalSessions();
+	} catch (error) {
+		tabs.pop();
+		if (tabs.length === 0) tabsByWorkspace.delete(workspaceId);
+		throw error;
+	}
+	broadcastTabs(workspaceId, listTerminals(workspaceId));
 	return tab;
 }
 
@@ -205,9 +244,12 @@ export function attachTerminal(
 	clientKey: string,
 	options: { title?: string; cols?: number; rows?: number } = {},
 ): AttachResult {
+	assertTerminalTabKey(tabKey);
+	if (options.title !== undefined) assertTerminalTitle(options.title);
 	const tabs = tabsFor(workspaceId);
 	const isNewTab = !tabs.some((tab) => tab.tabKey === tabKey);
 	if (isNewTab) {
+		assertTerminalCatalogCapacity(tabs);
 		tabs.push({ tabKey, title: options.title ?? `Terminal ${tabs.length + 1}` });
 	}
 
@@ -356,9 +398,10 @@ export function reviveTerminalSessions(): void {
 	for (const [workspaceId, tabs] of Object.entries(loadTerminalSessions())) {
 		if (!Array.isArray(tabs)) continue;
 		const restored: TabRecord[] = [];
-		for (const tab of tabs) {
-			if (typeof tab?.tabKey !== "string" || tab.tabKey === "") continue;
-			restored.push({ tabKey: tab.tabKey, title: tab.title ?? "Terminal" });
+		for (const tab of tabs.slice(0, MAX_TERMINAL_TABS_PER_WORKSPACE)) {
+			if (!isValidTerminalTabKey(tab?.tabKey)) continue;
+			const title = isValidTerminalTitle(tab.title) ? tab.title : "Terminal";
+			restored.push({ tabKey: tab.tabKey, title });
 			if (typeof tab.recorded === "string" && tab.recorded !== "") {
 				pendingReplay.set(tabIndex(workspaceId, tab.tabKey), tab.recorded);
 			}

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -161,6 +161,11 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   `kind: "default"` — forget would hand the archive teardown's `rm -rf` fallback the project folder,
   rename would `git branch -m` the user's real branch; the record carries `renamed: true` so both
   auto-rename passes stay away as belt-and-suspenders.
+- **Initial-terminal eligibility is creation-owned.** Every workspace record first persisted by
+  `createWorkspace`, `openExistingWorktree`, or Default ensure carries the optional literal marker
+  `initialTerminalEligible: true`. Existing records are never backfilled during list, refresh, or migration;
+  absence means legacy/ineligible. The web combines this host-owned creation fact with first-layout state, so
+  opening a pre-existing layoutless workspace after an upgrade cannot manufacture a default terminal.
 - **`ensureWorkspaceScratchDir(ws)`** — idempotent seed of the gitignored `WORKSPACE_CONTEXT_DIR`
   scratch dir (mkdir + self-ignoring `*` `.gitignore`); the host calls it on **session create** for
   every workspace, so the Default workspace writes into the user's repo only when a chat actually

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -81,9 +81,27 @@ test("createWorkspace cuts a fresh branch from baseRef and records it as the bas
 
 	const ws = await createWorkspace("p1", undefined, "feature/base");
 	expect(ws.baseBranch).toBe("feature/base");
+	expect(ws.initialTerminalEligible).toBe(true);
 	expect(gitOut(ws.worktreePath, "rev-parse", "HEAD")).toBe(baseSha);
 	expect(gitOut(ws.worktreePath, "rev-parse", "--abbrev-ref", "HEAD")).toBe(ws.branch);
 	expect(ws.branch).not.toBe("feature/base");
+});
+
+test("legacy workspace records never gain initial-terminal eligibility on read", async () => {
+	const ws = await createWorkspace("p1");
+	const file = join(dataDir, "workspaces.json");
+	const records = JSON.parse(readFileSync(file, "utf8")) as Array<Record<string, unknown>>;
+	const record = records.find((candidate) => candidate.id === ws.id);
+	if (!record) throw new Error("missing workspace record");
+	delete record.initialTerminalEligible;
+	writeFileSync(file, JSON.stringify(records));
+
+	expect(listWorkspaceRecords("p1").find((candidate) => candidate.id === ws.id)).not.toHaveProperty(
+		"initialTerminalEligible",
+	);
+	expect(listWorkspaces("p1").find((candidate) => candidate.id === ws.id)).not.toHaveProperty(
+		"initialTerminalEligible",
+	);
 });
 
 test("createWorkspace branches off a locally-present remote ref without a network fetch", async () => {
@@ -214,6 +232,7 @@ test("openExistingWorktree adopts idempotently and removal never reclaims the ch
 		worktreePath: external,
 		baseBranch: "main",
 		renamed: true,
+		initialTerminalEligible: true,
 	});
 	expect(events).toEqual([{ kind: "created", workspace }]);
 	expect(listExistingWorktrees("p1")).toHaveLength(0);
@@ -553,6 +572,7 @@ test("listWorkspaces ensures exactly one Default workspace, pinned first, with f
 	expect(def?.branch).toBe("main");
 	expect(def?.baseBranch).toBe("main");
 	expect(def?.renamed).toBe(true);
+	expect(def?.initialTerminalEligible).toBe(true);
 
 	const again = listWorkspaces("p1");
 	expect(again.filter((w) => w.kind === "default")).toHaveLength(1);

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -169,6 +169,7 @@ export function openExistingWorktree(projectId: string, requestedPath: string): 
 		worktreePath: entry.path,
 		baseBranch,
 		renamed: true,
+		initialTerminalEligible: true,
 	};
 	all.push(workspace);
 	saveWorkspaces(all);
@@ -261,6 +262,7 @@ export async function createWorkspace(
 		branch,
 		worktreePath,
 		baseBranch,
+		initialTerminalEligible: true,
 		...(displayName ? { renamed: true } : {}),
 	};
 	ensureWorkspaceScratchDir(workspace);
@@ -319,6 +321,7 @@ function ensureDefaultWorkspace(project: Project): Workspace {
 		worktreePath: project.path,
 		baseBranch,
 		renamed: true,
+		initialTerminalEligible: true,
 	};
 	all.push(workspace);
 	saveWorkspaces(all);


### PR DESCRIPTION
## Summary

- Add a synchronized bottom workbench panel for terminals and tools.
- Support alignment, resizing, folding, presets, keyboard controls, and responsive layouts.
- Migrate existing layouts safely and reserve hidden default terminals without starting a PTY.

## Related issues

Follow-up: #290

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

## Screens

### workbench

<img width="1440" height="900" alt="workbench-before" src="https://github.com/user-attachments/assets/ca1fdf76-9419-4c59-ac8f-29810a6609db" />
<img width="1440" height="900" alt="workbench-after" src="https://github.com/user-attachments/assets/ff84ccd8-d884-4973-8e96-4a947684ce9a" />

### tabs

<img width="800" height="720" alt="tab-overflow-before" src="https://github.com/user-attachments/assets/99d0d6f2-54eb-421a-ac6a-9d3837b8663a" />
<img width="800" height="720" alt="tab-overflow-after" src="https://github.com/user-attachments/assets/c8c9167b-ba9f-413c-ba18-2711eadc2619" />

