### PR TITLE
[Design] follow-up action chips above the composer

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -33,6 +33,8 @@ import {
 	type SubmitBehavior,
 } from "./Composer";
 import { ExtUiDialog } from "./ExtUiDialog";
+import { FollowUpChips } from "./FollowUpChips";
+import { deriveFollowUps } from "./followUps";
 import { HistoryOverlay } from "./HistoryOverlay";
 import { planGlance } from "./planView";
 import { QueueStrip } from "./QueueStrip";
@@ -156,6 +158,8 @@ export default function ChatView({
 			isStreaming && last?.kind !== "retry" ? streamStatus(turns, currentAssistantId) : null;
 		return { status };
 	}, [turns, isStreaming, currentAssistantId]);
+
+	const followUps = useMemo(() => deriveFollowUps(turns), [turns]);
 
 	const recentPrompts = useMemo(() => {
 		const texts = turns
@@ -599,6 +603,12 @@ export default function ChatView({
 						</div>
 					) : null}
 					<QueueStrip queue={queue} onEdit={onEditQueued} onRemove={onRemoveQueued} />
+					{!isStreaming && draft.trim() === "" ? (
+						<FollowUpChips
+							items={followUps}
+							onPick={(prompt) => composerRef.current?.insertText(prompt)}
+						/>
+					) : null}
 					<div className="relative shrink-0">
 						<HistoryOverlay
 							state={historyState}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -161,22 +161,23 @@ export default function ChatView({
 
 	const followUps = useMemo(() => deriveFollowUps(turns), [turns]);
 	const [usedFollowUps, setUsedFollowUps] = useState<ReadonlySet<string>>(() => new Set());
-	const [chipDraft, setChipDraft] = useState<string | null>(null);
 	useEffect(() => {
 		setUsedFollowUps((prev) => (prev.size ? new Set() : prev));
-		setChipDraft((prev) => (prev === null ? prev : null));
 	}, [followUps]);
 	const visibleFollowUps = useMemo(
 		() => followUps.filter((f) => !usedFollowUps.has(f.prompt)),
 		[followUps, usedFollowUps],
 	);
-	const onPickFollowUp = useCallback((prompt: string) => {
-		composerRef.current?.insertText(prompt);
-		setUsedFollowUps((prev) => new Set(prev).add(prompt));
-		setChipDraft(prompt);
-	}, []);
-	const showFollowUps =
-		!isStreaming && visibleFollowUps.length > 0 && (draft.trim() === "" || draft === chipDraft);
+	const onPickFollowUp = useCallback(
+		(prompt: string) => {
+			const current = useAppStore.getState().sessions[sessionId]?.draft ?? "";
+			const combined = current.trim() ? `${current.trimEnd()} ${prompt}` : prompt;
+			composerRef.current?.insertText(combined);
+			setUsedFollowUps((prev) => new Set(prev).add(prompt));
+		},
+		[sessionId],
+	);
+	const showFollowUps = !isStreaming && visibleFollowUps.length > 0;
 
 	const recentPrompts = useMemo(() => {
 		const texts = turns

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -583,6 +583,11 @@ export default function ChatView({
 								</div>
 							)}
 						/>
+						<div
+							aria-hidden
+							data-testid="chat-bottom-scrim"
+							className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-transparent to-container-workspace-bg"
+						/>
 						{showScrollButton ? (
 							<button
 								type="button"

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -160,6 +160,23 @@ export default function ChatView({
 	}, [turns, isStreaming, currentAssistantId]);
 
 	const followUps = useMemo(() => deriveFollowUps(turns), [turns]);
+	const [usedFollowUps, setUsedFollowUps] = useState<ReadonlySet<string>>(() => new Set());
+	const [chipDraft, setChipDraft] = useState<string | null>(null);
+	useEffect(() => {
+		setUsedFollowUps((prev) => (prev.size ? new Set() : prev));
+		setChipDraft((prev) => (prev === null ? prev : null));
+	}, [followUps]);
+	const visibleFollowUps = useMemo(
+		() => followUps.filter((f) => !usedFollowUps.has(f.prompt)),
+		[followUps, usedFollowUps],
+	);
+	const onPickFollowUp = useCallback((prompt: string) => {
+		composerRef.current?.insertText(prompt);
+		setUsedFollowUps((prev) => new Set(prev).add(prompt));
+		setChipDraft(prompt);
+	}, []);
+	const showFollowUps =
+		!isStreaming && visibleFollowUps.length > 0 && (draft.trim() === "" || draft === chipDraft);
 
 	const recentPrompts = useMemo(() => {
 		const texts = turns
@@ -608,12 +625,7 @@ export default function ChatView({
 						</div>
 					) : null}
 					<QueueStrip queue={queue} onEdit={onEditQueued} onRemove={onRemoveQueued} />
-					{!isStreaming && draft.trim() === "" ? (
-						<FollowUpChips
-							items={followUps}
-							onPick={(prompt) => composerRef.current?.insertText(prompt)}
-						/>
-					) : null}
+					{showFollowUps ? <FollowUpChips items={visibleFollowUps} onPick={onPickFollowUp} /> : null}
 					<div className="relative shrink-0">
 						<HistoryOverlay
 							state={historyState}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -501,7 +501,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	return (
-		<div className="relative flex shrink-0 flex-col border-border-muted border-t bg-container-workspace-bg">
+		<div className="relative flex shrink-0 flex-col bg-container-workspace-bg">
 			{mentionOpen ? (
 				<div
 					data-testid="mention-menu"

--- a/apps/web/src/chat/FollowUpChips.tsx
+++ b/apps/web/src/chat/FollowUpChips.tsx
@@ -11,7 +11,7 @@ export function FollowUpChips({
 	return (
 		<div
 			data-testid="followup-row"
-			className="flex w-full shrink-0 flex-wrap gap-xs bg-container-workspace-bg px-md pt-xs"
+			className="flex w-full shrink-0 flex-wrap gap-xs bg-linear-to-b from-transparent to-container-workspace-bg px-md pt-xs"
 		>
 			{items.map((item) => (
 				<button

--- a/apps/web/src/chat/FollowUpChips.tsx
+++ b/apps/web/src/chat/FollowUpChips.tsx
@@ -11,7 +11,7 @@ export function FollowUpChips({
 	return (
 		<div
 			data-testid="followup-row"
-			className="flex w-full shrink-0 flex-wrap gap-xs bg-linear-to-b from-transparent to-container-workspace-bg px-md pt-xs"
+			className="flex w-full shrink-0 flex-wrap gap-xs px-md pt-xs"
 		>
 			{items.map((item) => (
 				<button

--- a/apps/web/src/chat/FollowUpChips.tsx
+++ b/apps/web/src/chat/FollowUpChips.tsx
@@ -18,7 +18,6 @@ export function FollowUpChips({
 					key={item.label}
 					type="button"
 					data-testid="followup-chip"
-					title={item.prompt}
 					onClick={() => onPick(item.prompt)}
 					className="flex max-w-full items-center rounded-[var(--radius-sm)] border border-transparent bg-clip-padding bg-bubble-user-bg px-sm py-2xs text-text-muted tr-text-reading transition-colors hover:border-bubble-user-border"
 				>

--- a/apps/web/src/chat/FollowUpChips.tsx
+++ b/apps/web/src/chat/FollowUpChips.tsx
@@ -1,0 +1,30 @@
+import type { FollowUp } from "./followUps";
+
+export function FollowUpChips({
+	items,
+	onPick,
+}: {
+	items: FollowUp[];
+	onPick: (prompt: string) => void;
+}) {
+	if (items.length === 0) return null;
+	return (
+		<div
+			data-testid="followup-row"
+			className="flex w-full shrink-0 flex-wrap gap-xs bg-container-workspace-bg px-md pt-xs"
+		>
+			{items.map((item) => (
+				<button
+					key={item.label}
+					type="button"
+					data-testid="followup-chip"
+					title={item.prompt}
+					onClick={() => onPick(item.prompt)}
+					className="flex max-w-full items-center rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-sm py-2xs text-text-muted tr-text-metadata hover:bg-control-bg-hovered hover:text-text-default"
+				>
+					<span className="truncate">{item.label}</span>
+				</button>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/chat/FollowUpChips.tsx
+++ b/apps/web/src/chat/FollowUpChips.tsx
@@ -20,7 +20,7 @@ export function FollowUpChips({
 					data-testid="followup-chip"
 					title={item.prompt}
 					onClick={() => onPick(item.prompt)}
-					className="flex max-w-full items-center rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-sm py-2xs text-text-muted tr-text-metadata hover:bg-control-bg-hovered hover:text-text-default"
+					className="flex max-w-full items-center rounded-[var(--radius-sm)] border border-transparent bg-clip-padding bg-bubble-user-bg px-sm py-2xs text-text-muted tr-text-reading transition-colors hover:border-bubble-user-border"
 				>
 					<span className="truncate">{item.label}</span>
 				</button>

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -302,20 +302,20 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `tr-text-reading`) so a suggestion reads as a pre-drafted user reply — no follow-up-specific tokens.
   The default border is transparent (no visible border); hover reveals `border-bubble-user-border`
   (the same accent border role), background unchanged on hover.
-  Each chip carries a short `label` and a full `prompt`; clicking one populates the composer draft via
-  the existing `ComposerHandle.insertText` (→ `replaceDraft`, focus stays in the composer) and **never
-  sends** — the user reviews and presses Send through the unchanged path. They are **view-level**
-  suggestions, not a chat/domain entity: no store field, no wire type, no persistence; `deriveFollowUps`
-  is pure over the transcript so the set tracks the latest assistant turn. **Currently mocked** — the
-  derivation is a keyword heuristic over the last assistant message, a placeholder for real generation.
+  Each chip carries a short `label` and a full `prompt`; clicking one **appends** that prompt to the
+  composer draft as the next sentence (`ChatView` reads the live draft and passes
+  `current + " " + prompt` through `ComposerHandle.insertText`, focus stays in the composer) and
+  **never sends** — the user reviews and presses Send through the unchanged path. Append (not replace)
+  is deliberate: a click never overwrites what the user typed or a prompt an earlier chip inserted, so
+  suggestions compose into one message. They are **view-level** suggestions, not a chat/domain entity:
+  no store field, no wire type, no persistence; `deriveFollowUps` is pure over the transcript so the set
+  tracks the latest assistant turn. **Currently mocked** — the derivation is a keyword heuristic over the
+  last assistant message, a placeholder for real generation.
   **Clicking a chip dismisses only that chip; the rest stay** — `ChatView` tracks the used prompts and
-  filters them out of the passed `items`, so the row persists as a shrinking palette (pick a different
-  suggestion, or clear the draft to pick again). The row is shown when idle (`!isStreaming`), at least
-  one un-dismissed chip remains, **and the draft is either empty or exactly the prompt a chip just
-  inserted** (`draft === chipDraft`) — the draft-protection contract: a chip replaces the draft, so the
-  row only shows over an empty draft or its own chip-inserted text, never over what the user typed
-  themselves (a manual edit diverges the draft and hides the row). The used/inserted state resets when
-  the suggestion set changes (a new turn). Props-driven (`{ items, onPick }`), no store/transport. E2e: `data-testid="followup-row"`
+  filters them out of the passed `items`, so the row persists as a shrinking palette. The row is shown
+  whenever idle (`!isStreaming`) and at least one un-dismissed chip remains — **independent of the draft**
+  (typing does not hide it, since append can't clobber the draft). The used-chip state resets when the
+  suggestion set changes (a new turn). Props-driven (`{ items, onPick }`), no store/transport. E2e: `data-testid="followup-row"`
   / `followup-chip`.
 - **Streaming send modes: split send + interrupt** (`Composer`) — steer/queue semantics are pi's loop
   design (steer = injected at the next turn boundary, after the current assistant message + its tool

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -292,8 +292,12 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   only, so a queued image attachment shows no chip in the strip; the canonical transcript turn later
   renders its image blocks with the hydrated-turn fallback labels. E2e: `queue.live.spec.ts` (@agent).
 - **Follow-up chips** (`FollowUpChips.tsx` + the pure `deriveFollowUps(turns)` in `followUps.ts`) — a
-  compact `flex-wrap` row of low-weight suggestion chips (`tr-text-metadata`, semantic control roles)
-  rendered by `ChatView` **between `QueueStrip` and the composer wrapper** (never inside the composer).
+  compact `flex-wrap` row of suggestion chips rendered by `ChatView` **between `QueueStrip` and the
+  composer wrapper** (never inside the composer). The chips **reuse the user-message bubble roles**
+  (the `USER_BUBBLE` treatment in `turns.tsx`: `bg-bubble-user-bg` surface + `text-text-muted` +
+  `tr-text-reading`) so a suggestion reads as a pre-drafted user reply — no follow-up-specific tokens.
+  The default border is transparent (no visible border); hover reveals `border-bubble-user-border`
+  (the same accent border role), background unchanged on hover.
   Each chip carries a short `label` and a full `prompt`; clicking one populates the composer draft via
   the existing `ComposerHandle.insertText` (→ `replaceDraft`, focus stays in the composer) and **never
   sends** — the user reviews and presses Send through the unchanged path. They are **view-level**

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -200,6 +200,10 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   overrides with its centered `scrollToIndex`. Streaming follow stays `useChatScroll`'s job
   (pointer-aware `followOutput` — unchanged). E2e: `auto-open-chats.spec.ts` asserts a long seeded
   transcript's last message is in view without scrolling.
+  A `pointer-events-none` **bottom scrim** (`chat-bottom-scrim`, absolute inside the `relative`
+  `chat-scroll`, `bg-linear-to-b from-transparent to-container-workspace-bg`) fades the last of the
+  transcript's content into the composer surface — the fade reads only because it overlaps message
+  content, not the flat same-colour chat surface.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
   commands + template **slot sessions** (Tab-through placeholders — see the Template slots bullet
   below), image paste/drop — routed through **`imageAttachment.ts`**: `fileToAttachedImage` decodes in

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -308,9 +308,14 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   suggestions, not a chat/domain entity: no store field, no wire type, no persistence; `deriveFollowUps`
   is pure over the transcript so the set tracks the latest assistant turn. **Currently mocked** — the
   derivation is a keyword heuristic over the last assistant message, a placeholder for real generation.
-  The row is shown only when idle (`!isStreaming`) **and the draft is empty** — the empty-draft gate is
-  the draft-protection contract: a chip replaces the draft, so it is only offered when there is nothing
-  to overwrite. Props-driven (`{ items, onPick }`), no store/transport. E2e: `data-testid="followup-row"`
+  **Clicking a chip dismisses only that chip; the rest stay** — `ChatView` tracks the used prompts and
+  filters them out of the passed `items`, so the row persists as a shrinking palette (pick a different
+  suggestion, or clear the draft to pick again). The row is shown when idle (`!isStreaming`), at least
+  one un-dismissed chip remains, **and the draft is either empty or exactly the prompt a chip just
+  inserted** (`draft === chipDraft`) — the draft-protection contract: a chip replaces the draft, so the
+  row only shows over an empty draft or its own chip-inserted text, never over what the user typed
+  themselves (a manual edit diverges the draft and hides the row). The used/inserted state resets when
+  the suggestion set changes (a new turn). Props-driven (`{ items, onPick }`), no store/transport. E2e: `data-testid="followup-row"`
   / `followup-chip`.
 - **Streaming send modes: split send + interrupt** (`Composer`) — steer/queue semantics are pi's loop
   design (steer = injected at the next turn boundary, after the current assistant message + its tool

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -291,6 +291,19 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   text to the draft alongside the `appendErrorTurn`. Trade-off, accepted: `queue_update` carries text
   only, so a queued image attachment shows no chip in the strip; the canonical transcript turn later
   renders its image blocks with the hydrated-turn fallback labels. E2e: `queue.live.spec.ts` (@agent).
+- **Follow-up chips** (`FollowUpChips.tsx` + the pure `deriveFollowUps(turns)` in `followUps.ts`) — a
+  compact `flex-wrap` row of low-weight suggestion chips (`tr-text-metadata`, semantic control roles)
+  rendered by `ChatView` **between `QueueStrip` and the composer wrapper** (never inside the composer).
+  Each chip carries a short `label` and a full `prompt`; clicking one populates the composer draft via
+  the existing `ComposerHandle.insertText` (→ `replaceDraft`, focus stays in the composer) and **never
+  sends** — the user reviews and presses Send through the unchanged path. They are **view-level**
+  suggestions, not a chat/domain entity: no store field, no wire type, no persistence; `deriveFollowUps`
+  is pure over the transcript so the set tracks the latest assistant turn. **Currently mocked** — the
+  derivation is a keyword heuristic over the last assistant message, a placeholder for real generation.
+  The row is shown only when idle (`!isStreaming`) **and the draft is empty** — the empty-draft gate is
+  the draft-protection contract: a chip replaces the draft, so it is only offered when there is nothing
+  to overwrite. Props-driven (`{ items, onPick }`), no store/transport. E2e: `data-testid="followup-row"`
+  / `followup-chip`.
 - **Streaming send modes: split send + interrupt** (`Composer`) — steer/queue semantics are pi's loop
   design (steer = injected at the next turn boundary, after the current assistant message + its tool
   calls; queue = runs after the agent settles; only abort halts an in-flight response) and proved

--- a/apps/web/src/chat/followUps.test.ts
+++ b/apps/web/src/chat/followUps.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { deriveFollowUps } from "./followUps";
+import type { ChatTurn } from "./types";
+
+function assistant(text: string): ChatTurn {
+	return {
+		id: `a-${text.slice(0, 8)}`,
+		kind: "assistant",
+		streaming: false,
+		message: { role: "assistant", content: [{ type: "text", text }] },
+	} as unknown as ChatTurn;
+}
+
+function user(text: string): ChatTurn {
+	return {
+		id: `u-${text.slice(0, 8)}`,
+		kind: "user",
+		message: { role: "user", content: text },
+	} as ChatTurn;
+}
+
+describe("deriveFollowUps", () => {
+	it("returns nothing when there is no assistant turn", () => {
+		expect(deriveFollowUps([])).toEqual([]);
+		expect(deriveFollowUps([user("hello")])).toEqual([]);
+	});
+
+	it("returns nothing when the last assistant turn is empty", () => {
+		expect(deriveFollowUps([assistant("   ")])).toEqual([]);
+	});
+
+	it("suggests option-related follow-ups when the agent presents options", () => {
+		const items = deriveFollowUps([assistant("Here are two approaches; I recommend the first.")]);
+		expect(items.map((i) => i.label)).toContain("Use the recommended option");
+		for (const item of items) expect(item.prompt.length).toBeGreaterThan(item.label.length);
+	});
+
+	it("suggests fix follow-ups when the agent reports a failure", () => {
+		const items = deriveFollowUps([assistant("The build failed with an error.")]);
+		expect(items.map((i) => i.label)).toContain("Fix the issues");
+	});
+
+	it("falls back to defaults for unmatched content", () => {
+		const items = deriveFollowUps([assistant("Hello there, how are you?")]);
+		expect(items.map((i) => i.label)).toContain("Continue");
+	});
+
+	it("tracks the latest assistant turn (context changes)", () => {
+		const first = deriveFollowUps([assistant("Here are the options.")]);
+		const second = deriveFollowUps([
+			assistant("Here are the options."),
+			user("go"),
+			assistant("The test suite failed."),
+		]);
+		expect(first.map((i) => i.label)).toContain("Use the recommended option");
+		expect(second.map((i) => i.label)).not.toEqual(first.map((i) => i.label));
+	});
+});

--- a/apps/web/src/chat/followUps.ts
+++ b/apps/web/src/chat/followUps.ts
@@ -1,0 +1,71 @@
+import type { ChatTurn } from "./types";
+
+export type FollowUp = { label: string; prompt: string };
+
+const DEFAULT_FOLLOW_UPS: FollowUp[] = [
+	{ label: "Continue", prompt: "Continue with the implementation." },
+	{ label: "Explain this", prompt: "Explain what you just did and why." },
+	{ label: "Run the tests", prompt: "Run the tests and report the results." },
+];
+
+const RULES: { match: RegExp; items: FollowUp[] }[] = [
+	{
+		match: /\b(option|recommend|approach|alternativ|prefer)/i,
+		items: [
+			{
+				label: "Use the recommended option",
+				prompt: "Use the recommended option and continue with the implementation.",
+			},
+			{
+				label: "Compare the options",
+				prompt: "Compare the options in more detail before deciding.",
+			},
+		],
+	},
+	{
+		match: /\b(error|fail|issue|bug|broke|broken|exception|crash)/i,
+		items: [
+			{ label: "Fix the issues", prompt: "Fix the issues you found and re-run the checks." },
+			{ label: "Explain the cause", prompt: "Explain the root cause of the failure." },
+		],
+	},
+	{
+		match: /\b(test|spec|coverage)/i,
+		items: [
+			{ label: "Run the tests", prompt: "Run the tests and report the results." },
+			{ label: "Add tests", prompt: "Add tests covering the new behavior." },
+		],
+	},
+	{
+		match: /\b(implement|refactor|added|updated|created|changed|change)/i,
+		items: [
+			{
+				label: "Update the implementation",
+				prompt: "Update the implementation based on the notes above.",
+			},
+			{ label: "Explain this", prompt: "Explain what you just did and why." },
+		],
+	},
+];
+
+function lastAssistantText(turns: ChatTurn[]): string | null {
+	for (let i = turns.length - 1; i >= 0; i--) {
+		const turn = turns[i];
+		if (turn?.kind === "assistant") {
+			return turn.message.content
+				.filter((b) => b.type === "text")
+				.map((b) => b.text)
+				.join("\n");
+		}
+	}
+	return null;
+}
+
+export function deriveFollowUps(turns: ChatTurn[]): FollowUp[] {
+	const text = lastAssistantText(turns);
+	if (text === null || text.trim() === "") return [];
+	for (const rule of RULES) {
+		if (rule.match.test(text)) return rule.items;
+	}
+	return DEFAULT_FOLLOW_UPS;
+}

--- a/e2e/followup-actions.spec.ts
+++ b/e2e/followup-actions.spec.ts
@@ -44,6 +44,5 @@ test("a follow-up chip fills the composer draft without sending, and hides once 
 		"Use the recommended option and continue with the implementation.",
 	);
 	await expect(composer).toBeFocused();
-	// The row hides once a draft exists (draft-protection: a chip only replaces an empty draft).
 	await expect(row).toHaveCount(0);
 });

--- a/e2e/followup-actions.spec.ts
+++ b/e2e/followup-actions.spec.ts
@@ -1,0 +1,49 @@
+import { realpathSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_300_000_000;
+const repoCwd = () => realpathSync(E2E_FIXTURE_REPO);
+
+test.afterEach(() => {
+	rmSync(join(E2E_FIXTURE_REPO, ".thinkrail"), { recursive: true, force: true });
+});
+
+test("a follow-up chip fills the composer draft without sending, and hides once a draft exists", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+
+	seedWorkspaceSession(repoCwd(), {
+		name: "follow-up chat",
+		messages: [
+			{ role: "user", text: "which way should we go?", timestamp: BASE_TS },
+			{
+				role: "assistant",
+				text: "Here are two approaches; I recommend the first option.",
+				timestamp: BASE_TS + 1_000,
+			},
+		],
+	});
+
+	await enterDefaultWorkspace(page);
+	await expect(page.getByText("I recommend the first option")).toBeVisible();
+
+	const row = page.getByTestId("followup-row");
+	await expect(row).toBeVisible();
+	const chip = page.getByTestId("followup-chip").filter({ hasText: "Use the recommended option" });
+	await expect(chip).toBeVisible();
+
+	await chip.click();
+
+	const composer = page.getByTestId("chat-input");
+	await expect(composer).toHaveValue(
+		"Use the recommended option and continue with the implementation.",
+	);
+	await expect(composer).toBeFocused();
+	// The row hides once a draft exists (draft-protection: a chip only replaces an empty draft).
+	await expect(row).toHaveCount(0);
+});

--- a/e2e/followup-actions.spec.ts
+++ b/e2e/followup-actions.spec.ts
@@ -12,7 +12,7 @@ test.afterEach(() => {
 	rmSync(join(E2E_FIXTURE_REPO, ".thinkrail"), { recursive: true, force: true });
 });
 
-test("a follow-up chip fills the composer draft without sending, and hides once a draft exists", async ({
+test("clicking a follow-up chip fills the draft, dismisses only that chip, and keeps the rest", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
@@ -33,16 +33,21 @@ test("a follow-up chip fills the composer draft without sending, and hides once 
 	await expect(page.getByText("I recommend the first option")).toBeVisible();
 
 	const row = page.getByTestId("followup-row");
+	const chips = page.getByTestId("followup-chip");
 	await expect(row).toBeVisible();
-	const chip = page.getByTestId("followup-chip").filter({ hasText: "Use the recommended option" });
-	await expect(chip).toBeVisible();
+	await expect(chips).toHaveCount(2);
+	const picked = chips.filter({ hasText: "Use the recommended option" });
+	await expect(picked).toBeVisible();
 
-	await chip.click();
+	await picked.click();
 
 	const composer = page.getByTestId("chat-input");
 	await expect(composer).toHaveValue(
 		"Use the recommended option and continue with the implementation.",
 	);
 	await expect(composer).toBeFocused();
-	await expect(row).toHaveCount(0);
+	await expect(row).toBeVisible();
+	await expect(chips).toHaveCount(1);
+	await expect(chips.filter({ hasText: "Compare the options" })).toBeVisible();
+	await expect(picked).toHaveCount(0);
 });

--- a/e2e/followup-actions.spec.ts
+++ b/e2e/followup-actions.spec.ts
@@ -12,7 +12,7 @@ test.afterEach(() => {
 	rmSync(join(E2E_FIXTURE_REPO, ".thinkrail"), { recursive: true, force: true });
 });
 
-test("clicking a follow-up chip fills the draft, dismisses only that chip, and keeps the rest", async ({
+test("a follow-up chip appends its prompt, dismisses only itself, and survives typing", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
@@ -20,34 +20,36 @@ test("clicking a follow-up chip fills the draft, dismisses only that chip, and k
 	seedWorkspaceSession(repoCwd(), {
 		name: "follow-up chat",
 		messages: [
-			{ role: "user", text: "which way should we go?", timestamp: BASE_TS },
-			{
-				role: "assistant",
-				text: "Here are two approaches; I recommend the first option.",
-				timestamp: BASE_TS + 1_000,
-			},
+			{ role: "user", text: "where are we?", timestamp: BASE_TS },
+			{ role: "assistant", text: "All done here.", timestamp: BASE_TS + 1_000 },
 		],
 	});
 
 	await enterDefaultWorkspace(page);
-	await expect(page.getByText("I recommend the first option")).toBeVisible();
+	await expect(page.getByText("All done here.")).toBeVisible();
 
 	const row = page.getByTestId("followup-row");
 	const chips = page.getByTestId("followup-chip");
-	await expect(row).toBeVisible();
-	await expect(chips).toHaveCount(2);
-	const picked = chips.filter({ hasText: "Use the recommended option" });
-	await expect(picked).toBeVisible();
-
-	await picked.click();
-
 	const composer = page.getByTestId("chat-input");
-	await expect(composer).toHaveValue(
-		"Use the recommended option and continue with the implementation.",
-	);
+	await expect(row).toBeVisible();
+	await expect(chips).toHaveCount(3);
+
+	await composer.fill("hello");
+	await expect(composer).toHaveValue("hello");
+	await expect(row).toBeVisible();
+	await expect(chips).toHaveCount(3);
+
+	await chips.filter({ hasText: "Continue" }).click();
+	await expect(composer).toHaveValue("hello Continue with the implementation.");
 	await expect(composer).toBeFocused();
+	await expect(chips).toHaveCount(2);
+	await expect(chips.filter({ hasText: "Continue" })).toHaveCount(0);
+
+	await chips.filter({ hasText: "Explain this" }).click();
+	await expect(composer).toHaveValue(
+		"hello Continue with the implementation. Explain what you just did and why.",
+	);
 	await expect(row).toBeVisible();
 	await expect(chips).toHaveCount(1);
-	await expect(chips.filter({ hasText: "Compare the options" })).toBeVisible();
-	await expect(picked).toHaveCount(0);
+	await expect(chips.filter({ hasText: "Run the tests" })).toBeVisible();
 });


### PR DESCRIPTION
Adds contextual follow-up actions above the chat input, letting users quickly populate a suggested response and edit it before sending.

<img width="1037" height="234" alt="Screenshot 2026-08-26 at 12 42 07 PM" src="https://github.com/user-attachments/assets/48510e64-6a6c-4b40-961a-fb5fe3cbdc81" />


