### PR TITLE
Chat

### DIFF
--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -206,10 +206,7 @@ function GroupDisclosure({
 						{headline}
 					</strong>
 				) : null}
-				<span
-					className={cn("min-w-0 truncate", !expanded && headline && "shrink-0")}
-					title={summary}
-				>
+				<span className="min-w-0 truncate" title={summary}>
 					{summary}
 				</span>
 			</button>
@@ -226,6 +223,9 @@ function extractThinkingHeading(text: string): string | undefined {
 	if (!firstLine) return undefined;
 	for (const delimiter of ["**", "__"]) {
 		if (!firstLine.startsWith(delimiter) || !firstLine.endsWith(delimiter)) continue;
+		const marker = delimiter[0];
+		if (firstLine[delimiter.length] === marker || firstLine.at(-delimiter.length - 1) === marker)
+			return undefined;
 		const heading = firstLine.slice(delimiter.length, -delimiter.length);
 		return heading && heading === heading.trim() && !heading.includes(delimiter)
 			? heading

--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -117,6 +117,7 @@ export function ThinkingGroup({
 			stepCount={tools.length}
 			icon={<Brain className="size-12 shrink-0" />}
 			label="Thinking"
+			headline={extractThinkingHeading(thought.text)}
 			breadcrumbLabel="Thinking"
 			breadcrumbMeta={summary}
 			summary={summary}
@@ -149,6 +150,7 @@ function GroupDisclosure({
 	stepCount,
 	icon,
 	label,
+	headline,
 	breadcrumbLabel,
 	breadcrumbMeta,
 	summary,
@@ -162,6 +164,7 @@ function GroupDisclosure({
 	stepCount: number;
 	icon: React.ReactNode;
 	label?: string;
+	headline?: string | undefined;
 	breadcrumbLabel: string;
 	breadcrumbMeta: string;
 	summary: string;
@@ -198,13 +201,37 @@ function GroupDisclosure({
 					icon
 				)}
 				{label ? <span className="shrink-0 text-text-default">{label}</span> : null}
-				<span className="min-w-0 truncate" title={summary}>
+				{!expanded && headline ? (
+					<strong className="min-w-0 flex-1 truncate text-text-default" title={headline}>
+						{headline}
+					</strong>
+				) : null}
+				<span
+					className={cn("min-w-0 truncate", !expanded && headline && "shrink-0")}
+					title={summary}
+				>
 					{summary}
 				</span>
 			</button>
 			{expanded ? <div className="flex flex-col gap-px pl-12">{children}</div> : null}
 		</div>
 	);
+}
+
+function extractThinkingHeading(text: string): string | undefined {
+	const firstLine = text
+		.split(/\r?\n/)
+		.find((line) => line.trim().length > 0)
+		?.trim();
+	if (!firstLine) return undefined;
+	for (const delimiter of ["**", "__"]) {
+		if (!firstLine.startsWith(delimiter) || !firstLine.endsWith(delimiter)) continue;
+		const heading = firstLine.slice(delimiter.length, -delimiter.length);
+		return heading && heading === heading.trim() && !heading.includes(delimiter)
+			? heading
+			: undefined;
+	}
+	return undefined;
 }
 
 function splitSummary(summary: string): { label: string; meta: string } {

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -91,9 +91,13 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   media types are ignored, while canonical content arrays are never serialized into base64 JSON.
 - `activity` — one contiguous run of routine work stays one **collapsed outer disclosure** whose header
   summarizes every atomic step (thinking blocks + routine tool calls). Expanding it preserves tools before
-  the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure that
-  contains its exact text and every following routine tool call until the next thinking block or activity
-  boundary. Those thinking groups are siblings **inside** the outer run, even across assistant-message
+  the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure. When
+  that block's first non-empty line is a complete standalone Markdown strong span (`**…**` or `__…__`),
+  its folded header surfaces the model-authored inner text between `Thinking` and the trailing tool/character
+  metadata; the teaser truncates before that metadata and disappears when expanded, where the disclosure
+  contains the exact text. Blocks without that convention keep the generic header. Every following routine
+  tool call stays under that thought until the next thinking block or activity boundary. Those thinking
+  groups are siblings **inside** the outer run, even across assistant-message
   boundaries; the hierarchy is presentational, never invented pi entry parentage. A single atomic step
   still renders directly. Non-empty text, primary tools, and non-assistant turns break the outer run. Only
   its trailing instance carries the live ticker. Errored routine tools get **no special treatment**

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -91,13 +91,9 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   media types are ignored, while canonical content arrays are never serialized into base64 JSON.
 - `activity` — one contiguous run of routine work stays one **collapsed outer disclosure** whose header
   summarizes every atomic step (thinking blocks + routine tool calls). Expanding it preserves tools before
-  the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure. When
-  that block's first non-empty line is a complete standalone Markdown strong span (`**…**` or `__…__`),
-  its folded header surfaces the model-authored inner text between `Thinking` and the trailing tool/character
-  metadata; the teaser truncates before that metadata and disappears when expanded, where the disclosure
-  contains the exact text. Blocks without that convention keep the generic header. Every following routine
-  tool call stays under that thought until the next thinking block or activity boundary. Those thinking
-  groups are siblings **inside** the outer run, even across assistant-message
+  the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure that
+  contains its exact text and every following routine tool call until the next thinking block or activity
+  boundary. Those thinking groups are siblings **inside** the outer run, even across assistant-message
   boundaries; the hierarchy is presentational, never invented pi entry parentage. A single atomic step
   still renders directly. Non-empty text, primary tools, and non-assistant turns break the outer run. Only
   its trailing instance carries the live ticker. Errored routine tools get **no special treatment**

--- a/apps/web/src/chat/ThinkingGroup.test.tsx
+++ b/apps/web/src/chat/ThinkingGroup.test.tsx
@@ -41,4 +41,88 @@ describe("ThinkingGroup", () => {
 		expect(markup).toContain("2 steps · read, bash");
 		expect(markup).not.toContain("I should inspect the files first.");
 	});
+
+	test("surfaces a standalone bold first line in the collapsed header", () => {
+		const tools = [tool("t1", "read")];
+		const markup = renderToStaticMarkup(
+			<ThinkingGroup
+				id="a1:thinking:1"
+				thought={{
+					kind: "thinking",
+					id: "a1:thinking:1",
+					text: "**Evaluating formatting process**\n\nI should inspect the formatted file.",
+					streaming: false,
+					tools,
+				}}
+				tools={tools}
+				live={false}
+			/>,
+		);
+
+		expect(markup).toContain("Evaluating formatting process");
+		expect(markup).not.toContain("**Evaluating formatting process**");
+		expect(markup).not.toContain("I should inspect the formatted file.");
+		expect(markup).toContain("1 step · read");
+	});
+
+	test("recognizes an underscore-delimited heading after leading blank lines", () => {
+		const markup = renderToStaticMarkup(
+			<ThinkingGroup
+				id="a1:thinking:2"
+				thought={{
+					kind: "thinking",
+					id: "a1:thinking:2",
+					text: "\n \r\n__Reviewing formatter output__\r\n\r\nThe output looks consistent.",
+					streaming: false,
+					tools: [],
+				}}
+				tools={[]}
+				live={false}
+			/>,
+		);
+
+		expect(markup).toContain("Reviewing formatter output");
+		expect(markup).not.toContain("__Reviewing formatter output__");
+		expect(markup).not.toContain("The output looks consistent.");
+	});
+
+	test("does not treat mixed prose and bold runs as a standalone heading", () => {
+		const markup = renderToStaticMarkup(
+			<ThinkingGroup
+				id="a1:thinking:3"
+				thought={{
+					kind: "thinking",
+					id: "a1:thinking:3",
+					text: "**Planning** then reconsidering **\n\nThe plan is still changing.",
+					streaming: true,
+					tools: [],
+				}}
+				tools={[]}
+				live={true}
+			/>,
+		);
+
+		expect(markup).not.toContain("Planning** then reconsidering");
+		expect(markup).not.toContain("The plan is still changing.");
+	});
+
+	test("requires non-whitespace content directly inside the strong delimiters", () => {
+		const markup = renderToStaticMarkup(
+			<ThinkingGroup
+				id="a1:thinking:4"
+				thought={{
+					kind: "thinking",
+					id: "a1:thinking:4",
+					text: "** Not actually strong **\n\nThis is ordinary reasoning.",
+					streaming: false,
+					tools: [],
+				}}
+				tools={[]}
+				live={false}
+			/>,
+		);
+
+		expect(markup).not.toContain("Not actually strong");
+		expect(markup).not.toContain("This is ordinary reasoning.");
+	});
 });

--- a/apps/web/src/chat/ThinkingGroup.test.tsx
+++ b/apps/web/src/chat/ThinkingGroup.test.tsx
@@ -125,4 +125,29 @@ describe("ThinkingGroup", () => {
 		expect(markup).not.toContain("Not actually strong");
 		expect(markup).not.toContain("This is ordinary reasoning.");
 	});
+
+	test("rejects triple-emphasis runs instead of exposing leftover Markdown", () => {
+		for (const [id, text] of [
+			["stars", "***Evaluating formatter output***"],
+			["underscores", "___Evaluating formatter output___"],
+		] as const) {
+			const markup = renderToStaticMarkup(
+				<ThinkingGroup
+					id={`a1:thinking:${id}`}
+					thought={{
+						kind: "thinking",
+						id: `a1:thinking:${id}`,
+						text: `${text}\n\nThis uses bold italic emphasis.`,
+						streaming: false,
+						tools: [],
+					}}
+					tools={[]}
+					live={false}
+				/>,
+			);
+
+			expect(markup).not.toContain("Evaluating formatter output");
+			expect(markup).not.toContain("This uses bold italic emphasis.");
+		}
+	});
 });

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -29,15 +29,17 @@ function appendMessage(path: string, id: string, parentId: string, message: obje
 	return id;
 }
 
-test("a model-authored Thinking heading is visible only while its disclosure is folded", async ({
+test("a model-authored Thinking heading stays bounded and appears only while folded", async ({
 	page,
 }) => {
+	await page.setViewportSize({ width: 390, height: 780 });
 	await openFixtureProject(page);
 	const chat = seedWorkspaceSession(repoCwd(), {
 		name: "thinking summary",
 		messages: [{ role: "user", text: "Check the formatter output.", timestamp: BASE_TS }],
 	});
 	const assistantId = `${chat.id}-a1`;
+	const toolNames = ["get_search_content", "fetch_content", "web_search", "spec_grep", "read"];
 	appendMessage(chat.path, assistantId, `${chat.id}-m0`, {
 		role: "assistant",
 		content: [
@@ -46,21 +48,29 @@ test("a model-authored Thinking heading is visible only while its disclosure is 
 				thinking:
 					"**Evaluating formatting process**\n\nI should inspect the formatted file before continuing.",
 			},
-			{ type: "toolCall", id: "read-format", name: "read", arguments: { path: "format.ts" } },
+			...toolNames.map((name, index) => ({
+				type: "toolCall",
+				id: `summary-tool-${index}`,
+				name,
+				arguments: {},
+			})),
 		],
 		usage,
 		stopReason: "toolUse",
 		timestamp: BASE_TS + 1_000,
 	});
-	const resultId = appendMessage(chat.path, `${chat.id}-read-format`, assistantId, {
-		role: "toolResult",
-		toolCallId: "read-format",
-		toolName: "read",
-		content: [{ type: "text", text: "formatted source" }],
-		isError: false,
-		timestamp: BASE_TS + 2_000,
-	});
-	appendMessage(chat.path, `${chat.id}-a2`, resultId, {
+	let parentId = assistantId;
+	for (const [index, toolName] of toolNames.entries()) {
+		parentId = appendMessage(chat.path, `${chat.id}-summary-tool-${index}`, parentId, {
+			role: "toolResult",
+			toolCallId: `summary-tool-${index}`,
+			toolName,
+			content: [{ type: "text", text: "completed" }],
+			isError: false,
+			timestamp: BASE_TS + 2_000 + index,
+		});
+	}
+	appendMessage(chat.path, `${chat.id}-a2`, parentId, {
 		role: "assistant",
 		content: [{ type: "text", text: "The formatter output is consistent." }],
 		usage,
@@ -75,11 +85,35 @@ test("a model-authored Thinking heading is visible only while its disclosure is 
 	const activity = page.getByTestId("activity-group").first();
 	await activity.getByTestId("activity-group-toggle").click();
 	const thinking = activity.getByTestId("thinking-group").first();
+	const toggle = thinking.getByTestId("thinking-group-toggle");
 	const heading = thinking.locator("strong", { hasText: "Evaluating formatting process" });
+	const metadata = "5 steps · get_search_content, fetch_content, web_search, spec_grep, +1 more";
 	await expect(heading).toBeVisible();
-	await expect(thinking.getByTestId("thinking-group-toggle")).toContainText("1 step · read");
+	await expect(toggle).toContainText(metadata);
 
-	await thinking.getByTestId("thinking-group-toggle").click();
+	await thinking.evaluate((element) => {
+		element.style.width = "280px";
+	});
+	const layout = await toggle.evaluate((element, title) => {
+		const metadataElement = [...element.querySelectorAll<HTMLElement>("span")].find(
+			(candidate) => candidate.title === title,
+		);
+		const headingElement = element.querySelector<HTMLElement>("strong");
+		if (!metadataElement || !headingElement)
+			throw new Error("missing folded Thinking header parts");
+		return {
+			buttonClientWidth: element.clientWidth,
+			buttonScrollWidth: element.scrollWidth,
+			headingClientWidth: headingElement.clientWidth,
+			metadataClientWidth: metadataElement.clientWidth,
+			metadataScrollWidth: metadataElement.scrollWidth,
+		};
+	}, metadata);
+	expect(layout.headingClientWidth).toBe(0);
+	expect(layout.metadataClientWidth).toBeLessThan(layout.metadataScrollWidth);
+	expect(layout.buttonScrollWidth).toBeLessThanOrEqual(layout.buttonClientWidth);
+
+	await toggle.click();
 
 	await expect(thinking).toHaveAttribute("data-expanded", "true");
 	await expect(heading).toHaveCount(0);

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -29,6 +29,65 @@ function appendMessage(path: string, id: string, parentId: string, message: obje
 	return id;
 }
 
+test("a model-authored Thinking heading is visible only while its disclosure is folded", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const chat = seedWorkspaceSession(repoCwd(), {
+		name: "thinking summary",
+		messages: [{ role: "user", text: "Check the formatter output.", timestamp: BASE_TS }],
+	});
+	const assistantId = `${chat.id}-a1`;
+	appendMessage(chat.path, assistantId, `${chat.id}-m0`, {
+		role: "assistant",
+		content: [
+			{
+				type: "thinking",
+				thinking:
+					"**Evaluating formatting process**\n\nI should inspect the formatted file before continuing.",
+			},
+			{ type: "toolCall", id: "read-format", name: "read", arguments: { path: "format.ts" } },
+		],
+		usage,
+		stopReason: "toolUse",
+		timestamp: BASE_TS + 1_000,
+	});
+	const resultId = appendMessage(chat.path, `${chat.id}-read-format`, assistantId, {
+		role: "toolResult",
+		toolCallId: "read-format",
+		toolName: "read",
+		content: [{ type: "text", text: "formatted source" }],
+		isError: false,
+		timestamp: BASE_TS + 2_000,
+	});
+	appendMessage(chat.path, `${chat.id}-a2`, resultId, {
+		role: "assistant",
+		content: [{ type: "text", text: "The formatter output is consistent." }],
+		usage,
+		stopReason: "stop",
+		timestamp: BASE_TS + 3_000,
+	});
+	utimesSync(chat.path, new Date(BASE_TS), new Date(BASE_TS));
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+
+	const activity = page.getByTestId("activity-group").first();
+	await activity.getByTestId("activity-group-toggle").click();
+	const thinking = activity.getByTestId("thinking-group").first();
+	const heading = thinking.locator("strong", { hasText: "Evaluating formatting process" });
+	await expect(heading).toBeVisible();
+	await expect(thinking.getByTestId("thinking-group-toggle")).toContainText("1 step · read");
+
+	await thinking.getByTestId("thinking-group-toggle").click();
+
+	await expect(thinking).toHaveAttribute("data-expanded", "true");
+	await expect(heading).toHaveCount(0);
+	await expect(thinking.getByTestId("thinking-group-text")).toContainText(
+		"**Evaluating formatting process**",
+	);
+});
+
 test("sticky activity breadcrumbs expose the off-screen Activity → Thinking → tool path", async ({
 	page,
 }) => {

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -32,7 +32,7 @@ function appendMessage(path: string, id: string, parentId: string, message: obje
 test("a model-authored Thinking heading stays bounded and appears only while folded", async ({
 	page,
 }) => {
-	await page.setViewportSize({ width: 390, height: 780 });
+	await page.setViewportSize({ width: 1280, height: 780 });
 	await openFixtureProject(page);
 	const chat = seedWorkspaceSession(repoCwd(), {
 		name: "thinking summary",
@@ -91,6 +91,7 @@ test("a model-authored Thinking heading stays bounded and appears only while fol
 	await expect(heading).toBeVisible();
 	await expect(toggle).toContainText(metadata);
 
+	await page.setViewportSize({ width: 390, height: 780 });
 	await thinking.evaluate((element) => {
 		element.style.width = "280px";
 	});


### PR DESCRIPTION
Thinking disclosures show exact model-authored `**…**`/`__…__` headings only while folded, preserve the expanded reasoning body, and now stay bounded when both teaser and metadata are long. Exact delimiter checks reject triple emphasis, with unit coverage; the real-browser fixture also asserts the 280px overflow behavior. Chat tests pass 327/327, web typecheck and targeted formatting checks pass; the new e2e assertion was not run locally per instruction.

## Plan
### Show thinking summaries in folded activity rows
- [x] **Confirm current chat disclosure contract and draft task spec** (`231e01d`)
  Removed the folded-heading promise from the durable active chat spec in this discovery-step revision. The proposed behavior remains in the temporary task spec and will be promoted with the implementation step instead.
  Verified: `git diff --exit-code origin/main -- apps/web/src/chat/SPEC.md` — clean (durable spec restored to baseline for this step).
- [x] **Validate the compact-row design with the user** (`f9bf289`)
- [x] **Implement the approved design test-first** (`f9c8de1`)
  Removed the trailing metadata’s `shrink-0`, so the teaser yields first while long metadata can also shrink and ellipsize instead of overflowing; added a 390px-viewport/280px-row browser regression. Tightened heading extraction to reject longer emphasis runs and added star/underscore triple-emphasis fallback coverage.
  Verified: `bun test apps/web/src/chat` — 327 pass; `bun --filter @thinkrail/web typecheck` — exit 0; targeted Biome + `git diff --check` — clean. E2E regression added but not run locally per user instruction.
- [x] **Run app gates and review the full diff**
  Reviewed the full net diff, retired the temporary task spec, and confirmed no new suppressions, comments, unrelated files, or working-tree changes. The complete browser suite is green serially; the unit aggregate remains baseline-red only in unchanged terminal lifecycle tests, reproduced against `origin/main`.
  Verified: `check:deps` OK; `check:seams` OK; `lint` exit 0 (6 pre-existing warnings); `typecheck` 11/11; `e2e:serial` 297 pass. `bun run test`: 842 pass/4 terminal failures; focused `origin/main` reproduces 3, while the fourth passed on rerun.

Review: 4/4 steps reviewed in ThinkRail.