### PR TITLE
perf(review): cache open-review lookups across workspace switches

### DIFF
--- a/apps/web/src/panels/PlanPane.tsx
+++ b/apps/web/src/panels/PlanPane.tsx
@@ -517,6 +517,7 @@ export default function PlanPane({
 		review: openReview,
 		url: openReviewUrl,
 		noteOpenReview,
+		refreshOpenReview,
 	} = useOpenBranchReview(workspace, connection);
 	const [prBusy, setPrBusy] = useState(false);
 	const [prSetup, setPrSetup] = useState<PrSetupState | null>(null);
@@ -623,8 +624,7 @@ export default function PlanPane({
 			);
 			setPrCompose(null);
 			if (result.review) noteOpenReview(result.review, result.url);
-			else if (openReview?.unpushedCommits)
-				noteOpenReview({ kind: openReview.kind, number: openReview.number }, openReviewUrl);
+			refreshOpenReview();
 			const dirty =
 				result.dirtyFiles > 0
 					? `${result.dirtyFiles} uncommitted ${result.dirtyFiles === 1 ? "file" : "files"} stayed local.`

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -578,22 +578,29 @@ own section. The kebab menu (`plan-menu`, a
   **`unpushedCommits`** the label appends the count (`Push updates (N)`), the button turns
   primary-filled, and the next-action banner grows a `push` arm ("N new commits aren't in PR #N
   yet" + Push updates) so new work after the PR never sits silently local — a successful push
-  reseeds the state without the count, clearing both. Also a **`PR #N` chip**
+  re-reads the authoritative state and clears both when the remote-tracking branch caught up. Also a **`PR #N` chip**
   (`plan-pr-chip`) links out when the URL is known. The hook owns the ONE keyed PR state:
   `noteOpenReview(review, url?)` seeds it right after `pr.open` (no separate shadow state in the
-  page), and the focus-refetch overwrites it — a PR closed/merged on GitHub drops out of the chip,
-  the label, and the stepper on the next refetch instead of sticking until remount (the url is kept
-  across refetches while the review number matches). A `compare` result opens the prefilled GitHub
+  page) and supersedes any read already in flight for the same key, so a pre-mutation answer cannot
+  overwrite the mutation result. The keyed state and request generation are shared by every mounted
+  hook consumer, keeping the plan and shell scope label on one mutation result. A stale mutation closure
+  cannot write through after that hook has moved to another branch. The focus-refetch overwrites state.
+  Workspace activation explicitly opts into the host's 60-second settled-answer cache with
+  `allowCached: true`, while omission on focus preserves the wire's original force-fresh behavior for
+  older clients, so a PR closed/merged on GitHub drops out of the chip, label, and stepper on that
+  refetch instead of sticking until remount. Focus received while disconnected latches that fresh
+  intent and spends it on reconnect rather than falling back to a cache-eligible activation read. The
+  URL is kept across refetches while the review number matches. A `compare` result opens the prefilled
+  GitHub
   compare page (`window.open`); every outcome toasts, uncommitted files get a separate info toast.
   The `pr.open` request runs with a **180s timeout** (push + gh mutation can outlast the transport's
   60s default) and the header button wears a spinner while any PR work is in flight — the
   **Pushing…** label only during the actual submit (a preview fetch is not a push, and its failure
   toasts "Couldn't prepare the PR", never "Open PR failed"). The uncommitted-files info toast fires
-  once, before the outcome branches. A successful submit with no `review` in the result (gh broken
-  or non-GitHub remote) reseeds the open-review state WITHOUT `unpushedCommits` — the push
-  succeeded, so the count and the push banner must clear even when the PR lookup payload is absent —
-  but only when a count was actually showing, so the render-time closure can't overwrite a fresher
-  focus-refetch in the no-count case. The compose submit also reports whether the title was touched
+  once, before the outcome branches. Every successful submit starts a fresh shared open-review read
+  after seeding any review returned by `pr.open`. It never treats the mutation payload as the final
+  unpushed count: the post-push read decides whether the count cleared or newer local commits already
+  made it nonzero again. The compose submit also reports whether the title was touched
   (`titleEdited`) so the host never rewrites a GitHub-side rename with the regenerated prefill.
   **Failures that name a fixable setup gap open `PrSetupDialog` (`PrSetupDialog.tsx`,
   `pr-setup-dialog`) instead of a toast**: a `PUSH_AUTH_FAILED` rejection (matched via the

--- a/apps/web/src/panels/openBranchReviewState.test.ts
+++ b/apps/web/src/panels/openBranchReviewState.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { createOpenBranchReviewState } from "./openBranchReviewState";
+
+const pullRequest = (number: number, unpushedCommits?: number) => ({
+	kind: "pull-request" as const,
+	number,
+	...(unpushedCommits === undefined ? {} : { unpushedCommits }),
+});
+
+test("one keyed snapshot is shared by every subscriber", () => {
+	const state = createOpenBranchReviewState();
+	let first = 0;
+	let second = 0;
+	const stopFirst = state.subscribe("w\0feature", () => {
+		first += 1;
+	});
+	const stopSecond = state.subscribe("w\0feature", () => {
+		second += 1;
+	});
+
+	state.noteOpenReview("w\0feature", pullRequest(7), "https://github.com/acme/app/pull/7");
+	expect(state.getSnapshot("w\0feature")).toEqual({
+		review: pullRequest(7),
+		url: "https://github.com/acme/app/pull/7",
+	});
+	expect(first).toBe(1);
+	expect(second).toBe(1);
+
+	stopFirst();
+	state.noteOpenReview("w\0feature", pullRequest(8));
+	expect(first).toBe(1);
+	expect(second).toBe(2);
+	stopSecond();
+});
+
+test("only the newest request generation may update a key", () => {
+	const state = createOpenBranchReviewState();
+	const stale = state.beginRequest("w\0feature");
+	const fresh = state.beginRequest("w\0feature");
+
+	expect(state.resolveRequest("w\0feature", stale, pullRequest(1))).toBe(false);
+	expect(state.resolveRequest("w\0feature", fresh, pullRequest(2))).toBe(true);
+	expect(state.getSnapshot("w\0feature")?.review).toEqual(pullRequest(2));
+});
+
+test("an authoritative mutation supersedes a read already in flight", () => {
+	const state = createOpenBranchReviewState();
+	const pending = state.beginRequest("w\0feature");
+	state.noteOpenReview("w\0feature", pullRequest(7), "https://github.com/acme/app/pull/7");
+
+	expect(state.resolveRequest("w\0feature", pending, null)).toBe(false);
+	expect(state.getSnapshot("w\0feature")).toEqual({
+		review: pullRequest(7),
+		url: "https://github.com/acme/app/pull/7",
+	});
+});
+
+test("a same-review refresh preserves its known URL while a different review drops it", () => {
+	const state = createOpenBranchReviewState();
+	state.noteOpenReview("w\0feature", pullRequest(7), "https://github.com/acme/app/pull/7");
+	const same = state.beginRequest("w\0feature");
+	state.resolveRequest("w\0feature", same, pullRequest(7, 2));
+	expect(state.getSnapshot("w\0feature")).toEqual({
+		review: pullRequest(7, 2),
+		url: "https://github.com/acme/app/pull/7",
+	});
+
+	const different = state.beginRequest("w\0feature");
+	state.resolveRequest("w\0feature", different, pullRequest(8));
+	expect(state.getSnapshot("w\0feature")).toEqual({ review: pullRequest(8) });
+});

--- a/apps/web/src/panels/openBranchReviewState.ts
+++ b/apps/web/src/panels/openBranchReviewState.ts
@@ -1,0 +1,74 @@
+import type { OpenBranchReview } from "@thinkrail/contracts";
+
+export type OpenBranchReviewSnapshot = {
+	review: OpenBranchReview | null;
+	url?: string;
+};
+
+type Entry = {
+	generation: number;
+	snapshot: OpenBranchReviewSnapshot | null;
+};
+
+type Listener = () => void;
+
+function sameReview(left: OpenBranchReview | null, right: OpenBranchReview | null): boolean {
+	return (
+		left !== null && right !== null && left.kind === right.kind && left.number === right.number
+	);
+}
+
+export function createOpenBranchReviewState() {
+	const entries = new Map<string, Entry>();
+	const listeners = new Map<string, Set<Listener>>();
+	const entry = (key: string): Entry => {
+		const existing = entries.get(key);
+		if (existing) return existing;
+		const created = { generation: 0, snapshot: null };
+		entries.set(key, created);
+		return created;
+	};
+	const publish = (key: string, snapshot: OpenBranchReviewSnapshot): void => {
+		entry(key).snapshot = snapshot;
+		for (const listener of listeners.get(key) ?? []) listener();
+	};
+
+	return {
+		getSnapshot(key: string): OpenBranchReviewSnapshot | null {
+			return entries.get(key)?.snapshot ?? null;
+		},
+		subscribe(key: string, listener: Listener): () => void {
+			const current = listeners.get(key) ?? new Set<Listener>();
+			current.add(listener);
+			listeners.set(key, current);
+			return () => {
+				current.delete(listener);
+				if (current.size === 0) listeners.delete(key);
+			};
+		},
+		beginRequest(key: string): number {
+			const current = entry(key);
+			current.generation += 1;
+			return current.generation;
+		},
+		resolveRequest(key: string, generation: number, review: OpenBranchReview | null): boolean {
+			const current = entry(key);
+			if (current.generation !== generation) return false;
+			const url =
+				review !== null && sameReview(current.snapshot?.review ?? null, review)
+					? current.snapshot?.url
+					: undefined;
+			publish(key, { review, ...(url ? { url } : {}) });
+			return true;
+		},
+		noteOpenReview(key: string, review: OpenBranchReview, url?: string): void {
+			const current = entry(key);
+			current.generation += 1;
+			publish(key, { review, ...(url ? { url } : {}) });
+		},
+	};
+}
+
+export type OpenBranchReviewStateStore = ReturnType<typeof createOpenBranchReviewState>;
+
+export const openBranchReviewState = createOpenBranchReviewState();

--- a/apps/web/src/panels/useOpenBranchReview.test.ts
+++ b/apps/web/src/panels/useOpenBranchReview.test.ts
@@ -1,7 +1,52 @@
 import { expect, test } from "bun:test";
-import { openReviewLabel } from "./useOpenBranchReview";
+import { createOpenBranchReviewState } from "./openBranchReviewState";
+import { openReviewLabel, startOpenBranchReviewSync } from "./useOpenBranchReview";
 
 test("formats provider-native review references", () => {
 	expect(openReviewLabel({ kind: "pull-request", number: 214 })).toBe("PR #214");
 	expect(openReviewLabel({ kind: "merge-request", number: 73 })).toBe("MR !73");
+});
+
+test("activation opts into cache reuse while focus performs a fresh read", async () => {
+	const state = createOpenBranchReviewState();
+	const focusTarget = new EventTarget();
+	const calls: Array<{ workspaceId: string; allowCached?: true }> = [];
+	const releases: Array<(review: { kind: "pull-request"; number: number } | null) => void> = [];
+	const controller = startOpenBranchReviewSync({
+		workspaceId: "w1",
+		key: "w1\0feature",
+		state,
+		focusTarget,
+		connected: true,
+		request: (params) => {
+			calls.push(params);
+			return new Promise((resolve) => releases.push(resolve));
+		},
+	});
+
+	expect(calls).toEqual([{ workspaceId: "w1", allowCached: true }]);
+	focusTarget.dispatchEvent(new Event("focus"));
+	expect(calls).toEqual([{ workspaceId: "w1", allowCached: true }, { workspaceId: "w1" }]);
+	releases[0]?.({ kind: "pull-request", number: 1 });
+	releases[1]?.({ kind: "pull-request", number: 2 });
+	await Promise.resolve();
+	await Promise.resolve();
+	expect(state.getSnapshot("w1\0feature")?.review).toEqual({
+		kind: "pull-request",
+		number: 2,
+	});
+
+	controller.setConnected(false);
+	focusTarget.dispatchEvent(new Event("focus"));
+	expect(calls).toHaveLength(2);
+	controller.setConnected(true);
+	expect(calls).toEqual([
+		{ workspaceId: "w1", allowCached: true },
+		{ workspaceId: "w1" },
+		{ workspaceId: "w1" },
+	]);
+
+	controller.stop();
+	focusTarget.dispatchEvent(new Event("focus"));
+	expect(calls).toHaveLength(3);
 });

--- a/apps/web/src/panels/useOpenBranchReview.ts
+++ b/apps/web/src/panels/useOpenBranchReview.ts
@@ -1,14 +1,81 @@
 import type { OpenBranchReview, Workspace } from "@thinkrail/contracts";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import { type ConnectionStatus, getTransport } from "../transport";
+import { type OpenBranchReviewStateStore, openBranchReviewState } from "./openBranchReviewState";
 
-type LoadedReview = { key: string; review: OpenBranchReview | null; url?: string };
+type OpenReviewRequestParams = { workspaceId: string; allowCached?: true };
+type OpenReviewRequest = (params: OpenReviewRequestParams) => Promise<OpenBranchReview | null>;
 
 export interface OpenBranchReviewState {
 	review: OpenBranchReview | null;
 	url?: string;
 	noteOpenReview: (review: OpenBranchReview, url?: string) => void;
+	refreshOpenReview: () => void;
 }
+
+function requestOpenBranchReview(options: {
+	workspaceId: string;
+	key: string;
+	allowCached: boolean;
+	request: OpenReviewRequest;
+	state: OpenBranchReviewStateStore;
+}): void {
+	const generation = options.state.beginRequest(options.key);
+	void options
+		.request({
+			workspaceId: options.workspaceId,
+			...(options.allowCached ? { allowCached: true as const } : {}),
+		})
+		.then(
+			(review) => {
+				options.state.resolveRequest(options.key, generation, review);
+			},
+			() => {
+				options.state.resolveRequest(options.key, generation, null);
+			},
+		);
+}
+
+export function startOpenBranchReviewSync(options: {
+	workspaceId: string;
+	key: string;
+	request: OpenReviewRequest;
+	state: OpenBranchReviewStateStore;
+	focusTarget: EventTarget;
+	connected: boolean;
+}): { setConnected: (connected: boolean) => void; refresh: () => void; stop: () => void } {
+	let connected = options.connected;
+	let freshOnReconnect = false;
+	const load = (allowCached: boolean) =>
+		requestOpenBranchReview({
+			workspaceId: options.workspaceId,
+			key: options.key,
+			allowCached,
+			request: options.request,
+			state: options.state,
+		});
+	const refresh = () => {
+		if (connected) load(false);
+		else freshOnReconnect = true;
+	};
+	const setConnected = (next: boolean) => {
+		if (connected === next) return;
+		connected = next;
+		if (!connected) return;
+		load(!freshOnReconnect);
+		freshOnReconnect = false;
+	};
+	const stop = () => options.focusTarget.removeEventListener("focus", refresh);
+
+	if (connected) load(true);
+	options.focusTarget.addEventListener("focus", refresh);
+	return { setConnected, refresh, stop };
+}
+
+const transportRequest: OpenReviewRequest = (params) =>
+	getTransport().request("workspace.openReview", params);
+
+type OpenBranchReviewSync = ReturnType<typeof startOpenBranchReviewSync>;
 
 export function useOpenBranchReview(
 	workspace: Workspace | null,
@@ -16,57 +83,62 @@ export function useOpenBranchReview(
 ): OpenBranchReviewState {
 	const workspaceId = workspace?.id ?? null;
 	const key = workspace ? `${workspace.id}\0${workspace.branch}` : null;
-	const [loaded, setLoaded] = useState<LoadedReview | null>(null);
-	const requestToken = useRef(0);
+	const currentKey = useRef(key);
+	const connected = status === "connected";
+	const connectedRef = useRef(connected);
+	const sync = useRef<OpenBranchReviewSync | null>(null);
+	currentKey.current = key;
+	connectedRef.current = connected;
+	const subscribe = useCallback(
+		(listener: () => void) => (key ? openBranchReviewState.subscribe(key, listener) : () => {}),
+		[key],
+	);
+	const getSnapshot = useCallback(
+		() => (key ? openBranchReviewState.getSnapshot(key) : null),
+		[key],
+	);
+	const loaded = useSyncExternalStore(subscribe, getSnapshot, () => null);
 
 	useEffect(() => {
-		requestToken.current += 1;
-		if (!workspaceId || !key || status !== "connected") return;
-
-		const load = () => {
-			const token = ++requestToken.current;
-			void getTransport()
-				.request("workspace.openReview", { workspaceId })
-				.then(
-					(review) => {
-						if (requestToken.current !== token) return;
-						setLoaded((prev) => {
-							const url =
-								review !== null &&
-								prev?.key === key &&
-								prev.review?.kind === review.kind &&
-								prev.review.number === review.number
-									? prev.url
-									: undefined;
-							return { key, review, ...(url ? { url } : {}) };
-						});
-					},
-					() => {
-						if (requestToken.current === token) setLoaded({ key, review: null });
-					},
-				);
-		};
-
-		load();
-		window.addEventListener("focus", load);
+		if (!workspaceId || !key) {
+			sync.current = null;
+			return;
+		}
+		const controller = startOpenBranchReviewSync({
+			workspaceId,
+			key,
+			request: transportRequest,
+			state: openBranchReviewState,
+			focusTarget: window,
+			connected: connectedRef.current,
+		});
+		sync.current = controller;
 		return () => {
-			requestToken.current += 1;
-			window.removeEventListener("focus", load);
+			controller.stop();
+			if (sync.current === controller) sync.current = null;
 		};
-	}, [key, status, workspaceId]);
+	}, [key, workspaceId]);
+
+	useEffect(() => {
+		sync.current?.setConnected(connected);
+	}, [connected]);
 
 	const noteOpenReview = useCallback(
 		(review: OpenBranchReview, url?: string) => {
-			if (key) setLoaded({ key, review, ...(url ? { url } : {}) });
+			if (key && currentKey.current === key) openBranchReviewState.noteOpenReview(key, review, url);
 		},
 		[key],
 	);
+	const refreshOpenReview = useCallback(() => {
+		if (key && currentKey.current === key) sync.current?.refresh();
+	}, [key]);
 
-	const current = status === "connected" && loaded?.key === key ? loaded : null;
+	const current = connected ? loaded : null;
 	return {
 		review: current?.review ?? null,
 		...(current?.url ? { url: current.url } : {}),
 		noteOpenReview,
+		refreshOpenReview,
 	};
 }
 

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -333,7 +333,9 @@ of the host.
   changes the display name while preserving the Git branch + cwd, and broadcasts the ordinary full-snapshot
   `workspace.updated`; `WORKSPACE_RENAME_PROTOCOL_VERSION` pins its v55 introduction so a newer client with
   this action omits it against an older host) / **`workspace.openReview`** (the active
-  branch's optional `OpenBranchReview` metadata) /
+  branch's optional `OpenBranchReview` metadata; optional `allowCached: true` permits a settled host
+  cache hit while omission preserves the original force-fresh behavior for older independently shipped
+  clients; either form still joins a lookup already in flight) /
   **`project.setTrust`** (persist a project's trust grant → the updated `Project`; gates its committed
   cross-agent skill aliases) /
   **`skill.list`** (a pre-session, skill-only `SlashCommandInfo[]` preview for a `projectId`, resolved from

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -342,7 +342,7 @@ export interface WsMethodMap {
 		result: Workspace[];
 	};
 	"workspace.openReview": {
-		params: { workspaceId: string };
+		params: { workspaceId: string; allowCached?: boolean };
 		result: OpenBranchReview | null;
 	};
 	"workspace.remove": { params: { id: string }; result: Ack };

--- a/packages/server/src/branch-review/SPEC.md
+++ b/packages/server/src/branch-review/SPEC.md
@@ -15,8 +15,20 @@ Best-effort lookup of the open code review associated with a workspace branch: G
 
 ## Boundary
 
-- **Owns:** remote-host detection and bounded, asynchronous CLI lookup returning an `OpenBranchReview` or `null`.
-- **Public surface:** `findOpenBranchReview(cwd, branch)`; plus the read primitives the `pr` action module reuses — `providerFromRemoteUrl`, `reviewNumber`, and `runProviderCommand` (the bounded prompt-disabled CLI runner).
+- **Owns:** remote-host detection and bounded, asynchronous CLI lookup returning an `OpenBranchReview` or `null`, plus the short-lived memory of successful lookup answers.
+- **Public surface:** `findOpenBranchReview(cwd, branch, { fresh? })`, `forgetOpenBranchReview(cwd)`; plus the read primitives the `pr` action module reuses — `providerFromRemoteUrl`, `reviewNumber`, and `runProviderCommand` (the bounded prompt-disabled CLI runner).
+- **Successful answers are cached per `(worktree, branch)` for 60 seconds from settlement and lookups are
+  single-flighted.** A syntactically valid empty provider response is a successful `null` and is cached —
+  "no PR" is the common case and the expensive one to re-derive. A provider-CLI failure, failed mandatory
+  local-remote inspection, thrown runner, or malformed response still degrades to `null` for the caller
+  but is not retained, so fixing CLI auth or a
+  transient outage can recover on the next read. Expired entries are pruned lazily on cache activity.
+- Ordinary workspace activation may reuse a settled answer; `{ fresh: true }` bypasses one while still
+  joining an already-running lookup. The web uses the fresh path on window focus, preserving focus as the
+  explicit revalidation point for reviews opened, closed, or merged outside ThinkRail.
+- `forgetOpenBranchReview(cwd)` invalidates every branch generation for that worktree. A lookup superseded
+  while in flight must resolve through the current generation rather than return or re-cache its stale
+  answer; this is what makes invalidation safe against a concurrent read.
 - **Allowed deps:** `contracts` for the result type; the server `git` barrel for local remote inspection and for `nonInteractiveGitEnv()`, the one definition of the environment a subprocess runs under — `process.env` plus `GIT_TERMINAL_PROMPT=0` (this module layers its own `GH_PROMPT_DISABLED`/`GLAB_PROMPT_DISABLED` on top); the `subprocess` barrel, which runs the lookup under this module's `LOOKUP_TIMEOUT_MS`.
 - **Forbidden:** `host`, `workspaces`, browser code, persistence, or any PR/review action beyond this read (actions live in `pr`).
 - Missing CLI/authentication, unsupported remotes, timeouts, malformed output, and no open review all degrade to `null`.

--- a/packages/server/src/branch-review/branchReview.test.ts
+++ b/packages/server/src/branch-review/branchReview.test.ts
@@ -1,29 +1,68 @@
-import { afterEach, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, renameSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	detectReviewProvider,
 	findOpenBranchReviewWithRunner,
+	forgetOpenBranchReview,
+	OPEN_BRANCH_REVIEW_CACHE_TTL_MS,
 	providerFromRemoteUrl,
 	reviewNumber,
 } from "./branchReview";
 
 const dirs: string[] = [];
-afterEach(() => {
-	for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+const repositoryEnvironmentKeys = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_COMMON_DIR",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_NAMESPACE",
+	"GIT_CONFIG_NOSYSTEM",
+	"GIT_CONFIG_GLOBAL",
+	"GIT_CONFIG_COUNT",
+	"GIT_CONFIG_PARAMETERS",
+	"GIT_CONFIG",
+] as const;
+const savedRepositoryEnvironment = new Map<string, string | undefined>();
+for (const key of repositoryEnvironmentKeys) {
+	savedRepositoryEnvironment.set(key, process.env[key]);
+}
+
+beforeEach(() => {
+	for (const key of repositoryEnvironmentKeys) delete process.env[key];
+	process.env.GIT_CONFIG_NOSYSTEM = "1";
+	process.env.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+	process.env.GIT_CONFIG_COUNT = "0";
 });
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		forgetOpenBranchReview(dir);
+		rmSync(dir, { recursive: true, force: true });
+	}
+	for (const key of repositoryEnvironmentKeys) {
+		const value = savedRepositoryEnvironment.get(key);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+function runGit(cwd: string, ...args: string[]): void {
+	const result = Bun.spawnSync(["git", "-C", cwd, ...args], {
+		stderr: "pipe",
+		env: process.env,
+	});
+	if (!result.success) throw new Error(new TextDecoder().decode(result.stderr));
+}
 
 function repo(remote: string): string {
 	const cwd = mkdtempSync(join(tmpdir(), "thinkrail-branch-review-"));
 	dirs.push(cwd);
-	for (const args of [
-		["init", "-q", "-b", "feature"],
-		["remote", "add", "origin", remote],
-	]) {
-		const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stderr: "pipe" });
-		if (!result.success) throw new Error(new TextDecoder().decode(result.stderr));
-	}
+	runGit(cwd, "init", "-q", "-b", "feature");
+	runGit(cwd, "remote", "add", "origin", remote);
 	return cwd;
 }
 
@@ -37,8 +76,8 @@ test("recognizes hosted GitHub and GitLab remote URL forms only", () => {
 
 test("prefers the branch push remote", () => {
 	const cwd = repo("https://github.com/acme/app.git");
-	Bun.spawnSync(["git", "-C", cwd, "remote", "add", "mirror", "https://gitlab.com/acme/app.git"]);
-	Bun.spawnSync(["git", "-C", cwd, "config", "branch.feature.pushRemote", "mirror"]);
+	runGit(cwd, "remote", "add", "mirror", "https://gitlab.com/acme/app.git");
+	runGit(cwd, "config", "branch.feature.pushRemote", "mirror");
 	expect(detectReviewProvider(cwd, "feature")).toBe("gitlab");
 });
 
@@ -88,17 +127,192 @@ test("queries an open GitLab MR for the explicit branch", async () => {
 	expect(review).toEqual({ kind: "merge-request", number: 73 });
 });
 
-test("unavailable and malformed lookup results degrade to no review", async () => {
+test("failed and malformed lookups degrade to null without being cached", async () => {
 	const cwd = repo("https://github.com/acme/app.git");
-	expect(
-		await findOpenBranchReviewWithRunner(cwd, "feature", async () => ({ ok: false, out: "" })),
-	).toBeNull();
-	expect(
-		await findOpenBranchReviewWithRunner(cwd, "feature", async () => ({
-			ok: true,
-			out: "not json",
-		})),
-	).toBeNull();
+	let calls = 0;
+	const run = async () => {
+		calls += 1;
+		if (calls === 1) throw new Error("unavailable");
+		if (calls === 2) return { ok: false, out: "" };
+		if (calls === 3) return { ok: true, out: "not json" };
+		return { ok: true, out: '[{"number":9}]' };
+	};
+
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toBeNull();
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toBeNull();
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toBeNull();
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toEqual({
+		kind: "pull-request",
+		number: 9,
+	});
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toEqual({
+		kind: "pull-request",
+		number: 9,
+	});
+	expect(calls).toBe(4);
 	expect(reviewNumber("[]", "number")).toBeNull();
 	expect(reviewNumber('[{"number":0}]', "number")).toBeNull();
+});
+
+test("a failed repository inspection is retried after the worktree recovers", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	const gitDir = join(cwd, ".git");
+	const unavailable = join(cwd, ".git-unavailable");
+	let calls = 0;
+	const run = async () => {
+		calls += 1;
+		return { ok: true, out: '[{"number":11}]' };
+	};
+
+	renameSync(gitDir, unavailable);
+	try {
+		expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toBeNull();
+	} finally {
+		renameSync(unavailable, gitDir);
+	}
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toEqual({
+		kind: "pull-request",
+		number: 11,
+	});
+	expect(calls).toBe(1);
+});
+
+test("a valid empty answer is cached while a fresh read bypasses it", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	let calls = 0;
+	const run = async () => {
+		calls += 1;
+		return { ok: true, out: calls === 1 ? "[]" : '[{"number":7}]' };
+	};
+
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toBeNull();
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toBeNull();
+	expect(calls).toBe(1);
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run, { fresh: true })).toEqual({
+		kind: "pull-request",
+		number: 7,
+	});
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toEqual({
+		kind: "pull-request",
+		number: 7,
+	});
+	expect(calls).toBe(2);
+});
+
+test("concurrent and repeated lookups share one provider call", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	let calls = 0;
+	let release: (() => void) | undefined;
+	const run = async () => {
+		calls += 1;
+		await new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		return { ok: true, out: '[{"number":7}]' };
+	};
+
+	const first = findOpenBranchReviewWithRunner(cwd, "feature", run);
+	const concurrent = findOpenBranchReviewWithRunner(cwd, "feature", run, { fresh: true });
+	expect(calls).toBe(1);
+	release?.();
+	expect(await first).toEqual({ kind: "pull-request", number: 7 });
+	expect(await concurrent).toEqual({ kind: "pull-request", number: 7 });
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toEqual({
+		kind: "pull-request",
+		number: 7,
+	});
+	expect(calls).toBe(1);
+});
+
+test("cache keys isolate branches and worktrees while invalidation clears one worktree", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	const other = repo("git@github.com:acme/other.git");
+	let calls = 0;
+	const run = async () => {
+		calls += 1;
+		return { ok: true, out: `[{"number":${calls}}]` };
+	};
+
+	expect((await findOpenBranchReviewWithRunner(cwd, "feature", run))?.number).toBe(1);
+	expect((await findOpenBranchReviewWithRunner(cwd, "other", run))?.number).toBe(2);
+	expect((await findOpenBranchReviewWithRunner(other, "feature", run))?.number).toBe(3);
+	expect((await findOpenBranchReviewWithRunner(cwd, "feature", run))?.number).toBe(1);
+	expect((await findOpenBranchReviewWithRunner(cwd, "other", run))?.number).toBe(2);
+	expect((await findOpenBranchReviewWithRunner(other, "feature", run))?.number).toBe(3);
+	expect(calls).toBe(3);
+
+	forgetOpenBranchReview(cwd);
+	expect((await findOpenBranchReviewWithRunner(cwd, "feature", run))?.number).toBe(4);
+	expect((await findOpenBranchReviewWithRunner(cwd, "other", run))?.number).toBe(5);
+	expect((await findOpenBranchReviewWithRunner(other, "feature", run))?.number).toBe(3);
+	expect(calls).toBe(5);
+});
+
+test("settled answers expire exactly one TTL after settlement", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	let calls = 0;
+	let time = 1_000;
+	let release: ((result: { ok: boolean; out: string }) => void) | undefined;
+	const run = () => {
+		calls += 1;
+		if (calls > 1) return Promise.resolve({ ok: true, out: `[{"number":${calls}}]` });
+		return new Promise<{ ok: boolean; out: string }>((resolve) => {
+			release = resolve;
+		});
+	};
+	const options = { now: () => time };
+
+	const pending = findOpenBranchReviewWithRunner(cwd, "feature", run, options);
+	time += OPEN_BRANCH_REVIEW_CACHE_TTL_MS * 2;
+	release?.({ ok: true, out: '[{"number":1}]' });
+	expect((await pending)?.number).toBe(1);
+	time += OPEN_BRANCH_REVIEW_CACHE_TTL_MS - 1;
+	expect((await findOpenBranchReviewWithRunner(cwd, "feature", run, options))?.number).toBe(1);
+	time += 1;
+	expect((await findOpenBranchReviewWithRunner(cwd, "feature", run, options))?.number).toBe(2);
+	expect(calls).toBe(2);
+});
+
+test("a superseded lookup cannot overwrite a newer settled answer", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	const releases: Array<(result: { ok: boolean; out: string }) => void> = [];
+	let calls = 0;
+	const run = () => {
+		calls += 1;
+		return new Promise<{ ok: boolean; out: string }>((resolve) => releases.push(resolve));
+	};
+
+	const stale = findOpenBranchReviewWithRunner(cwd, "feature", run);
+	forgetOpenBranchReview(cwd);
+	const fresh = findOpenBranchReviewWithRunner(cwd, "feature", run);
+	releases[1]?.({ ok: true, out: '[{"number":2}]' });
+	expect(await fresh).toEqual({ kind: "pull-request", number: 2 });
+	releases[0]?.({ ok: true, out: '[{"number":1}]' });
+	expect(await stale).toEqual({ kind: "pull-request", number: 2 });
+	expect(await findOpenBranchReviewWithRunner(cwd, "feature", run)).toEqual({
+		kind: "pull-request",
+		number: 2,
+	});
+	expect(calls).toBe(2);
+});
+
+test("a superseded lookup joins the newer in-flight generation", async () => {
+	const cwd = repo("git@github.com:acme/app.git");
+	const releases: Array<(result: { ok: boolean; out: string }) => void> = [];
+	const run = () => new Promise<{ ok: boolean; out: string }>((resolve) => releases.push(resolve));
+
+	const stale = findOpenBranchReviewWithRunner(cwd, "feature", run);
+	forgetOpenBranchReview(cwd);
+	const fresh = findOpenBranchReviewWithRunner(cwd, "feature", run);
+	let staleSettled = false;
+	void stale.then(() => {
+		staleSettled = true;
+	});
+	releases[0]?.({ ok: true, out: '[{"number":1}]' });
+	await Promise.resolve();
+	await Promise.resolve();
+	expect(staleSettled).toBe(false);
+	releases[1]?.({ ok: true, out: '[{"number":2}]' });
+	expect(await stale).toEqual({ kind: "pull-request", number: 2 });
+	expect(await fresh).toEqual({ kind: "pull-request", number: 2 });
 });

