### PR TITLE
feat(web): add native /compact command

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -15,6 +15,7 @@ import {
 	EMPTY_RUNTIME,
 	SettingsSection,
 	selectCatalogModel,
+	selectCompactionTurnIds,
 	selectSkillsStale,
 	selectWorkspaceById,
 	specPathMatcher,
@@ -29,11 +30,17 @@ import { ChatPlanContent, ChatPlanStripContent } from "./ChatPlan";
 import {
 	Composer,
 	type ComposerHandle,
+	type ComposerSubmitDisposition,
 	type MentionCandidate,
 	type SubmitBehavior,
 } from "./Composer";
 import { ExtUiDialog } from "./ExtUiDialog";
 import { HistoryOverlay } from "./HistoryOverlay";
+import {
+	COMPACT_IMAGE_ERROR,
+	mergeNativeChatCommands,
+	parseNativeChatCommand,
+} from "./nativeCommands";
 import { planGlance } from "./planView";
 import { QueueStrip } from "./QueueStrip";
 import { type ChatRow, deriveRows, rowIndexForTurn } from "./rows";
@@ -219,7 +226,11 @@ export default function ChatView({
 	}, [slashActive, workspaceId]);
 
 	const mergedCommands = useMemo(
-		() => [...commands.filter((c) => c.source !== "prompt"), ...templates.map(templateToCommand)],
+		() =>
+			mergeNativeChatCommands([
+				...commands.filter((command) => command.source !== "prompt"),
+				...templates.map(templateToCommand),
+			]),
 		[commands, templates],
 	);
 
@@ -286,6 +297,29 @@ export default function ChatView({
 		composerRef.current?.refocus();
 	};
 
+	const restoreQueueToDraft = async (): Promise<void> => {
+		const { steering, followUp } = await getTransport().request("session.clearQueue", {
+			sessionId,
+		});
+		restoreTextToDraft([...steering, ...followUp].join("\n\n"));
+	};
+
+	const performCompact = (instructions?: string) => {
+		const observedTurnIds = selectCompactionTurnIds(useAppStore.getState(), sessionId);
+		void restoreQueueToDraft()
+			.then(() =>
+				getTransport().request("session.compact", {
+					sessionId,
+					...(instructions ? { instructions } : {}),
+				}),
+			)
+			.catch((err) =>
+				useAppStore
+					.getState()
+					.appendCompactionFailureUnlessObserved(sessionId, observedTurnIds, errorText(err)),
+			);
+	};
+
 	const performSend = (
 		text: string,
 		attachments: ChatAttachment[],
@@ -310,10 +344,20 @@ export default function ChatView({
 			});
 	};
 
-	const onSubmit = (text: string, attachments: ChatAttachment[], behavior: SubmitBehavior) => {
+	const onSubmit = (
+		text: string,
+		attachments: ChatAttachment[],
+		behavior: SubmitBehavior,
+	): ComposerSubmitDisposition => {
+		const nativeCommand = parseNativeChatCommand(text);
+		if (nativeCommand) {
+			if (attachments.length > 0) return { accepted: false, reason: COMPACT_IMAGE_ERROR };
+			performCompact(nativeCommand.instructions);
+			return { accepted: true };
+		}
 		if (behavior !== "interrupt") {
 			performSend(text, attachments, behavior);
-			return;
+			return { accepted: true };
 		}
 		getTransport()
 			.request("session.abort", { sessionId })
@@ -322,6 +366,7 @@ export default function ChatView({
 				useAppStore.getState().appendErrorTurn(sessionId, errorText(err));
 				restoreTextToDraft(text);
 			});
+		return { accepted: true };
 	};
 
 	const removeQueued = (kind: QueueLane, index: number) =>
@@ -336,13 +381,6 @@ export default function ChatView({
 
 	const onRemoveQueued = (kind: QueueLane, index: number) =>
 		void removeQueued(kind, index).catch(() => {});
-
-	const restoreQueueToDraft = async (): Promise<void> => {
-		const { steering, followUp } = await getTransport().request("session.clearQueue", {
-			sessionId,
-		});
-		restoreTextToDraft([...steering, ...followUp].join("\n\n"));
-	};
 
 	const onAbort = () => {
 		void restoreQueueToDraft().catch(() => {});

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -37,7 +37,7 @@ import {
 import { ExtUiDialog } from "./ExtUiDialog";
 import { HistoryOverlay } from "./HistoryOverlay";
 import {
-	COMPACT_IMAGE_ERROR,
+	compactSubmissionError,
 	mergeNativeChatCommands,
 	parseNativeChatCommand,
 } from "./nativeCommands";
@@ -300,6 +300,7 @@ export default function ChatView({
 	const restoreQueueToDraft = async (): Promise<void> => {
 		const { steering, followUp } = await getTransport().request("session.clearQueue", {
 			sessionId,
+			requireTextOnly: true,
 		});
 		restoreTextToDraft([...steering, ...followUp].join("\n\n"));
 	};
@@ -351,7 +352,11 @@ export default function ChatView({
 	): ComposerSubmitDisposition => {
 		const nativeCommand = parseNativeChatCommand(text);
 		if (nativeCommand) {
-			if (attachments.length > 0) return { accepted: false, reason: COMPACT_IMAGE_ERROR };
+			const submissionError = compactSubmissionError(
+				attachments.length > 0,
+				queue.hasImages === true,
+			);
+			if (submissionError) return { accepted: false, reason: submissionError };
 			performCompact(nativeCommand.instructions);
 			return { accepted: true };
 		}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -3,6 +3,7 @@ import type {
 	AskUserQuestionResult,
 	PromptHit,
 	QueueLane,
+	SessionQueueContent,
 	SlashCommandInfo,
 	TemplateInfo,
 	ThinkingLevel,
@@ -297,17 +298,29 @@ export default function ChatView({
 		composerRef.current?.refocus();
 	};
 
-	const restoreQueueToDraft = async (): Promise<void> => {
-		const { steering, followUp } = await getTransport().request("session.clearQueue", {
+	const restoreQueueContentToDraft = (content: SessionQueueContent): void => {
+		const messages = [...content.steering, ...content.followUp];
+		restoreTextToDraft(messages.map((message) => message.text).join("\n\n"));
+		const images = messages.flatMap((message) => message.images ?? []);
+		composerRef.current?.restoreAttachments(
+			images.map((image, index) => ({
+				name: `queued-image-${index + 1}`,
+				content: image,
+			})),
+		);
+	};
+
+	const drainQueueToDraft = async (): Promise<void> => {
+		const content = await getTransport().request("session.clearQueue", {
 			sessionId,
 			requireTextOnly: true,
 		});
-		restoreTextToDraft([...steering, ...followUp].join("\n\n"));
+		restoreQueueContentToDraft(content);
 	};
 
 	const performCompact = (instructions?: string) => {
 		const observedTurnIds = selectCompactionTurnIds(useAppStore.getState(), sessionId);
-		void restoreQueueToDraft()
+		void drainQueueToDraft()
 			.then(() =>
 				getTransport().request("session.compact", {
 					sessionId,
@@ -380,7 +393,8 @@ export default function ChatView({
 	const onEditQueued = (kind: QueueLane, index: number) =>
 		void removeQueued(kind, index)
 			.then(({ removed }) => {
-				if (removed !== null) restoreTextToDraft(removed);
+				if (removed === null) return;
+				restoreQueueContentToDraft({ steering: [removed], followUp: [] });
 			})
 			.catch(() => {});
 
@@ -388,9 +402,11 @@ export default function ChatView({
 		void removeQueued(kind, index).catch(() => {});
 
 	const onAbort = () => {
-		void restoreQueueToDraft().catch(() => {});
-		getTransport()
-			.request("session.abort", { sessionId })
+		void getTransport()
+			.request("session.abort", { sessionId, restoreQueue: true })
+			.then(({ restoredQueue }) => {
+				if (restoredQueue) restoreQueueContentToDraft(restoredQueue);
+			})
 			.catch(() => {});
 	};
 

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -10,7 +10,6 @@ import {
 } from "@remixicon/react";
 import {
 	REQUEST_IMAGE_BASE64_BUDGET,
-	type SlashCommandInfo,
 	type ThinkingLevel,
 	type WireModel,
 } from "@thinkrail/contracts";
@@ -31,6 +30,7 @@ import { FileChip } from "./FileChip";
 import { type AttachedImage, fileToAttachedImage } from "./imageAttachment";
 import { ModelSelector } from "./ModelSelector";
 import {
+	type SlashCommandItem,
 	SlashCommandMenu,
 	selectedSlashCommandValue,
 	slashCommandQuery,
@@ -48,6 +48,8 @@ import { ThinkingSelector } from "./ThinkingSelector";
 import type { ChatAttachment } from "./types";
 
 export type SubmitBehavior = "send" | "steer" | "followUp" | "interrupt";
+
+export type ComposerSubmitDisposition = { accepted: true } | { accepted: false; reason: string };
 
 const STREAMING_SEND_MODES = [
 	{
@@ -151,7 +153,7 @@ interface ComposerProps {
 	value: string;
 	onChange: (value: string) => void;
 	isStreaming: boolean;
-	commands: SlashCommandInfo[];
+	commands: SlashCommandItem[];
 	mentionCandidates: MentionCandidate[];
 	recentPrompts: string[];
 	models: WireModel[];
@@ -163,7 +165,11 @@ interface ComposerProps {
 	onSlashActive: (active: boolean) => void;
 	onSelectModel: (model: WireModel) => void;
 	onSelectThinking: (level: ThinkingLevel) => void;
-	onSubmit: (text: string, attachments: ChatAttachment[], behavior: SubmitBehavior) => void;
+	onSubmit: (
+		text: string,
+		attachments: ChatAttachment[],
+		behavior: SubmitBehavior,
+	) => ComposerSubmitDisposition;
 	onAbort: () => void;
 	onHistoryOpen?: () => void;
 	onPickTemplate?: (name: string) => void;
@@ -209,9 +215,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const [caret, setCaret] = useState(0);
 	const [images, setImages] = useState<PendingImage[]>([]);
 	const imagesRef = useRef<PendingImage[]>([]);
+	const [submitError, setSubmitError] = useState<string | null>(null);
 	const commitImages = (next: PendingImage[]) => {
 		imagesRef.current = next;
 		setImages(next);
+		if (next.length === 0) setSubmitError(null);
 	};
 	const [pendingImages, setPendingImages] = useState(0);
 	const [attachErrors, setAttachErrors] = useState<AttachError[]>([]);
@@ -268,6 +276,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		(text: string, caret: number = text.length) => {
 			recallIdxRef.current = null;
 			setSlots(null);
+			setSubmitError(null);
 			onChange(text);
 			focusSelection(caret);
 		},
@@ -279,11 +288,16 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const submitText = (raw: string, behavior: SubmitBehavior) => {
 		if (!canSubmit(raw)) return;
 		const text = raw.trim();
-		onSubmit(
+		const disposition = onSubmit(
 			text,
 			images.map(({ name, content }) => ({ name, content })),
 			behavior,
 		);
+		if (!disposition.accepted) {
+			setSubmitError(disposition.reason);
+			return;
+		}
+		setSubmitError(null);
 		onChange("");
 		commitImages([]);
 		setAttachErrors([]);
@@ -562,8 +576,17 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				</button>
 			) : null}
 
-			{images.length > 0 || pendingImages > 0 || attachErrors.length > 0 ? (
+			{images.length > 0 || pendingImages > 0 || attachErrors.length > 0 || submitError ? (
 				<div className="flex flex-wrap gap-4 px-12 pt-12" data-testid="composer-images">
+					{submitError ? (
+						<FileChip
+							data-testid="composer-command-error"
+							tone="error"
+							icon={false}
+							title={submitError}
+							label={submitError}
+						/>
+					) : null}
 					{attachErrors.map((err) => (
 						<FileChip
 							key={err.id}
@@ -657,6 +680,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 						onChange={(e) => {
 							const next = e.target.value;
 							const nextCaret = e.target.selectionStart;
+							setSubmitError(null);
 							const recalled = recallIdxRef.current;
 							if (recalled !== null && next !== recentPrompts[recalled]) {
 								recallIdxRef.current = null;

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -181,6 +181,7 @@ export interface ComposerHandle {
 	insertText: (text: string) => void;
 	insertAndSubmit: (text: string, behavior: SubmitBehavior) => void;
 	insertTemplate: (parsed: ParsedTemplate) => void;
+	restoreAttachments: (attachments: ChatAttachment[]) => void;
 	openHistory: () => void;
 	refocus: () => void;
 }
@@ -348,6 +349,18 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 			setSlots(parsed.slots);
 			setSlotIdx(0);
 			focusSelection(first.start, first.end);
+		},
+		restoreAttachments: (attachments: ChatAttachment[]) => {
+			if (attachments.length === 0) return;
+			commitImages([
+				...attachments.map((attachment) => ({
+					id: crypto.randomUUID(),
+					...attachment,
+				})),
+				...imagesRef.current,
+			]);
+			setSubmitError(null);
+			focusSelection(caret);
 		},
 		openHistory,
 		refocus: () => {

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -412,7 +412,19 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `source === "prompt"` entries, plus a fresh `template.list { workspaceId }` fetch mapped to
   `SlashCommandInfo` rows (`source: "prompt"`, `sourceInfo` synthesized to match pi's own prompt-template
   convention exactly: `{ path: filePath, source: "local", scope: scope === "global" ? "user" : "project",
-  origin: "top-level" }`) — one merged list. When a `template.list` response comes back **empty**,
+  origin: "top-level" }`) — one merged list. The chat prepends its one **browser-native command**,
+  `/compact [instructions]`, as a display-local `builtin` row labelled `Pi/built-in`; contracts' Pi-mirrored
+  command source stays unchanged. Native `compact` is reserved over an exact-name extension/template
+  collision (skill commands remain namespaced), and the exact Pi parser recognizes only `/compact` or
+  `/compact ` plus trimmed instructions — every near-miss remains an ordinary prompt. A compact submit
+  bypasses the optimistic user echo and every streaming send mode: completed images reject it in place with
+  an actionable composer chip (text + images preserved; pending images already hold all submits), otherwise
+  the command clears, drains `session.clearQueue` back into the composer in steering-then-follow-up order,
+  then calls `session.compact`; Pi owns abort, summarization, persistence, and lifecycle. The request snapshots
+  existing compaction-turn ids, and a rejected clear/compact asks the store to append a failed compaction row
+  only when no new lifecycle turn appeared, so Pi's emitted failure and a pre-lifecycle wire failure share one
+  surface without duplicating. Existing live/hydrated compaction rendering is unchanged. When a
+  `template.list` response comes back **empty**,
   `SlashCommandMenu` renders a `footer` nudge (`data-testid="slash-templates-empty"`) that
   deep-links to Settings → Templates via `ChatView`'s `onManageTemplates` — the discoverability half of
   the starter-templates offer (`panels/SPEC.md`), since a fresh install has an empty global prompts dir

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -286,12 +286,15 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   are position-addressed, matching the wire op); edit additionally prepends the removed text to the
   draft and refocuses. Per-row actions exist because the original all-or-nothing dequeue (click strip
   → `clearQueue` → every message merged into one draft blob) proved undiscoverable and lossy in use.
-  **Abort still restores the whole queue** (`onAbort` → `session.clearQueue` → texts prepended
-  `\n\n`-joined, pi's restore order, then `session.abort`) — pi's Escape parity: an aborted run must
-  not silently discard messages queued behind it. A **rejected** streaming send likewise restores its
-  text to the draft alongside the `appendErrorTurn`. Trade-off, accepted: `queue_update` carries text
-  only, so a queued image attachment shows no chip in the strip; the canonical transcript turn later
-  renders its image blocks with the hydrated-turn fallback labels. E2e: `queue.live.spec.ts` (@agent).
+  **Abort restores a text-only queue** (`onAbort` → guarded `session.clearQueue` → texts prepended
+  `\n\n`-joined in pi's order, then `session.abort`) — pi's Escape parity. Pi returns only text from a
+  destructive clear even when its internal queued messages carry image blocks, so the host refuses that
+  guarded clear while either lane has queued images; abort may then let those queued messages continue,
+  but never silently discards their attachments. A **rejected** streaming send likewise restores its text
+  to the draft alongside the `appendErrorTurn`. `queue_update` still carries only displayable text plus a
+  conservative `hasImages` aggregate — no image bytes — so a queued image shows no chip in the strip; the
+  canonical transcript turn later renders its image blocks with hydrated fallback labels. E2e:
+  `queue.live.spec.ts` (@agent).
 - **Streaming send modes: split send + interrupt** (`Composer`) — steer/queue semantics are pi's loop
   design (steer = injected at the next turn boundary, after the current assistant message + its tool
   calls; queue = runs after the agent settles; only abort halts an in-flight response) and proved
@@ -417,10 +420,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   command source stays unchanged. Native `compact` is reserved over an exact-name extension/template
   collision (skill commands remain namespaced), and the exact Pi parser recognizes only `/compact` or
   `/compact ` plus trimmed instructions — every near-miss remains an ordinary prompt. A compact submit
-  bypasses the optimistic user echo and every streaming send mode: completed images reject it in place with
-  an actionable composer chip (text + images preserved; pending images already hold all submits), otherwise
-  the command clears, drains `session.clearQueue` back into the composer in steering-then-follow-up order,
-  then calls `session.compact`; Pi owns abort, summarization, persistence, and lifecycle. The request snapshots
+  bypasses the optimistic user echo and every streaming send mode: completed draft images **or the queue's
+  host-authored `hasImages` aggregate** reject it in place with an actionable composer chip (draft + queue
+  preserved; pending draft images already hold all submits). Otherwise the command clears, drains
+  `session.clearQueue { requireTextOnly: true }` back into the composer in steering-then-follow-up order,
+  then calls `session.compact`; the host rechecks the image precondition at the destructive operation, so a
+  stale client or cross-client race still cannot drop queued bytes. Pi owns abort, summarization,
+  persistence, and lifecycle. The request snapshots
   existing compaction-turn ids, and a rejected clear/compact asks the store to append a failed compaction row
   only when no new lifecycle turn appeared, so Pi's emitted failure and a pre-lifecycle wire failure share one
   surface without duplicating. Existing live/hydrated compaction rendering is unchanged. When a

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -283,15 +283,15 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `queue-item` testids, `data-kind` + `data-index`; full text + delivery meaning in the row `title`),
   sourced from the runtime's `queue`. **Each row carries its own edit and remove actions**
   (`queue-item-edit` / `queue-item-remove`) — both call `session.removeQueued { kind, index }` (rows
-  are position-addressed, matching the wire op); edit additionally prepends the removed text to the
-  draft and refocuses. Per-row actions exist because the original all-or-nothing dequeue (click strip
-  → `clearQueue` → every message merged into one draft blob) proved undiscoverable and lossy in use.
-  **Abort restores a text-only queue** (`onAbort` → guarded `session.clearQueue` → texts prepended
-  `\n\n`-joined in pi's order, then `session.abort`) — pi's Escape parity. Pi returns only text from a
-  destructive clear even when its internal queued messages carry image blocks, so the host refuses that
-  guarded clear while either lane has queued images; abort may then let those queued messages continue,
-  but never silently discards their attachments. A **rejected** streaming send likewise restores its text
-  to the draft alongside the `appendErrorTurn`. `queue_update` still carries only displayable text plus a
+  are position-addressed, matching the wire op); edit additionally restores the removed message's text
+  and images to the draft and refocuses. Per-row actions exist because the original all-or-nothing dequeue
+  (click strip → `clearQueue` → every message merged into one draft blob) proved undiscoverable and lossy
+  in use. **Abort atomically restores the complete queue** (`onAbort` →
+  `session.abort { restoreQueue: true }`): the host drains both Pi lanes and signals abort as one operation,
+  waits for idle, then returns each queued message's text + image content; the web prepends the texts and
+  reattaches every image. Stop therefore cannot let a queued continuation run or silently discard an
+  attachment. A **rejected** streaming send likewise restores its text to the draft alongside the
+  `appendErrorTurn`. The ordinary `queue_update` projection still carries only displayable text plus a
   conservative `hasImages` aggregate — no image bytes — so a queued image shows no chip in the strip; the
   canonical transcript turn later renders its image blocks with hydrated fallback labels. E2e:
   `queue.live.spec.ts` (@agent).
@@ -425,7 +425,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   preserved; pending draft images already hold all submits). Otherwise the command clears, drains
   `session.clearQueue { requireTextOnly: true }` back into the composer in steering-then-follow-up order,
   then calls `session.compact`; the host rechecks the image precondition at the destructive operation, so a
-  stale client or cross-client race still cannot drop queued bytes. Pi owns abort, summarization,
+  stale client or cross-client race still cannot drop queued bytes. The host atomically rejects a second
+  manual compaction while one is already in flight for that session; Pi owns abort, summarization,
   persistence, and lifecycle. The request snapshots
   existing compaction-turn ids, and a rejected clear/compact asks the store to append a failed compaction row
   only when no new lifecycle turn appeared, so Pi's emitted failure and a pre-lifecycle wire failure share one

--- a/apps/web/src/chat/SlashCommandCompletion.tsx
+++ b/apps/web/src/chat/SlashCommandCompletion.tsx
@@ -2,6 +2,10 @@ import type { SlashCommandInfo } from "@thinkrail/contracts";
 import { type ReactNode, useState } from "react";
 import { cn } from "@/lib/utils";
 
+export type SlashCommandItem = Omit<SlashCommandInfo, "source"> & {
+	source: SlashCommandInfo["source"] | "builtin";
+};
+
 const MAX_MATCHES = 8;
 
 export async function slashCommandCatalogOrEmpty(
@@ -18,10 +22,10 @@ export function slashCommandQuery(value: string): string | null {
 	return value.startsWith("/") && !/\s/.test(value) ? value.slice(1) : null;
 }
 
-export function matchSlashCommands(
+export function matchSlashCommands<T extends SlashCommandItem>(
 	value: string,
-	commands: readonly SlashCommandInfo[],
-): SlashCommandInfo[] {
+	commands: readonly T[],
+): T[] {
 	const query = slashCommandQuery(value);
 	if (query === null) return [];
 	const normalized = query.toLowerCase();
@@ -30,7 +34,7 @@ export function matchSlashCommands(
 		.slice(0, MAX_MATCHES);
 }
 
-export function selectedSlashCommandValue(command: SlashCommandInfo): string {
+export function selectedSlashCommandValue(command: SlashCommandItem): string {
 	return `/${command.name} `;
 }
 
@@ -62,14 +66,14 @@ interface CompletionKeyEvent {
 	stopPropagation: () => void;
 }
 
-export function useSlashCommandCompletion({
+export function useSlashCommandCompletion<T extends SlashCommandItem>({
 	value,
 	commands,
 	onSelect,
 }: {
 	value: string;
-	commands: readonly SlashCommandInfo[];
-	onSelect: (command: SlashCommandInfo) => void;
+	commands: readonly T[];
+	onSelect: (command: T) => void;
 }) {
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [dismissed, setDismissed] = useState(false);
@@ -89,7 +93,7 @@ export function useSlashCommandCompletion({
 
 	const dismiss = () => setDismissed(true);
 
-	const pick = (command: SlashCommandInfo) => {
+	const pick = (command: T) => {
 		onSelect(command);
 		dismiss();
 	};
@@ -111,16 +115,16 @@ export function useSlashCommandCompletion({
 	return { activeIndex: visibleActiveIndex, dismiss, handleKeyDown, matches, open, pick };
 }
 
-export function SlashCommandMenu({
+export function SlashCommandMenu<T extends SlashCommandItem>({
 	commands,
 	activeIndex,
 	onSelect,
 	className,
 	footer,
 }: {
-	commands: readonly SlashCommandInfo[];
+	commands: readonly T[];
 	activeIndex: number;
-	onSelect: (command: SlashCommandInfo) => void;
+	onSelect: (command: T) => void;
 	className?: string;
 	footer?: ReactNode;
 }) {
@@ -149,7 +153,9 @@ export function SlashCommandMenu({
 						<span className="truncate tr-text-metadata">{command.description}</span>
 					) : null}
 					<span className="ml-auto shrink-0 text-text-muted tr-text-metadata">
-						{command.source}/{command.sourceInfo.scope}
+						{command.source === "builtin"
+							? "Pi/built-in"
+							: `${command.source}/${command.sourceInfo.scope}`}
 					</span>
 				</button>
 			))}

--- a/apps/web/src/chat/nativeCommands.test.ts
+++ b/apps/web/src/chat/nativeCommands.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import type { SlashCommandInfo } from "@thinkrail/contracts";
+import {
+	mergeNativeChatCommands,
+	NATIVE_CHAT_COMMANDS,
+	parseNativeChatCommand,
+} from "./nativeCommands";
+
+function command(name: string, source: SlashCommandInfo["source"] = "extension"): SlashCommandInfo {
+	return {
+		name,
+		description: `${name} description`,
+		source,
+		sourceInfo: {
+			path: `/${source}/${name}`,
+			source: "fixture",
+			scope: "project",
+			origin: "top-level",
+		},
+	};
+}
+
+describe("native chat command parsing", () => {
+	it("matches Pi's exact compact syntax and trims optional instructions", () => {
+		expect(parseNativeChatCommand("/compact")).toEqual({ kind: "compact" });
+		expect(parseNativeChatCommand("/compact keep exact filenames ")).toEqual({
+			kind: "compact",
+			instructions: "keep exact filenames",
+		});
+		expect(parseNativeChatCommand("/compact  \n preserve decisions \n")).toEqual({
+			kind: "compact",
+			instructions: "preserve decisions",
+		});
+		expect(parseNativeChatCommand("/compact ")).toEqual({ kind: "compact" });
+	});
+
+	it("leaves every near-miss for the ordinary prompt path", () => {
+		for (const text of [
+			"/Compact",
+			"/compactness",
+			"/compact\tkeep files",
+			"hello /compact",
+			" /compact",
+		]) {
+			expect(parseNativeChatCommand(text)).toBeNull();
+		}
+	});
+});
+
+describe("native chat command catalog", () => {
+	it("orders the built-in first and reserves only its exact name", () => {
+		const merged = mergeNativeChatCommands([
+			command("review"),
+			command("compact"),
+			command("compact", "prompt"),
+			command("skill:compact", "skill"),
+			command("Compact"),
+		]);
+
+		expect(merged.map(({ name }) => name)).toEqual([
+			"compact",
+			"review",
+			"skill:compact",
+			"Compact",
+		]);
+		expect(merged[0]).toEqual(NATIVE_CHAT_COMMANDS[0]);
+		expect(merged[0]?.source).toBe("builtin");
+	});
+});

--- a/apps/web/src/chat/nativeCommands.test.ts
+++ b/apps/web/src/chat/nativeCommands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { SlashCommandInfo } from "@thinkrail/contracts";
 import {
+	compactSubmissionError,
 	mergeNativeChatCommands,
 	NATIVE_CHAT_COMMANDS,
 	parseNativeChatCommand,
@@ -44,6 +45,14 @@ describe("native chat command parsing", () => {
 		]) {
 			expect(parseNativeChatCommand(text)).toBeNull();
 		}
+	});
+
+	it("rejects compaction before a text-only clear could discard draft or queued images", () => {
+		expect(compactSubmissionError(false, false)).toBeNull();
+		expect(compactSubmissionError(true, false)).toBe("Remove images to use /compact");
+		expect(compactSubmissionError(false, true)).toBe(
+			"Wait for queued image messages to send before using /compact",
+		);
 	});
 });
 

--- a/apps/web/src/chat/nativeCommands.ts
+++ b/apps/web/src/chat/nativeCommands.ts
@@ -1,0 +1,36 @@
+import type { SlashCommandInfo } from "@thinkrail/contracts";
+import type { SlashCommandItem } from "./SlashCommandCompletion";
+
+const COMPACT_NAME = "compact";
+
+export const COMPACT_IMAGE_ERROR = "Remove images to use /compact";
+
+export const NATIVE_CHAT_COMMANDS: readonly SlashCommandItem[] = [
+	{
+		name: COMPACT_NAME,
+		description: "Manually compact context · optional instructions",
+		source: "builtin",
+		sourceInfo: {
+			path: "<builtin:compact>",
+			source: "pi",
+			scope: "temporary",
+			origin: "top-level",
+		},
+	},
+];
+
+export interface CompactChatCommand {
+	kind: "compact";
+	instructions?: string;
+}
+
+export function parseNativeChatCommand(text: string): CompactChatCommand | null {
+	if (text === "/compact") return { kind: "compact" };
+	if (!text.startsWith("/compact ")) return null;
+	const instructions = text.slice(9).trim();
+	return instructions ? { kind: "compact", instructions } : { kind: "compact" };
+}
+
+export function mergeNativeChatCommands(commands: readonly SlashCommandInfo[]): SlashCommandItem[] {
+	return [...NATIVE_CHAT_COMMANDS, ...commands.filter((command) => command.name !== COMPACT_NAME)];
+}

--- a/apps/web/src/chat/nativeCommands.ts
+++ b/apps/web/src/chat/nativeCommands.ts
@@ -4,6 +4,16 @@ import type { SlashCommandItem } from "./SlashCommandCompletion";
 const COMPACT_NAME = "compact";
 
 export const COMPACT_IMAGE_ERROR = "Remove images to use /compact";
+export const COMPACT_QUEUED_IMAGE_ERROR =
+	"Wait for queued image messages to send before using /compact";
+
+export function compactSubmissionError(
+	hasDraftImages: boolean,
+	hasQueuedImages: boolean,
+): string | null {
+	if (hasDraftImages) return COMPACT_IMAGE_ERROR;
+	return hasQueuedImages ? COMPACT_QUEUED_IMAGE_ERROR : null;
+}
 
 export const NATIVE_CHAT_COMMANDS: readonly SlashCommandItem[] = [
 	{

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -193,6 +193,10 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   settled transcript never claims ongoing work) and still removes the superseded assistant attempt. The
   reducer relies on pi's guarantee that every emitted `compaction_start` is paired with a
   `compaction_end` (both success and failure paths emit it), the same trust every other event pair gets.
+  Manual-command transport rejection uses one atomic store mutation: given the compaction-turn ids observed
+  before the request, append a failed compaction turn only if none of the current ids is new. Thus a Pi failure
+  already represented by `compaction_end` is never duplicated, while rejection before lifecycle begins is
+  still visible on the same compaction surface.
   **`auto_retry_start` mirrors pi's live-context surgery**: pi's `_prepareRetry` trims the failed
   attempt's assistant message from the live context before re-running the turn (the retry re-streams it
   as a new message) while *keeping it in the session file*, so the reducer drops the superseded failed

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -244,8 +244,10 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime. **Only idle sends enter the transcript
   optimistically** (`ChatView.onSubmit` → `appendUserMessage`); the last-turn echo dedup below is
   sufficient precisely because nothing intervenes before the echo. A **streaming send (`steer`/`followUp`)
-  never appends a turn**: its text lives in `queue` (folded verbatim from pi's `queue_update`, seeded from
-  the summary's snapshot at hydration) and the turn lands only via pi's canonical user `message_start` —
+  never appends a turn**: its text lives in `queue` (folded verbatim from the host-projected
+  `queue_update`, seeded from the summary at hydration), alongside the optional conservative `hasImages`
+  aggregate that guards destructive text-only queue restoration; the turn lands only via pi's canonical
+  user `message_start` —
   at its true position, converging live with hydrated. (Mirrors pi's own interactive mode; replaces the
   optimistic-append-for-everything model whose last-turn dedup missed whenever assistant content landed
   between the append and the echo — reproduced live as a duplicated, mispositioned queued bubble.)

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -25,6 +25,7 @@ import {
 	useAppStore,
 } from "./appStore";
 import {
+	selectCompactionTurnIds,
 	selectCurrentRouteChatTarget,
 	selectDiffScope,
 	selectLastOpenChatSession,
@@ -740,6 +741,28 @@ test("a failed compaction settles into a visible, actionable notice — and a ca
 	store.handlePiEvent(compactionStart("manual"), "a");
 	store.handlePiEvent(compactionEnd({ reason: "manual", result: undefined, aborted: true }), "a");
 	expect(compactionTurns("a")).toMatchObject([{ status: "failed" }, { status: "cancelled" }]);
+});
+
+test("manual compaction rejection appends one failed row only when no lifecycle was observed", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+
+	const beforeEarlyFailure = selectCompactionTurnIds(useAppStore.getState(), "a");
+	store.appendCompactionFailureUnlessObserved("a", beforeEarlyFailure, "host unavailable");
+	expect(compactionTurns("a")).toMatchObject([{ status: "failed", detail: "host unavailable" }]);
+
+	const beforePiFailure = selectCompactionTurnIds(useAppStore.getState(), "a");
+	store.handlePiEvent(compactionStart("manual"), "a");
+	store.handlePiEvent(
+		compactionEnd({ reason: "manual", result: undefined, errorMessage: "Nothing to compact" }),
+		"a",
+	);
+	store.appendCompactionFailureUnlessObserved("a", beforePiFailure, "request rejected");
+
+	expect(compactionTurns("a")).toMatchObject([
+		{ status: "failed", detail: "host unavailable" },
+		{ status: "failed", detail: "Nothing to compact" },
+	]);
 });
 
 test("a compaction_end with no observed start still lands a settled notice (connected mid-compaction)", () => {

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -214,16 +214,25 @@ test("a host-fired USER message folds into the transcript; the composer's optimi
 });
 
 test("queue_update folds pi's queue into the runtime; the canonical echo lands the turn at its true position", () => {
-	const queueUpdate = (steering: string[], followUp: string[]) =>
-		({ type: "queue_update", steering, followUp }) as unknown as PiEvent;
+	const queueUpdate = (steering: string[], followUp: string[], hasImages = false) =>
+		({
+			type: "queue_update",
+			steering,
+			followUp,
+			...(hasImages ? { hasImages: true } : {}),
+		}) as unknown as PiEvent;
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");
 	store.handlePiEvent(agentStart, "a");
 	store.handlePiEvent(assistantStart, "a");
 	store.handlePiEvent(assistantText("first reply"), "a");
 
-	store.handlePiEvent(queueUpdate(["course-correct"], ["queued question"]), "a");
-	expect(rt("a").queue).toEqual({ steering: ["course-correct"], followUp: ["queued question"] });
+	store.handlePiEvent(queueUpdate(["course-correct"], ["queued question"], true), "a");
+	expect(rt("a").queue).toEqual({
+		steering: ["course-correct"],
+		followUp: ["queued question"],
+		hasImages: true,
+	});
 	expect(rt("a").turns.filter((t) => t.kind === "user")).toHaveLength(0);
 
 	store.handlePiEvent(queueUpdate([], ["queued question"]), "a");

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -788,6 +788,11 @@ interface AppState {
 	) => void;
 	appendUserMessage: (sessionId: string, text: string, attachments?: ChatAttachment[]) => void;
 	appendErrorTurn: (sessionId: string, text: string) => void;
+	appendCompactionFailureUnlessObserved: (
+		sessionId: string,
+		observedTurnIds: ReadonlySet<string>,
+		detail: string,
+	) => void;
 	handlePiEvent: (event: PiEvent, sessionId: string) => void;
 	setModelsForProviderVersion: (providerVersion: number, models: WireModel[]) => void;
 	noteProviderChanged: () => void;
@@ -2553,6 +2558,23 @@ export const useAppStore = create<AppState>((set, get) => ({
 				attemptAssistantId: null,
 				turns: [...clearTurnStreaming(rt.turns), { kind: "error", id: crypto.randomUUID(), text }],
 			})),
+		),
+	appendCompactionFailureUnlessObserved: (sessionId, observedTurnIds, detail) =>
+		set((s) =>
+			withRuntime(s, sessionId, (rt) => {
+				const lifecycleObserved = rt.turns.some(
+					(turn) => turn.kind === "compaction" && !observedTurnIds.has(turn.id),
+				);
+				return lifecycleObserved
+					? rt
+					: {
+							...rt,
+							turns: [
+								...rt.turns,
+								{ kind: "compaction", id: crypto.randomUUID(), status: "failed", detail },
+							],
+						};
+			}),
 		),
 	handlePiEvent: (event, sessionId) =>
 		set((s) => withRuntime(s, sessionId, (rt) => reduceSessionEvent(rt, event))),

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -395,7 +395,14 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 		case "agent_start":
 			return { ...rt, isStreaming: true, attemptAssistantId: null };
 		case "queue_update":
-			return { ...rt, queue: { steering: event.steering, followUp: event.followUp } };
+			return {
+				...rt,
+				queue: {
+					steering: event.steering,
+					followUp: event.followUp,
+					...(event.hasImages ? { hasImages: true as const } : {}),
+				},
+			};
 		case "message_start": {
 			if (event.message.role === "assistant")
 				return {

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -16,7 +16,13 @@ import {
 	normalizePath,
 	readLayoutSelection,
 } from "../lib";
-import type { ClosedChat, EditorTab, RouteChatTarget, TerminalTab } from "./appStore";
+import type {
+	ClosedChat,
+	EditorTab,
+	RouteChatTarget,
+	SessionRuntime,
+	TerminalTab,
+} from "./appStore";
 
 interface ConnectionGenerationState {
 	status: string;
@@ -341,6 +347,17 @@ export function selectChatTitle(
 	const tabs = state.tabsByWorkspace[workspaceId] ?? [];
 	const chatTab = tabs.find((t) => t.kind === "chat" && t.sessionId === sessionId);
 	return (chatTab?.name ?? "Chat").trim() || "Chat";
+}
+
+export function selectCompactionTurnIds(
+	state: { sessions: Record<string, SessionRuntime> },
+	sessionId: string,
+): ReadonlySet<string> {
+	return new Set(
+		(state.sessions[sessionId]?.turns ?? [])
+			.filter((turn) => turn.kind === "compaction")
+			.map((turn) => turn.id),
+	);
 }
 
 export function selectWorkspaceTick(

--- a/e2e/compact-command.spec.ts
+++ b/e2e/compact-command.spec.ts
@@ -1,0 +1,62 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { openWorkspaceChat } from "./fixtures/app";
+
+interface ClientFrame {
+	method?: string;
+	params?: { instructions?: string; text?: string };
+}
+
+async function observeClientFrames(page: Page, frames: ClientFrame[]): Promise<void> {
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			try {
+				frames.push(JSON.parse(raw) as ClientFrame);
+			} catch {}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+}
+
+test("/compact is discoverable and routes instructions without creating a user turn", async ({
+	page,
+}) => {
+	const frames: ClientFrame[] = [];
+	await observeClientFrames(page, frames);
+	await openWorkspaceChat(page);
+
+	const input = page.getByTestId("chat-input");
+	await input.fill("/comp");
+	const row = page.locator('[data-testid="slash-command"][data-source="builtin"]');
+	await expect(row).toHaveCount(1);
+	await expect(row).toContainText("/compact");
+	await expect(row).toContainText("optional instructions");
+	await expect(row).toContainText("Pi/built-in");
+	await input.press("Tab");
+	await expect(input).toHaveValue("/compact ");
+
+	await input.fill("/compact preserve exact filenames");
+	const userTurns = page.locator('[data-testid="chat-message"][data-role="user"]');
+	const userCount = await userTurns.count();
+	await page.getByTestId("chat-send").click();
+
+	await expect(input).toHaveValue("");
+	const notice = page.getByTestId("compaction-notice");
+	await expect(notice).toHaveCount(1, { timeout: 15_000 });
+	await expect(notice).toHaveAttribute("data-status", "failed");
+	await expect(userTurns).toHaveCount(userCount);
+	await expect
+		.poll(() => frames.find((frame) => frame.method === "session.compact")?.params?.instructions)
+		.toBe("preserve exact filenames");
+
+	const methods = frames.flatMap((frame) => (frame.method ? [frame.method] : []));
+	expect(methods.indexOf("session.clearQueue")).toBeLessThan(methods.indexOf("session.compact"));
+	expect(
+		frames.some(
+			(frame) => frame.method === "session.prompt" && frame.params?.text?.startsWith("/compact"),
+		),
+	).toBe(false);
+});

--- a/e2e/composer-images.spec.ts
+++ b/e2e/composer-images.spec.ts
@@ -112,3 +112,27 @@ test("an undecodable provider-unsupported file is refused with an error chip, ne
 	await error.getByRole("button", { name: "Dismiss" }).click();
 	await expect(error).toHaveCount(0);
 });
+
+test("/compact preserves attached images and its draft until the images are removed", async ({
+	page,
+}) => {
+	await openChatComposer(page);
+	await pastePng(page, 640, 480);
+
+	const input = page.getByTestId("chat-input");
+	const command = "/compact preserve exact filenames";
+	await input.fill(command);
+	await page.getByTestId("chat-send").click();
+
+	await expect(page.getByTestId("composer-command-error")).toContainText(
+		"Remove images to use /compact",
+	);
+	await expect(input).toHaveValue(command);
+	await expect(page.getByTestId("composer-image")).toHaveCount(1);
+	await expect(page.getByTestId("compaction-notice")).toHaveCount(0);
+	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(0);
+
+	await page.getByRole("button", { name: "Remove image" }).click();
+	await expect(page.getByTestId("composer-command-error")).toHaveCount(0);
+	await expect(input).toHaveValue(command);
+});

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -174,11 +174,6 @@ test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the r
 	await query.press("ControlOrMeta+Enter");
 	await expect(overlay).toBeHidden();
 
-	await expect(
-		page
-			.locator('[data-testid="chat-message"][data-role="user"]')
-			.filter({ hasText: "fix the flaky watcher test" }),
-	).toBeVisible();
 	await expect(input).toHaveValue("");
 	await expect(thumbnails).toBeHidden();
 
@@ -191,6 +186,14 @@ test("Cmd/Ctrl+Enter from the overlay sends pending image attachments with the r
 		expect(prompt).toContain('"image/png"');
 	}).toPass({ timeout: 5000 });
 	await settleSubmittedTurn(page);
+	await page.getByTestId("virtuoso-scroller").evaluate((element) => {
+		element.scrollTop = 0;
+	});
+	const sentTurn = page
+		.locator('[data-testid="chat-message"][data-role="user"]')
+		.filter({ hasText: "fix the flaky watcher test" });
+	await expect(sentTurn).toBeVisible();
+	await expect(sentTurn.getByTestId("chat-attachment-chip")).toContainText("pixel.png");
 });
 
 test("empty query in chat scope shows the empty state for a session with no history yet", async ({

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -92,7 +92,9 @@ of the host.
     only when non-empty — the hydration seed for the client's pending strip, since `queue_update` fires only
     on changes and a client attaching mid-run would otherwise never learn of messages queued before it
     connected. The same aggregate enriches projected `queue_update` events; image bytes never ride this
-    read-side queue state.
+    read-side queue state. Destructive operations use the separate **`SessionQueueContent`** /
+    **`QueuedMessageContent`** shapes, which return each drained message's text and optional images exactly
+    once so the composer can restore complete content without making ordinary queue broadcasts heavy.
     `session.getMessages` returns `{ summary, messages }` (the transcript is
     **`TranscriptMessage[]`** — the pi-canonical `Message` union widened with **`WireCustomMessage`**, a
     type-only mirror of pi-coding-agent's Node-only `CustomMessage`, so extension-injected messages like
@@ -318,13 +320,15 @@ of the host.
   per-skill `decision` + `group` — for a `workspaceId`) / **`project.skills`** (the same, project-scoped, for
   the pre-session manager) / **`session.reloadResources`** (re-scan skills + rebuild the system prompt for one
   running session; rejected while streaming) /
-  `session.*` — `create`/`prompt`/`steer`/`followUp`/**`clearQueue`** (drain pi's steering+followUp
-  queues, returning the texts — the client's abort-restores-queue path; pi itself emits the emptying
-  `queue_update`; optional `requireTextOnly` rejects without draining when the host has observed queued
-  images, because pi's return value cannot restore their bytes)/**`removeQueued`** (`{ kind, index }` → `RemovedQueuedMessage`: drop or extract ONE
-  queued message — the strip rows' edit/remove; position-addressed because pi's queue entries are bare
-  strings with no id, and the host emulates per-item removal over pi's all-or-nothing `clearQueue`, see
-  the server agent SPEC)/`abort`/`dispose`/**`delete`**/`setModel`/
+  `session.*` — `create`/`prompt`/`steer`/`followUp`/**`clearQueue`** (drain Pi's steering+followUp
+  queues, returning complete `SessionQueueContent`; Pi itself emits the emptying `queue_update`; optional
+  `requireTextOnly` rejects without draining when the host has observed queued images, which is the manual
+  compaction precondition)/**`removeQueued`** (`{ kind, index }` → `RemovedQueuedMessage`: drop or extract ONE
+  queued message with its complete content — the strip rows' edit/remove; position-addressed because Pi's
+  queue entries are bare strings with no id, and the host emulates per-item removal over Pi's all-or-nothing
+  `clearQueue`, see the server agent SPEC)/**`abort`** (ordinary abort preserves queued lanes for Interrupt;
+  `{ restoreQueue: true }` atomically drains complete content before signalling abort and returns it after the
+  session reaches idle, which is Stop's lossless path)/`dispose`/**`delete`**/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
   read side) / **`layout.get`** (hydrate one workspace snapshot, or `null` before first seeding) /

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -87,10 +87,12 @@ of the host.
     summary's optional **`lastSettlement`** retains the host-observed terminal (`null` = the live run is
     active or settled without an assistant) so reconnect can surface a final failure Pi removed from its rebuilt context; absent
     means this host process has not observed a settlement and the persisted transcript is authoritative.
-    The optional **`queue`** (**`SessionQueueState`**: pi's pending `steering`/`followUp` texts) rides a
-    live summary only when non-empty — the hydration seed for the client's pending strip, since
-    `queue_update` fires only on changes and a client attaching mid-run would otherwise never learn of
-    messages queued before it connected.
+    The optional **`queue`** (**`SessionQueueState`**: pi's pending `steering`/`followUp` texts plus
+    `hasImages?: true`, the host's conservative aggregate over queued browser sends) rides a live summary
+    only when non-empty — the hydration seed for the client's pending strip, since `queue_update` fires only
+    on changes and a client attaching mid-run would otherwise never learn of messages queued before it
+    connected. The same aggregate enriches projected `queue_update` events; image bytes never ride this
+    read-side queue state.
     `session.getMessages` returns `{ summary, messages }` (the transcript is
     **`TranscriptMessage[]`** — the pi-canonical `Message` union widened with **`WireCustomMessage`**, a
     type-only mirror of pi-coding-agent's Node-only `CustomMessage`, so extension-injected messages like
@@ -318,7 +320,8 @@ of the host.
   running session; rejected while streaming) /
   `session.*` — `create`/`prompt`/`steer`/`followUp`/**`clearQueue`** (drain pi's steering+followUp
   queues, returning the texts — the client's abort-restores-queue path; pi itself emits the emptying
-  `queue_update`)/**`removeQueued`** (`{ kind, index }` → `RemovedQueuedMessage`: drop or extract ONE
+  `queue_update`; optional `requireTextOnly` rejects without draining when the host has observed queued
+  images, because pi's return value cannot restore their bytes)/**`removeQueued`** (`{ kind, index }` → `RemovedQueuedMessage`: drop or extract ONE
   queued message — the strip rows' edit/remove; position-addressed because pi's queue entries are bare
   strings with no id, and the host emulates per-item removal over pi's all-or-nothing `clearQueue`, see
   the server agent SPEC)/`abort`/`dispose`/**`delete`**/`setModel`/

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -38,7 +38,12 @@ export type PiEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
 	| { type: "agent_end"; messages: AgentMessage[]; willRetry: boolean }
 	| { type: "agent_settled"; terminal: AgentSettlement | null }
-	| { type: "queue_update"; steering: readonly string[]; followUp: readonly string[] }
+	| {
+			type: "queue_update";
+			steering: readonly string[];
+			followUp: readonly string[];
+			hasImages?: true;
+	  }
 	| { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
 	| { type: "session_info_changed"; name: string | undefined }
 	| { type: "thinking_level_changed"; level: ThinkingLevel }
@@ -103,6 +108,7 @@ export type QueueLane = "steering" | "followUp";
 export interface SessionQueueState {
 	steering: readonly string[];
 	followUp: readonly string[];
+	hasImages?: true;
 }
 
 export interface RemovedQueuedMessage {

--- a/packages/contracts/src/piProtocol.ts
+++ b/packages/contracts/src/piProtocol.ts
@@ -111,8 +111,18 @@ export interface SessionQueueState {
 	hasImages?: true;
 }
 
+export interface QueuedMessageContent {
+	text: string;
+	images?: readonly ImageContent[];
+}
+
+export interface SessionQueueContent {
+	steering: readonly QueuedMessageContent[];
+	followUp: readonly QueuedMessageContent[];
+}
+
 export interface RemovedQueuedMessage {
-	removed: string | null;
+	removed: QueuedMessageContent | null;
 	queue: SessionQueueState;
 }
 

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -44,7 +44,7 @@ import type {
 	QueueLane,
 	RefreshedModels,
 	RemovedQueuedMessage,
-	SessionQueueState,
+	SessionQueueContent,
 	SessionStats,
 	SessionSummary,
 	SkillCatalogEntry,
@@ -81,7 +81,7 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 51;
+export const PROTOCOL_VERSION = 52;
 
 export interface ServerWelcome {
 	protocolVersion: number;
@@ -385,13 +385,16 @@ export interface WsMethodMap {
 	};
 	"session.clearQueue": {
 		params: { sessionId: string; requireTextOnly?: boolean };
-		result: SessionQueueState;
+		result: SessionQueueContent;
 	};
 	"session.removeQueued": {
 		params: { sessionId: string; kind: QueueLane; index: number };
 		result: RemovedQueuedMessage;
 	};
-	"session.abort": { params: { sessionId: string }; result: Ack };
+	"session.abort": {
+		params: { sessionId: string; restoreQueue?: boolean };
+		result: Ack & { restoredQueue?: SessionQueueContent };
+	};
 	"session.dispose": { params: { sessionId: string }; result: Ack };
 	"session.delete": { params: { workspaceId: string; sessionId: string }; result: Ack };
 	"session.setModel": { params: { sessionId: string; model: WireModel }; result: Ack };

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -81,7 +81,7 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 50;
+export const PROTOCOL_VERSION = 51;
 
 export interface ServerWelcome {
 	protocolVersion: number;
@@ -383,7 +383,10 @@ export interface WsMethodMap {
 		params: { sessionId: string; text: string; images?: ImageContent[] };
 		result: Ack;
 	};
-	"session.clearQueue": { params: { sessionId: string }; result: SessionQueueState };
+	"session.clearQueue": {
+		params: { sessionId: string; requireTextOnly?: boolean };
+		result: SessionQueueState;
+	};
 	"session.removeQueued": {
 		params: { sessionId: string; kind: QueueLane; index: number };
 		result: RemovedQueuedMessage;

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -108,7 +108,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     cannot reappear mid-run, while disk sessions remain transcript-authoritative. A live summary also
     carries pi's queue snapshot (`SessionQueueState`, only when non-empty): `queue_update` fires only on
     changes, so this is the read-side seed that lets a client attaching mid-run render messages queued
-    before it connected.
+    before it connected. Each queue lane also retains a conservative `hasImages` bit for browser sends;
+    it clears only when that lane empties and enriches the summary/projected queue event without carrying
+    image bytes.
     New-session and pre-session entrypoints capture the current generation; operations on a live session use
     that session's retained runtime. `abort` remains available as the cancellation control path.
     `prompt`/`steer`/`followUp` (with images) /
@@ -117,9 +119,12 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     back to `steer`), and pi's `followUp()` only *enqueues* into a queue that a run already in flight
     drains (so on an idle session it falls back to `prompt`, else the message parks forever — the way a
     `review.sendBatch` into a re-attached review chat marked its comments sent to an agent that never
-    saw them) / **`clearQueueSession`** (pi's `clearQueue()`, verbatim: drains both queues and returns the
-    texts for the client's dequeue-to-composer; pi emits the emptying `queue_update`, so the host adds no
-    bookkeeping) / **`removeQueuedSession(sessionId, kind, index)`** — per-item queue removal, which pi's
+    saw them) / **`clearQueueSession`** (pi's `clearQueue()`: drains both queues but returns only text,
+    even when its internal queued user messages carry image blocks; pi emits the emptying `queue_update`).
+    Its optional text-only precondition rejects before touching pi whenever either tracked lane has queued
+    images; every browser queue-to-draft path uses it, so manual compaction and abort restoration can never
+    silently discard image content /
+    **`removeQueuedSession(sessionId, kind, index)`** — per-item queue removal, which pi's
     API lacks (queues are bare string arrays, `clearQueue` is all-or-nothing): drain via `clearQueue()`,
     drop `lane[index]` (out-of-range → `removed: null`, everything re-queued), re-queue the keepers in
     order (`steer()`/`followUp()` per lane — each re-queue emits its own `queue_update`, so clients

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -108,9 +108,11 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     cannot reappear mid-run, while disk sessions remain transcript-authoritative. A live summary also
     carries pi's queue snapshot (`SessionQueueState`, only when non-empty): `queue_update` fires only on
     changes, so this is the read-side seed that lets a client attaching mid-run render messages queued
-    before it connected. Each queue lane also retains a conservative `hasImages` bit for browser sends;
-    it clears only when that lane empties and enriches the summary/projected queue event without carrying
-    image bytes.
+    before it connected. Each queue lane also retains the complete content of browser-queued messages only
+    while Pi reports the corresponding text entry pending. That transient mirror exists solely because Pi's
+    destructive queue API returns text but drops image blocks; Pi's queue events remain authoritative for
+    membership/order. The host projects only a conservative `hasImages` aggregate into summaries/events, so
+    image bytes do not ride the ordinary read stream.
     New-session and pre-session entrypoints capture the current generation; operations on a live session use
     that session's retained runtime. `abort` remains available as the cancellation control path.
     `prompt`/`steer`/`followUp` (with images) /
@@ -119,21 +121,24 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     back to `steer`), and pi's `followUp()` only *enqueues* into a queue that a run already in flight
     drains (so on an idle session it falls back to `prompt`, else the message parks forever — the way a
     `review.sendBatch` into a re-attached review chat marked its comments sent to an agent that never
-    saw them) / **`clearQueueSession`** (pi's `clearQueue()`: drains both queues but returns only text,
-    even when its internal queued user messages carry image blocks; pi emits the emptying `queue_update`).
-    Its optional text-only precondition rejects before touching pi whenever either tracked lane has queued
-    images; every browser queue-to-draft path uses it, so manual compaction and abort restoration can never
-    silently discard image content /
-    **`removeQueuedSession(sessionId, kind, index)`** — per-item queue removal, which pi's
-    API lacks (queues are bare string arrays, `clearQueue` is all-or-nothing): drain via `clearQueue()`,
-    drop `lane[index]` (out-of-range → `removed: null`, everything re-queued), re-queue the keepers in
-    order (`steer()`/`followUp()` per lane — each re-queue emits its own `queue_update`, so clients
-    converge by events alone). **No-loss guarantee:** if the run settled during the operation the
-    re-queued keepers would park forever (pi's queues only drain inside a run), so the idle case drains
-    them through the same idle-delivery fallback as `followUpSession` — the first becomes a `prompt`,
-    the rest steer into the run it starts; delivery timing may degrade across that race window, content
-    is never lost (pinned by the idle-fallback unit test) —
-    `setModel` / `setThinkingLevel` / `compact` / `getSessionStats` (+ contextUsage) / `getSessionCommands` /
+    saw them) / **`clearQueueSession`** (Pi's `clearQueue()`: drains both queues but returns only text,
+    while the host snapshots its reconciled transient mirror first and returns complete per-message text +
+    images. Pi emits the emptying `queue_update`). Its optional text-only precondition rejects before
+    touching Pi whenever either tracked lane has queued images; manual compaction uses that guard, while
+    **`abortSession(..., true)`** snapshots/drains and synchronously signals abort in one manager operation,
+    then waits for idle and returns the complete queue so Stop cannot race a continuation or lose images /
+    **`removeQueuedSession(sessionId, kind, index)`** — per-item queue removal, which Pi's
+    API lacks (queues are bare string arrays, `clearQueue` is all-or-nothing): drain via the complete-content
+    path, drop `lane[index]` (out-of-range → `removed: null`, everything re-queued), and re-queue each keeper
+    with its images in order (`steer()`/`followUp()` per lane — each re-queue emits its own `queue_update`, so
+    clients converge by events alone). **No-loss guarantee:** if the run settled during the operation the
+    re-queued keepers would park forever (Pi's queues only drain inside a run), so the idle case drains them
+    through the same idle-delivery fallback as `followUpSession` — the first becomes a `prompt`, the rest
+    steer into the run it starts; delivery timing may degrade across that race window, content is never lost
+    (pinned by the idle-fallback unit test) —
+    `setModel` / `setThinkingLevel` / **manual `compact` guarded per session** (a second overlapping request
+    is rejected before Pi can overwrite its one compaction controller; an active Pi compaction also blocks
+    entry) / `getSessionStats` (+ contextUsage) / `getSessionCommands` /
     `listAvailableModels` / **`clampThinkingForModel`** (pi's `clampThinkingLevel` for a `{model, level}`
     pair — `model.clampThinking`; the host owns it so the pre-session picker, `getDefaultModel`, and a live
     session all adjust effort identically) / `getDefaultModel` (the model + thinking a fresh session resolves to — settings

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
-import type { AgentSettlement, ExtUiRequest } from "@thinkrail/contracts";
+import type { AgentSettlement, ExtUiRequest, ImageContent } from "@thinkrail/contracts";
 import {
 	buildSessionSettings,
 	clampThinkingForModel,
@@ -853,7 +853,7 @@ test("followUpSession on an IDLE session runs the turn — pi's follow-up queue 
 	}
 });
 
-test("mid-stream followUpSession queues: the summary snapshot carries it, clearQueueSession hands it back", async () => {
+test("mid-stream queue state projects image risk and guarded clear preserves it", async () => {
 	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
 	const slow = createFauxCore({
 		provider: "fauxq",
@@ -878,7 +878,12 @@ test("mid-stream followUpSession queues: the summary snapshot carries it, clearQ
 			await new Promise((resolve) => setTimeout(resolve, 20));
 		}
 		await followUpSession(s.sessionId, "queued line");
-		await followUpSession(s.sessionId, "queued line two");
+		const queuedImage = {
+			type: "image",
+			data: "AA==",
+			mimeType: "image/png",
+		} satisfies ImageContent;
+		await followUpSession(s.sessionId, "queued line two", [queuedImage]);
 
 		const summary = (await listSessions("ws-queue", cwd)).find(
 			(row) => row.sessionId === s.sessionId,
@@ -886,8 +891,15 @@ test("mid-stream followUpSession queues: the summary snapshot carries it, clearQ
 		expect(summary?.queue).toEqual({
 			steering: [],
 			followUp: ["queued line", "queued line two"],
+			hasImages: true,
 		});
-		expect(seen(s.sessionId)).toContain("queue_update");
+		expect(seen(s.sessionId)).toContain('"type":"queue_update"');
+		expect(seen(s.sessionId)).toContain('"hasImages":true');
+
+		expect(() => clearQueueSession(s.sessionId, true)).toThrow("queued image");
+		expect(
+			(await listSessions("ws-queue", cwd)).find((row) => row.sessionId === s.sessionId)?.queue,
+		).toEqual(summary?.queue);
 
 		expect(await removeQueuedSession(s.sessionId, "followUp", 5)).toEqual({
 			removed: null,

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -11,9 +11,11 @@ import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/prov
 import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type { AgentSettlement, ExtUiRequest, ImageContent } from "@thinkrail/contracts";
 import {
+	abortSession,
 	buildSessionSettings,
 	clampThinkingForModel,
 	clearQueueSession,
+	compactSession,
 	createSession,
 	deleteSession,
 	disposeAllSessions,
@@ -853,7 +855,7 @@ test("followUpSession on an IDLE session runs the turn — pi's follow-up queue 
 	}
 });
 
-test("mid-stream queue state projects image risk and guarded clear preserves it", async () => {
+test("stop losslessly restores an image-bearing queue before aborting", async () => {
 	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
 	const slow = createFauxCore({
 		provider: "fauxq",
@@ -901,23 +903,120 @@ test("mid-stream queue state projects image risk and guarded clear preserves it"
 			(await listSessions("ws-queue", cwd)).find((row) => row.sessionId === s.sessionId)?.queue,
 		).toEqual(summary?.queue);
 
-		expect(await removeQueuedSession(s.sessionId, "followUp", 5)).toEqual({
-			removed: null,
-			queue: { steering: [], followUp: ["queued line", "queued line two"] },
+		expect(await abortSession(s.sessionId, true)).toEqual({
+			steering: [],
+			followUp: [{ text: "queued line" }, { text: "queued line two", images: [queuedImage] }],
 		});
-		expect(await removeQueuedSession(s.sessionId, "followUp", 0)).toEqual({
-			removed: "queued line",
-			queue: { steering: [], followUp: ["queued line two"] },
-		});
+		await turn.catch(() => {});
 
-		expect(clearQueueSession(s.sessionId)).toEqual({ steering: [], followUp: ["queued line two"] });
-		expect(clearQueueSession(s.sessionId)).toEqual({ steering: [], followUp: [] });
-
-		await turn;
+		expect(
+			(await listSessions("ws-queue", cwd)).find((row) => row.sessionId === s.sessionId)?.queue,
+		).toBeUndefined();
+		const transcript = await getSessionMessages(s.sessionId, "ws-queue", cwd);
+		expect(transcript.messages.filter((message) => message.role === "user")).toHaveLength(1);
 		removeSession(s.sessionId);
 	} finally {
 		runtime.unregisterProvider("fauxq");
 		setSessionManagerFactory(() => SessionManager.inMemory());
+	}
+}, 20000);
+
+test("removing one queued image message returns its complete content", async () => {
+	const s = await createSession({
+		cwd: tmpCwd("trpi-remove-image-"),
+		workspaceId: "ws-remove-image",
+		model: toWireModel(fauxA.getModel()),
+	});
+	const queuedImage = {
+		type: "image",
+		data: "AA==",
+		mimeType: "image/png",
+	} satisfies ImageContent;
+	await steerSession(s.sessionId, "edit this", [queuedImage]);
+
+	expect(await removeQueuedSession(s.sessionId, "steering", 0)).toEqual({
+		removed: { text: "edit this", images: [queuedImage] },
+		queue: { steering: [], followUp: [] },
+	});
+	removeSession(s.sessionId);
+});
+
+test("compactSession rejects an overlapping manual compaction", async () => {
+	const slow = createFauxCore({
+		provider: "faux-compact-lock",
+		api: "faux-compact-lock",
+		models: [modelDef("faux-compact-lock")],
+		tokensPerSecond: 1000,
+	});
+	runtime.registerProvider("faux-compact-lock", cfg(slow, "faux-compact-lock"));
+	let releaseCompaction = () => {};
+	const compactionGate = new Promise<void>((resolve) => {
+		releaseCompaction = resolve;
+	});
+	let sessionId: string | undefined;
+	let firstCompaction: Promise<void> | undefined;
+	let overlappingCompaction: Promise<void> | undefined;
+	try {
+		slow.setResponses([
+			fauxAssistantMessage("seeded oldest turn"),
+			fauxAssistantMessage("seeded large turn"),
+			fauxAssistantMessage("seeded recent turn"),
+			async () => {
+				await compactionGate;
+				return fauxAssistantMessage("FIRST_SUMMARY");
+			},
+			fauxAssistantMessage("SECOND_SUMMARY"),
+		]);
+		const cwd = tmpCwd("trpi-compact-lock-");
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(
+			join(cwd, ".pi", "settings.json"),
+			JSON.stringify({
+				compaction: { enabled: false, keepRecentTokens: 1, reserveTokens: 4096 },
+			}),
+		);
+		const session = await createSession({
+			cwd,
+			workspaceId: "ws-compact-lock",
+			model: toWireModel(slow.getModel()),
+		});
+		sessionId = session.sessionId;
+		await promptSession(sessionId, "old context");
+		await promptSession(sessionId, "middle context");
+		await promptSession(sessionId, "recent context");
+
+		firstCompaction = compactSession(sessionId, "first");
+		firstCompaction.catch(() => {});
+		const deadline = Date.now() + 5000;
+		while (!seen(sessionId).includes('"type":"compaction_start"') || slow.state.callCount < 4) {
+			if (Date.now() > deadline) throw new Error("first compaction never started");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+
+		overlappingCompaction = compactSession(sessionId, "second");
+		overlappingCompaction.catch(() => {});
+		const overlapOutcome = await Promise.race([
+			overlappingCompaction.then(
+				() => ({ status: "resolved" as const }),
+				(error: unknown) => ({
+					status: "rejected" as const,
+					message: error instanceof Error ? error.message : String(error),
+				}),
+			),
+			new Promise<{ status: "pending" }>((resolve) =>
+				setTimeout(() => resolve({ status: "pending" }), 250),
+			),
+		]);
+		expect(overlapOutcome).toEqual({
+			status: "rejected",
+			message: "Compaction is already in progress for this session",
+		});
+		releaseCompaction();
+		await firstCompaction;
+	} finally {
+		releaseCompaction();
+		if (sessionId) removeSession(sessionId);
+		runtime.unregisterProvider("faux-compact-lock");
 	}
 }, 20000);
 
@@ -932,7 +1031,7 @@ test("removeQueuedSession on an idle session never strands the keepers — they 
 	await steerSession(s.sessionId, "parked two");
 
 	const result = await removeQueuedSession(s.sessionId, "steering", 0);
-	expect(result.removed).toBe("parked one");
+	expect(result.removed).toEqual({ text: "parked one" });
 	expect(result.queue).toEqual({ steering: [], followUp: [] });
 	expect(seen(s.sessionId)).toContain("PARKED_DELIVERED");
 	removeSession(s.sessionId);

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -16,11 +16,13 @@ import type {
 	AskUserQuestionResult,
 	ImageContent,
 	Model,
+	QueuedMessageContent,
 	QueueLane,
 	RefreshedModels,
 	RemovedQueuedMessage,
 	SessionDeletedPayload,
 	SessionEventPayload,
+	SessionQueueContent,
 	SessionQueueState,
 	SessionStats,
 	SessionSummary,
@@ -48,13 +50,22 @@ import { cancelExtUiForSession, createWebUiContext, notifyExtUi } from "./webUiC
 
 const log = logger("agent");
 
+interface TrackedQueuedMessage {
+	id: number;
+	text: string;
+	images?: ImageContent[];
+}
+
 interface Entry {
 	session: AgentSession;
 	generation: PiRuntimeGeneration;
 	unsubscribe: () => void;
 	workspaceId: string;
 	lastSettlement: AgentSettlement | null | undefined;
-	queuedImageLanes: Record<QueueLane, boolean>;
+	queuedMessages: Record<QueueLane, TrackedQueuedMessage[]>;
+	nextQueuedMessageId: number;
+	manualCompactionInProgress: boolean;
+	piCompactionInProgress: boolean;
 }
 
 const sessions = new Map<string, Entry>();
@@ -199,13 +210,18 @@ async function prepareSessionEntry(
 		unsubscribe: () => {},
 		workspaceId,
 		lastSettlement,
-		queuedImageLanes: { steering: false, followUp: false },
+		queuedMessages: { steering: [], followUp: [] },
+		nextQueuedMessageId: 1,
+		manualCompactionInProgress: false,
+		piCompactionInProgress: false,
 	};
 	entry.unsubscribe = session.subscribe((event) => {
 		if (event.type === "queue_update") {
-			if (event.steering.length === 0) entry.queuedImageLanes.steering = false;
-			if (event.followUp.length === 0) entry.queuedImageLanes.followUp = false;
+			synchronizeQueuedLane(entry, "steering", event.steering);
+			synchronizeQueuedLane(entry, "followUp", event.followUp);
 		}
+		if (event.type === "compaction_start") entry.piCompactionInProgress = true;
+		if (event.type === "compaction_end") entry.piCompactionInProgress = false;
 		if (event.type === "agent_start") {
 			entry.lastSettlement = null;
 		}
@@ -574,26 +590,72 @@ export async function answerQuestion(
 	});
 }
 
+function synchronizeQueuedLane(entry: Entry, kind: QueueLane, texts: readonly string[]): void {
+	const current = entry.queuedMessages[kind];
+	if (texts.length >= current.length) {
+		entry.queuedMessages[kind] = texts.map((text, index) => {
+			const tracked = current[index];
+			return tracked ? { ...tracked, text } : { id: entry.nextQueuedMessageId++, text };
+		});
+		return;
+	}
+
+	const reconciled: TrackedQueuedMessage[] = [];
+	let currentIndex = current.length - 1;
+	for (let textIndex = texts.length - 1; textIndex >= 0; textIndex--) {
+		const text = texts[textIndex];
+		if (text === undefined) continue;
+		while (currentIndex >= 0 && current[currentIndex]?.text !== text) currentIndex--;
+		const tracked = currentIndex >= 0 ? current[currentIndex] : undefined;
+		reconciled.unshift(tracked ? { ...tracked, text } : { id: entry.nextQueuedMessageId++, text });
+		currentIndex--;
+	}
+	entry.queuedMessages[kind] = reconciled;
+}
+
+function synchronizeQueueFromSession(entry: Entry): void {
+	synchronizeQueuedLane(entry, "steering", entry.session.getSteeringMessages());
+	synchronizeQueuedLane(entry, "followUp", entry.session.getFollowUpMessages());
+}
+
 function hasQueuedImages(entry: Entry): boolean {
-	return entry.queuedImageLanes.steering || entry.queuedImageLanes.followUp;
+	return (["steering", "followUp"] as const).some((kind) =>
+		entry.queuedMessages[kind].some((message) => (message.images?.length ?? 0) > 0),
+	);
+}
+
+function queueContentOf(entry: Entry): SessionQueueContent {
+	synchronizeQueueFromSession(entry);
+	const project = (message: TrackedQueuedMessage): QueuedMessageContent => ({
+		text: message.text,
+		...(message.images && message.images.length > 0 ? { images: [...message.images] } : {}),
+	});
+	return {
+		steering: entry.queuedMessages.steering.map(project),
+		followUp: entry.queuedMessages.followUp.map(project),
+	};
 }
 
 async function queueSessionMessage(
 	entry: Entry,
 	kind: QueueLane,
+	text: string,
 	images: ImageContent[] | undefined,
 	send: () => Promise<void>,
 ): Promise<void> {
-	if (!images || images.length === 0) {
-		await send();
-		return;
-	}
-	const previous = entry.queuedImageLanes[kind];
-	entry.queuedImageLanes[kind] = true;
+	const tracked: TrackedQueuedMessage = {
+		id: entry.nextQueuedMessageId++,
+		text,
+		...(images && images.length > 0 ? { images: [...images] } : {}),
+	};
+	entry.queuedMessages[kind].push(tracked);
 	try {
 		await send();
 	} catch (error) {
-		entry.queuedImageLanes[kind] = previous;
+		entry.queuedMessages[kind] = entry.queuedMessages[kind].filter(
+			(message) => message.id !== tracked.id,
+		);
+		synchronizeQueueFromSession(entry);
 		throw error;
 	}
 }
@@ -605,7 +667,9 @@ export async function promptSession(
 ): Promise<void> {
 	const entry = mustGetEntry(sessionId);
 	if (entry.session.isStreaming) {
-		await queueSessionMessage(entry, "steering", images, () => entry.session.steer(text, images));
+		await queueSessionMessage(entry, "steering", text, images, () =>
+			entry.session.steer(text, images),
+		);
 		return;
 	}
 	await entry.session.prompt(text, images ? { images } : undefined);
@@ -617,7 +681,9 @@ export async function steerSession(
 	images?: ImageContent[],
 ): Promise<void> {
 	const entry = mustGetEntry(sessionId);
-	await queueSessionMessage(entry, "steering", images, () => entry.session.steer(text, images));
+	await queueSessionMessage(entry, "steering", text, images, () =>
+		entry.session.steer(text, images),
+	);
 }
 
 export async function followUpSession(
@@ -627,7 +693,7 @@ export async function followUpSession(
 ): Promise<void> {
 	const entry = mustGetEntry(sessionId);
 	if (entry.session.isStreaming) {
-		await queueSessionMessage(entry, "followUp", images, () =>
+		await queueSessionMessage(entry, "followUp", text, images, () =>
 			entry.session.followUp(text, images),
 		);
 		return;
@@ -636,10 +702,20 @@ export async function followUpSession(
 }
 
 export async function compactSession(sessionId: string, instructions?: string): Promise<void> {
-	await mustGet(sessionId).compact(instructions);
+	const entry = mustGetEntry(sessionId);
+	if (entry.manualCompactionInProgress || entry.piCompactionInProgress) {
+		throw new Error("Compaction is already in progress for this session");
+	}
+	entry.manualCompactionInProgress = true;
+	try {
+		await entry.session.compact(instructions);
+	} finally {
+		entry.manualCompactionInProgress = false;
+	}
 }
 
 function queueStateOf(entry: Entry): SessionQueueState {
+	synchronizeQueueFromSession(entry);
 	return {
 		steering: [...entry.session.getSteeringMessages()],
 		followUp: [...entry.session.getFollowUpMessages()],
@@ -647,12 +723,14 @@ function queueStateOf(entry: Entry): SessionQueueState {
 	};
 }
 
-export function clearQueueSession(sessionId: string, requireTextOnly = false): SessionQueueState {
+export function clearQueueSession(sessionId: string, requireTextOnly = false): SessionQueueContent {
 	const entry = mustGetEntry(sessionId);
+	const content = queueContentOf(entry);
 	if (requireTextOnly && hasQueuedImages(entry)) {
 		throw new Error("Cannot restore queued image messages as text");
 	}
-	return entry.session.clearQueue();
+	entry.session.clearQueue();
+	return content;
 }
 
 export async function removeQueuedSession(
@@ -662,23 +740,41 @@ export async function removeQueuedSession(
 ): Promise<RemovedQueuedMessage> {
 	const entry = mustGetEntry(sessionId);
 	const { session } = entry;
-	const drained = session.clearQueue();
+	const drained = clearQueueSession(sessionId);
 	const lane = [...drained[kind]];
 	const removed = index >= 0 && index < lane.length ? (lane.splice(index, 1)[0] ?? null) : null;
 	const keep = { ...drained, [kind]: lane };
-	for (const text of keep.steering) await session.steer(text);
-	for (const text of keep.followUp) await session.followUp(text);
+	for (const message of keep.steering) {
+		await steerSession(sessionId, message.text, message.images ? [...message.images] : undefined);
+	}
+	for (const message of keep.followUp) {
+		await followUpSession(
+			sessionId,
+			message.text,
+			message.images ? [...message.images] : undefined,
+		);
+	}
 	if (!session.isStreaming && session.pendingMessageCount > 0) {
-		const parked = session.clearQueue();
-		for (const text of [...parked.steering, ...parked.followUp]) {
-			await followUpSession(sessionId, text);
+		const parked = clearQueueSession(sessionId);
+		for (const message of [...parked.steering, ...parked.followUp]) {
+			await followUpSession(
+				sessionId,
+				message.text,
+				message.images ? [...message.images] : undefined,
+			);
 		}
 	}
 	return { removed, queue: queueStateOf(entry) };
 }
 
-export function abortSession(sessionId: string): Promise<void> {
-	return mustGet(sessionId).abort();
+export async function abortSession(
+	sessionId: string,
+	restoreQueue = false,
+): Promise<SessionQueueContent | undefined> {
+	const entry = mustGetEntry(sessionId);
+	const restoredQueue = restoreQueue ? clearQueueSession(sessionId) : undefined;
+	await entry.session.abort();
+	return restoredQueue;
 }
 
 export async function setSessionModel(sessionId: string, model: WireModel): Promise<void> {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -54,6 +54,7 @@ interface Entry {
 	unsubscribe: () => void;
 	workspaceId: string;
 	lastSettlement: AgentSettlement | null | undefined;
+	queuedImageLanes: Record<QueueLane, boolean>;
 }
 
 const sessions = new Map<string, Entry>();
@@ -198,8 +199,13 @@ async function prepareSessionEntry(
 		unsubscribe: () => {},
 		workspaceId,
 		lastSettlement,
+		queuedImageLanes: { steering: false, followUp: false },
 	};
 	entry.unsubscribe = session.subscribe((event) => {
+		if (event.type === "queue_update") {
+			if (event.steering.length === 0) entry.queuedImageLanes.steering = false;
+			if (event.followUp.length === 0) entry.queuedImageLanes.followUp = false;
+		}
 		if (event.type === "agent_start") {
 			entry.lastSettlement = null;
 		}
@@ -216,7 +222,11 @@ async function prepareSessionEntry(
 					}
 				: null;
 		}
-		const projected = projectSessionEvent(event, terminal);
+		const baseEvent = projectSessionEvent(event, terminal);
+		const projected =
+			baseEvent.type === "queue_update" && hasQueuedImages(entry)
+				? { ...baseEvent, hasImages: true as const }
+				: baseEvent;
 		if (event.type === "agent_settled") entry.lastSettlement = terminal;
 		if (sessions.get(sessionId) === entry) publish({ sessionId, event: projected });
 		if (event.type === "agent_settled") terminal = null;
@@ -290,7 +300,7 @@ function summaryOf(sessionId: string, entry: Entry): SessionSummary {
 		updatedAt: Date.now(),
 		live: true,
 		...(entry.lastSettlement !== undefined ? { lastSettlement: entry.lastSettlement } : {}),
-		...(session.pendingMessageCount > 0 ? { queue: queueStateOf(session) } : {}),
+		...(session.pendingMessageCount > 0 ? { queue: queueStateOf(entry) } : {}),
 	};
 }
 
@@ -564,25 +574,50 @@ export async function answerQuestion(
 	});
 }
 
+function hasQueuedImages(entry: Entry): boolean {
+	return entry.queuedImageLanes.steering || entry.queuedImageLanes.followUp;
+}
+
+async function queueSessionMessage(
+	entry: Entry,
+	kind: QueueLane,
+	images: ImageContent[] | undefined,
+	send: () => Promise<void>,
+): Promise<void> {
+	if (!images || images.length === 0) {
+		await send();
+		return;
+	}
+	const previous = entry.queuedImageLanes[kind];
+	entry.queuedImageLanes[kind] = true;
+	try {
+		await send();
+	} catch (error) {
+		entry.queuedImageLanes[kind] = previous;
+		throw error;
+	}
+}
+
 export async function promptSession(
 	sessionId: string,
 	text: string,
 	images?: ImageContent[],
 ): Promise<void> {
-	const session = mustGet(sessionId);
-	if (session.isStreaming) {
-		await session.steer(text, images);
+	const entry = mustGetEntry(sessionId);
+	if (entry.session.isStreaming) {
+		await queueSessionMessage(entry, "steering", images, () => entry.session.steer(text, images));
 		return;
 	}
-	await session.prompt(text, images ? { images } : undefined);
+	await entry.session.prompt(text, images ? { images } : undefined);
 }
 
-export function steerSession(
+export async function steerSession(
 	sessionId: string,
 	text: string,
 	images?: ImageContent[],
 ): Promise<void> {
-	return mustGet(sessionId).steer(text, images);
+	const entry = mustGetEntry(sessionId);
+	await queueSessionMessage(entry, "steering", images, () => entry.session.steer(text, images));
 }
 
 export async function followUpSession(
@@ -590,27 +625,34 @@ export async function followUpSession(
 	text: string,
 	images?: ImageContent[],
 ): Promise<void> {
-	const session = mustGet(sessionId);
-	if (session.isStreaming) {
-		await session.followUp(text, images);
+	const entry = mustGetEntry(sessionId);
+	if (entry.session.isStreaming) {
+		await queueSessionMessage(entry, "followUp", images, () =>
+			entry.session.followUp(text, images),
+		);
 		return;
 	}
-	await session.prompt(text, images ? { images } : undefined);
+	await entry.session.prompt(text, images ? { images } : undefined);
 }
 
 export async function compactSession(sessionId: string, instructions?: string): Promise<void> {
 	await mustGet(sessionId).compact(instructions);
 }
 
-function queueStateOf(session: AgentSession): SessionQueueState {
+function queueStateOf(entry: Entry): SessionQueueState {
 	return {
-		steering: [...session.getSteeringMessages()],
-		followUp: [...session.getFollowUpMessages()],
+		steering: [...entry.session.getSteeringMessages()],
+		followUp: [...entry.session.getFollowUpMessages()],
+		...(hasQueuedImages(entry) ? { hasImages: true as const } : {}),
 	};
 }
 
-export function clearQueueSession(sessionId: string): SessionQueueState {
-	return mustGet(sessionId).clearQueue();
+export function clearQueueSession(sessionId: string, requireTextOnly = false): SessionQueueState {
+	const entry = mustGetEntry(sessionId);
+	if (requireTextOnly && hasQueuedImages(entry)) {
+		throw new Error("Cannot restore queued image messages as text");
+	}
+	return entry.session.clearQueue();
 }
 
 export async function removeQueuedSession(
@@ -618,7 +660,8 @@ export async function removeQueuedSession(
 	kind: QueueLane,
 	index: number,
 ): Promise<RemovedQueuedMessage> {
-	const session = mustGet(sessionId);
+	const entry = mustGetEntry(sessionId);
+	const { session } = entry;
 	const drained = session.clearQueue();
 	const lane = [...drained[kind]];
 	const removed = index >= 0 && index < lane.length ? (lane.splice(index, 1)[0] ?? null) : null;
@@ -631,7 +674,7 @@ export async function removeQueuedSession(
 			await followUpSession(sessionId, text);
 		}
 	}
-	return { removed, queue: queueStateOf(session) };
+	return { removed, queue: queueStateOf(entry) };
 }
 
 export function abortSession(sessionId: string): Promise<void> {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -499,7 +499,8 @@ const handlers: Record<string, Handler> = {
 		return { ok: true } as const;
 	},
 	"session.clearQueue": (params) => {
-		return clearQueueSession((params as { sessionId: string }).sessionId);
+		const p = params as { sessionId: string; requireTextOnly?: boolean };
+		return clearQueueSession(p.sessionId, p.requireTextOnly);
 	},
 	"session.removeQueued": async (params) => {
 		const p = params as { sessionId: string; kind: QueueLane; index: number };

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -507,8 +507,12 @@ const handlers: Record<string, Handler> = {
 		return removeQueuedSession(p.sessionId, p.kind, p.index);
 	},
 	"session.abort": async (params) => {
-		await abortSession((params as { sessionId: string }).sessionId);
-		return { ok: true } as const;
+		const p = params as { sessionId: string; restoreQueue?: boolean };
+		const restoredQueue = await abortSession(p.sessionId, p.restoreQueue);
+		return {
+			ok: true,
+			...(restoredQueue ? { restoredQueue } : {}),
+		} as const;
 	},
 	"session.dispose": (params) => {
 		removeSession((params as { sessionId: string }).sessionId);


### PR DESCRIPTION
## Summary

- add native `/compact [instructions]` support to chat autocomplete
- route compaction through Pi without creating a user turn
- preserve queued messages and attached-image drafts, with unified failure feedback

## Changes

- add exact Pi-compatible command parsing and built-in precedence
- add composer guards, queue restoration, and lifecycle de-duplication
- update chat/store specs and focused coverage

## Testing

- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed
- `bun run typecheck` — passed
- `bun run test` — passed
- `bun run e2e` — not run locally per request; CI pending
