### PR TITLE
fix(server): drain the pipes on runBounded's timeout path too

### DIFF
--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -95,3 +95,13 @@ The single WebSocket client to the host, and its app-wide singleton.
   (welcome + event routing — a runtime edge owned by the parent graph); `lib` (plain-HTTP-safe random page
   identity); the browser `WebSocket`.
 - **Forbidden:** `server`/`shared`/any `pi` package; importing `panels`/`shell`.
+
+## Get right
+
+- **`DEFAULT_TIMEOUT_MS` is the ceiling a host-side budget has to fit under, and nothing enforces it.**
+  The server bounds network `git` at 55s precisely so its own error — naming the ref, carrying git's
+  stderr — wins the race against the causeless `request "…" timed out` this side raises at 60s (issue #209;
+  `packages/server/src/git/SPEC.md`). Lower this number below that budget and every stalled fetch silently
+  reverts to the generic timeout, with no test or type failing to say so. The two constants live in
+  independently-shipped artifacts and are correct by agreement; deriving them from one another belongs in
+  `contracts`. Raising a per-request `timeoutMs` is safe, lowering the default is not.

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -27,7 +27,12 @@ ref off the workspace-create critical path.
   running. The ssh-key hint is what we say when git wrote *nothing*, never advice pasted over an
   observation we already have (the message never names a cause we did not observe);
   **`remoteTrackingRef(ref)`** → `refs/remotes/<ref>` for an `origin/` ref, else `null` — **the one place
-  that spelling is built**, so the probe below and `workspaces`' `worktree add` cannot drift apart;
+  that spelling is built**, so the probe below and `workspaces`' `worktree add` cannot drift apart. Its
+  reach is **creation only**, and `resolveDiffRange` is the named survivor: `diffBaseRef` hands git the
+  `origin/<b>` shorthand recorded in `baseBranch`, so in the very setup create now guards against — a local
+  branch literally named `origin/main` — the worktree is cut from `refs/remotes/origin/main` while the diff
+  is measured against the decoy. Left alone because `diffBase` is separately user-settable and may name any
+  ref, so qualifying it is a change to what a *pinned* base means, not a spelling fix;
   **`remoteRefOid(repoPath, ref)`** → the oid `refs/remotes/<ref>` resolves to, or `null` — **the one way
   to ask whether a remote-tracking ref is present**, shared by `prefetchBranch` (which compares oids to
   report `moved`), `resolveDefaultBranch`'s `origin/main` fallback, and `workspaces`' create fallback. It

--- a/packages/server/src/subprocess/SPEC.md
+++ b/packages/server/src/subprocess/SPEC.md
@@ -24,8 +24,8 @@ never what a particular child's output means.
   persistence.
 - **Forbidden:** message wording, retry, truncation, or any policy about a specific program. `git`'s
   stalled/stderr text and `branch-review`'s degrade-to-`null` are the callers' business.
