### PR TITLE
feat(web): smooth streaming chat growth

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -9,7 +9,7 @@ import type {
 	ThinkingLevel,
 	WireModel,
 } from "@thinkrail/contracts";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type RefCallback, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { Popover, PopoverAnchor, PopoverTrigger } from "@/components/ui/popover";
 import {
@@ -94,14 +94,28 @@ function templateToCommand(t: TemplateInfo): SlashCommandInfo {
 	};
 }
 
-type ChatListContext = { status: StreamStatus | null };
+type ChatListContext = {
+	status: StreamStatus | null;
+	runwayActive: boolean;
+	streamEdgeRef: RefCallback<HTMLDivElement>;
+};
 
 function StreamFooter({ context }: { context: ChatListContext }) {
-	if (!context.status) return null;
+	if (!context.status && !context.runwayActive) return null;
 	return (
-		<div className="mx-auto max-w-3xl px-12 pb-8">
-			<StreamIndicator status={context.status} />
-		</div>
+		<>
+			{context.status ? (
+				<div className="mx-auto max-w-3xl px-12 pb-8">
+					<StreamIndicator status={context.status} />
+				</div>
+			) : null}
+			{context.runwayActive ? (
+				<>
+					<div ref={context.streamEdgeRef} data-testid="chat-stream-edge" className="h-0" />
+					<div data-testid="chat-stream-runway" className="h-[42cqh]" aria-hidden />
+				</>
+			) : null}
+		</>
 	);
 }
 
