### PR TITLE
ci: add Junie Slack bot workflow

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -8,12 +8,13 @@ parent: architecture
 
 ## Responsibility
 
-The repo's automation: PR **gates** and the multi-platform **release** pipeline. The shippable artifact
-is the single-file `thinkrail` binary that `apps/cli` produces (`build:binary` / `smoke:binary` — see
-`module-cli`); this module builds it for every platform, stamps a release version into it, and publishes
-GitHub releases. It owns no product code — only workflows, composite actions, and the version script.
+The repo's automation: PR **gates**, the multi-platform **release** pipeline, and the scheduled Junie
+Slack agent. The shippable artifact is the single-file `thinkrail` binary that `apps/cli` produces
+(`build:binary` / `smoke:binary` — see `module-cli`); this module builds it for every platform, stamps a
+release version into it, and publishes GitHub releases. It owns no product code — only workflows,
+composite actions, and the version script.
 
-## CI vs release
+## Automation lanes
 
 - **CI** (`ci.yml`, on PRs to `main`): lint+typecheck (incl. `check:seams` — the pi binary-seam canary,
   see `scripts/check-binary-seams.ts`), unit tests, no-agent e2e, and a **host-target** binary
@@ -23,6 +24,12 @@ GitHub releases. It owns no product code — only workflows, composite actions, 
   build+smoke** (`binary-windows`). Fast, no provider auth. Gates merges.
 - **Release** (`nightly.yml` / `stable.yml` → `_release.yml` → `_build.yml`): trusts a green `main` (no
   test gate of its own) and produces published binaries + a GitHub release.
+- **Junie Slack agent** (`junie-slack-bot.yml`, manual dispatch + four-hour schedule): runs the upstream
+  `JetBrains/junie-slack-bot@v1` action against `.junie-live/slack-bot.yaml`. The profile allow-lists
+  Slack channels and `slack-bot/*` push branches; Slack and repository credentials are brokered by Junie
+  Live. The workflow receives only the `JUNIE_SLACK_BOT_JUNIE_API_KEY` and
+  `JUNIE_SLACK_BOT_BACKEND_TOKEN` GitHub Actions secrets—credential values never enter git or the
+  agent-visible environment.
 
 **Why Windows gates PRs and macOS does not.** A release build is all-or-nothing: `release` needs
 `build.result == 'success'`, so one red matrix leg publishes *nothing* — quietly, with no notification, and