-- **Known non-consumers.** Three callers still spawn outside this module, each deliberately and each a
-  standing debt rather than a settled design:
+- **Known non-consumers.** Three callers spawn something that can outlast a human's patience and still do
+  it themselves, each deliberately and each a standing debt rather than a settled design:
   - `@thinkrail/shared/jbcentral` — already deadline-first, and a different contract (bounded-byte reads, a
     closed outcome vocabulary, an injectable `run` seam, Central's confidentiality rules). Folding it in
     would grow this surface for one caller in another package.
@@ -35,6 +35,13 @@ never what a particular child's output means.
   - `github`'s `githubAuthStatus` (`github.ts`) — a `spawnSync` HTTPS call on the single event loop, so it
     also caps this module's guarantee: while it blocks, no `runBounded` deadline can fire. Migrating it
     means making the call async first, which changes its handler on the wire side.
+
+  The census above is about *unbounded waits*, not about every spawn in the repo — the rest are already
+  bounded or cannot wait on anything: `git`'s sync `git()` and `shared/shellEnv` pass their own
+  `Bun.spawnSync` timeout, `terminal/shellBusy` shells out to `pgrep` locally, and `editors`,
+  `cli/bootstrap` and `cli/powershell` are fire-and-forget `.unref()`s whose output nobody reads.
+  `agent/trash`'s `execFile` is the one true straggler: unbounded, but a local trash helper with no
+  network and no prompt, so it fails the letter of this module and not its purpose.
 
 ## Get right
 
@@ -49,13 +56,22 @@ never what a particular child's output means.
   makes the grace run to full term every time. A `git fetch` that answered at 54.9s of its 55s came back as
   the stalled wording with `ok: false`, and its healthy process group was SIGKILLed on the way out. Pinned
   by a test whose child exits immediately behind a pipe-holding grandchild under a 250ms budget.
-- **The drain grace after exit (250ms) cannot truncate the child's own output.** A pipe holds at most its
-  buffer, and a child that writes more than that is *blocked* until the reader drains it — so at exit
-  everything left is already buffered and drains in microseconds; the grace only covers scheduler latency.
-  Anything arriving after it can only come from a process that is not our child — and is still captured as
-  if it were the child's, which is a known wart, not a guarantee. The constant is pinned from the other
-  side: a test asserts the exit path *waits it out* (and no longer) when a grandchild keeps the pipes from
-  ever reaching EOF, which is the only case where it is observable at all.
+- **The drain grace (250ms) runs on *both* outcomes, exit and expiry.** It cannot truncate the child's own
+  output: a pipe holds at most its buffer, and a child that writes more than that is *blocked* until the
+  reader drains it — so at exit everything left is already buffered and drains in microseconds; the grace
+  only covers scheduler latency. Anything arriving after it can only come from a process that is not our
+  child — and is still captured as if it were the child's, which is a known wart, not a guarantee. The
+  constant is pinned from the other side: a test asserts each path *waits it out* (and no longer) when a
+  grandchild keeps the pipes from ever reaching EOF, which is the only case where it is observable at all.
+- **The timeout path drains too — cancelling the readers on the spot dropped the diagnosis.** The group
+  kill is what closes the write ends, so the bytes still in the pipe at expiry are exactly the ones the
+  caller's message is built from: git's `Permission denied (publickey)`, a proxy's refusal, a `remote:`
+  progress line proving a large transfer was simply still running. Killing and then cancelling in the same
+  synchronous step raced a pending `read()` against that cancel and could throw the last chunk away —
+  a caller promising "whatever git wrote before the kill" while dropping git's last word. Post-kill the
+  reads hit EOF almost at once, so the grace costs nothing in the normal case and caps the pathological one
+  (a holder that escaped the group via its own `setsid`, which is what the test uses to make the wait
+  observable).
 - **`timeoutMs` is clamped before it reaches `setTimeout`.** The type says `number`, and `setTimeout`
   silently collapses `Infinity`, `NaN`, negatives, and anything ≥ 2^31 to ~1ms — so `Infinity`, the natural
   spelling of "no budget", bought an instant timeout, an immediate group-`SIGKILL` of a healthy child, and
@@ -73,11 +89,18 @@ never what a particular child's output means.
 - **The exit path never kills the group.** The grandchildren there are healthy and deliberate — an `ssh`
   `ControlMaster`, a credential-cache daemon — and killing them would cost the user their multiplexed
   connection or their cached credentials for a call that *succeeded*. The readers are cancelled instead.
-- **`setsid` drops the controlling terminal, and that is a feature.** A child can no longer open `/dev/tty`
-  to prompt, which for a host that is not the user's foreground process was never a usable flow — it was
-  the hang. `SSH_ASKPASS` is unaffected (no-tty is exactly its trigger), which is why the caller's budget
-  still has to be sized for a human at a dialog. It also puts the child outside the host terminal's signal
-  group, so the budget — never a `Ctrl-C` on the host — is what ends a stalled call.
+- **`setsid` drops the controlling terminal — a deliberate trade, not a free win.** A child can no longer
+  open `/dev/tty` to prompt, which is what turns issue #209 from a 55s wait into an immediate
+  `Permission denied (publickey)` for most users; `SSH_ASKPASS` is unaffected (no-tty is exactly its
+  trigger), which is why the caller's budget still has to be sized for a human at a dialog. **What it costs
+  is real:** V1's entrypoint is a `thinkrail` bin launched from a terminal that stays in the foreground, and
+  a user sitting there could until now *see* `ssh`'s `Enter passphrase for key …` on `/dev/tty` (ssh reads
+  the tty directly, so our piped stdio never hid it) and type it. They no longer can. Accepted because the
+  UI is a browser client and a hidden terminal prompt is not a flow it can ever show, wait on, or report —
+  a fast legible failure beats a prompt only the launching shell can see. It also puts the child outside the
+  host terminal's signal group, so the budget — never a `Ctrl-C` on the host — is what ends a stalled call.
+  Surfacing the passphrase request in the UI (#209's headline ask, as opposed to its "at minimum" clause)
+  stays unbuilt and needs the cancellation seam `dialog` wants above.
 - **Windows has no process groups.** `detached` maps to `UV_PROCESS_DETACHED` and the kill falls back to
   the direct child, so a grandchild there survives the timeout as before. The group-kill test is skipped
   there rather than pretending otherwise.
@@ -87,7 +110,12 @@ never what a particular child's output means.
   arriving at the child, and a post-startup mutation being visible to one spawned without `env` — because a
   test that only asserts the defaults cannot tell the two apart.
 - `stdin` is always `ignore`, and both output streams are always piped and **read from the moment of
-  spawn**, decoded incrementally — an undrained pipe is how a chatty child deadlocks. The readers are cancelled once the outcome
-  is decided, so on the timeout path they stop where the group kill left them rather than draining. Every
+  spawn**, decoded incrementally — an undrained pipe is how a chatty child deadlocks. The readers are
+  cancelled once the outcome is decided *and* the grace above has run, never before it. Every
   timer is `unref`'d, so a bounded wait never holds shutdown open, and `waitedMs` comes from
   `performance.now()`, so a clock adjustment cannot render a negative wait.
+- **Neither stream is capped.** `runBounded` accumulates whatever the child writes for as long as the
+  budget allows, so a caller's byte ceiling (`git`'s 2000-char `boundedStderr`) bounds what reaches a
+  client, never what this module holds in memory. Adequate for `git`/`gh`/`glab`, where the worst case is a
+  progress log measured in hundreds of KB; a caller that can spew unboundedly needs a `maxBytes` option
+  here rather than a truncation after the fact.