@@ -174,11 +188,9 @@ export default function ChatView({
 		[turns, toolResults, isStreaming, isSpec],
 	);
 
-	const listContext = useMemo<ChatListContext>(() => {
+	const currentStreamStatus = useMemo<StreamStatus | null>(() => {
 		const last = turns[turns.length - 1];
-		const status =
-			isStreaming && last?.kind !== "retry" ? streamStatus(turns, currentAssistantId) : null;
-		return { status };
+		return isStreaming && last?.kind !== "retry" ? streamStatus(turns, currentAssistantId) : null;
 	}, [turns, isStreaming, currentAssistantId]);
 
 	const recentPrompts = useMemo(() => {
@@ -199,12 +211,31 @@ export default function ChatView({
 	const [saveAsTemplateHit, setSaveAsTemplateHit] = useState<PromptHit | null>(null);
 
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
-	const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
-	const handleScrollerRef = useCallback((element: HTMLElement | Window | null) => {
-		setScrollerElement(element instanceof HTMLElement ? element : null);
-	}, []);
-	const { followOutput, handleAtBottom, showScrollButton, scrollToBottom, containerProps } =
-		useChatScroll(virtuosoRef);
+	const latestUserRow = useMemo(() => {
+		const index = rows.findLastIndex((row) => row.kind === "user");
+		const row = rows[index];
+		return index >= 0 && row ? { id: row.id, index } : null;
+	}, [rows]);
+	const {
+		followOutput,
+		handleAtBottom,
+		handleContentHeight,
+		handleScrollerRef,
+		streamEdgeRef,
+		scrollerElement,
+		showScrollButton,
+		scrollButtonLabel,
+		scrollToBottom,
+		armImmediateTurn,
+		releaseFollow,
+		runwayActive,
+		followState,
+		containerProps,
+	} = useChatScroll(virtuosoRef, isStreaming, latestUserRow);
+	const listContext = useMemo<ChatListContext>(
+		() => ({ status: currentStreamStatus, runwayActive, streamEdgeRef }),
+		[currentStreamStatus, runwayActive, streamEdgeRef],
+	);
 	const composerRef = useRef<ComposerHandle>(null);
 	const askFocusScope = useRef<object>({}).current;
 
@@ -359,8 +390,10 @@ export default function ChatView({
 		behavior: Exclude<SubmitBehavior, "interrupt">,
 	) => {
 		const queued = behavior !== "send";
-		if (!queued && (text || attachments.length > 0))
+		if (!queued && (text || attachments.length > 0)) {
+			armImmediateTurn();
 			useAppStore.getState().appendUserMessage(sessionId, text, attachments);
+		}
 		const images = attachments.map((a) => a.content);
 		const params = { sessionId, text, ...(images.length > 0 ? { images } : {}) };
 		const method =
@@ -513,10 +546,19 @@ export default function ChatView({
 			useAppStore.getState().clearChatLocation();
 			return;
 		}
+		releaseFollow();
 		virtuosoRef.current?.scrollToIndex({ index, align: "center" });
 		setFlashRowId(rows[index]?.id ?? null);
 		useAppStore.getState().clearChatLocation();
-	}, [chatLocationRequest, sessionId, rows, runtime.turnIdByMessageIndex, turns, workspaceId]);
+	}, [
+		chatLocationRequest,
+		releaseFollow,
+		rows,
+		runtime.turnIdByMessageIndex,
+		sessionId,
+		turns,
+		workspaceId,
+	]);
 
 	const historyOpenRequest = useAppStore((s) => s.historyOpenRequest);
 	const historyOverlayOpen = historyState.open;
@@ -631,7 +673,8 @@ export default function ChatView({
 					</Popover>
 					<div
 						data-testid="chat-scroll"
-						className="relative flex min-h-0 flex-1 flex-col"
+						data-follow-state={followState}
+						className="relative flex min-h-0 flex-1 flex-col [container-type:size]"
 						{...containerProps}
 					>
 						<Virtuoso<ChatRow, ChatListContext>
@@ -644,6 +687,7 @@ export default function ChatView({
 							initialTopMostItemIndex={{ index: Math.max(rows.length - 1, 0), align: "end" }}
 							followOutput={followOutput}
 							atBottomStateChange={handleAtBottom}
+							totalListHeightChanged={handleContentHeight}
 							atBottomThreshold={50}
 							computeItemKey={(_, row) => row.id}
 							itemContent={(_, row) => (
@@ -671,7 +715,7 @@ export default function ChatView({
 								className="-translate-x-1/2 absolute bottom-12 left-1/2 flex items-center gap-4 rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-8 py-4 text-text-muted tr-text-metadata shadow-[var(--shadow-md)] hover:bg-control-bg-hovered hover:text-text-default"
 							>
 								<ArrowDown className="size-12" />
-								New messages
+								{scrollButtonLabel}
 							</button>
 						) : null}
 					</div>

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -98,7 +98,12 @@ type ChatListContext = {
 	status: StreamStatus | null;
 	runwayActive: boolean;
 	streamEdgeRef: RefCallback<HTMLDivElement>;
+	runwayRef: RefCallback<HTMLDivElement>;
 };
+
+function StreamHeader({ context }: { context: ChatListContext }) {
+	return context.runwayActive ? <div className="h-[clamp(48px,10cqh,80px)]" aria-hidden /> : null;
+}
 
 function StreamFooter({ context }: { context: ChatListContext }) {
 	if (!context.status && !context.runwayActive) return null;
@@ -112,14 +117,19 @@ function StreamFooter({ context }: { context: ChatListContext }) {
 			{context.runwayActive ? (
 				<>
 					<div ref={context.streamEdgeRef} data-testid="chat-stream-edge" className="h-0" />
-					<div data-testid="chat-stream-runway" className="h-[42cqh]" aria-hidden />
+					<div
+						ref={context.runwayRef}
+						data-testid="chat-stream-runway"
+						className="h-[42cqh]"
+						aria-hidden
+					/>
 				</>
 			) : null}
 		</>
 	);
 }
 
-const CHAT_LIST_COMPONENTS = { Footer: StreamFooter };
+const CHAT_LIST_COMPONENTS = { Header: StreamHeader, Footer: StreamFooter };
 
 export default function ChatView({
 	sessionId,
@@ -222,6 +232,7 @@ export default function ChatView({
 		handleContentHeight,
 		handleScrollerRef,
 		streamEdgeRef,
+		runwayRef,
 		scrollerElement,
 		showScrollButton,
 		scrollButtonLabel,
@@ -233,8 +244,8 @@ export default function ChatView({
 		containerProps,
 	} = useChatScroll(virtuosoRef, isStreaming, latestUserRow);
 	const listContext = useMemo<ChatListContext>(
-		() => ({ status: currentStreamStatus, runwayActive, streamEdgeRef }),
-		[currentStreamStatus, runwayActive, streamEdgeRef],
+		() => ({ status: currentStreamStatus, runwayActive, streamEdgeRef, runwayRef }),
+		[currentStreamStatus, runwayActive, streamEdgeRef, runwayRef],
 	);
 	const composerRef = useRef<ComposerHandle>(null);
 	const askFocusScope = useRef<object>({}).current;
@@ -674,6 +685,7 @@ export default function ChatView({
 					<div
 						data-testid="chat-scroll"
 						data-follow-state={followState}
+						data-streaming={isStreaming}
 						className="relative flex min-h-0 flex-1 flex-col [container-type:size]"
 						{...containerProps}
 					>

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -235,12 +235,23 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   eye to it. Either resolving a row or giving up (toasted as "couldn't locate the message") clears that
   exact still-current request; an older effect may not clear a newer jump. `ChatView` is its only terminal
   consumer, so an unresolved current request must never linger.
-- **Open at the latest message** — the chat `Virtuoso` mounts with `initialTopMostItemIndex = { index:
-  last row, align: "end" }`, so every freshly shown transcript (new tab, reopen from history, auto-open,
-  reload) starts at the bottom instead of mid-scroll; jump-to-message (above) runs post-mount and
-  overrides with its centered `scrollToIndex`. Streaming follow stays `useChatScroll`'s job
-  (pointer-aware `followOutput` — unchanged). E2e: `auto-open-chats.spec.ts` asserts a long seeded
+- **Open at the latest message** — a settled chat `Virtuoso` mounts with `initialTopMostItemIndex = {
+  index: last row, align: "end" }`, so every freshly shown transcript (new tab, reopen from history,
+  auto-open, reload) starts at the bottom instead of mid-scroll; jump-to-message (above) runs post-mount
+  and overrides with its centered `scrollToIndex`. E2e: `auto-open-chats.spec.ts` asserts a long seeded
   transcript's last message is in view without scrolling.
+- **Streaming reading band** — `useChatScroll` owns one imperative, cancellable follow controller for
+  every kind of live row growth; renderers never scroll themselves. An immediate local send arms follow,
+  aligns its user row at 10% of transcript height clamped to 48–80px, and gives the response a one-way
+  60%-viewport runway. The active edge grows without movement until it crosses 82% of the viewport, then
+  one 220ms ease-out advances it to 58% (immediate under reduced motion); a large layout change is still
+  one move and moves never overlap. A queued continuation anchors only if follow stayed armed after it was
+  queued. Upward wheel/touch/scrollbar intent, keyboard transcript navigation, selection, interactive
+  focus, and message/history jumps cancel follow even within the bottom threshold. A deliberate manual
+  return, **Follow response**, or a new immediate send re-arms it; geometry changes alone do not. Settlement
+  neither catches up nor collapses remaining runway. An active-stream remount reconstructs band geometry
+  without animating; a settled remount has no runway and keeps the latest-message rule above. The detached
+  control reads **Follow response** during streaming and **Latest** after settlement.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
   commands + template **slot sessions** (Tab-through placeholders — see the Template slots bullet
   below), image paste/drop — routed through **`imageAttachment.ts`**: `fileToAttachedImage` decodes in

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -243,7 +243,10 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
 - **Streaming reading band** — `useChatScroll` owns one imperative, cancellable follow controller for
   every kind of live row growth; renderers never scroll themselves. An immediate local send arms follow,
   aligns its user row at 10% of transcript height clamped to 48–80px, and gives the response a one-way
-  60%-viewport runway. The active edge grows without movement until it crosses 82% of the viewport, then
+  60%-viewport runway. A transient list header makes that inset possible even for the first row; the tail
+  spacer starts as the 60% budget plus a 42% reading-band floor, shrinks one-for-one with response growth,
+  never re-inflates except to recalibrate after a viewport resize, and survives settlement in place. The
+  active edge grows without movement until it crosses 82% of the viewport, then
   one 220ms ease-out advances it to 58% (immediate under reduced motion); a large layout change is still
   one move and moves never overlap. A queued continuation anchors only if follow stayed armed after it was
   queued. Upward wheel/touch/scrollbar intent, keyboard transcript navigation, selection, interactive

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -10,6 +10,7 @@ interface Harness {
 	controller: ReturnType<typeof createReadingBandController>;
 	anchors: Array<{ index: number; inset: number }>;
 	writes: number[];
+	runwayHeights: number[];
 	states: ReadingBandSnapshot[];
 	setGeometry: (patch: Partial<ReadingBandGeometry>) => void;
 	advance: (milliseconds: number) => void;
@@ -38,6 +39,7 @@ function createHarness({
 	const frames = new Map<number, (time: number) => void>();
 	const anchors: Array<{ index: number; inset: number }> = [];
 	const writes: number[] = [];
+	const runwayHeights: number[] = [];
 	const states: ReadingBandSnapshot[] = [];
 
 	const environment: ReadingBandEnvironment = {
@@ -47,6 +49,7 @@ function createHarness({
 			const delta = top - geometry.scrollTop;
 			geometry = { ...geometry, scrollTop: top, edgeBottom: geometry.edgeBottom - delta };
 		},
+		writeRunwayHeight: (height) => runwayHeights.push(height),
 		anchorTurn: (index, inset) => anchors.push({ index, inset }),
 		prefersReducedMotion: () => reducedMotion,
 		now: () => now,
@@ -66,6 +69,7 @@ function createHarness({
 		controller,
 		anchors,
 		writes,
+		runwayHeights,
 		states,
 		setGeometry: (patch) => {
 			geometry = { ...geometry, ...patch };
@@ -128,6 +132,44 @@ describe("reading-band movement", () => {
 		harness.advance(220);
 		expect(harness.writes).toEqual([252]);
 		expect(harness.controller.getSnapshot().moving).toBe(false);
+	});
+
+	it("consumes a 60% runway down to the 42% reading-band floor without re-inflating", () => {
+		const harness = createHarness({ streaming: false });
+		harness.setGeometry({ edgeBottom: 300 });
+		harness.controller.armImmediateTurn();
+		harness.controller.userTurnArrived(2, "immediate");
+		expect(harness.runwayHeights).toEqual([612]);
+
+		harness.controller.setStreaming(true);
+		harness.controller.readerLeft();
+		harness.setGeometry({ edgeBottom: 400 });
+		harness.controller.contentChanged();
+		expect(harness.runwayHeights.at(-1)).toBe(512);
+
+		harness.setGeometry({ edgeBottom: 900 });
+		harness.controller.contentChanged();
+		expect(harness.runwayHeights.at(-1)).toBe(252);
+
+		harness.setGeometry({ edgeBottom: 500 });
+		harness.controller.contentChanged();
+		expect(harness.runwayHeights.at(-1)).toBe(252);
+	});
+
+	it("recalibrates retained runway when the transcript viewport resizes", () => {
+		const harness = createHarness({ streaming: false });
+		harness.setGeometry({ edgeBottom: 300 });
+		harness.controller.armImmediateTurn();
+		harness.controller.userTurnArrived(2, "immediate");
+		harness.controller.setStreaming(false);
+
+		harness.setGeometry({ viewportHeight: 800 });
+		harness.controller.contentChanged();
+		expect(harness.runwayHeights.at(-1)).toBe(816);
+
+		harness.setGeometry({ viewportHeight: 400 });
+		harness.controller.contentChanged();
+		expect(harness.runwayHeights.at(-1)).toBe(408);
 	});
 
 	it("turns one large layout expansion into one advance to the settle line", () => {
@@ -211,6 +253,7 @@ describe("reading-band reader intent", () => {
 		active.setGeometry({ scrollTop: 200, maxScrollTop: 900 });
 		active.controller.reconstructActiveStream();
 		active.controller.reconstructActiveStream();
+		expect(active.runwayHeights).toEqual([252]);
 		expect(active.writes).toEqual([900]);
 		expect(active.controller.getSnapshot().runway).toBe(true);
 
@@ -218,5 +261,14 @@ describe("reading-band reader intent", () => {
 		settled.controller.reconstructActiveStream();
 		expect(settled.writes).toEqual([]);
 		expect(settled.controller.getSnapshot().runway).toBe(false);
+	});
+
+	it("does not mistake a newly started turn for an active-stream remount", () => {
+		const harness = createHarness({ streaming: false });
+		harness.controller.armImmediateTurn();
+		harness.controller.setStreaming(true);
+		harness.setGeometry({ scrollTop: 200, maxScrollTop: 900 });
+		harness.controller.reconstructActiveStream();
+		expect(harness.writes).toEqual([]);
 	});
 });

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -3,7 +3,6 @@ import {
 	createReadingBandController,
 	type ReadingBandEnvironment,
 	type ReadingBandGeometry,
-	type ReadingBandSnapshot,
 } from "./readingBand";
 
 interface Harness {
@@ -11,7 +10,6 @@ interface Harness {
 	anchors: Array<{ index: number; inset: number }>;
 	writes: number[];
 	runwayHeights: number[];
-	states: ReadingBandSnapshot[];
 	setGeometry: (patch: Partial<ReadingBandGeometry>) => void;
 	advance: (milliseconds: number) => void;
 	pendingFrames: () => number;
@@ -40,7 +38,6 @@ function createHarness({
 	const anchors: Array<{ index: number; inset: number }> = [];
 	const writes: number[] = [];
 	const runwayHeights: number[] = [];
-	const states: ReadingBandSnapshot[] = [];
 
 	const environment: ReadingBandEnvironment = {
 		readGeometry: () => geometry,
@@ -61,7 +58,7 @@ function createHarness({
 		cancelFrame: (id) => {
 			if (frames.delete(id)) cancelled += 1;
 		},
-		onStateChange: (state) => states.push(state),
+		onStateChange: () => undefined,
 	};
 	const controller = createReadingBandController(environment, { streaming });
 
@@ -70,7 +67,6 @@ function createHarness({
 		anchors,
 		writes,
 		runwayHeights,
-		states,
 		setGeometry: (patch) => {
 			geometry = { ...geometry, ...patch };
 		},
@@ -129,8 +125,12 @@ describe("reading-band movement", () => {
 		harness.controller.contentChanged();
 		expect(harness.pendingFrames()).toBe(1);
 
-		harness.advance(220);
-		expect(harness.writes).toEqual([252]);
+		harness.advance(219);
+		expect(harness.writes.at(-1)).toBeLessThan(252);
+		expect(harness.controller.getSnapshot().moving).toBe(true);
+
+		harness.advance(1);
+		expect(harness.writes.at(-1)).toBe(252);
 		expect(harness.controller.getSnapshot().moving).toBe(false);
 	});
 

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -91,6 +91,8 @@ describe("reading-band turn anchoring", () => {
 			const harness = createHarness({ streaming: false, viewportHeight });
 			harness.controller.armImmediateTurn();
 			harness.controller.userTurnArrived(7, "immediate");
+			expect(harness.anchors).toEqual([]);
+			harness.advance(0);
 			expect(harness.anchors).toEqual([{ index: 7, inset }]);
 			expect(harness.controller.getSnapshot()).toEqual({
 				following: true,
@@ -104,9 +106,19 @@ describe("reading-band turn anchoring", () => {
 	it("anchors a queued turn only while the reader is still following", () => {
 		const harness = createHarness();
 		harness.controller.userTurnArrived(4, "queued");
+		harness.advance(0);
 		harness.controller.readerLeft();
 		harness.controller.userTurnArrived(8, "queued");
 		expect(harness.anchors).toEqual([{ index: 4, inset: 60 }]);
+	});
+
+	it("cancels a pending turn anchor when the reader moves first", () => {
+		const harness = createHarness({ streaming: false });
+		harness.controller.armImmediateTurn();
+		harness.controller.userTurnArrived(3, "immediate");
+		harness.controller.readerLeft();
+		harness.advance(16);
+		expect(harness.anchors).toEqual([]);
 	});
 });
 

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createReadingBandController,
+	type ReadingBandEnvironment,
+	type ReadingBandGeometry,
+	type ReadingBandSnapshot,
+} from "./readingBand";
+
+interface Harness {
+	controller: ReturnType<typeof createReadingBandController>;
+	anchors: Array<{ index: number; inset: number }>;
+	writes: number[];
+	states: ReadingBandSnapshot[];
+	setGeometry: (patch: Partial<ReadingBandGeometry>) => void;
+	advance: (milliseconds: number) => void;
+	pendingFrames: () => number;
+	cancelledFrames: () => number;
+}
+
+function createHarness({
+	streaming = true,
+	reducedMotion = false,
+	viewportHeight = 600,
+}: {
+	streaming?: boolean;
+	reducedMotion?: boolean;
+	viewportHeight?: number;
+} = {}): Harness {
+	let geometry: ReadingBandGeometry = {
+		viewportHeight,
+		scrollTop: 100,
+		maxScrollTop: 1_000,
+		edgeBottom: viewportHeight * 0.5,
+	};
+	let now = 0;
+	let frameId = 0;
+	let cancelled = 0;
+	const frames = new Map<number, (time: number) => void>();
+	const anchors: Array<{ index: number; inset: number }> = [];
+	const writes: number[] = [];
+	const states: ReadingBandSnapshot[] = [];
+
+	const environment: ReadingBandEnvironment = {
+		readGeometry: () => geometry,
+		writeScrollTop: (top) => {
+			writes.push(top);
+			const delta = top - geometry.scrollTop;
+			geometry = { ...geometry, scrollTop: top, edgeBottom: geometry.edgeBottom - delta };
+		},
+		anchorTurn: (index, inset) => anchors.push({ index, inset }),
+		prefersReducedMotion: () => reducedMotion,
+		now: () => now,
+		requestFrame: (callback) => {
+			frameId += 1;
+			frames.set(frameId, callback);
+			return frameId;
+		},
+		cancelFrame: (id) => {
+			if (frames.delete(id)) cancelled += 1;
+		},
+		onStateChange: (state) => states.push(state),
+	};
+	const controller = createReadingBandController(environment, { streaming });
+
+	return {
+		controller,
+		anchors,
+		writes,
+		states,
+		setGeometry: (patch) => {
+			geometry = { ...geometry, ...patch };
+		},
+		advance: (milliseconds) => {
+			now += milliseconds;
+			const pending = [...frames.values()];
+			frames.clear();
+			for (const callback of pending) callback(now);
+		},
+		pendingFrames: () => frames.size,
+		cancelledFrames: () => cancelled,
+	};
+}
+
+describe("reading-band turn anchoring", () => {
+	it("anchors an immediate turn at 10% of the viewport, clamped to 48–80px", () => {
+		for (const [viewportHeight, inset] of [
+			[320, 48],
+			[600, 60],
+			[1_200, 80],
+		] as const) {
+			const harness = createHarness({ streaming: false, viewportHeight });
+			harness.controller.armImmediateTurn();
+			harness.controller.userTurnArrived(7, "immediate");
+			expect(harness.anchors).toEqual([{ index: 7, inset }]);
+			expect(harness.controller.getSnapshot()).toEqual({
+				following: true,
+				moving: false,
+				runway: true,
+				buttonLabel: null,
+			});
+		}
+	});
+
+	it("anchors a queued turn only while the reader is still following", () => {
+		const harness = createHarness();
+		harness.controller.userTurnArrived(4, "queued");
+		harness.controller.readerLeft();
+		harness.controller.userTurnArrived(8, "queued");
+		expect(harness.anchors).toEqual([{ index: 4, inset: 60 }]);
+	});
+});
+
+describe("reading-band movement", () => {
+	it("holds inside the runway, then advances the 82% edge to 58% in one move", () => {
+		const harness = createHarness();
+		harness.setGeometry({ edgeBottom: 492 });
+		harness.controller.contentChanged();
+		expect(harness.writes).toEqual([]);
+
+		harness.setGeometry({ edgeBottom: 500 });
+		harness.controller.contentChanged();
+		expect(harness.pendingFrames()).toBe(1);
+		expect(harness.controller.getSnapshot().moving).toBe(true);
+
+		harness.controller.contentChanged();
+		expect(harness.pendingFrames()).toBe(1);
+
+		harness.advance(220);
+		expect(harness.writes).toEqual([252]);
+		expect(harness.controller.getSnapshot().moving).toBe(false);
+	});
+
+	it("turns one large layout expansion into one advance to the settle line", () => {
+		const harness = createHarness();
+		harness.setGeometry({ edgeBottom: 900, maxScrollTop: 900 });
+		harness.controller.contentChanged();
+		harness.advance(220);
+		expect(harness.writes).toEqual([652]);
+		expect(harness.pendingFrames()).toBe(0);
+	});
+
+	it("uses the same sparse destination without animation under reduced motion", () => {
+		const harness = createHarness({ reducedMotion: true });
+		harness.setGeometry({ edgeBottom: 500 });
+		harness.controller.contentChanged();
+		expect(harness.writes).toEqual([252]);
+		expect(harness.pendingFrames()).toBe(0);
+		expect(harness.controller.getSnapshot().moving).toBe(false);
+	});
+});
+
+describe("reading-band reader intent", () => {
+	it("cancels an in-flight advance immediately and ignores later content growth", () => {
+		const harness = createHarness();
+		harness.setGeometry({ edgeBottom: 500 });
+		harness.controller.contentChanged();
+		harness.advance(100);
+		const writesBeforeLeaving = harness.writes.length;
+
+		harness.controller.readerLeft();
+		harness.advance(120);
+		harness.setGeometry({ edgeBottom: 800 });
+		harness.controller.contentChanged();
+
+		expect(harness.writes).toHaveLength(writesBeforeLeaving);
+		expect(harness.cancelledFrames()).toBe(1);
+		expect(harness.controller.getSnapshot()).toEqual({
+			following: false,
+			moving: false,
+			runway: true,
+			buttonLabel: "Follow response",
+		});
+	});
+
+	it("does not re-arm from geometry alone, but manual return and the button do", () => {
+		const harness = createHarness();
+		harness.controller.readerLeft();
+		harness.setGeometry({ scrollTop: 1_000, edgeBottom: 348 });
+		harness.controller.contentChanged();
+		expect(harness.controller.getSnapshot().following).toBe(false);
+
+		harness.controller.readerReachedEdge();
+		expect(harness.controller.getSnapshot().following).toBe(true);
+
+		harness.controller.readerLeft();
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
+		harness.controller.returnToEdge();
+		expect(harness.writes.at(-1)).toBe(900);
+		expect(harness.controller.getSnapshot().following).toBe(true);
+	});
+
+	it("settles without catch-up or runway collapse and changes the detached action to Latest", () => {
+		const harness = createHarness();
+		harness.setGeometry({ edgeBottom: 500 });
+		harness.controller.contentChanged();
+		harness.controller.setStreaming(false);
+		harness.advance(220);
+		harness.controller.readerLeft();
+
+		expect(harness.writes).toEqual([]);
+		expect(harness.controller.getSnapshot()).toEqual({
+			following: false,
+			moving: false,
+			runway: true,
+			buttonLabel: "Latest",
+		});
+	});
+
+	it("reconstructs an active remount at the band edge but leaves a settled mount untouched", () => {
+		const active = createHarness();
+		active.setGeometry({ scrollTop: 200, maxScrollTop: 900 });
+		active.controller.reconstructActiveStream();
+		active.controller.reconstructActiveStream();
+		expect(active.writes).toEqual([900]);
+		expect(active.controller.getSnapshot().runway).toBe(true);
+
+		const settled = createHarness({ streaming: false });
+		settled.controller.reconstructActiveStream();
+		expect(settled.writes).toEqual([]);
+		expect(settled.controller.getSnapshot().runway).toBe(false);
+	});
+});

--- a/apps/web/src/chat/readingBand.ts
+++ b/apps/web/src/chat/readingBand.ts
@@ -1,0 +1,61 @@
+export interface ReadingBandGeometry {
+	viewportHeight: number;
+	scrollTop: number;
+	maxScrollTop: number;
+	edgeBottom: number;
+}
+
+export interface ReadingBandSnapshot {
+	following: boolean;
+	moving: boolean;
+	runway: boolean;
+	buttonLabel: "Follow response" | "Latest" | null;
+}
+
+export interface ReadingBandEnvironment {
+	readGeometry: () => ReadingBandGeometry | null;
+	writeScrollTop: (top: number) => void;
+	anchorTurn: (index: number, inset: number) => void;
+	prefersReducedMotion: () => boolean;
+	now: () => number;
+	requestFrame: (callback: (time: number) => void) => number;
+	cancelFrame: (id: number) => void;
+	onStateChange: (state: ReadingBandSnapshot) => void;
+}
+
+export interface ReadingBandController {
+	getSnapshot: () => ReadingBandSnapshot;
+	armImmediateTurn: () => void;
+	userTurnArrived: (index: number, source: "immediate" | "queued") => void;
+	contentChanged: () => void;
+	readerLeft: () => void;
+	readerReachedEdge: () => void;
+	returnToEdge: () => void;
+	setStreaming: (streaming: boolean) => void;
+	reconstructActiveStream: () => void;
+	dispose: () => void;
+}
+
+export function createReadingBandController(
+	_environment: ReadingBandEnvironment,
+	{ streaming }: { streaming: boolean },
+): ReadingBandController {
+	const snapshot: ReadingBandSnapshot = {
+		following: true,
+		moving: false,
+		runway: streaming,
+		buttonLabel: null,
+	};
+	return {
+		getSnapshot: () => snapshot,
+		armImmediateTurn: () => {},
+		userTurnArrived: () => {},
+		contentChanged: () => {},
+		readerLeft: () => {},
+		readerReachedEdge: () => {},
+		returnToEdge: () => {},
+		setStreaming: () => {},
+		reconstructActiveStream: () => {},
+		dispose: () => {},
+	};
+}

--- a/apps/web/src/chat/readingBand.ts
+++ b/apps/web/src/chat/readingBand.ts
@@ -1,8 +1,10 @@
 const TURN_INSET_RATIO = 0.1;
 const TURN_INSET_MIN = 48;
 const TURN_INSET_MAX = 80;
+const RESPONSE_RUNWAY_RATIO = 0.6;
 const EDGE_TRIGGER_RATIO = 0.82;
 const EDGE_SETTLE_RATIO = 0.58;
+const TAIL_RUNWAY_RATIO = 1 - EDGE_SETTLE_RATIO;
 const ADVANCE_DURATION_MS = 220;
 const GEOMETRY_EPSILON = 0.5;
 
@@ -23,6 +25,7 @@ export interface ReadingBandSnapshot {
 export interface ReadingBandEnvironment {
 	readGeometry: () => ReadingBandGeometry | null;
 	writeScrollTop: (top: number) => void;
+	writeRunwayHeight: (height: number) => void;
 	anchorTurn: (index: number, inset: number) => void;
 	prefersReducedMotion: () => boolean;
 	now: () => number;
@@ -83,7 +86,12 @@ export function createReadingBandController(
 		streaming,
 	};
 	let frame: number | null = null;
+	const activeStreamMount = streaming;
 	let reconstructed = false;
+	let runwayMode: "turn" | "floor" | null = null;
+	let runwayStartEdge: number | null = null;
+	let runwayHeight: number | null = null;
+	let runwayViewportHeight: number | null = null;
 
 	const publish = (patch: Partial<ReadingBandState>) => {
 		const next = { ...state, ...patch };
@@ -105,10 +113,45 @@ export function createReadingBandController(
 		if (state.moving) publish({ moving: false });
 	};
 
+	const writeRunwayHeight = (height: number) => {
+		const pixels = Math.round(height);
+		if (runwayHeight !== null && Math.abs(runwayHeight - pixels) <= GEOMETRY_EPSILON) return;
+		runwayHeight = pixels;
+		environment.writeRunwayHeight(pixels);
+	};
+
+	const beginTurnRunway = (geometry: ReadingBandGeometry) => {
+		runwayMode = "turn";
+		runwayStartEdge = geometry.scrollTop + geometry.edgeBottom;
+		runwayViewportHeight = geometry.viewportHeight;
+		writeRunwayHeight(geometry.viewportHeight * (RESPONSE_RUNWAY_RATIO + TAIL_RUNWAY_RATIO));
+	};
+
+	const resizeRunway = (geometry: ReadingBandGeometry) => {
+		if (runwayMode === null || runwayHeight === null) return;
+		const viewportChanged =
+			runwayViewportHeight === null ||
+			Math.abs(runwayViewportHeight - geometry.viewportHeight) > GEOMETRY_EPSILON;
+		runwayViewportHeight = geometry.viewportHeight;
+		const floor = geometry.viewportHeight * TAIL_RUNWAY_RATIO;
+		if (runwayMode === "floor") {
+			if (viewportChanged) writeRunwayHeight(floor);
+			return;
+		}
+		if (runwayStartEdge === null) return;
+		const growth = Math.max(0, geometry.scrollTop + geometry.edgeBottom - runwayStartEdge);
+		const available =
+			geometry.viewportHeight * (RESPONSE_RUNWAY_RATIO + TAIL_RUNWAY_RATIO) - growth;
+		const next = Math.max(floor, available);
+		writeRunwayHeight(viewportChanged ? next : Math.min(runwayHeight, next));
+	};
+
 	const contentChanged = () => {
-		if (!state.streaming || !state.following || state.moving) return;
-		const geometry = environment.readGeometry();
+		let geometry = environment.readGeometry();
 		if (!geometry || geometry.viewportHeight <= 0) return;
+		resizeRunway(geometry);
+		if (!state.streaming || !state.following || state.moving) return;
+		geometry = environment.readGeometry() ?? geometry;
 		const trigger = geometry.viewportHeight * EDGE_TRIGGER_RATIO;
 		if (geometry.edgeBottom <= trigger + GEOMETRY_EPSILON) return;
 		const target = Math.min(
@@ -151,6 +194,7 @@ export function createReadingBandController(
 			if (source === "immediate") publish({ following: true, runway: true });
 			const geometry = environment.readGeometry();
 			if (!geometry || geometry.viewportHeight <= 0) return;
+			beginTurnRunway(geometry);
 			environment.anchorTurn(index, turnInset(geometry.viewportHeight));
 		},
 		contentChanged,
@@ -173,11 +217,16 @@ export function createReadingBandController(
 			});
 		},
 		reconstructActiveStream: () => {
-			if (!state.streaming || reconstructed) return;
-			const geometry = environment.readGeometry();
+			if (!activeStreamMount || !state.streaming || reconstructed) return;
+			let geometry = environment.readGeometry();
 			if (!geometry) return;
 			reconstructed = true;
 			publish({ runway: true });
+			runwayMode = "floor";
+			runwayStartEdge = null;
+			runwayViewportHeight = geometry.viewportHeight;
+			writeRunwayHeight(geometry.viewportHeight * TAIL_RUNWAY_RATIO);
+			geometry = environment.readGeometry() ?? geometry;
 			environment.writeScrollTop(geometry.maxScrollTop);
 		},
 		dispose: cancelMotion,

--- a/apps/web/src/chat/readingBand.ts
+++ b/apps/web/src/chat/readingBand.ts
@@ -86,6 +86,7 @@ export function createReadingBandController(
 		streaming,
 	};
 	let frame: number | null = null;
+	let anchorFrame: number | null = null;
 	const activeStreamMount = streaming;
 	let reconstructed = false;
 	let runwayMode: "turn" | "floor" | null = null;
@@ -111,6 +112,11 @@ export function createReadingBandController(
 		if (frame !== null) environment.cancelFrame(frame);
 		frame = null;
 		if (state.moving) publish({ moving: false });
+	};
+
+	const cancelAnchor = () => {
+		if (anchorFrame !== null) environment.cancelFrame(anchorFrame);
+		anchorFrame = null;
 	};
 
 	const writeRunwayHeight = (height: number) => {
@@ -187,6 +193,7 @@ export function createReadingBandController(
 		getSnapshot: () => snapshotOf(state),
 		armImmediateTurn: () => {
 			cancelMotion();
+			cancelAnchor();
 			publish({ following: true, runway: true });
 		},
 		userTurnArrived: (index, source) => {
@@ -195,16 +202,23 @@ export function createReadingBandController(
 			const geometry = environment.readGeometry();
 			if (!geometry || geometry.viewportHeight <= 0) return;
 			beginTurnRunway(geometry);
-			environment.anchorTurn(index, turnInset(geometry.viewportHeight));
+			const inset = turnInset(geometry.viewportHeight);
+			cancelAnchor();
+			anchorFrame = environment.requestFrame(() => {
+				anchorFrame = null;
+				if (state.following) environment.anchorTurn(index, inset);
+			});
 		},
 		contentChanged,
 		readerLeft: () => {
 			cancelMotion();
+			cancelAnchor();
 			publish({ following: false });
 		},
 		readerReachedEdge: () => publish({ following: true }),
 		returnToEdge: () => {
 			cancelMotion();
+			cancelAnchor();
 			publish({ following: true });
 			const geometry = environment.readGeometry();
 			if (geometry) environment.writeScrollTop(geometry.maxScrollTop);
@@ -229,6 +243,9 @@ export function createReadingBandController(
 			geometry = environment.readGeometry() ?? geometry;
 			environment.writeScrollTop(geometry.maxScrollTop);
 		},
-		dispose: cancelMotion,
+		dispose: () => {
+			cancelMotion();
+			cancelAnchor();
+		},
 	};
 }

--- a/apps/web/src/chat/readingBand.ts
+++ b/apps/web/src/chat/readingBand.ts
@@ -1,3 +1,11 @@
+const TURN_INSET_RATIO = 0.1;
+const TURN_INSET_MIN = 48;
+const TURN_INSET_MAX = 80;
+const EDGE_TRIGGER_RATIO = 0.82;
+const EDGE_SETTLE_RATIO = 0.58;
+const ADVANCE_DURATION_MS = 220;
+const GEOMETRY_EPSILON = 0.5;
+
 export interface ReadingBandGeometry {
 	viewportHeight: number;
 	scrollTop: number;
@@ -36,26 +44,142 @@ export interface ReadingBandController {
 	dispose: () => void;
 }
 
+interface ReadingBandState {
+	following: boolean;
+	moving: boolean;
+	runway: boolean;
+	streaming: boolean;
+}
+
+function snapshotOf(state: ReadingBandState): ReadingBandSnapshot {
+	return {
+		following: state.following,
+		moving: state.moving,
+		runway: state.runway,
+		buttonLabel: state.following ? null : state.streaming ? "Follow response" : "Latest",
+	};
+}
+
+export function initialReadingBandSnapshot(streaming: boolean): ReadingBandSnapshot {
+	return snapshotOf({ following: true, moving: false, runway: streaming, streaming });
+}
+
+function turnInset(viewportHeight: number): number {
+	return Math.min(TURN_INSET_MAX, Math.max(TURN_INSET_MIN, viewportHeight * TURN_INSET_RATIO));
+}
+
+function easeOutCubic(progress: number): number {
+	return 1 - (1 - progress) ** 3;
+}
+
 export function createReadingBandController(
-	_environment: ReadingBandEnvironment,
+	environment: ReadingBandEnvironment,
 	{ streaming }: { streaming: boolean },
 ): ReadingBandController {
-	const snapshot: ReadingBandSnapshot = {
+	let state: ReadingBandState = {
 		following: true,
 		moving: false,
 		runway: streaming,
-		buttonLabel: null,
+		streaming,
 	};
+	let frame: number | null = null;
+	let reconstructed = false;
+
+	const publish = (patch: Partial<ReadingBandState>) => {
+		const next = { ...state, ...patch };
+		if (
+			next.following === state.following &&
+			next.moving === state.moving &&
+			next.runway === state.runway &&
+			next.streaming === state.streaming
+		) {
+			return;
+		}
+		state = next;
+		environment.onStateChange(snapshotOf(state));
+	};
+
+	const cancelMotion = () => {
+		if (frame !== null) environment.cancelFrame(frame);
+		frame = null;
+		if (state.moving) publish({ moving: false });
+	};
+
+	const contentChanged = () => {
+		if (!state.streaming || !state.following || state.moving) return;
+		const geometry = environment.readGeometry();
+		if (!geometry || geometry.viewportHeight <= 0) return;
+		const trigger = geometry.viewportHeight * EDGE_TRIGGER_RATIO;
+		if (geometry.edgeBottom <= trigger + GEOMETRY_EPSILON) return;
+		const target = Math.min(
+			geometry.maxScrollTop,
+			geometry.scrollTop + geometry.edgeBottom - geometry.viewportHeight * EDGE_SETTLE_RATIO,
+		);
+		if (target <= geometry.scrollTop + GEOMETRY_EPSILON) return;
+		if (environment.prefersReducedMotion()) {
+			environment.writeScrollTop(target);
+			return;
+		}
+
+		const start = geometry.scrollTop;
+		const distance = target - start;
+		const startedAt = environment.now();
+		publish({ moving: true });
+		const advance = (time: number) => {
+			if (!state.following || !state.streaming) return;
+			const progress = Math.min(1, Math.max(0, (time - startedAt) / ADVANCE_DURATION_MS));
+			environment.writeScrollTop(start + distance * easeOutCubic(progress));
+			if (progress < 1) {
+				frame = environment.requestFrame(advance);
+				return;
+			}
+			frame = null;
+			publish({ moving: false });
+			contentChanged();
+		};
+		frame = environment.requestFrame(advance);
+	};
+
 	return {
-		getSnapshot: () => snapshot,
-		armImmediateTurn: () => {},
-		userTurnArrived: () => {},
-		contentChanged: () => {},
-		readerLeft: () => {},
-		readerReachedEdge: () => {},
-		returnToEdge: () => {},
-		setStreaming: () => {},
-		reconstructActiveStream: () => {},
-		dispose: () => {},
+		getSnapshot: () => snapshotOf(state),
+		armImmediateTurn: () => {
+			cancelMotion();
+			publish({ following: true, runway: true });
+		},
+		userTurnArrived: (index, source) => {
+			if (source === "queued" && !state.following) return;
+			if (source === "immediate") publish({ following: true, runway: true });
+			const geometry = environment.readGeometry();
+			if (!geometry || geometry.viewportHeight <= 0) return;
+			environment.anchorTurn(index, turnInset(geometry.viewportHeight));
+		},
+		contentChanged,
+		readerLeft: () => {
+			cancelMotion();
+			publish({ following: false });
+		},
+		readerReachedEdge: () => publish({ following: true }),
+		returnToEdge: () => {
+			cancelMotion();
+			publish({ following: true });
+			const geometry = environment.readGeometry();
+			if (geometry) environment.writeScrollTop(geometry.maxScrollTop);
+		},
+		setStreaming: (nextStreaming) => {
+			if (!nextStreaming) cancelMotion();
+			publish({
+				streaming: nextStreaming,
+				...(nextStreaming ? { runway: true } : {}),
+			});
+		},
+		reconstructActiveStream: () => {
+			if (!state.streaming || reconstructed) return;
+			const geometry = environment.readGeometry();
+			if (!geometry) return;
+			reconstructed = true;
+			publish({ runway: true });
+			environment.writeScrollTop(geometry.maxScrollTop);
+		},
+		dispose: cancelMotion,
 	};
 }

--- a/apps/web/src/chat/useChatScroll.ts
+++ b/apps/web/src/chat/useChatScroll.ts
@@ -1,77 +1,278 @@
 import {
+	type FocusEventHandler,
+	type KeyboardEventHandler,
 	type PointerEventHandler,
+	type RefCallback,
 	type RefObject,
-	type TouchEventHandler,
 	useCallback,
+	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 	type WheelEventHandler,
 } from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
+import {
+	createReadingBandController,
+	initialReadingBandSnapshot,
+	type ReadingBandController,
+	type ReadingBandSnapshot,
+} from "./readingBand";
 
 interface ScrollContainerProps {
+	onFocusCapture: FocusEventHandler;
+	onKeyDown: KeyboardEventHandler;
+	onPointerCancel: PointerEventHandler;
 	onPointerDown: PointerEventHandler;
 	onPointerUp: PointerEventHandler;
 	onWheel: WheelEventHandler;
-	onTouchStart: TouchEventHandler;
-	onTouchEnd: TouchEventHandler;
+}
+
+interface UserRowLocation {
+	id: string;
+	index: number;
 }
 
 export interface ChatScroll {
-	followOutput: (isAtBottom: boolean) => false | "smooth" | "auto";
+	followOutput: false;
 	handleAtBottom: (atBottom: boolean) => void;
+	handleContentHeight: () => void;
+	handleScrollerRef: (element: HTMLElement | Window | null) => void;
+	streamEdgeRef: RefCallback<HTMLDivElement>;
+	scrollerElement: HTMLElement | null;
 	showScrollButton: boolean;
+	scrollButtonLabel: "Follow response" | "Latest" | null;
 	scrollToBottom: () => void;
+	armImmediateTurn: () => void;
+	releaseFollow: () => void;
+	runwayActive: boolean;
+	followState: "following" | "detached";
 	containerProps: ScrollContainerProps;
 }
 
-export function useChatScroll(virtuosoRef: RefObject<VirtuosoHandle | null>): ChatScroll {
+function isInteractiveTarget(target: EventTarget | null): boolean {
+	return (
+		target instanceof Element &&
+		target.closest("a, button, input, textarea, select, [contenteditable=true], [tabindex]") !==
+			null
+	);
+}
+
+export function useChatScroll(
+	virtuosoRef: RefObject<VirtuosoHandle | null>,
+	isStreaming: boolean,
+	latestUserRow: UserRowLocation | null,
+): ChatScroll {
+	const scrollerRef = useRef<HTMLElement | null>(null);
+	const edgeRef = useRef<HTMLDivElement | null>(null);
 	const atBottom = useRef(true);
 	const interacting = useRef(false);
-	const pinnedAway = useRef(false);
-	const [showScrollButton, setShowScrollButton] = useState(false);
-
-	const followOutput = useCallback(
-		(isAtBottom: boolean): false | "smooth" =>
-			!pinnedAway.current && isAtBottom ? "smooth" : false,
-		[],
+	const interactionStartScrollTop = useRef(0);
+	const returnIntentUntil = useRef(0);
+	const pendingImmediateTurn = useRef(false);
+	const previousUserRowId = useRef(latestUserRow?.id ?? null);
+	const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
+	const [streamEdgeElement, setStreamEdgeElement] = useState<HTMLDivElement | null>(null);
+	const [snapshot, setSnapshot] = useState<ReadingBandSnapshot>(() =>
+		initialReadingBandSnapshot(isStreaming),
+	);
+	const [controller] = useState<ReadingBandController>(() =>
+		createReadingBandController(
+			{
+				readGeometry: () => {
+					const scroller = scrollerRef.current;
+					const edge = edgeRef.current;
+					if (!scroller || !edge) return null;
+					const viewport = scroller.getBoundingClientRect();
+					const marker = edge.getBoundingClientRect();
+					return {
+						viewportHeight: scroller.clientHeight,
+						scrollTop: scroller.scrollTop,
+						maxScrollTop: Math.max(0, scroller.scrollHeight - scroller.clientHeight),
+						edgeBottom: marker.bottom - viewport.top,
+					};
+				},
+				writeScrollTop: (top) => {
+					const scroller = scrollerRef.current;
+					if (scroller) scroller.scrollTop = top;
+				},
+				anchorTurn: (index, inset) => {
+					virtuosoRef.current?.scrollToIndex({
+						index,
+						align: "start",
+						offset: -inset,
+						behavior: "auto",
+					});
+				},
+				prefersReducedMotion: () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+				now: () => performance.now(),
+				requestFrame: (callback) => requestAnimationFrame(callback),
+				cancelFrame: (id) => cancelAnimationFrame(id),
+				onStateChange: setSnapshot,
+			},
+			{ streaming: isStreaming },
+		),
 	);
 
-	const handleAtBottom = useCallback((next: boolean) => {
-		atBottom.current = next;
-		if (next) {
-			pinnedAway.current = false;
-		} else if (interacting.current) {
-			pinnedAway.current = true;
-		}
-		setShowScrollButton(!next);
+	useLayoutEffect(() => {
+		controller.setStreaming(isStreaming);
+	}, [controller, isStreaming]);
+
+	useLayoutEffect(() => {
+		const row = latestUserRow;
+		if (!row || row.id === previousUserRowId.current) return;
+		previousUserRowId.current = row.id;
+		const source = pendingImmediateTurn.current ? "immediate" : "queued";
+		pendingImmediateTurn.current = false;
+		if (source === "queued" && !isStreaming) return;
+		controller.userTurnArrived(row.index, source);
+	}, [controller, isStreaming, latestUserRow]);
+
+	useLayoutEffect(() => {
+		if (!scrollerElement || !streamEdgeElement || !isStreaming) return;
+		controller.reconstructActiveStream();
+	}, [controller, isStreaming, scrollerElement, streamEdgeElement]);
+
+	useEffect(() => {
+		if (!scrollerElement) return;
+		const observer = new ResizeObserver(() => controller.contentChanged());
+		observer.observe(scrollerElement);
+		return () => observer.disconnect();
+	}, [controller, scrollerElement]);
+
+	useEffect(() => {
+		const onSelectionChange = () => {
+			const scroller = scrollerRef.current;
+			const selection = document.getSelection();
+			if (
+				!scroller ||
+				!selection ||
+				selection.isCollapsed ||
+				!selection.anchorNode ||
+				!scroller.contains(selection.anchorNode)
+			) {
+				return;
+			}
+			controller.readerLeft();
+		};
+		document.addEventListener("selectionchange", onSelectionChange);
+		return () => document.removeEventListener("selectionchange", onSelectionChange);
+	}, [controller]);
+
+	useEffect(() => () => controller.dispose(), [controller]);
+
+	const handleScrollerRef = useCallback((element: HTMLElement | Window | null) => {
+		const next = element instanceof HTMLElement ? element : null;
+		scrollerRef.current = next;
+		setScrollerElement(next);
 	}, []);
 
-	const scrollToBottom = useCallback(() => {
-		pinnedAway.current = false;
-		virtuosoRef.current?.scrollToIndex({ index: "LAST", behavior: "smooth" });
-	}, [virtuosoRef]);
+	const streamEdgeRef = useCallback<RefCallback<HTMLDivElement>>((element) => {
+		edgeRef.current = element;
+		setStreamEdgeElement(element);
+	}, []);
 
-	const onInteractStart = useCallback(() => {
+	const armImmediateTurn = useCallback(() => {
+		pendingImmediateTurn.current = true;
+		controller.armImmediateTurn();
+	}, [controller]);
+
+	const releaseFollow = useCallback(() => controller.readerLeft(), [controller]);
+	const scrollToBottom = useCallback(() => controller.returnToEdge(), [controller]);
+	const handleContentHeight = useCallback(() => controller.contentChanged(), [controller]);
+
+	const handleAtBottom = useCallback(
+		(next: boolean) => {
+			atBottom.current = next;
+			if (next && performance.now() <= returnIntentUntil.current) {
+				controller.readerReachedEdge();
+			}
+		},
+		[controller],
+	);
+
+	const onPointerDown = useCallback<PointerEventHandler>(() => {
 		interacting.current = true;
-	}, []);
+		interactionStartScrollTop.current = scrollerRef.current?.scrollTop ?? 0;
+		controller.readerLeft();
+	}, [controller]);
 
-	const onInteractEnd = useCallback(() => {
+	const onPointerUp = useCallback<PointerEventHandler>(() => {
 		interacting.current = false;
-		if (!atBottom.current) pinnedAway.current = true;
+		const movedTowardEnd =
+			(scrollerRef.current?.scrollTop ?? 0) > interactionStartScrollTop.current + 1;
+		if (movedTowardEnd && atBottom.current) controller.readerReachedEdge();
+	}, [controller]);
+
+	const onPointerCancel = useCallback<PointerEventHandler>(() => {
+		interacting.current = false;
 	}, []);
 
-	const onWheel = useCallback<WheelEventHandler>((e) => {
-		if (e.deltaY < 0) pinnedAway.current = true;
-	}, []);
+	const onWheel = useCallback<WheelEventHandler>(
+		(event) => {
+			if (event.deltaY < 0) {
+				controller.readerLeft();
+				return;
+			}
+			if (event.deltaY > 0) {
+				returnIntentUntil.current = performance.now() + 500;
+				if (atBottom.current) controller.readerReachedEdge();
+			}
+		},
+		[controller],
+	);
 
-	const containerProps: ScrollContainerProps = {
-		onPointerDown: onInteractStart,
-		onPointerUp: onInteractEnd,
-		onWheel,
-		onTouchStart: onInteractStart,
-		onTouchEnd: onInteractEnd,
+	const onKeyDown = useCallback<KeyboardEventHandler>(
+		(event) => {
+			const movesTowardStart =
+				event.key === "ArrowUp" ||
+				event.key === "PageUp" ||
+				event.key === "Home" ||
+				(event.key === " " && event.shiftKey);
+			if (movesTowardStart) {
+				controller.readerLeft();
+				return;
+			}
+			const movesTowardEnd =
+				event.key === "ArrowDown" ||
+				event.key === "PageDown" ||
+				event.key === "End" ||
+				(event.key === " " && !event.shiftKey);
+			if (!movesTowardEnd) return;
+			returnIntentUntil.current = performance.now() + 500;
+			if (atBottom.current) controller.readerReachedEdge();
+		},
+		[controller],
+	);
+
+	const onFocusCapture = useCallback<FocusEventHandler>(
+		(event) => {
+			if (isInteractiveTarget(event.target)) controller.readerLeft();
+		},
+		[controller],
+	);
+
+	return {
+		followOutput: false,
+		handleAtBottom,
+		handleContentHeight,
+		handleScrollerRef,
+		streamEdgeRef,
+		scrollerElement,
+		showScrollButton: snapshot.buttonLabel !== null,
+		scrollButtonLabel: snapshot.buttonLabel,
+		scrollToBottom,
+		armImmediateTurn,
+		releaseFollow,
+		runwayActive: snapshot.runway,
+		followState: snapshot.following ? "following" : "detached",
+		containerProps: {
+			onFocusCapture,
+			onKeyDown,
+			onPointerCancel,
+			onPointerDown,
+			onPointerUp,
+			onWheel,
+		},
 	};
-
-	return { followOutput, handleAtBottom, showScrollButton, scrollToBottom, containerProps };
 }

--- a/apps/web/src/chat/useChatScroll.ts
+++ b/apps/web/src/chat/useChatScroll.ts
@@ -39,6 +39,7 @@ export interface ChatScroll {
 	handleContentHeight: () => void;
 	handleScrollerRef: (element: HTMLElement | Window | null) => void;
 	streamEdgeRef: RefCallback<HTMLDivElement>;
+	runwayRef: RefCallback<HTMLDivElement>;
 	scrollerElement: HTMLElement | null;
 	showScrollButton: boolean;
 	scrollButtonLabel: "Follow response" | "Latest" | null;
@@ -65,6 +66,7 @@ export function useChatScroll(
 ): ChatScroll {
 	const scrollerRef = useRef<HTMLElement | null>(null);
 	const edgeRef = useRef<HTMLDivElement | null>(null);
+	const runwayElementRef = useRef<HTMLDivElement | null>(null);
 	const atBottom = useRef(true);
 	const interacting = useRef(false);
 	const interactionStartScrollTop = useRef(0);
@@ -95,6 +97,10 @@ export function useChatScroll(
 				writeScrollTop: (top) => {
 					const scroller = scrollerRef.current;
 					if (scroller) scroller.scrollTop = top;
+				},
+				writeRunwayHeight: (height) => {
+					const runway = runwayElementRef.current;
+					if (runway) runway.style.height = `${height}px`;
 				},
 				anchorTurn: (index, inset) => {
 					virtuosoRef.current?.scrollToIndex({
@@ -170,6 +176,10 @@ export function useChatScroll(
 	const streamEdgeRef = useCallback<RefCallback<HTMLDivElement>>((element) => {
 		edgeRef.current = element;
 		setStreamEdgeElement(element);
+	}, []);
+
+	const runwayRef = useCallback<RefCallback<HTMLDivElement>>((element) => {
+		runwayElementRef.current = element;
 	}, []);
 
 	const armImmediateTurn = useCallback(() => {
@@ -258,6 +268,7 @@ export function useChatScroll(
 		handleContentHeight,
 		handleScrollerRef,
 		streamEdgeRef,
+		runwayRef,
 		scrollerElement,
 		showScrollButton: snapshot.buttonLabel !== null,
 		scrollButtonLabel: snapshot.buttonLabel,

--- a/e2e/chat-scroll.live.spec.ts
+++ b/e2e/chat-scroll.live.spec.ts
@@ -10,36 +10,79 @@ async function openChatAndSend(
 	await page.getByTestId("chat-send").click();
 }
 
-test("jump button appears when scrolled up and returns to the latest on click", {
+test("the reading band anchors a turn, retains its runway, and yields to reader intent", {
 	tag: "@agent",
 }, async ({ page }) => {
 	test.setTimeout(120_000);
-	await page.setViewportSize({ width: 1100, height: 360 });
-	await openChatAndSend(
-		page,
-		"List every integer from 1 to 100, each as its own paragraph separated by a blank line, and nothing else.",
-	);
-
-	await waitForDone(page);
-
-	await expect(page.getByTestId("scroll-to-bottom")).toHaveCount(0);
-
-	const scrolledUp = await page.getByTestId("chat-scroll").evaluate((root) => {
-		const el = Array.from(root.querySelectorAll<HTMLElement>("*")).find(
-			(e) => e.scrollHeight > e.clientHeight + 8,
+	await openWorkspaceChat(page);
+	await page.setViewportSize({ width: 1100, height: 800 });
+	await page
+		.getByTestId("chat-input")
+		.fill(
+			"List every integer from 1 to 40, each as its own paragraph separated by a blank line, and nothing else.",
 		);
-		if (!el) return false;
-		el.scrollTop = 0;
-		return true;
+	await page.getByTestId("chat-send").click();
+
+	const chatScroll = page.getByTestId("chat-scroll");
+	await expect(page.getByTestId("chat-stream-runway")).toBeVisible();
+	await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+	const userMessage = page.locator('[data-testid="chat-message"][data-role="user"]').last();
+	await expect(userMessage).toBeVisible();
+	const turnInset = await chatScroll.evaluate((root) => {
+		const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+		const messages = root.querySelectorAll<HTMLElement>(
+			'[data-testid="chat-message"][data-role="user"]',
+		);
+		const message = messages.item(messages.length - 1);
+		if (!scroller || !message) return null;
+		return message.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
 	});
-	expect(scrolledUp, "chat content should overflow the short viewport so it can be scrolled").toBe(
-		true,
-	);
+	expect(typeof turnInset).toBe("number");
+	if (typeof turnInset !== "number") return;
+	expect(turnInset).toBeGreaterThanOrEqual(40);
+	expect(turnInset).toBeLessThanOrEqual(90);
 
-	await expect(page.getByTestId("scroll-to-bottom")).toBeVisible();
+	await expect(chatScroll).toHaveAttribute("data-streaming", "false", { timeout: 90_000 });
 
-	await page.getByTestId("scroll-to-bottom").click();
+	const runway = page.getByTestId("chat-stream-runway");
+	await expect(runway).toBeVisible();
 	await expect(page.getByTestId("scroll-to-bottom")).toHaveCount(0);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect(chatScroll).toBeVisible();
+	await expect
+		.poll(() =>
+			chatScroll.evaluate((root) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				const spacer = root.querySelector<HTMLElement>('[data-testid="chat-stream-runway"]');
+				if (!scroller || !spacer) return Number.POSITIVE_INFINITY;
+				return Math.abs(spacer.getBoundingClientRect().height - scroller.clientHeight * 0.42);
+			}),
+		)
+		.toBeLessThanOrEqual(2);
+
+	const scrollPoint = await chatScroll.evaluate((root) => {
+		const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+		if (!scroller || scroller.scrollHeight <= scroller.clientHeight + 8) return null;
+		const rect = scroller.getBoundingClientRect();
+		return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+	});
+	expect(
+		scrollPoint,
+		"chat content should overflow the transcript viewport so it can be scrolled",
+	).not.toBeNull();
+	if (!scrollPoint) return;
+	await page.mouse.move(scrollPoint.x, scrollPoint.y);
+	await page.mouse.wheel(0, -10_000);
+
+	const latest = page.getByTestId("scroll-to-bottom");
+	await expect(latest).toBeVisible();
+	await expect(latest).toContainText("Latest");
+	await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+
+	await latest.click();
+	await expect(latest).toHaveCount(0);
+	await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
 });
 
 test("the outer activity run reveals a thinking subtree that owns its following tools", {


### PR DESCRIPTION
## Summary

- replace per-line bottom following with a stable reading band
- reserve response runway, then advance in sparse cancellable steps
- preserve reader intent across scrolling, tools, jumps, resize, and remounts

## Testing

- `bun --filter @thinkrail/web test` — 784 passed
- `bun run typecheck` — passed
- `bun run lint` — passed (existing warnings only)
- `bun run check:deps` — passed
- `bun run check:seams` — passed
- local e2e not run, per request
- `bun run test` — 3 existing macOS PTY replay/exit failures in `terminalManager.test.ts`

## Screenshots

Same stream and viewport.

| Before: bottom follow | After: reading band |
| --- | --- |
| ![Current bottom follow](https://github.com/JetBrains/thinkrail/blob/a9e83db65de6039ad65e15b0cbe2f24d94426e9b/streaming-before.png?raw=true) | ![Anchored reading band](https://github.com/JetBrains/thinkrail/blob/a9e83db65de6039ad65e15b0cbe2f24d94426e9b/streaming-after.png?raw=true) |


