### PR TITLE
fix(web): preserve IME composition in composer

### DIFF
--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -60,6 +60,8 @@ const COMPOSER_EDITOR_LIMIT_CLASS = {
 		"max-h-[calc(50cqh-var(--space-16)-var(--space-16)-var(--space-4)-var(--space-4)-var(--space-4)-var(--space-4))]",
 } satisfies Record<ComposerGrowthLimit, string>;
 
+const IME_SENTINEL_KEYCODE = 229;
+
 const STREAMING_SEND_MODES = [
 	{
 		behavior: "steer" as const,
@@ -475,6 +477,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+		if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === IME_SENTINEL_KEYCODE) return;
 		if (slots && !menuOpen) {
 			if (e.key === "Tab") {
 				e.preventDefault();

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -326,7 +326,10 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   newline, or width change that makes the draft exceed one visual line grows the message row without moving
   the footer; fitting one line again shrinks only the message row. This is one persistent textarea, never
   conditional twins — the transition cannot lose focus, caret/selection, recall, draft, or a template-slot
-  session. Streaming deliberately uses the expanded message row even with an empty draft, because Stop +
+  session. Every composer keyboard shortcut stands down when the native key event reports IME composition,
+  including Safari's `229` sentinel after `compositionend`, leaving candidate confirmation and navigation to
+  the input method instead of sending or transforming the unfinished draft. Streaming deliberately uses the
+  expanded message row even with an empty draft, because Stop +
   send options join the footer. `ChatView` passes the server-synced
   `ComposerGrowthLimit` prop: `compact` caps at 6 visual lines, `roomy` at 10, and the default `half-chat`
   caps the **editor shell** (textarea + footer) at 50% of the mounted chat panel, never the browser viewport;

--- a/e2e/composer-adaptive.spec.ts
+++ b/e2e/composer-adaptive.spec.ts
@@ -7,6 +7,61 @@ async function box(locator: import("@playwright/test").Locator) {
 	return value;
 }
 
+test("IME composition owns Enter before composer shortcuts", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const input = page.getByTestId("chat-input");
+	await input.fill("ni hao ma");
+	await input.evaluate((element) => {
+		const event = new KeyboardEvent("keydown", {
+			key: "Enter",
+			code: "Enter",
+			bubbles: true,
+			cancelable: true,
+		});
+		Object.defineProperty(event, "isComposing", { value: true });
+		element.dispatchEvent(event);
+	});
+
+	await expect(input).toHaveValue("ni hao ma");
+	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(0);
+});
+
+test("Safari IME sentinel owns Enter after composition ends", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const input = page.getByTestId("chat-input");
+	await input.fill("ni hao ma");
+	await input.evaluate((element) => {
+		const event = new KeyboardEvent("keydown", {
+			key: "Enter",
+			code: "Enter",
+			bubbles: true,
+			cancelable: true,
+		});
+		Object.defineProperty(event, "keyCode", { value: 229 });
+		element.dispatchEvent(event);
+	});
+
+	await expect(input).toHaveValue("ni hao ma");
+	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(0);
+});
+
+test("ordinary Enter submits after IME composition ends", async ({ page }) => {
+	await openWorkspaceChat(page);
+
+	const input = page.getByTestId("chat-input");
+	await input.fill("How are you?");
+	await input.dispatchEvent("compositionstart");
+	await input.dispatchEvent("compositionend");
+	await input.press("Enter");
+
+	await expect(input).toHaveValue("");
+	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveText([
+		"How are you?",
+	]);
+});
+
 test("idle composer keeps one message line above a stable controls row", async ({ page }) => {
 	await openWorkspaceChat(page);
 


### PR DESCRIPTION
## Summary

- prevent composer shortcuts from handling key events while an IME composition is active
- preserve Safari IME confirmation by recognizing the legacy `keyCode` 229 sentinel
- document the composer contract and add browser regressions for composing Enter, Safari confirmation, and normal Enter after `compositionend`

## Testing

- `bun run check:deps`
- `bun run check:seams`
- `bun run lint`
- `bun run typecheck`
- `bun --filter @thinkrail/web test` — 771 passed
- `bun run e2e -- e2e/composer-adaptive.spec.ts` — 8 passed
- `bun run e2e` — 295 passed / 4 failed: three workspace tests require Git support for `worktree list --porcelain -z`; the history-search stress case passed on its single targeted retry. Global teardown also reported `ENOTEMPTY` after the failed workspace cases.

## Local baseline note

`bun run test` reaches 840 passing server tests but has five existing worktree failures because this machine's Git does not support `git worktree list --porcelain -z`. The same five failures reproduce on an unmodified `origin/main` worktree. The affected Web suite passes 771/771.

Fixes #320