--- a/packages/server/src/subprocess/runBounded.test.ts
+++ b/packages/server/src/subprocess/runBounded.test.ts
@@ -18,6 +18,8 @@ const pipeHoldingChild = (body: string) =>
 		`Bun.spawn(["sh", "-c", "sleep 5"], { stdout: "inherit", stderr: "inherit" }).unref(); ${body}`,
 	);
 
+const escapedPipeHolder = `Bun.spawn(["sh", "-c", "sleep 5"], { stdout: "inherit", stderr: "inherit", detached: true }).unref();`;
+
 const SENTINEL = "THINKRAIL_SPAWN_SENTINEL";
 
 async function gone(pid: number): Promise<boolean> {
@@ -154,4 +156,20 @@ posix("the timeout kills the whole process group, not just the child", async () 
 	expect(result.ok).toBe(false);
 	expect(existsSync(pidFile)).toBe(true);
 	expect(await gone(Number(readFileSync(pidFile, "utf8")))).toBe(true);
+});
+
+posix("the timeout path drains after the kill, bounded by the grace", async () => {
+	const budget = 500;
+
+	const result = await runBounded(
+		bun(
+			`${escapedPipeHolder} process.stderr.write("REMOTE-SAID-THIS"); await new Promise(() => {});`,
+		),
+		{ timeoutMs: budget },
+	);
+
+	expect(result.timedOut).toBe(true);
+	expect(result.err).toBe("REMOTE-SAID-THIS");
+	expect(result.waitedMs).toBeGreaterThanOrEqual(budget + DRAIN_GRACE_MS);
+	expect(result.waitedMs).toBeLessThan(budget + DRAIN_GRACE_MS * 8);
 });

