### PR TITLE
fix(web): keep controls responsive while agents stream

### DIFF
--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -49,9 +49,11 @@ Every child is a directory module with `index.ts` as its public surface:
 The sibling dependency graph is: `layoutSync → layout`; `chatReconciliation → layout + layoutSync`;
 `terminalReconciliation → layout`; `layoutIntents → layout + chatReconciliation +
 terminalReconciliation`; `legacySelection` reaches store selectors/actions only; and
-`WorkspaceWorkbench` composes every orchestration barrel with `layout`, panels, and render callbacks. Siblings
-import only through these barrels. Tests live with the orchestration module that owns the behavior rather than
-making store tests import shell runtime synchronization.
+`WorkspaceWorkbench` composes every orchestration barrel with `layout`, panels, and render callbacks. Chat
+resource availability is isolated behind a per-session selector component; the parent workbench never
+subscribes to the whole `sessions` record, so a streaming runtime cannot invalidate every tab renderer and
+side tool behind it. Siblings import only through these barrels. Tests live with the orchestration module that
+owns the behavior rather than making store tests import shell runtime synchronization.
 
 ## Composition
 

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -90,6 +90,62 @@ function MissingResource({ label }: { label: string }) {
 	);
 }
 
+function ChatResourceBody({
+	workspaceId,
+	tab,
+	onOpenFile,
+}: {
+	workspaceId: string;
+	tab: Extract<LayoutCenterTab, { kind: "chat" }>;
+	onOpenFile: (path: string) => void;
+}) {
+	const available = useAppStore((state) => state.sessions[tab.sessionId] !== undefined);
+	if (available) {
+		return (
+			<ErrorBoundary label="chat" resetKeys={[workspaceId, tab.id]}>
+				<Suspense fallback={<MissingResource label="chat" />}>
+					<ChatView sessionId={tab.sessionId} workspaceId={workspaceId} onOpenFile={onOpenFile} />
+				</Suspense>
+			</ErrorBoundary>
+		);
+	}
+	return (
+		<div className="flex h-full flex-col items-center justify-center gap-8 text-text-muted">
+			<MissingResource label="chat" />
+			<button
+				type="button"
+				onClick={() => {
+					void hydrateChatResource(workspaceId, tab.sessionId)
+						.then((installed) => {
+							if (installed) return;
+							const { state, current } = currentChatDestination(workspaceId, tab, undefined);
+							if (
+								current &&
+								!state.removedWorkspaceIds[workspaceId] &&
+								!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
+							) {
+								toast.error("The chat could not be restored.", "Couldn't restore the chat");
+							}
+						})
+						.catch((error) => {
+							const { state, current } = currentChatDestination(workspaceId, tab, undefined);
+							if (
+								current &&
+								!state.removedWorkspaceIds[workspaceId] &&
+								!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
+							) {
+								toast.error(errorText(error), "Couldn't restore the chat");
+							}
+						});
+				}}
+				className="rounded-[var(--radius-sm)] border border-border-default px-8 py-4 tr-text-ui hover:bg-control-bg-hovered"
+			>
+				Retry
+			</button>
+		</div>
+	);
+}
+
 function useTerminalReservation(workspaceId: string): void {
 	const status = useAppStore((state) => state.status);
 	const connectionGeneration = useAppStore((state) => state.connectionGeneration);
@@ -163,7 +219,6 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const initialTerminalEligible = workspace?.initialTerminalEligible === true;
 	const contextProject = useAppStore(selectContextProject);
 	const editorTabs = useAppStore((state) => state.tabsByWorkspace[workspaceId] ?? NO_EDITOR_TABS);
-	const sessions = useAppStore((state) => state.sessions);
 	const deletedSessions = useAppStore((state) => state.deletedSessionsByWorkspace[workspaceId]);
 	const terminalClose = useTerminalClose();
 	const specs = useWorkspaceSpecs(workspaceId);
@@ -420,51 +475,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 	const renderTabBody = useCallback(
 		(tab: LayoutCenterTab | Extract<LayoutTab, { kind: "terminal" }>) => {
 			if (tab.kind === "chat") {
-				return sessions[tab.sessionId] ? (
-					<ErrorBoundary label="chat" resetKeys={[workspaceId, tab.id]}>
-						<Suspense fallback={<MissingResource label="chat" />}>
-							<ChatView
-								sessionId={tab.sessionId}
-								workspaceId={workspaceId}
-								onOpenFile={openToolFile}
-							/>
-						</Suspense>
-					</ErrorBoundary>
-				) : (
-					<div className="flex h-full flex-col items-center justify-center gap-8 text-text-muted">
-						<MissingResource label="chat" />
-						<button
-							type="button"
-							onClick={() => {
-								void hydrateChatResource(workspaceId, tab.sessionId)
-									.then((installed) => {
-										if (installed) return;
-										const { state, current } = currentChatDestination(workspaceId, tab, undefined);
-										if (
-											current &&
-											!state.removedWorkspaceIds[workspaceId] &&
-											!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
-										) {
-											toast.error("The chat could not be restored.", "Couldn't restore the chat");
-										}
-									})
-									.catch((error) => {
-										const { state, current } = currentChatDestination(workspaceId, tab, undefined);
-										if (
-											current &&
-											!state.removedWorkspaceIds[workspaceId] &&
-											!state.deletedSessionsByWorkspace[workspaceId]?.[tab.sessionId]
-										) {
-											toast.error(errorText(error), "Couldn't restore the chat");
-										}
-									});
-							}}
-							className="rounded-[var(--radius-sm)] border border-border-default px-8 py-4 tr-text-ui hover:bg-control-bg-hovered"
-						>
-							Retry
-						</button>
-					</div>
-				);
+				return <ChatResourceBody workspaceId={workspaceId} tab={tab} onOpenFile={openToolFile} />;
 			}
 			if (tab.kind === "document") {
 				if (deletedSessions?.[tab.sourceId]) return <MissingResource label="plan" />;
@@ -523,7 +534,6 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 			editorById,
 			editorByResource,
 			openToolFile,
-			sessions,
 			terminalByKey,
 			workspaceId,
 		],

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -252,8 +252,12 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   connected generation and advances the revision so two reads cannot regress one another. When the latest
   live compaction matches the durable record, its id + estimated-after count survive, and `resuming` survives
   only while the returned summary is still streaming. The
-  pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime; **`handlePiEvent` increments the revision even
-  for a UI-ignored Pi event**, because ignored still means it crossed the snapshot ordering boundary. **Only idle sends enter the transcript
+  pure **`reduceSessionEvent`** folds a `PiEvent` into a runtime; **`handlePiEvents` folds an ordered batch in
+  one atomic store write while incrementing each affected runtime's revision once per event, even for a
+  UI-ignored event**, because ignored still means it crossed the snapshot ordering boundary. The
+  single-event **`handlePiEvent`** delegates to that same path so tests and non-wire callers cannot drift.
+  Transport flushes a pending batch before delivering any later response or non-Pi push, preserving the
+  revision fence's received-message ordering. **Only idle sends enter the transcript
   optimistically** (`ChatView.onSubmit` → `appendUserMessage`); the last-turn echo dedup below is
   sufficient precisely because nothing intervenes before the echo. A **streaming send (`steer`/`followUp`)
   never appends a turn**: its text lives in `queue` (folded verbatim from the host-projected

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -4,6 +4,7 @@ import {
 	type ExtUiRequest,
 	type PiEvent,
 	type Project,
+	type SessionEventPayload,
 	type SessionSummary,
 	type SpecGraphNode,
 	type WireModel,
@@ -197,6 +198,34 @@ test("pi events route to the right session runtime; chats stay independent", () 
 	expect(rt("a").turns.some((t) => t.kind === "system" && t.text === "✓ Done")).toBe(true);
 	expect(rt("b").isStreaming).toBe(true);
 	expect(rt("b").turns).toHaveLength(0);
+});
+
+test("an ordered Pi-event batch commits once while preserving every session revision", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+	store.openChatSession("ws1", "b", null, "high");
+	const partial = { content: [{ type: "text", text: "partial" }] };
+	const payloads: SessionEventPayload[] = [
+		{ sessionId: "a", event: agentStart },
+		{ sessionId: "a", event: toolStart("t1") },
+		{ sessionId: "b", event: agentStart },
+		{ sessionId: "a", event: toolUpdate("t1", partial) },
+		{ sessionId: "missing", event: agentStart },
+	];
+	let commits = 0;
+	const unsubscribe = useAppStore.subscribe(() => {
+		commits += 1;
+	});
+
+	store.handlePiEvents(payloads);
+	unsubscribe();
+
+	expect(commits).toBe(1);
+	expect(rt("a").eventRevision).toBe(3);
+	expect(rt("a").isStreaming).toBe(true);
+	expect(rt("a").toolResults.t1).toEqual({ status: "running", raw: partial });
+	expect(rt("b").eventRevision).toBe(1);
+	expect(rt("b").isStreaming).toBe(true);
 });
 
 test("a host-fired USER message folds into the transcript; the composer's optimistic twin doesn't duplicate", () => {

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -210,6 +210,7 @@ test("an ordered Pi-event batch commits once while preserving every session revi
 		{ sessionId: "a", event: toolStart("t1") },
 		{ sessionId: "b", event: agentStart },
 		{ sessionId: "a", event: toolUpdate("t1", partial) },
+		{ sessionId: "a", event: agentEnd },
 		{ sessionId: "missing", event: agentStart },
 	];
 	let commits = 0;
@@ -221,7 +222,7 @@ test("an ordered Pi-event batch commits once while preserving every session revi
 	unsubscribe();
 
 	expect(commits).toBe(1);
-	expect(rt("a").eventRevision).toBe(3);
+	expect(rt("a").eventRevision).toBe(4);
 	expect(rt("a").isStreaming).toBe(true);
 	expect(rt("a").toolResults.t1).toEqual({ status: "running", raw: partial });
 	expect(rt("b").eventRevision).toBe(1);

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -16,6 +16,7 @@ import type {
 	RefreshedModels,
 	ReviewChangedPayload,
 	ReviewSnapshot,
+	SessionEventPayload,
 	SessionQueueState,
 	SessionStats,
 	SessionSummary,
@@ -856,6 +857,7 @@ interface AppState {
 		detail: string,
 	) => void;
 	handlePiEvent: (event: PiEvent, sessionId: string) => void;
+	handlePiEvents: (payloads: readonly SessionEventPayload[]) => void;
 	setModelsForProviderVersion: (providerVersion: number, models: WireModel[]) => void;
 	noteProviderChanged: () => void;
 	bumpTemplatesVersion: () => void;
@@ -2790,13 +2792,22 @@ export const useAppStore = create<AppState>((set, get) => ({
 						};
 			}),
 		),
-	handlePiEvent: (event, sessionId) =>
-		set((s) =>
-			withRuntime(s, sessionId, (rt) => ({
-				...reduceSessionEvent(rt, event),
-				eventRevision: rt.eventRevision + 1,
-			})),
-		),
+	handlePiEvent: (event, sessionId) => get().handlePiEvents([{ event, sessionId }]),
+	handlePiEvents: (payloads) =>
+		set((s) => {
+			let sessions = s.sessions;
+			for (const { event, sessionId } of payloads) {
+				const runtime = sessions[sessionId];
+				if (!runtime) continue;
+				if (sessions === s.sessions) sessions = { ...sessions };
+				const next = reduceSessionEvent(runtime, event);
+				sessions[sessionId] = {
+					...next,
+					eventRevision: runtime.eventRevision + 1,
+				};
+			}
+			return sessions === s.sessions ? s : { sessions };
+		}),
 	setModelsForProviderVersion: (providerVersion, models) =>
 		set((s) => (s.providerVersion === providerVersion ? { models, modelsFresh: false } : s)),
 	noteProviderChanged: () =>

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -10,7 +10,8 @@ tags: [v1]
 
 ## Responsibility
 
-The single WebSocket client to the host, and its app-wide singleton.
+The single WebSocket client to the host, its app-wide singleton, and the ordered delivery boundary that
+batches high-frequency Pi events without allowing later wire messages to overtake them.
 
 ## Boundary
 
@@ -36,7 +37,10 @@ The single WebSocket client to the host, and its app-wide singleton.
   `inferUrl` defaults to
   same-origin; **`httpBase()`** derives the host's HTTP origin
   from the WS `url` — for building host HTTP URLs like the `/files/<workspaceId>/<path>` worktree-file
-  endpoint the markdown viewer points relative `<img>`s at, targeting the same host the transport dials); `wireTransport.ts` (`initTransport`/
+  endpoint the markdown viewer points relative `<img>`s at, targeting the same host the transport dials); `piEventBatcher.ts`
+  (the browser-side bounded queue for consecutive `pi.event` frames: exact arrival order, no dropped events,
+  one atomic delivery at roughly 30 Hz, a 128-event forced-flush ceiling, and `flush`/`dispose` lifecycle);
+  `wireTransport.ts` (`initTransport`/
   `getTransport` singleton; routes `server.welcome`, **`project.updated`**, `pi.event`, `pi.extensionUi`,
   **`session.deleted`**, **`provider.changed`**, **`layout.changed`**, **the
   `workspace.created`/`updated`/`removed` lifecycle trio, and `workspace.fsChanged`** into the store — and
@@ -44,7 +48,8 @@ The single WebSocket client to the host, and its app-wide singleton.
   `setStatus`, whose connected generation gives active-workspace hydration a distinct trigger on every
   reconnect; the complete welcome (protocol + open/recent project views + optional config) via the atomic
   `installWelcomeSnapshot`, whose separate `welcomeGeneration` is the cold-navigation readiness edge;
-  project snapshots via `applyProjectUpdated`, `pi.event` via `handlePiEvent(event, sessionId)`, `pi.extensionUi` via `applyExtUi(request)`,
+  project snapshots via `applyProjectUpdated`, consecutive `pi.event` frames through the batcher into one
+  `handlePiEvents(payloads)` store commit, `pi.extensionUi` via `applyExtUi(request)`,
   `workspace.created` via `addWorkspace(workspace)`, `workspace.updated` via `updateWorkspace(workspace)`,
   `workspace.removed` via `applyWorkspaceRemoved(projectId, id)`, `session.deleted` via the idempotent
   `deleteChat(workspaceId, sessionId)` tombstone fold (an online fast path; because this event channel is
@@ -60,8 +65,10 @@ The single WebSocket client to the host, and its app-wide singleton.
   revision before rendering it),
   `workspace.fsChanged` via `noteFsChanged(payload)`, and
   **`settings.changed`** via `applyConfig(config)` — the post-startup server-synced app config broadcast;
-  welcome config lands in the atomic install above. All subscriptions happen once at init, never in
-  component effects);
+  welcome config lands in the atomic install above. Before `WsTransport` dispatches any response or non-Pi
+  push, `wireTransport` flushes queued Pi events synchronously; connection-status transitions do the same.
+  This dispatch barrier preserves cross-message order and the store's transcript-revision fence while still
+  collapsing consecutive stream frames. All subscriptions happen once at init, never in component effects);
   `errorText.ts` (**`errorText(err, fallback?)`** — normalizes a rejected `request` (the host's error
   string / a timeout / a thrown non-Error) into a short, display-ready line for an error turn/notice);
   `requestError.ts` (**`RequestError`** + **`wsErrorCode(err)`** — a rejection that carries the host's named

--- a/apps/web/src/transport/piEventBatcher.test.ts
+++ b/apps/web/src/transport/piEventBatcher.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import type { PiEvent, SessionEventPayload, WsServerMessage } from "@thinkrail/contracts";
+import { WS_CHANNELS } from "@thinkrail/contracts";
+import { createPiEventBatcher, shouldFlushPiEventsBefore } from "./piEventBatcher";
+
+const payload = (sessionId: string, type: PiEvent["type"]): SessionEventPayload => ({
+	sessionId,
+	event: { type } as PiEvent,
+});
+
+test("batches consecutive Pi events in exact arrival order", () => {
+	const delivered: (readonly SessionEventPayload[])[] = [];
+	let scheduled: (() => void) | null = null;
+	const batcher = createPiEventBatcher((events) => delivered.push(events), {
+		schedule: (flush) => {
+			scheduled = flush;
+			return () => {
+				if (scheduled === flush) scheduled = null;
+			};
+		},
+	});
+	const first = payload("a", "agent_start");
+	const second = payload("b", "turn_start");
+
+	batcher.enqueue(first);
+	batcher.enqueue(second);
+	expect(delivered).toEqual([]);
+	expect(scheduled).not.toBeNull();
+	scheduled?.();
+
+	expect(delivered).toEqual([[first, second]]);
+	expect(scheduled).toBeNull();
+});
+
+test("the queue ceiling forces a flush and disposal drops pending work", () => {
+	const delivered: (readonly SessionEventPayload[])[] = [];
+	let scheduled: (() => void) | null = null;
+	const batcher = createPiEventBatcher((events) => delivered.push(events), {
+		maxBatchSize: 2,
+		schedule: (flush) => {
+			scheduled = flush;
+			return () => {
+				if (scheduled === flush) scheduled = null;
+			};
+		},
+	});
+	const first = payload("a", "agent_start");
+	const second = payload("a", "turn_start");
+	const third = payload("a", "agent_end");
+
+	batcher.enqueue(first);
+	batcher.enqueue(second);
+	expect(delivered).toEqual([[first, second]]);
+	expect(scheduled).toBeNull();
+
+	batcher.enqueue(third);
+	expect(scheduled).not.toBeNull();
+	batcher.dispose();
+	scheduled?.();
+	batcher.enqueue(first);
+	batcher.flush();
+
+	expect(delivered).toEqual([[first, second]]);
+});
+
+test("responses and non-Pi pushes form dispatch barriers", () => {
+	const piPush = {
+		channel: WS_CHANNELS.piEvent,
+		data: payload("a", "agent_start"),
+	} as WsServerMessage;
+	const otherPush = {
+		channel: WS_CHANNELS.workspaceFsChanged,
+		data: {},
+	} as WsServerMessage;
+	const response = { id: "r1", ok: true, result: {} } as WsServerMessage;
+
+	expect(shouldFlushPiEventsBefore(piPush)).toBe(false);
+	expect(shouldFlushPiEventsBefore(otherPush)).toBe(true);
+	expect(shouldFlushPiEventsBefore(response)).toBe(true);
+});

--- a/apps/web/src/transport/piEventBatcher.ts
+++ b/apps/web/src/transport/piEventBatcher.ts
@@ -1,0 +1,67 @@
+import type { SessionEventPayload, WsServerMessage } from "@thinkrail/contracts";
+import { WS_CHANNELS } from "@thinkrail/contracts";
+
+const DEFAULT_DELAY_MS = 32;
+const DEFAULT_MAX_BATCH_SIZE = 128;
+
+type CancelScheduledFlush = () => void;
+type ScheduleFlush = (flush: () => void) => CancelScheduledFlush;
+
+interface PiEventBatcherOptions {
+	maxBatchSize?: number;
+	schedule?: ScheduleFlush;
+}
+
+export interface PiEventBatcher {
+	enqueue: (payload: SessionEventPayload) => void;
+	flush: () => void;
+	dispose: () => void;
+}
+
+function defaultSchedule(flush: () => void): CancelScheduledFlush {
+	const timer = setTimeout(flush, DEFAULT_DELAY_MS);
+	return () => clearTimeout(timer);
+}
+
+export function createPiEventBatcher(
+	deliver: (payloads: readonly SessionEventPayload[]) => void,
+	options: PiEventBatcherOptions = {},
+): PiEventBatcher {
+	const maxBatchSize = options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
+	const schedule = options.schedule ?? defaultSchedule;
+	let queued: SessionEventPayload[] = [];
+	let cancelScheduled: CancelScheduledFlush | null = null;
+	let disposed = false;
+
+	const flush = () => {
+		cancelScheduled?.();
+		cancelScheduled = null;
+		if (disposed || queued.length === 0) return;
+		const payloads = queued;
+		queued = [];
+		deliver(payloads);
+	};
+
+	return {
+		enqueue: (payload) => {
+			if (disposed) return;
+			queued.push(payload);
+			if (queued.length >= maxBatchSize) {
+				flush();
+				return;
+			}
+			cancelScheduled ??= schedule(flush);
+		},
+		flush,
+		dispose: () => {
+			disposed = true;
+			queued = [];
+			cancelScheduled?.();
+			cancelScheduled = null;
+		},
+	};
+}
+
+export function shouldFlushPiEventsBefore(message: WsServerMessage): boolean {
+	return !("channel" in message) || message.channel !== WS_CHANNELS.piEvent;
+}

--- a/apps/web/src/transport/transport.test.ts
+++ b/apps/web/src/transport/transport.test.ts
@@ -101,6 +101,33 @@ describe("WsTransport channel replay", () => {
 	});
 });
 
+describe("WsTransport dispatch barriers", () => {
+	test("runs the barrier before channel subscribers and response settlement", async () => {
+		const order: string[] = [];
+		const transport = new WsTransport(
+			{ url: "ws://localhost:24242/ws" },
+			{ beforeDispatch: () => order.push("barrier") },
+		);
+		transport.subscribe(WS_CHANNELS.projectUpdated, () => order.push("push"));
+		transport.connect();
+		const socket = TestWebSocket.instances[0];
+		socket?.open();
+
+		socket?.message(JSON.stringify({ channel: WS_CHANNELS.projectUpdated, data: {} }));
+		expect(order).toEqual(["barrier", "push"]);
+
+		order.length = 0;
+		const result = transport.request("project.list", {}).then((value) => {
+			order.push("response");
+			return value;
+		});
+		const id = requestsIn(socket?.sent ?? [])[0]?.id;
+		socket?.message(JSON.stringify({ id, ok: true, result: [] }));
+		expect(await result).toEqual([]);
+		expect(order).toEqual(["barrier", "response"]);
+	});
+});
+
 describe("WsTransport reconnect delivery", () => {
 	test("replays an unresolved frame under the same id and resolves from the replacement socket", async () => {
 		const statuses: string[] = [];

--- a/apps/web/src/transport/transport.ts
+++ b/apps/web/src/transport/transport.ts
@@ -11,6 +11,10 @@ export interface TransportOptions {
 	onStatus?: (status: ConnectionStatus) => void;
 }
 
+interface TransportDispatchHooks {
+	beforeDispatch?: (message: WsServerMessage) => void;
+}
+
 const DEFAULT_TIMEOUT_MS = 60_000;
 
 const NON_REPLAYABLE_CHANNELS: ReadonlySet<string> = new Set([
@@ -43,6 +47,7 @@ export class WsTransport {
 	private ws: WebSocket | null = null;
 	private readonly url: string;
 	private readonly onStatus: ((status: ConnectionStatus) => void) | undefined;
+	private readonly beforeDispatch: ((message: WsServerMessage) => void) | undefined;
 	private seq = 0;
 	private readonly pending = new Map<
 		string,
@@ -59,9 +64,10 @@ export class WsTransport {
 	private ackScheduled = false;
 	private backoff = 500;
 
-	constructor(opts: TransportOptions = {}) {
+	constructor(opts: TransportOptions = {}, dispatchHooks: TransportDispatchHooks = {}) {
 		this.url = opts.url ?? inferUrl();
 		this.onStatus = opts.onStatus;
+		this.beforeDispatch = dispatchHooks.beforeDispatch;
 	}
 
 	httpBase(): string {
@@ -166,6 +172,7 @@ export class WsTransport {
 		} catch {
 			return;
 		}
+		this.beforeDispatch?.(msg);
 		if ("channel" in msg) {
 			if (!NON_REPLAYABLE_CHANNELS.has(msg.channel)) this.latest.set(msg.channel, msg.data);
 			const set = this.subscribers.get(msg.channel);

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -14,16 +14,30 @@ import type {
 } from "@thinkrail/contracts";
 import { WS_CHANNELS } from "@thinkrail/contracts";
 import { useAppStore } from "../store";
+import { createPiEventBatcher, shouldFlushPiEventsBefore } from "./piEventBatcher";
 import { WsTransport } from "./transport";
 
 let transport: WsTransport | null = null;
 
 export function initTransport(): WsTransport {
 	if (transport) return transport;
+	const piEvents = createPiEventBatcher((payloads) =>
+		useAppStore.getState().handlePiEvents(payloads),
+	);
 
-	transport = new WsTransport({
-		onStatus: (status) => useAppStore.getState().setStatus(status),
-	});
+	transport = new WsTransport(
+		{
+			onStatus: (status) => {
+				piEvents.flush();
+				useAppStore.getState().setStatus(status);
+			},
+		},
+		{
+			beforeDispatch: (message) => {
+				if (shouldFlushPiEventsBefore(message)) piEvents.flush();
+			},
+		},
+	);
 
 	transport.subscribe(WS_CHANNELS.serverWelcome, (data) => {
 		const welcome = data as Partial<ServerWelcome>;
@@ -48,8 +62,7 @@ export function initTransport(): WsTransport {
 	});
 
 	transport.subscribe(WS_CHANNELS.piEvent, (data) => {
-		const { sessionId, event } = data as SessionEventPayload;
-		useAppStore.getState().handlePiEvent(event, sessionId);
+		piEvents.enqueue(data as SessionEventPayload);
 	});
 
 	transport.subscribe(WS_CHANNELS.piExtensionUi, (data) => {


### PR DESCRIPTION
## Summary

Opening or saving a prompt template could take several seconds while an agent was writing a reply.

The template code was not broken. The server read and saved the files quickly. The slowdown happened in the browser: every small piece of the agent reply caused a new state update and too much of the page was rendered again. The browser stayed busy and could not handle the small template response promptly.

The agent stream and settings requests do share one WebSocket, so the template response also waited behind stream messages. That made the delay worse, but it was not the main problem. A second socket would still leave the browser too busy to update the screen.

This PR fixes the browser work first. It groups agent events into small batches and stops the whole workbench from reacting to every streamed update.

## What changed

### Group stream updates

- Consecutive `pi.event` messages are delivered to the store together, roughly 30 times per second instead of once for every incoming frame.
- Every event is still processed, in the same order. Nothing is dropped or replaced.
- The queue has a 128-event limit, so a slow or background tab cannot grow it forever.
- Before handling a settings response, another kind of push message, or a connection change, the client flushes pending agent events first. This keeps the original wire order exact.

### Update state once per batch

- The store reduces a whole ordered batch in one atomic write.
- `eventRevision` still advances once for every received event, including events that do not change anything visible. Transcript reconciliation therefore keeps the same safety rules as before.
- The old single-event action uses the same batch path, so the two paths cannot drift apart.

### Keep the workbench out of the stream hot path

- `WorkspaceWorkbench` no longer subscribes to the complete `sessions` object.
- A small per-chat boundary only watches whether its session exists.
- The active `ChatView` still receives live updates, but unrelated tabs and side panels no longer render again for every piece of the reply.

## Why this approach

This is the smallest change that addresses the measured cause:

- no server changes;
- no protocol changes;
- no second WebSocket;
- no lost or reordered agent events;
- no change to template storage.

Server-side coalescing or separate sockets can still be considered later, but the new profile shows they are not needed for this problem.

## Measured result

I repeated the same template interaction on the same machine, workspace, and real provider while the agent was streaming. About 90 Pi frames arrived during the second before the click.

| Measurement | Before | After |
| --- | ---: | ---: |
| Template read response | 2.16 s | 13.7 ms |
| Template editor ready | 2.72 s | 33.4 ms |
| Stream data handled before the response | 159 frames / 2.68 MiB | 1 frame / 12.1 KiB |
| Template save fully settled | several-second visible stall | 38.6 ms |

The browser and server error logs were empty. The temporary template and profiling chat were removed after the run.

## Testing

- `bun run check:deps` — passed
- `bun run check:boundaries` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed with 6 existing unused-suppression warnings outside this change
- `bun run typecheck` — 12/12 package tasks passed
- `bun run test` — 12/12 package tasks passed
- `bun run e2e` — 298 browser tests passed across 8 shards
- Real-browser Chrome profile during a live agent stream — template read, editor readiness, and save timings verified

New unit tests cover ordered batching, the queue limit, disposal, response/push ordering barriers, one store commit per batch, multiple sessions, ignored events, and exact revision advancement.
