### PR TITLE
fix(web): prevent long-chat crashes and resync compaction

### DIFF
--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -55,6 +55,14 @@ cached first-paint theme hint pre-React, initializes transport + client-local na
 `components/ErrorBoundary` as the last-resort boundary (a crash escaping every region shows a reload
 screen, not a blank root).
 
+**React is one exact, matching `react` + `react-dom` 19.3 canary pin until the first stable release carrying
+upstream fix #34803.** React 19.2's development Performance Tracks retained every
+`performance.measure()` record; Pi-rate chat renders grew a Vite tab past 10 GB while the JS heap stayed
+flat, then Chrome killed the renderer and Vite reported the dead socket as `EPIPE` / `ECONNRESET` (React
+#34770). The selected canary contains React's own `clearMeasures` fix; ThinkRail deliberately carries no
+second measure-reaping policy. Every React move upgrades both packages together and repeats the mounted-chat
+memory stress probe before this temporary canary pin can return to stable.
+
 ### Dependency graph
 
 - `navigation` → `store`, `transport`, `contracts` (type-only); neither dependency imports it, and `main.tsx` initializes the integration

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -59,6 +59,7 @@ import type { ChatAttachment, ChatTurn } from "./types";
 import { useChatScroll } from "./useChatScroll";
 import { useChatTodos } from "./useChatTodos";
 import { useHistorySearch } from "./useHistorySearch";
+import { useTranscriptSync } from "./useTranscriptSync";
 
 function turnAnchorText(turn: ChatTurn): string {
 	if (turn.kind === "user") {
@@ -113,7 +114,18 @@ export default function ChatView({
 	sessionId: string;
 	workspaceId: string;
 }) {
-	const runtime = useAppStore((s) => s.sessions[sessionId]) ?? EMPTY_RUNTIME;
+	const sessionRuntime = useAppStore((s) => s.sessions[sessionId]);
+	const runtime = sessionRuntime ?? EMPTY_RUNTIME;
+	const status = useAppStore((s) => s.status);
+	const connectionGeneration = useAppStore((s) => s.connectionGeneration);
+	useTranscriptSync({
+		workspaceId,
+		sessionId,
+		runtime,
+		status,
+		connectionGeneration,
+		enabled: sessionRuntime !== undefined,
+	});
 	const { models, refreshing: modelsRefreshing, refresh: onRefreshModels } = useModelCatalog();
 	const projectId = useAppStore(
 		(s) =>
@@ -240,7 +252,6 @@ export default function ChatView({
 		[commands, templates],
 	);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: `isStreaming` is the refetch trigger, not read
 	useEffect(() => {
 		getTransport()
 			.request("session.getStats", { sessionId })

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -126,6 +126,7 @@ export default function ChatView({
 		connectionGeneration,
 		enabled: sessionRuntime !== undefined,
 	});
+	const composerGrowthLimit = useAppStore((state) => state.composerGrowthLimit);
 	const { models, refreshing: modelsRefreshing, refresh: onRefreshModels } = useModelCatalog();
 	const projectId = useAppStore(
 		(s) =>
@@ -591,7 +592,10 @@ export default function ChatView({
 	return (
 		<ChatActionsContext.Provider value={chatActions}>
 			<AskStatesContext.Provider value={askContext}>
-				<div className="flex h-full min-h-0 flex-col bg-container-workspace-bg">
+				<div
+					data-testid="chat-view"
+					className="flex h-full min-h-0 min-w-0 flex-col bg-container-workspace-bg [container-type:size]"
+				>
 					<Popover open={planOpen} onOpenChange={setPlanOpen}>
 						<PopoverAnchor asChild>
 							<div className="shrink-0">
@@ -696,6 +700,7 @@ export default function ChatView({
 							value={draft}
 							onChange={(v) => useAppStore.getState().setChatDraft(sessionId, v)}
 							isStreaming={isStreaming}
+							growthLimit={composerGrowthLimit}
 							commands={mergedCommands}
 							mentionCandidates={mentionCandidates}
 							recentPrompts={recentPrompts}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -9,6 +9,7 @@ import {
 	RiCloseLine as X,
 } from "@remixicon/react";
 import {
+	type ComposerGrowthLimit,
 	REQUEST_IMAGE_BASE64_BUDGET,
 	type ThinkingLevel,
 	type WireModel,
@@ -26,6 +27,7 @@ import {
 	useState,
 } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib";
 import { FileChip } from "./FileChip";
 import { type AttachedImage, fileToAttachedImage } from "./imageAttachment";
 import { ModelSelector } from "./ModelSelector";
@@ -50,6 +52,13 @@ import type { ChatAttachment } from "./types";
 export type SubmitBehavior = "send" | "steer" | "followUp" | "interrupt";
 
 export type ComposerSubmitDisposition = { accepted: true } | { accepted: false; reason: string };
+
+const COMPOSER_EDITOR_LIMIT_CLASS = {
+	compact: "max-h-[calc(6lh+var(--space-8)+var(--space-8))]",
+	roomy: "max-h-[calc(10lh+var(--space-8)+var(--space-8))]",
+	"half-chat":
+		"max-h-[calc(50cqh-var(--space-16)-var(--space-16)-var(--space-4)-var(--space-4)-var(--space-4)-var(--space-4))]",
+} satisfies Record<ComposerGrowthLimit, string>;
 
 const STREAMING_SEND_MODES = [
 	{
@@ -153,6 +162,7 @@ interface ComposerProps {
 	value: string;
 	onChange: (value: string) => void;
 	isStreaming: boolean;
+	growthLimit: ComposerGrowthLimit;
 	commands: SlashCommandItem[];
 	mentionCandidates: MentionCandidate[];
 	recentPrompts: string[];
@@ -191,6 +201,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		value,
 		onChange,
 		isStreaming,
+		growthLimit,
 		commands,
 		mentionCandidates,
 		recentPrompts,
@@ -231,14 +242,46 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const [slots, setSlots] = useState<TemplateSlot[] | null>(null);
 	const [slotIdx, setSlotIdx] = useState(0);
 	const backdropRef = useRef<HTMLDivElement | null>(null);
-	const attachBackdrop = (el: HTMLDivElement | null) => {
-		backdropRef.current = el;
+	const editorSizerRef = useRef<HTMLDivElement | null>(null);
+	const [draftNeedsExpansion, setDraftNeedsExpansion] = useState(false);
+	const expanded = isStreaming || draftNeedsExpansion;
+	const syncBackdropScroll = useCallback(() => {
+		const backdrop = backdropRef.current;
 		const textarea = ref.current;
-		if (el && textarea) {
-			el.scrollLeft = textarea.scrollLeft;
-			el.scrollTop = textarea.scrollTop;
-		}
-	};
+		if (!backdrop || !textarea) return;
+		backdrop.scrollLeft = textarea.scrollLeft;
+		backdrop.scrollTop = textarea.scrollTop;
+	}, []);
+	const attachBackdrop = useCallback(
+		(el: HTMLDivElement | null) => {
+			backdropRef.current = el;
+			syncBackdropScroll();
+		},
+		[syncBackdropScroll],
+	);
+	const measureDraftExpansion = useCallback(() => {
+		const sizer = editorSizerRef.current;
+		if (!sizer) return;
+		const styles = getComputedStyle(sizer);
+		const oneLineHeight =
+			Number.parseFloat(styles.lineHeight) +
+			Number.parseFloat(styles.paddingTop) +
+			Number.parseFloat(styles.paddingBottom);
+		setDraftNeedsExpansion(value.includes("\n") || sizer.scrollHeight > oneLineHeight + 1);
+	}, [value]);
+
+	useLayoutEffect(() => {
+		const sizer = editorSizerRef.current;
+		if (!sizer) return;
+		measureDraftExpansion();
+		const observer = new ResizeObserver(measureDraftExpansion);
+		observer.observe(sizer);
+		return () => observer.disconnect();
+	}, [measureDraftExpansion]);
+
+	useLayoutEffect(() => {
+		syncBackdropScroll();
+	});
 
 	const { token, start } = activeToken(value, caret);
 	const mentionQuery = token.startsWith("@") ? token.slice(1) : null;
@@ -528,7 +571,12 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	return (
-		<div className="relative flex shrink-0 flex-col border-border-muted border-t bg-container-workspace-bg">
+		<div
+			data-testid="chat-composer"
+			data-expanded={expanded}
+			data-streaming={isStreaming}
+			className="relative flex shrink-0 flex-col border-border-muted border-t bg-container-workspace-bg"
+		>
 			{mentionOpen ? (
 				<div
 					data-testid="mention-menu"
@@ -656,108 +704,134 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				</div>
 			) : null}
 
-			<div className="flex flex-col gap-8 p-12">
-				<div className="relative rounded-[var(--radius-md)] border border-control-border-default bg-control-bg bg-clip-padding transition-colors focus-within:border-control-border-active">
-					{slots ? (
-						<div
-							ref={attachBackdrop}
-							data-testid="slot-backdrop"
-							aria-hidden
-							className="pointer-events-none absolute inset-0 overflow-hidden rounded-[var(--radius-md)]"
-						>
-							<div className="w-full whitespace-pre-wrap break-words px-12 py-8 tr-text-ui">
-								{withOffsets(highlightSegments(value, slots, slotIdx)).map((seg) => (
-									<span
-										key={seg.start}
-										data-testid={seg.state === "plain" ? undefined : "slot-highlight"}
-										data-slot-state={seg.state === "plain" ? undefined : seg.state}
-										className={`text-transparent ${highlightTint(seg.state)}`}
-									>
-										{seg.text}
-									</span>
-								))}
-							</div>
-						</div>
-					) : null}
-					<textarea
-						ref={ref}
-						data-testid="chat-input"
-						value={value}
-						onScroll={(e) => {
-							const backdrop = backdropRef.current;
-							if (backdrop) {
-								backdrop.scrollLeft = e.currentTarget.scrollLeft;
-								backdrop.scrollTop = e.currentTarget.scrollTop;
-							}
-						}}
-						onChange={(e) => {
-							const next = e.target.value;
-							const nextCaret = e.target.selectionStart;
-							setSubmitError(null);
-							const recalled = recallIdxRef.current;
-							if (recalled !== null && next !== recentPrompts[recalled]) {
-								recallIdxRef.current = null;
-							}
-							if (slots) {
-								const { editStart, removedLen, insertedLen } = diffValues(value, next, nextCaret);
-								if (editStart === 0 && removedLen === value.length) {
-									setSlots(null);
-								} else {
-									const editEnd = editStart + removedLen;
-									const active = slots[slotIdx];
-									const growing =
-										removedLen === 0 &&
-										insertedLen > 0 &&
-										active !== undefined &&
-										active.end === editStart;
-									const shifted = shiftSlots(slots, editStart, removedLen, insertedLen).map(
-										(slot, i) => {
-											const grown =
-												growing && i === slotIdx
-													? { ...slot, end: slot.end + insertedLen, filled: true, edited: true }
-													: slot;
-											const original = slots[i];
-											return original && touches(original, editStart, editEnd)
-												? { ...grown, filled: true, edited: true }
-												: grown;
-										},
-									);
-									setSlots(shifted);
-								}
-							}
-							onChange(next);
-							setCaret(nextCaret);
-						}}
-						onKeyUp={(e) => setCaret(e.currentTarget.selectionStart)}
-						onClick={(e) => setCaret(e.currentTarget.selectionStart)}
-						onKeyDown={onKeyDown}
-						onPaste={onPaste}
-						onDrop={onDrop}
-						rows={4}
-						placeholder={
-							isStreaming
-								? "Enter steers at the next step · Cmd/Ctrl+Enter queues for when it finishes"
-								: "Message the agent…  (@ files · / commands · Enter to send)"
-						}
-						className="relative min-h-[108px] w-full resize-none rounded-[var(--radius-sm)] bg-transparent px-12 py-8 tr-text-ui text-text-default outline-none placeholder:text-text-muted"
-					/>
-				</div>
-				<div className="flex flex-wrap items-center gap-8">
-					<div className="flex min-w-0 flex-1 flex-wrap items-center gap-8">
+			<div className="p-12">
+				<div
+					data-testid="chat-composer-shell"
+					className={cn(
+						"relative grid grid-cols-[auto_minmax(0,1fr)_auto] grid-rows-[minmax(0,1fr)_auto] items-end gap-x-4 gap-y-4 overflow-hidden rounded-[var(--radius-md)] border border-control-border-default bg-control-bg bg-clip-padding p-4 transition-colors focus-within:border-control-border-active",
+						expanded && growthLimit === "half-chat" && "max-h-[50cqh]",
+					)}
+				>
+					<div className="col-start-1 row-start-2 flex min-w-0 items-center gap-4 self-end sm:gap-8">
 						<ModelSelector
 							models={models}
 							current={currentModel}
 							refreshing={modelsRefreshing}
 							onRefresh={onRefreshModels}
 							onSelect={onSelectModel}
+							className="max-w-80 gap-4 px-4 sm:max-w-144"
 						/>
 						<ThinkingSelector
 							level={thinkingLevel}
 							levels={currentModel?.thinkingLevels ?? []}
 							onSelect={onSelectThinking}
+							showLabel={false}
+							className="gap-4 px-4"
 						/>
 					</div>
-					<div className="flex shrink-0 items-center gap-8">
+					<div
+						className={cn(
+							"relative col-span-3 col-start-1 row-start-1 min-h-0 overflow-hidden rounded-[var(--radius-sm)] tr-text-ui",
+							COMPOSER_EDITOR_LIMIT_CLASS[growthLimit],
+						)}
+					>
+						<div
+							ref={editorSizerRef}
+							data-testid="chat-input-sizer"
+							aria-hidden
+							className="invisible w-full whitespace-pre-wrap break-words px-12 py-8 tr-text-ui"
+						>
+							{`${value}\u200b`}
+						</div>
+						{slots ? (
+							<div
+								ref={attachBackdrop}
+								data-testid="slot-backdrop"
+								aria-hidden
+								className="pointer-events-none absolute inset-0 overflow-hidden rounded-[var(--radius-sm)]"
+							>
+								<div className="w-full whitespace-pre-wrap break-words px-12 py-8 tr-text-ui">
+									{withOffsets(highlightSegments(value, slots, slotIdx)).map((seg) => (
+										<span
+											key={seg.start}
+											data-testid={seg.state === "plain" ? undefined : "slot-highlight"}
+											data-slot-state={seg.state === "plain" ? undefined : seg.state}
+											className={`text-transparent ${highlightTint(seg.state)}`}
+										>
+											{seg.text}
+										</span>
+									))}
+								</div>
+							</div>
+						) : null}
+						<textarea
+							ref={ref}
+							data-testid="chat-input"
+							value={value}
+							onScroll={syncBackdropScroll}
+							onChange={(e) => {
+								const next = e.target.value;
+								const nextCaret = e.target.selectionStart;
+								setSubmitError(null);
+								const recalled = recallIdxRef.current;
+								if (recalled !== null && next !== recentPrompts[recalled]) {
+									recallIdxRef.current = null;
+								}
+								if (slots) {
+									const { editStart, removedLen, insertedLen } = diffValues(value, next, nextCaret);
+									if (editStart === 0 && removedLen === value.length) {
+										setSlots(null);
+									} else {
+										const editEnd = editStart + removedLen;
+										const active = slots[slotIdx];
+										const growing =
+											removedLen === 0 &&
+											insertedLen > 0 &&
+											active !== undefined &&
+											active.end === editStart;
+										const shifted = shiftSlots(slots, editStart, removedLen, insertedLen).map(
+											(slot, i) => {
+												const grown =
+													growing && i === slotIdx
+														? {
+																...slot,
+																end: slot.end + insertedLen,
+																filled: true,
+																edited: true,
+															}
+														: slot;
+												const original = slots[i];
+												return original && touches(original, editStart, editEnd)
+													? { ...grown, filled: true, edited: true }
+													: grown;
+											},
+										);
+										setSlots(shifted);
+									}
+								}
+								onChange(next);
+								setCaret(nextCaret);
+							}}
+							onKeyUp={(e) => setCaret(e.currentTarget.selectionStart)}
+							onClick={(e) => setCaret(e.currentTarget.selectionStart)}
+							onKeyDown={onKeyDown}
+							onPaste={onPaste}
+							onDrop={onDrop}
+							rows={1}
+							placeholder={
+								isStreaming
+									? "Enter steers at the next step · Cmd/Ctrl+Enter queues for when it finishes"
+									: expanded
+										? "Message the agent…  (@ files · / commands · Enter to send)"
+										: "Message…"
+							}
+							className={cn(
+								"absolute inset-0 size-full resize-none overflow-x-hidden overflow-y-auto rounded-[var(--radius-sm)] bg-transparent px-12 py-8 tr-text-ui text-text-default outline-none placeholder:text-text-muted",
+								expanded ? "whitespace-pre-wrap" : "whitespace-nowrap",
+							)}
+						/>
+					</div>
+					<div className="col-start-3 row-start-2 flex shrink-0 items-center gap-4 self-end">
 						<button
 							type="button"
 							data-testid="history-open"

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -35,6 +35,7 @@ export function ModelSelector({
 	refreshing,
 	onRefresh,
 	container,
+	className,
 }: {
 	models: WireModel[];
 	current: WireModel | null;
@@ -42,6 +43,7 @@ export function ModelSelector({
 	refreshing: boolean;
 	onRefresh: (force: boolean) => void;
 	container?: HTMLElement | null;
+	className?: string;
 }) {
 	const [open, setOpen] = useState(false);
 	const providers = [...new Set(models.map((m) => m.provider))];
@@ -62,7 +64,10 @@ export function ModelSelector({
 			<PopoverTrigger
 				data-testid="model-selector"
 				data-open={open}
-				className="flex h-32 max-w-[220px] items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
+				className={cn(
+					"flex h-32 max-w-[220px] items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
+					className,
+				)}
 			>
 				<span className="truncate text-text-muted tr-text-metadata">
 					{current?.name ?? "Select model"}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -60,8 +60,15 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   muted notice. These states are assertable via `data-testid="compaction-notice"` +
   `data-status="running|done|failed|cancelled"`. A successful live end asks the app-integration transcript
   synchronizer to read Pi's canonical summary-plus-tail; reconnect does the same for a runtime from an older
-  connection generation. Store reconciliation replaces only host-derived conversation state and preserves
-  browser-local state. The persisted `compactionSummary` then becomes the same row in place (the live id,
+  connection generation. A **generation-only reconnect snapshot is never installed while its host summary
+  is streaming**: Pi's persisted `session.messages` omits the in-flight assistant partial, so the synchronizer
+  waits for settlement and re-reads rather than deleting that partial and clearing its correlation id.
+  A compaction-triggered read may still install a streaming summary behind the Pi-event revision fence: at
+  that boundary the canonical summary-plus-tail is the intended replacement, and any intervening assistant
+  event rejects the snapshot. Transient transcript-read failures retry with a bounded backoff; only exhaustion
+  raises the refresh error, and a new generation/compaction key gets a fresh budget. Store reconciliation
+  replaces only host-derived conversation state and preserves browser-local state. The persisted
+  `compactionSummary` then becomes the same row in place (the live id,
   estimated-after count, and live `resuming` flag survive when they still apply), and the messages Pi
   summarized disappear immediately rather than only after reload. Its `summary` opens on click
   (`data-testid="chat-compaction"`). Hydration/reopen starts directly from that same durable form. Both forms

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -53,15 +53,19 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   a failed turn can't look like nothing happened. Live settlement and transcript hydration share the
   same assistant-failure classifier, so reload cannot turn the latest unresolved failure into success;
   recovered historical `length` attempts followed by later work are not re-labeled as current failures.
-- `compaction` — a 1:1, fold-breaking row with two sources. Live `compaction_start` / `compaction_end`
-  events produce `CompactionNotice` (see the store SPEC): running "Compacting context…" (spinner), done
-  "Context compacted" (+ "— resuming…" while pi's overflow retry continues the run, + tokens before→after
-  when the result carried them), failed with the actionable error text, or cancelled as a muted notice.
-  These states are assertable via `data-testid="compaction-notice"` +
-  `data-status="running|done|failed|cancelled"`. Hydration turns the persisted `compactionSummary` into the
-  same `compaction` state (`done`) at its canonical position, plus the durable `summary`; that richer record
-  renders as `CompactionTurn`, a labelled rule whose summary opens on click (`data-testid="chat-compaction"`).
-  Thus a live run exposes every beat, while reload preserves main's explanation of the messages pi replaced.
+- `compaction` — a 1:1, fold-breaking row with two sources that converge. Live `compaction_start` /
+  `compaction_end` events produce `CompactionNotice` (see the store SPEC): running "Compacting context…"
+  (spinner), done **"Context compacted"** (+ "— resuming…" while pi's overflow retry continues the run, +
+  tokens before→after when the result carried them), failed with the actionable error text, or cancelled as a
+  muted notice. These states are assertable via `data-testid="compaction-notice"` +
+  `data-status="running|done|failed|cancelled"`. A successful live end asks the app-integration transcript
+  synchronizer to read Pi's canonical summary-plus-tail; reconnect does the same for a runtime from an older
+  connection generation. Store reconciliation replaces only host-derived conversation state and preserves
+  browser-local state. The persisted `compactionSummary` then becomes the same row in place (the live id,
+  estimated-after count, and live `resuming` flag survive when they still apply), and the messages Pi
+  summarized disappear immediately rather than only after reload. Its `summary` opens on click
+  (`data-testid="chat-compaction"`). Hydration/reopen starts directly from that same durable form. Both forms
+  share the **"Context compacted"** title; only facts unavailable after reload disappear.
 - `markdown` — a non-empty assistant text block (react-markdown + remark-gfm + shiki). A fenced
   ```mermaid block renders as a themed diagram via `tools/visualize`'s `MermaidView` (fullscreen
   pan-zoom, error → source fallback) — uniform across every `Markdown` surface (chat, file/specs
@@ -740,7 +744,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 - **Allowed deps:** `contracts` (pi message/content-block types, **type-only**); `store` + `transport`
   (**app-integration files only** — a renderer that takes props must never reach for either. Today that
   is `ChatView.tsx` plus the hooks and dialogs it composes: `useChatTodos.ts`, `useHistorySearch.ts`,
-  `useModelCatalog.ts`, `SkillsDialog.tsx`, `TemplateEditorDialog.tsx`. `useModelCatalog` is the shared
+  `useModelCatalog.ts`, **`useTranscriptSync.ts`** (successful-compaction + connection-generation canonical
+  transcript reconciliation), `SkillsDialog.tsx`, `TemplateEditorDialog.tsx`. `useModelCatalog` is the shared
   models-catalog seam `panels/NewWorkspaceDialog` also imports per-file, so the two pickers cannot
   drift; on activation it **drops catalog authority synchronously** (a flag an earlier consumer set says
   nothing about the list this one inherited) and reads `model.list` only when the shared list is **empty** —
@@ -762,8 +767,9 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   receives the single path the user picked) plus its view switch (`onReveal` → the tool-reveal intent), and the
   `isSpec` classifier it builds from the store's `specsByWorkspace` snapshot (subscribed as the stored array
   — a stable ref — and memoized into a matcher here, never a fresh Set inside the selector) — together with
-  **`useHistorySearch.ts`** (the Ctrl+R history-recall overlay's store/transport edge) and
-  **`TemplateEditorDialog.tsx`** (the shared template save form), the other two integration points. A
+  **`useHistorySearch.ts`** (the Ctrl+R history-recall overlay's store/transport edge),
+  **`useTranscriptSync.ts`** (the guarded authoritative read that converges an existing runtime), and
+  **`TemplateEditorDialog.tsx`** (the shared template save form), the other integration points. A
   **rejected** send (`prompt`/`steer`/`followUp`) lands in the chat via the store's `appendErrorTurn` —
   never swallowed; *streaming* faults arrive as pi events instead.
 

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -63,8 +63,9 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   connection generation. A **generation-only reconnect snapshot is never installed while its host summary
   is streaming**: Pi's persisted `session.messages` omits the in-flight assistant partial, so the synchronizer
   waits for settlement and re-reads rather than deleting that partial and clearing its correlation id.
-  A compaction-triggered read may still install a streaming summary behind the Pi-event revision fence: at
-  that boundary the canonical summary-plus-tail is the intended replacement, and any intervening assistant
+  A pending connection-generation sync dominates even when the same read also satisfies an unresolved
+  compaction need. Only a compaction-only read may install a streaming summary behind the Pi-event revision
+  fence: at that boundary the canonical summary-plus-tail is the intended replacement, and any intervening assistant
   event rejects the snapshot. Transient transcript-read failures retry with a bounded backoff; only exhaustion
   raises the refresh error, and a new generation/compaction key gets a fresh budget. Store reconciliation
   replaces only host-derived conversation state and preserves browser-local state. The persisted

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -301,6 +301,20 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   skill overrides, + a **Reload** that applies changes to this chat's session via `session.reloadResources`,
   disabled while streaming) or project (`project.skills`, per-project-baseline toggles, no session) — the
   latter reused by `panels` pre-session). All props-driven; behavior detail lives in the components' jsdoc.
+- **Adaptive composer geometry** (`Composer`) — an idle draft that fits one visual line renders as a
+  shared two-tier shell: a full-width, one-visual-line message row above a stable action footer. Model and
+  effort share a compact visual group on the footer's left while remaining two independently
+  focusable/clickable picker triggers; History and Send remain explicit on the right. A wrap, explicit
+  newline, or width change that makes the draft exceed one visual line grows the message row without moving
+  the footer; fitting one line again shrinks only the message row. This is one persistent textarea, never
+  conditional twins — the transition cannot lose focus, caret/selection, recall, draft, or a template-slot
+  session. Streaming deliberately uses the expanded message row even with an empty draft, because Stop +
+  send options join the footer. `ChatView` passes the server-synced
+  `ComposerGrowthLimit` prop: `compact` caps at 6 visual lines, `roomy` at 10, and the default `half-chat`
+  caps the **editor shell** (textarea + footer) at 50% of the mounted chat panel, never the browser viewport;
+  overflow then scrolls inside the textarea. Attachment chips, completion menus, slot hints, and QueueStrip
+  keep their existing separate chrome. The slot-highlight backdrop must follow every dynamic textarea box
+  change with the exact box-model and scroll-sync invariants under Template slots below.
 - **Queued messages: the pending strip** (`QueueStrip.tsx`, props-driven: `queue` + `onEdit`/`onRemove`)
   — the web mirror of pi's interactive-mode pending-messages area. A **streaming send never renders an
   optimistic transcript bubble** (see the store SPEC's echo contract): `ChatView.onSubmit` skips

--- a/apps/web/src/chat/SessionStatsBar.tsx
+++ b/apps/web/src/chat/SessionStatsBar.tsx
@@ -40,7 +40,7 @@ export function SessionStatsBar({ stats }: { stats: SessionStats | null }) {
 	return (
 		<div
 			data-testid="session-stats"
-			className="flex shrink-0 flex-nowrap items-center justify-end gap-x-4 text-text-muted tr-text-metadata"
+			className="flex min-w-0 flex-nowrap items-center justify-end gap-x-4 overflow-hidden text-text-muted tr-text-metadata"
 			title="Cumulative usage: ↑ input · ↓ output · R cache read · W cache write"
 		>
 			{parts.map((part, index) => (

--- a/apps/web/src/chat/ThinkingSelector.tsx
+++ b/apps/web/src/chat/ThinkingSelector.tsx
@@ -2,17 +2,22 @@ import { RiCheckLine as Check, RiArrowDownSLine as ChevronDown } from "@remixico
 import type { ThinkingLevel } from "@thinkrail/contracts";
 import { useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib";
 
 export function ThinkingSelector({
 	level,
 	levels,
 	onSelect,
 	container,
+	className,
+	showLabel = true,
 }: {
 	level: ThinkingLevel;
 	levels: readonly ThinkingLevel[];
 	onSelect: (level: ThinkingLevel) => void;
 	container?: HTMLElement | null;
+	className?: string;
+	showLabel?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	return (
@@ -21,9 +26,12 @@ export function ThinkingSelector({
 				data-testid="thinking-selector"
 				data-open={open}
 				disabled={levels.length === 0}
-				className="flex h-32 items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:border-control-disabled-border disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected"
+				className={cn(
+					"flex h-32 items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:border-control-disabled-border disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
+					className,
+				)}
 			>
-				<span className="tr-text-eyebrow text-text-muted">Effort</span>
+				{showLabel ? <span className="tr-text-eyebrow text-text-muted">Effort</span> : null}
 				<span className="capitalize">{level}</span>
 				<ChevronDown className="size-16 shrink-0 text-text-muted" />
 			</PopoverTrigger>

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -53,7 +53,13 @@ export function ChatTurnView({
 			return <ErrorTurn text={row.text} />;
 		case "compaction":
 			return row.summary !== undefined && row.tokensBefore !== undefined ? (
-				<CompactionTurn id={row.id} summary={row.summary} tokensBefore={row.tokensBefore} />
+				<CompactionTurn
+					id={row.id}
+					summary={row.summary}
+					tokensBefore={row.tokensBefore}
+					tokensAfter={row.tokensAfter}
+					resuming={row.resuming}
+				/>
 			) : (
 				<CompactionNotice {...row} />
 			);
@@ -359,12 +365,21 @@ function CompactionTurn({
 	id,
 	summary,
 	tokensBefore,
+	tokensAfter,
+	resuming,
 }: {
 	id: string;
 	summary: string;
 	tokensBefore: number;
+	tokensAfter?: number | undefined;
+	resuming?: boolean | undefined;
 }) {
 	const [open, toggle] = useFold(id);
+	const label = resuming ? "Context compacted — resuming…" : "Context compacted";
+	const tokens =
+		tokensAfter === undefined
+			? `${formatTokens(tokensBefore)} tokens`
+			: `${formatTokens(tokensBefore)} → ${formatTokens(tokensAfter)} tokens`;
 	return (
 		<div data-testid="chat-compaction" className="flex flex-col gap-8">
 			<button
@@ -376,7 +391,7 @@ function CompactionTurn({
 				<span className="h-px flex-1 bg-border-default" />
 				{open ? <ChevronDown className="size-16" /> : <ChevronRight className="size-16" />}
 				<span>
-					Earlier messages summarized ({formatTokens(tokensBefore)} tokens of context compacted)
+					{label} ({tokens})
 				</span>
 				<span className="h-px flex-1 bg-border-default" />
 			</button>

--- a/apps/web/src/chat/useTranscriptSync.test.ts
+++ b/apps/web/src/chat/useTranscriptSync.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test";
 import type { SessionSummary } from "@thinkrail/contracts";
 import type { SessionRuntime } from "../store/appStore";
-import { synchronizeTranscript, transcriptSyncNeed } from "./useTranscriptSync";
+import {
+	synchronizeTranscript,
+	transcriptSyncNeed,
+	transcriptSyncRetryDelay,
+} from "./useTranscriptSync";
 
 function runtime(overrides: Partial<SessionRuntime> = {}): SessionRuntime {
 	return {
@@ -81,6 +85,7 @@ test("synchronizeTranscript compare-and-installs one canonical snapshot", async 
 			sessionId: "session-1",
 			expectedEventRevision: 9,
 			connectionGeneration: 6,
+			reason: "compaction",
 		},
 		{
 			read: async () => ({ result: { summary: hostSummary, messages: [] }, syncedTick: 0 }),
@@ -100,6 +105,79 @@ test("synchronizeTranscript compare-and-installs one canonical snapshot", async 
 	expect(installed).toEqual([hostSummary, hydrated, 9, 6]);
 });
 
+test("synchronizeTranscript defers a reconnect-only streaming snapshot without hydrating it", async () => {
+	let hydrated = false;
+	let reconciled = false;
+	const outcome = await synchronizeTranscript(
+		{
+			workspaceId: "workspace-1",
+			sessionId: "session-1",
+			expectedEventRevision: 9,
+			connectionGeneration: 6,
+			reason: "reconnect",
+		},
+		{
+			read: async () => ({
+				result: { summary: summary({ isStreaming: true }), messages: [] },
+				syncedTick: 0,
+			}),
+			hydrate: () => {
+				hydrated = true;
+				return { turns: [], toolResults: {}, askAnswers: {} };
+			},
+			state: () => ({
+				status: "connected",
+				connectionGeneration: 6,
+				reconcileSession: () => {
+					reconciled = true;
+					return true;
+				},
+			}),
+		},
+	);
+
+	expect(outcome).toBe("deferred-streaming");
+	expect(hydrated).toBe(false);
+	expect(reconciled).toBe(false);
+});
+
+test("synchronizeTranscript allows a revision-fenced streaming compaction snapshot", async () => {
+	let reconciled = false;
+	const outcome = await synchronizeTranscript(
+		{
+			workspaceId: "workspace-1",
+			sessionId: "session-1",
+			expectedEventRevision: 9,
+			connectionGeneration: 6,
+			reason: "compaction",
+		},
+		{
+			read: async () => ({
+				result: { summary: summary({ isStreaming: true }), messages: [] },
+				syncedTick: 0,
+			}),
+			hydrate: () => ({ turns: [], toolResults: {}, askAnswers: {} }),
+			state: () => ({
+				status: "connected",
+				connectionGeneration: 6,
+				reconcileSession: () => {
+					reconciled = true;
+					return true;
+				},
+			}),
+		},
+	);
+
+	expect(outcome).toBe("applied");
+	expect(reconciled).toBe(true);
+});
+
+test("transcript read failures use a bounded backoff", () => {
+	expect(transcriptSyncRetryDelay(1)).toBe(500);
+	expect(transcriptSyncRetryDelay(2)).toBe(1_500);
+	expect(transcriptSyncRetryDelay(3)).toBeNull();
+});
+
 test("synchronizeTranscript rejects a response from an overtaken connection generation", async () => {
 	let reconciled = false;
 	const outcome = await synchronizeTranscript(
@@ -108,6 +186,7 @@ test("synchronizeTranscript rejects a response from an overtaken connection gene
 			sessionId: "session-1",
 			expectedEventRevision: 2,
 			connectionGeneration: 4,
+			reason: "reconnect",
 		},
 		{
 			read: async () => ({ result: { summary: summary(), messages: [] }, syncedTick: 0 }),
@@ -134,6 +213,7 @@ test("synchronizeTranscript distinguishes an idle crossed snapshot so a stale st
 			sessionId: "session-1",
 			expectedEventRevision: 2,
 			connectionGeneration: 4,
+			reason: "reconnect",
 		},
 		{
 			read: async () => ({ result: { summary: summary(), messages: [] }, syncedTick: 0 }),

--- a/apps/web/src/chat/useTranscriptSync.test.ts
+++ b/apps/web/src/chat/useTranscriptSync.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import type { SessionSummary } from "@thinkrail/contracts";
 import type { SessionRuntime } from "../store/appStore";
 import { synchronizeTranscript, transcriptSyncNeed } from "./useTranscriptSync";
 
@@ -22,6 +23,21 @@ function runtime(overrides: Partial<SessionRuntime> = {}): SessionRuntime {
 		extUiQueue: [],
 		extUiStatus: {},
 		extUiWidget: {},
+		...overrides,
+	};
+}
+
+function summary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+	return {
+		sessionId: "session-1",
+		workspaceId: "workspace-1",
+		title: "Chat",
+		model: null,
+		thinkingLevel: "medium",
+		isStreaming: false,
+		messageCount: 0,
+		updatedAt: 1,
+		live: true,
 		...overrides,
 	};
 }
@@ -56,17 +72,7 @@ test("transcriptSyncNeed recognizes only successful live compactions without a d
 });
 
 test("synchronizeTranscript compare-and-installs one canonical snapshot", async () => {
-	const summary = {
-		sessionId: "session-1",
-		workspaceId: "workspace-1",
-		title: "Chat",
-		model: null,
-		thinkingLevel: "medium" as const,
-		isStreaming: false,
-		messageCount: 0,
-		updatedAt: 1,
-		live: true,
-	};
+	const hostSummary = summary();
 	const hydrated = { turns: [], toolResults: {}, askAnswers: {}, turnIdByMessageIndex: [] };
 	let installed: unknown[] | null = null;
 	const outcome = await synchronizeTranscript(
@@ -77,7 +83,7 @@ test("synchronizeTranscript compare-and-installs one canonical snapshot", async 
 			connectionGeneration: 6,
 		},
 		{
-			read: async () => ({ result: { summary, messages: [] }, syncedTick: 0 }),
+			read: async () => ({ result: { summary: hostSummary, messages: [] }, syncedTick: 0 }),
 			hydrate: () => hydrated,
 			state: () => ({
 				status: "connected",
@@ -91,7 +97,7 @@ test("synchronizeTranscript compare-and-installs one canonical snapshot", async 
 	);
 
 	expect(outcome).toBe("applied");
-	expect(installed).toEqual([summary, hydrated, 9, 6]);
+	expect(installed).toEqual([hostSummary, hydrated, 9, 6]);
 });
 
 test("synchronizeTranscript rejects a response from an overtaken connection generation", async () => {
@@ -104,23 +110,7 @@ test("synchronizeTranscript rejects a response from an overtaken connection gene
 			connectionGeneration: 4,
 		},
 		{
-			read: async () => ({
-				result: {
-					summary: {
-						sessionId: "session-1",
-						workspaceId: "workspace-1",
-						title: "Chat",
-						model: null,
-						thinkingLevel: "medium" as const,
-						isStreaming: false,
-						messageCount: 0,
-						updatedAt: 1,
-						live: true,
-					},
-					messages: [],
-				},
-				syncedTick: 0,
-			}),
+			read: async () => ({ result: { summary: summary(), messages: [] }, syncedTick: 0 }),
 			hydrate: () => ({ turns: [], toolResults: {}, askAnswers: {} }),
 			state: () => ({
 				status: "connected",
@@ -146,23 +136,7 @@ test("synchronizeTranscript distinguishes an idle crossed snapshot so a stale st
 			connectionGeneration: 4,
 		},
 		{
-			read: async () => ({
-				result: {
-					summary: {
-						sessionId: "session-1",
-						workspaceId: "workspace-1",
-						title: "Chat",
-						model: null,
-						thinkingLevel: "medium" as const,
-						isStreaming: false,
-						messageCount: 0,
-						updatedAt: 1,
-						live: true,
-					},
-					messages: [],
-				},
-				syncedTick: 0,
-			}),
+			read: async () => ({ result: { summary: summary(), messages: [] }, syncedTick: 0 }),
 			hydrate: () => ({ turns: [], toolResults: {}, askAnswers: {} }),
 			state: () => ({
 				status: "connected",
@@ -178,9 +152,7 @@ test("synchronizeTranscript distinguishes an idle crossed snapshot so a stale st
 test("transcriptSyncNeed combines reconnect and compaction into one read", () => {
 	expect(
 		transcriptSyncNeed(
-			runtime({
-				turns: [{ kind: "compaction", id: "compact-1", status: "done" }],
-			}),
+			runtime({ turns: [{ kind: "compaction", id: "compact-1", status: "done" }] }),
 			8,
 		),
 	).toEqual({ connectionGeneration: 8, compactionTurnId: "compact-1" });

--- a/apps/web/src/chat/useTranscriptSync.test.ts
+++ b/apps/web/src/chat/useTranscriptSync.test.ts
@@ -51,6 +51,7 @@ test("transcriptSyncNeed requests an authoritative read for an older connection 
 	expect(transcriptSyncNeed(runtime(), 5)).toEqual({
 		connectionGeneration: 5,
 		compactionTurnId: null,
+		reason: "reconnect",
 	});
 });
 
@@ -64,6 +65,7 @@ test("transcriptSyncNeed recognizes only successful live compactions without a d
 	expect(transcriptSyncNeed(runtime({ turns: [liveDone] }), 4)).toEqual({
 		connectionGeneration: null,
 		compactionTurnId: "live-done",
+		reason: "compaction",
 	});
 	for (const turn of [
 		{ ...liveDone, status: "running" as const },
@@ -235,5 +237,9 @@ test("transcriptSyncNeed combines reconnect and compaction into one read", () =>
 			runtime({ turns: [{ kind: "compaction", id: "compact-1", status: "done" }] }),
 			8,
 		),
-	).toEqual({ connectionGeneration: 8, compactionTurnId: "compact-1" });
+	).toEqual({
+		connectionGeneration: 8,
+		compactionTurnId: "compact-1",
+		reason: "reconnect",
+	});
 });

--- a/apps/web/src/chat/useTranscriptSync.test.ts
+++ b/apps/web/src/chat/useTranscriptSync.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import type { SessionRuntime } from "../store/appStore";
+import { transcriptSyncNeed } from "./useTranscriptSync";
+
+function runtime(overrides: Partial<SessionRuntime> = {}): SessionRuntime {
+	return {
+		turns: [],
+		toolResults: {},
+		askAnswers: {},
+		currentAssistantId: null,
+		attemptAssistantId: null,
+		isStreaming: false,
+		queue: { steering: [], followUp: [] },
+		model: null,
+		thinkingLevel: "medium",
+		eventRevision: 0,
+		syncedConnectionGeneration: 4,
+		stats: null,
+		commands: [],
+		draft: "",
+		pendingExtUi: null,
+		extUiQueue: [],
+		extUiStatus: {},
+		extUiWidget: {},
+		...overrides,
+	};
+}
+
+test("transcriptSyncNeed requests an authoritative read for an older connection generation", () => {
+	expect(transcriptSyncNeed(runtime(), 4)).toBeNull();
+	expect(transcriptSyncNeed(runtime(), 5)).toEqual({
+		connectionGeneration: 5,
+		compactionTurnId: null,
+	});
+});
+
+test("transcriptSyncNeed recognizes only successful live compactions without a durable summary", () => {
+	const liveDone = {
+		kind: "compaction" as const,
+		id: "live-done",
+		status: "done" as const,
+		tokensBefore: 268_000,
+	};
+	expect(transcriptSyncNeed(runtime({ turns: [liveDone] }), 4)).toEqual({
+		connectionGeneration: null,
+		compactionTurnId: "live-done",
+	});
+	for (const turn of [
+		{ ...liveDone, status: "running" as const },
+		{ ...liveDone, status: "failed" as const },
+		{ ...liveDone, status: "cancelled" as const },
+		{ ...liveDone, summary: "already canonical" },
+	]) {
+		expect(transcriptSyncNeed(runtime({ turns: [turn] }), 4)).toBeNull();
+	}
+});
+
+test("transcriptSyncNeed combines reconnect and compaction into one read", () => {
+	expect(
+		transcriptSyncNeed(
+			runtime({
+				turns: [{ kind: "compaction", id: "compact-1", status: "done" }],
+			}),
+			8,
+		),
+	).toEqual({ connectionGeneration: 8, compactionTurnId: "compact-1" });
+});

--- a/apps/web/src/chat/useTranscriptSync.test.ts
+++ b/apps/web/src/chat/useTranscriptSync.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { SessionRuntime } from "../store/appStore";
-import { transcriptSyncNeed } from "./useTranscriptSync";
+import { synchronizeTranscript, transcriptSyncNeed } from "./useTranscriptSync";
 
 function runtime(overrides: Partial<SessionRuntime> = {}): SessionRuntime {
 	return {
@@ -53,6 +53,126 @@ test("transcriptSyncNeed recognizes only successful live compactions without a d
 	]) {
 		expect(transcriptSyncNeed(runtime({ turns: [turn] }), 4)).toBeNull();
 	}
+});
+
+test("synchronizeTranscript compare-and-installs one canonical snapshot", async () => {
+	const summary = {
+		sessionId: "session-1",
+		workspaceId: "workspace-1",
+		title: "Chat",
+		model: null,
+		thinkingLevel: "medium" as const,
+		isStreaming: false,
+		messageCount: 0,
+		updatedAt: 1,
+		live: true,
+	};
+	const hydrated = { turns: [], toolResults: {}, askAnswers: {}, turnIdByMessageIndex: [] };
+	let installed: unknown[] | null = null;
+	const outcome = await synchronizeTranscript(
+		{
+			workspaceId: "workspace-1",
+			sessionId: "session-1",
+			expectedEventRevision: 9,
+			connectionGeneration: 6,
+		},
+		{
+			read: async () => ({ result: { summary, messages: [] }, syncedTick: 0 }),
+			hydrate: () => hydrated,
+			state: () => ({
+				status: "connected",
+				connectionGeneration: 6,
+				reconcileSession: (...args: unknown[]) => {
+					installed = args;
+					return true;
+				},
+			}),
+		},
+	);
+
+	expect(outcome).toBe("applied");
+	expect(installed).toEqual([summary, hydrated, 9, 6]);
+});
+
+test("synchronizeTranscript rejects a response from an overtaken connection generation", async () => {
+	let reconciled = false;
+	const outcome = await synchronizeTranscript(
+		{
+			workspaceId: "workspace-1",
+			sessionId: "session-1",
+			expectedEventRevision: 2,
+			connectionGeneration: 4,
+		},
+		{
+			read: async () => ({
+				result: {
+					summary: {
+						sessionId: "session-1",
+						workspaceId: "workspace-1",
+						title: "Chat",
+						model: null,
+						thinkingLevel: "medium" as const,
+						isStreaming: false,
+						messageCount: 0,
+						updatedAt: 1,
+						live: true,
+					},
+					messages: [],
+				},
+				syncedTick: 0,
+			}),
+			hydrate: () => ({ turns: [], toolResults: {}, askAnswers: {} }),
+			state: () => ({
+				status: "connected",
+				connectionGeneration: 5,
+				reconcileSession: () => {
+					reconciled = true;
+					return true;
+				},
+			}),
+		},
+	);
+
+	expect(outcome).toBe("stale");
+	expect(reconciled).toBe(false);
+});
+
+test("synchronizeTranscript distinguishes an idle crossed snapshot so a stale streaming UI can retry", async () => {
+	const outcome = await synchronizeTranscript(
+		{
+			workspaceId: "workspace-1",
+			sessionId: "session-1",
+			expectedEventRevision: 2,
+			connectionGeneration: 4,
+		},
+		{
+			read: async () => ({
+				result: {
+					summary: {
+						sessionId: "session-1",
+						workspaceId: "workspace-1",
+						title: "Chat",
+						model: null,
+						thinkingLevel: "medium" as const,
+						isStreaming: false,
+						messageCount: 0,
+						updatedAt: 1,
+						live: true,
+					},
+					messages: [],
+				},
+				syncedTick: 0,
+			}),
+			hydrate: () => ({ turns: [], toolResults: {}, askAnswers: {} }),
+			state: () => ({
+				status: "connected",
+				connectionGeneration: 4,
+				reconcileSession: () => false,
+			}),
+		},
+	);
+
+	expect(outcome).toBe("crossed-idle");
 });
 
 test("transcriptSyncNeed combines reconnect and compaction into one read", () => {

--- a/apps/web/src/chat/useTranscriptSync.ts
+++ b/apps/web/src/chat/useTranscriptSync.ts
@@ -17,6 +17,7 @@ interface TranscriptSyncInput {
 	sessionId: string;
 	expectedEventRevision: number;
 	connectionGeneration: number;
+	reason: "compaction" | "reconnect";
 }
 
 interface TranscriptSyncDependencies {
@@ -37,7 +38,7 @@ const transcriptSyncDependencies: TranscriptSyncDependencies = {
 export async function synchronizeTranscript(
 	input: TranscriptSyncInput,
 	deps: TranscriptSyncDependencies = transcriptSyncDependencies,
-): Promise<"applied" | "crossed-idle" | "crossed-streaming" | "stale"> {
+): Promise<"applied" | "crossed-idle" | "crossed-streaming" | "deferred-streaming" | "stale"> {
 	const { result } = await deps.read({
 		workspaceId: input.workspaceId,
 		sessionId: input.sessionId,
@@ -46,6 +47,7 @@ export async function synchronizeTranscript(
 	if (state.status !== "connected" || state.connectionGeneration !== input.connectionGeneration) {
 		return "stale";
 	}
+	if (input.reason === "reconnect" && result.summary.isStreaming) return "deferred-streaming";
 	const applied = state.reconcileSession(
 		result.summary,
 		deps.hydrate(result.messages, result.summary.lastSettlement),
@@ -54,6 +56,12 @@ export async function synchronizeTranscript(
 	);
 	if (applied) return "applied";
 	return result.summary.isStreaming ? "crossed-streaming" : "crossed-idle";
+}
+
+const TRANSCRIPT_SYNC_RETRY_DELAYS = [500, 1_500] as const;
+
+export function transcriptSyncRetryDelay(failureCount: number): number | null {
+	return TRANSCRIPT_SYNC_RETRY_DELAYS[failureCount - 1] ?? null;
 }
 
 export function transcriptSyncNeed(
@@ -88,53 +96,76 @@ export function useTranscriptSync({
 	enabled?: boolean;
 }): void {
 	const [retry, setRetry] = useState(0);
-	const waitingForIdle = useRef<string | null>(null);
-	const failed = useRef<string | null>(null);
+	const waitingForIdle = useRef<{ key: string; eventRevision: number } | null>(null);
+	const failure = useRef<{ key: string; count: number } | null>(null);
 	const need = transcriptSyncNeed(runtime, connectionGeneration);
 	const needKey = need ? `${connectionGeneration}:${need.compactionTurnId ?? "generation"}` : null;
+	const failureCount = failure.current?.key === needKey ? failure.current.count : 0;
+	const exhausted = failureCount > 0 && transcriptSyncRetryDelay(failureCount) === null;
 
 	useEffect(() => {
-		if (!enabled || !needKey || status !== "connected" || failed.current === needKey) return;
-		if (waitingForIdle.current === needKey && runtime.isStreaming) return;
+		if (!enabled || !needKey || status !== "connected" || exhausted) return;
+		const waiting = waitingForIdle.current;
+		if (waiting?.key === needKey) {
+			if (waiting.eventRevision === runtime.eventRevision || runtime.isStreaming) return;
+		} else if (waiting) {
+			waitingForIdle.current = null;
+		}
 		waitingForIdle.current = null;
 		let current = true;
+		let retryTimer: ReturnType<typeof setTimeout> | undefined;
 		const expectedEventRevision = runtime.eventRevision;
 		void synchronizeTranscript({
 			workspaceId,
 			sessionId,
 			expectedEventRevision,
 			connectionGeneration,
+			reason: need?.compactionTurnId ? "compaction" : "reconnect",
 		})
 			.then((outcome) => {
 				if (!current || outcome === "stale") return;
-				if (outcome === "applied") {
-					failed.current = null;
-					return;
-				}
+				failure.current = null;
+				if (outcome === "applied") return;
 				const latest = useAppStore.getState().sessions[sessionId];
 				if (!latest) return;
+				if (outcome === "deferred-streaming") {
+					waitingForIdle.current = { key: needKey, eventRevision: latest.eventRevision };
+					return;
+				}
 				if (outcome === "crossed-idle" || !latest.isStreaming) {
 					setRetry((value) => value + 1);
 					return;
 				}
-				waitingForIdle.current = needKey;
+				waitingForIdle.current = { key: needKey, eventRevision: latest.eventRevision };
 			})
 			.catch((error: unknown) => {
 				if (!current) return;
+				const previous = failure.current?.key === needKey ? failure.current.count : 0;
+				const count = previous + 1;
+				failure.current = { key: needKey, count };
+				const delay = transcriptSyncRetryDelay(count);
+				if (delay !== null) {
+					retryTimer = setTimeout(() => {
+						if (current) setRetry((value) => value + 1);
+					}, delay);
+					return;
+				}
 				const state = useAppStore.getState();
 				if (state.status === "connected" && state.connectionGeneration === connectionGeneration) {
 					toast.error(errorText(error), "Couldn't refresh this chat");
 				}
-				failed.current = needKey;
 			});
 		return () => {
 			current = false;
+			if (retryTimer !== undefined) clearTimeout(retryTimer);
 		};
 	}, [
 		connectionGeneration,
 		enabled,
 		needKey,
+		exhausted,
 		retry,
+		runtime.eventRevision,
 		runtime.isStreaming,
 		sessionId,
 		status,

--- a/apps/web/src/chat/useTranscriptSync.ts
+++ b/apps/web/src/chat/useTranscriptSync.ts
@@ -10,6 +10,7 @@ import { messagesToRuntime } from "./hydrate";
 export interface TranscriptSyncNeed {
 	connectionGeneration: number | null;
 	compactionTurnId: string | null;
+	reason: "compaction" | "reconnect";
 }
 
 interface TranscriptSyncInput {
@@ -77,6 +78,7 @@ export function transcriptSyncNeed(
 	return {
 		connectionGeneration: generation,
 		compactionTurnId: compaction?.id ?? null,
+		reason: generation !== null ? "reconnect" : "compaction",
 	};
 }
 
@@ -120,7 +122,7 @@ export function useTranscriptSync({
 			sessionId,
 			expectedEventRevision,
 			connectionGeneration,
-			reason: need?.compactionTurnId ? "compaction" : "reconnect",
+			reason: need?.reason ?? "reconnect",
 		})
 			.then((outcome) => {
 				if (!current || outcome === "stale") return;

--- a/apps/web/src/chat/useTranscriptSync.ts
+++ b/apps/web/src/chat/useTranscriptSync.ts
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from "react";
+import { type SessionRuntime, toast, useAppStore } from "../store";
+import {
+	type ConnectionStatus,
+	errorText,
+	getSessionMessagesWithSkillBaseline,
+} from "../transport";
+import { messagesToRuntime } from "./hydrate";
+
+export interface TranscriptSyncNeed {
+	connectionGeneration: number | null;
+	compactionTurnId: string | null;
+}
+
+interface TranscriptSyncInput {
+	workspaceId: string;
+	sessionId: string;
+	expectedEventRevision: number;
+	connectionGeneration: number;
+}
+
+interface TranscriptSyncDependencies {
+	read: typeof getSessionMessagesWithSkillBaseline;
+	hydrate: typeof messagesToRuntime;
+	state: () => Pick<
+		ReturnType<typeof useAppStore.getState>,
+		"status" | "connectionGeneration" | "reconcileSession"
+	>;
+}
+
+const transcriptSyncDependencies: TranscriptSyncDependencies = {
+	read: getSessionMessagesWithSkillBaseline,
+	hydrate: messagesToRuntime,
+	state: useAppStore.getState,
+};
+
+export async function synchronizeTranscript(
+	input: TranscriptSyncInput,
+	deps: TranscriptSyncDependencies = transcriptSyncDependencies,
+): Promise<"applied" | "crossed-idle" | "crossed-streaming" | "stale"> {
+	const { result } = await deps.read({
+		workspaceId: input.workspaceId,
+		sessionId: input.sessionId,
+	});
+	const state = deps.state();
+	if (state.status !== "connected" || state.connectionGeneration !== input.connectionGeneration) {
+		return "stale";
+	}
+	const applied = state.reconcileSession(
+		result.summary,
+		deps.hydrate(result.messages, result.summary.lastSettlement),
+		input.expectedEventRevision,
+		input.connectionGeneration,
+	);
+	if (applied) return "applied";
+	return result.summary.isStreaming ? "crossed-streaming" : "crossed-idle";
+}
+
+export function transcriptSyncNeed(
+	runtime: SessionRuntime,
+	connectionGeneration: number,
+): TranscriptSyncNeed | null {
+	const compaction = runtime.turns.findLast(
+		(turn) => turn.kind === "compaction" && turn.status === "done" && turn.summary === undefined,
+	);
+	const generation =
+		runtime.syncedConnectionGeneration < connectionGeneration ? connectionGeneration : null;
+	if (generation === null && compaction === undefined) return null;
+	return {
+		connectionGeneration: generation,
+		compactionTurnId: compaction?.id ?? null,
+	};
+}
+
+export function useTranscriptSync({
+	workspaceId,
+	sessionId,
+	runtime,
+	status,
+	connectionGeneration,
+	enabled = true,
+}: {
+	workspaceId: string;
+	sessionId: string;
+	runtime: SessionRuntime;
+	status: ConnectionStatus;
+	connectionGeneration: number;
+	enabled?: boolean;
+}): void {
+	const [retry, setRetry] = useState(0);
+	const waitingForIdle = useRef<string | null>(null);
+	const failed = useRef<string | null>(null);
+	const need = transcriptSyncNeed(runtime, connectionGeneration);
+	const needKey = need ? `${connectionGeneration}:${need.compactionTurnId ?? "generation"}` : null;
+
+	useEffect(() => {
+		if (!enabled || !needKey || status !== "connected" || failed.current === needKey) return;
+		if (waitingForIdle.current === needKey && runtime.isStreaming) return;
+		waitingForIdle.current = null;
+		let current = true;
+		const expectedEventRevision = runtime.eventRevision;
+		void synchronizeTranscript({
+			workspaceId,
+			sessionId,
+			expectedEventRevision,
+			connectionGeneration,
+		})
+			.then((outcome) => {
+				if (!current || outcome === "stale") return;
+				if (outcome === "applied") {
+					failed.current = null;
+					return;
+				}
+				const latest = useAppStore.getState().sessions[sessionId];
+				if (!latest) return;
+				if (outcome === "crossed-idle" || !latest.isStreaming) {
+					setRetry((value) => value + 1);
+					return;
+				}
+				waitingForIdle.current = needKey;
+			})
+			.catch((error: unknown) => {
+				if (!current) return;
+				const state = useAppStore.getState();
+				if (state.status === "connected" && state.connectionGeneration === connectionGeneration) {
+					toast.error(errorText(error), "Couldn't refresh this chat");
+				}
+				failed.current = needKey;
+			});
+		return () => {
+			current = false;
+		};
+	}, [
+		connectionGeneration,
+		enabled,
+		needKey,
+		retry,
+		runtime.isStreaming,
+		sessionId,
+		status,
+		workspaceId,
+	]);
+}

--- a/apps/web/src/panels/ChatSettings.tsx
+++ b/apps/web/src/panels/ChatSettings.tsx
@@ -1,0 +1,89 @@
+import { RiCheckLine as Check } from "@remixicon/react";
+import type { ComposerGrowthLimit } from "@thinkrail/contracts";
+import { cn } from "@/lib";
+import { toast, useAppStore } from "@/store";
+import { getTransport } from "@/transport";
+
+const GROWTH_CHOICES: {
+	id: ComposerGrowthLimit;
+	label: string;
+	hint: string;
+	description: string;
+}[] = [
+	{
+		id: "compact",
+		label: "Compact",
+		hint: "6 lines",
+		description: "Keeps long drafts to six visual lines before scrolling.",
+	},
+	{
+		id: "roomy",
+		label: "Roomy",
+		hint: "10 lines",
+		description: "Keeps long drafts to ten visual lines before scrolling.",
+	},
+	{
+		id: "half-chat",
+		label: "Half chat",
+		hint: "Default",
+		description: "Uses up to half of the mounted chat panel before scrolling.",
+	},
+];
+
+export function ChatSettings() {
+	const growthLimit = useAppStore((state) => state.composerGrowthLimit);
+
+	const select = (composerGrowthLimit: ComposerGrowthLimit) => {
+		if (composerGrowthLimit === growthLimit) return;
+		getTransport()
+			.request("settings.update", { config: { composerGrowthLimit } })
+			.catch(() => toast.error("Couldn't change composer growth"));
+	};
+
+	return (
+		<section data-testid="settings-chat" className="flex flex-col gap-8">
+			<div className="flex flex-col gap-4">
+				<h3 className="tr-title-section text-text-default">Composer growth</h3>
+				<p className="text-text-muted tr-text-metadata">
+					Choose how tall long drafts may grow before the message field scrolls. Your choice is
+					saved on the host and follows you across devices.
+				</p>
+			</div>
+			<div role="radiogroup" aria-label="Composer growth limit" className="flex flex-col gap-4">
+				{GROWTH_CHOICES.map(({ id, label, hint, description }) => {
+					const active = id === growthLimit;
+					return (
+						<label
+							key={id}
+							data-testid={`composer-growth-${id}`}
+							data-active={active}
+							className={cn(
+								"flex cursor-pointer items-center gap-8 rounded-[var(--radius-sm)] border px-12 py-8 text-left transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary",
+								active
+									? "border-primary-muted bg-clip-padding bg-primary-subtle"
+									: "border-border-default hover:bg-control-bg-hovered",
+							)}
+						>
+							<input
+								type="radio"
+								name="composer-growth-limit"
+								value={id}
+								checked={active}
+								onChange={() => select(id)}
+								className="sr-only"
+							/>
+							<span className="min-w-0 flex-1">
+								<span className="flex items-center gap-4 tr-title-compact text-text-default">
+									{label}
+									<span className="text-text-muted tr-text-metadata">{hint}</span>
+								</span>
+								<span className="block text-text-muted tr-text-metadata">{description}</span>
+							</span>
+							{active ? <Check className="size-16 shrink-0 text-primary" /> : null}
+						</label>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -340,7 +340,11 @@ a project picker, the prompt hero, and the reused
   bundled catalog from `themes`, with the resolved active selection from `store.theme` marked; clicking
   one fires `settings.update` and the UI **converges on the `settings.changed` broadcast** (no optimistic
   apply), a rejected update raising a toast; the picker never owns a theme list — it renders the catalog
-  the glob discovered at build time); the **shell-owned injected Layout section** (Balanced/Focus/Review
+  the glob discovered at build time); **`ChatSettings`** (the live section immediately after Appearance —
+  three radio cards over `store.composerGrowthLimit`, updating `AppConfig.composerGrowthLimit` with the same
+  converge-on-`settings.changed`, toast-on-rejection pattern; the labels explain when the one-line composer
+  stops growing, while `contracts` owns the closed preset ids/default); the **shell-owned injected Layout
+  section** (Balanced/Focus/Review
   plus named custom preset cards, one host-synchronized default selection, capture-current/rename/delete
   for customs, and the default-6 maximum side groups per side; settings changes converge through
   `settings.changed`. With an active workspace each preset offers confirmable **Apply now…**, which asks
@@ -383,8 +387,8 @@ a project picker, the prompt hero, and the reused
   toggle** — a switch over `store.analyticsEnabled`, fired via `settings.update { analyticsEnabled }`
   with the same converge-on-broadcast pattern as the theme, plus the what-is/isn't-collected copy; only
   the boolean ever crosses the wire, see `submodule-server-analytics`. A single dimmed "General" nav item ("Soon") still signals the shell is
-  built to grow. `ProvidersSettings`/`AppearanceSettings`/`TemplatesSettings`/`PrivacySettings` are the
-  panels-owned **integration pieces** (store + transport); `SettingsDialog` receives the Layout section
+  built to grow. `ProvidersSettings`/`AppearanceSettings`/`ChatSettings`/`TemplatesSettings`/
+  `PrivacySettings` are the panels-owned **integration pieces** (store + transport); `SettingsDialog` receives the Layout section
   from the shell composition root so no panel reaches sideways into shell, and the `LoginDialog` stays
   presentational (`auth` module).
 

--- a/apps/web/src/panels/SettingsDialog.tsx
+++ b/apps/web/src/panels/SettingsDialog.tsx
@@ -4,6 +4,7 @@ import {
 	RiLayoutTop2Line as LayoutPanelTop,
 	RiLayoutGridLine as LayoutTemplate,
 	type RemixiconComponentType as LucideIcon,
+	RiChat2Line as MessageSquareText,
 	RiPaletteLine as Palette,
 	RiShieldCheckLine as ShieldCheck,
 	RiEqualizerLine as SlidersHorizontal,
@@ -14,6 +15,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { cn } from "@/lib";
 import { SettingsSection, useAppStore } from "@/store";
 import { AppearanceSettings } from "./AppearanceSettings";
+import { ChatSettings } from "./ChatSettings";
 import { GithubSettings } from "./GithubSettings";
 import { PrivacySettings } from "./PrivacySettings";
 import { ProvidersSettings } from "./ProvidersSettings";
@@ -24,6 +26,7 @@ const SECTIONS: { id: SettingsSection; label: string; icon: LucideIcon }[] = [
 	{ id: SettingsSection.Providers, label: "Providers", icon: KeyRound },
 	{ id: SettingsSection.Github, label: "GitHub", icon: GitBranch },
 	{ id: SettingsSection.Appearance, label: "Appearance", icon: Palette },
+	{ id: SettingsSection.Chat, label: "Chat", icon: MessageSquareText },
 	{ id: SettingsSection.Layout, label: "Layout", icon: LayoutPanelTop },
 	{ id: SettingsSection.Terminal, label: "Terminal", icon: SquareTerminal },
 	{ id: SettingsSection.Templates, label: "Templates", icon: LayoutTemplate },
@@ -95,6 +98,8 @@ export function SettingsDialog({ layoutSettings }: { layoutSettings: ReactNode }
 							<ProvidersSettings />
 						) : section === SettingsSection.Github ? (
 							<GithubSettings />
+						) : section === SettingsSection.Chat ? (
+							<ChatSettings />
 						) : section === SettingsSection.Layout ? (
 							layoutSettings
 						) : section === SettingsSection.Terminal ? (

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -300,7 +300,7 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   `provider.login` frame (creating `activeLogin` if the frame arrived first; ignoring frames for a different
   live login), **`clearLoginInput()`** drops the live input the instant a reply is sent (no double-submit),
   and **`clearLogin()`** dismisses it. The **settings surface** state — **`settingsOpen`** +
-  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Layout`/`Terminal`/`Templates`/`Privacy`) with
+  **`settingsSection`** (a const-object enum: `Providers`/`Github`/`Appearance`/`Chat`/`Layout`/`Terminal`/`Templates`/`Privacy`) with
   **`openSettings(section?)`** (deep-links to a section, defaults to Providers) / **`closeSettings()`** /
   **`setSettingsSection()`** — lives here so the top-bar gear AND the Welcome provider warning open Settings
   to a section without prop-drilling through the shell. The **theme** state — **`theme: ThemeId`** (the
@@ -308,9 +308,9 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   (folds the server-synced `AppConfig` in from
   `server.welcome` / the `settings.changed` broadcast) — lives here too; it's a **pure value only** (the
   theme-application side-effect is the shell's, keyed off `theme`), and defaults to
-  `DEFAULT_CONFIG.theme` until the welcome arrives. **`layoutSettings: LayoutSettings`** and
-  **`analyticsEnabled: boolean`** ride the same `applyConfig` fold (host-owned, defaulted from
-  `DEFAULT_CONFIG`) — the Layout and Privacy sections' read sides. Layout settings are not a second copy of
+  `DEFAULT_CONFIG.theme` until the welcome arrives. **`composerGrowthLimit: ComposerGrowthLimit`**,
+  **`layoutSettings: LayoutSettings`**, and **`analyticsEnabled: boolean`** ride the same `applyConfig` fold
+  (host-owned, defaulted from `DEFAULT_CONFIG`) — the Chat, Layout, and Privacy sections' read sides. Layout settings are not a second copy of
   any workspace document: they carry only the portable preset catalog/default and group limit. The
   **toast queue** — **`toasts: Toast[]`** (oldest-first) with **`pushToast(toast) → id`** / **`dismissToast(id)`**
   and the ergonomic **`toast.error/success/info(message, title?)`** helper (wraps `pushToast` so a non-React

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -170,8 +170,10 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   one chat's `turns` (pi-canonical) / `toolResults` / `askAnswers` (the `ask-user-answers` replies keyed
   by tool call id — indexed by the reducer and hydration, never turned into bubbles) /
   `currentAssistantId` / `attemptAssistantId` (scopes overflow removal to the attempt actually observed) /
-  `isStreaming` / `model` /
-  `thinkingLevel` / `stats` / `commands` / `draft` and its **extension-UI state** (`pendingExtUi` (typed by
+  `isStreaming` / `model` / `thinkingLevel` / **`eventRevision`** (browser-local, incremented for every
+  received Pi event; the compare-and-install fence for an authoritative transcript read) /
+  **`syncedConnectionGeneration`** (which connected host generation the runtime's transcript was last read
+  from) / `stats` / `commands` / `draft` and its **extension-UI state** (`pendingExtUi` (typed by
   `chat`'s `ExtUiDialogRequest`) + `extUiQueue` (overlapping dialogs FIFO so none orphans its server
   promise) + `extUiStatus` / `extUiWidget`). `openChatSession` creates a runtime; `closeChatRuntime` /
   `clearWorkspaceState` drop it; per-session mutators (`appendUserMessage` / **`appendErrorTurn`** / `setStats` / `setCommands` /
@@ -190,7 +192,9 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   cap — a failed compaction must be visible, never swallowed) or appends the settled turn when no
   running one exists (reconnect mid-compaction). A successful `compaction_end` with `willRetry: true`
   additionally marks the turn `resuming` (pi continues the same run; settlement clears the flag — a
-  settled transcript never claims ongoing work) and still removes the superseded assistant attempt. The
+  settled transcript never claims ongoing work) and still removes the superseded assistant attempt. A
+  successful live turn without a durable `summary` is also the chat integration's signal to read Pi's
+  canonical compacted transcript; the reducer never guesses the cut boundary itself. The
   reducer relies on pi's guarantee that every emitted `compaction_start` is paired with a
   `compaction_end` (both success and failure paths emit it), the same trust every other event pair gets.
   Manual-command transport rejection uses one atomic store mutation: given the compaction-turn ids observed
@@ -240,8 +244,16 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   live summary's `lastSettlement` is authoritative when present; otherwise only a failure on
   the persisted transcript's final conversational message is current (historical `length` attempts followed
   by later work must not become stale warnings). Hydration is a no-op if a runtime already exists, so a
-  live/ahead chat is never clobbered. The
-  pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime. **Only idle sends enter the transcript
+  live/ahead chat is never clobbered. **`reconcileSession(summary, hydrated, expectedEventRevision,
+  connectionGeneration)`** is the separate authoritative path for an existing runtime after successful
+  compaction or reconnect. It compare-and-installs only at the expected Pi-event revision, rejects a removed
+  workspace/session or cross-workspace identity, replaces turns/tool results/ask answers/queue/model/thinking
+  + streaming state, and preserves draft/stats/commands/extension UI/placement/history/focus. It marks the
+  connected generation and advances the revision so two reads cannot regress one another. When the latest
+  live compaction matches the durable record, its id + estimated-after count survive, and `resuming` survives
+  only while the returned summary is still streaming. The
+  pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime; **`handlePiEvent` increments the revision even
+  for a UI-ignored Pi event**, because ignored still means it crossed the snapshot ordering boundary. **Only idle sends enter the transcript
   optimistically** (`ChatView.onSubmit` → `appendUserMessage`); the last-turn echo dedup below is
   sufficient precisely because nothing intervenes before the echo. A **streaming send (`steer`/`followUp`)
   never appends a turn**: its text lives in `queue` (folded verbatim from the host-projected

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1,15 +1,16 @@
 import { beforeEach, expect, test } from "bun:test";
-import type {
-	ExtUiRequest,
-	PiEvent,
-	Project,
-	SessionSummary,
-	SpecGraphNode,
-	WireModel,
-	Workspace,
-	WorkspaceFsChangedPayload,
-	WorkspaceLayoutDocument,
-	WorkspaceSkillChange,
+import {
+	DEFAULT_CONFIG,
+	type ExtUiRequest,
+	type PiEvent,
+	type Project,
+	type SessionSummary,
+	type SpecGraphNode,
+	type WireModel,
+	type Workspace,
+	type WorkspaceFsChangedPayload,
+	type WorkspaceLayoutDocument,
+	type WorkspaceSkillChange,
 } from "@thinkrail/contracts";
 import type { ChatTurn } from "../chat/types";
 import { userText } from "../lib";
@@ -2615,6 +2616,14 @@ test("applyConfig folds the server-synced app config in (theme is an opaque host
 	expect(useAppStore.getState().theme).toBe("acme.solarized");
 	useAppStore.getState().applyConfig({ theme: "custom.high-contrast" });
 	expect(useAppStore.getState().theme).toBe("custom.high-contrast");
+});
+
+test("applyConfig projects the composer growth limit", () => {
+	useAppStore.getState().applyConfig({
+		...DEFAULT_CONFIG,
+		composerGrowthLimit: "roomy",
+	});
+	expect(useAppStore.getState()).toHaveProperty("composerGrowthLimit", "roomy");
 });
 
 test("diff tabs: openTab dedupes by id + activates; view + contents update in place", () => {

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -368,7 +368,9 @@ test("message_end finalizes the turn the moment its message completes (not at ag
 		{ type: "message_end", message: { role: "toolResult" } } as unknown as PiEvent,
 		"a",
 	);
-	expect(rt("a")).toBe(before);
+	const ignored = rt("a");
+	expect(ignored.turns).toBe(before.turns);
+	expect(ignored.eventRevision).toBe(before.eventRevision + 1);
 });
 
 test("an ask-user-answers custom message_end indexes into askAnswers (never the turn list)", () => {
@@ -403,7 +405,10 @@ test("an ask-user-answers custom message_end indexes into askAnswers (never the 
 		} as unknown as PiEvent,
 		"a",
 	);
-	expect(rt("a")).toBe(before);
+	const ignored = rt("a");
+	expect(ignored.turns).toBe(before.turns);
+	expect(ignored.askAnswers).toBe(before.askAnswers);
+	expect(ignored.eventRevision).toBe(before.eventRevision + 1);
 });
 
 test("the tool lifecycle folds into toolResults (the status + raw the renderers read)", () => {

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1260,6 +1260,110 @@ test("hydrateSession rebuilds a runtime + tab on connect, and never clobbers a l
 	expect(useAppStore.getState().sessions.h1?.turns).toHaveLength(1);
 });
 
+test("reconcileSession replaces stale host state while preserving browser-local state", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "sync", null, "medium");
+	store.setChatDraft("sync", "keep my draft");
+	store.appendUserMessage("sync", "old summarized prompt");
+	store.handlePiEvent(agentStart, "sync");
+	store.handlePiEvent({ type: "compaction_start", reason: "overflow" }, "sync");
+	store.handlePiEvent(
+		{
+			type: "compaction_end",
+			reason: "overflow",
+			result: { tokensBefore: 268_000, estimatedTokensAfter: 24_000 },
+			aborted: false,
+			willRetry: true,
+		},
+		"sync",
+	);
+
+	const before = rt("sync");
+	const liveCompaction = before.turns.findLast((turn) => turn.kind === "compaction");
+	if (liveCompaction?.kind !== "compaction") throw new Error("live compaction missing");
+	const summary: SessionSummary = {
+		sessionId: "sync",
+		workspaceId: "ws1",
+		title: "Chat",
+		model: null,
+		thinkingLevel: "high",
+		isStreaming: true,
+		messageCount: 2,
+		updatedAt: 2,
+		live: true,
+		queue: { steering: [], followUp: ["continue afterward"] },
+	};
+	const applied = store.reconcileSession(
+		summary,
+		{
+			turns: [
+				{
+					kind: "compaction",
+					id: "persisted-compaction",
+					status: "done",
+					summary: "## Earlier work\nFinished the investigation.",
+					tokensBefore: 268_000,
+				},
+			],
+			toolResults: {},
+			askAnswers: {},
+			turnIdByMessageIndex: [null],
+		},
+		before.eventRevision,
+		7,
+	);
+
+	expect(applied).toBe(true);
+	const after = rt("sync");
+	expect(after.turns).toHaveLength(1);
+	expect(after.turns[0]).toEqual({
+		kind: "compaction",
+		id: liveCompaction.id,
+		status: "done",
+		summary: "## Earlier work\nFinished the investigation.",
+		tokensBefore: 268_000,
+		tokensAfter: 24_000,
+		resuming: true,
+	});
+	expect(after.draft).toBe("keep my draft");
+	expect(after.queue).toEqual({ steering: [], followUp: ["continue afterward"] });
+	expect(after.thinkingLevel).toBe("high");
+	expect(after.syncedConnectionGeneration).toBe(7);
+	expect(after.eventRevision).toBe(before.eventRevision + 1);
+});
+
+test("reconcileSession rejects a transcript read crossed by even a UI-ignored Pi event", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "sync-race", null, "medium");
+	store.appendUserMessage("sync-race", "keep this turn");
+	const expectedRevision = rt("sync-race").eventRevision;
+
+	store.handlePiEvent({ type: "turn_start" } as PiEvent, "sync-race");
+	const crossed = rt("sync-race");
+	expect(crossed.eventRevision).toBe(expectedRevision + 1);
+
+	const applied = store.reconcileSession(
+		{
+			sessionId: "sync-race",
+			workspaceId: "ws1",
+			title: "Chat",
+			model: null,
+			thinkingLevel: "medium",
+			isStreaming: false,
+			messageCount: 0,
+			updatedAt: 2,
+			live: true,
+		},
+		{ turns: [], toolResults: {}, askAnswers: {}, turnIdByMessageIndex: [] },
+		expectedRevision,
+		3,
+	);
+
+	expect(applied).toBe(false);
+	expect(rt("sync-race").turns).toHaveLength(1);
+	expect(rt("sync-race").syncedConnectionGeneration).not.toBe(3);
+});
+
 test("noteClosedChats surfaces disk-only sessions in history, skipping live/open/known ones", () => {
 	const store = useAppStore.getState();
 	useAppStore.setState({ activeWorkspaceId: "ws1" });

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -276,6 +276,8 @@ export interface SessionRuntime {
 	queue: SessionQueueState;
 	model: WireModel | null;
 	thinkingLevel: ThinkingLevel;
+	eventRevision: number;
+	syncedConnectionGeneration: number;
 	stats: SessionStats | null;
 	commands: SlashCommandInfo[];
 	draft: string;
@@ -287,7 +289,11 @@ export interface SessionRuntime {
 
 const EMPTY_QUEUE: SessionQueueState = { steering: [], followUp: [] };
 
-function newRuntime(model: WireModel | null, thinkingLevel: ThinkingLevel): SessionRuntime {
+function newRuntime(
+	model: WireModel | null,
+	thinkingLevel: ThinkingLevel,
+	syncedConnectionGeneration = 0,
+): SessionRuntime {
 	return {
 		turns: [],
 		toolResults: {},
@@ -298,6 +304,8 @@ function newRuntime(model: WireModel | null, thinkingLevel: ThinkingLevel): Sess
 		queue: EMPTY_QUEUE,
 		model,
 		thinkingLevel,
+		eventRevision: 0,
+		syncedConnectionGeneration,
 		stats: null,
 		commands: [],
 		draft: "",
@@ -359,6 +367,34 @@ function settleCompactionTurn(
 	const index = turns.findLastIndex((t) => t.kind === "compaction" && t.status === "running");
 	if (index < 0) return [...turns, { kind: "compaction", id: crypto.randomUUID(), ...outcome }];
 	return turns.map((t, i) => (i === index ? { kind: "compaction", id: t.id, ...outcome } : t));
+}
+
+function reconcileCompactionTurns(
+	current: ChatTurn[],
+	hydrated: ChatTurn[],
+	isStreaming: boolean,
+): ChatTurn[] {
+	const live = current.findLast(
+		(turn) => turn.kind === "compaction" && turn.status === "done" && turn.summary === undefined,
+	);
+	if (live?.kind !== "compaction") return hydrated;
+	const index = hydrated.findLastIndex(
+		(turn) =>
+			turn.kind === "compaction" &&
+			turn.summary !== undefined &&
+			(live.tokensBefore === undefined || turn.tokensBefore === live.tokensBefore),
+	);
+	if (index < 0) return hydrated;
+	return hydrated.map((turn, turnIndex) =>
+		turnIndex === index && turn.kind === "compaction"
+			? {
+					...turn,
+					id: live.id,
+					...(live.tokensAfter !== undefined ? { tokensAfter: live.tokensAfter } : {}),
+					...(isStreaming && live.resuming ? { resuming: true as const } : {}),
+				}
+			: turn,
+	);
 }
 
 type RetrySource = Extract<ChatTurn, { kind: "retry" }>["source"];
@@ -793,6 +829,12 @@ interface AppState {
 		syncedTick?: number,
 		options?: LayoutOpenOptions,
 	) => void;
+	reconcileSession: (
+		summary: SessionSummary,
+		hydrated: HydratedRuntime,
+		expectedEventRevision: number,
+		connectionGeneration: number,
+	) => boolean;
 	appendUserMessage: (sessionId: string, text: string, attachments?: ChatAttachment[]) => void;
 	appendErrorTurn: (sessionId: string, text: string) => void;
 	appendCompactionFailureUnlessObserved: (
@@ -2250,7 +2292,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 						? s.navTickByWorkspace
 						: bumpNav(s, workspaceId),
 				sessions: fresh
-					? { ...s.sessions, [sessionId]: newRuntime(model, thinkingLevel) }
+					? {
+							...s.sessions,
+							[sessionId]: newRuntime(model, thinkingLevel, s.connectionGeneration),
+						}
 					: s.sessions,
 				...(fresh
 					? {
@@ -2458,7 +2503,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 			if (s.sessions[summary.sessionId]) return {};
 			const wsId = summary.workspaceId;
 			const runtime: SessionRuntime = {
-				...newRuntime(summary.model, summary.thinkingLevel),
+				...newRuntime(summary.model, summary.thinkingLevel, s.connectionGeneration),
 				turns: hydrated.turns,
 				toolResults: hydrated.toolResults,
 				askAnswers: hydrated.askAnswers,
@@ -2529,6 +2574,46 @@ export const useAppStore = create<AppState>((set, get) => ({
 					: s.closedChatsByWorkspace,
 			};
 		}),
+	reconcileSession: (summary, hydrated, expectedEventRevision, connectionGeneration) => {
+		let applied = false;
+		set((s) => {
+			const current = s.sessions[summary.sessionId];
+			if (
+				!current ||
+				current.eventRevision !== expectedEventRevision ||
+				s.removedWorkspaceIds[summary.workspaceId] ||
+				isSessionDeleted(s, summary.workspaceId, summary.sessionId) ||
+				!selectWorkspaceSessionIds(s, summary.workspaceId).includes(summary.sessionId)
+			) {
+				return {};
+			}
+			const { turnIdByMessageIndex: _previousMessageIndex, ...preserved } = current;
+			void _previousMessageIndex;
+			const runtime: SessionRuntime = {
+				...preserved,
+				turns: reconcileCompactionTurns(current.turns, hydrated.turns, summary.isStreaming),
+				toolResults: hydrated.toolResults,
+				askAnswers: hydrated.askAnswers,
+				currentAssistantId: null,
+				attemptAssistantId: null,
+				isStreaming: summary.isStreaming,
+				queue: summary.queue ?? EMPTY_QUEUE,
+				model: summary.model,
+				thinkingLevel: summary.thinkingLevel,
+				eventRevision: current.eventRevision + 1,
+				syncedConnectionGeneration: Math.max(
+					current.syncedConnectionGeneration,
+					connectionGeneration,
+				),
+				...(hydrated.turnIdByMessageIndex
+					? { turnIdByMessageIndex: hydrated.turnIdByMessageIndex }
+					: {}),
+			};
+			applied = true;
+			return { sessions: { ...s.sessions, [summary.sessionId]: runtime } };
+		});
+		return applied;
+	},
 	appendUserMessage: (sessionId, text, attachments) =>
 		set((s) =>
 			withRuntime(s, sessionId, (rt) => ({
@@ -2584,7 +2669,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 			}),
 		),
 	handlePiEvent: (event, sessionId) =>
-		set((s) => withRuntime(s, sessionId, (rt) => reduceSessionEvent(rt, event))),
+		set((s) =>
+			withRuntime(s, sessionId, (rt) => ({
+				...reduceSessionEvent(rt, event),
+				eventRevision: rt.eventRevision + 1,
+			})),
+		),
 	setModelsForProviderVersion: (providerVersion, models) =>
 		set((s) => (s.providerVersion === providerVersion ? { models, modelsFresh: false } : s)),
 	noteProviderChanged: () =>

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1,6 +1,7 @@
 import type {
 	AppConfig,
 	AskUserQuestionResult,
+	ComposerGrowthLimit,
 	ExtUiRequest,
 	GitDiffScope,
 	LayoutAuxiliaryRegion,
@@ -226,6 +227,7 @@ export const SettingsSection = {
 	Providers: "providers",
 	Github: "github",
 	Appearance: "appearance",
+	Chat: "chat",
 	Layout: "layout",
 	Terminal: "terminal",
 	Templates: "templates",
@@ -692,6 +694,7 @@ interface AppState {
 	theme: ThemeId;
 	analyticsEnabled: boolean;
 	terminalReplayKb: number;
+	composerGrowthLimit: ComposerGrowthLimit;
 	layoutSettings: LayoutSettings;
 	toasts: Toast[];
 	setStatus: (status: ConnectionStatus) => void;
@@ -891,6 +894,7 @@ function configPatch(config: AppConfig) {
 		theme: config.theme,
 		analyticsEnabled: config.analyticsEnabled,
 		terminalReplayKb: config.terminalReplayKb,
+		composerGrowthLimit: config.composerGrowthLimit ?? DEFAULT_CONFIG.composerGrowthLimit,
 		layoutSettings: config.layout ?? DEFAULT_CONFIG.layout,
 	};
 }
@@ -1396,6 +1400,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	theme: DEFAULT_CONFIG.theme,
 	analyticsEnabled: DEFAULT_CONFIG.analyticsEnabled,
 	terminalReplayKb: DEFAULT_CONFIG.terminalReplayKb,
+	composerGrowthLimit: DEFAULT_CONFIG.composerGrowthLimit,
 	layoutSettings: DEFAULT_CONFIG.layout,
 	toasts: [],
 	setStatus: (status) =>

--- a/architecture.md
+++ b/architecture.md
@@ -118,7 +118,9 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
     the root `workspaces.catalog` and referenced via `catalog:`, so their version lives in exactly one place.
     **Enforced**, not just documented: `scripts/check-catalog.ts` (`bun run check:deps`, in pre-commit + CI)
     rejects any range and any catalog drift. Exempt: `peerDependencies` (extension packages declare `"*"` on
-    purpose — the host provides the dep) and local protocols (`workspace:` / `link:` / `file:`).
+    purpose — the host provides the dep) and local protocols (`workspace:` / `link:` / `file:`). An exact
+    SemVer prerelease/build suffix is still an exact pin (`19.3.0-canary-a1124489-20260826`); the checker
+    accepts the full identifier grammar, including hyphens, without admitting a range.
 
 11. **Terminal = xterm.js on the DOM renderer.** The browser terminal is `@xterm/xterm`, driven from
     `apps/web/src/panels/TerminalInstance.tsx` against a real PTY (`bun-pty`) in

--- a/bun.lock
+++ b/bun.lock
@@ -248,8 +248,8 @@
     "@types/react-dom": "19.2.3",
     "astro": "7.2.4",
     "lucide-react": "1.21.0",
-    "react": "19.2.7",
-    "react-dom": "19.2.7",
+    "react": "19.3.0-canary-a1124489-20260826",
+    "react-dom": "19.3.0-canary-a1124489-20260826",
     "tailwindcss": "4.3.1",
     "typebox": "1.3.7",
     "typescript": "6.0.3",
@@ -1779,9 +1779,9 @@
 
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
-    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+    "react": ["react@19.3.0-canary-a1124489-20260826", "", {}, "sha512-ia+DfeR/WBsrLngDmCWLnMLukF8IzB4/hXZDIs0jGQkNZ/+jS2QEF9ylMd+BK5evFqmPISwS+BJajs6+oo0G8Q=="],
 
-    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+    "react-dom": ["react-dom@19.3.0-canary-a1124489-20260826", "", { "dependencies": { "scheduler": "0.28.0-canary-a1124489-20260826" }, "peerDependencies": { "react": "19.3.0-canary-a1124489-20260826" } }, "sha512-ph4ugp6H6iI+78Xy75JoIjFaHJ7dCjTHyOnmxxbzLF+I0vJa05hB5HxEVV1jeiRZ9AjnoA5pZiGStDvkRYduMw=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
@@ -1847,7 +1847,7 @@
 
     "sax": ["sax@1.6.1", "", {}, "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q=="],
 
-    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+    "scheduler": ["scheduler@0.28.0-canary-a1124489-20260826", "", {}, "sha512-4A1cEyZlH9w6WTY/CHBJjBwrjOjp5oxncD8SlQNOuUvBfwL5405gENnOLuX57cYKR1jcJCZakMvcSwWagxNhDQ=="],
 
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
@@ -2083,6 +2083,10 @@
 
     "@astrojs/react/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
+    "@astrojs/react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@astrojs/react/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1071.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/nested-clients": "^3.997.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg=="],
@@ -2101,15 +2105,47 @@
 
     "@bruits/satteri-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
 
+    "@dnd-kit/accessibility/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@dnd-kit/core/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@dnd-kit/core/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@dnd-kit/utilities/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
     "@earendil-works/pi-tui/marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "@floating-ui/react-dom/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@floating-ui/react-dom/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
+    "@monaco-editor/react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@monaco-editor/react/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
+
+    "@radix-ui/react-arrow/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-arrow/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.2.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg=="],
 
     "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-collection/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-collection/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@radix-ui/react-compose-refs/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-context/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-context-menu/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-context-menu/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "@radix-ui/react-dialog/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
@@ -2119,9 +2155,19 @@
 
     "@radix-ui/react-dialog/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
 
+    "@radix-ui/react-dialog/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-dialog/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@radix-ui/react-direction/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
     "@radix-ui/react-dismissable-layer/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
     "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
+
+    "@radix-ui/react-dismissable-layer/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-dismissable-layer/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "@radix-ui/react-dropdown-menu/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
@@ -2133,7 +2179,19 @@
 
     "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
 
+    "@radix-ui/react-dropdown-menu/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-dropdown-menu/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@radix-ui/react-focus-guards/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
     "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
+
+    "@radix-ui/react-focus-scope/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-focus-scope/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@radix-ui/react-id/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "@radix-ui/react-menu/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.15", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA=="],
 
@@ -2157,6 +2215,10 @@
 
     "@radix-ui/react-menu/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ=="],
 
+    "@radix-ui/react-menu/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-menu/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "@radix-ui/react-popover/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
     "@radix-ui/react-popover/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
@@ -2165,13 +2227,33 @@
 
     "@radix-ui/react-popover/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
 
+    "@radix-ui/react-popover/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-popover/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "@radix-ui/react-popper/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
 
     "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
 
+    "@radix-ui/react-popper/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-popper/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
 
+    "@radix-ui/react-portal/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-portal/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@radix-ui/react-presence/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-presence/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-primitive/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-primitive/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "@radix-ui/react-roving-focus/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.15", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA=="],
 
@@ -2182,6 +2264,12 @@
     "@radix-ui/react-roving-focus/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ=="],
 
     "@radix-ui/react-roving-focus/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-roving-focus/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-roving-focus/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@radix-ui/react-slot/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "@radix-ui/react-toast/@radix-ui/primitive": ["@radix-ui/primitive@1.1.5", "", {}, "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg=="],
 
@@ -2197,6 +2285,10 @@
 
     "@radix-ui/react-toast/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
 
+    "@radix-ui/react-toast/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-toast/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "@radix-ui/react-tooltip/@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
@@ -2207,11 +2299,37 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.6", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ=="],
 
+    "@radix-ui/react-tooltip/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-tooltip/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@radix-ui/react-use-callback-ref/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
     "@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-use-controllable-state/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "@radix-ui/react-use-effect-event/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
 
+    "@radix-ui/react-use-effect-event/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-use-escape-keydown/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-use-is-hydrated/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-use-layout-effect/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-use-rect/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-use-size/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
+
+    "@radix-ui/react-visually-hidden/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "@radix-ui/react-visually-hidden/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "@remixicon/react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "@tailwindcss/node/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -2239,6 +2357,10 @@
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
 
+    "cmdk/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "cmdk/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
@@ -2255,6 +2377,8 @@
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
+    "lucide-react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "monaco-editor/dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
@@ -2269,6 +2393,22 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "react-markdown/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-remove-scroll/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-remove-scroll-bar/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-resizable-panels/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-resizable-panels/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "react-style-singleton/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-virtuoso/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-virtuoso/react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
     "satteri/@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
@@ -2282,6 +2422,10 @@
     "typescript-auto-import-cache/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "use-callback-ref/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "use-sidecar/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "volar-service-typescript/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -2299,6 +2443,8 @@
 
     "yaml-language-server/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
+    "zustand/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
     "@astrojs/compiler-binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@astrojs/internal-helpers/shiki/@shikijs/core": ["@shikijs/core@4.4.3", "", { "dependencies": { "@shikijs/primitive": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5", "hast-util-to-html": "^9.0.5" } }, "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg=="],
@@ -2315,11 +2461,29 @@
 
     "@astrojs/react/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
+    "@astrojs/react/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
     "@bruits/satteri-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@bruits/satteri-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
+    "@dnd-kit/core/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@floating-ui/react-dom/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@monaco-editor/react/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-arrow/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-collection/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-context-menu/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
     "@radix-ui/react-dialog/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-dialog/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-dismissable-layer/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@radix-ui/react-dropdown-menu/@radix-ui/react-menu/@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.10", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g=="],
 
@@ -2328,6 +2492,10 @@
     "@radix-ui/react-dropdown-menu/@radix-ui/react-menu/@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.10", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw=="],
 
     "@radix-ui/react-dropdown-menu/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-dropdown-menu/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-focus-scope/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@radix-ui/react-menu/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
 
@@ -2345,17 +2513,37 @@
 
     "@radix-ui/react-menu/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
 
+    "@radix-ui/react-menu/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
     "@radix-ui/react-popover/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-popover/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-popper/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-portal/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-presence/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
 
+    "@radix-ui/react-primitive/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
     "@radix-ui/react-roving-focus/@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-roving-focus/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@radix-ui/react-toast/@radix-ui/react-dismissable-layer/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
 
     "@radix-ui/react-toast/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
 
+    "@radix-ui/react-toast/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
     "@radix-ui/react-tooltip/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-tooltip/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@radix-ui/react-visually-hidden/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "astro/shiki/@shikijs/core": ["@shikijs/core@4.4.3", "", { "dependencies": { "@shikijs/primitive": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5", "hast-util-to-html": "^9.0.5" } }, "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg=="],
 
@@ -2371,6 +2559,8 @@
 
     "astro/shiki/@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
+    "cmdk/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
@@ -2378,6 +2568,10 @@
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "react-resizable-panels/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "react-virtuoso/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "sitemap/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/e2e/compaction.spec.ts
+++ b/e2e/compaction.spec.ts
@@ -41,7 +41,7 @@ test("a compacted transcript marks where the summarized messages were", async ({
 	await expect(page.getByText("summarized question")).toHaveCount(0);
 
 	const marker = page.getByTestId("chat-compaction");
-	await expect(marker).toContainText("Earlier messages summarized");
+	await expect(marker).toContainText("Context compacted");
 	await expect(marker).toContainText("148k tokens");
 	await expect(page.getByText("Renamed the widget factory.")).toHaveCount(0);
 	await marker.getByRole("button").click();

--- a/e2e/composer-adaptive.spec.ts
+++ b/e2e/composer-adaptive.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "@playwright/test";
+import { hideAuxiliaryWorkbench, openWorkspaceChat, PHONE_VIEWPORT } from "./fixtures/app";
+
+async function box(locator: import("@playwright/test").Locator) {
+	const value = await locator.boundingBox();
+	if (!value) throw new Error("composer element has no layout box");
+	return value;
+}
+
+test("idle composer keeps one message line above a stable controls row", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const composer = page.getByTestId("chat-composer");
+	const shell = page.getByTestId("chat-composer-shell");
+	const input = page.getByTestId("chat-input");
+	const model = page.getByTestId("model-selector");
+	const effort = page.getByTestId("thinking-selector");
+	const history = page.getByTestId("history-open");
+	const send = page.getByTestId("chat-send");
+
+	const compactShell = await box(shell);
+	const compactInput = await box(input);
+	const compactWrapMeasure = await box(page.getByTestId("chat-input-sizer"));
+	const compactModel = await box(model);
+	expect(compactInput.height).toBeGreaterThanOrEqual(32);
+	expect(compactInput.height).toBeLessThanOrEqual(40);
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	expect(compactShell.height).toBeGreaterThanOrEqual(compactInput.height + compactModel.height);
+	expect(compactInput.x).toBeLessThanOrEqual(compactShell.x + 8);
+	expect(compactInput.x + compactInput.width).toBeGreaterThanOrEqual(
+		compactShell.x + compactShell.width - 8,
+	);
+	expect(Math.abs(compactWrapMeasure.x - compactInput.x)).toBeLessThanOrEqual(0.5);
+	expect(Math.abs(compactWrapMeasure.width - compactInput.width)).toBeLessThanOrEqual(0.5);
+
+	const compactFooterBottom = compactModel.y + compactModel.height;
+	for (const control of [model, effort, history, send]) {
+		const controlBox = await box(control);
+		expect(controlBox.y).toBeGreaterThanOrEqual(compactInput.y + compactInput.height);
+		expect(Math.abs(controlBox.y + controlBox.height - compactFooterBottom)).toBeLessThanOrEqual(4);
+	}
+
+	await input.fill("Inspect the retry flow.\nThen add focused coverage.");
+	await expect(composer).toHaveAttribute("data-expanded", "true");
+	const expandedInput = await box(input);
+	const expandedModel = await box(model);
+	expect(expandedInput.height).toBeGreaterThan(compactInput.height);
+	expect(expandedModel.y).toBeGreaterThanOrEqual(expandedInput.y + expandedInput.height);
+	expect(Math.abs(expandedModel.y - compactModel.y)).toBeLessThanOrEqual(2);
+
+	await input.fill("Short follow-up");
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	expect((await box(input)).height).toBeLessThanOrEqual(40);
+	expect(Math.abs((await box(model)).y - compactModel.y)).toBeLessThanOrEqual(2);
+});
+
+test("panel width changes expand and collapse the same textarea", async ({ page }) => {
+	await page.setViewportSize({ width: 1920, height: 900 });
+	await openWorkspaceChat(page);
+
+	const composer = page.getByTestId("chat-composer");
+	const input = page.getByTestId("chat-input");
+	const initialElement = await input.elementHandle();
+	if (!initialElement) throw new Error("composer textarea missing");
+	await input.fill(
+		"Keep the same focused draft and selection while a narrower mounted chat panel makes this line wrap.",
+	);
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	await input.evaluate((element) => element.setSelectionRange(18, 18));
+
+	await page.setViewportSize({ width: 700, height: 900 });
+	await expect(composer).toHaveAttribute("data-expanded", "true");
+	expect(await input.evaluate((element, initial) => element === initial, initialElement)).toBe(
+		true,
+	);
+	expect(await input.evaluate((element) => element.selectionStart)).toBe(18);
+
+	await page.setViewportSize({ width: 1920, height: 900 });
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	expect(await input.evaluate((element, initial) => element === initial, initialElement)).toBe(
+		true,
+	);
+});
+
+test("half-chat growth caps the editor shell and scrolls the textarea", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const chat = page.getByTestId("chat-view");
+	const composer = page.getByTestId("chat-composer");
+	const shell = page.getByTestId("chat-composer-shell");
+	const input = page.getByTestId("chat-input");
+	await input.fill(Array.from({ length: 80 }, (_, index) => `line ${index + 1}`).join("\n"));
+	await expect(composer).toHaveAttribute("data-expanded", "true");
+
+	const chatBox = await box(chat);
+	const shellBox = await box(shell);
+	expect(shellBox.height).toBeLessThanOrEqual(chatBox.height * 0.5 + 2);
+	const overflow = await input.evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		scrollHeight: element.scrollHeight,
+		overflowY: getComputedStyle(element).overflowY,
+	}));
+	expect(overflow.scrollHeight).toBeGreaterThan(overflow.clientHeight);
+	expect(overflow.overflowY).toBe("auto");
+});
+
+test("chat growth setting persists and compact means six visual lines", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+
+	const compact = page.getByTestId("composer-growth-compact");
+	const roomy = page.getByTestId("composer-growth-roomy");
+	const half = page.getByTestId("composer-growth-half-chat");
+	await expect(compact).toBeVisible();
+	await expect(roomy).toBeVisible();
+	await expect(half).toHaveAttribute("data-active", "true");
+	await compact.click();
+	await expect(compact).toHaveAttribute("data-active", "true");
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	await expect(compact).toHaveAttribute("data-active", "true");
+	await page.keyboard.press("Escape");
+
+	await openWorkspaceChat(page);
+	const input = page.getByTestId("chat-input");
+	await input.fill(Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join("\n"));
+	const lines = await input.evaluate((element) => {
+		const styles = getComputedStyle(element);
+		return (
+			(element.clientHeight -
+				Number.parseFloat(styles.paddingTop) -
+				Number.parseFloat(styles.paddingBottom)) /
+			Number.parseFloat(styles.lineHeight)
+		);
+	});
+	expect(lines).toBeGreaterThanOrEqual(5.9);
+	expect(lines).toBeLessThanOrEqual(6.1);
+
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	await half.click();
+	await expect(half).toHaveAttribute("data-active", "true");
+});
+
+test("compact phone controls remain inside the chat viewport", async ({ page }) => {
+	await openWorkspaceChat(page);
+	await hideAuxiliaryWorkbench(page);
+	await page.setViewportSize(PHONE_VIEWPORT);
+
+	const composer = page.getByTestId("chat-composer");
+	await expect(composer).toHaveAttribute("data-expanded", "false");
+	const shellBox = await box(page.getByTestId("chat-composer-shell"));
+	const idleTextMetrics = await page.getByTestId("chat-input").evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		scrollHeight: element.scrollHeight,
+	}));
+	expect(idleTextMetrics.scrollHeight).toBeLessThanOrEqual(idleTextMetrics.clientHeight);
+	expect(shellBox.x).toBeGreaterThanOrEqual(0);
+	expect(shellBox.x + shellBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
+	for (const control of [
+		page.getByTestId("model-selector"),
+		page.getByTestId("thinking-selector"),
+		page.getByTestId("history-open"),
+		page.getByTestId("chat-send"),
+	]) {
+		const controlBox = await box(control);
+		expect(controlBox.x).toBeGreaterThanOrEqual(0);
+		expect(controlBox.x + controlBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
+	}
+	const inputBox = await box(page.getByTestId("chat-input"));
+	expect(inputBox.height).toBeLessThanOrEqual(40);
+	expect(inputBox.x).toBeLessThanOrEqual(shellBox.x + 8);
+	expect(inputBox.x + inputBox.width).toBeGreaterThanOrEqual(shellBox.x + shellBox.width - 8);
+	expect((await box(page.getByTestId("model-selector"))).y).toBeGreaterThanOrEqual(
+		inputBox.y + inputBox.height,
+	);
+});

--- a/e2e/composer.live.spec.ts
+++ b/e2e/composer.live.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+import {
+	createWorkspaceViaDialog,
+	hideAuxiliaryWorkbench,
+	openFixtureProject,
+	PHONE_VIEWPORT,
+	worktreeRows,
+} from "./fixtures/app";
 
 async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await openFixtureProject(page);
@@ -14,35 +20,45 @@ async function openChat(page: import("@playwright/test").Page): Promise<void> {
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 }
 
-test("composer prompt is moderately tall with model and effort controls underneath", {
+test("streaming unfolds the one-line draft into a complete action rail", {
 	tag: "@agent",
 }, async ({ page }) => {
+	test.setTimeout(90_000);
 	await openChat(page);
+	await hideAuxiliaryWorkbench(page);
+	await page.setViewportSize(PHONE_VIEWPORT);
 
 	const input = page.getByTestId("chat-input");
-	const modelSelector = page.getByTestId("model-selector");
-	const effortSelector = page.getByTestId("thinking-selector");
-	const send = page.getByTestId("chat-send");
+	await input.fill("Use the bash tool to run `sleep 8`, then reply with done.");
+	await page.getByTestId("chat-send").click();
 
-	await expect(input).toBeVisible();
-	await expect(modelSelector).toBeVisible();
-	await expect(effortSelector).toBeVisible();
-	await expect(send).toBeVisible();
-
+	const composer = page.getByTestId("chat-composer");
+	await expect(page.getByTestId("chat-abort")).toBeVisible();
+	await expect(page.getByTestId("send-menu")).toBeVisible();
+	await expect(composer).toHaveAttribute("data-expanded", "true");
 	const inputBox = await input.boundingBox();
-	const modelBox = await modelSelector.boundingBox();
-	const effortBox = await effortSelector.boundingBox();
-	const sendBox = await send.boundingBox();
-	if (!inputBox || !modelBox || !effortBox || !sendBox) {
-		throw new Error("Composer layout boxes were not measurable");
+	const modelBox = await page.getByTestId("model-selector").boundingBox();
+	if (!inputBox || !modelBox) throw new Error("Composer layout boxes were not measurable");
+	expect(inputBox.height).toBeLessThanOrEqual(40);
+	expect(modelBox.y).toBeGreaterThanOrEqual(inputBox.y + inputBox.height);
+	const shellBox = await page.getByTestId("chat-composer-shell").boundingBox();
+	if (!shellBox) throw new Error("Composer shell was not measurable");
+	expect(shellBox.x).toBeGreaterThanOrEqual(0);
+	expect(shellBox.x + shellBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
+	for (const control of [
+		page.getByTestId("history-open"),
+		page.getByTestId("chat-abort"),
+		page.getByTestId("send-menu"),
+		page.getByTestId("chat-send"),
+	]) {
+		const controlBox = await control.boundingBox();
+		if (!controlBox) throw new Error("Streaming composer control was not measurable");
+		expect(controlBox.x).toBeGreaterThanOrEqual(0);
+		expect(controlBox.x + controlBox.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	}
 
-	expect(inputBox.height).toBeGreaterThanOrEqual(100);
-	expect(inputBox.height).toBeLessThanOrEqual(130);
-	const belowInputY = inputBox.y + inputBox.height;
-	expect(modelBox.y).toBeGreaterThanOrEqual(belowInputY);
-	expect(effortBox.y).toBeGreaterThanOrEqual(belowInputY);
-	expect(sendBox.y).toBeGreaterThanOrEqual(belowInputY);
+	await page.getByTestId("chat-abort").click();
+	await expect(page.getByTestId("chat-abort")).toBeHidden();
 });
 
 test("model picker plus file and portable-skill completion use the live session catalog", {
@@ -97,7 +113,14 @@ test("stats refresh after a turn completes (cheap win #3)", { tag: "@agent" }, a
 	await expect(stats).toBeVisible();
 	await expect(stats).toContainText(/[↑↓RW]/);
 
-	await page.setViewportSize({ width: 320, height: 720 });
+	await hideAuxiliaryWorkbench(page);
+	await page.setViewportSize(PHONE_VIEWPORT);
+	await expect
+		.poll(async () => {
+			const chatBox = await page.getByTestId("chat-view").boundingBox();
+			return chatBox ? chatBox.x + chatBox.width : Number.POSITIVE_INFINITY;
+		})
+		.toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	const skills = page.getByTestId("open-skills");
 	await expect(skills).toBeVisible();
 	const statsBox = await stats.boundingBox();
@@ -105,6 +128,6 @@ test("stats refresh after a turn completes (cheap win #3)", { tag: "@agent" }, a
 	if (!statsBox || !skillsBox) throw new Error("chat header item has no bounding box");
 	for (const box of [statsBox, skillsBox]) {
 		expect(box.x).toBeGreaterThanOrEqual(0);
-		expect(box.x + box.width).toBeLessThanOrEqual(320);
+		expect(box.x + box.width).toBeLessThanOrEqual(PHONE_VIEWPORT.width);
 	}
 });

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -17,6 +17,8 @@ import {
 } from "./paths";
 import { fixtureRepoHealthy, seedFixtureRepo } from "./repo";
 
+export const PHONE_VIEWPORT = { width: 390, height: 780 } as const;
+
 function removeTree(path: string): void {
 	rmSync(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
 }
@@ -24,6 +26,19 @@ function removeTree(path: string): void {
 export async function pressPlatformShortcut(page: Page, key: string): Promise<void> {
 	const apple = await page.evaluate(() => /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? ""));
 	await page.keyboard.press(`${apple ? "Meta" : "Control"}+${key}`);
+}
+
+export async function hideAuxiliaryWorkbench(page: Page): Promise<void> {
+	for (const [testId, shortcut] of [
+		["left-stack", "B"],
+		["right-stack", "J"],
+		["bottom-panel", "Shift+J"],
+	] as const) {
+		const panel = page.getByTestId(testId);
+		if ((await panel.count()) === 0) continue;
+		await pressPlatformShortcut(page, shortcut);
+		await expect(panel).toHaveCount(0);
+	}
 }
 
 function resetState(): void {

--- a/e2e/templates-compose.spec.ts
+++ b/e2e/templates-compose.spec.ts
@@ -185,6 +185,50 @@ test.describe("prompt templates in the composer", () => {
 		await expect(backdrop).not.toBeVisible();
 	});
 
+	test("the slot backdrop shares dynamic textarea geometry and capped scrolling", async ({
+		page,
+	}) => {
+		await openWorkspaceChat(page);
+		const input = page.getByTestId("chat-input");
+
+		await input.fill("/rena");
+		await page.locator('[data-testid="slash-command"][data-source="prompt"]').first().click();
+		await expect(input).toHaveValue(/^Rename ⟨name⟩ and update every ⟨name⟩ reference\.\s*$/);
+		await page.keyboard.insertText("Widget ".repeat(300));
+		await expect(page.getByTestId("chat-composer")).toHaveAttribute("data-expanded", "true");
+
+		const backdrop = page.getByTestId("slot-backdrop");
+		const geometry = await input.evaluate((element) => {
+			const overlay = document.querySelector<HTMLElement>('[data-testid="slot-backdrop"]');
+			if (!overlay) throw new Error("slot backdrop missing");
+			const inputRect = element.getBoundingClientRect();
+			const backdropRect = overlay.getBoundingClientRect();
+			return {
+				input: { x: inputRect.x, y: inputRect.y, width: inputRect.width, height: inputRect.height },
+				backdrop: {
+					x: backdropRect.x,
+					y: backdropRect.y,
+					width: backdropRect.width,
+					height: backdropRect.height,
+				},
+				scrollHeight: element.scrollHeight,
+				clientHeight: element.clientHeight,
+			};
+		});
+		expect(geometry.input.height).toBeGreaterThan(108);
+		expect(geometry.backdrop.x).toBeCloseTo(geometry.input.x, 0);
+		expect(geometry.backdrop.y).toBeCloseTo(geometry.input.y, 0);
+		expect(geometry.backdrop.width).toBeCloseTo(geometry.input.width, 0);
+		expect(geometry.backdrop.height).toBeCloseTo(geometry.input.height, 0);
+		expect(geometry.scrollHeight).toBeGreaterThan(geometry.clientHeight);
+
+		await input.evaluate((element) => {
+			element.scrollTop = element.scrollHeight;
+			element.dispatchEvent(new Event("scroll"));
+		});
+		await expect.poll(() => backdrop.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+	});
+
 	test("sending directly (no Tab) still mirrors a filled slot's text into its same-group sibling", async ({
 		page,
 	}) => {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 			"@types/react-dom": "19.2.3",
 			"astro": "7.2.4",
 			"lucide-react": "1.21.0",
-			"react": "19.2.7",
-			"react-dom": "19.2.7",
+			"react": "19.3.0-canary-a1124489-20260826",
+			"react-dom": "19.3.0-canary-a1124489-20260826",
 			"tailwindcss": "4.3.1",
 			"typebox": "1.3.7",
 			"typescript": "6.0.3"

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -191,7 +191,11 @@ of the host.
   and raw PI models are structurally absent; server and web map codes to their own generic copy);
   the **theme/config selection** — **`ThemeId`** is an open string on the wire, because the host persists
   an opaque selection while the independently shipped web client owns the available manifest catalog;
-  **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, layout }` — an extensible bag; `layout` is the
+  **`ComposerGrowthLimit`** (`"compact" | "roomy" | "half-chat"`) is the closed, server-synced composer
+  height preference: 6 visual lines, 10 visual lines, or 50% of the mounted chat panel respectively;
+  `"half-chat"` is the default, and the web owns translating these semantic ids into geometry;
+  **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, composerGrowthLimit, layout }` — an
+  extensible bag; `layout` is the
   **`LayoutSettings`** selection (`defaultPresetId`, named portable `customPresets`, `maxSideGroups`
   defaulting to 6, and independent `maxBottomGroups` defaulting to 3); `analyticsEnabled` is the
   anonymous-usage-analytics switch, default `true`

--- a/packages/contracts/src/domain.test.ts
+++ b/packages/contracts/src/domain.test.ts
@@ -40,9 +40,13 @@ describe("isRetriedAttempt", () => {
 	});
 });
 
-describe("layout defaults", () => {
+describe("config defaults", () => {
 	test("bottom groups have an independent default limit", () => {
 		expect(DEFAULT_CONFIG.layout.maxBottomGroups).toBe(3);
+	});
+
+	test("the composer grows to half the chat by default", () => {
+		expect(DEFAULT_CONFIG).toHaveProperty("composerGrowthLimit", "half-chat");
 	});
 });
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -473,10 +473,18 @@ export interface LayoutSettings {
 	maxBottomGroups: number;
 }
 
+export const COMPOSER_GROWTH_LIMITS = ["compact", "roomy", "half-chat"] as const;
+export type ComposerGrowthLimit = (typeof COMPOSER_GROWTH_LIMITS)[number];
+
+export function isComposerGrowthLimit(value: unknown): value is ComposerGrowthLimit {
+	return COMPOSER_GROWTH_LIMITS.some((limit) => limit === value);
+}
+
 export interface AppConfig {
 	theme: ThemeId;
 	analyticsEnabled: boolean;
 	terminalReplayKb: number;
+	composerGrowthLimit: ComposerGrowthLimit;
 	layout: LayoutSettings;
 }
 
@@ -486,6 +494,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	theme: "dark",
 	analyticsEnabled: true,
 	terminalReplayKb: TERMINAL_REPLAY_KB.default,
+	composerGrowthLimit: "half-chat",
 	layout: {
 		defaultPresetId: "balanced",
 		customPresets: [],

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,8 +2,10 @@ export type * from "./domain";
 export {
 	ACCEPTED_IMAGE_TYPES,
 	base64EncodedLength,
+	COMPOSER_GROWTH_LIMITS,
 	DEFAULT_CONFIG,
 	IMAGE_MAX_BASE64_BYTES,
+	isComposerGrowthLimit,
 	isControlMessage,
 	isRetriedAttempt,
 	MAX_HISTORY_LIMIT,

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -17,8 +17,9 @@ and the install identity — as JSON under the data dir.
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`);
   `loadProjects`/`saveProjects`, `loadWorkspaces`/`saveWorkspaces`, `loadConfig`/`saveConfig`
-  (`config.json`, fieldwise-normalized over `DEFAULT_CONFIG`—including both nested layout group limits—so a
-  missing file or key degrades cleanly, while unknown top-level extension fields survive known-field updates),
+  (`config.json`, fieldwise-normalized over `DEFAULT_CONFIG`—including the closed composer-growth preset and
+  both nested layout group limits—so a missing/invalid known value or key degrades cleanly, while unknown
+  top-level extension fields survive known-field updates),
   `loadWorkspaceLayout`/`loadWorkspaceLayoutBackup`/`saveWorkspaceLayout`/`removeWorkspaceLayout`
   (versioned full snapshots in traversal-safe workspace-keyed filenames; atomic replacement with a
   last-known-good copy so a torn/corrupt write cannot blank a workspace; complete cleanup when its

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
 	type AppConfig,
 	DEFAULT_CONFIG,
+	isComposerGrowthLimit,
 	type Project,
 	type Workspace,
 	type WorkspaceLayoutSnapshot,
@@ -78,6 +79,9 @@ export function loadConfig(): AppConfig {
 			typeof value.terminalReplayKb === "number" && Number.isFinite(value.terminalReplayKb)
 				? value.terminalReplayKb
 				: DEFAULT_CONFIG.terminalReplayKb,
+		composerGrowthLimit: isComposerGrowthLimit(value.composerGrowthLimit)
+			? value.composerGrowthLimit
+			: DEFAULT_CONFIG.composerGrowthLimit,
 		layout: {
 			defaultPresetId:
 				typeof layoutValue.defaultPresetId === "string" &&

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -11,8 +11,8 @@ tags: [v1]
 ## Responsibility
 
 The server-synced app config — OUR settings (an opaque theme selection, the analytics switch, terminal
-replay budget, and workbench default/custom presets + independent side/bottom group limits), an extensible
-`AppConfig` bag.
+replay budget, the chat composer growth preset, and workbench default/custom presets + independent
+side/bottom group limits), an extensible `AppConfig` bag.
 Reads/merges/persists it and fans changes out to every client,
 so a preference set on one client follows the user to the others (architecture #9: shared domain state). The
 web client owns the available theme manifests; settings stores only the selected string id.

--- a/packages/server/src/settings/settings.test.ts
+++ b/packages/server/src/settings/settings.test.ts
@@ -65,6 +65,15 @@ test("an older host preserves unknown top-level config extensions when updating 
 	expect(onDisk.futureSetting).toEqual({ mode: "new" });
 });
 
+test("loadConfig replaces an invalid composer growth preset with the default", () => {
+	writeFileSync(
+		join(dataDir, "config.json"),
+		JSON.stringify({ ...DEFAULT_CONFIG, composerGrowthLimit: "enormous" }),
+	);
+	resetConfigCache();
+	expect(getConfig()).toHaveProperty("composerGrowthLimit", "half-chat");
+});
+
 test("loadConfig normalizes nested layout fields independently", () => {
 	writeFileSync(
 		join(dataDir, "config.json"),

--- a/scripts/check-catalog.ts
+++ b/scripts/check-catalog.ts
@@ -2,6 +2,7 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { isExactVersion } from "./exactVersion";
 
 interface Manifest {
 	workspaces?: { packages?: string[]; catalog?: Record<string, string> } | string[];
@@ -37,10 +38,8 @@ function manifestPaths(): string[] {
 const SECTIONS = ["dependencies", "devDependencies", "optionalDependencies"] as const;
 const violations: string[] = [];
 
-const EXACT_VERSION = /^\d+\.\d+\.\d+(?:[-+][\w.]+)?$/;
-
 for (const [name, version] of Object.entries(catalog)) {
-	if (!EXACT_VERSION.test(version)) {
+	if (!isExactVersion(version)) {
 		violations.push(`package.json: catalog.${name} is "${version}" — catalog entries pin exact`);
 	}
 }
@@ -63,7 +62,7 @@ for (const path of [join(root, "package.json"), ...manifestPaths()]) {
 				continue;
 			}
 			if (version.includes(":")) continue;
-			if (!EXACT_VERSION.test(version)) {
+			if (!isExactVersion(version)) {
 				violations.push(
 					`${rel}: ${section}.${name} pins "${version}" — pin an exact version (no ranges)`,
 				);

--- a/scripts/exactVersion.test.ts
+++ b/scripts/exactVersion.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { isExactVersion } from "./exactVersion";
+
+test("exact versions include complete SemVer prerelease and build identifiers", () => {
+	for (const version of [
+		"19.2.8",
+		"19.3.0-canary-a1124489-20260826",
+		"1.0.0-alpha.1-feature-7+build.42-linux",
+	]) {
+		expect(isExactVersion(version)).toBe(true);
+	}
+});
+
+test("ranges and malformed versions are not exact pins", () => {
+	for (const version of ["^19.2.8", "~1.0.0", "19.3.x", "1.0.0-", "1.0", "latest"])
+		expect(isExactVersion(version)).toBe(false);
+});

--- a/scripts/exactVersion.ts
+++ b/scripts/exactVersion.ts
@@ -1,4 +1,5 @@
-const EXACT_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const EXACT_SEMVER =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
 
 export function isExactVersion(version: string): boolean {
 	return EXACT_SEMVER.test(version);

--- a/scripts/exactVersion.ts
+++ b/scripts/exactVersion.ts
@@ -1,0 +1,5 @@
+const EXACT_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+export function isExactVersion(version: string): boolean {
+	return EXACT_SEMVER.test(version);
+}


### PR DESCRIPTION
## Summary

> Stacked after #318 .

Fix long-running ThinkRail development tabs that crash Chrome and leave chats stuck after compaction or a WebSocket reset.

The renderer crash was React 19.2 development Performance Tracks retaining every `performance.measure()` entry during Pi-rate chat renders. Chrome eventually killed the multi-gigabyte renderer; Vite's `EPIPE` / `ECONNRESET` messages were the aftermath rather than a host or Pi compaction crash.

## Changes

### Web runtime

- Pin matching React 19.3 canary packages containing upstream fix facebook/react#34803.
- Extend the exact-version dependency gate to accept complete SemVer prerelease/build identifiers without accepting ranges.
- Record the temporary canary decision and the return-to-stable condition in the web architecture spec.

### Chat recovery

- Re-read Pi's canonical summary-plus-tail after successful compaction and after reconnecting an existing chat runtime.
- Compare-and-install transcripts by browser-side Pi-event revision so a late read cannot overwrite newer streamed events.
- Preserve browser-local draft, layout, focus, commands, stats, and extension UI state while replacing host-derived conversation state.
- Reuse the live compaction row identity and retain live-only token estimates / `resuming` state when they still apply.

### Presentation

- Use one label, **Context compacted**, for both live and hydrated compaction records.
- Keep the durable summary disclosure after hydration while immediately removing messages Pi summarized away.

## Testing

- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed
- `bun run typecheck` — all 11 packages passed
- `bun run test` — all 11 package test tasks passed
- `bun run build` — web, website, and CLI builds passed
- React canary browser stress probe — three 500-render bursts retained zero Performance Measures; embedder memory stayed approximately 4.14 → 4.22 MB
- Baseline/target/final heap snapshots + MemLab — no recurrence of the unbounded React PerformanceMeasure leak
- Local E2E — intentionally not run after rebase, per request
- CI `E2E (no-agent)` — passed in 8m11s
- CI `Binary smoke & e2e` — passed in 12m15s

## Screenshots

| Before | After |
| --- | --- |
| ![Earlier messages summarized](https://github.com/JetBrains/thinkrail/blob/a1edd42722c826c76ab5b8699d6cf53bafd817d6/compaction-before.png?raw=true) | ![Context compacted](https://github.com/JetBrains/thinkrail/blob/a1edd42722c826c76ab5b8699d6cf53bafd817d6/compaction-after.png?raw=true) |