--- a/packages/server/src/subprocess/runBounded.ts
+++ b/packages/server/src/subprocess/runBounded.ts
@@ -95,11 +95,9 @@ export async function runBounded(argv: string[], opts: BoundedRunOptions): Promi
 	]);
 	deadline.cancel();
 	if (outcome === "timed-out") killTree(proc);
-	else {
-		const grace = delay(DRAIN_GRACE_MS);
-		await Promise.race([drained, grace.promise]);
-		grace.cancel();
-	}
+	const grace = delay(DRAIN_GRACE_MS);
+	await Promise.race([drained, grace.promise]);
+	grace.cancel();
 	out.cancel();
 	err.cancel();
 


### PR DESCRIPTION
Follow-up to #281 — one small bug plus three SPEC claims that were stated more strongly than the code earns.

## The bug

`runBounded` killed the process group and cancelled the readers in the same synchronous step, so a pending `read()` raced the cancel: whatever the child wrote in the last microtask could be dropped. That's precisely the bytes `gitAsync`'s stalled message is built from — `Permission denied (publickey)`, a proxy's refusal, a `remote:` progress line proving a large transfer was still running. A caller promising "whatever git wrote before the kill" while dropping git's last word.

The group kill is what closes the write ends, so the drain grace that already guarded the exit path now runs on both outcomes. Post-kill the reads hit EOF at once, so it costs nothing normally and caps the pathological case (a holder that escaped the group with its own `setsid` — which is what the new test uses to make the wait observable; it fails at `500ms` against the old code, passes at `750ms` with the fix).

## SPEC corrections

- **`setsid` dropping the controlling terminal is a trade, not a free win.** It's also the mechanism that turns #209 into an immediate `Permission denied` for most users rather than the 55s wait we advertise. But V1's entrypoint is a `thinkrail` bin in a foreground terminal, and a user sitting there could until now *see* ssh's passphrase prompt on `/dev/tty` and type it. They no longer can. Worth accepting — a browser client can't show or wait on a prompt only the launching shell sees — but worth recording as a cost, not as "was never a usable flow".
- **The non-consumer census read as exhaustive and wasn't** — `shellBusy`, `agent/trash`, `editors`, `cli/bootstrap`, `cli/powershell`, `shared/shellEnv` also spawn. Almost all are bounded or fire-and-forget; `agent/trash`'s `execFile` is the one real straggler. Scoped the list to unbounded waits and named the rest.
- **`remoteTrackingRef`'s "one place that spelling is built" stops at create.** `diffBaseRef` still hands git the `origin/<b>` shorthand, so in the same local-decoy-branch setup create now guards against, the diff is measured against the decoy. Left as-is (`diffBase` is separately user-settable, so qualifying it changes what a pinned base *means*) and named as the survivor.

Also noted in `transport/SPEC.md` that `DEFAULT_TIMEOUT_MS` is the ceiling the host's 55s budget has to fit under — lowering it silently reverts #209, and nothing fails to say so.

## Not done

`runBounded` still caps neither stream. Fine for `git`/`gh` (worst case is a progress log in the hundreds of KB) and it wants a `maxBytes` option rather than a truncation after the fact, so I only wrote it down.

## Verifying

`bun run lint`, `bun run typecheck`, `bun run test` (714 server tests) green. E2E not run locally — nothing here touches a UI path.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes — not run locally; server-internal + specs only
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
