### PR TITLE
fix(website): restore spaces lost to JSX whitespace compression

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -7,6 +7,8 @@ import { youTubeEmbeds } from "./src/youTubeEmbeds";
 
 export default defineConfig({
 	site: "https://thinkrail.ai",
+	// HTML whitespace rules; the 'jsx' default drops newline spacing around inline tags
+	compressHTML: true,
 	integrations: [react(), sitemap()],
 	vite: {
 		plugins: [tailwindcss()],

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -137,7 +137,7 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 							<h3>Agents deserve worktrees, not your working tree.</h3>
 							<p>
 								Every workspace is a real <code>git worktree</code> — its own branch, its own
-								cwd. Run several agents in parallel; each one's mess stays on its branch, and{" "}
+								cwd. Run several agents in parallel; each one's mess stays on its branch, and
 								<code>main</code> stays clean until you say otherwise.
 							</p>
 						</div>
@@ -152,7 +152,7 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 						<div class="beat">
 							<h3>A thin host, a real engine.</h3>
 							<p>
-								The <a href="https://pi.dev"><code>pi</code> coding agent</a>{" "}
+								The <a href="https://pi.dev"><code>pi</code> coding agent</a>
 								runs in-process and owns models, skills, compaction, and cost. ThinkRail owns
 								the workspace, the editor, and the wire — it never assembles prompts behind
 								your back.
@@ -233,8 +233,8 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 							<p data-step>The <strong>three rings</strong>:</p>
 							<ol>
 								<li data-step>
-									<strong>Engine host</strong> (<code>packages/server</code>) —{" "}
-									<code>createServer()</code> runs an HTTP+WS host plus an{" "}
+									<strong>Engine host</strong> (<code>packages/server</code>) —
+									<code>createServer()</code> runs an HTTP+WS host plus an
 									<code>AgentSessionManager</code>: one in-process <code>pi</code> session per tab.
 								</li>
 								<li data-step>
@@ -342,8 +342,8 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 						<li><strong>Prebuilt:</strong> macOS (Apple Silicon), Linux arm64 + x64, Windows x64.</li>
 						<li><strong>Needs:</strong> <code>git</code> on PATH and an authenticated <code>pi</code> provider — the agent runs against your real credentials.</li>
 						<li>
-							Prefer manual? Grab a binary + <code>SHA256SUMS</code> from the{" "}
-							<a href="https://github.com/JetBrains/thinkrail/releases">releases page</a>, verify,{" "}
+							Prefer manual? Grab a binary + <code>SHA256SUMS</code> from the
+							<a href="https://github.com/JetBrains/thinkrail/releases">releases page</a>, verify,
 							<code>chmod +x</code>, done. App state lives under <code>~/.thinkrail</code>.
 						</li>
 					</ul>

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -137,7 +137,7 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 							<h3>Agents deserve worktrees, not your working tree.</h3>
 							<p>
 								Every workspace is a real <code>git worktree</code> — its own branch, its own
-								cwd. Run several agents in parallel; each one's mess stays on its branch, and
+								cwd. Run several agents in parallel; each one's mess stays on its branch, and{" "}
 								<code>main</code> stays clean until you say otherwise.
 							</p>
 						</div>
@@ -152,7 +152,7 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 						<div class="beat">
 							<h3>A thin host, a real engine.</h3>
 							<p>
-								The <a href="https://pi.dev"><code>pi</code> coding agent</a>
+								The <a href="https://pi.dev"><code>pi</code> coding agent</a>{" "}
 								runs in-process and owns models, skills, compaction, and cost. ThinkRail owns
 								the workspace, the editor, and the wire — it never assembles prompts behind
 								your back.
@@ -233,8 +233,8 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 							<p data-step>The <strong>three rings</strong>:</p>
 							<ol>
 								<li data-step>
-									<strong>Engine host</strong> (<code>packages/server</code>) —
-									<code>createServer()</code> runs an HTTP+WS host plus an
+									<strong>Engine host</strong> (<code>packages/server</code>) —{" "}
+									<code>createServer()</code> runs an HTTP+WS host plus an{" "}
 									<code>AgentSessionManager</code>: one in-process <code>pi</code> session per tab.
 								</li>
 								<li data-step>
@@ -342,8 +342,8 @@ import { installCommands, windowsShellLabels } from "../installCommands";
 						<li><strong>Prebuilt:</strong> macOS (Apple Silicon), Linux arm64 + x64, Windows x64.</li>
 						<li><strong>Needs:</strong> <code>git</code> on PATH and an authenticated <code>pi</code> provider — the agent runs against your real credentials.</li>
 						<li>
-							Prefer manual? Grab a binary + <code>SHA256SUMS</code> from the
-							<a href="https://github.com/JetBrains/thinkrail/releases">releases page</a>, verify,
+							Prefer manual? Grab a binary + <code>SHA256SUMS</code> from the{" "}
+							<a href="https://github.com/JetBrains/thinkrail/releases">releases page</a>, verify,{" "}
 							<code>chmod +x</code>, done. App state lives under <code>~/.thinkrail</code>.
 						</li>
 					</ul>


### PR DESCRIPTION
Astro 7 made 'jsx' the default for compressHTML, so whitespace containing a newline next to an element is stripped. Six line breaks on the landing page sat directly before or after an inline tag and lost their space, rendering "andmain", "agentruns", "—createServer()", "anAgentSessionManager", "thereleases page" and "verify,chmod +x".

Add explicit {" "} at those six boundaries, per the compressHTML reference, which recommends it over changing the setting globally. Line wrapping is unchanged.

## Summary

What does this PR change, and why?

## Related issues

Closes #...

## Checklist

- [ ] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [ ] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [ ] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [ ] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
