### PR TITLE
Refine scrollbar sizing

### DIFF
--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -30,8 +30,8 @@ a {
 }
 
 ::-webkit-scrollbar {
-	width: 10px;
-	height: 10px;
+	width: 6px;
+	height: 6px;
 }
 ::-webkit-scrollbar-thumb {
 	background: var(--border-default);


### PR DESCRIPTION
## Summary
Compact ThinkRail's application scrollbars so they read as secondary
chrome. The shared native `::-webkit-scrollbar` shrinks from 10px to
**6px** (width + height) in `apps/web/src/styles/global.css` — one
centralized edit; the thumb keeps the semantic `--border-default` token.


## Testing
- `apps/web` typecheck — pass
- biome — pass
- `bun run e2e` (no-agent) — all green (one flaky terminal spec passed on retry)


## Screenshots

Projects sidebar, **barely overflowing** (content clears the viewport by ~28px) — the case where the native proportional thumb spans most of the track. Native macOS scrollbars are overlay, so these are captured mid-scroll.

| Before — 10px | After — 6px |
| --- | --- |
| 
<img width="1884" height="870" alt="Screenshot 2026-08-28 at 5 54 42 PM" src="https://github.com/user-attachments/assets/5a3af52a-b892-4790-905a-981438391f8f" />
 | 
<img width="1881" height="870" alt="Screenshot 2026-08-28 at 6 00 25 PM" src="https://github.com/user-attachments/assets/fd82441a-2047-431c-bcb6-d81016898c9b" />
 |
