### PR TITLE
feat(web): improve tool previews

### DIFF
--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -19,11 +19,13 @@ export function ActivityGroup({
 	steps,
 	live,
 	workspaceRoot,
+	onOpenFile,
 }: {
 	id: string;
 	steps: ActivityStep[];
 	live: boolean;
 	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
 }) {
 	const flatSteps = flattenActivitySteps(steps);
 	const single = flatSteps.length === 1 ? steps[0] : undefined;
@@ -35,9 +37,10 @@ export function ActivityGroup({
 				tools={single.tools}
 				live={live}
 				workspaceRoot={workspaceRoot}
+				onOpenFile={onOpenFile}
 			/>
 		) : (
-			<RoutineToolRow step={single} workspaceRoot={workspaceRoot} />
+			<RoutineToolRow step={single} workspaceRoot={workspaceRoot} onOpenFile={onOpenFile} />
 		);
 
 	const settledSummary = summarizeSteps(steps);
@@ -65,9 +68,16 @@ export function ActivityGroup({
 						tools={step.tools}
 						live={false}
 						workspaceRoot={workspaceRoot}
+						onOpenFile={onOpenFile}
 					/>
 				) : (
-					<RoutineToolRow key={step.id} step={step} parentId={id} workspaceRoot={workspaceRoot} />
+					<RoutineToolRow
+						key={step.id}
+						step={step}
+						parentId={id}
+						workspaceRoot={workspaceRoot}
+						onOpenFile={onOpenFile}
+					/>
 				),
 			)}
 		</GroupDisclosure>
@@ -81,6 +91,7 @@ export function ThinkingGroup({
 	tools,
 	live,
 	workspaceRoot,
+	onOpenFile,
 }: {
 	id: string;
 	parentId?: string;
@@ -88,6 +99,7 @@ export function ThinkingGroup({
 	tools: RoutineToolStep[];
 	live: boolean;
 	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
 }) {
 	const summary =
 		tools.length > 0
@@ -116,7 +128,13 @@ export function ThinkingGroup({
 				{thought.text}
 			</div>
 			{tools.map((step) => (
-				<RoutineToolRow key={step.id} step={step} parentId={id} workspaceRoot={workspaceRoot} />
+				<RoutineToolRow
+					key={step.id}
+					step={step}
+					parentId={id}
+					workspaceRoot={workspaceRoot}
+					onOpenFile={onOpenFile}
+				/>
 			))}
 		</GroupDisclosure>
 	);
@@ -227,6 +245,7 @@ function liveActivityTicker(steps: ActivityStep[], workspaceRoot: string | undef
 function toolRenderProps(
 	step: RoutineToolStep,
 	workspaceRoot: string | undefined,
+	onOpenFile?: ((path: string) => void) | undefined,
 ): ToolRenderProps {
 	return {
 		toolCallId: step.toolCallId,
@@ -235,6 +254,7 @@ function toolRenderProps(
 		result: step.tool?.raw,
 		status: step.tool?.status ?? (step.dead ? "error" : "running"),
 		workspaceRoot,
+		onOpenFile,
 		streaming: step.streaming,
 	};
 }
@@ -243,14 +263,16 @@ function RoutineToolRow({
 	step,
 	parentId,
 	workspaceRoot,
+	onOpenFile,
 }: {
 	step: RoutineToolStep;
 	parentId?: string;
 	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
 }) {
 	const [expanded, toggle] = useFold(step.id);
 	const status: ToolStatus = step.tool?.status ?? (step.dead ? "error" : "running");
-	const renderProps = toolRenderProps(step, workspaceRoot);
+	const renderProps = toolRenderProps(step, workspaceRoot, onOpenFile);
 	const summary = getToolSummary(step.toolName, renderProps);
 	return (
 		<div

--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -10,7 +10,8 @@ import { cn } from "@/lib";
 import type { ActivityBreadcrumbKind } from "./activityBreadcrumbs";
 import { useFold } from "./foldState";
 import type { ActivityStep, RoutineToolStep, ThinkingStep } from "./rows";
-import { getToolRenderer, getToolSummary, type ToolRenderProps } from "./toolRegistry";
+import { ToolRendererBody } from "./ToolRendererBody";
+import { getToolSummary, type ToolRenderProps } from "./toolRegistry";
 import type { ToolStatus } from "./types";
 
 export function ActivityGroup({
@@ -249,7 +250,6 @@ function RoutineToolRow({
 }) {
 	const [expanded, toggle] = useFold(step.id);
 	const status: ToolStatus = step.tool?.status ?? (step.dead ? "error" : "running");
-	const Renderer = getToolRenderer(step.toolName);
 	const renderProps = toolRenderProps(step, workspaceRoot);
 	const summary = getToolSummary(step.toolName, renderProps);
 	return (
@@ -283,7 +283,7 @@ function RoutineToolRow({
 			/>
 			{expanded ? (
 				<div className={cn("px-8 pb-4 pl-16", status === "error" && "text-feedback-error")}>
-					<Renderer {...renderProps} />
+					<ToolRendererBody {...renderProps} imageLabel={summary} />
 				</div>
 			) : null}
 		</div>

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -110,9 +110,11 @@ const CHAT_LIST_COMPONENTS = { Footer: StreamFooter };
 export default function ChatView({
 	sessionId,
 	workspaceId,
+	onOpenFile,
 }: {
 	sessionId: string;
 	workspaceId: string;
+	onOpenFile?: ((path: string) => void) | undefined;
 }) {
 	const sessionRuntime = useAppStore((s) => s.sessions[sessionId]);
 	const runtime = sessionRuntime ?? EMPTY_RUNTIME;
@@ -652,6 +654,7 @@ export default function ChatView({
 									<ChatTurnView
 										row={row}
 										workspaceRoot={workspaceRoot}
+										onOpenFile={onOpenFile}
 										onOpenSpec={onOpenSpec}
 										onOpenChange={onOpenChange}
 										onReveal={onReveal}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -151,8 +151,9 @@ the **capability** registers with the pi session server-side (custom tool or pi 
 **presentation** registers here. A registration is:
 
 - a **renderer** (the specialized card body; `ToolRenderProps` carries `toolCallId`/`args`/`result`/
-  `status`/`workspaceRoot`/`streaming` — enough to stay props-driven; the common invocation seam decorates
-  its completed canonical image results consistently), plus optionally
+  `status`/`workspaceRoot`/`streaming` plus an optional shell-injected `onOpenFile` callback — enough to
+  stay props-driven; the common invocation seam decorates its completed canonical image results
+  consistently), plus optionally
 - a **`summary`** — a pure one-liner for collapsed headers and activity-step rows,
 - a **`chrome`** — `"card"` (default, the `ToolCard` frame) or `"bare"` (owns its frame; for
   interactive/primary tools like `ask_user_question`),
@@ -171,6 +172,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 
 ## Interaction seams
 
+- **Structured tool-file navigation** — `ChatView` accepts an optional `onOpenFile(path)` from the shell and
+  passes it through every `ToolRenderProps` path (routine, primary, card, or bare). The shared tool-file
+  primitive offers that action only for a non-empty relative path or an absolute path contained by
+  `workspaceRoot`; URLs, escaping relatives, and foreign absolute paths remain selectable text. Renderers
+  source candidates only from explicit tool args/details — never regex guesses over Bash output, code, or
+  prose. A standalone renderer has no callback and therefore stays inert. The callback's preview-slot
+  semantics belong to [[submodule-web-panels]].
 - **`ChatActions`** — a React context (provided by `ChatView`, `null` standalone): how a renderer talks
   **back** to the agent without importing store/transport. Today: `answerQuestion(toolCallId, result)` —
   it rejects when the host refuses (unknown/answered/superseded call), and the caller owns the failure UX —

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -81,7 +81,14 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
 - `tool` — a **primary** tool call: the collapsible `ToolCard` frame (collapsed unless registered
   `defaultExpanded`; errors auto-expand; a manual toggle wins), or a `"bare"` renderer that owns its
   frame. A `"bare"` call on a dead message (`stopReason` aborted/error — pi never executes those calls)
-  renders as errored rather than staying interactive forever.
+  renders as errored rather than staying interactive forever. Every renderer invocation — registered or
+  fallback, routine or primary, card or bare — passes through one common result-content layer. Once a result
+  completes, each valid canonical image block appends a bounded in-card preview with an explicit full-screen
+  dialog action; multiple images retain block order. This is content-type behavior, not a `read` special case,
+  and it does not promote or auto-expand the tool. The result bytes are already in the transcript, so preview
+  needs no host fetch and works for paths outside the workspace. Previewable blocks require non-empty data
+  and one of `contracts`' shared raster media types (PNG/JPEG/GIF/WebP); malformed shapes and unsupported
+  media types are ignored, while canonical content arrays are never serialized into base64 JSON.
 - `activity` — one contiguous run of routine work stays one **collapsed outer disclosure** whose header
   summarizes every atomic step (thinking blocks + routine tool calls). Expanding it preserves tools before
   the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure that
@@ -143,8 +150,9 @@ entry/exit obeys reduced motion.
 the **capability** registers with the pi session server-side (custom tool or pi extension/skill), the
 **presentation** registers here. A registration is:
 
-- a **renderer** (the card body; `ToolRenderProps` carries `toolCallId`/`args`/`result`/`status`/
-  `workspaceRoot`/`streaming` — enough to stay props-driven), plus optionally
+- a **renderer** (the specialized card body; `ToolRenderProps` carries `toolCallId`/`args`/`result`/
+  `status`/`workspaceRoot`/`streaming` — enough to stay props-driven; the common invocation seam decorates
+  its completed canonical image results consistently), plus optionally
 - a **`summary`** — a pure one-liner for collapsed headers and activity-step rows,
 - a **`chrome`** — `"card"` (default, the `ToolCard` frame) or `"bare"` (owns its frame; for
   interactive/primary tools like `ask_user_question`),

--- a/apps/web/src/chat/ToolCard.tsx
+++ b/apps/web/src/chat/ToolCard.tsx
@@ -6,7 +6,8 @@ import {
 } from "@remixicon/react";
 import { cn } from "@/lib";
 import { useFold } from "./foldState";
-import { getToolRenderer, getToolSummary, resolveProminence } from "./toolRegistry";
+import { ToolRendererBody } from "./ToolRendererBody";
+import { getToolSummary, resolveProminence } from "./toolRegistry";
 import type { ToolResultState } from "./types";
 
 export function ToolCard({
@@ -28,7 +29,6 @@ export function ToolCard({
 }) {
 	const status = tool?.status ?? (dead ? "error" : "running");
 	const isError = status === "error";
-	const Renderer = getToolRenderer(toolName);
 	const renderProps = {
 		toolCallId,
 		toolName,
@@ -79,7 +79,7 @@ export function ToolCard({
 			</button>
 			{expanded ? (
 				<div className={cn("px-8 pb-4", isError && "text-feedback-error")}>
-					<Renderer {...renderProps} />
+					<ToolRendererBody {...renderProps} imageLabel={summary} />
 				</div>
 			) : null}
 		</div>

--- a/apps/web/src/chat/ToolCard.tsx
+++ b/apps/web/src/chat/ToolCard.tsx
@@ -18,6 +18,7 @@ export function ToolCard({
 	dead = false,
 	streaming,
 	workspaceRoot,
+	onOpenFile,
 }: {
 	toolCallId: string;
 	toolName: string;
@@ -26,6 +27,7 @@ export function ToolCard({
 	dead?: boolean;
 	streaming: boolean;
 	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
 }) {
 	const status = tool?.status ?? (dead ? "error" : "running");
 	const isError = status === "error";
@@ -36,6 +38,7 @@ export function ToolCard({
 		result: tool?.raw,
 		status,
 		workspaceRoot,
+		onOpenFile,
 		streaming,
 	};
 	const summary = getToolSummary(toolName, renderProps);

--- a/apps/web/src/chat/ToolRendererBody.test.ts
+++ b/apps/web/src/chat/ToolRendererBody.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ToolCard } from "./ToolCard";
+import { registerToolRenderer } from "./toolRegistry";
+
+describe("tool result images", () => {
+	it("appends a preview after a registered tool's specialized body", () => {
+		registerToolRenderer(
+			"registered-image-output",
+			() => createElement("span", null, "specialized body"),
+			{
+				summary: () => "/tmp/tab-overflow-mockups.png",
+				defaultExpanded: true,
+			},
+		);
+		const markup = renderToStaticMarkup(
+			createElement(ToolCard, {
+				toolCallId: "registered-image-call",
+				toolName: "registered-image-output",
+				args: {},
+				tool: {
+					status: "done",
+					raw: {
+						content: [{ type: "image", data: "cG5n", mimeType: "image/png" }],
+					},
+				},
+				streaming: false,
+			}),
+		);
+
+		expect(markup).toContain("specialized body");
+		expect(markup).toContain('data-testid="tool-result-image-thumbnail"');
+		expect(markup).toContain('src="data:image/png;base64,cG5n"');
+		expect(markup).toContain('aria-label="View /tmp/tab-overflow-mockups.png full screen"');
+	});
+
+	it("renders accepted fallback-result images in block order without dumping content JSON", () => {
+		const markup = renderToStaticMarkup(
+			createElement(ToolCard, {
+				toolCallId: "fallback-image-call",
+				toolName: "unregistered-image-output",
+				args: {},
+				tool: {
+					status: "error",
+					raw: {
+						content: [
+							{ type: "text", text: "Captured two frames" },
+							{ type: "image", data: "Zmlyc3Q=", mimeType: "image/png" },
+							{ type: "image", data: "c2Vjb25k", mimeType: "image/jpeg" },
+							{ type: "image", data: "PHN2Zz4=", mimeType: "image/svg+xml" },
+						],
+					},
+				},
+				streaming: false,
+			}),
+		);
+
+		expect(markup).toContain("Captured two frames");
+		expect(markup).not.toContain("&quot;mimeType&quot;");
+		expect(markup.match(/data-testid="tool-result-image-thumbnail"/g)).toHaveLength(2);
+		expect(markup.indexOf("data:image/png;base64,Zmlyc3Q=")).toBeLessThan(
+			markup.indexOf("data:image/jpeg;base64,c2Vjb25k"),
+		);
+		expect(markup).not.toContain("data:image/svg+xml");
+	});
+});

--- a/apps/web/src/chat/ToolRendererBody.tsx
+++ b/apps/web/src/chat/ToolRendererBody.tsx
@@ -1,0 +1,17 @@
+import { ToolResultImages } from "./ToolResultImages";
+import { getToolRenderer, type ToolRenderProps } from "./toolRegistry";
+import { parseToolResultContent } from "./toolResultContent";
+
+export function ToolRendererBody({
+	imageLabel,
+	...props
+}: ToolRenderProps & { imageLabel: string }) {
+	const Renderer = getToolRenderer(props.toolName);
+	const images = props.status === "running" ? [] : parseToolResultContent(props.result).images;
+	return (
+		<>
+			<Renderer {...props} />
+			<ToolResultImages images={images} label={imageLabel || `${props.toolName} image output`} />
+		</>
+	);
+}

--- a/apps/web/src/chat/ToolResultImages.tsx
+++ b/apps/web/src/chat/ToolResultImages.tsx
@@ -1,0 +1,74 @@
+import { RiFullscreenLine as Maximize2 } from "@remixicon/react";
+import type { ImageContent } from "@thinkrail/contracts";
+import { useState } from "react";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+
+function ToolResultImage({ image, label }: { image: ImageContent; label: string }) {
+	const [open, setOpen] = useState(false);
+	const src = `data:${image.mimeType};base64,${image.data}`;
+	return (
+		<div
+			data-testid="tool-result-image-preview"
+			className="relative flex min-h-64 w-full items-center justify-center overflow-hidden rounded-[var(--radius-sm)] border border-border-default bg-sunken"
+		>
+			<img
+				data-testid="tool-result-image-thumbnail"
+				src={src}
+				alt={label}
+				loading="lazy"
+				decoding="async"
+				className="block max-h-[240px] max-w-full object-contain"
+			/>
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogTrigger asChild>
+					<button
+						type="button"
+						data-testid="tool-result-image-fullscreen"
+						aria-label={`View ${label} full screen`}
+						title="Full screen"
+						className="absolute top-4 right-4 rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg p-4 text-text-muted transition-colors hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
+					>
+						<Maximize2 className="size-14" />
+					</button>
+				</DialogTrigger>
+				<DialogContent
+					data-testid="tool-result-image-dialog"
+					className="flex h-[90vh] w-[95vw] max-w-[95vw] flex-col gap-8"
+				>
+					<DialogHeader>
+						<DialogTitle>{label}</DialogTitle>
+					</DialogHeader>
+					<div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-sunken">
+						<img
+							src={src}
+							alt={label}
+							decoding="async"
+							className="max-h-[80vh] max-w-full object-contain"
+						/>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}
+
+export function ToolResultImages({ images, label }: { images: ImageContent[]; label: string }) {
+	if (images.length === 0) return null;
+	return (
+		<div data-testid="tool-result-images" className="mt-4 flex flex-col gap-4">
+			{images.map((image, index) => (
+				<ToolResultImage
+					key={`${image.mimeType}:${image.data.length}:${image.data.slice(-24)}:${index}`}
+					image={image}
+					label={images.length === 1 ? label : `${label} (${index + 1} of ${images.length})`}
+				/>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/chat/toolRegistry.tsx
+++ b/apps/web/src/chat/toolRegistry.tsx
@@ -9,6 +9,7 @@ export interface ToolRenderProps {
 	result: unknown;
 	status: ToolStatus;
 	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
 	streaming: boolean;
 }
 

--- a/apps/web/src/chat/toolRegistry.tsx
+++ b/apps/web/src/chat/toolRegistry.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { parseToolResultContent, toolValueText } from "./toolResultContent";
 import type { ToolStatus } from "./types";
 
 export interface ToolRenderProps {
@@ -63,19 +64,9 @@ export function resolveProminence(toolName: string): ResolvedProminence {
 	return { prominence, defaultExpanded: reg?.defaultExpanded ?? false };
 }
 
-export function toText(value: unknown): string {
-	if (value == null) return "";
-	if (typeof value === "string") return value;
-	try {
-		return JSON.stringify(value, null, 2);
-	} catch {
-		return String(value);
-	}
-}
-
 export function DefaultToolRenderer({ args, result, status }: ToolRenderProps): ReactNode {
-	const argsText = toText(args);
-	const resultText = toText(result);
+	const argsText = toolValueText(args);
+	const resultText = parseToolResultContent(result).text;
 	return (
 		<div className="flex flex-col gap-4">
 			{argsText && argsText !== "{}" ? (

--- a/apps/web/src/chat/toolResultContent.ts
+++ b/apps/web/src/chat/toolResultContent.ts
@@ -1,0 +1,58 @@
+import { ACCEPTED_IMAGE_TYPES, type ImageContent } from "@thinkrail/contracts";
+
+const acceptedImageTypes = new Set(ACCEPTED_IMAGE_TYPES);
+
+export interface ParsedToolResultContent {
+	text: string;
+	images: ImageContent[];
+}
+
+export function toolValueText(value: unknown): string {
+	if (value == null) return "";
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
+}
+
+export function parseToolResultContent(result: unknown): ParsedToolResultContent {
+	if (result == null || typeof result === "string") {
+		return { text: toolValueText(result), images: [] };
+	}
+	if (typeof result !== "object" || !("content" in result)) {
+		return { text: toolValueText(result), images: [] };
+	}
+
+	const content = (result as { content: unknown }).content;
+	if (!Array.isArray(content)) {
+		return { text: toolValueText(result), images: [] };
+	}
+
+	const text: string[] = [];
+	const images: ImageContent[] = [];
+	for (const block of content) {
+		if (typeof block !== "object" || block === null) continue;
+		const candidate = block as {
+			type?: unknown;
+			text?: unknown;
+			data?: unknown;
+			mimeType?: unknown;
+		};
+		if (candidate.type === "text" && typeof candidate.text === "string") {
+			text.push(candidate.text);
+			continue;
+		}
+		if (
+			candidate.type === "image" &&
+			typeof candidate.data === "string" &&
+			candidate.data.length > 0 &&
+			typeof candidate.mimeType === "string" &&
+			acceptedImageTypes.has(candidate.mimeType)
+		) {
+			images.push({ type: "image", data: candidate.data, mimeType: candidate.mimeType });
+		}
+	}
+	return { text: text.join(""), images };
+}

--- a/apps/web/src/chat/tools/EditCard.tsx
+++ b/apps/web/src/chat/tools/EditCard.tsx
@@ -1,10 +1,10 @@
 import { RiPencilLine as Pencil } from "@remixicon/react";
-import { projectRelativePath } from "@/lib";
 import type { ToolRenderProps } from "../toolRegistry";
 import { Collapsible } from "./Collapsible";
+import { ToolFileLink } from "./ToolFileLink";
 import { resultText, strArg } from "./toolHelpers";
 
-export function EditCard({ args, result, status, workspaceRoot }: ToolRenderProps) {
+export function EditCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
 	const path = strArg(args, "path");
 	const oldText = strArg(args, "oldText") || strArg(args, "old_string") || strArg(args, "old");
 	const newText = strArg(args, "newText") || strArg(args, "new_string") || strArg(args, "new");
@@ -13,7 +13,12 @@ export function EditCard({ args, result, status, workspaceRoot }: ToolRenderProp
 	if (status === "error") {
 		return (
 			<div data-testid="tool-edit" className="flex flex-col gap-4">
-				<EditHeader path={path} workspaceRoot={workspaceRoot} />
+				<EditHeader
+					path={path}
+					workspaceRoot={workspaceRoot}
+					onOpenFile={onOpenFile}
+					disabled={true}
+				/>
 				<pre className="overflow-auto px-8 py-4 text-feedback-error tr-code-text">{message}</pre>
 			</div>
 		);
@@ -24,7 +29,12 @@ export function EditCard({ args, result, status, workspaceRoot }: ToolRenderProp
 
 	return (
 		<div data-testid="tool-edit" className="flex flex-col gap-4">
-			<EditHeader path={path} workspaceRoot={workspaceRoot} />
+			<EditHeader
+				path={path}
+				workspaceRoot={workspaceRoot}
+				onOpenFile={onOpenFile}
+				disabled={status !== "done"}
+			/>
 			<Collapsible
 				lines={oldLines.length + newLines.length}
 				fadeClass="bg-[linear-gradient(to_top,var(--container-elevated-bg),transparent)]"
@@ -58,14 +68,27 @@ export function EditCard({ args, result, status, workspaceRoot }: ToolRenderProp
 	);
 }
 
-function EditHeader({ path, workspaceRoot }: { path: string; workspaceRoot?: string | undefined }) {
-	const displayPath = projectRelativePath(path, workspaceRoot);
+function EditHeader({
+	path,
+	workspaceRoot,
+	onOpenFile,
+	disabled,
+}: {
+	path: string;
+	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
+	disabled: boolean;
+}) {
 	return (
 		<div className="flex items-center gap-4 tr-text-metadata">
 			<Pencil className="size-12 shrink-0 text-feedback-warning" />
-			<span className="truncate text-text-default" title={path}>
-				{displayPath}
-			</span>
+			<ToolFileLink
+				path={path}
+				workspaceRoot={workspaceRoot}
+				onOpenFile={onOpenFile}
+				disabled={disabled}
+				className="text-text-default"
+			/>
 			<span className="shrink-0 text-text-muted">edited</span>
 		</div>
 	);

--- a/apps/web/src/chat/tools/ReadCard.tsx
+++ b/apps/web/src/chat/tools/ReadCard.tsx
@@ -1,13 +1,12 @@
 import { RiFileTextLine as FileText } from "@remixicon/react";
-import { projectRelativePath } from "@/lib";
 import type { ToolRenderProps } from "../toolRegistry";
 import { CodeBlock } from "./CodeBlock";
 import { Collapsible, countLines } from "./Collapsible";
+import { ToolFileLink } from "./ToolFileLink";
 import { languageFromPath, numArg, resultText, strArg } from "./toolHelpers";
 
-export function ReadCard({ args, result, status, workspaceRoot }: ToolRenderProps) {
+export function ReadCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
 	const path = strArg(args, "path");
-	const displayPath = projectRelativePath(path, workspaceRoot);
 	const offset = numArg(args, "offset");
 	const limit = numArg(args, "limit");
 	const output = resultText(result);
@@ -24,9 +23,13 @@ export function ReadCard({ args, result, status, workspaceRoot }: ToolRenderProp
 		<div data-testid="tool-read" className="flex flex-col gap-4">
 			<div className="flex items-center gap-4 tr-text-metadata">
 				<FileText className="size-12 shrink-0 text-text-muted" />
-				<span className="truncate text-primary" title={path}>
-					{displayPath}
-				</span>
+				<ToolFileLink
+					path={path}
+					workspaceRoot={workspaceRoot}
+					onOpenFile={onOpenFile}
+					disabled={status === "running"}
+					className="text-primary"
+				/>
 				{range ? <span className="shrink-0 text-text-muted">{range}</span> : null}
 			</div>
 			{status === "running" ? (

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -189,8 +189,9 @@ registration runs once when the chat module mounts. Unregistered tools fall back
   `pi-visualize` extension.
 - **Spec-graph tools** — one defensive `SpecToolCard` registered for all seven `spec_*` names. Each keeps
   the capability's readable text, folds long output, replaces redundant args JSON with a meaningful
-  activity summary, and turns only exact worktree paths obtained from known successful result `details`
-  shapes into preview actions. `spec_delete` never links its successful deleted path. Routine.
+  activity summary, and turns only exact standalone worktree-path tokens obtained from known successful
+  result `details` shapes into preview actions; a shorter known path never links a suffix inside another
+  path. `spec_delete` never links its successful deleted path. Routine.
 - **`web/`** — search/fetch/stored-content renderers for `pi-web-access`; own child spec
   ([web/SPEC.md](web/SPEC.md)). Routine.
 - **The five `todo_*` tools** deliberately keep routine fallback receipts: their connected product surface

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -19,7 +19,9 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 ## What's here
 
 - **Core pi tools** — `BashCard` (terminal block), `ReadCard`/`WriteCard` (project-relative path +
-  highlighted file), `EditCard` (path + removed/added line diff). All **routine**.
+  highlighted textual file), `EditCard` (path + removed/added line diff). All **routine**. Image content
+  returned by `read` is previewed by the parent chat module's common result-content layer, the same path as
+  every other image-producing tool; `ReadCard` does not special-case image payloads.
 - **`ResolveCommentCard`** — the compact receipt for the host-owned `resolve_comment` review tool
   (capability: the server's `agent` module + `reviews` seam; see [[submodule-server-reviews]]): a ✓ +
   the resolved comment id/note. **Routine** — the review sidebar is where resolution state lives; the
@@ -186,6 +188,8 @@ registration runs once when the chat module mounts. Unregistered tools fall back
   ([web/SPEC.md](web/SPEC.md)). Routine.
 - **Shared pieces** — `CodeBlock` (shiki), `Collapsible` ("Show all N lines" fold for long output),
   pure `toolHelpers` (arg readers, `resultText`, `languageFromPath`) + `lib`'s `projectRelativePath`.
+  `resultText` delegates canonical result parsing to the parent chat primitive, so text extraction and the
+  common image layer cannot disagree about what constitutes a valid content block.
 
 ## Boundary
 

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -19,7 +19,9 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 ## What's here
 
 - **Core pi tools** — `BashCard` (terminal block), `ReadCard`/`WriteCard` (project-relative path +
-  highlighted textual file), `EditCard` (path + removed/added line diff). All **routine**. Image content
+  highlighted textual file), `EditCard` (path + removed/added line diff). All **routine**. A settled
+  `read`/`write`/`edit` path uses the shared structured file-link primitive when it belongs to the active
+  worktree, opening the shell's preview slot; a running mutation or foreign path stays text. Image content
   returned by `read` is previewed by the parent chat module's common result-content layer, the same path as
   every other image-producing tool; `ReadCard` does not special-case image payloads.
 - **`ResolveCommentCard`** — the compact receipt for the host-owned `resolve_comment` review tool
@@ -184,12 +186,19 @@ registration runs once when the chat module mounts. Unregistered tools fall back
   visualization is output *for the user*, not plumbing: it escapes the activity fold and renders open on
   completion (while its args stream it stays a slim running row). Capability: the bundled
   `pi-visualize` extension.
-- **`web/`** — search/fetch renderers for `pi-web-access`; own child spec
+- **Spec-graph tools** — one defensive `SpecToolCard` registered for all seven `spec_*` names. Each keeps
+  the capability's readable text, folds long output, replaces redundant args JSON with a meaningful
+  activity summary, and turns only exact worktree paths obtained from the known result `details` shapes
+  into preview actions. `spec_delete` never links its successful deleted path. Routine.
+- **`web/`** — search/fetch/stored-content renderers for `pi-web-access`; own child spec
   ([web/SPEC.md](web/SPEC.md)). Routine.
+- **The five `todo_*` tools** deliberately keep routine fallback receipts: their connected product surface
+  is the chat plan, not a second renderer system in this module.
 - **Shared pieces** — `CodeBlock` (shiki), `Collapsible` ("Show all N lines" fold for long output),
-  pure `toolHelpers` (arg readers, `resultText`, `languageFromPath`) + `lib`'s `projectRelativePath`.
-  `resultText` delegates canonical result parsing to the parent chat primitive, so text extraction and the
-  common image layer cannot disagree about what constitutes a valid content block.
+  `ToolFileLink` + exact-reference linked text, pure `toolHelpers` (arg readers, `resultText`,
+  `languageFromPath`) + `lib`'s `projectRelativePath`. `resultText` delegates canonical result parsing to
+  the parent chat primitive, so text extraction and the common image layer cannot disagree about what
+  constitutes a valid content block.
 
 ## Boundary
 
@@ -204,6 +213,8 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 ## Get right
 
 - **Render defensively:** a tool's `details` result shape is not a stable API — read best-effort and
-  fall back to its text content (`resultText`).
+  fall back to its text content (`resultText`). Missing structured references remove links, never prose.
+- File actions come only from explicit args/details and only through `ToolRenderProps.onOpenFile`; never
+  infer them from arbitrary result text or import app integration into a renderer.
 - Tool names must match the capability exactly — the name is the join key.
 - Token-utility styling only (no raw hex / inline `style`).

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -19,9 +19,10 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 ## What's here
 
 - **Core pi tools** — `BashCard` (terminal block), `ReadCard`/`WriteCard` (project-relative path +
-  highlighted textual file), `EditCard` (path + removed/added line diff). All **routine**. A settled
-  `read`/`write`/`edit` path uses the shared structured file-link primitive when it belongs to the active
-  worktree, opening the shell's preview slot; a running mutation or foreign path stays text. Image content
+  highlighted textual file), `EditCard` (path + removed/added line diff). All **routine**. A settled `read`
+  (success or error) and a successful `write`/`edit` use the shared structured file-link primitive when the
+  path belongs to the active worktree, opening the shell's preview slot; a running/failed mutation or foreign
+  path stays text. Image content
   returned by `read` is previewed by the parent chat module's common result-content layer, the same path as
   every other image-producing tool; `ReadCard` does not special-case image payloads.
 - **`ResolveCommentCard`** — the compact receipt for the host-owned `resolve_comment` review tool
@@ -188,8 +189,8 @@ registration runs once when the chat module mounts. Unregistered tools fall back
   `pi-visualize` extension.
 - **Spec-graph tools** — one defensive `SpecToolCard` registered for all seven `spec_*` names. Each keeps
   the capability's readable text, folds long output, replaces redundant args JSON with a meaningful
-  activity summary, and turns only exact worktree paths obtained from the known result `details` shapes
-  into preview actions. `spec_delete` never links its successful deleted path. Routine.
+  activity summary, and turns only exact worktree paths obtained from known successful result `details`
+  shapes into preview actions. `spec_delete` never links its successful deleted path. Routine.
 - **`web/`** — search/fetch/stored-content renderers for `pi-web-access`; own child spec
   ([web/SPEC.md](web/SPEC.md)). Routine.
 - **The five `todo_*` tools** deliberately keep routine fallback receipts: their connected product surface

--- a/apps/web/src/chat/tools/SpecToolCard.tsx
+++ b/apps/web/src/chat/tools/SpecToolCard.tsx
@@ -9,6 +9,28 @@ interface LinkedTextSegment {
 	path?: string;
 }
 
+const PATH_PREFIX_BOUNDARY = /[\s([{"'=]/;
+const PATH_SUFFIX_BOUNDARY = /[\s)\]}"',;:]/;
+
+function boundedPathIndex(text: string, path: string, cursor: number): number {
+	let from = cursor;
+	while (from < text.length) {
+		const index = text.indexOf(path, from);
+		if (index < 0) return -1;
+		const before = index === 0 ? "" : text[index - 1];
+		const afterIndex = index + path.length;
+		const after = afterIndex === text.length ? "" : text[afterIndex];
+		if (
+			(!before || PATH_PREFIX_BOUNDARY.test(before)) &&
+			(!after || PATH_SUFFIX_BOUNDARY.test(after))
+		) {
+			return index;
+		}
+		from = index + 1;
+	}
+	return -1;
+}
+
 function objectValue(value: unknown): Record<string, unknown> | null {
 	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
 }
@@ -81,7 +103,7 @@ export function splitKnownPathReferences(text: string, paths: string[]): LinkedT
 		let nextIndex = -1;
 		let nextPath = "";
 		for (const path of references) {
-			const index = text.indexOf(path, cursor);
+			const index = boundedPathIndex(text, path, cursor);
 			if (index < 0) continue;
 			if (
 				nextIndex < 0 ||

--- a/apps/web/src/chat/tools/SpecToolCard.tsx
+++ b/apps/web/src/chat/tools/SpecToolCard.tsx
@@ -1,0 +1,183 @@
+import type { ReactNode } from "react";
+import type { ToolRenderProps } from "../toolRegistry";
+import { Collapsible, countLines } from "./Collapsible";
+import { ToolFileLink } from "./ToolFileLink";
+import { resultText, strArg } from "./toolHelpers";
+
+interface LinkedTextSegment {
+	text: string;
+	path?: string;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function stringField(value: unknown, key: string): string | null {
+	const object = objectValue(value);
+	return object && typeof object[key] === "string" ? object[key] : null;
+}
+
+function objectsField(value: unknown, key: string): Record<string, unknown>[] {
+	const object = objectValue(value);
+	const items = object?.[key];
+	return Array.isArray(items)
+		? items.flatMap((item) => {
+				const record = objectValue(item);
+				return record ? [record] : [];
+			})
+		: [];
+}
+
+function uniquePaths(paths: Array<string | null>): string[] {
+	return [...new Set(paths.filter((path): path is string => Boolean(path)))];
+}
+
+export function specToolPaths(
+	toolName: string,
+	args: Record<string, unknown>,
+	result: unknown,
+): string[] {
+	const details = objectValue(result)?.details;
+	switch (toolName) {
+		case "spec_grep":
+			return uniquePaths(
+				objectsField(details, "matches").map((match) => stringField(match, "path")),
+			);
+		case "spec_get":
+			return uniquePaths([
+				stringField(details, "path"),
+				...objectsField(details, "links").map((link) => stringField(link, "path")),
+				...objectsField(details, "reverseLinks").map((link) => stringField(link, "path")),
+			]);
+		case "spec_graph":
+			return uniquePaths(objectsField(details, "nodes").map((node) => stringField(node, "path")));
+		case "spec_create":
+			return uniquePaths([strArg(args, "path"), stringField(details, "path")]);
+		case "spec_update":
+			return uniquePaths([stringField(details, "path")]);
+		case "spec_validate":
+			return uniquePaths([
+				...objectsField(details, "duplicateIds").flatMap((duplicate) => {
+					const paths = duplicate.paths;
+					return Array.isArray(paths)
+						? paths.filter((path): path is string => typeof path === "string")
+						: [];
+				}),
+				...objectsField(details, "danglingLinks").map((link) => stringField(link, "fromPath")),
+			]);
+		default:
+			return [];
+	}
+}
+
+export function splitKnownPathReferences(text: string, paths: string[]): LinkedTextSegment[] {
+	const references = [...new Set(paths.filter(Boolean))].sort((a, b) => b.length - a.length);
+	if (!text || references.length === 0) return text ? [{ text }] : [];
+
+	const segments: LinkedTextSegment[] = [];
+	let cursor = 0;
+	while (cursor < text.length) {
+		let nextIndex = -1;
+		let nextPath = "";
+		for (const path of references) {
+			const index = text.indexOf(path, cursor);
+			if (index < 0) continue;
+			if (
+				nextIndex < 0 ||
+				index < nextIndex ||
+				(index === nextIndex && path.length > nextPath.length)
+			) {
+				nextIndex = index;
+				nextPath = path;
+			}
+		}
+		if (nextIndex < 0) {
+			segments.push({ text: text.slice(cursor) });
+			break;
+		}
+		if (nextIndex > cursor) segments.push({ text: text.slice(cursor, nextIndex) });
+		segments.push({ text: nextPath, path: nextPath });
+		cursor = nextIndex + nextPath.length;
+	}
+	return segments;
+}
+
+function LinkedResultText({
+	text,
+	paths,
+	workspaceRoot,
+	onOpenFile,
+}: {
+	text: string;
+	paths: string[];
+	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
+}): ReactNode {
+	return splitKnownPathReferences(text, paths).map((segment, index) =>
+		segment.path ? (
+			<ToolFileLink
+				key={`${index}:${segment.path}`}
+				path={segment.path}
+				label={segment.text}
+				workspaceRoot={workspaceRoot}
+				onOpenFile={onOpenFile}
+				className="text-primary"
+			/>
+		) : (
+			segment.text
+		),
+	);
+}
+
+export function specToolSummary({ toolName, args }: ToolRenderProps): string {
+	switch (toolName) {
+		case "spec_grep":
+			return strArg(args, "pattern");
+		case "spec_graph":
+			return strArg(args, "root");
+		case "spec_create":
+			return strArg(args, "path");
+		case "spec_validate":
+			return "graph";
+		default:
+			return strArg(args, "id");
+	}
+}
+
+export function SpecToolCard({
+	toolName,
+	args,
+	result,
+	status,
+	workspaceRoot,
+	onOpenFile,
+}: ToolRenderProps) {
+	const output = resultText(result);
+	if (status === "running") {
+		return <span className="text-text-muted tr-text-metadata">Inspecting specs…</span>;
+	}
+	if (!output) {
+		return <span className="text-text-muted tr-text-metadata italic">(no result)</span>;
+	}
+	const content = (
+		<pre
+			data-testid="tool-spec-result"
+			className={`overflow-auto whitespace-pre-wrap px-8 py-4 tr-code-text ${
+				status === "error" ? "text-feedback-error" : "text-text-default"
+			}`}
+		>
+			<LinkedResultText
+				text={output}
+				paths={status === "done" ? specToolPaths(toolName, args, result) : []}
+				workspaceRoot={workspaceRoot}
+				onOpenFile={onOpenFile}
+			/>
+		</pre>
+	);
+	return (
+		<div data-testid={`tool-${toolName}`}>
+			<Collapsible lines={countLines(output)}>{content}</Collapsible>
+		</div>
+	);
+}

--- a/apps/web/src/chat/tools/ToolFileLink.tsx
+++ b/apps/web/src/chat/tools/ToolFileLink.tsx
@@ -1,0 +1,64 @@
+import { cn, isAbsolutePath, projectRelativePath } from "@/lib";
+
+const URI_SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+
+export function toolFileTarget(path: string, workspaceRoot?: string | undefined): string | null {
+	const candidate = path.trim();
+	if (!candidate) return null;
+	if (!isAbsolutePath(candidate) && URI_SCHEME.test(candidate)) return null;
+	const relative = projectRelativePath(candidate, workspaceRoot);
+	if (!relative || isAbsolutePath(relative) || relative === ".." || relative.startsWith("../")) {
+		return null;
+	}
+	return relative;
+}
+
+export function ToolFileLink({
+	path,
+	workspaceRoot,
+	onOpenFile,
+	disabled = false,
+	className,
+	label,
+}: {
+	path: string;
+	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
+	disabled?: boolean;
+	className?: string;
+	label?: string;
+}) {
+	const candidate = path.trim();
+	const displayPath =
+		label ??
+		(candidate && !isAbsolutePath(candidate) && URI_SCHEME.test(candidate)
+			? candidate
+			: projectRelativePath(candidate, workspaceRoot));
+	const target = disabled ? null : toolFileTarget(candidate, workspaceRoot);
+	if (!target || !onOpenFile) {
+		return (
+			<span
+				data-testid="tool-file-reference"
+				className={cn("min-w-0 truncate", className)}
+				title={path}
+			>
+				{displayPath}
+			</span>
+		);
+	}
+	return (
+		<button
+			type="button"
+			data-testid="tool-file-link"
+			data-path={target}
+			title={path}
+			onClick={() => onOpenFile(target)}
+			className={cn(
+				"min-w-0 cursor-pointer truncate rounded-[var(--radius-xs)] text-left outline-none hover:underline focus-visible:ring-2 focus-visible:ring-primary",
+				className,
+			)}
+		>
+			{displayPath}
+		</button>
+	);
+}

--- a/apps/web/src/chat/tools/ToolFileLinks.test.ts
+++ b/apps/web/src/chat/tools/ToolFileLinks.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ToolRenderProps } from "../toolRegistry";
+import { EditCard } from "./EditCard";
+import { ReadCard } from "./ReadCard";
+import { toolFileTarget } from "./ToolFileLink";
+import { WriteCard } from "./WriteCard";
+
+const result = { content: [{ type: "text", text: "ok" }] };
+
+function props(
+	toolName: string,
+	path: string,
+	status: ToolRenderProps["status"] = "done",
+): ToolRenderProps & { onOpenFile: (path: string) => void } {
+	return {
+		toolCallId: `${toolName}-call`,
+		toolName,
+		args: { path, content: "hello", oldText: "old", newText: "new" },
+		result,
+		status,
+		workspaceRoot: "/repo",
+		streaming: false,
+		onOpenFile: () => {},
+	};
+}
+
+function markup(
+	Card: (props: ToolRenderProps) => React.ReactNode,
+	toolName: string,
+	path: string,
+	status?: ToolRenderProps["status"],
+): string {
+	return renderToStaticMarkup(createElement(Card, props(toolName, path, status)));
+}
+
+describe("structured tool file links", () => {
+	it("canonicalizes only paths contained by the active worktree", () => {
+		for (const [path, root, expected] of [
+			["module-a/../README.md", "/repo", "README.md"],
+			["/repo/module-a/SPEC.md", "/repo", "module-a/SPEC.md"],
+			["C:\\repo\\module-a\\SPEC.md", "C:\\repo", "module-a/SPEC.md"],
+			["/repo-other/SPEC.md", "/repo", null],
+			["../outside.md", "/repo", null],
+			["https://example.com/a.md", "/repo", null],
+			["file:///repo/a.md", "/repo", null],
+			["", "/repo", null],
+		] as const) {
+			expect(toolFileTarget(path, root)).toBe(expected);
+		}
+	});
+
+	it("opens relative and in-worktree absolute read paths under one canonical relative label", () => {
+		const relative = markup(ReadCard, "read", "module-a/../README.md");
+		const absolute = markup(ReadCard, "read", "/repo/module-a/SPEC.md");
+
+		expect(relative).toContain('data-testid="tool-file-link"');
+		expect(relative).toContain('data-path="README.md"');
+		expect(relative).toContain(">README.md</button>");
+		expect(absolute).toContain('data-path="module-a/SPEC.md"');
+	});
+
+	it("leaves foreign, escaping, URL, and empty read paths as inert selectable text", () => {
+		for (const path of ["/tmp/outside.png", "../outside.md", "https://example.com/a.md", ""]) {
+			const html = markup(ReadCard, "read", path);
+			expect(html).not.toContain('data-testid="tool-file-link"');
+			expect(html).toContain('data-testid="tool-file-reference"');
+		}
+	});
+
+	it("links write and edit receipts only after their mutation settles", () => {
+		for (const [Card, toolName] of [
+			[WriteCard, "write"],
+			[EditCard, "edit"],
+		] as const) {
+			expect(markup(Card, toolName, "README.md", "running")).not.toContain(
+				'data-testid="tool-file-link"',
+			);
+			expect(markup(Card, toolName, "README.md", "error")).not.toContain(
+				'data-testid="tool-file-link"',
+			);
+			expect(markup(Card, toolName, "README.md", "done")).toContain('data-testid="tool-file-link"');
+		}
+	});
+});

--- a/apps/web/src/chat/tools/WriteCard.tsx
+++ b/apps/web/src/chat/tools/WriteCard.tsx
@@ -1,13 +1,12 @@
 import { RiFileAddLine as FilePlus } from "@remixicon/react";
-import { projectRelativePath } from "@/lib";
 import type { ToolRenderProps } from "../toolRegistry";
 import { CodeBlock } from "./CodeBlock";
 import { Collapsible, countLines } from "./Collapsible";
+import { ToolFileLink } from "./ToolFileLink";
 import { languageFromPath, resultText, strArg } from "./toolHelpers";
 
-export function WriteCard({ args, result, status, workspaceRoot }: ToolRenderProps) {
+export function WriteCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
 	const path = strArg(args, "path");
-	const displayPath = projectRelativePath(path, workspaceRoot);
 	const content = strArg(args, "content");
 	const lang = languageFromPath(path);
 	const message = resultText(result);
@@ -16,9 +15,13 @@ export function WriteCard({ args, result, status, workspaceRoot }: ToolRenderPro
 		<div data-testid="tool-write" className="flex flex-col gap-4">
 			<div className="flex items-center gap-4 tr-text-metadata">
 				<FilePlus className="size-12 shrink-0 text-feedback-success" />
-				<span className="truncate text-text-default" title={path}>
-					{displayPath}
-				</span>
+				<ToolFileLink
+					path={path}
+					workspaceRoot={workspaceRoot}
+					onOpenFile={onOpenFile}
+					disabled={status !== "done"}
+					className="text-text-default"
+				/>
 				<span className="shrink-0 text-text-muted">written</span>
 			</div>
 			{status === "error" ? (

--- a/apps/web/src/chat/tools/register.ts
+++ b/apps/web/src/chat/tools/register.ts
@@ -5,6 +5,7 @@ import { BashCard } from "./BashCard";
 import { EditCard } from "./EditCard";
 import { ReadCard } from "./ReadCard";
 import { ResolveCommentCard } from "./ResolveCommentCard";
+import { SpecToolCard, specToolSummary } from "./SpecToolCard";
 import { strArg } from "./toolHelpers";
 import "./visualize/register";
 import "./web/register";
@@ -20,6 +21,18 @@ registerToolRenderer("edit", EditCard, {
 registerToolRenderer("write", WriteCard, {
 	summary: ({ args, workspaceRoot }) => projectRelativePath(strArg(args, "path"), workspaceRoot),
 });
+
+for (const toolName of [
+	"spec_grep",
+	"spec_get",
+	"spec_graph",
+	"spec_create",
+	"spec_update",
+	"spec_delete",
+	"spec_validate",
+]) {
+	registerToolRenderer(toolName, SpecToolCard, { summary: specToolSummary });
+}
 
 registerToolRenderer("resolve_comment", ResolveCommentCard, {
 	summary: ({ args }) => strArg(args, "commentId"),

--- a/apps/web/src/chat/tools/registeredTools.test.ts
+++ b/apps/web/src/chat/tools/registeredTools.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+	DefaultToolRenderer,
+	getToolRenderer,
+	getToolSummary,
+	type ToolRenderProps,
+} from "../toolRegistry";
+import "./register";
+import { specToolPaths, splitKnownPathReferences } from "./SpecToolCard";
+
+const INTENTIONAL_TOOLS = [
+	"read",
+	"write",
+	"edit",
+	"bash",
+	"web_search",
+	"fetch_content",
+	"get_search_content",
+	"visualize",
+	"spec_grep",
+	"spec_get",
+	"spec_graph",
+	"spec_create",
+	"spec_update",
+	"spec_delete",
+	"spec_validate",
+	"ask_user_question",
+	"resolve_comment",
+] as const;
+
+function props(
+	toolName: string,
+	args: Record<string, unknown>,
+	result: unknown,
+): ToolRenderProps & { onOpenFile: (path: string) => void } {
+	return {
+		toolCallId: `${toolName}-call`,
+		toolName,
+		args,
+		result,
+		status: "done",
+		workspaceRoot: "/repo",
+		streaming: false,
+		onOpenFile: () => {},
+	};
+}
+
+function renderTool(toolName: string, args: Record<string, unknown>, result: unknown): string {
+	return renderToStaticMarkup(
+		createElement(getToolRenderer(toolName), props(toolName, args, result)),
+	);
+}
+
+describe("intentional bundled tool renderers", () => {
+	it("extracts paths only from each spec tool's known structured result fields", () => {
+		const cases: Array<[string, Record<string, unknown>, unknown, string[]]> = [
+			[
+				"spec_grep",
+				{},
+				{ details: { matches: [{ path: "grep/SPEC.md" }, { path: 42 }] } },
+				["grep/SPEC.md"],
+			],
+			[
+				"spec_get",
+				{},
+				{
+					details: {
+						path: "get/SPEC.md",
+						links: [{ path: "forward/SPEC.md" }, { path: null }],
+						reverseLinks: [{ path: "reverse/SPEC.md" }],
+					},
+				},
+				["get/SPEC.md", "forward/SPEC.md", "reverse/SPEC.md"],
+			],
+			["spec_graph", {}, { details: { nodes: [{ path: "graph/SPEC.md" }] } }, ["graph/SPEC.md"]],
+			[
+				"spec_create",
+				{ path: "create/SPEC.md" },
+				{ details: { path: "create/SPEC.md" } },
+				["create/SPEC.md"],
+			],
+			["spec_update", {}, { details: { path: "update/SPEC.md" } }, ["update/SPEC.md"]],
+			["spec_delete", {}, { details: { path: "deleted/SPEC.md" } }, []],
+			[
+				"spec_validate",
+				{},
+				{
+					details: {
+						duplicateIds: [{ paths: ["one/SPEC.md", "two/SPEC.md"] }],
+						danglingLinks: [{ fromPath: "source/SPEC.md" }],
+					},
+				},
+				["one/SPEC.md", "two/SPEC.md", "source/SPEC.md"],
+			],
+		];
+
+		for (const [toolName, args, result, expected] of cases) {
+			expect(specToolPaths(toolName, args, result)).toEqual(expected);
+		}
+	});
+
+	it("segments exact known path strings without letting a shorter path split a longer one", () => {
+		const text = "root SPEC.md; child module-a/SPEC.md; done";
+		const segments = splitKnownPathReferences(text, ["SPEC.md", "module-a/SPEC.md"]);
+
+		expect(segments.map((segment) => segment.path).filter(Boolean)).toEqual([
+			"SPEC.md",
+			"module-a/SPEC.md",
+		]);
+		expect(segments.map((segment) => segment.text).join("")).toBe(text);
+	});
+
+	it("registers every non-TODO tool exposed by a normal session", () => {
+		for (const toolName of INTENTIONAL_TOOLS) {
+			expect(getToolRenderer(toolName)).not.toBe(DefaultToolRenderer);
+		}
+	});
+
+	it("leaves the five TODO tools on their plan-owned fallback receipts", () => {
+		for (const toolName of ["todo_list", "todo_add", "todo_update", "todo_remove", "todo_write"]) {
+			expect(getToolRenderer(toolName)).toBe(DefaultToolRenderer);
+		}
+	});
+
+	it("renders only structured in-worktree spec_get paths as exact preview links", () => {
+		const html = renderTool(
+			"spec_get",
+			{ id: "sample-root" },
+			{
+				content: [
+					{
+						type: "text",
+						text: [
+							"sample-root [goal-and-requirements] — Sample Project",
+							"path: SPEC.md",
+							"links:",
+							"  parent -> sample-parent (module-a/SPEC.md)",
+							"  references -> foreign (/tmp/outside.md)",
+						].join("\n"),
+					},
+				],
+				details: {
+					path: "SPEC.md",
+					links: [{ path: "module-a/SPEC.md" }, { path: "/tmp/outside.md" }],
+					reverseLinks: [],
+				},
+			},
+		);
+
+		expect(html).not.toContain("&quot;id&quot;");
+		expect(html.match(/data-testid="tool-file-link"/g)).toHaveLength(2);
+		expect(html).toContain('data-path="SPEC.md"');
+		expect(html).toContain('data-path="module-a/SPEC.md"');
+		expect(html).toContain("/tmp/outside.md");
+		expect(html).not.toContain('data-path="/tmp/outside.md"');
+	});
+
+	it("keeps a failed spec mutation path inert", () => {
+		const rendererProps = props(
+			"spec_create",
+			{ path: "missing/SPEC.md", id: "missing" },
+			{
+				content: [{ type: "text", text: "Error: failed to create missing/SPEC.md" }],
+				details: { path: "missing/SPEC.md", error: "failed" },
+			},
+		);
+		const html = renderToStaticMarkup(
+			createElement(getToolRenderer("spec_create"), { ...rendererProps, status: "error" }),
+		);
+
+		expect(html).toContain("missing/SPEC.md");
+		expect(html).not.toContain('data-testid="tool-file-link"');
+	});
+
+	it("keeps a successful spec_delete path inert", () => {
+		const html = renderTool(
+			"spec_delete",
+			{ id: "removed" },
+			{
+				content: [{ type: "text", text: "Deleted removed/SPEC.md (id: removed)." }],
+				details: { id: "removed", path: "removed/SPEC.md" },
+			},
+		);
+
+		expect(html).toContain("removed/SPEC.md");
+		expect(html).not.toContain('data-testid="tool-file-link"');
+	});
+
+	it("summarizes the first query, URL, or selected stored-content target", () => {
+		expect(
+			getToolSummary(
+				"web_search",
+				props("web_search", { queries: ["first query", "second query"] }, null),
+			),
+		).toBe("first query");
+		expect(
+			getToolSummary(
+				"fetch_content",
+				props(
+					"fetch_content",
+					{ urls: ["https://example.com/one", "https://example.com/two"] },
+					null,
+				),
+			),
+		).toBe("https://example.com/one");
+		expect(
+			getToolSummary(
+				"get_search_content",
+				props(
+					"get_search_content",
+					{ responseId: "response-123", urlIndex: 0 },
+					{
+						details: { url: "https://example.com/selected" },
+					},
+				),
+			),
+		).toBe("https://example.com/selected");
+	});
+
+	it("treats only HTTP fetch targets as external links and gates local targets as files", () => {
+		const result = { content: [{ type: "text", text: "Fetched." }] };
+		const external = renderTool("fetch_content", { url: "https://www.example.com/docs" }, result);
+		const local = renderTool("fetch_content", { url: "module-a/SPEC.md" }, result);
+		const foreign = renderTool("fetch_content", { url: "/tmp/video.mp4" }, result);
+
+		expect(external).toContain('href="https://www.example.com/docs"');
+		expect(external).toContain(">example.com</a>");
+		expect(local).toContain('data-path="module-a/SPEC.md"');
+		expect(foreign).not.toContain('data-testid="tool-file-link"');
+		expect(foreign).toContain("/tmp/video.mp4");
+	});
+
+	it("renders search and stored web content as Markdown with safe external links", () => {
+		for (const [toolName, args] of [
+			["web_search", { query: "preview tabs" }],
+			["get_search_content", { responseId: "response-123", queryIndex: 0 }],
+		] as const) {
+			const html = renderTool(toolName, args, {
+				content: [
+					{ type: "text", text: "# Answer\n\nRead the [source](https://example.com/source)." },
+				],
+				details: { query: "preview tabs" },
+			});
+			expect(html).toContain("<h1>Answer</h1>");
+			expect(html).toContain('href="https://example.com/source"');
+			expect(html).not.toContain("&quot;responseId&quot;");
+		}
+	});
+});

--- a/apps/web/src/chat/tools/registeredTools.test.ts
+++ b/apps/web/src/chat/tools/registeredTools.test.ts
@@ -112,6 +112,14 @@ describe("intentional bundled tool renderers", () => {
 		expect(segments.map((segment) => segment.text).join("")).toBe(text);
 	});
 
+	it("does not link a known path as a suffix inside another path", () => {
+		const text = "foreign /tmp/SPEC.md; local SPEC.md:12; backup SPEC.md.bak; nested other/SPEC.md";
+		const segments = splitKnownPathReferences(text, ["SPEC.md"]);
+
+		expect(segments.map((segment) => segment.path).filter(Boolean)).toEqual(["SPEC.md"]);
+		expect(segments.map((segment) => segment.text).join("")).toBe(text);
+	});
+
 	it("registers every non-TODO tool exposed by a normal session", () => {
 		for (const toolName of INTENTIONAL_TOOLS) {
 			expect(getToolRenderer(toolName)).not.toBe(DefaultToolRenderer);

--- a/apps/web/src/chat/tools/toolHelpers.ts
+++ b/apps/web/src/chat/tools/toolHelpers.ts
@@ -1,23 +1,7 @@
+import { parseToolResultContent } from "../toolResultContent";
+
 export function resultText(result: unknown): string {
-	if (result == null) return "";
-	if (typeof result === "string") return result;
-	if (typeof result === "object" && "content" in result) {
-		const content = (result as { content: unknown }).content;
-		if (Array.isArray(content)) {
-			return content
-				.filter(
-					(c): c is { type: "text"; text: string } =>
-						typeof c === "object" && c !== null && (c as { type?: string }).type === "text",
-				)
-				.map((c) => c.text)
-				.join("");
-		}
-	}
-	try {
-		return JSON.stringify(result, null, 2);
-	} catch {
-		return String(result);
-	}
+	return parseToolResultContent(result).text;
 }
 
 export function strArg(args: Record<string, unknown>, key: string): string {

--- a/apps/web/src/chat/tools/web/SPEC.md
+++ b/apps/web/src/chat/tools/web/SPEC.md
@@ -1,8 +1,8 @@
 ---
 id: submodule-web-chat-tools-web
 type: submodule-design
-status: draft
-title: web tool renderers (web_search / fetch_content)
+status: active
+title: web tool renderers (search / fetch / stored content)
 parent: submodule-web-chat-tools
 depends-on: [module-contracts]
 tags: [v1, chat, web-tools]
@@ -10,19 +10,20 @@ tags: [v1, chat, web-tools]
 
 ## Responsibility
 
-Presentational renderers for the bundled **`pi-web-access`** extension's tools, joined to the capability by
-**tool name**: `WebSearchCard` (`web_search`) and `WebFetchCard` (`fetch_content`). `register.ts` wires
-both via `registerToolRenderer` (+ a collapsed-header summary) and is imported for its side effect by the
-parent `tools/register`.
+Presentational renderers for all three tools exposed by the pinned **`pi-web-access`** extension, joined to
+that capability by **tool name**: `WebSearchCard` (`web_search`), `WebFetchCard` (`fetch_content`), and
+`WebStoredContentCard` (`get_search_content`). `register.ts` wires all three via `registerToolRenderer`
+(+ collapsed-header summaries) and is imported for its side effect by the parent `tools/register`.
 
 ## Boundary
 
-- **Owns:** `WebSearchCard` (query + provider + synthesized answer/sources) and `WebFetchCard` (fetched URL
-  + extracted content), both via the shared `CodeBlock`/`Collapsible`, and their registration.
+- **Owns:** `WebSearchCard` (query + provider + synthesized answer/sources), `WebFetchCard` (fetched URL or
+  local-video path + extracted content), `WebStoredContentCard` (response id + selected query/URL + recovered
+  full content), their shared folded Markdown result body, and registration.
 - **Public surface:** none beyond the side-effect `register` (no barrel — chat pulls shiki; per-file like
   its siblings).
-- **Allowed deps:** sibling chat primitives (`toolRegistry`, `toolHelpers`, `CodeBlock`, `Collapsible`);
-  `@remixicon/react`.
+- **Allowed deps:** sibling/parent chat primitives (`toolRegistry`, `toolHelpers`, `ToolFileLink`,
+  `Collapsible`, `Markdown`); `@remixicon/react`.
 - **Forbidden:** value-importing any `pi` package or `pi-web-access`; `store`/`transport` (renderers stay
   presentational — extraction-ready into `packages/chat-ui`).
 
@@ -30,7 +31,12 @@ parent `tools/register`.
 
 - **Render defensively.** `pi-web-access`'s `details` shape is not a stable public API, so read `result`
   best-effort (provider name via optional chaining) and otherwise render the tool's **text content**
-  (`resultText`) — never hard-depend on a `details` field. `args` (`query`/`queries[0]`, `url`/`urls[0]`)
-  drive the header + collapsed summary.
+  (`resultText`) — never hard-depend on a `details` field. Args drive headers/summaries: first query for
+  search; first URL/local path for fetch; selected query/URL then response id for stored content.
+- Successful text content is folded and rendered as Markdown, so synthesized citations and fetched links
+  are real safe new-tab links rather than highlighted Markdown source. Error text remains plain.
+- `fetch_content` treats only HTTP(S) as an external anchor. Any other input is a structured local-path
+  candidate and uses the parent's worktree gate; a foreign absolute path stays inert instead of becoming a
+  broken same-origin link.
 - Token-utility styling only (no raw hex / inline `style`).
-- Tool names `web_search` / `fetch_content` must match the extension exactly.
+- Tool names `web_search` / `fetch_content` / `get_search_content` must match the extension exactly.

--- a/apps/web/src/chat/tools/web/WebFetchCard.tsx
+++ b/apps/web/src/chat/tools/web/WebFetchCard.tsx
@@ -1,14 +1,15 @@
 import { RiLinksLine as LinkIcon } from "@remixicon/react";
 import type { ToolRenderProps } from "../../toolRegistry";
-import { CodeBlock } from "../CodeBlock";
-import { Collapsible, countLines } from "../Collapsible";
+import { ToolFileLink } from "../ToolFileLink";
 import { resultText, strArg } from "../toolHelpers";
+import { WebResultBody } from "./WebResultBody";
 
-function hostOf(url: string): string {
+function httpUrl(value: string): URL | null {
 	try {
-		return new URL(url).hostname.replace(/^www\./, "");
+		const url = new URL(value);
+		return url.protocol === "http:" || url.protocol === "https:" ? url : null;
 	} catch {
-		return url;
+		return null;
 	}
 }
 
@@ -19,18 +20,23 @@ function firstUrl(args: Record<string, unknown>): string {
 	return Array.isArray(many) && typeof many[0] === "string" ? many[0] : "";
 }
 
-export function WebFetchCard({ args, result, status }: ToolRenderProps) {
+export function webFetchSummary({ args }: ToolRenderProps): string {
+	return firstUrl(args);
+}
+
+export function WebFetchCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
 	const url = firstUrl(args);
-	const label = url ? hostOf(url) : "fetch";
+	const external = httpUrl(url);
+	const label = external ? external.hostname.replace(/^www\./, "") : "fetch";
 	const output = resultText(result);
 
 	return (
 		<div data-testid="tool-fetch_content" className="flex flex-col gap-4">
 			<div className="flex items-center gap-4 tr-text-metadata">
 				<LinkIcon className="size-12 shrink-0 text-text-muted" />
-				{url ? (
+				{external ? (
 					<a
-						href={url}
+						href={external.href}
 						target="_blank"
 						rel="noreferrer"
 						className="truncate text-primary hover:underline"
@@ -38,21 +44,24 @@ export function WebFetchCard({ args, result, status }: ToolRenderProps) {
 					>
 						{label}
 					</a>
+				) : url ? (
+					<ToolFileLink
+						path={url}
+						workspaceRoot={workspaceRoot}
+						onOpenFile={onOpenFile}
+						disabled={status === "running"}
+						className="text-primary"
+					/>
 				) : (
 					<span className="text-primary">{label}</span>
 				)}
 			</div>
-			{status === "running" ? (
-				<span className="text-text-muted tr-text-metadata">Fetching…</span>
-			) : status === "error" ? (
-				<pre className="overflow-auto px-8 py-4 text-feedback-error tr-code-text">{output}</pre>
-			) : output ? (
-				<Collapsible lines={countLines(output)}>
-					<CodeBlock code={output} lang="markdown" />
-				</Collapsible>
-			) : (
-				<span className="text-text-muted tr-text-metadata italic">(no content)</span>
-			)}
+			<WebResultBody
+				output={output}
+				status={status}
+				runningLabel="Fetching…"
+				emptyLabel="(no content)"
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/chat/tools/web/WebResultBody.tsx
+++ b/apps/web/src/chat/tools/web/WebResultBody.tsx
@@ -1,0 +1,30 @@
+import { Markdown } from "../../Markdown";
+import type { ToolStatus } from "../../types";
+import { Collapsible, countLines } from "../Collapsible";
+
+export function WebResultBody({
+	output,
+	status,
+	runningLabel,
+	emptyLabel,
+}: {
+	output: string;
+	status: ToolStatus;
+	runningLabel: string;
+	emptyLabel: string;
+}) {
+	if (status === "running") {
+		return <span className="text-text-muted tr-text-metadata">{runningLabel}</span>;
+	}
+	if (status === "error") {
+		return <pre className="overflow-auto px-8 py-4 text-feedback-error tr-code-text">{output}</pre>;
+	}
+	if (!output) {
+		return <span className="text-text-muted tr-text-metadata italic">{emptyLabel}</span>;
+	}
+	return (
+		<Collapsible lines={countLines(output)}>
+			<Markdown text={output} />
+		</Collapsible>
+	);
+}

--- a/apps/web/src/chat/tools/web/WebSearchCard.tsx
+++ b/apps/web/src/chat/tools/web/WebSearchCard.tsx
@@ -1,14 +1,17 @@
 import { RiSearchLine as Search } from "@remixicon/react";
 import type { ToolRenderProps } from "../../toolRegistry";
-import { CodeBlock } from "../CodeBlock";
-import { Collapsible, countLines } from "../Collapsible";
 import { resultText, strArg } from "../toolHelpers";
+import { WebResultBody } from "./WebResultBody";
 
 function firstQuery(args: Record<string, unknown>): string {
 	const single = strArg(args, "query");
 	if (single) return single;
 	const many = args.queries;
 	return Array.isArray(many) && typeof many[0] === "string" ? many[0] : "";
+}
+
+export function webSearchSummary({ args }: ToolRenderProps): string {
+	return firstQuery(args);
 }
 
 function providerOf(result: unknown): string {
@@ -33,17 +36,12 @@ export function WebSearchCard({ args, result, status }: ToolRenderProps) {
 				</span>
 				{provider ? <span className="shrink-0 text-text-muted">via {provider}</span> : null}
 			</div>
-			{status === "running" ? (
-				<span className="text-text-muted tr-text-metadata">Searching…</span>
-			) : status === "error" ? (
-				<pre className="overflow-auto px-8 py-4 text-feedback-error tr-code-text">{output}</pre>
-			) : output ? (
-				<Collapsible lines={countLines(output)}>
-					<CodeBlock code={output} lang="markdown" />
-				</Collapsible>
-			) : (
-				<span className="text-text-muted tr-text-metadata italic">No results.</span>
-			)}
+			<WebResultBody
+				output={output}
+				status={status}
+				runningLabel="Searching…"
+				emptyLabel="No results."
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/chat/tools/web/WebStoredContentCard.tsx
+++ b/apps/web/src/chat/tools/web/WebStoredContentCard.tsx
@@ -1,0 +1,55 @@
+import { RiLinksLine as LinkIcon } from "@remixicon/react";
+import type { ToolRenderProps } from "../../toolRegistry";
+import { numArg, resultText, strArg } from "../toolHelpers";
+import { WebResultBody } from "./WebResultBody";
+
+function detailString(result: unknown, key: string): string {
+	if (typeof result !== "object" || result === null || !("details" in result)) return "";
+	const details = (result as { details: unknown }).details;
+	if (typeof details !== "object" || details === null) return "";
+	const value = (details as Record<string, unknown>)[key];
+	return typeof value === "string" ? value : "";
+}
+
+export function storedContentTarget(args: Record<string, unknown>, result: unknown): string {
+	const query = strArg(args, "query") || detailString(result, "query");
+	if (query) return query;
+	const url = strArg(args, "url") || detailString(result, "url");
+	if (url) return url;
+	const queryIndex = numArg(args, "queryIndex");
+	if (queryIndex !== null) return `query ${queryIndex}`;
+	const urlIndex = numArg(args, "urlIndex");
+	if (urlIndex !== null) return `URL ${urlIndex}`;
+	return "";
+}
+
+export function storedContentSummary({ args, result }: ToolRenderProps): string {
+	return storedContentTarget(args, result) || strArg(args, "responseId");
+}
+
+export function WebStoredContentCard({ args, result, status }: ToolRenderProps) {
+	const responseId = strArg(args, "responseId");
+	const target = storedContentTarget(args, result);
+	const output = resultText(result);
+	return (
+		<div data-testid="tool-get_search_content" className="flex flex-col gap-4">
+			<div className="flex items-center gap-4 tr-text-metadata">
+				<LinkIcon className="size-12 shrink-0 text-text-muted" />
+				<span className="min-w-0 truncate text-primary" title={target || responseId}>
+					{target || responseId || "stored content"}
+				</span>
+				{target && responseId ? (
+					<span className="shrink-0 text-text-muted" title={responseId}>
+						{responseId}
+					</span>
+				) : null}
+			</div>
+			<WebResultBody
+				output={output}
+				status={status}
+				runningLabel="Loading stored content…"
+				emptyLabel="(no stored content)"
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/chat/tools/web/register.ts
+++ b/apps/web/src/chat/tools/web/register.ts
@@ -1,7 +1,10 @@
 import { registerToolRenderer } from "../../toolRegistry";
-import { strArg } from "../toolHelpers";
-import { WebFetchCard } from "./WebFetchCard";
-import { WebSearchCard } from "./WebSearchCard";
+import { WebFetchCard, webFetchSummary } from "./WebFetchCard";
+import { WebSearchCard, webSearchSummary } from "./WebSearchCard";
+import { storedContentSummary, WebStoredContentCard } from "./WebStoredContentCard";
 
-registerToolRenderer("web_search", WebSearchCard, { summary: ({ args }) => strArg(args, "query") });
-registerToolRenderer("fetch_content", WebFetchCard, { summary: ({ args }) => strArg(args, "url") });
+registerToolRenderer("web_search", WebSearchCard, { summary: webSearchSummary });
+registerToolRenderer("fetch_content", WebFetchCard, { summary: webFetchSummary });
+registerToolRenderer("get_search_content", WebStoredContentCard, {
+	summary: storedContentSummary,
+});

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -28,7 +28,8 @@ import { parseReviewPackage, type ReviewPackageItem, reviewPackageLabel } from "
 import type { ChatRow, TurnDividerData } from "./rows";
 import { formatTokens } from "./SessionStatsBar";
 import { ToolCard } from "./ToolCard";
-import { getToolChrome, getToolRenderer } from "./toolRegistry";
+import { ToolRendererBody } from "./ToolRendererBody";
+import { getToolChrome, getToolSummary, type ToolRenderProps } from "./toolRegistry";
 import type { CompactionState } from "./types";
 
 export function ChatTurnView({
@@ -321,18 +322,18 @@ function ToolRow({
 	workspaceRoot?: string | undefined;
 }) {
 	if (getToolChrome(row.toolName) === "bare") {
-		const Renderer = getToolRenderer(row.toolName);
+		const renderProps: ToolRenderProps = {
+			toolCallId: row.toolCallId,
+			toolName: row.toolName,
+			args: row.args,
+			result: row.tool?.raw,
+			status: row.tool?.status ?? (row.dead ? "error" : "running"),
+			workspaceRoot,
+			streaming: row.streaming,
+		};
 		return (
 			<div className="tr-text-ui text-text-default">
-				<Renderer
-					toolCallId={row.toolCallId}
-					toolName={row.toolName}
-					args={row.args}
-					result={row.tool?.raw}
-					status={row.tool?.status ?? (row.dead ? "error" : "running")}
-					workspaceRoot={workspaceRoot}
-					streaming={row.streaming}
-				/>
+				<ToolRendererBody {...renderProps} imageLabel={getToolSummary(row.toolName, renderProps)} />
 			</div>
 		);
 	}

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -35,12 +35,14 @@ import type { CompactionState } from "./types";
 export function ChatTurnView({
 	row,
 	workspaceRoot,
+	onOpenFile,
 	onOpenSpec,
 	onOpenChange,
 	onReveal,
 }: {
 	row: ChatRow;
 	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
 	onOpenSpec?: ((path: string) => void) | undefined;
 	onOpenChange?: ((path: string) => void) | undefined;
 	onReveal?: ((tab: "specs" | "changes") => void) | undefined;
@@ -84,7 +86,7 @@ export function ChatTurnView({
 				</div>
 			);
 		case "tool":
-			return <ToolRow row={row} workspaceRoot={workspaceRoot} />;
+			return <ToolRow row={row} workspaceRoot={workspaceRoot} onOpenFile={onOpenFile} />;
 		case "activity":
 			return (
 				<ActivityGroup
@@ -92,6 +94,7 @@ export function ChatTurnView({
 					steps={row.steps}
 					live={row.live}
 					workspaceRoot={workspaceRoot}
+					onOpenFile={onOpenFile}
 				/>
 			);
 		case "divider":
@@ -317,9 +320,11 @@ function PackageCommentRow({ foldId, item }: { foldId: string; item: ReviewPacka
 function ToolRow({
 	row,
 	workspaceRoot,
+	onOpenFile,
 }: {
 	row: Extract<ChatRow, { kind: "tool" }>;
 	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
 }) {
 	if (getToolChrome(row.toolName) === "bare") {
 		const renderProps: ToolRenderProps = {
@@ -329,6 +334,7 @@ function ToolRow({
 			result: row.tool?.raw,
 			status: row.tool?.status ?? (row.dead ? "error" : "running"),
 			workspaceRoot,
+			onOpenFile,
 			streaming: row.streaming,
 		};
 		return (
@@ -346,6 +352,7 @@ function ToolRow({
 			dead={row.dead}
 			streaming={row.streaming}
 			workspaceRoot={workspaceRoot}
+			onOpenFile={onOpenFile}
 		/>
 	);
 }

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -25,6 +25,7 @@ import { ChangesPanel } from "../panels/ChangesPanel";
 import { DiffPane } from "../panels/DiffPane";
 import { FilePane } from "../panels/FilePane";
 import { FileTree } from "../panels/FileTree";
+import { openFileInTab } from "../panels/openTabs";
 import { ProjectTree } from "../panels/ProjectTree";
 import { ReviewPanel, selectActiveReviewedPath } from "../panels/ReviewPanel";
 import { reviewFlags } from "../panels/reviewModel";
@@ -173,6 +174,12 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const activeReviewedPath = useAppStore((state) => selectActiveReviewedPath(state, workspaceId));
 	const readActiveReviewedPath = useCallback(
 		() => selectActiveReviewedPath(useAppStore.getState(), workspaceId),
+		[workspaceId],
+	);
+	const openToolFile = useCallback(
+		(path: string) => {
+			void openFileInTab(workspaceId, path, "preview");
+		},
 		[workspaceId],
 	);
 
@@ -414,7 +421,11 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 				return sessions[tab.sessionId] ? (
 					<ErrorBoundary label="chat" resetKeys={[workspaceId, tab.id]}>
 						<Suspense fallback={<MissingResource label="chat" />}>
-							<ChatView sessionId={tab.sessionId} workspaceId={workspaceId} />
+							<ChatView
+								sessionId={tab.sessionId}
+								workspaceId={workspaceId}
+								onOpenFile={openToolFile}
+							/>
 						</Suspense>
 					</ErrorBoundary>
 				) : (
@@ -504,7 +515,16 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 				</ErrorBoundary>
 			);
 		},
-		[deletedSessions, document, editorById, editorByResource, sessions, terminalByKey, workspaceId],
+		[
+			deletedSessions,
+			document,
+			editorById,
+			editorByResource,
+			openToolFile,
+			sessions,
+			terminalByKey,
+			workspaceId,
+		],
 	);
 
 	const renderToolBody = useCallback(

--- a/e2e/tool-file-links.spec.ts
+++ b/e2e/tool-file-links.spec.ts
@@ -1,0 +1,229 @@
+import { appendFileSync, realpathSync, utimesSync } from "node:fs";
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_800_000_000;
+const repoCwd = () => realpathSync(E2E_FIXTURE_REPO);
+
+type ToolFixture = {
+	id: string;
+	name: string;
+	args: Record<string, unknown>;
+	text: string;
+	details?: unknown;
+};
+
+const TOOLS: ToolFixture[] = [
+	{
+		id: "read-local",
+		name: "read",
+		args: { path: "README.md" },
+		text: "# sample-project",
+	},
+	{
+		id: "read-external",
+		name: "read",
+		args: { path: "/tmp/outside.png" },
+		text: "/tmp/outside.png\nRead image file [image/png]",
+	},
+	{
+		id: "edit-local",
+		name: "edit",
+		args: { path: "README.md", oldText: "sample", newText: "sample-project" },
+		text: "Updated README.md",
+	},
+	{
+		id: "spec-grep",
+		name: "spec_grep",
+		args: { pattern: "Responsibility" },
+		text: "1 match(es):\nmodule-a/SPEC.md:11: ## Responsibility",
+		details: {
+			matches: [{ path: "module-a/SPEC.md", line: 11, snippet: "## Responsibility" }],
+			truncated: false,
+		},
+	},
+	{
+		id: "spec-get",
+		name: "spec_get",
+		args: { id: "sample-root" },
+		text: [
+			"sample-root [goal-and-requirements] — Sample Project",
+			"path: SPEC.md",
+			"links:",
+			"  parent -> sample-module (module-a/SPEC.md)",
+		].join("\n"),
+		details: {
+			path: "SPEC.md",
+			links: [{ path: "module-a/SPEC.md" }],
+			reverseLinks: [],
+		},
+	},
+	{
+		id: "spec-create",
+		name: "spec_create",
+		args: { path: "module-a/SPEC.md", id: "sample-module" },
+		text: "Created module-a/SPEC.md (id: sample-module).",
+		details: { path: "module-a/SPEC.md", id: "sample-module" },
+	},
+	{
+		id: "spec-delete",
+		name: "spec_delete",
+		args: { id: "removed" },
+		text: "Deleted removed/SPEC.md (id: removed).",
+		details: { path: "removed/SPEC.md", id: "removed" },
+	},
+	{
+		id: "fetch-local-video",
+		name: "fetch_content",
+		args: { url: "/tmp/video.mp4" },
+		text: "# Fetched content\n\nRead the [external source](https://example.com/source).",
+		details: { urls: ["/tmp/video.mp4"], responseId: "response-123" },
+	},
+	{
+		id: "stored-content",
+		name: "get_search_content",
+		args: { responseId: "response-123", urlIndex: 0 },
+		text: "# Stored content\n\nRecovered the complete document.",
+		details: { url: "https://example.com/docs", title: "Stored content" },
+	},
+];
+
+function appendToolResults(path: string, sessionId: string): void {
+	const assistantId = `${sessionId}-tools`;
+	const entries: object[] = [
+		{
+			type: "message",
+			id: assistantId,
+			parentId: `${sessionId}-m0`,
+			timestamp: new Date(BASE_TS + 1_000).toISOString(),
+			message: {
+				role: "assistant",
+				content: TOOLS.map((tool) => ({
+					type: "toolCall",
+					id: tool.id,
+					name: tool.name,
+					arguments: tool.args,
+				})),
+				stopReason: "toolUse",
+				timestamp: BASE_TS + 1_000,
+			},
+		},
+	];
+	let parentId = assistantId;
+	for (const [index, tool] of TOOLS.entries()) {
+		const id = `${sessionId}-result-${index}`;
+		entries.push({
+			type: "message",
+			id,
+			parentId,
+			timestamp: new Date(BASE_TS + 2_000 + index).toISOString(),
+			message: {
+				role: "toolResult",
+				toolCallId: tool.id,
+				toolName: tool.name,
+				content: [{ type: "text", text: tool.text }],
+				details: tool.details,
+				isError: false,
+				timestamp: BASE_TS + 2_000 + index,
+			},
+		});
+		parentId = id;
+	}
+	entries.push({
+		type: "message",
+		id: `${sessionId}-done`,
+		parentId,
+		timestamp: new Date(BASE_TS + 3_000).toISOString(),
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "Finished inspecting the tool outputs." }],
+			stopReason: "stop",
+			timestamp: BASE_TS + 3_000,
+		},
+	});
+	appendFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+	utimesSync(path, new Date(BASE_TS), new Date(BASE_TS));
+}
+
+async function toolStep(page: Page, toolName: string, index = 0): Promise<Locator> {
+	const activity = page.getByTestId("activity-group").first();
+	if ((await activity.getAttribute("data-expanded")) !== "true") {
+		await activity.getByTestId("activity-group-toggle").click();
+		await expect(activity).toHaveAttribute("data-expanded", "true");
+	}
+	const step = activity
+		.locator(`[data-testid="activity-step"][data-tool="${toolName}"]`)
+		.nth(index);
+	await expect(step).toBeVisible();
+	if ((await step.getAttribute("data-expanded")) !== "true") {
+		await step.getByTestId("activity-step-toggle").click();
+		await expect(step).toHaveAttribute("data-expanded", "true");
+	}
+	return step;
+}
+
+async function returnToChat(page: Page): Promise<void> {
+	await page.locator('[data-testid="editor-tab"][data-kind="chat"]').click();
+	await expect(page.getByTestId("chat-view")).toBeVisible();
+}
+
+test("structured tool paths reuse the preview tab while rich tool results stay intentional", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const chat = seedWorkspaceSession(repoCwd(), {
+		name: "tool file links",
+		messages: [{ role: "user", text: "inspect structured tool outputs", timestamp: BASE_TS }],
+	});
+	appendToolResults(chat.path, chat.id);
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+
+	const localRead = await toolStep(page, "read");
+	await localRead.getByTestId("tool-file-link").click();
+	const fileTabs = page.locator('[data-testid="editor-tab"][data-kind="file"]');
+	await expect(fileTabs).toHaveCount(1);
+	await expect(fileTabs.first()).toContainText("README.md");
+	await expect(fileTabs.first()).toHaveAttribute("data-preview", "true");
+
+	await returnToChat(page);
+	const specGet = await toolStep(page, "spec_get");
+	await expect(specGet).not.toContainText('"id"');
+	await specGet.getByTestId("tool-file-link").filter({ hasText: "module-a/SPEC.md" }).click();
+	await expect(fileTabs).toHaveCount(1);
+	await expect(fileTabs.first()).toContainText("SPEC.md");
+	await expect(fileTabs.first()).toHaveAttribute("data-preview", "true");
+
+	await returnToChat(page);
+	const externalRead = await toolStep(page, "read", 1);
+	await expect(externalRead).toContainText("/tmp/outside.png");
+	await expect(externalRead.getByTestId("tool-file-link")).toHaveCount(0);
+
+	const edit = await toolStep(page, "edit");
+	await expect(edit.getByTestId("tool-file-link")).toHaveText("README.md");
+
+	const specGrep = await toolStep(page, "spec_grep");
+	await expect(specGrep.getByTestId("tool-file-link")).toHaveText("module-a/SPEC.md");
+	const specCreate = await toolStep(page, "spec_create");
+	await expect(specCreate.getByTestId("tool-file-link")).toHaveText("module-a/SPEC.md");
+	const specDelete = await toolStep(page, "spec_delete");
+	await expect(specDelete).toContainText("removed/SPEC.md");
+	await expect(specDelete.getByTestId("tool-file-link")).toHaveCount(0);
+
+	const fetch = await toolStep(page, "fetch_content");
+	await expect(fetch).toContainText("/tmp/video.mp4");
+	await expect(fetch.getByTestId("tool-file-link")).toHaveCount(0);
+	await expect(fetch.getByRole("heading", { name: "Fetched content" })).toBeVisible();
+	await expect(fetch.getByRole("link", { name: "external source" })).toHaveAttribute(
+		"href",
+		"https://example.com/source",
+	);
+
+	const stored = await toolStep(page, "get_search_content");
+	await expect(stored.getByRole("heading", { name: "Stored content" })).toBeVisible();
+	await expect(stored).not.toContainText('"responseId"');
+});

--- a/e2e/tool-result-images.spec.ts
+++ b/e2e/tool-result-images.spec.ts
@@ -1,0 +1,86 @@
+import { appendFileSync, realpathSync, utimesSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+	defaultWorkspaceRow,
+	enterDefaultWorkspace,
+	expandActivityStep,
+	openFixtureProject,
+} from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_700_000_000;
+const IMAGE_PATH = "/tmp/tab-overflow-mockups.png";
+const IMAGE_DATA =
+	"iVBORw0KGgoAAAANSUhEUgAAAKAAAABaBAMAAADN6EBhAAAALVBMVEURExgcJx1KfzF52UaN/0952kZKfzEcJx09Zyw9ZyxrvUAuSiUuSiVqvUBGeC8W2BlUAAAA4UlEQVRYw2NgGAWjYLAARmUXioFrOpKBLS7UABPg5nFSxTwXD7iBJdQx0EUAZmAKlQxUgBkYQiUDDWAGgjirKUsnPFeAZjggGehHacrjQzPwAsVpeQmqgQcoNnALqoGU5zaWUQOHhoHkZjmHUQNHDRzMBo4WDqMGDrECdtTAUQOHjoGjhcOogUO0BTtq4KiBg9/A0cJhmBu4gWIDj6AauIBiA6/QeOzL5Q5l5nEvQTbQhErjhwEwA1WoZGACzEARKhlYADOQgzrmeSKCdApVDGxAGMieSrlxzoqjMxajgFwAAJtSvgebw8WoAAAAAElFTkSuQmCC";
+
+const repoCwd = () => realpathSync(E2E_FIXTURE_REPO);
+
+function appendToolImageResult(path: string, sessionId: string): void {
+	const toolCallId = `${sessionId}-read-image`;
+	const entries = [
+		{
+			type: "message",
+			id: `${sessionId}-m1`,
+			parentId: `${sessionId}-m0`,
+			timestamp: new Date(BASE_TS + 1_000).toISOString(),
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: IMAGE_PATH } },
+				],
+				timestamp: BASE_TS + 1_000,
+			},
+		},
+		{
+			type: "message",
+			id: `${sessionId}-m2`,
+			parentId: `${sessionId}-m1`,
+			timestamp: new Date(BASE_TS + 2_000).toISOString(),
+			message: {
+				role: "toolResult",
+				toolCallId,
+				toolName: "read",
+				content: [
+					{ type: "text", text: `${IMAGE_PATH}\nRead image file [image/png]` },
+					{ type: "image", data: IMAGE_DATA, mimeType: "image/png" },
+				],
+				isError: false,
+				timestamp: BASE_TS + 2_000,
+			},
+		},
+	];
+	appendFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+	utimesSync(path, new Date(BASE_TS), new Date(BASE_TS));
+}
+
+test("an image tool result previews inline and opens full screen", async ({ page }) => {
+	await openFixtureProject(page);
+	const chat = seedWorkspaceSession(repoCwd(), {
+		name: "image result",
+		messages: [{ role: "user", text: "read the mockup image", timestamp: BASE_TS }],
+	});
+	appendToolImageResult(chat.path, chat.id);
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+
+	const step = await expandActivityStep(page, "read");
+	const thumbnail = step.getByTestId("tool-result-image-thumbnail");
+	await expect(thumbnail).toBeVisible();
+	await expect(thumbnail).toHaveAttribute("src", `data:image/png;base64,${IMAGE_DATA}`);
+
+	const fullScreen = step.getByTestId("tool-result-image-fullscreen");
+	await expect(fullScreen).toHaveAccessibleName(`View ${IMAGE_PATH} full screen`);
+	await fullScreen.click();
+
+	const dialog = page.getByTestId("tool-result-image-dialog");
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByRole("img", { name: IMAGE_PATH })).toHaveAttribute(
+		"src",
+		`data:image/png;base64,${IMAGE_DATA}`,
+	);
+	await page.keyboard.press("Escape");
+	await expect(dialog).toBeHidden();
+	await expect(fullScreen).toBeFocused();
+});


### PR DESCRIPTION
## Summary

- Render image tool results inline with a full-screen view.
- Open structured in-worktree tool paths in the shared preview tab; keep external and unsafe paths inert.
- Give spec and web tools readable renderers, including Markdown and stored content.

## Testing

- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed with 6 existing warnings
- `bun run typecheck` — 11 packages passed
- `bun --filter @thinkrail/web test` — 767 passed
- `bun run e2e:serial` — 290 passed before the final rebase; the patch is unchanged
- `bun run test` — 10/11 package tasks passed; 2 local PTY replay tests remain red in the server suite


## Screenshots

| Before | After |
| --- | --- |
| ![Tool output before](https://github.com/JetBrains/thinkrail/blob/be16eb9f1fcfc1fda2ade6e35a4ad1db9ee4a679/tool-output-before.png?raw=true) | ![Tool output after](https://github.com/JetBrains/thinkrail/blob/be16eb9f1fcfc1fda2ade6e35a4ad1db9ee4a679/tool-output-after.png?raw=true) |
