### PR TITLE
feat(web): add an adaptive chat composer

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -594,7 +594,7 @@ export default function ChatView({
 			<AskStatesContext.Provider value={askContext}>
 				<div
 					data-testid="chat-view"
-					className="flex h-full min-h-0 flex-col bg-container-workspace-bg [container-type:size]"
+					className="flex h-full min-h-0 min-w-0 flex-col bg-container-workspace-bg [container-type:size]"
 				>
 					<Popover open={planOpen} onOpenChange={setPlanOpen}>
 						<PopoverAnchor asChild>

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -126,6 +126,7 @@ export default function ChatView({
 		connectionGeneration,
 		enabled: sessionRuntime !== undefined,
 	});
+	const composerGrowthLimit = useAppStore((state) => state.composerGrowthLimit);
 	const { models, refreshing: modelsRefreshing, refresh: onRefreshModels } = useModelCatalog();
 	const projectId = useAppStore(
 		(s) =>
@@ -591,7 +592,10 @@ export default function ChatView({
 	return (
 		<ChatActionsContext.Provider value={chatActions}>
 			<AskStatesContext.Provider value={askContext}>
-				<div className="flex h-full min-h-0 flex-col bg-container-workspace-bg">
+				<div
+					data-testid="chat-view"
+					className="flex h-full min-h-0 flex-col bg-container-workspace-bg [container-type:size]"
+				>
 					<Popover open={planOpen} onOpenChange={setPlanOpen}>
 						<PopoverAnchor asChild>
 							<div className="shrink-0">
@@ -696,6 +700,7 @@ export default function ChatView({
 							value={draft}
 							onChange={(v) => useAppStore.getState().setChatDraft(sessionId, v)}
 							isStreaming={isStreaming}
+							growthLimit={composerGrowthLimit}
 							commands={mergedCommands}
 							mentionCandidates={mentionCandidates}
 							recentPrompts={recentPrompts}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -708,44 +708,37 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				<div
 					data-testid="chat-composer-shell"
 					className={cn(
-						"relative grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-x-4 overflow-hidden rounded-[var(--radius-md)] border border-control-border-default bg-control-bg bg-clip-padding p-4 transition-colors focus-within:border-control-border-active",
-						expanded ? "grid-rows-[minmax(0,1fr)_auto] gap-y-4" : "grid-rows-[auto]",
+						"relative grid grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[minmax(0,1fr)_auto] items-end gap-x-4 gap-y-4 overflow-hidden rounded-[var(--radius-md)] border border-control-border-default bg-control-bg bg-clip-padding p-4 transition-colors focus-within:border-control-border-active",
 						expanded && growthLimit === "half-chat" && "max-h-[50cqh]",
 					)}
 				>
 					<div
 						ref={compactProbeRef}
 						aria-hidden
-						className="pointer-events-none invisible absolute inset-x-0 top-0 col-start-2 col-end-3 row-start-1 whitespace-pre-wrap break-words px-12 py-8 tr-text-ui"
+						className="pointer-events-none invisible absolute inset-x-0 top-0 col-span-3 col-start-1 row-start-1 whitespace-pre-wrap break-words px-12 py-8 tr-text-ui"
 					>
 						{`${value}\u200b`}
 					</div>
-					<div
-						className={cn(
-							"flex min-w-0 items-center self-end",
-							expanded ? "col-start-1 row-start-2 gap-4 sm:gap-8" : "col-start-1 row-start-1 gap-0",
-						)}
-					>
+					<div className="col-start-1 row-start-2 flex min-w-0 items-center gap-4 self-end sm:gap-8">
 						<ModelSelector
 							models={models}
 							current={currentModel}
 							refreshing={modelsRefreshing}
 							onRefresh={onRefreshModels}
 							onSelect={onSelectModel}
-							className={cn("max-w-80 gap-4 px-4 sm:max-w-144", !expanded && "rounded-r-none")}
+							className="max-w-80 gap-4 px-4 sm:max-w-144"
 						/>
 						<ThinkingSelector
 							level={thinkingLevel}
 							levels={currentModel?.thinkingLevels ?? []}
 							onSelect={onSelectThinking}
 							showLabel={false}
-							className={cn("gap-4 px-4", !expanded && "-ml-px rounded-l-none")}
+							className="gap-4 px-4"
 						/>
 					</div>
 					<div
 						className={cn(
-							"relative min-h-0 overflow-hidden rounded-[var(--radius-sm)] tr-text-ui",
-							expanded ? "col-span-3 col-start-1 row-start-1" : "col-start-2 row-start-1",
+							"relative col-span-3 col-start-1 row-start-1 min-h-0 overflow-hidden rounded-[var(--radius-sm)] tr-text-ui",
 							COMPOSER_EDITOR_LIMIT_CLASS[growthLimit],
 						)}
 					>
@@ -843,12 +836,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							)}
 						/>
 					</div>
-					<div
-						className={cn(
-							"flex shrink-0 items-center gap-4 self-end",
-							expanded ? "col-start-3 row-start-2" : "col-start-3 row-start-1",
-						)}
-					>
+					<div className="col-start-3 row-start-2 flex shrink-0 items-center gap-4 self-end">
 						<button
 							type="button"
 							data-testid="history-open"

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -242,7 +242,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const [slots, setSlots] = useState<TemplateSlot[] | null>(null);
 	const [slotIdx, setSlotIdx] = useState(0);
 	const backdropRef = useRef<HTMLDivElement | null>(null);
-	const compactProbeRef = useRef<HTMLDivElement | null>(null);
+	const editorSizerRef = useRef<HTMLDivElement | null>(null);
 	const [draftNeedsExpansion, setDraftNeedsExpansion] = useState(false);
 	const expanded = isStreaming || draftNeedsExpansion;
 	const syncBackdropScroll = useCallback(() => {
@@ -260,22 +260,22 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		[syncBackdropScroll],
 	);
 	const measureDraftExpansion = useCallback(() => {
-		const probe = compactProbeRef.current;
-		if (!probe) return;
-		const styles = getComputedStyle(probe);
+		const sizer = editorSizerRef.current;
+		if (!sizer) return;
+		const styles = getComputedStyle(sizer);
 		const oneLineHeight =
 			Number.parseFloat(styles.lineHeight) +
 			Number.parseFloat(styles.paddingTop) +
 			Number.parseFloat(styles.paddingBottom);
-		setDraftNeedsExpansion(value.includes("\n") || probe.scrollHeight > oneLineHeight + 1);
+		setDraftNeedsExpansion(value.includes("\n") || sizer.scrollHeight > oneLineHeight + 1);
 	}, [value]);
 
 	useLayoutEffect(() => {
-		const probe = compactProbeRef.current;
-		if (!probe) return;
+		const sizer = editorSizerRef.current;
+		if (!sizer) return;
 		measureDraftExpansion();
 		const observer = new ResizeObserver(measureDraftExpansion);
-		observer.observe(probe);
+		observer.observe(sizer);
 		return () => observer.disconnect();
 	}, [measureDraftExpansion]);
 
@@ -712,13 +712,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 						expanded && growthLimit === "half-chat" && "max-h-[50cqh]",
 					)}
 				>
-					<div
-						ref={compactProbeRef}
-						aria-hidden
-						className="pointer-events-none invisible absolute inset-x-0 top-0 col-span-3 col-start-1 row-start-1 whitespace-pre-wrap break-words px-12 py-8 tr-text-ui"
-					>
-						{`${value}\u200b`}
-					</div>
 					<div className="col-start-1 row-start-2 flex min-w-0 items-center gap-4 self-end sm:gap-8">
 						<ModelSelector
 							models={models}
@@ -743,6 +736,8 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 						)}
 					>
 						<div
+							ref={editorSizerRef}
+							data-testid="chat-input-sizer"
 							aria-hidden
 							className="invisible w-full whitespace-pre-wrap break-words px-12 py-8 tr-text-ui"
 						>

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -732,17 +732,14 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							refreshing={modelsRefreshing}
 							onRefresh={onRefreshModels}
 							onSelect={onSelectModel}
-							className={cn(
-								"max-w-80 gap-4 px-4 sm:max-w-144",
-								!expanded && "rounded-r-none border-r-0",
-							)}
+							className={cn("max-w-80 gap-4 px-4 sm:max-w-144", !expanded && "rounded-r-none")}
 						/>
 						<ThinkingSelector
 							level={thinkingLevel}
 							levels={currentModel?.thinkingLevels ?? []}
 							onSelect={onSelectThinking}
 							showLabel={false}
-							className={cn("gap-4 px-4", !expanded && "rounded-l-none")}
+							className={cn("gap-4 px-4", !expanded && "-ml-px rounded-l-none")}
 						/>
 					</div>
 					<div

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -9,6 +9,7 @@ import {
 	RiCloseLine as X,
 } from "@remixicon/react";
 import {
+	type ComposerGrowthLimit,
 	REQUEST_IMAGE_BASE64_BUDGET,
 	type ThinkingLevel,
 	type WireModel,
@@ -26,6 +27,7 @@ import {
 	useState,
 } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib";
 import { FileChip } from "./FileChip";
 import { type AttachedImage, fileToAttachedImage } from "./imageAttachment";
 import { ModelSelector } from "./ModelSelector";
@@ -50,6 +52,13 @@ import type { ChatAttachment } from "./types";
 export type SubmitBehavior = "send" | "steer" | "followUp" | "interrupt";
 
 export type ComposerSubmitDisposition = { accepted: true } | { accepted: false; reason: string };
+
+const COMPOSER_EDITOR_LIMIT_CLASS = {
+	compact: "max-h-[calc(6lh+var(--space-8)+var(--space-8))]",
+	roomy: "max-h-[calc(10lh+var(--space-8)+var(--space-8))]",
+	"half-chat":
+		"max-h-[calc(50cqh-var(--space-16)-var(--space-16)-var(--space-4)-var(--space-4)-var(--space-4)-var(--space-4))]",
+} satisfies Record<ComposerGrowthLimit, string>;
 
 const STREAMING_SEND_MODES = [
 	{
@@ -153,6 +162,7 @@ interface ComposerProps {
 	value: string;
 	onChange: (value: string) => void;
 	isStreaming: boolean;
+	growthLimit: ComposerGrowthLimit;
 	commands: SlashCommandItem[];
 	mentionCandidates: MentionCandidate[];
 	recentPrompts: string[];
@@ -191,6 +201,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		value,
 		onChange,
 		isStreaming,
+		growthLimit,
 		commands,
 		mentionCandidates,
 		recentPrompts,
@@ -231,14 +242,46 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const [slots, setSlots] = useState<TemplateSlot[] | null>(null);
 	const [slotIdx, setSlotIdx] = useState(0);
 	const backdropRef = useRef<HTMLDivElement | null>(null);
-	const attachBackdrop = (el: HTMLDivElement | null) => {
-		backdropRef.current = el;
+	const compactProbeRef = useRef<HTMLDivElement | null>(null);
+	const [draftNeedsExpansion, setDraftNeedsExpansion] = useState(false);
+	const expanded = isStreaming || draftNeedsExpansion;
+	const syncBackdropScroll = useCallback(() => {
+		const backdrop = backdropRef.current;
 		const textarea = ref.current;
-		if (el && textarea) {
-			el.scrollLeft = textarea.scrollLeft;
-			el.scrollTop = textarea.scrollTop;
-		}
-	};
+		if (!backdrop || !textarea) return;
+		backdrop.scrollLeft = textarea.scrollLeft;
+		backdrop.scrollTop = textarea.scrollTop;
+	}, []);
+	const attachBackdrop = useCallback(
+		(el: HTMLDivElement | null) => {
+			backdropRef.current = el;
+			syncBackdropScroll();
+		},
+		[syncBackdropScroll],
+	);
+	const measureDraftExpansion = useCallback(() => {
+		const probe = compactProbeRef.current;
+		if (!probe) return;
+		const styles = getComputedStyle(probe);
+		const oneLineHeight =
+			Number.parseFloat(styles.lineHeight) +
+			Number.parseFloat(styles.paddingTop) +
+			Number.parseFloat(styles.paddingBottom);
+		setDraftNeedsExpansion(value.includes("\n") || probe.scrollHeight > oneLineHeight + 1);
+	}, [value]);
+
+	useLayoutEffect(() => {
+		const probe = compactProbeRef.current;
+		if (!probe) return;
+		measureDraftExpansion();
+		const observer = new ResizeObserver(measureDraftExpansion);
+		observer.observe(probe);
+		return () => observer.disconnect();
+	}, [measureDraftExpansion]);
+
+	useLayoutEffect(() => {
+		syncBackdropScroll();
+	});
 
 	const { token, start } = activeToken(value, caret);
 	const mentionQuery = token.startsWith("@") ? token.slice(1) : null;
@@ -528,7 +571,12 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	return (
-		<div className="relative flex shrink-0 flex-col border-border-muted border-t bg-container-workspace-bg">
+		<div
+			data-testid="chat-composer"
+			data-expanded={expanded}
+			data-streaming={isStreaming}
+			className="relative flex shrink-0 flex-col border-border-muted border-t bg-container-workspace-bg"
+		>
 			{mentionOpen ? (
 				<div
 					data-testid="mention-menu"
@@ -656,108 +704,154 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				</div>
 			) : null}
 
-			<div className="flex flex-col gap-8 p-12">
-				<div className="relative rounded-[var(--radius-md)] border border-control-border-default bg-control-bg bg-clip-padding transition-colors focus-within:border-control-border-active">
-					{slots ? (
-						<div
-							ref={attachBackdrop}
-							data-testid="slot-backdrop"
-							aria-hidden
-							className="pointer-events-none absolute inset-0 overflow-hidden rounded-[var(--radius-md)]"
-						>
-							<div className="w-full whitespace-pre-wrap break-words px-12 py-8 tr-text-ui">
-								{withOffsets(highlightSegments(value, slots, slotIdx)).map((seg) => (
-									<span
-										key={seg.start}
-										data-testid={seg.state === "plain" ? undefined : "slot-highlight"}
-										data-slot-state={seg.state === "plain" ? undefined : seg.state}
-										className={`text-transparent ${highlightTint(seg.state)}`}
-									>
-										{seg.text}
-									</span>
-								))}
-							</div>
-						</div>
-					) : null}
-					<textarea
-						ref={ref}
-						data-testid="chat-input"
-						value={value}
-						onScroll={(e) => {
-							const backdrop = backdropRef.current;
-							if (backdrop) {
-								backdrop.scrollLeft = e.currentTarget.scrollLeft;
-								backdrop.scrollTop = e.currentTarget.scrollTop;
-							}
-						}}
-						onChange={(e) => {
-							const next = e.target.value;
-							const nextCaret = e.target.selectionStart;
-							setSubmitError(null);
-							const recalled = recallIdxRef.current;
-							if (recalled !== null && next !== recentPrompts[recalled]) {
-								recallIdxRef.current = null;
-							}
-							if (slots) {
-								const { editStart, removedLen, insertedLen } = diffValues(value, next, nextCaret);
-								if (editStart === 0 && removedLen === value.length) {
-									setSlots(null);
-								} else {
-									const editEnd = editStart + removedLen;
-									const active = slots[slotIdx];
-									const growing =
-										removedLen === 0 &&
-										insertedLen > 0 &&
-										active !== undefined &&
-										active.end === editStart;
-									const shifted = shiftSlots(slots, editStart, removedLen, insertedLen).map(
-										(slot, i) => {
-											const grown =
-												growing && i === slotIdx
-													? { ...slot, end: slot.end + insertedLen, filled: true, edited: true }
-													: slot;
-											const original = slots[i];
-											return original && touches(original, editStart, editEnd)
-												? { ...grown, filled: true, edited: true }
-												: grown;
-										},
-									);
-									setSlots(shifted);
-								}
-							}
-							onChange(next);
-							setCaret(nextCaret);
-						}}
-						onKeyUp={(e) => setCaret(e.currentTarget.selectionStart)}
-						onClick={(e) => setCaret(e.currentTarget.selectionStart)}
-						onKeyDown={onKeyDown}
-						onPaste={onPaste}
-						onDrop={onDrop}
-						rows={4}
-						placeholder={
-							isStreaming
-								? "Enter steers at the next step · Cmd/Ctrl+Enter queues for when it finishes"
-								: "Message the agent…  (@ files · / commands · Enter to send)"
-						}
-						className="relative min-h-[108px] w-full resize-none rounded-[var(--radius-sm)] bg-transparent px-12 py-8 tr-text-ui text-text-default outline-none placeholder:text-text-muted"
-					/>
-				</div>
-				<div className="flex flex-wrap items-center gap-8">
-					<div className="flex min-w-0 flex-1 flex-wrap items-center gap-8">
+			<div className="p-12">
+				<div
+					data-testid="chat-composer-shell"
+					className={cn(
+						"relative grid grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-x-4 overflow-hidden rounded-[var(--radius-md)] border border-control-border-default bg-control-bg bg-clip-padding p-4 transition-colors focus-within:border-control-border-active",
+						expanded ? "grid-rows-[minmax(0,1fr)_auto] gap-y-4" : "grid-rows-[auto]",
+						expanded && growthLimit === "half-chat" && "max-h-[50cqh]",
+					)}
+				>
+					<div
+						ref={compactProbeRef}
+						aria-hidden
+						className="pointer-events-none invisible absolute inset-x-0 top-0 col-start-2 col-end-3 row-start-1 whitespace-pre-wrap break-words px-12 py-8 tr-text-ui"
+					>
+						{`${value}\u200b`}
+					</div>
+					<div
+						className={cn(
+							"flex min-w-0 items-center self-end",
+							expanded ? "col-start-1 row-start-2 gap-4 sm:gap-8" : "col-start-1 row-start-1 gap-0",
+						)}
+					>
 						<ModelSelector
 							models={models}
 							current={currentModel}
 							refreshing={modelsRefreshing}
 							onRefresh={onRefreshModels}
 							onSelect={onSelectModel}
+							className={cn(
+								"max-w-80 gap-4 px-4 sm:max-w-144",
+								!expanded && "rounded-r-none border-r-0",
+							)}
 						/>
 						<ThinkingSelector
 							level={thinkingLevel}
 							levels={currentModel?.thinkingLevels ?? []}
 							onSelect={onSelectThinking}
+							showLabel={false}
+							className={cn("gap-4 px-4", !expanded && "rounded-l-none")}
 						/>
 					</div>
-					<div className="flex shrink-0 items-center gap-8">
+					<div
+						className={cn(
+							"relative min-h-0 overflow-hidden rounded-[var(--radius-sm)] tr-text-ui",
+							expanded ? "col-span-3 col-start-1 row-start-1" : "col-start-2 row-start-1",
+							COMPOSER_EDITOR_LIMIT_CLASS[growthLimit],
+						)}
+					>
+						<div
+							aria-hidden
+							className="invisible w-full whitespace-pre-wrap break-words px-12 py-8 tr-text-ui"
+						>
+							{`${value}\u200b`}
+						</div>
+						{slots ? (
+							<div
+								ref={attachBackdrop}
+								data-testid="slot-backdrop"
+								aria-hidden
+								className="pointer-events-none absolute inset-0 overflow-hidden rounded-[var(--radius-sm)]"
+							>
+								<div className="w-full whitespace-pre-wrap break-words px-12 py-8 tr-text-ui">
+									{withOffsets(highlightSegments(value, slots, slotIdx)).map((seg) => (
+										<span
+											key={seg.start}
+											data-testid={seg.state === "plain" ? undefined : "slot-highlight"}
+											data-slot-state={seg.state === "plain" ? undefined : seg.state}
+											className={`text-transparent ${highlightTint(seg.state)}`}
+										>
+											{seg.text}
+										</span>
+									))}
+								</div>
+							</div>
+						) : null}
+						<textarea
+							ref={ref}
+							data-testid="chat-input"
+							value={value}
+							onScroll={syncBackdropScroll}
+							onChange={(e) => {
+								const next = e.target.value;
+								const nextCaret = e.target.selectionStart;
+								setSubmitError(null);
+								const recalled = recallIdxRef.current;
+								if (recalled !== null && next !== recentPrompts[recalled]) {
+									recallIdxRef.current = null;
+								}
+								if (slots) {
+									const { editStart, removedLen, insertedLen } = diffValues(value, next, nextCaret);
+									if (editStart === 0 && removedLen === value.length) {
+										setSlots(null);
+									} else {
+										const editEnd = editStart + removedLen;
+										const active = slots[slotIdx];
+										const growing =
+											removedLen === 0 &&
+											insertedLen > 0 &&
+											active !== undefined &&
+											active.end === editStart;
+										const shifted = shiftSlots(slots, editStart, removedLen, insertedLen).map(
+											(slot, i) => {
+												const grown =
+													growing && i === slotIdx
+														? {
+																...slot,
+																end: slot.end + insertedLen,
+																filled: true,
+																edited: true,
+															}
+														: slot;
+												const original = slots[i];
+												return original && touches(original, editStart, editEnd)
+													? { ...grown, filled: true, edited: true }
+													: grown;
+											},
+										);
+										setSlots(shifted);
+									}
+								}
+								onChange(next);
+								setCaret(nextCaret);
+							}}
+							onKeyUp={(e) => setCaret(e.currentTarget.selectionStart)}
+							onClick={(e) => setCaret(e.currentTarget.selectionStart)}
+							onKeyDown={onKeyDown}
+							onPaste={onPaste}
+							onDrop={onDrop}
+							rows={1}
+							placeholder={
+								isStreaming
+									? "Enter steers at the next step · Cmd/Ctrl+Enter queues for when it finishes"
+									: expanded
+										? "Message the agent…  (@ files · / commands · Enter to send)"
+										: "Message…"
+							}
+							className={cn(
+								"absolute inset-0 size-full resize-none overflow-x-hidden overflow-y-auto rounded-[var(--radius-sm)] bg-transparent px-12 py-8 tr-text-ui text-text-default outline-none placeholder:text-text-muted",
+								expanded ? "whitespace-pre-wrap" : "whitespace-nowrap",
+							)}
+						/>
+					</div>
+					<div
+						className={cn(
+							"flex shrink-0 items-center gap-4 self-end",
+							expanded ? "col-start-3 row-start-2" : "col-start-3 row-start-1",
+						)}
+					>
 						<button
 							type="button"
 							data-testid="history-open"

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -35,6 +35,7 @@ export function ModelSelector({
 	refreshing,
 	onRefresh,
 	container,
+	className,
 }: {
 	models: WireModel[];
 	current: WireModel | null;
@@ -42,6 +43,7 @@ export function ModelSelector({
 	refreshing: boolean;
 	onRefresh: (force: boolean) => void;
 	container?: HTMLElement | null;
+	className?: string;
 }) {
 	const [open, setOpen] = useState(false);
 	const providers = [...new Set(models.map((m) => m.provider))];
@@ -62,7 +64,10 @@ export function ModelSelector({
 			<PopoverTrigger
 				data-testid="model-selector"
 				data-open={open}
-				className="flex h-32 max-w-[220px] items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
+				className={cn(
+					"flex h-32 max-w-[220px] items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
+					className,
+				)}
 			>
 				<span className="truncate text-text-muted tr-text-metadata">
 					{current?.name ?? "Select model"}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -301,6 +301,19 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   skill overrides, + a **Reload** that applies changes to this chat's session via `session.reloadResources`,
   disabled while streaming) or project (`project.skills`, per-project-baseline toggles, no session) — the
   latter reused by `panels` pre-session). All props-driven; behavior detail lives in the components' jsdoc.
+- **Adaptive composer geometry** (`Composer`) — an idle draft that fits one visual line renders as a
+  **46px one-line dock**: model and effort share one compact visual group on the left while remaining two
+  independently focusable/clickable picker triggers; History and Send remain explicit on the right. A wrap,
+  explicit newline, or width change that makes the draft exceed one visual line unfolds the same shell into
+  a full-width textarea plus a stable 42px action footer; fitting one line again collapses it. This is one
+  persistent textarea, never conditional twins — the transition cannot lose focus, caret/selection, recall,
+  draft, or a template-slot session. Streaming deliberately uses the expanded form even with an empty draft,
+  because Stop + send options join the footer. `ChatView` passes the server-synced
+  `ComposerGrowthLimit` prop: `compact` caps at 6 visual lines, `roomy` at 10, and the default `half-chat`
+  caps the **editor shell** (textarea + footer) at 50% of the mounted chat panel, never the browser viewport;
+  overflow then scrolls inside the textarea. Attachment chips, completion menus, slot hints, and QueueStrip
+  keep their existing separate chrome. The slot-highlight backdrop must follow every dynamic textarea box
+  change with the exact box-model and scroll-sync invariants under Template slots below.
 - **Queued messages: the pending strip** (`QueueStrip.tsx`, props-driven: `queue` + `onEdit`/`onRemove`)
   — the web mirror of pi's interactive-mode pending-messages area. A **streaming send never renders an
   optimistic transcript bubble** (see the store SPEC's echo contract): `ChatView.onSubmit` skips
@@ -325,8 +338,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   design (steer = injected at the next turn boundary, after the current assistant message + its tool
   calls; queue = runs after the agent settles; only abort halts an in-flight response) and proved
   illegible from key-name hints alone. While streaming the composer therefore self-documents: the
-  placeholder states meanings ("Enter steers at the next step · Cmd/Ctrl+Enter queues for when it
-  finishes") and a **send-options menu** (`send-menu` trigger beside the send button; rows
+  compact placeholder states meanings ("Enter steers · Ctrl/Cmd+Enter queues") and a
+  **send-options menu** (`send-menu` trigger beside the send button; rows
   `send-mode-steer` / `send-mode-queue` / `send-mode-interrupt`) names each mode with a one-line
   meaning + shortcut. Menu rows are **actions** (send the current draft with that mode), never a
   sticky mode switch — a persistent mode would make the next plain Enter silently obey hidden state.

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -302,13 +302,14 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   disabled while streaming) or project (`project.skills`, per-project-baseline toggles, no session) — the
   latter reused by `panels` pre-session). All props-driven; behavior detail lives in the components' jsdoc.
 - **Adaptive composer geometry** (`Composer`) — an idle draft that fits one visual line renders as a
-  **46px one-line dock**: model and effort share one compact visual group on the left while remaining two
-  independently focusable/clickable picker triggers; History and Send remain explicit on the right. A wrap,
-  explicit newline, or width change that makes the draft exceed one visual line unfolds the same shell into
-  a full-width textarea plus a stable 42px action footer; fitting one line again collapses it. This is one
-  persistent textarea, never conditional twins — the transition cannot lose focus, caret/selection, recall,
-  draft, or a template-slot session. Streaming deliberately uses the expanded form even with an empty draft,
-  because Stop + send options join the footer. `ChatView` passes the server-synced
+  shared two-tier shell: a full-width, one-visual-line message row above a stable action footer. Model and
+  effort share a compact visual group on the footer's left while remaining two independently
+  focusable/clickable picker triggers; History and Send remain explicit on the right. A wrap, explicit
+  newline, or width change that makes the draft exceed one visual line grows the message row without moving
+  the footer; fitting one line again shrinks only the message row. This is one persistent textarea, never
+  conditional twins — the transition cannot lose focus, caret/selection, recall, draft, or a template-slot
+  session. Streaming deliberately uses the expanded message row even with an empty draft, because Stop +
+  send options join the footer. `ChatView` passes the server-synced
   `ComposerGrowthLimit` prop: `compact` caps at 6 visual lines, `roomy` at 10, and the default `half-chat`
   caps the **editor shell** (textarea + footer) at 50% of the mounted chat panel, never the browser viewport;
   overflow then scrolls inside the textarea. Attachment chips, completion menus, slot hints, and QueueStrip

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -338,8 +338,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   design (steer = injected at the next turn boundary, after the current assistant message + its tool
   calls; queue = runs after the agent settles; only abort halts an in-flight response) and proved
   illegible from key-name hints alone. While streaming the composer therefore self-documents: the
-  compact placeholder states meanings ("Enter steers · Ctrl/Cmd+Enter queues") and a
-  **send-options menu** (`send-menu` trigger beside the send button; rows
+  placeholder states meanings ("Enter steers at the next step · Cmd/Ctrl+Enter queues for when it
+  finishes") and a **send-options menu** (`send-menu` trigger beside the send button; rows
   `send-mode-steer` / `send-mode-queue` / `send-mode-interrupt`) names each mode with a one-line
   meaning + shortcut. Menu rows are **actions** (send the current draft with that mode), never a
   sticky mode switch — a persistent mode would make the next plain Enter silently obey hidden state.

--- a/apps/web/src/chat/SessionStatsBar.tsx
+++ b/apps/web/src/chat/SessionStatsBar.tsx
@@ -40,7 +40,7 @@ export function SessionStatsBar({ stats }: { stats: SessionStats | null }) {
 	return (
 		<div
 			data-testid="session-stats"
-			className="flex shrink-0 flex-nowrap items-center justify-end gap-x-4 text-text-muted tr-text-metadata"
+			className="flex min-w-0 flex-nowrap items-center justify-end gap-x-4 overflow-hidden text-text-muted tr-text-metadata"
 			title="Cumulative usage: ↑ input · ↓ output · R cache read · W cache write"
 		>
 			{parts.map((part, index) => (

--- a/apps/web/src/chat/ThinkingSelector.tsx
+++ b/apps/web/src/chat/ThinkingSelector.tsx
@@ -2,17 +2,22 @@ import { RiCheckLine as Check, RiArrowDownSLine as ChevronDown } from "@remixico
 import type { ThinkingLevel } from "@thinkrail/contracts";
 import { useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib";
 
 export function ThinkingSelector({
 	level,
 	levels,
 	onSelect,
 	container,
+	className,
+	showLabel = true,
 }: {
 	level: ThinkingLevel;
 	levels: readonly ThinkingLevel[];
 	onSelect: (level: ThinkingLevel) => void;
 	container?: HTMLElement | null;
+	className?: string;
+	showLabel?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	return (
@@ -21,9 +26,12 @@ export function ThinkingSelector({
 				data-testid="thinking-selector"
 				data-open={open}
 				disabled={levels.length === 0}
-				className="flex h-32 items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:border-control-disabled-border disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
+				className={cn(
+					"flex h-32 items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:border-control-disabled-border disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
+					className,
+				)}
 			>
-				<span className="tr-text-eyebrow text-text-muted">Effort</span>
+				{showLabel ? <span className="tr-text-eyebrow text-text-muted">Effort</span> : null}
 				<span className="capitalize">{level}</span>
 				<ChevronDown className="size-16 shrink-0 text-text-muted" />
 			</PopoverTrigger>

--- a/apps/web/src/panels/ChatSettings.tsx
+++ b/apps/web/src/panels/ChatSettings.tsx
@@ -1,5 +1,5 @@
+import { RiCheckLine as Check } from "@remixicon/react";
 import type { ComposerGrowthLimit } from "@thinkrail/contracts";
-import { Check } from "lucide-react";
 import { cn } from "@/lib";
 import { toast, useAppStore } from "@/store";
 import { getTransport } from "@/transport";
@@ -41,42 +41,46 @@ export function ChatSettings() {
 	};
 
 	return (
-		<section data-testid="settings-chat" className="flex flex-col gap-sm">
-			<div className="flex flex-col gap-xs">
+		<section data-testid="settings-chat" className="flex flex-col gap-8">
+			<div className="flex flex-col gap-4">
 				<h3 className="tr-title-section text-text-default">Composer growth</h3>
 				<p className="text-text-muted tr-text-metadata">
 					Choose how tall long drafts may grow before the message field scrolls. Your choice is
 					saved on the host and follows you across devices.
 				</p>
 			</div>
-			<div role="radiogroup" aria-label="Composer growth limit" className="flex flex-col gap-xs">
+			<div role="radiogroup" aria-label="Composer growth limit" className="flex flex-col gap-4">
 				{GROWTH_CHOICES.map(({ id, label, hint, description }) => {
 					const active = id === growthLimit;
 					return (
-						<button
+						<label
 							key={id}
-							type="button"
-							role="radio"
-							aria-checked={active}
 							data-testid={`composer-growth-${id}`}
 							data-active={active}
-							onClick={() => select(id)}
 							className={cn(
-								"flex items-center gap-sm rounded-[var(--radius-sm)] border px-md py-sm text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+								"flex cursor-pointer items-center gap-8 rounded-[var(--radius-sm)] border px-12 py-8 text-left transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary",
 								active
 									? "border-primary-muted bg-clip-padding bg-primary-subtle"
 									: "border-border-default hover:bg-control-bg-hovered",
 							)}
 						>
+							<input
+								type="radio"
+								name="composer-growth-limit"
+								value={id}
+								checked={active}
+								onChange={() => select(id)}
+								className="sr-only"
+							/>
 							<span className="min-w-0 flex-1">
-								<span className="flex items-center gap-xs tr-title-compact text-text-default">
+								<span className="flex items-center gap-4 tr-title-compact text-text-default">
 									{label}
 									<span className="text-text-muted tr-text-metadata">{hint}</span>
 								</span>
 								<span className="block text-text-muted tr-text-metadata">{description}</span>
 							</span>
-							{active ? <Check className="size-4 shrink-0 text-primary" /> : null}
-						</button>
+							{active ? <Check className="size-16 shrink-0 text-primary" /> : null}
+						</label>
 					);
 				})}
 			</div>

--- a/apps/web/src/panels/ChatSettings.tsx
+++ b/apps/web/src/panels/ChatSettings.tsx
@@ -1,0 +1,85 @@
+import type { ComposerGrowthLimit } from "@thinkrail/contracts";
+import { Check } from "lucide-react";
+import { cn } from "@/lib";
+import { toast, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+
+const GROWTH_CHOICES: {
+	id: ComposerGrowthLimit;
+	label: string;
+	hint: string;
+	description: string;
+}[] = [
+	{
+		id: "compact",
+		label: "Compact",
+		hint: "6 lines",
+		description: "Keeps long drafts to six visual lines before scrolling.",
+	},
+	{
+		id: "roomy",
+		label: "Roomy",
+		hint: "10 lines",
+		description: "Keeps long drafts to ten visual lines before scrolling.",
+	},
+	{
+		id: "half-chat",
+		label: "Half chat",
+		hint: "Default",
+		description: "Uses up to half of the mounted chat panel before scrolling.",
+	},
+];
+
+export function ChatSettings() {
+	const growthLimit = useAppStore((state) => state.composerGrowthLimit);
+
+	const select = (composerGrowthLimit: ComposerGrowthLimit) => {
+		if (composerGrowthLimit === growthLimit) return;
+		getTransport()
+			.request("settings.update", { config: { composerGrowthLimit } })
+			.catch(() => toast.error("Couldn't change composer growth"));
+	};
+
+	return (
+		<section data-testid="settings-chat" className="flex flex-col gap-sm">
+			<div className="flex flex-col gap-xs">
+				<h3 className="tr-title-section text-text-default">Composer growth</h3>
+				<p className="text-text-muted tr-text-metadata">
+					Choose how tall long drafts may grow before the message field scrolls. Your choice is
+					saved on the host and follows you across devices.
+				</p>
+			</div>
+			<div role="radiogroup" aria-label="Composer growth limit" className="flex flex-col gap-xs">
+				{GROWTH_CHOICES.map(({ id, label, hint, description }) => {
+					const active = id === growthLimit;
+					return (
+						<button
+							key={id}
+							type="button"
+							role="radio"
+							aria-checked={active}
+							data-testid={`composer-growth-${id}`}
+							data-active={active}
+							onClick={() => select(id)}
+							className={cn(
+								"flex items-center gap-sm rounded-[var(--radius-sm)] border px-md py-sm text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+								active
+									? "border-primary-muted bg-clip-padding bg-primary-subtle"
+									: "border-border-default hover:bg-control-bg-hovered",
+							)}
+						>
+							<span className="min-w-0 flex-1">
+								<span className="flex items-center gap-xs tr-title-compact text-text-default">
+									{label}
+									<span className="text-text-muted tr-text-metadata">{hint}</span>
+								</span>
+								<span className="block text-text-muted tr-text-metadata">{description}</span>
+							</span>
+							{active ? <Check className="size-4 shrink-0 text-primary" /> : null}
+						</button>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -340,7 +340,11 @@ a project picker, the prompt hero, and the reused
   bundled catalog from `themes`, with the resolved active selection from `store.theme` marked; clicking
   one fires `settings.update` and the UI **converges on the `settings.changed` broadcast** (no optimistic
   apply), a rejected update raising a toast; the picker never owns a theme list — it renders the catalog
-  the glob discovered at build time); the **shell-owned injected Layout section** (Balanced/Focus/Review
+  the glob discovered at build time); **`ChatSettings`** (the live section immediately after Appearance —
+  three radio cards over `store.composerGrowthLimit`, updating `AppConfig.composerGrowthLimit` with the same
+  converge-on-`settings.changed`, toast-on-rejection pattern; the labels explain when the one-line composer
+  stops growing, while `contracts` owns the closed preset ids/default); the **shell-owned injected Layout
+  section** (Balanced/Focus/Review
   plus named custom preset cards, one host-synchronized default selection, capture-current/rename/delete
   for customs, and the default-6 maximum side groups per side; settings changes converge through
   `settings.changed`. With an active workspace each preset offers confirmable **Apply now…**, which asks
@@ -383,8 +387,8 @@ a project picker, the prompt hero, and the reused
   toggle** — a switch over `store.analyticsEnabled`, fired via `settings.update { analyticsEnabled }`
   with the same converge-on-broadcast pattern as the theme, plus the what-is/isn't-collected copy; only
   the boolean ever crosses the wire, see `submodule-server-analytics`. A single dimmed "General" nav item ("Soon") still signals the shell is
-  built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings`/`PrivacySettings` are the
-  panels-owned **integration pieces** (store + transport); `SettingsDialog` receives the Layout section
+  built to grow. `ProvidersSettings`/`AppearanceSettings`/`ChatSettings`/`TemplatesSettings`/
+  `PrivacySettings` are the panels-owned **integration pieces** (store + transport); `SettingsDialog` receives the Layout section
   from the shell composition root so no panel reaches sideways into shell, and the `LoginDialog` stays
   presentational (`auth` module).
 

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -1,4 +1,5 @@
 import {
+	RiChat2Line as MessageSquareText,
 	RiGitBranchLine as GitBranch,
 	RiKeyLine as KeyRound,
 	RiLayoutTop2Line as LayoutPanelTop,
@@ -14,6 +15,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { cn } from "@/lib";
 import { SettingsSection, useAppStore } from "@/store";
 import { AppearanceSettings } from "./AppearanceSettings";
+import { ChatSettings } from "./ChatSettings";
 import { GithubSettings } from "./GithubSettings";
 import { PrivacySettings } from "./PrivacySettings";
 import { ProvidersSettings } from "./ProvidersSettings";
@@ -24,6 +26,7 @@ const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
 	{ id: SettingsSection.Providers, label: "Providers", icon: KeyRound },
 	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
 	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
+	{ id: SettingsSection.Chat, label: "Chat", icon: MessageSquareText },
 	{ id: SettingsSection.Layout, label: "Layout", icon: LayoutPanelTop },
 	{ id: SettingsSection.Terminal, label: "Terminal", icon: SquareTerminal },
 	{ id: SettingsSection.Templates, label: "Templates", icon: LayoutTemplate },
@@ -95,6 +98,8 @@ export function SettingsDialog({ layoutSettings }: { layoutSettings: ReactNode }
 							<ProvidersSettings />
 						) : section === SettingsSection.Github ? (
 							<GithubSettings />
+						) : section === SettingsSection.Chat ? (
+							<ChatSettings />
 						) : section === SettingsSection.Layout ? (
 							layoutSettings
 						) : section === SettingsSection.Terminal ? (

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -1,10 +1,10 @@
 import {
-	RiChat2Line as MessageSquareText,
 	RiGitBranchLine as GitBranch,
 	RiKeyLine as KeyRound,
 	RiLayoutTop2Line as LayoutPanelTop,
 	RiLayoutGridLine as LayoutTemplate,
 	type RemixiconComponentType as LucideIcon,
+	RiChat2Line as MessageSquareText,
 	RiPaletteLine as Palette,
 	RiShieldCheckLine as ShieldCheck,
 	RiEqualizerLine as SlidersHorizontal,

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -300,7 +300,7 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   `provider.login` frame (creating `activeLogin` if the frame arrived first; ignoring frames for a different
   live login), **`clearLoginInput()`** drops the live input the instant a reply is sent (no double-submit),
   and **`clearLogin()`** dismisses it. The **settings surface** state — **`settingsOpen`** +
-  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Layout`/`Terminal`/`Templates`/`Privacy`) with
+  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Chat`/`Layout`/`Terminal`/`Templates`/`Privacy`) with
   **`openSettings(section?)`** (deep-links to a section, defaults to Providers) / **`closeSettings()`** /
   **`setSettingsSection()`** — lives here so the top-bar gear AND the Welcome provider warning open Settings
   to a section without prop-drilling through the shell. The **theme** state — **`theme: ThemeId`** (the
@@ -308,9 +308,9 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   (folds the server-synced `AppConfig` in from
   `server.welcome` / the `settings.changed` broadcast) — lives here too; it's a **pure value only** (the
   theme-application side-effect is the shell's, keyed off `theme`), and defaults to
-  `DEFAULT_CONFIG.theme` until the welcome arrives. **`layoutSettings: LayoutSettings`** and
-  **`analyticsEnabled: boolean`** ride the same `applyConfig` fold (host-owned, defaulted from
-  `DEFAULT_CONFIG`) — the Layout and Privacy sections' read sides. Layout settings are not a second copy of
+  `DEFAULT_CONFIG.theme` until the welcome arrives. **`composerGrowthLimit: ComposerGrowthLimit`**,
+  **`layoutSettings: LayoutSettings`**, and **`analyticsEnabled: boolean`** ride the same `applyConfig` fold
+  (host-owned, defaulted from `DEFAULT_CONFIG`) — the Chat, Layout, and Privacy sections' read sides. Layout settings are not a second copy of
   any workspace document: they carry only the portable preset catalog/default and group limit. The
   **toast queue** — **`toasts: Toast[]`** (oldest-first) with **`pushToast(toast) → id`** / **`dismissToast(id)`**
   and the ergonomic **`toast.error/success/info(message, title?)`** helper (wraps `pushToast` so a non-React

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -2,15 +2,15 @@ import { beforeEach, expect, test } from "bun:test";
 import {
 	DEFAULT_CONFIG,
 	type ExtUiRequest,
-	PiEvent,
-	Project,
-	SessionSummary,
-	SpecGraphNode,
-	WireModel,
-	Workspace,
-	WorkspaceFsChangedPayload,
-	WorkspaceLayoutDocument,
-	WorkspaceSkillChange,
+	type PiEvent,
+	type Project,
+	type SessionSummary,
+	type SpecGraphNode,
+	type WireModel,
+	type Workspace,
+	type WorkspaceFsChangedPayload,
+	type WorkspaceLayoutDocument,
+	type WorkspaceSkillChange,
 } from "@thinkrail/contracts";
 import type { ChatTurn } from "../chat/types";
 import { userText } from "../lib";

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, test } from "bun:test";
-import type {
-	ExtUiRequest,
+import {
+	DEFAULT_CONFIG,
+	type ExtUiRequest,
 	PiEvent,
 	Project,
 	SessionSummary,
@@ -2615,6 +2616,14 @@ test("applyConfig folds the server-synced app config in (theme is an opaque host
 	expect(useAppStore.getState().theme).toBe("acme.solarized");
 	useAppStore.getState().applyConfig({ theme: "custom.high-contrast" });
 	expect(useAppStore.getState().theme).toBe("custom.high-contrast");
+});
+
+test("applyConfig projects the composer growth limit", () => {
+	useAppStore.getState().applyConfig({
+		...DEFAULT_CONFIG,
+		composerGrowthLimit: "roomy",
+	});
+	expect(useAppStore.getState()).toHaveProperty("composerGrowthLimit", "roomy");
 });
 
 test("diff tabs: openTab dedupes by id + activates; view + contents update in place", () => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1,6 +1,7 @@
 import type {
 	AppConfig,
 	AskUserQuestionResult,
+	ComposerGrowthLimit,
 	ExtUiRequest,
 	GitDiffScope,
 	LayoutAuxiliaryRegion,
@@ -226,6 +227,7 @@ export const SettingsSection = {
 	Providers: "providers",
 	Github: "github",
 	Appearance: "appearance",
+	Chat: "chat",
 	Layout: "layout",
 	Terminal: "terminal",
 	Templates: "templates",
@@ -692,6 +694,7 @@ interface AppState {
 	theme: ThemeId;
 	analyticsEnabled: boolean;
 	terminalReplayKb: number;
+	composerGrowthLimit: ComposerGrowthLimit;
 	layoutSettings: LayoutSettings;
 	toasts: Toast[];
 	setStatus: (status: ConnectionStatus) => void;
@@ -891,6 +894,7 @@ function configPatch(config: AppConfig) {
 		theme: config.theme,
 		analyticsEnabled: config.analyticsEnabled,
 		terminalReplayKb: config.terminalReplayKb,
+		composerGrowthLimit: config.composerGrowthLimit ?? DEFAULT_CONFIG.composerGrowthLimit,
 		layoutSettings: config.layout ?? DEFAULT_CONFIG.layout,
 	};
 }
@@ -1396,6 +1400,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	theme: DEFAULT_CONFIG.theme,
 	analyticsEnabled: DEFAULT_CONFIG.analyticsEnabled,
 	terminalReplayKb: DEFAULT_CONFIG.terminalReplayKb,
+	composerGrowthLimit: DEFAULT_CONFIG.composerGrowthLimit,
 	layoutSettings: DEFAULT_CONFIG.layout,
 	toasts: [],
 	setStatus: (status) =>

--- a/e2e/composer-adaptive.spec.ts
+++ b/e2e/composer-adaptive.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openWorkspaceChat } from "./fixtures/app";
+import { hideAuxiliaryWorkbench, openWorkspaceChat, PHONE_VIEWPORT } from "./fixtures/app";
 
 async function box(locator: import("@playwright/test").Locator) {
 	const value = await locator.boundingBox();
@@ -26,7 +26,9 @@ test("idle composer is one line and unfolds only when the draft needs it", async
 
 	for (const control of [model, effort, history, send]) {
 		const controlBox = await box(control);
-		expect(Math.abs(controlBox.y + controlBox.height - (compactInput.y + compactInput.height))).toBeLessThanOrEqual(4);
+		expect(
+			Math.abs(controlBox.y + controlBox.height - (compactInput.y + compactInput.height)),
+		).toBeLessThanOrEqual(4);
 	}
 
 	await input.fill("Inspect the retry flow.\nThen add focused coverage.");
@@ -38,6 +40,34 @@ test("idle composer is one line and unfolds only when the draft needs it", async
 	await input.fill("Short follow-up");
 	await expect(composer).toHaveAttribute("data-expanded", "false");
 	expect((await box(input)).height).toBeLessThanOrEqual(40);
+});
+
+test("panel width changes expand and collapse the same textarea", async ({ page }) => {
+	await page.setViewportSize({ width: 1920, height: 900 });
+	await openWorkspaceChat(page);
+
+	const composer = page.getByTestId("chat-composer");
+	const input = page.getByTestId("chat-input");
+	const initialElement = await input.elementHandle();
+	if (!initialElement) throw new Error("composer textarea missing");
+	await input.fill(
+		"Keep the same focused draft and selection while a narrower mounted chat panel makes this line wrap.",
+	);
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	await input.evaluate((element) => element.setSelectionRange(18, 18));
+
+	await page.setViewportSize({ width: 700, height: 900 });
+	await expect(composer).toHaveAttribute("data-expanded", "true");
+	expect(await input.evaluate((element, initial) => element === initial, initialElement)).toBe(
+		true,
+	);
+	expect(await input.evaluate((element) => element.selectionStart)).toBe(18);
+
+	await page.setViewportSize({ width: 1920, height: 900 });
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	expect(await input.evaluate((element, initial) => element === initial, initialElement)).toBe(
+		true,
+	);
 });
 
 test("half-chat growth caps the editor shell and scrolls the textarea", async ({ page }) => {
@@ -90,7 +120,9 @@ test("chat growth setting persists and compact means six visual lines", async ({
 	const lines = await input.evaluate((element) => {
 		const styles = getComputedStyle(element);
 		return (
-			(element.clientHeight - Number.parseFloat(styles.paddingTop) - Number.parseFloat(styles.paddingBottom)) /
+			(element.clientHeight -
+				Number.parseFloat(styles.paddingTop) -
+				Number.parseFloat(styles.paddingBottom)) /
 			Number.parseFloat(styles.lineHeight)
 		);
 	});
@@ -105,10 +137,19 @@ test("chat growth setting persists and compact means six visual lines", async ({
 
 test("compact phone controls remain inside the chat viewport", async ({ page }) => {
 	await openWorkspaceChat(page);
-	await page.setViewportSize({ width: 320, height: 720 });
+	await hideAuxiliaryWorkbench(page);
+	await page.setViewportSize(PHONE_VIEWPORT);
 
 	const composer = page.getByTestId("chat-composer");
 	await expect(composer).toHaveAttribute("data-expanded", "false");
+	const shellBox = await box(page.getByTestId("chat-composer-shell"));
+	const idleTextMetrics = await page.getByTestId("chat-input").evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		scrollHeight: element.scrollHeight,
+	}));
+	expect(idleTextMetrics.scrollHeight).toBeLessThanOrEqual(idleTextMetrics.clientHeight);
+	expect(shellBox.x).toBeGreaterThanOrEqual(0);
+	expect(shellBox.x + shellBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	for (const control of [
 		page.getByTestId("model-selector"),
 		page.getByTestId("thinking-selector"),
@@ -117,7 +158,7 @@ test("compact phone controls remain inside the chat viewport", async ({ page }) 
 	]) {
 		const controlBox = await box(control);
 		expect(controlBox.x).toBeGreaterThanOrEqual(0);
-		expect(controlBox.x + controlBox.width).toBeLessThanOrEqual(320);
+		expect(controlBox.x + controlBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	}
 	expect((await box(page.getByTestId("chat-input"))).height).toBeLessThanOrEqual(40);
 });

--- a/e2e/composer-adaptive.spec.ts
+++ b/e2e/composer-adaptive.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+import { openWorkspaceChat } from "./fixtures/app";
+
+async function box(locator: import("@playwright/test").Locator) {
+	const value = await locator.boundingBox();
+	if (!value) throw new Error("composer element has no layout box");
+	return value;
+}
+
+test("idle composer is one line and unfolds only when the draft needs it", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const composer = page.getByTestId("chat-composer");
+	const shell = page.getByTestId("chat-composer-shell");
+	const input = page.getByTestId("chat-input");
+	const model = page.getByTestId("model-selector");
+	const effort = page.getByTestId("thinking-selector");
+	const history = page.getByTestId("history-open");
+	const send = page.getByTestId("chat-send");
+
+	const compactInput = await box(input);
+	expect(compactInput.height).toBeGreaterThanOrEqual(32);
+	expect(compactInput.height).toBeLessThanOrEqual(40);
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	expect((await box(shell)).height).toBeLessThanOrEqual(50);
+
+	for (const control of [model, effort, history, send]) {
+		const controlBox = await box(control);
+		expect(Math.abs(controlBox.y + controlBox.height - (compactInput.y + compactInput.height))).toBeLessThanOrEqual(4);
+	}
+
+	await input.fill("Inspect the retry flow.\nThen add focused coverage.");
+	await expect(composer).toHaveAttribute("data-expanded", "true");
+	const expandedInput = await box(input);
+	expect(expandedInput.height).toBeGreaterThan(compactInput.height);
+	expect((await box(model)).y).toBeGreaterThanOrEqual(expandedInput.y + expandedInput.height);
+
+	await input.fill("Short follow-up");
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	expect((await box(input)).height).toBeLessThanOrEqual(40);
+});
+
+test("half-chat growth caps the editor shell and scrolls the textarea", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const chat = page.getByTestId("chat-view");
+	const composer = page.getByTestId("chat-composer");
+	const shell = page.getByTestId("chat-composer-shell");
+	const input = page.getByTestId("chat-input");
+	await input.fill(Array.from({ length: 80 }, (_, index) => `line ${index + 1}`).join("\n"));
+	await expect(composer).toHaveAttribute("data-expanded", "true");
+
+	const chatBox = await box(chat);
+	const shellBox = await box(shell);
+	expect(shellBox.height).toBeLessThanOrEqual(chatBox.height * 0.5 + 2);
+	const overflow = await input.evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		scrollHeight: element.scrollHeight,
+		overflowY: getComputedStyle(element).overflowY,
+	}));
+	expect(overflow.scrollHeight).toBeGreaterThan(overflow.clientHeight);
+	expect(overflow.overflowY).toBe("auto");
+});
+
+test("chat growth setting persists and compact means six visual lines", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+
+	const compact = page.getByTestId("composer-growth-compact");
+	const roomy = page.getByTestId("composer-growth-roomy");
+	const half = page.getByTestId("composer-growth-half-chat");
+	await expect(compact).toBeVisible();
+	await expect(roomy).toBeVisible();
+	await expect(half).toHaveAttribute("data-active", "true");
+	await compact.click();
+	await expect(compact).toHaveAttribute("data-active", "true");
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	await expect(compact).toHaveAttribute("data-active", "true");
+	await page.keyboard.press("Escape");
+
+	await openWorkspaceChat(page);
+	const input = page.getByTestId("chat-input");
+	await input.fill(Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join("\n"));
+	const lines = await input.evaluate((element) => {
+		const styles = getComputedStyle(element);
+		return (
+			(element.clientHeight - Number.parseFloat(styles.paddingTop) - Number.parseFloat(styles.paddingBottom)) /
+			Number.parseFloat(styles.lineHeight)
+		);
+	});
+	expect(lines).toBeGreaterThanOrEqual(5.9);
+	expect(lines).toBeLessThanOrEqual(6.1);
+
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	await half.click();
+	await expect(half).toHaveAttribute("data-active", "true");
+});
+
+test("compact phone controls remain inside the chat viewport", async ({ page }) => {
+	await openWorkspaceChat(page);
+	await page.setViewportSize({ width: 320, height: 720 });
+
+	const composer = page.getByTestId("chat-composer");
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	for (const control of [
+		page.getByTestId("model-selector"),
+		page.getByTestId("thinking-selector"),
+		page.getByTestId("history-open"),
+		page.getByTestId("chat-send"),
+	]) {
+		const controlBox = await box(control);
+		expect(controlBox.x).toBeGreaterThanOrEqual(0);
+		expect(controlBox.x + controlBox.width).toBeLessThanOrEqual(320);
+	}
+	expect((await box(page.getByTestId("chat-input"))).height).toBeLessThanOrEqual(40);
+});

--- a/e2e/composer-adaptive.spec.ts
+++ b/e2e/composer-adaptive.spec.ts
@@ -20,6 +20,7 @@ test("idle composer keeps one message line above a stable controls row", async (
 
 	const compactShell = await box(shell);
 	const compactInput = await box(input);
+	const compactWrapMeasure = await box(page.getByTestId("chat-input-sizer"));
 	const compactModel = await box(model);
 	expect(compactInput.height).toBeGreaterThanOrEqual(32);
 	expect(compactInput.height).toBeLessThanOrEqual(40);
@@ -29,6 +30,8 @@ test("idle composer keeps one message line above a stable controls row", async (
 	expect(compactInput.x + compactInput.width).toBeGreaterThanOrEqual(
 		compactShell.x + compactShell.width - 8,
 	);
+	expect(Math.abs(compactWrapMeasure.x - compactInput.x)).toBeLessThanOrEqual(0.5);
+	expect(Math.abs(compactWrapMeasure.width - compactInput.width)).toBeLessThanOrEqual(0.5);
 
 	const compactFooterBottom = compactModel.y + compactModel.height;
 	for (const control of [model, effort, history, send]) {

--- a/e2e/composer-adaptive.spec.ts
+++ b/e2e/composer-adaptive.spec.ts
@@ -7,7 +7,7 @@ async function box(locator: import("@playwright/test").Locator) {
 	return value;
 }
 
-test("idle composer is one line and unfolds only when the draft needs it", async ({ page }) => {
+test("idle composer keeps one message line above a stable controls row", async ({ page }) => {
 	await openWorkspaceChat(page);
 
 	const composer = page.getByTestId("chat-composer");
@@ -18,28 +18,37 @@ test("idle composer is one line and unfolds only when the draft needs it", async
 	const history = page.getByTestId("history-open");
 	const send = page.getByTestId("chat-send");
 
+	const compactShell = await box(shell);
 	const compactInput = await box(input);
+	const compactModel = await box(model);
 	expect(compactInput.height).toBeGreaterThanOrEqual(32);
 	expect(compactInput.height).toBeLessThanOrEqual(40);
 	await expect(composer).toHaveAttribute("data-expanded", "false");
-	expect((await box(shell)).height).toBeLessThanOrEqual(50);
+	expect(compactShell.height).toBeGreaterThanOrEqual(compactInput.height + compactModel.height);
+	expect(compactInput.x).toBeLessThanOrEqual(compactShell.x + 8);
+	expect(compactInput.x + compactInput.width).toBeGreaterThanOrEqual(
+		compactShell.x + compactShell.width - 8,
+	);
 
+	const compactFooterBottom = compactModel.y + compactModel.height;
 	for (const control of [model, effort, history, send]) {
 		const controlBox = await box(control);
-		expect(
-			Math.abs(controlBox.y + controlBox.height - (compactInput.y + compactInput.height)),
-		).toBeLessThanOrEqual(4);
+		expect(controlBox.y).toBeGreaterThanOrEqual(compactInput.y + compactInput.height);
+		expect(Math.abs(controlBox.y + controlBox.height - compactFooterBottom)).toBeLessThanOrEqual(4);
 	}
 
 	await input.fill("Inspect the retry flow.\nThen add focused coverage.");
 	await expect(composer).toHaveAttribute("data-expanded", "true");
 	const expandedInput = await box(input);
+	const expandedModel = await box(model);
 	expect(expandedInput.height).toBeGreaterThan(compactInput.height);
-	expect((await box(model)).y).toBeGreaterThanOrEqual(expandedInput.y + expandedInput.height);
+	expect(expandedModel.y).toBeGreaterThanOrEqual(expandedInput.y + expandedInput.height);
+	expect(Math.abs(expandedModel.y - compactModel.y)).toBeLessThanOrEqual(2);
 
 	await input.fill("Short follow-up");
 	await expect(composer).toHaveAttribute("data-expanded", "false");
 	expect((await box(input)).height).toBeLessThanOrEqual(40);
+	expect(Math.abs((await box(model)).y - compactModel.y)).toBeLessThanOrEqual(2);
 });
 
 test("panel width changes expand and collapse the same textarea", async ({ page }) => {
@@ -160,5 +169,11 @@ test("compact phone controls remain inside the chat viewport", async ({ page }) 
 		expect(controlBox.x).toBeGreaterThanOrEqual(0);
 		expect(controlBox.x + controlBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	}
-	expect((await box(page.getByTestId("chat-input"))).height).toBeLessThanOrEqual(40);
+	const inputBox = await box(page.getByTestId("chat-input"));
+	expect(inputBox.height).toBeLessThanOrEqual(40);
+	expect(inputBox.x).toBeLessThanOrEqual(shellBox.x + 8);
+	expect(inputBox.x + inputBox.width).toBeGreaterThanOrEqual(shellBox.x + shellBox.width - 8);
+	expect((await box(page.getByTestId("model-selector"))).y).toBeGreaterThanOrEqual(
+		inputBox.y + inputBox.height,
+	);
 });

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -113,7 +113,14 @@ test("stats refresh after a turn completes (cheap win #3)", { tag: "@agent" }, a
 	await expect(stats).toBeVisible();
 	await expect(stats).toContainText(/[↑↓RW]/);
 
-	await page.setViewportSize({ width: 320, height: 720 });
+	await hideAuxiliaryWorkbench(page);
+	await page.setViewportSize(PHONE_VIEWPORT);
+	await expect
+		.poll(async () => {
+			const chatBox = await page.getByTestId("chat-view").boundingBox();
+			return chatBox ? chatBox.x + chatBox.width : Number.POSITIVE_INFINITY;
+		})
+		.toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	const skills = page.getByTestId("open-skills");
 	await expect(skills).toBeVisible();
 	const statsBox = await stats.boundingBox();
@@ -121,6 +128,6 @@ test("stats refresh after a turn completes (cheap win #3)", { tag: "@agent" }, a
 	if (!statsBox || !skillsBox) throw new Error("chat header item has no bounding box");
 	for (const box of [statsBox, skillsBox]) {
 		expect(box.x).toBeGreaterThanOrEqual(0);
-		expect(box.x + box.width).toBeLessThanOrEqual(320);
+		expect(box.x + box.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	}
 });

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -14,35 +14,28 @@ async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 }
 
-test("composer prompt is moderately tall with model and effort controls underneath", {
+test("streaming unfolds the one-line draft into a complete action rail", {
 	tag: "@agent",
 }, async ({ page }) => {
+	test.setTimeout(90_000);
 	await openChat(page);
 
 	const input = page.getByTestId("chat-input");
-	const modelSelector = page.getByTestId("model-selector");
-	const effortSelector = page.getByTestId("thinking-selector");
-	const send = page.getByTestId("chat-send");
+	await input.fill("Use the bash tool to run `sleep 8`, then reply with done.");
+	await page.getByTestId("chat-send").click();
 
-	await expect(input).toBeVisible();
-	await expect(modelSelector).toBeVisible();
-	await expect(effortSelector).toBeVisible();
-	await expect(send).toBeVisible();
-
+	const composer = page.getByTestId("chat-composer");
+	await expect(page.getByTestId("chat-abort")).toBeVisible();
+	await expect(page.getByTestId("send-menu")).toBeVisible();
+	await expect(composer).toHaveAttribute("data-expanded", "true");
 	const inputBox = await input.boundingBox();
-	const modelBox = await modelSelector.boundingBox();
-	const effortBox = await effortSelector.boundingBox();
-	const sendBox = await send.boundingBox();
-	if (!inputBox || !modelBox || !effortBox || !sendBox) {
-		throw new Error("Composer layout boxes were not measurable");
-	}
+	const modelBox = await page.getByTestId("model-selector").boundingBox();
+	if (!inputBox || !modelBox) throw new Error("Composer layout boxes were not measurable");
+	expect(inputBox.height).toBeLessThanOrEqual(40);
+	expect(modelBox.y).toBeGreaterThanOrEqual(inputBox.y + inputBox.height);
 
-	expect(inputBox.height).toBeGreaterThanOrEqual(100);
-	expect(inputBox.height).toBeLessThanOrEqual(130);
-	const belowInputY = inputBox.y + inputBox.height;
-	expect(modelBox.y).toBeGreaterThanOrEqual(belowInputY);
-	expect(effortBox.y).toBeGreaterThanOrEqual(belowInputY);
-	expect(sendBox.y).toBeGreaterThanOrEqual(belowInputY);
+	await page.getByTestId("chat-abort").click();
+	await expect(page.getByTestId("chat-abort")).toBeHidden();
 });
 
 test("model picker plus file and portable-skill completion use the live session catalog", {

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+import {
+	createWorkspaceViaDialog,
+	hideAuxiliaryWorkbench,
+	openFixtureProject,
+	PHONE_VIEWPORT,
+	worktreeRows,
+} from "./fixtures/app";
 
 async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await openFixtureProject(page);
@@ -19,6 +25,8 @@ test("streaming unfolds the one-line draft into a complete action rail", {
 }, async ({ page }) => {
 	test.setTimeout(90_000);
 	await openChat(page);
+	await hideAuxiliaryWorkbench(page);
+	await page.setViewportSize(PHONE_VIEWPORT);
 
 	const input = page.getByTestId("chat-input");
 	await input.fill("Use the bash tool to run `sleep 8`, then reply with done.");
@@ -33,6 +41,21 @@ test("streaming unfolds the one-line draft into a complete action rail", {
 	if (!inputBox || !modelBox) throw new Error("Composer layout boxes were not measurable");
 	expect(inputBox.height).toBeLessThanOrEqual(40);
 	expect(modelBox.y).toBeGreaterThanOrEqual(inputBox.y + inputBox.height);
+	const shellBox = await page.getByTestId("chat-composer-shell").boundingBox();
+	if (!shellBox) throw new Error("Composer shell was not measurable");
+	expect(shellBox.x).toBeGreaterThanOrEqual(0);
+	expect(shellBox.x + shellBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
+	for (const control of [
+		page.getByTestId("history-open"),
+		page.getByTestId("chat-abort"),
+		page.getByTestId("send-menu"),
+		page.getByTestId("chat-send"),
+	]) {
+		const controlBox = await control.boundingBox();
+		if (!controlBox) throw new Error("Streaming composer control was not measurable");
+		expect(controlBox.x).toBeGreaterThanOrEqual(0);
+		expect(controlBox.x + controlBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
+	}
 
 	await page.getByTestId("chat-abort").click();
 	await expect(page.getByTestId("chat-abort")).toBeHidden();

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -17,6 +17,8 @@ import {
 } from "./paths";
 import { fixtureRepoHealthy, seedFixtureRepo } from "./repo";
 
+export const PHONE_VIEWPORT = { width: 390, height: 780 } as const;
+
 function removeTree(path: string): void {
 	rmSync(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
 }
@@ -24,6 +26,19 @@ function removeTree(path: string): void {
 export async function pressPlatformShortcut(page: Page, key: string): Promise<void> {
 	const apple = await page.evaluate(() => /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? ""));
 	await page.keyboard.press(`${apple ? "Meta" : "Control"}+${key}`);
+}
+
+export async function hideAuxiliaryWorkbench(page: Page): Promise<void> {
+	for (const [testId, shortcut] of [
+		["left-stack", "B"],
+		["right-stack", "J"],
+		["bottom-panel", "Shift+J"],
+	] as const) {
+		const panel = page.getByTestId(testId);
+		if ((await panel.count()) === 0) continue;
+		await pressPlatformShortcut(page, shortcut);
+		await expect(panel).toHaveCount(0);
+	}
 }
 
 function resetState(): void {

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -185,6 +185,50 @@ test.describe("prompt templates in the composer", () => {
 		await expect(backdrop).not.toBeVisible();
 	});
 
+	test("the slot backdrop shares dynamic textarea geometry and capped scrolling", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rena");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		await expect(input).toHaveValue(/^Rename ⟨name⟩ and update every ⟨name⟩ reference\.\s*$/);
+		await page.keyboard.insertText("Widget ".repeat(300));
+		await expect(page.getByTestId("chat-composer")).toHaveAttribute("data-expanded", "true");
+
+		const backdrop = page.getByTestId("slot-backdrop");
+		const geometry = await input.evaluate((element) => {
+			const overlay = document.querySelector<HTMLElement>('[data-testid="slot-backdrop"]');
+			if (!overlay) throw new Error("slot backdrop missing");
+			const inputRect = element.getBoundingClientRect();
+			const backdropRect = overlay.getBoundingClientRect();
+			return {
+				input: { x: inputRect.x, y: inputRect.y, width: inputRect.width, height: inputRect.height },
+				backdrop: {
+					x: backdropRect.x,
+					y: backdropRect.y,
+					width: backdropRect.width,
+					height: backdropRect.height,
+				},
+				scrollHeight: element.scrollHeight,
+				clientHeight: element.clientHeight,
+			};
+		});
+		expect(geometry.input.height).toBeGreaterThan(108);
+		expect(geometry.backdrop.x).toBeCloseTo(geometry.input.x, 0);
+		expect(geometry.backdrop.y).toBeCloseTo(geometry.input.y, 0);
+		expect(geometry.backdrop.width).toBeCloseTo(geometry.input.width, 0);
+		expect(geometry.backdrop.height).toBeCloseTo(geometry.input.height, 0);
+		expect(geometry.scrollHeight).toBeGreaterThan(geometry.clientHeight);
+
+		await input.evaluate((element) => {
+			element.scrollTop = element.scrollHeight;
+			element.dispatchEvent(new Event("scroll"));
+		});
+		await expect.poll(() => backdrop.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+	});
+
 	test("sending directly (no Tab) still mirrors a filled slot's text into its same-group sibling", async ({
 		page,
 	}) => {

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -191,7 +191,11 @@ of the host.
   and raw PI models are structurally absent; server and web map codes to their own generic copy);
   the **theme/config selection** — **`ThemeId`** is an open string on the wire, because the host persists
   an opaque selection while the independently shipped web client owns the available manifest catalog;
-  **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, layout }` — an extensible bag; `layout` is the
+  **`ComposerGrowthLimit`** (`"compact" | "roomy" | "half-chat"`) is the closed, server-synced composer
+  height preference: 6 visual lines, 10 visual lines, or 50% of the mounted chat panel respectively;
+  `"half-chat"` is the default, and the web owns translating these semantic ids into geometry;
+  **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, composerGrowthLimit, layout }` — an
+  extensible bag; `layout` is the
   **`LayoutSettings`** selection (`defaultPresetId`, named portable `customPresets`, `maxSideGroups`
   defaulting to 6, and independent `maxBottomGroups` defaulting to 3); `analyticsEnabled` is the
   anonymous-usage-analytics switch, default `true`

--- a/packages/contracts/src/domain.test.ts
+++ b/packages/contracts/src/domain.test.ts
@@ -40,9 +40,13 @@ describe("isRetriedAttempt", () => {
 	});
 });
 
-describe("layout defaults", () => {
+describe("config defaults", () => {
 	test("bottom groups have an independent default limit", () => {
 		expect(DEFAULT_CONFIG.layout.maxBottomGroups).toBe(3);
+	});
+
+	test("the composer grows to half the chat by default", () => {
+		expect(DEFAULT_CONFIG).toHaveProperty("composerGrowthLimit", "half-chat");
 	});
 });
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -473,10 +473,18 @@ export interface LayoutSettings {
 	maxBottomGroups: number;
 }
 
+export const COMPOSER_GROWTH_LIMITS = ["compact", "roomy", "half-chat"] as const;
+export type ComposerGrowthLimit = (typeof COMPOSER_GROWTH_LIMITS)[number];
+
+export function isComposerGrowthLimit(value: unknown): value is ComposerGrowthLimit {
+	return COMPOSER_GROWTH_LIMITS.some((limit) => limit === value);
+}
+
 export interface AppConfig {
 	theme: ThemeId;
 	analyticsEnabled: boolean;
 	terminalReplayKb: number;
+	composerGrowthLimit: ComposerGrowthLimit;
 	layout: LayoutSettings;
 }
 
@@ -486,6 +494,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	theme: "dark",
 	analyticsEnabled: true,
 	terminalReplayKb: TERMINAL_REPLAY_KB.default,
+	composerGrowthLimit: "half-chat",
 	layout: {
 		defaultPresetId: "balanced",
 		customPresets: [],

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,8 +2,10 @@ export type * from "./domain";
 export {
 	ACCEPTED_IMAGE_TYPES,
 	base64EncodedLength,
+	COMPOSER_GROWTH_LIMITS,
 	DEFAULT_CONFIG,
 	IMAGE_MAX_BASE64_BYTES,
+	isComposerGrowthLimit,
 	isControlMessage,
 	isRetriedAttempt,
 	MAX_HISTORY_LIMIT,

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -17,8 +17,9 @@ and the install identity — as JSON under the data dir.
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
   `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, `loadConfig`/`saveConfig`
-  (`config.json`, fieldwise-normalized over `DEFAULT_CONFIG`—including both nested layout group limits—so a
-  missing file or key degrades cleanly, while unknown top-level extension fields survive known-field updates),
+  (`config.json`, fieldwise-normalized over `DEFAULT_CONFIG`—including the closed composer-growth preset and
+  both nested layout group limits—so a missing/invalid known value or key degrades cleanly, while unknown
+  top-level extension fields survive known-field updates),
   `loadWorkspaceLayout`/`loadWorkspaceLayoutBackup`/`saveWorkspaceLayout`/`removeWorkspaceLayout`
   (versioned full snapshots in traversal-safe workspace-keyed filenames; atomic replacement with a
   last-known-good copy so a torn/corrupt write cannot blank a workspace; complete cleanup when its

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
 	type AppConfig,
 	DEFAULT_CONFIG,
+	isComposerGrowthLimit,
 	type Project,
 	type Workspace,
 	type WorkspaceLayoutSnapshot,
@@ -78,6 +79,9 @@ export function loadConfig(): AppConfig {
 			typeof value.terminalReplayKb === "number" && Number.isFinite(value.terminalReplayKb)
 				? value.terminalReplayKb
 				: DEFAULT_CONFIG.terminalReplayKb,
+		composerGrowthLimit: isComposerGrowthLimit(value.composerGrowthLimit)
+			? value.composerGrowthLimit
+			: DEFAULT_CONFIG.composerGrowthLimit,
 		layout: {
 			defaultPresetId:
 				typeof layoutValue.defaultPresetId === "string" &&

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -11,8 +11,8 @@ tags: [v1]
 ## Responsibility
 
 The server-synced app config — OUR settings (an opaque theme selection, the analytics switch, terminal
-replay budget, and workbench default/custom presets + independent side/bottom group limits), an extensible
-`AppConfig` bag.
+replay budget, the chat composer growth preset, and workbench default/custom presets + independent
+side/bottom group limits), an extensible `AppConfig` bag.
 Reads/merges/persists it and fans changes out to every client,
 so a preference set on one client follows the user to the others (architecture #9: shared domain state). The
 web client owns the available theme manifests; settings stores only the selected string id.

--- a/packages/server/src/settings/settings.test.ts
+++ b/packages/server/src/settings/settings.test.ts
@@ -65,6 +65,15 @@ test("an older host preserves unknown top-level config extensions when updating 
 	expect(onDisk.futureSetting).toEqual({ mode: "new" });
 });
 
+test("loadConfig replaces an invalid composer growth preset with the default", () => {
+	writeFileSync(
+		join(dataDir, "config.json"),
+		JSON.stringify({ ...DEFAULT_CONFIG, composerGrowthLimit: "enormous" }),
+	);
+	resetConfigCache();
+	expect(getConfig()).toHaveProperty("composerGrowthLimit", "half-chat");
+});
+
 test("loadConfig normalizes nested layout fields independently", () => {
 	writeFileSync(
 		join(dataDir, "config.json"),


### PR DESCRIPTION
## Summary

Replace the fixed-height chat prompt with an adaptive composer that gives one-line drafts a full-width message row above a stable controls footer, then grows only the message row when text wraps, contains an explicit newline, or the agent is streaming.

The composer keeps one persistent textarea across layout changes, preserving focus, caret and selection state, history recall, drafts, attachments, and template-slot sessions. Long drafts use a server-synchronized growth preference and scroll only after reaching the selected limit.

## Stack

This PR is stacked directly after #315 (`fix-summarization-crashes`). Its base is that PR's head, so #315 should land first; #308 can then be retargeted to `main` without changing its composer commits.

## Changes

### Composer and responsive behavior

- Add a full-width, one-visual-line message row above a stable footer with compact model/effort controls plus explicit History and Send actions.
- Grow only the message row on wrapping, explicit newlines, width changes, or streaming, keeping the action footer fixed in place.
- Add Compact (6 lines), Roomy (10 lines), and Half chat growth limits; Half chat measures the mounted chat panel rather than the browser viewport.
- Keep template-slot backdrop geometry and scroll offsets synchronized with the textarea.
- Preserve Stop, send-mode, queue, mention, command, attachment, and history behavior in the expanded layout.
- Harden phone-width containment for composer controls and session statistics.

### Settings, contracts, and persistence

- Add `ComposerGrowthLimit` to the shared app config, defaulting to `half-chat`.
- Normalize invalid or legacy persisted values on the host while preserving unknown config extensions.
- Project the setting through the web store and add a Chat settings section with host-broadcast convergence.
- Update the owning chat, panels, store, contracts, settings, and persistence specs.

### Coverage

- Add geometry, width-driven expansion, textarea persistence, growth-cap, phone-containment, streaming, settings-persistence, and template-backdrop coverage.

## Screenshots

### Empty draft

| Before: fixed-height composer | After: one-line message over controls |
| --- | --- |
| ![Before: the empty chat composer occupies a fixed 168-pixel footer](https://github.com/JetBrains/thinkrail/blob/356e26f9f3a8370d7d661d420322bd3878c110f4/composer-idle-before.png?raw=true) | ![After: the empty composer gives the message its own one-line row above the controls](https://github.com/JetBrains/thinkrail/blob/356e26f9f3a8370d7d661d420322bd3878c110f4/composer-idle-after.png?raw=true) |

### Wrapped draft

| Before: fixed editor and split controls | After: content-sized message and stable footer |
| --- | --- |
| ![Before: a wrapped draft remains in the fixed-height editor](https://github.com/JetBrains/thinkrail/blob/356e26f9f3a8370d7d661d420322bd3878c110f4/composer-long-before.png?raw=true) | ![After: a wrapped draft grows only the message row while the controls remain fixed](https://github.com/JetBrains/thinkrail/blob/356e26f9f3a8370d7d661d420322bd3878c110f4/composer-long-after.png?raw=true) |

### Phone

![After: the one-line message row and complete controls footer remain contained at 390 by 780](https://github.com/JetBrains/thinkrail/blob/356e26f9f3a8370d7d661d420322bd3878c110f4/composer-phone-idle-after.png?raw=true)

## Testing

Current stacked head (`85d31d42`) on #315 (`67733d50`):

- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed
- `bun run typecheck` — 11 workspace tasks passed
- `bun run typography:check && bun run colors:check && bun run spacing:check` — passed
- `SHELL=/bin/bash bun run test` — 11 workspace tasks passed; server suite 743 passed, 0 failed
- Review fix — wrap detection now observes the in-flow editor sizer; regression coverage asserts its x/width match the textarea within 0.5px

Earlier branch verification before stacking:

- `SHELL=/bin/bash bun run e2e` — 283 no-agent tests passed across 8 shards
- Relevant `@agent` composer checks — streaming rail and post-turn stats/phone containment passed
- GitHub CI passed the prior revised head, including no-agent and compiled-binary E2E

Per request, local E2E was not run after stacking. Repository CI is configured only for pull requests targeting `main`, so GitHub will run the focused browser regression and the complete suite when #308 is retargeted after #315 lands.

## Checklist

- [x] Fast gates pass
- [x] Browser regression added; local E2E intentionally not run after stacking (see Testing)
- [x] Relevant specs updated





