### PR TITLE
feat(web): simplify folded thinking headers

### DIFF
--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -200,7 +200,16 @@ function GroupDisclosure({
 				) : (
 					icon
 				)}
-				{label ? <span className="shrink-0 text-text-default">{label}</span> : null}
+				{label ? (
+					<span
+						className={cn(
+							"shrink-0 text-text-default",
+							!expanded && headline && "sr-only",
+						)}
+					>
+						{label}
+					</span>
+				) : null}
 				{!expanded && headline ? (
 					<strong className="min-w-0 flex-1 truncate text-text-default" title={headline}>
 						{headline}

--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -201,12 +201,7 @@ function GroupDisclosure({
 					icon
 				)}
 				{label ? (
-					<span
-						className={cn(
-							"shrink-0 text-text-default",
-							!expanded && headline && "sr-only",
-						)}
-					>
+					<span className={cn("shrink-0 text-text-default", !expanded && headline && "sr-only")}>
 						{label}
 					</span>
 				) : null}

--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -206,9 +206,13 @@ function GroupDisclosure({
 					</span>
 				) : null}
 				{!expanded && headline ? (
-					<strong className="min-w-0 flex-1 truncate text-text-default" title={headline}>
+					<span
+						data-testid={`${testId}-headline`}
+						className="min-w-0 flex-1 truncate text-text-default"
+						title={headline}
+					>
 						{headline}
-					</strong>
+					</span>
 				) : null}
 				<span className="min-w-0 truncate" title={summary}>
 					{summary}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -93,9 +93,11 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   summarizes every atomic step (thinking blocks + routine tool calls). Expanding it preserves tools before
   the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure. When
   that block's first non-empty line is a complete standalone Markdown strong span (`**…**` or `__…__`),
-  its folded header surfaces the model-authored inner text between `Thinking` and the trailing tool/character
-  metadata; the teaser truncates before that metadata and disappears when expanded, where the disclosure
-  contains the exact text. Blocks without that convention keep the generic header. Every following routine
+  its folded header surfaces the model-authored inner text in place of the redundant visible `Thinking`
+  label, before the trailing tool/character metadata; the teaser truncates before that metadata and
+  disappears when expanded, where the disclosure retains the generic label and contains the exact text.
+  Blocks without that convention keep the generic label while folded. Semantic breadcrumb and assistive
+  labels remain `Thinking` in every state. Every following routine
   tool call stays under that thought until the next thinking block or activity boundary. Those thinking
   groups are siblings **inside** the outer run, even across assistant-message
   boundaries; the hierarchy is presentational, never invented pi entry parentage. A single atomic step

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -94,7 +94,8 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure. When
   that block's first non-empty line is a complete standalone Markdown strong span (`**…**` or `__…__`),
   its folded header surfaces the model-authored inner text in place of the redundant visible `Thinking`
-  label, before the trailing tool/character metadata; the teaser truncates before that metadata and
+  label, using the row's ordinary inherited weight while retaining its default text colour, before the
+  trailing tool/character metadata; the teaser truncates before that metadata and
   disappears when expanded, where the disclosure retains the generic label and contains the exact text.
   Blocks without that convention keep the generic label while folded. Semantic breadcrumb and assistive
   labels remain `Thinking` in every state. Every following routine

--- a/apps/web/src/chat/ThinkingGroup.test.tsx
+++ b/apps/web/src/chat/ThinkingGroup.test.tsx
@@ -45,7 +45,7 @@ describe("ThinkingGroup", () => {
 		expect(markup).not.toContain("I should inspect the files first.");
 	});
 
-	test("surfaces a standalone bold first line in the collapsed header", () => {
+	test("surfaces a standalone bold first line as a normal-weight collapsed summary", () => {
 		const tools = [tool("t1", "read")];
 		const markup = renderToStaticMarkup(
 			<ThinkingGroup
@@ -63,6 +63,8 @@ describe("ThinkingGroup", () => {
 		);
 
 		expect(markup).toContain("Evaluating formatting process");
+		expect(markup).toContain('data-testid="thinking-group-headline"');
+		expect(markup).not.toContain("<strong");
 		expect(markup).toContain('<span class="shrink-0 text-text-default sr-only">Thinking</span>');
 		expect(markup).not.toContain("**Evaluating formatting process**");
 		expect(markup).not.toContain("I should inspect the formatted file.");

--- a/apps/web/src/chat/ThinkingGroup.test.tsx
+++ b/apps/web/src/chat/ThinkingGroup.test.tsx
@@ -37,9 +37,7 @@ describe("ThinkingGroup", () => {
 		expect(markup).toContain('data-activity-node-kind="thinking"');
 		expect(markup).toContain('data-activity-parent-id="activity:a1"');
 		expect(markup).toContain("data-activity-node-toggle");
-		expect(markup).toContain(
-			'<span class="shrink-0 text-text-default">Thinking</span>',
-		);
+		expect(markup).toContain('<span class="shrink-0 text-text-default">Thinking</span>');
 		expect(markup).not.toContain(
 			'<span class="shrink-0 text-text-default sr-only">Thinking</span>',
 		);
@@ -65,9 +63,7 @@ describe("ThinkingGroup", () => {
 		);
 
 		expect(markup).toContain("Evaluating formatting process");
-		expect(markup).toContain(
-			'<span class="shrink-0 text-text-default sr-only">Thinking</span>',
-		);
+		expect(markup).toContain('<span class="shrink-0 text-text-default sr-only">Thinking</span>');
 		expect(markup).not.toContain("**Evaluating formatting process**");
 		expect(markup).not.toContain("I should inspect the formatted file.");
 		expect(markup).toContain("1 step · read");

--- a/apps/web/src/chat/ThinkingGroup.test.tsx
+++ b/apps/web/src/chat/ThinkingGroup.test.tsx
@@ -37,7 +37,12 @@ describe("ThinkingGroup", () => {
 		expect(markup).toContain('data-activity-node-kind="thinking"');
 		expect(markup).toContain('data-activity-parent-id="activity:a1"');
 		expect(markup).toContain("data-activity-node-toggle");
-		expect(markup).toContain("Thinking");
+		expect(markup).toContain(
+			'<span class="shrink-0 text-text-default">Thinking</span>',
+		);
+		expect(markup).not.toContain(
+			'<span class="shrink-0 text-text-default sr-only">Thinking</span>',
+		);
 		expect(markup).toContain("2 steps · read, bash");
 		expect(markup).not.toContain("I should inspect the files first.");
 	});
@@ -60,6 +65,9 @@ describe("ThinkingGroup", () => {
 		);
 
 		expect(markup).toContain("Evaluating formatting process");
+		expect(markup).toContain(
+			'<span class="shrink-0 text-text-default sr-only">Thinking</span>',
+		);
 		expect(markup).not.toContain("**Evaluating formatting process**");
 		expect(markup).not.toContain("I should inspect the formatted file.");
 		expect(markup).toContain("1 step · read");

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -86,10 +86,12 @@ test("a model-authored Thinking heading stays bounded and appears only while fol
 	await activity.getByTestId("activity-group-toggle").click();
 	const thinking = activity.getByTestId("thinking-group").first();
 	const toggle = thinking.getByTestId("thinking-group-toggle");
-	const heading = thinking.locator("strong", { hasText: "Evaluating formatting process" });
+	const heading = thinking.getByTestId("thinking-group-headline");
 	const thinkingLabel = toggle.locator("span", { hasText: /^Thinking$/ });
 	const metadata = "5 steps · get_search_content, fetch_content, web_search, spec_grep, +1 more";
 	await expect(heading).toBeVisible();
+	await expect(heading).toHaveText("Evaluating formatting process");
+	await expect(heading).toHaveCSS("font-weight", "370");
 	await expect(thinkingLabel).toHaveClass(/sr-only/);
 	await expect(toggle).toContainText(metadata);
 
@@ -101,7 +103,9 @@ test("a model-authored Thinking heading stays bounded and appears only while fol
 		const metadataElement = [...element.querySelectorAll<HTMLElement>("span")].find(
 			(candidate) => candidate.title === title,
 		);
-		const headingElement = element.querySelector<HTMLElement>("strong");
+		const headingElement = element.querySelector<HTMLElement>(
+			'[data-testid="thinking-group-headline"]',
+		);
 		if (!metadataElement || !headingElement)
 			throw new Error("missing folded Thinking header parts");
 		return {

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -87,8 +87,10 @@ test("a model-authored Thinking heading stays bounded and appears only while fol
 	const thinking = activity.getByTestId("thinking-group").first();
 	const toggle = thinking.getByTestId("thinking-group-toggle");
 	const heading = thinking.locator("strong", { hasText: "Evaluating formatting process" });
+	const thinkingLabel = toggle.locator("span", { hasText: /^Thinking$/ });
 	const metadata = "5 steps · get_search_content, fetch_content, web_search, spec_grep, +1 more";
 	await expect(heading).toBeVisible();
+	await expect(thinkingLabel).toHaveClass(/sr-only/);
 	await expect(toggle).toContainText(metadata);
 
 	await page.setViewportSize({ width: 390, height: 780 });
@@ -117,6 +119,7 @@ test("a model-authored Thinking heading stays bounded and appears only while fol
 	await toggle.click();
 
 	await expect(thinking).toHaveAttribute("data-expanded", "true");
+	await expect(thinkingLabel).not.toHaveClass(/sr-only/);
 	await expect(heading).toHaveCount(0);
 	await expect(thinking.getByTestId("thinking-group-text")).toContainText(
 		"**Evaluating formatting process**",


### PR DESCRIPTION
## Summary

Simplify folded thinking disclosures by removing the redundant visible `Thinking` prefix when a model-authored summary already labels the thought, and render that summary at the row's usual weight instead of bold.

The semantic label remains available to assistive technology, while heading-less folded rows and expanded rows continue to show `Thinking` visibly.

## Changes

- make the generic thinking label screen-reader-only beside a folded model-authored summary
- render the extracted summary as plain, normal-weight row text while retaining its default colour
- preserve the visible label in fallback and expanded states
- update the chat rendering contract and focused unit/browser coverage

## Testing

- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed (6 pre-existing unused-suppression warnings)
- `bun run typecheck` — 11/11 package tasks passed
- `bun run test` — 11/11 package tasks passed
- `bun test apps/web/src/chat/ThinkingGroup.test.tsx` — 6 passed
- `bun run e2e -- e2e/activity-breadcrumbs.spec.ts` — 2 passed
- `bun run e2e` — 298 passed during initial implementation; not rerun locally for the typography follow-up per request