--- a/packages/server/src/branch-review/branchReview.ts
+++ b/packages/server/src/branch-review/branchReview.ts
@@ -3,35 +3,48 @@ import { git, nonInteractiveGitEnv } from "../git";
 import { runBounded } from "../subprocess";
 
 const LOOKUP_TIMEOUT_MS = 8_000;
+export const OPEN_BRANCH_REVIEW_CACHE_TTL_MS = 60_000;
 
 type ReviewProvider = "github" | "gitlab";
+type ProviderDetection = { provider: ReviewProvider | null; cacheable: boolean };
 type CommandResult = { ok: boolean; out: string };
 type CommandRunner = (cwd: string, command: string[]) => Promise<CommandResult>;
+type LookupResult = { value: OpenBranchReview | null; cacheable: boolean };
+type LookupOptions = { fresh?: boolean; now?: () => number };
+type ParsedReviewNumber = { valid: true; value: number | null } | { valid: false };
 
-export function detectReviewProvider(cwd: string, branch: string): ReviewProvider | null {
+function detectReviewProviderResult(cwd: string, branch: string): ProviderDetection {
 	const configured = [
 		git(cwd, ["config", "--get", `branch.${branch}.pushRemote`]).out,
 		git(cwd, ["config", "--get", "remote.pushDefault"]).out,
 		git(cwd, ["config", "--get", `branch.${branch}.remote`]).out,
 	];
 	const listed = git(cwd, ["remote"]);
-	const names = [
-		...new Set([...configured, "origin", ...(listed.ok ? listed.out.split("\n") : [])]),
-	];
+	if (!listed.ok) return { provider: null, cacheable: false };
+	const listedNames = new Set(listed.out.split("\n").filter(Boolean));
+	const names = [...new Set([...configured, "origin", ...listedNames])];
+	let failedListedRemote = false;
 
 	for (const name of names) {
 		if (!name || name === ".") continue;
+		let resolved = false;
 		for (const args of [
 			["remote", "get-url", "--push", name],
 			["remote", "get-url", name],
 		]) {
 			const remote = git(cwd, args);
 			if (!remote.ok) continue;
+			resolved = true;
 			const provider = providerFromRemoteUrl(remote.out);
-			if (provider) return provider;
+			if (provider) return { provider, cacheable: true };
 		}
+		if (listedNames.has(name) && !resolved) failedListedRemote = true;
 	}
-	return null;
+	return { provider: null, cacheable: !failedListedRemote };
+}
+
+export function detectReviewProvider(cwd: string, branch: string): ReviewProvider | null {
+	return detectReviewProviderResult(cwd, branch).provider;
 }
 
 export function providerFromRemoteUrl(remoteUrl: string): ReviewProvider | null {
@@ -49,21 +62,73 @@ function remoteHost(remoteUrl: string): string | null {
 	return /^(?:[^@/:\s]+@)?([^/:\s]+):/.exec(remoteUrl)?.[1]?.toLowerCase() ?? null;
 }
 
+const cached = new Map<string, { at: number; value: OpenBranchReview | null }>();
+const inFlight = new Map<string, Promise<OpenBranchReview | null>>();
+
+const cacheKey = (cwd: string, branch: string) => `${cwd}\u0000${branch}`;
+
 export function findOpenBranchReview(
 	cwd: string,
 	branch: string,
+	options: { fresh?: boolean } = {},
 ): Promise<OpenBranchReview | null> {
-	return findOpenBranchReviewWithRunner(cwd, branch, runProviderCommand);
+	return findOpenBranchReviewWithRunner(cwd, branch, runProviderCommand, options);
 }
 
-export async function findOpenBranchReviewWithRunner(
+export function forgetOpenBranchReview(cwd: string): void {
+	const prefix = `${cwd}\u0000`;
+	for (const map of [cached, inFlight]) {
+		for (const key of map.keys()) if (key.startsWith(prefix)) map.delete(key);
+	}
+}
+
+function pruneCached(now: number): void {
+	for (const [key, entry] of cached) {
+		if (now - entry.at >= OPEN_BRANCH_REVIEW_CACHE_TTL_MS) cached.delete(key);
+	}
+}
+
+export function findOpenBranchReviewWithRunner(
 	cwd: string,
 	branch: string,
 	run: CommandRunner,
+	options: LookupOptions = {},
 ): Promise<OpenBranchReview | null> {
+	const now = options.now ?? Date.now;
+	const key = cacheKey(cwd, branch);
+	pruneCached(now());
+	const running = inFlight.get(key);
+	if (running) return running;
+	if (!options.fresh) {
+		const hit = cached.get(key);
+		if (hit) return Promise.resolve(hit.value);
+	} else {
+		cached.delete(key);
+	}
+	const lookup: Promise<OpenBranchReview | null> = lookupOpenBranchReview(cwd, branch, run).then(
+		(result) => {
+			if (inFlight.get(key) !== lookup) {
+				return findOpenBranchReviewWithRunner(cwd, branch, run, { now });
+			}
+			inFlight.delete(key);
+			if (result.cacheable) cached.set(key, { at: now(), value: result.value });
+			else cached.delete(key);
+			return result.value;
+		},
+	);
+	inFlight.set(key, lookup);
+	return lookup;
+}
+
+async function lookupOpenBranchReview(
+	cwd: string,
+	branch: string,
+	run: CommandRunner,
+): Promise<LookupResult> {
 	try {
-		const provider = detectReviewProvider(cwd, branch);
-		if (!provider) return null;
+		const detection = detectReviewProviderResult(cwd, branch);
+		const provider = detection.provider;
+		if (!provider) return { value: null, cacheable: detection.cacheable };
 
 		const command =
 			provider === "github"
@@ -82,27 +147,44 @@ export async function findOpenBranchReviewWithRunner(
 					]
 				: ["glab", "mr", "list", "--source-branch", branch, "--output", "json", "--per-page", "1"];
 		const result = await run(cwd, command);
-		if (!result.ok) return null;
+		if (!result.ok) return { value: null, cacheable: false };
 
-		const number = reviewNumber(result.out, provider === "github" ? "number" : "iid");
-		if (number === null) return null;
-		return { kind: provider === "github" ? "pull-request" : "merge-request", number };
+		const parsed = parseReviewNumber(result.out, provider === "github" ? "number" : "iid");
+		if (!parsed.valid) return { value: null, cacheable: false };
+		return {
+			value:
+				parsed.value === null
+					? null
+					: {
+							kind: provider === "github" ? "pull-request" : "merge-request",
+							number: parsed.value,
+						},
+			cacheable: true,
+		};
 	} catch {
-		return null;
+		return { value: null, cacheable: false };
+	}
+}
+
+function parseReviewNumber(output: string, field: "number" | "iid"): ParsedReviewNumber {
+	try {
+		const rows: unknown = JSON.parse(output);
+		if (!Array.isArray(rows)) return { valid: false };
+		if (rows.length === 0) return { valid: true, value: null };
+		const first: unknown = rows[0];
+		if (typeof first !== "object" || first === null) return { valid: false };
+		const value = (first as Record<string, unknown>)[field];
+		return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+			? { valid: true, value }
+			: { valid: false };
+	} catch {
+		return { valid: false };
 	}
 }
 
 export function reviewNumber(output: string, field: "number" | "iid"): number | null {
-	try {
-		const rows: unknown = JSON.parse(output);
-		if (!Array.isArray(rows) || rows.length === 0) return null;
-		const first: unknown = rows[0];
-		if (typeof first !== "object" || first === null) return null;
-		const value = (first as Record<string, unknown>)[field];
-		return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null;
-	} catch {
-		return null;
-	}
+	const parsed = parseReviewNumber(output, field);
+	return parsed.valid ? parsed.value : null;
 }
 
 export async function runProviderCommand(

--- a/packages/server/src/branch-review/index.ts
+++ b/packages/server/src/branch-review/index.ts
@@ -1,5 +1,6 @@
 export {
 	findOpenBranchReview,
+	forgetOpenBranchReview,
 	providerFromRemoteUrl,
 	reviewNumber,
 	runProviderCommand,

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -8,7 +8,7 @@ import { recordAcceptedMessage, resetFeedbackForTests, setFeedbackPublisher } fr
 import { addComment, getReviewSnapshot } from "../reviews";
 import { todoReviewRecord } from "../todos";
 import { stopAllWatches } from "../watch";
-import { handleRequest, requestMethodDiagnostic } from "./handlers";
+import { handleRequest, requestMethodDiagnostic, shouldRefreshOpenReview } from "./handlers";
 
 const CTX = { clientKey: "test-client" };
 
@@ -51,6 +51,12 @@ afterEach(() => {
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+});
+
+test("open-review cache reuse is opt-in so older clients remain fresh", () => {
+	expect(shouldRefreshOpenReview(undefined)).toBe(true);
+	expect(shouldRefreshOpenReview(false)).toBe(true);
+	expect(shouldRefreshOpenReview(true)).toBe(false);
 });
 
 test("request diagnostics expose only registered method names", async () => {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -328,9 +328,12 @@ const handlers: Record<string, Handler> = {
 		).map((workspace) => ({ ...workspace, ...provisionInitialTerminal(workspace) }));
 	},
 	"workspace.openReview": async (params) => {
-		const ws = getWorkspace((params as { workspaceId: string }).workspaceId);
+		const p = params as { workspaceId: string; allowCached?: boolean };
+		const ws = getWorkspace(p.workspaceId);
 		const [review, unpushed] = await Promise.all([
-			findOpenBranchReview(ws.worktreePath, ws.branch),
+			findOpenBranchReview(ws.worktreePath, ws.branch, {
+				fresh: shouldRefreshOpenReview(p.allowCached),
+			}),
 			countUnpushedCommits(ws.worktreePath, ws.branch),
 		]);
 		if (!review) return review;
@@ -868,6 +871,10 @@ const handlers: Record<string, Handler> = {
 
 export function requestMethodDiagnostic(method: string): string {
 	return Object.hasOwn(handlers, method) ? method : "unknown method";
+}
+
+export function shouldRefreshOpenReview(allowCached: boolean | undefined): boolean {
+	return allowCached !== true;
 }
 
 export async function handleRequest(

--- a/packages/server/src/pr/SPEC.md
+++ b/packages/server/src/pr/SPEC.md
@@ -99,7 +99,11 @@ value. Then:
    won't be in the PR. Dirty state never blocks.
 
 The open-PR *read* side stays `workspace.openReview` (`branch-review`) — this module persists
-nothing; the client re-derives button/chip state from that lookup plus this call's result.
+nothing; the client re-derives button/chip state from that lookup plus this call's result. That
+lookup is cached, so every successful push drops the worktree's prior answer: pushing may change the
+branch's remote configuration even when the remote is not GitHub or the action falls back to compare.
+A GitHub mutation attempt drops it again after settlement, so a concurrent "no PR" read cannot survive
+an update, a create, or an ambiguous create result.
 
 ## Boundary
 
@@ -107,7 +111,8 @@ nothing; the client re-derives button/chip state from that lookup plus this call
   derivation.
 - **Public surface (barrel):** `openPr`, `previewPr`.
 - **Allowed deps:** `workspaces` (workspace record, `refreshUserOwnedWorkspace`), `git` (exec + status), `todos` (`listTodos` for
-  the body), `branch-review` (provider detection, existing-PR lookup, the shared command runner),
+  the body), `branch-review` (provider detection, existing-PR lookup, the shared command runner,
+  `forgetOpenBranchReview`),
   `github` (`ghSetupProblem` — the named compare-fallback reason); `contracts` types;
   `shared/codedError` (`PUSH_AUTH_FAILED`).
 - **Forbidden:** `host`; provider HTTP APIs or stored tokens (auth stays external — the user's `gh`

--- a/packages/server/src/pr/pr.test.ts
+++ b/packages/server/src/pr/pr.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import type { TodoPlan } from "@thinkrail/contracts";
+import { findOpenBranchReview, forgetOpenBranchReview } from "../branch-review";
 import {
 	compareQuickPullUrl,
 	ghPrFlow,
@@ -301,6 +302,213 @@ describe("ghPrFlow", () => {
 				"release/x",
 			]);
 		}
+	});
+});
+
+describe("openPr — invalidates the open-review cache", () => {
+	let dataDir: string;
+	let repo: string;
+	let remote: string;
+	let reviewMode: string;
+	const environmentKeys = [
+		"THINKRAIL_DATA_DIR",
+		"THINKRAIL_GH_OFFLINE",
+		"THINKRAIL_TEST_REVIEW_MODE",
+		"PATH",
+		"HOME",
+		"XDG_CONFIG_HOME",
+		"GIT_CONFIG_NOSYSTEM",
+		"GIT_CONFIG_GLOBAL",
+		"GIT_CONFIG_COUNT",
+		"GIT_CONFIG_KEY_0",
+		"GIT_CONFIG_VALUE_0",
+		"GIT_CONFIG_KEY_1",
+		"GIT_CONFIG_VALUE_1",
+		"GIT_CONFIG_PARAMETERS",
+		"GIT_CONFIG",
+		"GIT_ALLOW_PROTOCOL",
+		"GIT_TEMPLATE_DIR",
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_COMMON_DIR",
+		"GIT_INDEX_FILE",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+		"GIT_NAMESPACE",
+		"PATHEXT",
+	] as const;
+	const savedEnvironment = new Map<string, string | undefined>();
+	for (const key of environmentKeys) savedEnvironment.set(key, process.env[key]);
+
+	const sh = (cwd: string, ...args: string[]) => {
+		const result = Bun.spawnSync(["git", "-C", cwd, ...args], {
+			stdout: "ignore",
+			stderr: "pipe",
+			env: process.env,
+		});
+		if (!result.success) throw new Error(new TextDecoder().decode(result.stderr));
+	};
+
+	beforeEach(() => {
+		dataDir = mkdtempSync(join(tmpdir(), "trpi-pr-cache-"));
+		repo = join(dataDir, "repo");
+		remote = join(dataDir, "remote.git");
+		const bin = join(dataDir, "bin");
+		const home = join(dataDir, "home");
+		const hooks = join(dataDir, "hooks");
+		const template = join(dataDir, "template");
+		reviewMode = join(dataDir, "review-mode");
+		for (const path of [repo, remote, bin, home, hooks, template]) mkdirSync(path);
+		for (const key of [
+			"GIT_CONFIG_PARAMETERS",
+			"GIT_CONFIG",
+			"GIT_DIR",
+			"GIT_WORK_TREE",
+			"GIT_COMMON_DIR",
+			"GIT_INDEX_FILE",
+			"GIT_OBJECT_DIRECTORY",
+			"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+			"GIT_NAMESPACE",
+		]) {
+			delete process.env[key];
+		}
+
+		process.env.THINKRAIL_DATA_DIR = dataDir;
+		process.env.THINKRAIL_TEST_REVIEW_MODE = reviewMode;
+		process.env.PATH = `${bin}${delimiter}${savedEnvironment.get("PATH") ?? ""}`;
+		process.env.HOME = home;
+		process.env.XDG_CONFIG_HOME = join(home, ".config");
+		process.env.GIT_CONFIG_NOSYSTEM = "1";
+		process.env.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+		process.env.GIT_CONFIG_COUNT = "2";
+		process.env.GIT_CONFIG_KEY_0 = "commit.gpgSign";
+		process.env.GIT_CONFIG_VALUE_0 = "false";
+		process.env.GIT_CONFIG_KEY_1 = "core.hooksPath";
+		process.env.GIT_CONFIG_VALUE_1 = hooks;
+		process.env.GIT_ALLOW_PROTOCOL = "file";
+		process.env.GIT_TEMPLATE_DIR = template;
+		if (process.platform === "win32") {
+			const pathExtensions = savedEnvironment.get("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD";
+			process.env.PATHEXT = pathExtensions.toUpperCase().split(";").includes(".CMD")
+				? pathExtensions
+				: `${pathExtensions};.CMD`;
+		}
+		delete process.env.THINKRAIL_GH_OFFLINE;
+
+		sh(repo, "init", "-q", "-b", "main");
+		sh(repo, "config", "user.email", "t@thinkrail.test");
+		sh(repo, "config", "user.name", "test");
+		writeFileSync(join(repo, "README.md"), "# repo\n");
+		sh(repo, "add", "-A");
+		sh(repo, "commit", "-q", "-m", "init");
+		sh(repo, "switch", "-q", "-c", "feature");
+		writeFileSync(join(repo, "feature.txt"), "feature\n");
+		sh(repo, "add", "-A");
+		sh(repo, "commit", "-q", "-m", "feature");
+		sh(remote, "init", "-q", "--bare");
+		sh(repo, "remote", "add", "origin", "https://github.com/acme/widgets.git");
+		sh(repo, "remote", "set-url", "--push", "origin", remote);
+
+		writeFileSync(reviewMode, "closed\n");
+		if (process.platform === "win32") {
+			writeFileSync(
+				join(bin, "gh.cmd"),
+				'@echo off\r\nset /p MODE=<"%THINKRAIL_TEST_REVIEW_MODE%"\r\nif "%MODE%"=="open" (\r\n  echo [{"number":7}]\r\n) else (\r\n  echo []\r\n)\r\n',
+			);
+		} else {
+			const gh = join(bin, "gh");
+			writeFileSync(
+				gh,
+				"#!/bin/sh\nif [ \"$(cat \"$THINKRAIL_TEST_REVIEW_MODE\")\" = \"open\" ]; then\n  printf '%s\\n' '[{\"number\":7}]'\nelse\n  printf '%s\\n' '[]'\nfi\n",
+			);
+			chmodSync(gh, 0o755);
+		}
+
+		writeFileSync(
+			join(dataDir, "projects.json"),
+			JSON.stringify([{ id: "p1", name: "repo", path: repo, slug: "repo", lastOpened: 1 }]),
+		);
+		writeFileSync(
+			join(dataDir, "workspaces.json"),
+			JSON.stringify([
+				{
+					id: "w1",
+					projectId: "p1",
+					name: "Feature",
+					branch: "feature",
+					baseBranch: "main",
+					worktreePath: repo,
+					createdAt: 1,
+				},
+			]),
+		);
+	});
+
+	afterEach(() => {
+		forgetOpenBranchReview(repo);
+		rmSync(dataDir, { recursive: true, force: true });
+		for (const key of environmentKeys) {
+			const value = savedEnvironment.get(key);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	test("a successful push clears a settled answer even when gh is offline", async () => {
+		expect(await findOpenBranchReview(repo, "feature")).toBeNull();
+		writeFileSync(reviewMode, "open\n");
+		process.env.THINKRAIL_GH_OFFLINE = "1";
+
+		const result = await openPr({
+			workspaceId: "w1",
+			sessionId: "s1",
+			title: "Feature",
+			body: "Body",
+		});
+		expect(result.action).toBe("compare");
+		expect(await findOpenBranchReview(repo, "feature")).toEqual({
+			kind: "pull-request",
+			number: 7,
+		});
+	});
+
+	test("an ambiguous gh mutation clears a null cached concurrently with the attempt", async () => {
+		expect(await findOpenBranchReview(repo, "feature")).toBeNull();
+		const run: PrCommandRunner = async (_cwd, command) => {
+			if (command[2] === "create") {
+				expect(await findOpenBranchReview(repo, "feature")).toBeNull();
+				writeFileSync(reviewMode, "open\n");
+				return { ok: true, out: "ambiguous" };
+			}
+			return { ok: true, out: "[]" };
+		};
+
+		const result = await openPr(
+			{ workspaceId: "w1", sessionId: "s1", title: "Feature", body: "Body" },
+			run,
+			async () => null,
+		);
+		expect(result.action).toBe("compare");
+		expect(await findOpenBranchReview(repo, "feature")).toEqual({
+			kind: "pull-request",
+			number: 7,
+		});
+	});
+
+	test("a successful non-GitHub push clears an answer before the pushed return", async () => {
+		expect(await findOpenBranchReview(repo, "feature")).toBeNull();
+		sh(repo, "remote", "set-url", "origin", remote);
+		const result = await openPr({ workspaceId: "w1", sessionId: "s1" }, async () => {
+			throw new Error("a non-GitHub push must not run gh");
+		});
+		expect(result.action).toBe("pushed");
+
+		sh(repo, "remote", "set-url", "origin", "https://github.com/acme/widgets.git");
+		writeFileSync(reviewMode, "open\n");
+		expect(await findOpenBranchReview(repo, "feature")).toEqual({
+			kind: "pull-request",
+			number: 7,
+		});
 	});
 });
 

--- a/packages/server/src/pr/pr.ts
+++ b/packages/server/src/pr/pr.ts
@@ -1,6 +1,11 @@
 import type { GhSetupProblem, OpenPrResult, PrDraft } from "@thinkrail/contracts";
 import { CodedError } from "@thinkrail/shared/codedError";
-import { providerFromRemoteUrl, reviewNumber, runProviderCommand } from "../branch-review";
+import {
+	forgetOpenBranchReview,
+	providerFromRemoteUrl,
+	reviewNumber,
+	runProviderCommand,
+} from "../branch-review";
 import { assertSafeRef, git, gitAsync, gitStatus } from "../git";
 import { ghSetupProblem } from "../github";
 import { listTodos } from "../todos";
@@ -220,6 +225,7 @@ export async function openPr(
 		if (isPushAuthFailure(detail)) throw new CodedError("PUSH_AUTH_FAILED", detail);
 		throw new Error(detail);
 	}
+	forgetOpenBranchReview(cwd);
 
 	const slug = providerFromRemoteUrl(origin.out) === "github" ? githubSlug(origin.out) : null;
 	if (!slug) return { action: "pushed", dirtyFiles };
@@ -241,7 +247,7 @@ export async function openPr(
 				...(params.draft ? { draft: true } : {}),
 			},
 			run,
-		);
+		).finally(() => forgetOpenBranchReview(cwd));
 		if (outcome) return { ...outcome, dirtyFiles };
 		problem = await ghProblem();
 	}


### PR DESCRIPTION
Every workspace activation asked the host for the branch's open PR/MR, and so did every mounted consumer of that state. The host answered by repeating synchronous remote inspection and a bounded `gh pr list` / `glab mr list` call. Switching between worktrees therefore kept paying for an answer that usually had not changed.

This change caches successful lookup answers per `(worktree, branch)` for 60 seconds and single-flights concurrent readers. A syntactically valid empty result is cached because “no open review” is the common case; CLI failures, failed repository inspection, thrown runners, and malformed output still degrade to `null` but are not retained, so recovery is immediate on the next read.

Cache reuse is explicit and freshness remains deterministic:

- workspace activation sends `allowCached: true`;
- window focus bypasses settled cache entries while joining any lookup already in flight;
- a focus received while disconnected is replayed as a fresh read on reconnect;
- omission remains force-fresh, preserving behavior for independently shipped older clients;
- invalidating an in-flight generation makes its callers resolve through the current generation rather than re-cache or return stale data.

The shell and plan now share one keyed browser snapshot and request generation, so a PR mutation or newer read cannot leave the two surfaces disagreeing. Every successful push invalidates the prior host answer, every GitHub mutation attempt invalidates again after settlement (including ambiguous creates), and the client performs an authoritative post-push refresh. The earlier broad repo-metadata invalidation and `workspaces` API expansion were removed: branch identity is already part of the cache key, while focus and explicit mutation invalidation cover the facts that can actually change the review answer.

The original measurement on the same host and repository reduced repeated workspace-switch lookup time from roughly 450 ms to a cache hit; focus intentionally remains a fresh network revalidation.

## Verification

Passed on the rebased final tree:

- `bun run check:deps`
- `bun run check:boundaries`
- `bun run check:seams`
- `bun run typography:check`
- `bun run colors:check`
- `bun run spacing:check`
- `bun run lint` (exit 0; six existing unused-suppression warnings outside this diff)
- `bun run typecheck` — 14/14 tasks
- `bun run test` — 14/14 tasks; server 908 tests pass
- focused review-cache/web/PR/handler suites — 62 tests pass

Local e2e was not run by request; the PR's required no-agent, binary, and desktop checks will exercise the final SHA in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