@@ -32,9 +39,9 @@ diverge most (executable resolution, `PATH` shape, `USERPROFILE` vs `HOME`, real
 the cheap half of that risk; macOS divergence is narrower (path canonicalization) and its runner minutes are
 dearer, so it stays release-matrix-only. A red release matrix still notifies nobody — an open gap.
 
-## Channels
+## Release channels
 
-Both channels are `main`-only, versioned by `scripts/next-version.sh` (channel-aware semver from git
+Both release channels are `main`-only, versioned by `scripts/next-version.sh` (channel-aware semver from git
 tags: `vX.Y.Z` stable, `vX.Y.Z-nightly.N`):
 
 - **Nightly** — cron 06:00 UTC + manual dispatch. Computes the next nightly, **skips when no commits**
@@ -123,13 +130,15 @@ in place.
 
 ## Boundary
 
-- **Owns:** everything under `.github/` (workflows, composite actions, the version script) — the CI +
-  release automation and the artifact/version contract.
+- **Owns:** everything under `.github/` (workflows, composite actions, the version script) — CI,
+  release, and operational automation plus the artifact/version contract.
 - **Consumes:** `apps/cli`'s `build:binary` / `smoke:binary` and its `version.ts` stamping seam; the
-  repo's root scripts (`build:web`, `lint`, `typecheck`, `test`, `e2e`). It **injects** the version at
-  build time but does not otherwise reach into product code.
+  repo's root scripts (`build:web`, `lint`, `typecheck`, `test`, `e2e`); and the root
+  `.junie-live/slack-bot.yaml` profile. It **injects** the version at build time but does not otherwise
+  reach into product code.
 - **Forbidden:** baking release logic into product code (the pipeline calls the same scripts a developer
-  runs); a release-only build path that CI never exercises (CI builds+smokes the host target every PR).
+  runs); a release-only build path that CI never exercises (CI builds+smokes the host target every PR);
+  literal Junie, backend, GitHub, or Slack credentials in repository files or agent-visible environment.
 
 ## Get right
 

--- a/.github/workflows/junie-slack-bot.yml
+++ b/.github/workflows/junie-slack-bot.yml
@@ -1,0 +1,19 @@
+name: Junie Slack Bot
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+
+jobs:
+  run-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jetbrains/junie-slack-bot/.github/actions/run-agent@v1
+        with:
+          config: .junie-live/slack-bot.yaml
+          run-id-prefix: github-slack-bot
+          configuration-envs: |
+            JUNIE_SLACK_BOT_JUNIE_API_KEY=${{ secrets.JUNIE_SLACK_BOT_JUNIE_API_KEY }}
+            JUNIE_SLACK_BOT_BACKEND_TOKEN=${{ secrets.JUNIE_SLACK_BOT_BACKEND_TOKEN }}

--- a/.junie-live/slack-bot.yaml
+++ b/.junie-live/slack-bot.yaml
@@ -1,0 +1,61 @@
+schema-version: 1
+profile: slack-bot
+
+git:
+  allowed-branches: ["slack-bot/*"]
+  commit-identity:
+    name: Junie The Developer
+    email: junie-live-agent@users.noreply.github.com
+  connections:
+    github:
+      repositories:
+        - url: https://github.com/JetBrains/thinkrail.git
+          path: .
+          branch: main
+
+slack:
+  bot-token: "not-needed"
+  app-token: "not-needed"
+  channels:
+    - name: thinkrail-internal
+      id: C09C94GKLUX
+    - name: thinkrail-devs
+      id: C0BG1507K7V
+  respond-in-threads: true
+
+backend:
+  backend_url: https://junie-live-staging-ext.labs.jb.gg
+  project_id: 843f9245-3884-4ba4-9806-beb3d82e268d
+  token: ${JUNIE_SLACK_BOT_BACKEND_TOKEN}
+  state:
+    enabled: true
+    checkpoint_interval_seconds: 300
+    fail_if_not_restored: true
+
+ingrazzio:
+  api-key: ${JUNIE_SLACK_BOT_JUNIE_API_KEY}
+
+agent-settings:
+  junie-cli:
+    model:
+      - id: grok-4.6
+        provider: ingrazzio/xai
+
+web-search:
+  provider: ingrazzio/tavily
+  headers:
+    X-Accept-EAP-License: "true"
+
+sandbox:
+  network:
+    allowed-domains:
+      - github.com
+      - api.github.com
+      - objects.githubusercontent.com
+      - raw.githubusercontent.com
+      - ingrazzio-cloud-prod.labs.jb.gg
+      - files.slack.com
+    endpoint-proxies: []
+
+hermes:
+  dashboard: false


### PR DESCRIPTION
## Summary

Add the Junie Live Slack agent for ThinkRail so Junie can respond in the approved internal and developer Slack channels while working against the repository through the installed GitHub App.

## Changes

- add the Junie Live profile with both allow-listed Slack channels, `main` as the working branch, and pushes restricted to `slack-bot/*`
- add the scheduled and manually dispatchable GitHub Actions workflow using the upstream `run-agent@v1` action
- pass the Junie and backend credentials exclusively through GitHub Actions secrets
- update the automation module spec with the Junie workflow, dependency, and credential boundary

## Testing

- Junie profile and workflow parsed with `Bun.YAML`; required channels, triggers, and secret references asserted
- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed
- `bun run typecheck` — passed
- repository credential-literal and suppression audits — passed

Browser e2e was not run because this changes repository automation only and does not alter the application.
