### PR TITLE
fix(web): stop background streams from rerendering the workbench

### DIFF
--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -98,6 +98,12 @@ browser's render cache and history membership without selecting the tab; placed-
 semantic placement after the read before installing its cache, and resource hydration otherwise remains a
 separate background concern.
 
+Session-runtime invalidation is leaf-scoped. `WorkspaceWorkbench` never subscribes to the mutable runtime
+map: each mounted chat resource body observes only whether its own session id is present, while `ChatView`
+observes that session's content. Runtime arrival/removal still swaps the missing-resource retry and live chat,
+but an update from a retained background session cannot rerender the active workbench or sibling resource
+bodies.
+
 Project/file/change/review/chat/terminal views receive only resource identity, visibility, and container
 bounds. Moving a view cannot change its module dependencies or make it inspect the layout tree. A visible
 terminal is mounted through the layout visibility gate; hidden terminal tabs stay unmounted while their PTYs

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -45,6 +45,7 @@ import {
 	selectContextProject,
 	selectDiffTabTargetRef,
 	selectReviewDraftCount,
+	selectSessionRuntimePresent,
 	selectWorkspaceById,
 	selectWorkspaceNavTick,
 	selectWorkspaceTick,
@@ -86,6 +87,62 @@ function MissingResource({ label }: { label: string }) {
 	return (
 		<div className="flex h-full items-center justify-center px-16 text-center tr-text-ui text-text-muted">
 			Restoring {label}…
+		</div>
+	);
+}
+
+function ChatResourceBody({
+	tab,
+	workspaceId,
+	onOpenFile,
+}: {
+	tab: Extract<LayoutCenterTab, { kind: "chat" }>;
+	workspaceId: string;
+	onOpenFile: (path: string) => void;
+}) {
+	const sessionPresent = useAppStore((state) => selectSessionRuntimePresent(state, tab.sessionId));
+	if (sessionPresent) {
+		return (
+			<ErrorBoundary label="chat" resetKeys={[workspaceId, tab.id]}>
+				<Suspense fallback={<MissingResource label="chat" />}>
+					<ChatView sessionId={tab.sessionId} workspaceId={workspaceId} onOpenFile={onOpenFile} />
+				</Suspense>
+			</ErrorBoundary>
+		);
+	}
+	return (
+		<div className="flex h-full flex-col items-center justify-center gap-8 text-text-muted">
+			<MissingResource label="chat" />
+			<button
+				type="button"
+				onClick={() => {
+					void hydrateChatResource(workspaceId, tab.sessionId)
+						.then((installed) => {
+							if (installed) return;
+							const { state, current } = currentChatDestination(workspaceId, tab, undefined);
+							if (
+								current &&
+								!state.removedWorkspaceIds[workspaceId] &&
+								!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
+							) {
+								toast.error("The chat could not be restored.", "Couldn't restore the chat");
+							}
+						})
+						.catch((error) => {
+							const { state, current } = currentChatDestination(workspaceId, tab, undefined);
+							if (
+								current &&
+								!state.removedWorkspaceIds[workspaceId] &&
+								!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
+							) {
+								toast.error(errorText(error), "Couldn't restore the chat");
+							}
+						});
+				}}
+				className="rounded-[var(--radius-sm)] border border-border-default px-8 py-4 tr-text-ui hover:bg-control-bg-hovered"
+			>
+				Retry
+			</button>
 		</div>
 	);
 }
@@ -163,7 +220,6 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const initialTerminalEligible = workspace?.initialTerminalEligible === true;
 	const contextProject = useAppStore(selectContextProject);
 	const editorTabs = useAppStore((state) => state.tabsByWorkspace[workspaceId] ?? NO_EDITOR_TABS);
-	const sessions = useAppStore((state) => state.sessions);
 	const deletedSessions = useAppStore((state) => state.deletedSessionsByWorkspace[workspaceId]);
 	const terminalClose = useTerminalClose();
 	const specs = useWorkspaceSpecs(workspaceId);
@@ -420,51 +476,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const renderTabBody = useCallback(
 		(tab: LayoutCenterTab | Extract<LayoutTab, { kind: "terminal" }>) => {
 			if (tab.kind === "chat") {
-				return sessions[tab.sessionId] ? (
-					<ErrorBoundary label="chat" resetKeys={[workspaceId, tab.id]}>
-						<Suspense fallback={<MissingResource label="chat" />}>
-							<ChatView
-								sessionId={tab.sessionId}
-								workspaceId={workspaceId}
-								onOpenFile={openToolFile}
-							/>
-						</Suspense>
-					</ErrorBoundary>
-				) : (
-					<div className="flex h-full flex-col items-center justify-center gap-8 text-text-muted">
-						<MissingResource label="chat" />
-						<button
-							type="button"
-							onClick={() => {
-								void hydrateChatResource(workspaceId, tab.sessionId)
-									.then((installed) => {
-										if (installed) return;
-										const { state, current } = currentChatDestination(workspaceId, tab, undefined);
-										if (
-											current &&
-											!state.removedWorkspaceIds[workspaceId] &&
-											!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
-										) {
-											toast.error("The chat could not be restored.", "Couldn't restore the chat");
-										}
-									})
-									.catch((error) => {
-										const { state, current } = currentChatDestination(workspaceId, tab, undefined);
-										if (
-											current &&
-											!state.removedWorkspaceIds[workspaceId] &&
-											!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
-										) {
-											toast.error(errorText(error), "Couldn't restore the chat");
-										}
-									});
-							}}
-							className="rounded-[var(--radius-sm)] border border-border-default px-8 py-4 tr-text-ui hover:bg-control-bg-hovered"
-						>
-							Retry
-						</button>
-					</div>
-				);
+				return <ChatResourceBody tab={tab} workspaceId={workspaceId} onOpenFile={openToolFile} />;
 			}
 			if (tab.kind === "document") {
 				if (deletedSessions?.[tab.sourceId]) return <MissingResource label="plan" />;
@@ -523,7 +535,6 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 			editorById,
 			editorByResource,
 			openToolFile,
-			sessions,
 			terminalByKey,
 			workspaceId,
 		],

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -489,7 +489,9 @@ branch's review — a commit sha means nothing in another worktree — and dropp
   (that ref *as an open diff tab's live dimension*: the target for a branch-scope tab, `""` for a
   commit/uncommitted one whose sides can't move — derived here, never re-assembled in a panel),
   `selectWorkspaceTick` (the sync-baseline snapshot), `selectWorkspaceSessionIds` (the deduplicated chat
-  layout-reference + history membership used as a reconnect-reconciliation baseline);
+  layout-reference + history membership used as a reconnect-reconciliation baseline),
+  `selectSessionRuntimePresent` (the allocation-free boolean leaf gate for a mounted chat resource; runtime
+  content replacement leaves it stable);
   `matchesWorktreePath` (line an agent-reported path — relative or absolute — up against a worktree-relative
   one; shared by the Changes deep link and the spec classifier. The suffix rule is for **absolute reports
   only** and is anchored at a separator: unanchored, `/wt/src/a-foo.ts` would match `src/foo.ts`; applied to

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -21,6 +21,7 @@ import {
 	selectLayoutResourcePlacement,
 	selectLayoutTabPlaced,
 	selectLayoutTabPlacement,
+	selectSessionRuntimePresent,
 	selectSkillsStale,
 	specPathMatcher,
 } from "./selectors";
@@ -43,6 +44,24 @@ test("connection generations reject stale or disconnected read settlements", () 
 	expect(isConnectedGeneration({ status: "connected", connectionGeneration: 4 }, 4)).toBe(true);
 	expect(isConnectedGeneration({ status: "connected", connectionGeneration: 5 }, 4)).toBe(false);
 	expect(isConnectedGeneration({ status: "disconnected", connectionGeneration: 4 }, 4)).toBe(false);
+});
+
+test("session runtime presence changes only at membership boundaries", () => {
+	const initial = { sessions: { active: { eventRevision: 1 } } };
+	const contentReplaced = {
+		sessions: {
+			...initial.sessions,
+			active: { eventRevision: 2 },
+			background: { eventRevision: 1 },
+		},
+	};
+
+	expect(selectSessionRuntimePresent(initial, "active")).toBe(true);
+	expect(selectSessionRuntimePresent(contentReplaced, "active")).toBe(true);
+	expect(selectSessionRuntimePresent(contentReplaced, "missing")).toBe(false);
+	expect(
+		selectSessionRuntimePresent({ sessions: { background: { eventRevision: 2 } } }, "active"),
+	).toBe(false);
 });
 
 test("workspace kind predicates distinguish managed and user-owned checkouts", () => {

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -349,6 +349,13 @@ export function selectChatTitle(
 	return (chatTab?.name ?? "Chat").trim() || "Chat";
 }
 
+export function selectSessionRuntimePresent(
+	state: { sessions: Readonly<Record<string, unknown>> },
+	sessionId: string,
+): boolean {
+	return state.sessions[sessionId] !== undefined;
+}
+
 export function selectCompactionTurnIds(
 	state: { sessions: Record<string, SessionRuntime> },
 	sessionId: string,


### PR DESCRIPTION
## Summary

- Stop background Pi session updates from rerendering the entire active workbench.
- Prevent the resulting Chrome renderer stalls and downstream Vite `/ws` `ECONNRESET` errors under concurrent agent activity.

## Changes

- Move chat-runtime presence tracking into a leaf `ChatResourceBody` that observes only its own session id.
- Keep active-chat rendering, lazy loading, hydration/removal, and restore/retry behavior unchanged.
- Add an allocation-free presence selector with regression coverage and record the render-isolation boundary in the shell/store specs.
- Leave WebSocket event ordering, host fan-out, and Vite proxy diagnostics unchanged.

## Testing

- `bun run check:deps && bun run check:seams && bun run lint && bun run typecheck && bun run test` — passed after rebasing onto `origin/main`.
- `bun run e2e` — 298 passed across 8 shards after rebasing.
- `bun run e2e -- e2e/reload-navigation.spec.ts` — 8 passed.
- Matched live-stream diagnostic (same 60 frames / 248,800 bytes over 10 seconds): main-thread task time fell from 3.23s to 0.12s; script time fell from 3.07s to 0.018s.
