### PR TITLE
feat(web): subagent Agent cards, completion turns, and the child transcript dialog

### DIFF
--- a/apps/web/src/chat/ChatActions.tsx
+++ b/apps/web/src/chat/ChatActions.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext } from "react";
 export interface ChatActions {
 	answerQuestion: (toolCallId: string, result: AskUserQuestionResult) => Promise<void>;
 	focusComposer: () => void;
+	openSubagentTranscript: (childSessionId: string) => void;
 }
 
 export const ChatActionsContext = createContext<ChatActions | null>(null);

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -48,6 +48,7 @@ import { QueueStrip } from "./QueueStrip";
 import { type ChatRow, deriveRows, rowIndexForTurn } from "./rows";
 import { SkillsDialog } from "./SkillsDialog";
 import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
+import { SubagentTranscriptDialog } from "./SubagentTranscriptDialog";
 import { parseTemplateSlots } from "./slotSession";
 import { TemplateEditorDialog } from "./TemplateEditorDialog";
 import { shouldApplyTemplatePick } from "./templatePick";
@@ -221,6 +222,7 @@ export default function ChatView({
 	const [templates, setTemplates] = useState<TemplateInfo[]>([]);
 	const [templatesEmpty, setTemplatesEmpty] = useState(false);
 	const [saveAsTemplateHit, setSaveAsTemplateHit] = useState<PromptHit | null>(null);
+	const [transcriptChildId, setTranscriptChildId] = useState<string | null>(null);
 
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
 	const latestUserRow = useMemo(() => {
@@ -631,6 +633,7 @@ export default function ChatView({
 					.request("session.answerQuestion", { sessionId, toolCallId, result })
 					.then(() => undefined),
 			focusComposer: () => composerRef.current?.refocus(),
+			openSubagentTranscript: setTranscriptChildId,
 		}),
 		[sessionId],
 	);
@@ -793,6 +796,16 @@ export default function ChatView({
 					/>
 					{pendingExtUi ? (
 						<ExtUiDialog key={pendingExtUi.id} request={pendingExtUi} onReply={onExtUiReply} />
+					) : null}
+					{transcriptChildId ? (
+						<SubagentTranscriptDialog
+							workspaceId={workspaceId}
+							parentSessionId={sessionId}
+							childSessionId={transcriptChildId}
+							onOpenChange={(open) => {
+								if (!open) setTranscriptChildId(null);
+							}}
+						/>
 					) : null}
 					{projectId ? (
 						<SkillsDialog

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -213,11 +213,15 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   through `ChatActions.openSubagentTranscript`; rendered under a `null` `ChatActions` provider so
   nothing inside can talk back (and a nested transcript link cannot exist). Liveness comes from the
   **host** with each response: `subagent.getTranscript` carries the run's current registry `status`
-  (absent once the host no longer knows the run — restart, dispose), and the open dialog polls every
-  ~2.5s exactly while that reports queued/running — never from this chat's own runtime, whose frozen
-  background ack can't tell a live run from one lost to a restart. Works during the run, after
-  completion, and after a host restart (transcripts persist on disk; only the in-memory registry is
-  lost — and its absence is precisely what stops the polling).
+  (absent once the host no longer knows the run — restart, dispose). The open dialog keeps exactly one
+  read in flight, scheduling the next ~2.5s poll only after a response while status is queued/running —
+  never from this chat's own runtime, whose frozen background ack can't tell a live run from one lost to
+  a restart. A terminal/absent status or the wire's permanent `SUBAGENT_TRANSCRIPT_NOT_FOUND` stops;
+  plain transport failures retry while the dialog stays open with a capped backoff. Poll snapshots
+  hydrate with child-scoped ids derived from each persisted message's role/timestamp/index, so an
+  append-only refresh preserves row identity and manual folds instead of remounting the transcript.
+  Works during the run, after completion, and after a host restart (transcripts persist on disk; only
+  the in-memory registry is lost — and its absence is precisely what stops the polling).
 - **`askState`** — the questionnaire lifecycle seam: the pure `deriveAskStates(turns, askAnswers)` +
   `AskStatesContext`/`useAskState` (provided by `ChatView`, `null` standalone). The ask tool is **ack +
   terminate** (its tool result is just an ack; the reply arrives later as an `ask-user-answers` message),
@@ -231,10 +235,11 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   intended read (you returned to the chat that needs you), not just a side effect. It carries no store or
   transport state.
 - **Hydration** (`hydrate.ts`) — the pure
-  `messagesToRuntime(TranscriptMessage[], lastSettlement?)` converter (read-side counterpart of the event
-  reducer): rebuilds `{ turns, toolResults, askAnswers, turnIdByMessageIndex }` (a `HydratedRuntime`) from a
-  persisted transcript so a reconnecting/second client renders identically to the live path (same `raw`
-  result shape). When supplied, the live summary's `lastSettlement` is authoritative; otherwise only the
+  `messagesToRuntime(TranscriptMessage[], lastSettlement?, { idScope? })` converter (read-side counterpart
+  of the event reducer): rebuilds `{ turns, toolResults, askAnswers, turnIdByMessageIndex }` (a
+  `HydratedRuntime`) from a persisted transcript so a reconnecting/second client renders identically to
+  the live path (same `raw` result shape). One-shot consumers keep freshly minted ids; a repeated-snapshot
+  consumer supplies its session scope to derive stable role/timestamp/index ids for persisted turns. When supplied, the live summary's `lastSettlement` is authoritative; otherwise only the
   final conversational assistant can synthesize an error/length turn. Compacted historical length attempts
   followed by later messages remain history, not a stale current warning. One retry-presentation rule on
   both paths: pi persists a superseded auto-retry attempt ("keep in session for history") that the live

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -111,6 +111,11 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   still renders directly. Non-empty text, primary tools, and non-assistant turns break the outer run. Only
   its trailing instance carries the live ticker. Errored routine tools get **no special treatment**
   (deliberate — agents often recover; `ErrorTurn` and primary error-auto-expand are the safety nets).
+- `subagentCompletion` — a `subagent-completion` custom message: a detached (background) subagent run's
+  terminal report, injected into the parent by `pi-subagents` when the run finishes. Rendered as a compact
+  self-framed card (`tools/subagent/SubagentCompletionCard`) — **the** terminal signal for a background
+  run, whose `Agent` tool card froze at its ack (why + card anatomy:
+  [tools/subagent/SPEC.md](tools/subagent/SPEC.md)). Never folded into activity groups.
 - `divider` — the round-end summary (`TurnDivider` + pure `turnDivider` deriver), anchored the instant a
   round ends: elapsed time, tool-call count, and the round's written files as **two chips split by owning
   tool** — “N specs” and “N files changed”. The split is a **partition** (a path lands on exactly
@@ -193,12 +198,26 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   prose. A standalone renderer has no callback and therefore stays inert. The callback's preview-slot
   semantics belong to [[submodule-web-panels]].
 - **`ChatActions`** — a React context (provided by `ChatView`, `null` standalone): how a renderer talks
-  **back** to the agent without importing store/transport. Today: `answerQuestion(toolCallId, result)` —
+  **back** to the agent — or asks the integration layer to open something — without importing
+  store/transport. Today: `answerQuestion(toolCallId, result)` —
   it rejects when the host refuses (unknown/answered/superseded call), and the caller owns the failure UX —
   plus `focusComposer()`, for a renderer that resolves *itself*: it unmounts the control the user was
   standing on, and focus would otherwise fall to `<body>` and swallow every following keystroke (the same
   stranding the history overlay's dismiss refocus avoids). Only the card's own reply path calls it, and
-  only while the card still holds focus.
+  only while the card still holds focus. Plus `openSubagentTranscript(childSessionId)` — the subagent
+  cards' transcript link (no provider → the cards hide the action).
+- **Subagent transcript view** (`SubagentTranscriptDialog.tsx` — an integration file, like
+  `SkillsDialog`): a **read-only overlay** over the chat rendering a hidden child's transcript with the
+  same primitives (`messagesToRuntime` → `deriveRows` → `ChatTurnView`), fetched via
+  `subagent.getTranscript` keyed `(workspaceId, parentSessionId = this chat, childSessionId)`. Opened
+  through `ChatActions.openSubagentTranscript`; rendered under a `null` `ChatActions` provider so
+  nothing inside can talk back (and a nested transcript link cannot exist). Liveness comes from the
+  **host** with each response: `subagent.getTranscript` carries the run's current registry `status`
+  (absent once the host no longer knows the run — restart, dispose), and the open dialog polls every
+  ~2.5s exactly while that reports queued/running — never from this chat's own runtime, whose frozen
+  background ack can't tell a live run from one lost to a restart. Works during the run, after
+  completion, and after a host restart (transcripts persist on disk; only the in-memory registry is
+  lost — and its absence is precisely what stops the polling).
 - **`askState`** — the questionnaire lifecycle seam: the pure `deriveAskStates(turns, askAnswers)` +
   `AskStatesContext`/`useAskState` (provided by `ChatView`, `null` standalone). The ask tool is **ack +
   terminate** (its tool result is just an ack; the reply arrives later as an `ask-user-answers` message),
@@ -226,12 +245,15 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   settlement-derived error turn. It also
   returns `turnIdByMessageIndex` (message-position → minted turn id) — the jump anchor map a
   history-search "jump to message" deep link (`chatLocationRequest`, see `store/SPEC.md`) resolves
-  against; entries are `null` for a `toolResult`/`custom` message (never its own turn) and for a
+  against; entries are `null` for a `toolResult` or non-turn `custom` message (a `subagent-completion`
+  message maps to its own completion turn's id; text-less, it is still never an anchor match) and for a
   `compactionSummary` (its own turn, but never a search hit — the host's index consumes the same slot, so
   the two stay aligned), and a message that
   ended in `stopReason: "error"` maps to its own assistant turn's id, never the synthesized error turn's.
-  `custom` messages never become turns: known ones (`ask-user-answers`) index into `askAnswers`; unknown
-  customTypes are ignored. No store/transport/shiki.
+  `custom` messages: `ask-user-answers` indexes into `askAnswers` (never a turn — the questionnaire card
+  is its rendering); `subagent-completion` **becomes its own `subagentCompletion` turn** (the completion
+  card is transcript-positioned, so it maps its message index too); unknown customTypes are ignored. No
+  store/transport/shiki.
 - **Jump-to-message** (`chatLocationRequest` — set by `useHistorySearch.ts`'s `openMessage` on Enter over
   a mapped message hit; see `store/SPEC.md` for the store-level request/clear contract and
   the workbench shell integration's open/reopen/hydrate half) — `ChatView` is the sole consumer. Once
@@ -840,7 +862,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   (**app-integration files only** — a renderer that takes props must never reach for either. Today that
   is `ChatView.tsx` plus the hooks and dialogs it composes: `useChatTodos.ts`, `useHistorySearch.ts`,
   `useModelCatalog.ts`, **`useTranscriptSync.ts`** (successful-compaction + connection-generation canonical
-  transcript reconciliation), `SkillsDialog.tsx`, `TemplateEditorDialog.tsx`. `useModelCatalog` is the shared
+  transcript reconciliation), `SkillsDialog.tsx`, `TemplateEditorDialog.tsx`,
+  `SubagentTranscriptDialog.tsx`. `useModelCatalog` is the shared
   models-catalog seam `panels/NewWorkspaceDialog` also imports per-file, so the two pickers cannot
   drift; on activation it **drops catalog authority synchronously** (a flag an earlier consumer set says
   nothing about the list this one inherited) and reads `model.list` only when the shared list is **empty** —
@@ -880,7 +903,8 @@ it can still precede auto-compaction/retry); `agent_settled` alone closes the au
 session loader, and appends one success/error marker. A successful overflow `compaction_end` with
 `willRetry: true` removes the superseded errored/truncated attempt, matching Pi's rebuilt context. Tool results are
 indexed by `toolCallId` in `toolResults`; `ask-user-answers` custom messages index into `askAnswers`
-(never the turn list — the questionnaire card is their rendering). The view re-derives rows each render
+(never the turn list — the questionnaire card is their rendering); `subagent-completion` custom messages
+append a `subagentCompletion` turn (the shared contracts guard narrows both, on the live and read paths). The view re-derives rows each render
 (`deriveRows` is pure; `ChatView` memoizes) — stable row/step ids keep fold state across snapshots.
 
 **One live indicator, always.** pi splits a run into several assistant messages, so the reducer sweeps

--- a/apps/web/src/chat/SessionStatsBar.tsx
+++ b/apps/web/src/chat/SessionStatsBar.tsx
@@ -8,13 +8,24 @@ export function formatTokens(count: number): string {
 	return `${Math.round(count / 1_000_000)}M`;
 }
 
+export function formatCost(cost: number): string {
+	return `$${cost.toFixed(3)}`;
+}
+
+export function formatElapsed(ms: number): string {
+	const totalSec = Math.round(ms / 1000);
+	const m = Math.floor(totalSec / 60);
+	const s = totalSec % 60;
+	return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
 export function usageParts(stats: SessionStats): string[] {
 	const parts: string[] = [];
 	if (stats.tokens.input) parts.push(`↑${formatTokens(stats.tokens.input)}`);
 	if (stats.tokens.output) parts.push(`↓${formatTokens(stats.tokens.output)}`);
 	if (stats.tokens.cacheRead) parts.push(`R${formatTokens(stats.tokens.cacheRead)}`);
 	if (stats.tokens.cacheWrite) parts.push(`W${formatTokens(stats.tokens.cacheWrite)}`);
-	if (stats.cost) parts.push(`$${stats.cost.toFixed(3)}`);
+	if (stats.cost) parts.push(formatCost(stats.cost));
 	return parts;
 }
 

--- a/apps/web/src/chat/SubagentTranscriptDialog.tsx
+++ b/apps/web/src/chat/SubagentTranscriptDialog.tsx
@@ -1,0 +1,112 @@
+import type { TranscriptMessage } from "@thinkrail/contracts";
+import { useEffect, useMemo, useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { errorText, getTransport } from "@/transport";
+import { AskStatesContext, deriveAskStates } from "./askState";
+import { ChatActionsContext } from "./ChatActions";
+import { messagesToRuntime } from "./hydrate";
+import { deriveRows } from "./rows";
+import { ChatTurnView } from "./turns";
+
+export function SubagentTranscriptDialog({
+	workspaceId,
+	parentSessionId,
+	childSessionId,
+	onOpenChange,
+}: {
+	workspaceId: string;
+	parentSessionId: string;
+	childSessionId: string;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const [messages, setMessages] = useState<TranscriptMessage[] | null>(null);
+	const [live, setLive] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		let timer: ReturnType<typeof setInterval> | undefined = setInterval(fetchTranscript, 2500);
+		const stopPolling = () => {
+			if (timer !== undefined) clearInterval(timer);
+			timer = undefined;
+		};
+		function fetchTranscript() {
+			getTransport()
+				.request("subagent.getTranscript", { workspaceId, parentSessionId, childSessionId })
+				.then((res) => {
+					if (cancelled) return;
+					setMessages(res.messages);
+					setError(null);
+					const stillLive = res.status === "queued" || res.status === "running";
+					setLive(stillLive);
+					if (!stillLive) stopPolling();
+				})
+				.catch((err) => {
+					if (cancelled) return;
+					setError(errorText(err));
+					stopPolling(); // an unreadable transcript won't become readable by asking again
+				});
+		}
+		fetchTranscript();
+		return () => {
+			cancelled = true;
+			stopPolling();
+		};
+	}, [workspaceId, parentSessionId, childSessionId]);
+
+	const runtime = useMemo(() => (messages ? messagesToRuntime(messages) : null), [messages]);
+	const rows = useMemo(
+		() => (runtime ? deriveRows(runtime.turns, runtime.toolResults, live) : []),
+		[runtime, live],
+	);
+	const askContext = useMemo(
+		() => ({
+			states: runtime ? deriveAskStates(runtime.turns, runtime.askAnswers) : {},
+			focusScope: {},
+		}),
+		[runtime],
+	);
+
+	return (
+		<Dialog open onOpenChange={onOpenChange}>
+			<DialogContent
+				data-testid="subagent-transcript-dialog"
+				className="h-[85vh] max-w-3xl gap-16 p-16"
+			>
+				<div className="flex min-w-0 items-baseline gap-8 pr-8">
+					<DialogTitle className="shrink-0 tr-text-ui text-text-default">
+						Subagent transcript
+					</DialogTitle>
+					<span className="min-w-0 truncate text-text-muted tr-text-metadata">
+						{childSessionId}
+						{live ? " · live" : ""}
+					</span>
+				</div>
+				<ChatActionsContext.Provider value={null}>
+					<AskStatesContext.Provider value={askContext}>
+						<div
+							data-testid="subagent-transcript"
+							className="flex min-h-0 flex-1 flex-col gap-8 overflow-y-auto"
+						>
+							{error ? (
+								<span className="text-feedback-error tr-text-ui">{error}</span>
+							) : messages === null ? (
+								<span className="text-text-muted tr-text-metadata">Loading…</span>
+							) : rows.length === 0 ? (
+								<span className="text-text-muted tr-text-metadata italic">
+									Nothing in the transcript yet.
+								</span>
+							) : (
+								rows.map((row) => (
+									<div key={row.id}>
+										<ChatTurnView row={row} />
+									</div>
+								))
+							)}
+						</div>
+					</AskStatesContext.Provider>
+				</ChatActionsContext.Provider>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/chat/SubagentTranscriptDialog.tsx
+++ b/apps/web/src/chat/SubagentTranscriptDialog.tsx
@@ -1,12 +1,21 @@
-import type { TranscriptMessage } from "@thinkrail/contracts";
+import type { DelegationRunStatus, TranscriptMessage } from "@thinkrail/contracts";
 import { useEffect, useMemo, useState } from "react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { errorText, getTransport } from "@/transport";
+import { errorText, getTransport, wsErrorCode } from "@/transport";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { ChatActionsContext } from "./ChatActions";
 import { messagesToRuntime } from "./hydrate";
 import { deriveRows } from "./rows";
+import { startSubagentTranscriptPolling } from "./subagentTranscriptPolling";
 import { ChatTurnView } from "./turns";
+
+function isLiveTranscriptStatus(status: DelegationRunStatus | undefined): boolean {
+	return status === "queued" || status === "running";
+}
+
+function isPermanentTranscriptError(error: unknown): boolean {
+	return wsErrorCode(error) === "SUBAGENT_TRANSCRIPT_NOT_FOUND";
+}
 
 export function SubagentTranscriptDialog({
 	workspaceId,
@@ -23,38 +32,37 @@ export function SubagentTranscriptDialog({
 	const [live, setLive] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
-	useEffect(() => {
-		let cancelled = false;
-		let timer: ReturnType<typeof setInterval> | undefined = setInterval(fetchTranscript, 2500);
-		const stopPolling = () => {
-			if (timer !== undefined) clearInterval(timer);
-			timer = undefined;
-		};
-		function fetchTranscript() {
-			getTransport()
-				.request("subagent.getTranscript", { workspaceId, parentSessionId, childSessionId })
-				.then((res) => {
-					if (cancelled) return;
-					setMessages(res.messages);
+	useEffect(
+		() =>
+			startSubagentTranscriptPolling({
+				read: () =>
+					getTransport().request("subagent.getTranscript", {
+						workspaceId,
+						parentSessionId,
+						childSessionId,
+					}),
+				isLive: (response) => isLiveTranscriptStatus(response.status),
+				isPermanentError: isPermanentTranscriptError,
+				onResult: (response) => {
+					setMessages(response.messages);
 					setError(null);
-					const stillLive = res.status === "queued" || res.status === "running";
-					setLive(stillLive);
-					if (!stillLive) stopPolling();
-				})
-				.catch((err) => {
-					if (cancelled) return;
-					setError(errorText(err));
-					stopPolling(); // an unreadable transcript won't become readable by asking again
-				});
-		}
-		fetchTranscript();
-		return () => {
-			cancelled = true;
-			stopPolling();
-		};
-	}, [workspaceId, parentSessionId, childSessionId]);
+					setLive(isLiveTranscriptStatus(response.status));
+				},
+				onError: (requestError) => {
+					setError(errorText(requestError));
+					if (isPermanentTranscriptError(requestError)) setLive(false);
+				},
+			}),
+		[workspaceId, parentSessionId, childSessionId],
+	);
 
-	const runtime = useMemo(() => (messages ? messagesToRuntime(messages) : null), [messages]);
+	const runtime = useMemo(
+		() =>
+			messages
+				? messagesToRuntime(messages, undefined, { idScope: `subagent:${childSessionId}` })
+				: null,
+		[messages, childSessionId],
+	);
 	const rows = useMemo(
 		() => (runtime ? deriveRows(runtime.turns, runtime.toolResults, live) : []),
 		[runtime, live],

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -34,6 +34,27 @@ test("messagesToRuntime folds a transcript into ordered turns + a toolResults ma
 	expect(toolResults.tc1?.status).toBe("done");
 });
 
+test("a scoped append-only hydration preserves existing turn ids", () => {
+	const first = messagesToRuntime(messages, undefined, { idScope: "subagent:child-1" });
+	const second = messagesToRuntime(
+		[
+			...messages,
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "one more thing" }],
+				timestamp: 4,
+			},
+		] as unknown as Message[],
+		undefined,
+		{ idScope: "subagent:child-1" },
+	);
+
+	expect(second.turns.slice(0, first.turns.length).map((turn) => turn.id)).toEqual(
+		first.turns.map((turn) => turn.id),
+	);
+	expect(new Set(second.turns.map((turn) => turn.id)).size).toBe(second.turns.length);
+});
+
 test("an assistant turn that ended in a provider error hydrates a following error turn", () => {
 	const { turns } = messagesToRuntime([
 		{ role: "user", content: "hi", timestamp: 1 },

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -171,6 +171,41 @@ test("turnIdByMessageIndex maps each message's position to its own turn id, null
 	expect(turnIdByMessageIndex[4]).not.toBe(turns[3]?.id);
 });
 
+test("a subagent-completion custom message hydrates as its own subagentCompletion turn", () => {
+	const details = {
+		childSessionId: "child-1",
+		roleName: "scout",
+		task: "map the repo",
+		status: "completed",
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.01,
+			turns: 3,
+			contextTokens: 15,
+		},
+		durationMs: 4200,
+	};
+	const { turns, turnIdByMessageIndex } = messagesToRuntime([
+		{ role: "user", content: "go", timestamp: 1 },
+		{
+			role: "custom",
+			customType: "subagent-completion",
+			content: [{ type: "text", text: 'Subagent "scout" (child-1) completed:\n\nthe report' }],
+			display: true,
+			details,
+			timestamp: 2,
+		},
+	] as unknown as Message[]);
+	expect(turns.map((t) => t.kind)).toEqual(["user", "subagentCompletion"]);
+	const turn = turns[1];
+	expect(turn?.kind === "subagentCompletion" && turn.details.childSessionId).toBe("child-1");
+	expect(turn?.kind === "subagentCompletion" && turn.text).toContain("the report");
+	expect(turnIdByMessageIndex[1]).toBe(turns[1]?.id ?? null);
+});
+
 test("a failed tool result maps to error status", () => {
 	const { toolResults } = messagesToRuntime([
 		{

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import type { TranscriptMessage } from "@thinkrail/contracts";
 import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
 import { messagesToRuntime } from "./hydrate";
+import { readRunDetails } from "./tools/subagent/runDetails";
 
 type Message = TranscriptMessage;
 
@@ -218,6 +219,38 @@ test("a failed tool result maps to error status", () => {
 		},
 	] as unknown as Message[]);
 	expect(toolResults.x?.status).toBe("error");
+});
+
+test("a failed Agent result keeps its run details — the transcript stays openable after reload", () => {
+	const details = {
+		childSessionId: "child-err",
+		roleName: "scout",
+		task: "doomed task",
+		status: "error",
+		usage: {
+			input: 1,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			turns: 1,
+			contextTokens: 1,
+		},
+		durationMs: 10,
+	};
+	const { toolResults } = messagesToRuntime([
+		{
+			role: "toolResult",
+			toolCallId: "ag1",
+			toolName: "Agent",
+			content: [{ type: "text", text: 'Subagent "scout" (child-err) failed: boom' }],
+			isError: true,
+			details,
+			timestamp: 1,
+		},
+	] as unknown as Message[]);
+	expect(toolResults.ag1?.status).toBe("error");
+	expect(readRunDetails(toolResults.ag1?.raw)?.childSessionId).toBe("child-err");
 });
 
 test("a toolCall with no matching toolResult has no entry — the call renders as still running", () => {

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -21,9 +21,24 @@ export interface HydratedRuntime {
 	turnIdByMessageIndex: (string | null)[];
 }
 
+export interface HydrationOptions {
+	idScope?: string;
+}
+
+function transcriptTurnId(
+	message: TranscriptMessage,
+	index: number,
+	options: HydrationOptions,
+): string {
+	return options.idScope
+		? `${options.idScope}:${message.role}:${message.timestamp}:${index}`
+		: crypto.randomUUID();
+}
+
 export function messagesToRuntime(
 	messages: TranscriptMessage[],
 	lastSettlement?: AgentSettlement | null,
+	options: HydrationOptions = {},
 ): HydratedRuntime {
 	const turns: ChatTurn[] = [];
 	const toolResults: Record<string, ToolResultState> = {};
@@ -33,19 +48,19 @@ export function messagesToRuntime(
 		let turnId: string | null = null;
 		if (message.role === "user") {
 			if (!isControlMessage(userText(message.content))) {
-				turnId = crypto.randomUUID();
+				turnId = transcriptTurnId(message, index, options);
 				turns.push({ kind: "user", id: turnId, message });
 			}
 		} else if (message.role === "assistant") {
 			if (isRetriedAttempt(messages, index)) {
 			} else {
-				turnId = crypto.randomUUID();
+				turnId = transcriptTurnId(message, index, options);
 				turns.push({ kind: "assistant", id: turnId, message, streaming: false });
 			}
 		} else if (message.role === "compactionSummary") {
 			turns.push({
 				kind: "compaction",
-				id: crypto.randomUUID(),
+				id: transcriptTurnId(message, index, options),
 				status: "done",
 				summary: message.summary,
 				tokensBefore: message.tokensBefore,
@@ -58,7 +73,7 @@ export function messagesToRuntime(
 		} else if (isAskUserAnswersMessage(message)) {
 			askAnswers[message.details.toolCallId] = message.details.result;
 		} else if (isSubagentCompletionMessage(message)) {
-			turnId = crypto.randomUUID();
+			turnId = transcriptTurnId(message, index, options);
 			turns.push({
 				kind: "subagentCompletion",
 				id: turnId,
@@ -80,7 +95,9 @@ export function messagesToRuntime(
 	if (failure)
 		turns.push({
 			kind: "error",
-			id: crypto.randomUUID(),
+			id: options.idScope
+				? `${options.idScope}:error:${persistedTerminal?.timestamp ?? "settlement"}`
+				: crypto.randomUUID(),
 			text: failure,
 			recovery: "try-again",
 		});

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -3,7 +3,13 @@ import type {
 	AskUserAnswersDetails,
 	TranscriptMessage,
 } from "@thinkrail/contracts";
-import { isAskUserAnswersMessage, isControlMessage, isRetriedAttempt } from "@thinkrail/contracts";
+import {
+	customMessageText,
+	isAskUserAnswersMessage,
+	isControlMessage,
+	isRetriedAttempt,
+	isSubagentCompletionMessage,
+} from "@thinkrail/contracts";
 import { userText } from "../lib";
 import { assistantFailureText } from "./assistantFailure";
 import type { ChatTurn, ToolResultState } from "./types";
@@ -51,6 +57,14 @@ export function messagesToRuntime(
 			};
 		} else if (isAskUserAnswersMessage(message)) {
 			askAnswers[message.details.toolCallId] = message.details.result;
+		} else if (isSubagentCompletionMessage(message)) {
+			turnId = crypto.randomUUID();
+			turns.push({
+				kind: "subagentCompletion",
+				id: turnId,
+				details: message.details,
+				text: customMessageText(message.content),
+			});
 		}
 		turnIdByMessageIndex.push(turnId);
 	}

--- a/apps/web/src/chat/rows.test.ts
+++ b/apps/web/src/chat/rows.test.ts
@@ -168,6 +168,36 @@ describe("deriveRows grouping", () => {
 		expect(rows[4]?.kind === "activity" && rows[4].steps.length).toBe(1);
 	});
 
+	test("a subagentCompletion turn breaks the run and maps 1:1 to its own row", () => {
+		const details = {
+			childSessionId: "child-1",
+			roleName: "scout",
+			task: "map",
+			status: "completed",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: 0,
+				turns: 1,
+				contextTokens: 2,
+			},
+			durationMs: 1000,
+		} as const;
+		const turns: ChatTurn[] = [
+			user("u1"),
+			assistant("a1", [tc("t1")]),
+			{ kind: "subagentCompletion", id: "sc1", details, text: "the report" },
+			assistant("a2", [tc("t2")]),
+		];
+		const rows = deriveRows(turns, {}, true);
+		expect(kinds(rows)).toEqual(["user", "activity", "subagentCompletion", "activity"]);
+		const row = rows[2];
+		expect(row?.kind === "subagentCompletion" && row.details.childSessionId).toBe("child-1");
+		expect(row?.kind === "subagentCompletion" && row.text).toBe("the report");
+	});
+
 	test("steps carry dead from the owning message's stopReason (aborted calls never execute)", () => {
 		const turns = [
 			user("u1"),

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -1,4 +1,4 @@
-import type { UserMessage } from "@thinkrail/contracts";
+import type { DelegationRunDetails, UserMessage } from "@thinkrail/contracts";
 import { resolveProminence } from "./toolRegistry";
 import { strArg } from "./tools/toolHelpers";
 import type { ChatTurn, CompactionState, FailureRecovery, ToolResultState } from "./types";
@@ -38,6 +38,7 @@ export type ChatRow =
 			delayMs: number;
 	  }
 	| { kind: "markdown"; id: string; text: string }
+	| { kind: "subagentCompletion"; id: string; details: DelegationRunDetails; text: string }
 	| ({ kind: "tool"; id: string } & ToolCallData)
 	| {
 			kind: "activity";
@@ -151,6 +152,14 @@ export function deriveRows(
 						attempt: turn.attempt,
 						maxAttempts: turn.maxAttempts,
 						delayMs: turn.delayMs,
+					});
+					break;
+				case "subagentCompletion":
+					rows.push({
+						kind: "subagentCompletion",
+						id: turn.id,
+						details: turn.details,
+						text: turn.text,
 					});
 					break;
 			}

--- a/apps/web/src/chat/subagentTranscriptPolling.test.ts
+++ b/apps/web/src/chat/subagentTranscriptPolling.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+import {
+	SUBAGENT_TRANSCRIPT_POLL_MS,
+	startSubagentTranscriptPolling,
+	subagentTranscriptRetryDelay,
+	type TranscriptPollScheduler,
+} from "./subagentTranscriptPolling";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function controlledScheduler() {
+	const tasks: { callback: () => void; delayMs: number }[] = [];
+	const scheduler: TranscriptPollScheduler = {
+		set: (callback, delayMs) => {
+			const task = { callback, delayMs };
+			tasks.push(task);
+			return task;
+		},
+		clear: (timer) => {
+			const index = tasks.indexOf(timer as (typeof tasks)[number]);
+			if (index >= 0) tasks.splice(index, 1);
+		},
+	};
+	return {
+		scheduler,
+		tasks,
+		runNext: () => tasks.shift()?.callback(),
+	};
+}
+
+async function flushPromises() {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+test("polling waits for each live response before scheduling the next read", async () => {
+	const first = deferred<{ status: "running" | "completed"; revision: number }>();
+	const second = deferred<{ status: "running" | "completed"; revision: number }>();
+	const reads = [first, second];
+	const results: number[] = [];
+	const { scheduler, tasks, runNext } = controlledScheduler();
+	let readCount = 0;
+
+	const stop = startSubagentTranscriptPolling({
+		read: () => {
+			const read = reads[readCount++];
+			if (!read) throw new Error("Unexpected read");
+			return read.promise;
+		},
+		isLive: (result) => result.status === "running",
+		isPermanentError: () => false,
+		onResult: (result) => results.push(result.revision),
+		onError: () => {},
+		scheduler,
+	});
+
+	expect(readCount).toBe(1);
+	expect(tasks).toHaveLength(0);
+	first.resolve({ status: "running", revision: 1 });
+	await flushPromises();
+	expect(results).toEqual([1]);
+	expect(tasks.map((task) => task.delayMs)).toEqual([SUBAGENT_TRANSCRIPT_POLL_MS]);
+
+	runNext();
+	expect(readCount).toBe(2);
+	expect(tasks).toHaveLength(0);
+	second.resolve({ status: "completed", revision: 2 });
+	await flushPromises();
+	expect(results).toEqual([1, 2]);
+	expect(tasks).toHaveLength(0);
+	stop();
+});
+
+test("transient failures back off while a permanent miss stops polling", async () => {
+	const transient = new Error("offline");
+	const permanent = new Error("missing");
+	const errors: unknown[] = [];
+	const { scheduler, tasks, runNext } = controlledScheduler();
+	let readCount = 0;
+
+	startSubagentTranscriptPolling({
+		read: async () => {
+			readCount++;
+			throw readCount === 1 ? transient : permanent;
+		},
+		isLive: () => true,
+		isPermanentError: (error) => error === permanent,
+		onResult: () => {},
+		onError: (error) => errors.push(error),
+		scheduler,
+	});
+
+	await flushPromises();
+	expect(errors).toEqual([transient]);
+	expect(tasks.map((task) => task.delayMs)).toEqual([500]);
+	runNext();
+	await flushPromises();
+	expect(errors).toEqual([transient, permanent]);
+	expect(tasks).toHaveLength(0);
+});
+
+test("transcript retry backoff is capped while the dialog remains open", () => {
+	expect(subagentTranscriptRetryDelay(1)).toBe(500);
+	expect(subagentTranscriptRetryDelay(2)).toBe(1_500);
+	expect(subagentTranscriptRetryDelay(3)).toBe(5_000);
+	expect(subagentTranscriptRetryDelay(20)).toBe(5_000);
+});

--- a/apps/web/src/chat/subagentTranscriptPolling.ts
+++ b/apps/web/src/chat/subagentTranscriptPolling.ts
@@ -1,0 +1,68 @@
+export const SUBAGENT_TRANSCRIPT_POLL_MS = 2_500;
+
+const TRANSIENT_RETRY_DELAYS_MS = [500, 1_500, 5_000] as const;
+
+export interface TranscriptPollScheduler {
+	set(callback: () => void, delayMs: number): unknown;
+	clear(timer: unknown): void;
+}
+
+interface StartTranscriptPollingOptions<T> {
+	read: () => Promise<T>;
+	isLive: (result: T) => boolean;
+	isPermanentError: (error: unknown) => boolean;
+	onResult: (result: T) => void;
+	onError: (error: unknown) => void;
+	scheduler?: TranscriptPollScheduler;
+}
+
+const defaultScheduler: TranscriptPollScheduler = {
+	set: (callback, delayMs) => setTimeout(callback, delayMs),
+	clear: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+};
+
+export function subagentTranscriptRetryDelay(failureCount: number): number {
+	const index = Math.max(0, Math.min(failureCount - 1, TRANSIENT_RETRY_DELAYS_MS.length - 1));
+	return TRANSIENT_RETRY_DELAYS_MS[index] ?? TRANSIENT_RETRY_DELAYS_MS[0];
+}
+
+export function startSubagentTranscriptPolling<T>(
+	options: StartTranscriptPollingOptions<T>,
+): () => void {
+	const scheduler = options.scheduler ?? defaultScheduler;
+	let active = true;
+	let timer: unknown;
+	let failureCount = 0;
+
+	const schedule = (delayMs: number) => {
+		if (!active) return;
+		timer = scheduler.set(() => {
+			timer = undefined;
+			void poll();
+		}, delayMs);
+	};
+
+	const poll = async () => {
+		let result: T;
+		try {
+			result = await options.read();
+		} catch (error) {
+			if (!active) return;
+			options.onError(error);
+			if (options.isPermanentError(error)) return;
+			failureCount++;
+			schedule(subagentTranscriptRetryDelay(failureCount));
+			return;
+		}
+		if (!active) return;
+		failureCount = 0;
+		options.onResult(result);
+		if (options.isLive(result)) schedule(SUBAGENT_TRANSCRIPT_POLL_MS);
+	};
+
+	void poll();
+	return () => {
+		active = false;
+		if (timer !== undefined) scheduler.clear(timer);
+	};
+}

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -196,6 +196,9 @@ registration runs once when the chat module mounts. Unregistered tools fall back
   ([web/SPEC.md](web/SPEC.md)). Routine.
 - **The five `todo_*` tools** deliberately keep routine fallback receipts: their connected product surface
   is the chat plan, not a second renderer system in this module.
+- **`subagent/`** — delegation renderers for `pi-subagents`: `AgentCard` (the `Agent` tool — **primary**;
+  also registered for `get_subagent_result`, routine), the `SubagentCompletionCard` turn card, and the
+  pure `runDetails` readers/formatters; own child spec ([subagent/SPEC.md](subagent/SPEC.md)).
 - **Shared pieces** — `CodeBlock` (shiki), `Collapsible` ("Show all N lines" fold for long output),
   `ToolFileLink` + exact-reference linked text, pure `toolHelpers` (arg readers, `resultText`,
   `languageFromPath`) + `lib`'s `projectRelativePath`. `resultText` delegates canonical result parsing to

--- a/apps/web/src/chat/tools/register.ts
+++ b/apps/web/src/chat/tools/register.ts
@@ -7,6 +7,7 @@ import { ReadCard } from "./ReadCard";
 import { ResolveCommentCard } from "./ResolveCommentCard";
 import { SpecToolCard, specToolSummary } from "./SpecToolCard";
 import { strArg } from "./toolHelpers";
+import "./subagent/register";
 import "./visualize/register";
 import "./web/register";
 import { WriteCard } from "./WriteCard";

--- a/apps/web/src/chat/tools/subagent/AgentCard.tsx
+++ b/apps/web/src/chat/tools/subagent/AgentCard.tsx
@@ -1,0 +1,104 @@
+import { Bot, ChevronDown, ChevronRight, Loader2, ScrollText } from "lucide-react";
+import { useChatActions } from "../../ChatActions";
+import { useFold } from "../../foldState";
+import { Markdown } from "../../Markdown";
+import type { ToolRenderProps } from "../../toolRegistry";
+import { Collapsible, countLines } from "../Collapsible";
+import { resultText, strArg } from "../toolHelpers";
+import { isTerminalRunStatus, readRunDetails, runCounters } from "./runDetails";
+
+export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps) {
+	const actions = useChatActions();
+	const details = readRunDetails(result);
+	const role = details?.roleName ?? strArg(args, "subagent_type");
+	const task = details?.task || strArg(args, "task");
+	const terminal = details !== undefined && isTerminalRunStatus(details.status);
+	const backgroundAck = args.run_in_background === true && details !== undefined && !terminal;
+	const meta = details ? [details.model, ...runCounters(details, "split")].filter(Boolean) : [];
+	const output = resultText(result);
+	const [reportOpen, toggleReport] = useFold(`${toolCallId}:report`, false);
+
+	return (
+		<div data-testid="tool-agent" className="flex flex-col gap-4">
+			<div className="flex items-center gap-4 tr-text-metadata">
+				<Bot className="size-3.5 shrink-0 text-text-muted" />
+				<span className="shrink-0 text-primary">{role || "subagent"}</span>
+				{details?.childSessionId ? (
+					<span className="min-w-0 truncate text-text-muted" title={details.childSessionId}>
+						{details.childSessionId}
+					</span>
+				) : null}
+			</div>
+			{task ? (
+				<Collapsible lines={countLines(task)}>
+					<div className="whitespace-pre-wrap break-words text-text-muted tr-text-metadata">
+						{task}
+					</div>
+				</Collapsible>
+			) : null}
+			{status === "running" ? (
+				details?.status === "queued" ? (
+					<span className="text-text-muted tr-text-metadata">
+						Queued — waiting for a delegation slot…
+					</span>
+				) : (
+					<span
+						data-testid="agent-activity"
+						className="flex items-center gap-4 text-text-muted tr-text-metadata"
+					>
+						<Loader2 className="size-3 shrink-0 animate-spin motion-reduce:animate-none" />
+						<span className="min-w-0 truncate">{details?.activity ?? "Working…"}</span>
+					</span>
+				)
+			) : null}
+			{meta.length > 0 ? (
+				<span className="text-text-muted tr-text-metadata">{meta.join(" · ")}</span>
+			) : null}
+			{status === "error" ? (
+				<pre className="overflow-auto whitespace-pre-wrap px-8 py-4 text-feedback-error tr-code-text">
+					{output}
+				</pre>
+			) : backgroundAck ? (
+				<span className="text-text-muted tr-text-metadata italic">
+					Running in the background — a completion message lands in this chat when it finishes; the
+					transcript below follows it live.
+				</span>
+			) : status === "done" && !terminal ? (
+				<span className="whitespace-pre-wrap text-text-muted tr-text-metadata">{output}</span>
+			) : status === "done" && output ? (
+				<div className="flex flex-col gap-4">
+					<button
+						type="button"
+						data-testid="agent-report-toggle"
+						aria-expanded={reportOpen}
+						onClick={toggleReport}
+						className="flex items-center gap-4 self-start text-primary tr-text-metadata hover:underline"
+					>
+						{reportOpen ? (
+							<ChevronDown className="size-3 shrink-0" />
+						) : (
+							<ChevronRight className="size-3 shrink-0" />
+						)}
+						Report
+					</button>
+					{reportOpen ? (
+						<div data-testid="agent-report">
+							<Markdown text={output} />
+						</div>
+					) : null}
+				</div>
+			) : null}
+			{actions && details?.childSessionId ? (
+				<button
+					type="button"
+					data-testid="agent-open-transcript"
+					onClick={() => actions.openSubagentTranscript(details.childSessionId)}
+					className="flex items-center gap-4 self-start text-primary tr-text-metadata hover:underline"
+				>
+					<ScrollText className="size-3 shrink-0" />
+					Open transcript
+				</button>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/chat/tools/subagent/AgentCard.tsx
+++ b/apps/web/src/chat/tools/subagent/AgentCard.tsx
@@ -1,4 +1,10 @@
-import { Bot, ChevronDown, ChevronRight, Loader2, ScrollText } from "lucide-react";
+import {
+	RiRobotLine as Bot,
+	RiArrowDownSLine as ChevronDown,
+	RiArrowRightSLine as ChevronRight,
+	RiLoader4Line as Loader2,
+	RiFileList3Line as ScrollText,
+} from "@remixicon/react";
 import { useChatActions } from "../../ChatActions";
 import { useFold } from "../../foldState";
 import { Markdown } from "../../Markdown";
@@ -21,7 +27,7 @@ export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps)
 	return (
 		<div data-testid="tool-agent" className="flex flex-col gap-4">
 			<div className="flex items-center gap-4 tr-text-metadata">
-				<Bot className="size-3.5 shrink-0 text-text-muted" />
+				<Bot className="size-12 shrink-0 text-text-muted" />
 				<span className="shrink-0 text-primary">{role || "subagent"}</span>
 				{details?.childSessionId ? (
 					<span className="min-w-0 truncate text-text-muted" title={details.childSessionId}>
@@ -46,7 +52,7 @@ export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps)
 						data-testid="agent-activity"
 						className="flex items-center gap-4 text-text-muted tr-text-metadata"
 					>
-						<Loader2 className="size-3 shrink-0 animate-spin motion-reduce:animate-none" />
+						<Loader2 className="size-12 shrink-0 animate-spin motion-reduce:animate-none" />
 						<span className="min-w-0 truncate">{details?.activity ?? "Working…"}</span>
 					</span>
 				)
@@ -75,9 +81,9 @@ export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps)
 						className="flex items-center gap-4 self-start text-primary tr-text-metadata hover:underline"
 					>
 						{reportOpen ? (
-							<ChevronDown className="size-3 shrink-0" />
+							<ChevronDown className="size-16 shrink-0" />
 						) : (
-							<ChevronRight className="size-3 shrink-0" />
+							<ChevronRight className="size-16 shrink-0" />
 						)}
 						Report
 					</button>
@@ -95,7 +101,7 @@ export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps)
 					onClick={() => actions.openSubagentTranscript(details.childSessionId)}
 					className="flex items-center gap-4 self-start text-primary tr-text-metadata hover:underline"
 				>
-					<ScrollText className="size-3 shrink-0" />
+					<ScrollText className="size-12 shrink-0" />
 					Open transcript
 				</button>
 			) : null}

--- a/apps/web/src/chat/tools/subagent/SPEC.md
+++ b/apps/web/src/chat/tools/subagent/SPEC.md
@@ -52,7 +52,7 @@ Adopted:
   chat's `turns.tsx`); `runDetails`'s pure helpers.
 - **Allowed deps:** parent chat primitives (`toolRegistry`, `ChatActions`, `Markdown`, `foldState`,
   chat `types`); sibling `toolHelpers`/`Collapsible`; `contracts` (type-only + the
-  `SUBAGENT_COMPLETION_CUSTOM_TYPE` guard family); `lucide-react`; `lib`.
+  `SUBAGENT_COMPLETION_CUSTOM_TYPE` guard family); `@remixicon/react`; `lib`.
 - **Forbidden:** value-importing any `pi` package, `pi-subagents`, or `pi-delegation`; `store`/
   `transport` (renderers stay presentational — the transcript dialog lives in `chat/` as an
   integration file, reached only through `ChatActions.openSubagentTranscript`).

--- a/apps/web/src/chat/tools/subagent/SPEC.md
+++ b/apps/web/src/chat/tools/subagent/SPEC.md
@@ -1,0 +1,62 @@
+---
+id: submodule-web-chat-tools-subagent
+type: submodule-design
+status: active
+title: subagent renderers (Agent / get_subagent_result / completion card)
+parent: submodule-web-chat-tools
+depends-on: [module-contracts]
+references: [module-pi-subagents]
+tags: [v1, chat, subagents]
+---
+
+## Responsibility
+
+Presentational renderers for the **`pi-subagents`** capability, joined by tool name / custom-message
+type: `AgentCard` (the `Agent` tool — also registered for `get_subagent_result`, whose result carries
+the same `DelegationRunDetails`), `SubagentCompletionCard` (the `subagent-completion` custom message a
+detached run injects — rendered by `turns.tsx` as its own `subagentCompletion` row, not through the tool
+registry), and the pure `runDetails` module (defensive `DelegationRunDetails` readers, token/cost/
+duration formatters, and the collapsed-header summary line). Run *liveness* is deliberately not
+derived here: the transcript dialog reads the host's registry `status` off each
+`subagent.getTranscript` response (rationale: the parent chat SPEC's transcript-view seam).
+
+## The rendering convention (user-settled, 2026-08, research-backed)
+
+Surveyed: Claude Code (collapsed one-liner whose row ticks live — `Running… 45s · 12 tool uses · 30k
+tokens` → `Done (…)`; detail opt-in), Codex (pinned live runtime panel + short completion notices),
+OpenCode (compact clickable box → opens the child session; one-line background-completion notice).
+Adopted:
+
+- **`Agent` is a primary, stock `ToolCard` — collapsed by default, but its header summary IS the live
+  line**: `role · N turns · X tok · $c · elapsed · current-step`, re-derived from each
+  `partialResult.details` REPLACE snapshot. Expanded: task, live activity line, model/usage detail,
+  Open-transcript action, and the final report behind a fold once terminal. Errors auto-expand
+  (existing chrome).
+- **A background run's tool card freezes at its ack** (pi ignores `onUpdate` after the tool promise
+  settles) — deliberate: the card says "started in the background", and the **completion card** is the
+  terminal signal (OpenCode's notice pattern), carrying the final details + report fold + transcript
+  link.
+- `get_subagent_result` stays **routine** (folds into activity) with the same body + summary.
+
+## Boundary
+
+- **Owns:** `AgentCard`, `SubagentCompletionCard`, `runDetails` (pure, unit-tested), and their
+  registration (`register.ts`, side-effect imported by the parent `tools/register`).
+- **Public surface:** the side-effect `register`; `SubagentCompletionCard` (imported by the parent
+  chat's `turns.tsx`); `runDetails`'s pure helpers.
+- **Allowed deps:** parent chat primitives (`toolRegistry`, `ChatActions`, `Markdown`, `foldState`,
+  chat `types`); sibling `toolHelpers`/`Collapsible`; `contracts` (type-only + the
+  `SUBAGENT_COMPLETION_CUSTOM_TYPE` guard family); `lucide-react`; `lib`.
+- **Forbidden:** value-importing any `pi` package, `pi-subagents`, or `pi-delegation`; `store`/
+  `transport` (renderers stay presentational — the transcript dialog lives in `chat/` as an
+  integration file, reached only through `ChatActions.openSubagentTranscript`).
+
+## Get right
+
+- **Render defensively:** `DelegationRunDetails` arrives as untyped `result.details` — narrow via
+  `readRunDetails` (childSessionId/status/task present), never trust the shape; fall back to `args`
+  (`subagent_type`, `task`) before the first update lands.
+- `partialResult` is **REPLACE** — every snapshot is complete; nothing accumulates renderer-side.
+- Tool names `Agent` / `get_subagent_result` and the `subagent-completion` customType must match the
+  `pi-subagents` capability exactly — the name is the join key.
+- Token-utility styling only (no raw hex / inline `style`).

--- a/apps/web/src/chat/tools/subagent/SPEC.md
+++ b/apps/web/src/chat/tools/subagent/SPEC.md
@@ -35,6 +35,9 @@ Adopted:
   result still carries the run's final details — `pi-subagents` re-injects them via its
   `tool_result` override (its SPEC, PR #304 review finding) — so the `details.childSessionId` gate
   lights on both the live and hydrated paths (hydrate-pinned).
+- **The completion card's icon is three-state**: green check only for `completed`, red X for
+  `error`, warning triangle for `aborted` — an aborted (e.g. turn-capped) run must not read as
+  success (PR #304 review finding); `data-status` carries the raw status for tests.
 - **A background run's tool card freezes at its ack** (pi ignores `onUpdate` after the tool promise
   settles) — deliberate: the card says "started in the background", and the **completion card** is the
   terminal signal (OpenCode's notice pattern), carrying the final details + report fold + transcript

--- a/apps/web/src/chat/tools/subagent/SPEC.md
+++ b/apps/web/src/chat/tools/subagent/SPEC.md
@@ -31,7 +31,10 @@ Adopted:
   line**: `role · N turns · X tok · $c · elapsed · current-step`, re-derived from each
   `partialResult.details` REPLACE snapshot. Expanded: task, live activity line, model/usage detail,
   Open-transcript action, and the final report behind a fold once terminal. Errors auto-expand
-  (existing chrome).
+  (existing chrome). **Failed runs keep the transcript action**: an error outcome's thrown tool
+  result still carries the run's final details — `pi-subagents` re-injects them via its
+  `tool_result` override (its SPEC, PR #304 review finding) — so the `details.childSessionId` gate
+  lights on both the live and hydrated paths (hydrate-pinned).
 - **A background run's tool card freezes at its ack** (pi ignores `onUpdate` after the tool promise
   settles) — deliberate: the card says "started in the background", and the **completion card** is the
   terminal signal (OpenCode's notice pattern), carrying the final details + report fold + transcript

--- a/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
+++ b/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
@@ -1,5 +1,5 @@
 import type { DelegationRunDetails } from "@thinkrail/contracts";
-import { Bot, Check, ChevronDown, ChevronRight, ScrollText, X } from "lucide-react";
+import { Bot, Check, ChevronDown, ChevronRight, ScrollText, TriangleAlert, X } from "lucide-react";
 import { useChatActions } from "../../ChatActions";
 import { useFold } from "../../foldState";
 
@@ -25,7 +25,6 @@ export function SubagentCompletionCard({
 }) {
 	const actions = useChatActions();
 	const [reportOpen, toggleReport] = useFold(`${id}:report`, false);
-	const failed = details.status === "error";
 	const role = details.roleName ?? "subagent";
 	const counters = runCounters(details).join(" · ");
 
@@ -36,10 +35,12 @@ export function SubagentCompletionCard({
 			className="flex flex-col gap-4 rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-8 py-4 tr-text-metadata"
 		>
 			<div className="flex items-center gap-4">
-				{failed ? (
+				{details.status === "error" ? (
 					<X className="size-3 shrink-0 text-feedback-error" />
-				) : (
+				) : details.status === "completed" ? (
 					<Check className="size-3 shrink-0 text-feedback-success" />
+				) : (
+					<TriangleAlert className="size-3 shrink-0 text-feedback-warning" />
 				)}
 				<Bot className="size-3.5 shrink-0 text-text-muted" />
 				<span className="shrink-0 text-text-default">

--- a/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
+++ b/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
@@ -1,0 +1,93 @@
+import type { DelegationRunDetails } from "@thinkrail/contracts";
+import { Bot, Check, ChevronDown, ChevronRight, ScrollText, X } from "lucide-react";
+import { useChatActions } from "../../ChatActions";
+import { useFold } from "../../foldState";
+
+import { Markdown } from "../../Markdown";
+import { runCounters } from "./runDetails";
+
+const OUTCOME_WORD: Record<DelegationRunDetails["status"], string> = {
+	queued: "queued",
+	running: "running",
+	completed: "finished",
+	error: "failed",
+	aborted: "aborted",
+};
+
+export function SubagentCompletionCard({
+	id,
+	details,
+	text,
+}: {
+	id: string;
+	details: DelegationRunDetails;
+	text: string;
+}) {
+	const actions = useChatActions();
+	const [reportOpen, toggleReport] = useFold(`${id}:report`, false);
+	const failed = details.status === "error";
+	const role = details.roleName ?? "subagent";
+	const counters = runCounters(details).join(" · ");
+
+	return (
+		<div
+			data-testid="subagent-completion"
+			data-status={details.status}
+			className="flex flex-col gap-4 rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-8 py-4 tr-text-metadata"
+		>
+			<div className="flex items-center gap-4">
+				{failed ? (
+					<X className="size-3 shrink-0 text-feedback-error" />
+				) : (
+					<Check className="size-3 shrink-0 text-feedback-success" />
+				)}
+				<Bot className="size-3.5 shrink-0 text-text-muted" />
+				<span className="shrink-0 text-text-default">
+					{role} {OUTCOME_WORD[details.status]}
+				</span>
+				{counters ? (
+					<span className="min-w-0 truncate text-text-muted" title={counters}>
+						{counters}
+					</span>
+				) : (
+					<span className="flex-1" />
+				)}
+				{actions ? (
+					<button
+						type="button"
+						data-testid="subagent-completion-transcript"
+						onClick={() => actions.openSubagentTranscript(details.childSessionId)}
+						title="Open transcript"
+						className="ml-auto flex shrink-0 items-center gap-4 text-primary hover:underline"
+					>
+						<ScrollText className="size-3 shrink-0" />
+						Transcript
+					</button>
+				) : null}
+			</div>
+			{text ? (
+				<div className="flex flex-col gap-4">
+					<button
+						type="button"
+						data-testid="subagent-completion-report-toggle"
+						aria-expanded={reportOpen}
+						onClick={toggleReport}
+						className="flex items-center gap-4 self-start text-primary hover:underline"
+					>
+						{reportOpen ? (
+							<ChevronDown className="size-3 shrink-0" />
+						) : (
+							<ChevronRight className="size-3 shrink-0" />
+						)}
+						Report
+					</button>
+					{reportOpen ? (
+						<div data-testid="subagent-completion-report">
+							<Markdown text={text} />
+						</div>
+					) : null}
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
+++ b/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
@@ -1,5 +1,13 @@
+import {
+	RiRobotLine as Bot,
+	RiCheckLine as Check,
+	RiArrowDownSLine as ChevronDown,
+	RiArrowRightSLine as ChevronRight,
+	RiFileList3Line as ScrollText,
+	RiAlertLine as TriangleAlert,
+	RiCloseLine as X,
+} from "@remixicon/react";
 import type { DelegationRunDetails } from "@thinkrail/contracts";
-import { Bot, Check, ChevronDown, ChevronRight, ScrollText, TriangleAlert, X } from "lucide-react";
 import { useChatActions } from "../../ChatActions";
 import { useFold } from "../../foldState";
 
@@ -36,13 +44,13 @@ export function SubagentCompletionCard({
 		>
 			<div className="flex items-center gap-4">
 				{details.status === "error" ? (
-					<X className="size-3 shrink-0 text-feedback-error" />
+					<X className="size-12 shrink-0 text-feedback-error" />
 				) : details.status === "completed" ? (
-					<Check className="size-3 shrink-0 text-feedback-success" />
+					<Check className="size-12 shrink-0 text-feedback-success" />
 				) : (
-					<TriangleAlert className="size-3 shrink-0 text-feedback-warning" />
+					<TriangleAlert className="size-12 shrink-0 text-feedback-warning" />
 				)}
-				<Bot className="size-3.5 shrink-0 text-text-muted" />
+				<Bot className="size-12 shrink-0 text-text-muted" />
 				<span className="shrink-0 text-text-default">
 					{role} {OUTCOME_WORD[details.status]}
 				</span>
@@ -61,7 +69,7 @@ export function SubagentCompletionCard({
 						title="Open transcript"
 						className="ml-auto flex shrink-0 items-center gap-4 text-primary hover:underline"
 					>
-						<ScrollText className="size-3 shrink-0" />
+						<ScrollText className="size-12 shrink-0" />
 						Transcript
 					</button>
 				) : null}
@@ -76,9 +84,9 @@ export function SubagentCompletionCard({
 						className="flex items-center gap-4 self-start text-primary hover:underline"
 					>
 						{reportOpen ? (
-							<ChevronDown className="size-3 shrink-0" />
+							<ChevronDown className="size-16 shrink-0" />
 						) : (
-							<ChevronRight className="size-3 shrink-0" />
+							<ChevronRight className="size-16 shrink-0" />
 						)}
 						Report
 					</button>

--- a/apps/web/src/chat/tools/subagent/register.ts
+++ b/apps/web/src/chat/tools/subagent/register.ts
@@ -1,0 +1,6 @@
+import { registerToolRenderer } from "../../toolRegistry";
+import { AgentCard } from "./AgentCard";
+import { agentSummary } from "./runDetails";
+
+registerToolRenderer("Agent", AgentCard, { summary: agentSummary, prominence: "primary" });
+registerToolRenderer("get_subagent_result", AgentCard, { summary: agentSummary });

--- a/apps/web/src/chat/tools/subagent/runDetails.test.ts
+++ b/apps/web/src/chat/tools/subagent/runDetails.test.ts
@@ -47,6 +47,15 @@ test("readRunDetails narrows a result's details and rejects malformed shapes", (
 	expect(
 		readRunDetails({ details: { childSessionId: "c", status: "running", task: "t" } }),
 	).toBeUndefined();
+	expect(
+		readRunDetails({ content: [], details: details({ status: "done" as never }) }),
+	).toBeUndefined();
+	expect(
+		readRunDetails({
+			content: [],
+			details: { ...details(), usage: {} as never },
+		}),
+	).toBeUndefined();
 });
 
 test("runCounters formats turns/tokens/cost/duration, skipping zeros", () => {

--- a/apps/web/src/chat/tools/subagent/runDetails.test.ts
+++ b/apps/web/src/chat/tools/subagent/runDetails.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test";
+import type { DelegationRunDetails } from "@thinkrail/contracts";
+import type { ToolRenderProps } from "../../toolRegistry";
+import { agentSummary, readRunDetails, runCounters } from "./runDetails";
+
+function details(overrides: Partial<DelegationRunDetails> = {}): DelegationRunDetails {
+	return {
+		childSessionId: "child-1",
+		roleName: "scout",
+		task: "map the repo",
+		status: "running",
+		model: "anthropic/claude-test",
+		usage: {
+			input: 25_100,
+			output: 5_300,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.04,
+			turns: 12,
+			contextTokens: 30_000,
+		},
+		durationMs: 45_000,
+		activity: 'bash: rg -n "createServer"',
+		...overrides,
+	};
+}
+
+function props(overrides: Partial<ToolRenderProps> = {}): ToolRenderProps {
+	return {
+		toolCallId: "tc1",
+		toolName: "Agent",
+		args: { subagent_type: "scout", task: "map the repo" },
+		result: { content: [{ type: "text", text: "running" }], details: details() },
+		status: "running",
+		streaming: false,
+		workspaceRoot: undefined,
+		...overrides,
+	};
+}
+
+test("readRunDetails narrows a result's details and rejects malformed shapes", () => {
+	expect(readRunDetails({ content: [], details: details() })?.childSessionId).toBe("child-1");
+	expect(readRunDetails({ content: [], details: {} })).toBeUndefined();
+	expect(readRunDetails({ content: [] })).toBeUndefined();
+	expect(readRunDetails(undefined)).toBeUndefined();
+	expect(readRunDetails("plain text")).toBeUndefined();
+	expect(
+		readRunDetails({ details: { childSessionId: "c", status: "running", task: "t" } }),
+	).toBeUndefined();
+});
+
+test("runCounters formats turns/tokens/cost/duration, skipping zeros", () => {
+	expect(runCounters(details())).toEqual(["12 turns", "30k tok", "$0.040", "45s"]);
+	expect(runCounters(details(), "split")).toEqual([
+		"12 turns",
+		"in 25k / out 5.3k",
+		"$0.040",
+		"45s",
+	]);
+	const fresh = details({
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			turns: 0,
+			contextTokens: 0,
+		},
+		durationMs: 0,
+	});
+	expect(runCounters(fresh)).toEqual([]);
+});
+
+test("agentSummary is the live collapsed-header line, per status", () => {
+	expect(agentSummary(props({ result: undefined }))).toBe("scout: map the repo");
+	expect(agentSummary(props())).toBe(
+		'scout · 12 turns · 30k tok · $0.040 · 45s · bash: rg -n "createServer"',
+	);
+	expect(
+		agentSummary(
+			props({ result: { details: details({ status: "queued", usage: details().usage }) } }),
+		),
+	).toContain("scout · queued");
+	expect(agentSummary(props({ result: { details: details({ status: "completed" }) } }))).toBe(
+		"scout · 12 turns · 30k tok · $0.040 · 45s",
+	);
+	expect(
+		agentSummary(props({ args: { subagent_type: "scout", task: "t", run_in_background: true } })),
+	).toContain("background");
+	expect(
+		agentSummary(
+			props({
+				toolName: "get_subagent_result",
+				args: { session_id: "child-1" },
+				result: undefined,
+			}),
+		),
+	).toBe("child-1");
+});

--- a/apps/web/src/chat/tools/subagent/runDetails.ts
+++ b/apps/web/src/chat/tools/subagent/runDetails.ts
@@ -1,0 +1,59 @@
+import type { DelegationRunDetails, DelegationRunStatus } from "@thinkrail/contracts";
+import { formatCost, formatElapsed, formatTokens } from "../../SessionStatsBar";
+import type { ToolRenderProps } from "../../toolRegistry";
+import { strArg } from "../toolHelpers";
+
+export function readRunDetails(value: unknown): DelegationRunDetails | undefined {
+	if (!value || typeof value !== "object" || !("details" in value)) return undefined;
+	const details = (value as { details: unknown }).details;
+	if (!details || typeof details !== "object") return undefined;
+	const d = details as Partial<DelegationRunDetails>;
+	return typeof d.childSessionId === "string" &&
+		typeof d.status === "string" &&
+		typeof d.task === "string" &&
+		typeof d.usage === "object" &&
+		d.usage !== null
+		? (details as DelegationRunDetails)
+		: undefined;
+}
+
+export function isTerminalRunStatus(status: DelegationRunStatus): boolean {
+	return status === "completed" || status === "error" || status === "aborted";
+}
+
+export function runCounters(
+	details: DelegationRunDetails,
+	tokens: "total" | "split" = "total",
+): string[] {
+	const parts: string[] = [];
+	const u = details.usage;
+	if (u.turns > 0) parts.push(`${u.turns} ${u.turns === 1 ? "turn" : "turns"}`);
+	if (u.input > 0 || u.output > 0) {
+		parts.push(
+			tokens === "split"
+				? `in ${formatTokens(u.input)} / out ${formatTokens(u.output)}`
+				: `${formatTokens(u.input + u.output)} tok`,
+		);
+	}
+	if (u.cost > 0) parts.push(formatCost(u.cost));
+	if (details.durationMs > 0) parts.push(formatElapsed(details.durationMs));
+	return parts;
+}
+
+export function agentSummary({ args, result }: ToolRenderProps): string {
+	const details = readRunDetails(result);
+	if (!details) {
+		const role = strArg(args, "subagent_type") || strArg(args, "session_id");
+		const task = strArg(args, "task");
+		return role && task ? `${role}: ${task}` : role || task;
+	}
+	const parts = [details.roleName ?? "subagent"];
+	if (details.status === "queued") parts.push("queued");
+	if (details.status === "aborted") parts.push("aborted");
+	if (args.run_in_background === true && !isTerminalRunStatus(details.status)) {
+		parts.push("background");
+	}
+	parts.push(...runCounters(details));
+	if (details.status === "running" && details.activity) parts.push(details.activity);
+	return parts.join(" · ");
+}

--- a/apps/web/src/chat/tools/subagent/runDetails.ts
+++ b/apps/web/src/chat/tools/subagent/runDetails.ts
@@ -1,4 +1,5 @@
 import type { DelegationRunDetails, DelegationRunStatus } from "@thinkrail/contracts";
+import { isDelegationRunDetails } from "@thinkrail/contracts";
 import { formatCost, formatElapsed, formatTokens } from "../../SessionStatsBar";
 import type { ToolRenderProps } from "../../toolRegistry";
 import { strArg } from "../toolHelpers";
@@ -6,15 +7,7 @@ import { strArg } from "../toolHelpers";
 export function readRunDetails(value: unknown): DelegationRunDetails | undefined {
 	if (!value || typeof value !== "object" || !("details" in value)) return undefined;
 	const details = (value as { details: unknown }).details;
-	if (!details || typeof details !== "object") return undefined;
-	const d = details as Partial<DelegationRunDetails>;
-	return typeof d.childSessionId === "string" &&
-		typeof d.status === "string" &&
-		typeof d.task === "string" &&
-		typeof d.usage === "object" &&
-		d.usage !== null
-		? (details as DelegationRunDetails)
-		: undefined;
+	return isDelegationRunDetails(details) ? details : undefined;
 }
 
 export function isTerminalRunStatus(status: DelegationRunStatus): boolean {

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -27,10 +27,11 @@ import { useFold, useSelection } from "./foldState";
 import { Markdown } from "./Markdown";
 import { parseReviewPackage, type ReviewPackageItem, reviewPackageLabel } from "./reviewPackage";
 import type { ChatRow, TurnDividerData } from "./rows";
-import { formatTokens } from "./SessionStatsBar";
+import { formatElapsed, formatTokens } from "./SessionStatsBar";
 import { ToolCard } from "./ToolCard";
 import { ToolRendererBody } from "./ToolRendererBody";
 import { getToolChrome, getToolSummary, type ToolRenderProps } from "./toolRegistry";
+import { SubagentCompletionCard } from "./tools/subagent/SubagentCompletionCard";
 import type { CompactionState } from "./types";
 
 export function ChatTurnView({
@@ -93,6 +94,8 @@ export function ChatTurnView({
 					<Markdown text={row.text} />
 				</div>
 			);
+		case "subagentCompletion":
+			return <SubagentCompletionCard id={row.id} details={row.details} text={row.text} />;
 		case "tool":
 			return <ToolRow row={row} workspaceRoot={workspaceRoot} onOpenFile={onOpenFile} />;
 		case "activity":
@@ -531,13 +534,6 @@ function RetryIndicator({
 			</div>
 		</div>
 	);
-}
-
-function formatElapsed(ms: number): string {
-	const totalSec = Math.round(ms / 1000);
-	const m = Math.floor(totalSec / 60);
-	const s = totalSec % 60;
-	return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }
 
 function FileDiffGlyph({ className }: { className?: string }) {

--- a/apps/web/src/chat/types.ts
+++ b/apps/web/src/chat/types.ts
@@ -1,5 +1,6 @@
 import type {
 	AssistantMessage,
+	DelegationRunDetails,
 	ExtUiRequest,
 	ImageContent,
 	UserMessage,
@@ -23,6 +24,7 @@ export type ChatTurn =
 	| { kind: "system"; id: string; text: string; endedAt?: number }
 	| ({ kind: "compaction"; id: string } & CompactionState)
 	| { kind: "error"; id: string; text: string; recovery?: FailureRecovery }
+	| { kind: "subagentCompletion"; id: string; details: DelegationRunDetails; text: string }
 	| {
 			kind: "retry";
 			id: string;

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -168,7 +168,10 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   existing exclusive attach/takeover contract decides which client controls a given PTY. The
   **per-session chat state** — `sessions: Record<sessionId, SessionRuntime>`, where a `SessionRuntime` holds
   one chat's `turns` (pi-canonical) / `toolResults` / `askAnswers` (the `ask-user-answers` replies keyed
-  by tool call id — indexed by the reducer and hydration, never turned into bubbles) /
+  by tool call id — indexed by the reducer and hydration, never turned into bubbles; the sibling
+  `subagent-completion` custom message is instead **appended as a `subagentCompletion` turn** — a
+  detached subagent's terminal report is transcript-positioned, rendered by `chat`'s completion card —
+  both narrowed by the shared contracts guards) /
   `currentAssistantId` / `attemptAssistantId` (scopes overflow removal to the attempt actually observed) /
   `isStreaming` / `model` / `thinkingLevel` / **`eventRevision`** (browser-local, incremented for every
   received Pi event; the compare-and-install fence for an authoritative transcript read) /

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -448,6 +448,63 @@ test("an ask-user-answers custom message_end indexes into askAnswers (never the 
 	expect(ignored.eventRevision).toBe(before.eventRevision + 1);
 });
 
+test("a subagent-completion custom message_end appends a subagentCompletion turn", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+
+	const details = {
+		childSessionId: "child-1",
+		roleName: "scout",
+		task: "map the repo",
+		status: "completed",
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.01,
+			turns: 3,
+			contextTokens: 15,
+		},
+		durationMs: 4200,
+	};
+	store.handlePiEvent(
+		{
+			type: "message_end",
+			message: {
+				role: "custom",
+				customType: "subagent-completion",
+				content: 'Subagent "scout" (child-1) completed:\n\nthe report',
+				display: true,
+				details,
+			},
+		} as unknown as PiEvent,
+		"a",
+	);
+	const turn = rt("a").turns.at(-1);
+	expect(turn?.kind).toBe("subagentCompletion");
+	expect(turn?.kind === "subagentCompletion" && turn.details.childSessionId).toBe("child-1");
+	expect(turn?.kind === "subagentCompletion" && turn.text).toContain("the report");
+
+	const before = rt("a");
+	store.handlePiEvent(
+		{
+			type: "message_end",
+			message: {
+				role: "custom",
+				customType: "subagent-completion",
+				content: "x",
+				display: true,
+				details: { nope: true },
+			},
+		} as unknown as PiEvent,
+		"a",
+	);
+	const ignored = rt("a");
+	expect(ignored.turns).toBe(before.turns);
+	expect(ignored.eventRevision).toBe(before.eventRevision + 1);
+});
+
 test("the tool lifecycle folds into toolResults (the status + raw the renderers read)", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -32,7 +32,13 @@ import type {
 	WorkspaceLayoutDocument,
 	WorkspaceLayoutSnapshot,
 } from "@thinkrail/contracts";
-import { DEFAULT_CONFIG, isAskUserAnswersMessage, isControlMessage } from "@thinkrail/contracts";
+import {
+	customMessageText,
+	DEFAULT_CONFIG,
+	isAskUserAnswersMessage,
+	isControlMessage,
+	isSubagentCompletionMessage,
+} from "@thinkrail/contracts";
 import { create } from "zustand";
 import type { LoginState } from "../auth";
 import { assistantFailureText } from "../chat/assistantFailure";
@@ -516,6 +522,20 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 			if (isAskUserAnswersMessage(event.message)) {
 				const { toolCallId, result } = event.message.details;
 				return { ...rt, askAnswers: { ...rt.askAnswers, [toolCallId]: result } };
+			}
+			if (isSubagentCompletionMessage(event.message)) {
+				return {
+					...rt,
+					turns: [
+						...rt.turns,
+						{
+							kind: "subagentCompletion",
+							id: crypto.randomUUID(),
+							details: event.message.details,
+							text: customMessageText(event.message.content),
+						},
+					],
+				};
 			}
 			if (event.message.role !== "assistant" || !rt.currentAssistantId) return rt;
 			const id = rt.currentAssistantId;

--- a/e2e/fixtures/agents.ts
+++ b/e2e/fixtures/agents.ts
@@ -1,0 +1,20 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { E2E_PI_AGENT_DIR } from "./paths";
+
+export function seedAgentDefinitionFixtures(agentDir: string = E2E_PI_AGENT_DIR): void {
+	const dir = join(agentDir, "agents");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(
+		join(dir, "echo.md"),
+		`---
+name: echo
+description: Test subagent that follows the task instruction exactly and replies tersely.
+tools: read
+max_turns: 3
+---
+You are EchoAgent, a test subagent. Follow the task instruction exactly and reply with exactly the
+text it asks for — nothing else. Do not use tools unless the task explicitly requires reading a file.
+`,
+	);
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,6 +1,7 @@
 import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { seedAgentDefinitionFixtures } from "./fixtures/agents";
 import {
 	E2E_CENTRAL_BAD_EXTENSION_SOURCE,
 	E2E_CENTRAL_EXTENSION_SOURCE,
@@ -61,6 +62,8 @@ export default function globalSetup(): void {
 	seedExternalCwdSessions();
 
 	seedTemplateFixtures();
+
+	seedAgentDefinitionFixtures();
 
 	seedFixtureRepo();
 

--- a/e2e/subagents.live.spec.ts
+++ b/e2e/subagents.live.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+import { openWorkspaceChat, waitForDone } from "./fixtures/app";
+
+const agentCards = '[data-testid="tool-card"][data-tool="Agent"]';
+
+test("foreground parallel fan-out: live Agent cards, report fold, child transcript dialog", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(300_000);
+	await openWorkspaceChat(page);
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			'Call the Agent tool TWICE in this single reply (two tool calls in one message): both with subagent_type "echo", one with task "Reply with exactly: ALPHA-MARKER", the other with task "Reply with exactly: BRAVO-MARKER". After both return, reply with the single word done.',
+		);
+	await page.getByTestId("chat-send").click();
+
+	const cards = page.locator(agentCards);
+	await expect(cards).toHaveCount(2, { timeout: 180_000 });
+	await expect(cards.first()).toHaveAttribute("data-status", "done", { timeout: 180_000 });
+	await expect(cards.nth(1)).toHaveAttribute("data-status", "done", { timeout: 180_000 });
+	await waitForDone(page, 120_000);
+
+	const header = cards.first().getByTestId("tool-card-toggle");
+	await expect(header).toContainText("echo");
+	await expect(header).toContainText("turn");
+
+	await header.click();
+	const body = cards.first().getByTestId("tool-agent");
+	await expect(body).toBeVisible();
+	await body.getByTestId("agent-report-toggle").click();
+	await expect(body.getByTestId("agent-report")).toContainText(/(ALPHA|BRAVO)-MARKER/);
+
+	await body.getByTestId("agent-open-transcript").click();
+	const dialog = page.getByTestId("subagent-transcript-dialog");
+	await expect(dialog).toBeVisible();
+	const transcript = dialog.getByTestId("subagent-transcript");
+	await expect(transcript.locator('[data-testid="chat-message"][data-role="user"]')).toContainText(
+		/Reply with exactly: (ALPHA|BRAVO)-MARKER/,
+		{ timeout: 15_000 },
+	);
+	await expect(
+		transcript.locator('[data-testid="chat-message"][data-role="assistant"]').last(),
+	).toContainText(/(ALPHA|BRAVO)-MARKER/);
+	await page.keyboard.press("Escape");
+	await expect(dialog).not.toBeVisible();
+});
+
+test("background run: completion card arrives live, with report + transcript", {
+	tag: "@agent",
+}, async ({ page }) => {
+	test.setTimeout(300_000);
+	await openWorkspaceChat(page);
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			'Call the Agent tool once with subagent_type "echo", task "Reply with exactly: CHARLIE-MARKER", and run_in_background set to true. Then reply with the single word started. Do NOT call get_subagent_result — the result arrives on its own.',
+		);
+	await page.getByTestId("chat-send").click();
+
+	const card = page.locator(agentCards).first();
+	await expect(card).toHaveAttribute("data-status", "done", { timeout: 180_000 });
+
+	const completion = page.getByTestId("subagent-completion");
+	await expect(completion).toBeVisible({ timeout: 180_000 });
+	await expect(completion).toHaveAttribute("data-status", "completed");
+	await expect(completion).toContainText("echo finished");
+
+	await completion.getByTestId("subagent-completion-report-toggle").click();
+	await expect(completion.getByTestId("subagent-completion-report")).toContainText(
+		"CHARLIE-MARKER",
+	);
+
+	await completion.getByTestId("subagent-completion-transcript").click();
+	const dialog = page.getByTestId("subagent-transcript-dialog");
+	await expect(dialog).toBeVisible();
+	await expect(
+		dialog
+			.getByTestId("subagent-transcript")
+			.locator('[data-testid="chat-message"][data-role="assistant"]')
+			.last(),
+	).toContainText("CHARLIE-MARKER", { timeout: 15_000 });
+});

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"desktop:package:stable": "bun run build:web && bun apps/desktop/build.ts --env=stable",
 		"smoke:desktop": "bun apps/desktop/smoke.ts",
 		"smoke:desktop:installer": "bun apps/desktop/installerSmoke.ts",
+		"smoke:subagents": "bun scripts/smoke-pure-pi-subagents.ts",
 		"typecheck": "turbo run typecheck",
 		"test": "turbo run test",
 		"lint": "biome check .",

--- a/scripts/smoke-pure-pi-subagents.ts
+++ b/scripts/smoke-pure-pi-subagents.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..");
+const piBin = join(repoRoot, "node_modules", ".bin", "pi");
+const extensionEntry = join(repoRoot, "packages", "pi-subagents", "index.ts");
+
+function fail(message: string): never {
+	console.error(`smoke-pure-pi-subagents: FAIL — ${message}`);
+	process.exit(1);
+}
+
+const agentDir = mkdtempSync(join(tmpdir(), "thinkrail-smoke-pi-agent-"));
+const workDir = mkdtempSync(join(tmpdir(), "thinkrail-smoke-cwd-"));
+try {
+	const userAgentDir = process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	let copied = 0;
+	for (const file of ["auth.json", "models.json"]) {
+		const src = join(userAgentDir, file);
+		if (existsSync(src)) {
+			copyFileSync(src, join(agentDir, file));
+			copied += 1;
+		}
+	}
+	if (copied === 0) {
+		fail(
+			`no auth found under ${userAgentDir} — authenticate pi first (this smoke drives a real provider)`,
+		);
+	}
+	const [provider, ...idParts] = (
+		process.env.THINKRAIL_E2E_MODEL ?? "anthropic/claude-opus-4-8"
+	).split("/");
+	writeFileSync(
+		join(agentDir, "settings.json"),
+		`${JSON.stringify(
+			{ defaultProvider: provider, defaultModel: idParts.join("/"), defaultThinkingLevel: "low" },
+			null,
+			2,
+		)}\n`,
+	);
+
+	const prompt =
+		'Use the Agent tool with subagent_type "scout" and task "Reply with exactly the single word pong. Do not use any tools." After it returns, reply with the single word done.';
+	console.log(`smoke-pure-pi-subagents: running vanilla pi (${provider}/${idParts.join("/")}) …`);
+	let stdout = "";
+	try {
+		stdout = execFileSync(
+			piBin,
+			["-p", "--mode", "json", "--no-session", "-e", extensionEntry, prompt],
+			{
+				cwd: workDir,
+				env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+				encoding: "utf8",
+				timeout: 300_000,
+				maxBuffer: 64 * 1024 * 1024,
+			},
+		);
+	} catch (error) {
+		const e = error as { stdout?: string; stderr?: string; message?: string };
+		fail(
+			`pi exited abnormally: ${e.message}\n--- stdout tail ---\n${(e.stdout ?? "").slice(-2000)}\n--- stderr tail ---\n${(e.stderr ?? "").slice(-2000)}`,
+		);
+	}
+
+	const events = stdout
+		.split("\n")
+		.filter((line) => line.trim().startsWith("{"))
+		.flatMap((line) => {
+			try {
+				return [JSON.parse(line) as Record<string, unknown>];
+			} catch {
+				return [];
+			}
+		});
+	const agentEnd = events.find((e) => e.type === "tool_execution_end" && e.toolName === "Agent") as
+		| { isError?: boolean; result?: { content?: Array<{ type?: string; text?: string }> } }
+		| undefined;
+	if (!agentEnd) {
+		fail(
+			`no Agent tool_execution_end in pi's event stream — did the extension load?\n--- stdout tail ---\n${stdout.slice(-2000)}`,
+		);
+	}
+	if (agentEnd.isError) {
+		const text = agentEnd.result?.content?.find((c) => c.type === "text")?.text ?? "";
+		fail(`the Agent run errored: ${text.slice(0, 500)}`);
+	}
+
+	const delegationRoot = join(agentDir, "delegation", "default");
+	const parents = existsSync(delegationRoot) ? readdirSync(delegationRoot) : [];
+	const transcripts = parents.flatMap((parent) =>
+		readdirSync(join(delegationRoot, parent)).filter((f) => f.endsWith(".jsonl")),
+	);
+	if (transcripts.length === 0) {
+		fail(
+			`no child transcript under ${delegationRoot} — the default storage binding did not engage`,
+		);
+	}
+
+	console.log(
+		`smoke-pure-pi-subagents: OK — Agent tool completed under vanilla pi; ${transcripts.length} child transcript(s) in ${delegationRoot}`,
+	);
+} finally {
+	rmSync(agentDir, { recursive: true, force: true });
+	rmSync(workDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Layer 3/3 of the subagents stack: the **web UI for subagent runs** — live `Agent` tool cards, background-completion turns, and the child transcript dialog — plus the `@agent` e2e coverage and the pure-pi smoke script.

Squashed from `subagent-research-planning` (the remote archive branch of the original history). This layer's tree is byte-identical to the verified squash-merge of the feature branch onto main.

Stack: #302 (packages) ← #303 (host) ← **#304 (this)**.

## Changes

- **`apps/web/src/chat/tools/subagent`** — the `Agent` tool renderer: live run card fed by `partialResult.details` (REPLACE semantics), report fold on completion, `runDetails` readers/formatters. Registered via the tool registry (capability and presentation joined by tool name). Spec: `apps/web/src/chat/tools/subagent/SPEC.md`.
- **`apps/web/src/chat`** — `subagent-completion` custom messages become their own `subagentCompletion` turn (a background run's tool card freezes at its ack — the completion turn is the terminal signal), on both the live reducer and hydration paths; `SubagentTranscriptDialog` (an integration file, like `ChatView`) reads the child transcript via `subagent.getTranscript` and polls only while the host still reports a registry `status`. Reached through `ChatActions.openSubagentTranscript` — the cards stay presentational.
- **`e2e`** — `subagents.live.spec.ts` (`@agent`): foreground parallel fan-out (live cards → report fold → transcript dialog) and a background run's completion card arriving live; `fixtures/agents.ts` seeds an echo-agent definition.
- **`scripts` + root `package.json`** — `bun run smoke:subagents`: the pure-pi smoke proving the packages work under vanilla pi, no ThinkRail.

## Testing

- `bun run test` — full suite green (14 turbo tasks).
- `bun run e2e` — **all 8 shards passed** (122s).
- `bun run e2e:agent -- e2e/subagents.live.spec.ts` — **2 passed** against a real provider.
- `bun run e2e:binary` — **273 passed** on this tree; `build:binary` + `smoke:binary` green.
- `bun run smoke:subagents` — OK against a real provider (child transcript persisted).
- Pre-commit gates: `check:deps`, `check:seams`, `lint`, `typecheck` — all green.

## Screenshots

All captured on this stack's final tree (post theme/spacing overhaul), driven by the seeded echo agent against a real provider.

**Before** (this layer's UI stripped — the host's `Agent` tool renders through the generic fallbacks):

| collapsed activity group | expanded: raw JSON |
| --- | --- |
| ![before collapsed](https://github.com/JetBrains/thinkrail/blob/f9055f16d93bcd716d741b9aea60b90b1c3a205f/agent-cards-before-02-activity-group-collapsed.png?raw=true) | ![before raw json](https://github.com/JetBrains/thinkrail/blob/f9055f16d93bcd716d741b9aea60b90b1c3a205f/agent-cards-before-03-raw-json-expanded.png?raw=true) |

**After**:

| live running cards | done, collapsed |
| --- | --- |
| ![running](https://github.com/JetBrains/thinkrail/blob/f9055f16d93bcd716d741b9aea60b90b1c3a205f/agent-cards-after-01-live-running.png?raw=true) | ![done collapsed](https://github.com/JetBrains/thinkrail/blob/f9055f16d93bcd716d741b9aea60b90b1c3a205f/agent-cards-after-02-done-collapsed.png?raw=true) |

| expanded card + report | child transcript dialog | background completion turn |
| --- | --- | --- |
| ![expanded report](https://github.com/JetBrains/thinkrail/blob/f9055f16d93bcd716d741b9aea60b90b1c3a205f/agent-cards-after-03-expanded-report.png?raw=true) | ![transcript dialog](https://github.com/JetBrains/thinkrail/blob/f9055f16d93bcd716d741b9aea60b90b1c3a205f/agent-cards-after-04-transcript-dialog.png?raw=true) | ![background completion](https://github.com/JetBrains/thinkrail/blob/f9055f16d93bcd716d741b9aea60b90b1c3a205f/agent-cards-after-05-background-completion.png?raw=true) |

