### PR TITLE
feat(web): add Try again recovery for agent failures

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -61,6 +61,8 @@ import { useChatTodos } from "./useChatTodos";
 import { useHistorySearch } from "./useHistorySearch";
 import { useTranscriptSync } from "./useTranscriptSync";
 
+const TRY_AGAIN_PROMPT = "Try again.";
+
 function turnAnchorText(turn: ChatTurn): string {
 	if (turn.kind === "user") {
 		const { content } = turn.message;
@@ -714,6 +716,7 @@ export default function ChatView({
 										onOpenSpec={onOpenSpec}
 										onOpenChange={onOpenChange}
 										onReveal={onReveal}
+										onTryAgain={() => performSend(TRY_AGAIN_PROMPT, [], "send")}
 									/>
 								</div>
 							)}

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -50,9 +50,15 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   end event clears only its own), and `RetryIndicator` labels them apart ("Retrying" vs "Retrying
   summarization"). **`ErrorTurn`** is a persistent tinted failure notice
   (provider/model error, an unrecovered `length` truncation, or a rejected send) — **never folded**, so
-  a failed turn can't look like nothing happened. Live settlement and transcript hydration share the
-  same assistant-failure classifier, so reload cannot turn the latest unresolved failure into success;
-  recovered historical `length` attempts followed by later work are not re-labeled as current failures.
+  a failed turn can't look like nothing happened. Only the current settlement-derived failure carries the
+  web-local `try-again` recovery action; its **Try again** button sends one visible ordinary `Try again.` user
+  message through `ChatView`'s existing immediate-send path. Rejected sends, extension notifications, and
+  generic app errors stay non-actionable because the missing prompt or repair may not be in Pi's context.
+  The optimistic user append consumes the action immediately, and any later `agent_start` consumes it for
+  other-client/custom-message starts, so a historical error never regains the affordance. Live settlement
+  and transcript hydration share the same assistant-failure classifier and action derivation, so reload
+  cannot turn the latest unresolved failure into success or lose its recovery; recovered historical
+  `length` attempts followed by later work are not re-labeled as current failures.
 - `compaction` — a 1:1, fold-breaking row with two sources that converge. Live `compaction_start` /
   `compaction_end` events produce `CompactionNotice` (see the store SPEC): running "Compacting context…"
   (spinner), done **"Context compacted"** (+ "— resuming…" while pi's overflow retry continues the run, +
@@ -860,7 +866,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   **`useTranscriptSync.ts`** (the guarded authoritative read that converges an existing runtime), and
   **`TemplateEditorDialog.tsx`** (the shared template save form), the other integration points. A
   **rejected** send (`prompt`/`steer`/`followUp`) lands in the chat via the store's `appendErrorTurn` —
-  never swallowed; *streaming* faults arrive as pi events instead.
+  never swallowed and never given the settlement-only Try again affordance; *streaming* faults arrive as pi
+  events instead.
 
 ## Streaming model
 

--- a/apps/web/src/chat/hydrate.test.ts
+++ b/apps/web/src/chat/hydrate.test.ts
@@ -46,6 +46,7 @@ test("an assistant turn that ended in a provider error hydrates a following erro
 	expect(turns.map((t) => t.kind)).toEqual(["user", "assistant", "error"]);
 	const err = turns.find((t) => t.kind === "error");
 	expect(err?.kind === "error" && err.text).toContain("gpt-5.5");
+	expect(err?.kind === "error" ? err.recovery : undefined).toBe("try-again");
 });
 
 test("an assistant turn that ended at length hydrates a visible truncation failure", () => {
@@ -57,6 +58,7 @@ test("an assistant turn that ended at length hydrates a visible truncation failu
 	expect(turns.map((turn) => turn.kind)).toEqual(["user", "assistant", "error"]);
 	const error = turns.find((turn) => turn.kind === "error");
 	expect(error?.kind === "error" && error.text.toLowerCase()).toContain("truncated");
+	expect(error?.kind === "error" ? error.recovery : undefined).toBe("try-again");
 });
 
 test("a recovered historical length stop does not become the current chat failure", () => {
@@ -77,6 +79,7 @@ test("a recovered historical length stop does not become the current chat failur
 	] as unknown as Message[]);
 
 	expect(turns.filter((turn) => turn.kind === "error")).toHaveLength(0);
+	expect(turns.some((turn) => turn.kind === "error" && turn.recovery)).toBe(false);
 });
 
 test("settlement metadata restores a failure Pi removed from a live session's context", () => {

--- a/apps/web/src/chat/hydrate.ts
+++ b/apps/web/src/chat/hydrate.ts
@@ -63,7 +63,13 @@ export function messagesToRuntime(
 	const failure = assistantFailureText(
 		lastSettlement === undefined ? persistedTerminal : lastSettlement,
 	);
-	if (failure) turns.push({ kind: "error", id: crypto.randomUUID(), text: failure });
+	if (failure)
+		turns.push({
+			kind: "error",
+			id: crypto.randomUUID(),
+			text: failure,
+			recovery: "try-again",
+		});
 
 	return { turns, toolResults, askAnswers, turnIdByMessageIndex };
 }

--- a/apps/web/src/chat/rows.test.ts
+++ b/apps/web/src/chat/rows.test.ts
@@ -149,7 +149,7 @@ describe("deriveRows grouping", () => {
 		const turns: ChatTurn[] = [
 			user("u1"),
 			assistant("a1", [tc("t1")]),
-			{ kind: "error", id: "e1", text: "boom" },
+			{ kind: "error", id: "e1", text: "boom", recovery: "try-again" },
 			{
 				kind: "retry",
 				id: "r1",
@@ -162,6 +162,7 @@ describe("deriveRows grouping", () => {
 		];
 		const rows = deriveRows(turns, {}, true);
 		expect(kinds(rows)).toEqual(["user", "activity", "error", "retry", "activity"]);
+		expect(rows[2]?.kind === "error" ? rows[2].recovery : undefined).toBe("try-again");
 		expect(rows[3]?.kind === "retry" && rows[3].source).toBe("summarization");
 		expect(rows[1]?.kind === "activity" && rows[1].steps.length).toBe(1);
 		expect(rows[4]?.kind === "activity" && rows[4].steps.length).toBe(1);

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -1,7 +1,7 @@
 import type { UserMessage } from "@thinkrail/contracts";
 import { resolveProminence } from "./toolRegistry";
 import { strArg } from "./tools/toolHelpers";
-import type { ChatTurn, CompactionState, ToolResultState } from "./types";
+import type { ChatTurn, CompactionState, FailureRecovery, ToolResultState } from "./types";
 
 export interface ToolCallData {
 	toolCallId: string;
@@ -27,7 +27,7 @@ export type ActivityStep = RoutineToolStep | ThinkingStep;
 export type ChatRow =
 	| { kind: "user"; id: string; message: UserMessage; attachmentNames?: string[] }
 	| { kind: "system"; id: string; text: string }
-	| { kind: "error"; id: string; text: string }
+	| { kind: "error"; id: string; text: string; recovery?: FailureRecovery }
 	| ({ kind: "compaction"; id: string } & CompactionState)
 	| {
 			kind: "retry";
@@ -133,7 +133,12 @@ export function deriveRows(
 					rows.push({ kind: "system", id: turn.id, text: turn.text });
 					break;
 				case "error":
-					rows.push({ kind: "error", id: turn.id, text: turn.text });
+					rows.push({
+						kind: "error",
+						id: turn.id,
+						text: turn.text,
+						...(turn.recovery ? { recovery: turn.recovery } : {}),
+					});
 					break;
 				case "compaction":
 					rows.push(turn);

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -12,6 +12,7 @@ import {
 import type { ImageContent, UserMessage } from "@thinkrail/contracts";
 import { type ReactNode, useEffect, useState } from "react";
 import { CustomIcon } from "@/components/CustomIcon";
+import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
 	cn,
@@ -39,6 +40,7 @@ export function ChatTurnView({
 	onOpenSpec,
 	onOpenChange,
 	onReveal,
+	onTryAgain,
 }: {
 	row: ChatRow;
 	workspaceRoot?: string | undefined;
@@ -46,6 +48,7 @@ export function ChatTurnView({
 	onOpenSpec?: ((path: string) => void) | undefined;
 	onOpenChange?: ((path: string) => void) | undefined;
 	onReveal?: ((tab: "specs" | "changes") => void) | undefined;
+	onTryAgain?: (() => void) | undefined;
 }) {
 	switch (row.kind) {
 		case "user":
@@ -53,7 +56,12 @@ export function ChatTurnView({
 		case "system":
 			return <SystemTurn text={row.text} />;
 		case "error":
-			return <ErrorTurn text={row.text} />;
+			return (
+				<ErrorTurn
+					text={row.text}
+					onTryAgain={row.recovery === "try-again" ? onTryAgain : undefined}
+				/>
+			);
 		case "compaction":
 			return row.summary !== undefined && row.tokensBefore !== undefined ? (
 				<CompactionTurn
@@ -412,7 +420,13 @@ function CompactionTurn({
 	);
 }
 
-function ErrorTurn({ text }: { text: string }) {
+function ErrorTurn({
+	text,
+	onTryAgain,
+}: {
+	text: string;
+	onTryAgain?: (() => void) | undefined;
+}) {
 	return (
 		<div
 			data-testid="chat-message"
@@ -420,7 +434,19 @@ function ErrorTurn({ text }: { text: string }) {
 			className="flex items-start gap-8 rounded-[var(--radius-sm)] border border-feedback-error-muted bg-clip-padding bg-feedback-error-subtle px-12 py-8 text-feedback-error tr-text-ui"
 		>
 			<TriangleAlert className="mt-2 size-12 shrink-0" />
-			<span className="min-w-0 whitespace-pre-wrap break-words">{text}</span>
+			<span className="min-w-0 flex-1 whitespace-pre-wrap break-words">{text}</span>
+			{onTryAgain ? (
+				<Button
+					variant="outline"
+					size="sm"
+					data-testid="agent-try-again"
+					className="shrink-0"
+					onClick={onTryAgain}
+				>
+					<RotateCw className="size-12" />
+					Try again
+				</Button>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -420,13 +420,7 @@ function CompactionTurn({
 	);
 }
 
-function ErrorTurn({
-	text,
-	onTryAgain,
-}: {
-	text: string;
-	onTryAgain?: (() => void) | undefined;
-}) {
+function ErrorTurn({ text, onTryAgain }: { text: string; onTryAgain?: (() => void) | undefined }) {
 	return (
 		<div
 			data-testid="chat-message"

--- a/apps/web/src/chat/types.ts
+++ b/apps/web/src/chat/types.ts
@@ -15,12 +15,14 @@ export type ExtUiDialogRequest = Extract<
 	{ kind: "select" | "confirm" | "input" | "editor" }
 >;
 
+export type FailureRecovery = "try-again";
+
 export type ChatTurn =
 	| { kind: "user"; id: string; message: UserMessage; attachmentNames?: string[] }
 	| { kind: "assistant"; id: string; message: AssistantMessage; streaming: boolean }
 	| { kind: "system"; id: string; text: string; endedAt?: number }
 	| ({ kind: "compaction"; id: string } & CompactionState)
-	| { kind: "error"; id: string; text: string }
+	| { kind: "error"; id: string; text: string; recovery?: FailureRecovery }
 	| {
 			kind: "retry";
 			id: string;

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -180,11 +180,17 @@ snapshots plus device-local attention, terminal catalogs, and one **per-session 
   `setCurrentModel` / `setThinkingLevel` / `setChatDraft` / `clearPendingExtUi`) take a `sessionId`.
   **`appendErrorTurn(sessionId, text)`** appends an `error` turn for a **rejected** turn-driving wire call
   (`session.prompt`/`steer`/`followUp`/`create`) — e.g. `prompt()` throwing "no API key" / a bad model —
-  so a failed send lands in the chat instead of being swallowed; a *streaming* fault instead ends the run
-  through **`reduceSessionEvent`** at `agent_settled`, using the host-projected final terminal metadata:
+  so a failed send lands in the chat instead of being swallowed; it carries no recovery action because Pi
+  never accepted the missing turn. A *streaming* fault instead ends the run through
+  **`reduceSessionEvent`** at `agent_settled`, using the host-projected final terminal metadata:
   `stopReason: "error"` carries Pi's `errorMessage`, and `stopReason: "length"` becomes an actionable
-  truncation error — neither may become "✓ Done". `agent_end` is attempt-level and never clears
-  `isStreaming`; settlement alone finishes retries, compaction, and queued continuations. The
+  truncation error — neither may become "✓ Done". That settlement-created error turn alone carries the
+  web-local `recovery: "try-again"` marker; hydration gives the same marker only to its synthesized current
+  final failure. `appendUserMessage` consumes every prior marker in the same optimistic write that adds the
+  follow-on user turn, while `agent_start` consumes it for work begun by another client or a custom message.
+  Thus the renderer can offer one ordinary `Try again.` send without parsing errors or leaving an actionable
+  historical failure. `agent_end` is attempt-level and never clears `isStreaming`; settlement alone finishes
+  retries, compaction, and queued continuations. The
   **compaction lifecycle is a first-class turn**: `compaction_start` appends a `compaction` turn
   (`running`), `compaction_end` settles the trailing running one in place (success → `done` +
   tokens-before/after from the typed `CompactionEndResult`, guarded — wire data is untrusted; `aborted`

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -587,6 +587,7 @@ test("a turn that ends in a provider error surfaces the error (not a false ✓ D
 	expect(after.isStreaming).toBe(false);
 	const err = after.turns.find((t) => t.kind === "error");
 	expect(err?.kind === "error" && err.text).toContain("gpt-5.5");
+	expect(err?.kind === "error" ? err.recovery : undefined).toBe("try-again");
 	expect(after.turns.some((t) => t.kind === "system" && t.text === "✓ Done")).toBe(false);
 });
 
@@ -601,8 +602,29 @@ test("a terminal length stop is a visible failure, never a false ✓ Done", () =
 	const after = rt("a");
 	const error = after.turns.find((turn) => turn.kind === "error");
 	expect(error?.kind === "error" && error.text.toLowerCase()).toContain("truncated");
+	expect(error?.kind === "error" ? error.recovery : undefined).toBe("try-again");
 	expect(after.turns.some((turn) => turn.kind === "system" && turn.text === "✓ Done")).toBe(false);
 	expect(after.isStreaming).toBe(false);
+});
+
+test("a local follow-on or another client's agent start consumes the failure recovery", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+	store.openChatSession("ws1", "b", null, "medium");
+	for (const sessionId of ["a", "b"]) {
+		store.handlePiEvent(
+			agentSettled({ stopReason: "error", errorMessage: "fetch failed" }),
+			sessionId,
+		);
+	}
+
+	store.appendUserMessage("a", "Try again.");
+	store.handlePiEvent(agentStart, "b");
+
+	for (const sessionId of ["a", "b"]) {
+		const error = rt(sessionId).turns.find((turn) => turn.kind === "error");
+		expect(error?.kind === "error" ? error.recovery : undefined).toBeUndefined();
+	}
 });
 
 test("a successful overflow compaction removes the superseded assistant attempt", () => {
@@ -817,6 +839,7 @@ test("appendErrorTurn surfaces a failed send (a rejected prompt) as a visible er
 
 	const err = rt("a").turns.find((t) => t.kind === "error");
 	expect(err?.kind === "error" && err.text).toContain("No API key");
+	expect(err?.kind === "error" ? err.recovery : undefined).toBeUndefined();
 	expect(rt("a").isStreaming).toBe(false);
 });
 

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -12,7 +12,7 @@ import {
 	type WorkspaceLayoutDocument,
 	type WorkspaceSkillChange,
 } from "@thinkrail/contracts";
-import type { ChatTurn } from "../chat/types";
+import type { ChatTurn, FailureRecovery } from "../chat/types";
 import { userText } from "../lib";
 import {
 	captureCenterNavigation,
@@ -150,6 +150,11 @@ function rt(sessionId: string): SessionRuntime {
 	const runtime = useAppStore.getState().sessions[sessionId];
 	if (!runtime) throw new Error(`no runtime for ${sessionId}`);
 	return runtime;
+}
+
+function failureRecovery(sessionId: string): FailureRecovery | undefined {
+	const error = rt(sessionId).turns.find((turn) => turn.kind === "error");
+	return error?.kind === "error" ? error.recovery : undefined;
 }
 
 test("each connected status advances the reconnect generation atomically", () => {
@@ -587,7 +592,7 @@ test("a turn that ends in a provider error surfaces the error (not a false ✓ D
 	expect(after.isStreaming).toBe(false);
 	const err = after.turns.find((t) => t.kind === "error");
 	expect(err?.kind === "error" && err.text).toContain("gpt-5.5");
-	expect(err?.kind === "error" ? err.recovery : undefined).toBe("try-again");
+	expect(failureRecovery("a")).toBe("try-again");
 	expect(after.turns.some((t) => t.kind === "system" && t.text === "✓ Done")).toBe(false);
 });
 
@@ -602,12 +607,12 @@ test("a terminal length stop is a visible failure, never a false ✓ Done", () =
 	const after = rt("a");
 	const error = after.turns.find((turn) => turn.kind === "error");
 	expect(error?.kind === "error" && error.text.toLowerCase()).toContain("truncated");
-	expect(error?.kind === "error" ? error.recovery : undefined).toBe("try-again");
+	expect(failureRecovery("a")).toBe("try-again");
 	expect(after.turns.some((turn) => turn.kind === "system" && turn.text === "✓ Done")).toBe(false);
 	expect(after.isStreaming).toBe(false);
 });
 
-test("a local follow-on or another client's agent start consumes the failure recovery", () => {
+test("a local follow-on consumes only its session's failure recovery", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");
 	store.openChatSession("ws1", "b", null, "medium");
@@ -619,12 +624,26 @@ test("a local follow-on or another client's agent start consumes the failure rec
 	}
 
 	store.appendUserMessage("a", "Try again.");
+
+	expect(failureRecovery("a")).toBeUndefined();
+	expect(failureRecovery("b")).toBe("try-again");
+});
+
+test("another client's agent start consumes only its session's failure recovery", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+	store.openChatSession("ws1", "b", null, "medium");
+	for (const sessionId of ["a", "b"]) {
+		store.handlePiEvent(
+			agentSettled({ stopReason: "error", errorMessage: "fetch failed" }),
+			sessionId,
+		);
+	}
+
 	store.handlePiEvent(agentStart, "b");
 
-	for (const sessionId of ["a", "b"]) {
-		const error = rt(sessionId).turns.find((turn) => turn.kind === "error");
-		expect(error?.kind === "error" ? error.recovery : undefined).toBeUndefined();
-	}
+	expect(failureRecovery("a")).toBe("try-again");
+	expect(failureRecovery("b")).toBeUndefined();
 });
 
 test("a successful overflow compaction removes the superseded assistant attempt", () => {
@@ -839,7 +858,7 @@ test("appendErrorTurn surfaces a failed send (a rejected prompt) as a visible er
 
 	const err = rt("a").turns.find((t) => t.kind === "error");
 	expect(err?.kind === "error" && err.text).toContain("No API key");
-	expect(err?.kind === "error" ? err.recovery : undefined).toBeUndefined();
+	expect(failureRecovery("a")).toBeUndefined();
 	expect(rt("a").isStreaming).toBe(false);
 });
 

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -327,6 +327,15 @@ function clearTurnStreaming(turns: ChatTurn[]): ChatTurn[] {
 	return turns.map((t) => (t.kind === "assistant" && t.streaming ? { ...t, streaming: false } : t));
 }
 
+function consumeFailureRecoveries(turns: ChatTurn[]): ChatTurn[] {
+	if (!turns.some((turn) => turn.kind === "error" && turn.recovery)) return turns;
+	return turns.map((turn) => {
+		if (turn.kind !== "error" || !turn.recovery) return turn;
+		const { recovery, ...rest } = turn;
+		return rest;
+	});
+}
+
 function removeSupersededAssistant(
 	turns: ChatTurn[],
 	attemptAssistantId: string | null,
@@ -433,7 +442,12 @@ function clearRetryTurns(rt: SessionRuntime, source: RetrySource): SessionRuntim
 export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionRuntime {
 	switch (event.type) {
 		case "agent_start":
-			return { ...rt, isStreaming: true, attemptAssistantId: null };
+			return {
+				...rt,
+				turns: consumeFailureRecoveries(rt.turns),
+				isStreaming: true,
+				attemptAssistantId: null,
+			};
 		case "queue_update":
 			return {
 				...rt,
@@ -543,7 +557,12 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 		case "agent_settled": {
 			const failure = assistantFailureText(event.terminal);
 			const closer: ChatTurn = failure
-				? { kind: "error", id: crypto.randomUUID(), text: failure }
+				? {
+						kind: "error",
+						id: crypto.randomUUID(),
+						text: failure,
+						recovery: "try-again",
+					}
 				: { kind: "system", id: crypto.randomUUID(), text: "✓ Done", endedAt: Date.now() };
 			return {
 				...rt,
@@ -2741,7 +2760,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 			withRuntime(s, sessionId, (rt) => ({
 				...rt,
 				turns: [
-					...rt.turns,
+					...consumeFailureRecoveries(rt.turns),
 					{
 						kind: "user",
 						id: crypto.randomUUID(),

--- a/e2e/try-again.spec.ts
+++ b/e2e/try-again.spec.ts
@@ -10,7 +10,7 @@ const BASE_TS = 1_700_700_000_000;
 interface ClientFrame {
 	id?: string;
 	method?: string;
-	params?: { sessionId?: string; text?: string };
+	params?: { sessionId?: string; text?: string; images?: unknown[] };
 }
 
 async function interceptTryAgain(page: Page, prompts: ClientFrame[]): Promise<void> {
@@ -79,5 +79,6 @@ test("a final agent failure offers Try again as an ordinary visible prompt", asy
 	).toHaveCount(1);
 	await expect
 		.poll(() => prompts.at(-1)?.params)
-		.toMatchObject({ sessionId: chat.id, text: "Try again." });
+		.toEqual({ sessionId: chat.id, text: "Try again." });
+	expect(prompts).toHaveLength(1);
 });

--- a/e2e/try-again.spec.ts
+++ b/e2e/try-again.spec.ts
@@ -73,7 +73,9 @@ test("a final agent failure offers Try again as an ordinary visible prompt", asy
 
 	await expect(page.getByTestId("agent-try-again")).toHaveCount(0);
 	await expect(
-		page.locator('[data-testid="chat-message"][data-role="user"]').filter({ hasText: "Try again." }),
+		page
+			.locator('[data-testid="chat-message"][data-role="user"]')
+			.filter({ hasText: "Try again." }),
 	).toHaveCount(1);
 	await expect
 		.poll(() => prompts.at(-1)?.params)

--- a/e2e/try-again.spec.ts
+++ b/e2e/try-again.spec.ts
@@ -1,0 +1,81 @@
+import { realpathSync } from "node:fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_700_000_000;
+
+interface ClientFrame {
+	id?: string;
+	method?: string;
+	params?: { sessionId?: string; text?: string };
+}
+
+async function interceptTryAgain(page: Page, prompts: ClientFrame[]): Promise<void> {
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			let frame: ClientFrame;
+			try {
+				frame = JSON.parse(raw) as ClientFrame;
+			} catch {
+				server.send(message);
+				return;
+			}
+			if (frame.id && frame.method === "session.prompt" && frame.params?.text === "Try again.") {
+				prompts.push(frame);
+				ws.send(JSON.stringify({ id: frame.id, ok: true, result: { ok: true } }));
+				return;
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+}
+
+test("a final agent failure offers Try again as an ordinary visible prompt", async ({ page }) => {
+	const prompts: ClientFrame[] = [];
+	await interceptTryAgain(page, prompts);
+	await openFixtureProject(page);
+
+	const chat = seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "network failure chat",
+		messages: [
+			{ role: "user", text: "finish the task", timestamp: BASE_TS },
+			{
+				role: "assistant",
+				text: "I was checking the final step",
+				timestamp: BASE_TS + 1_000,
+				stopReason: "error",
+				errorMessage: "fetch failed",
+			},
+		],
+	});
+
+	await enterDefaultWorkspace(page);
+	await expect(
+		page.locator('[data-testid="editor-tab"][data-kind="chat"]').filter({
+			hasText: "network failure chat",
+		}),
+	).toBeVisible();
+
+	const failure = page
+		.locator('[data-testid="chat-message"][data-role="error"]')
+		.filter({ hasText: "fetch failed" });
+	await expect(failure).toBeVisible();
+	const tryAgain = failure.getByTestId("agent-try-again");
+	await expect(tryAgain).toHaveText("Try again");
+
+	await tryAgain.click();
+
+	await expect(page.getByTestId("agent-try-again")).toHaveCount(0);
+	await expect(
+		page.locator('[data-testid="chat-message"][data-role="user"]').filter({ hasText: "Try again." }),
+	).toHaveCount(1);
+	await expect
+		.poll(() => prompts.at(-1)?.params)
+		.toMatchObject({ sessionId: chat.id, text: "Try again." });
+});

--- a/packages/server/src/history/testFixtures.ts
+++ b/packages/server/src/history/testFixtures.ts
@@ -1,6 +1,17 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import type { StopReason } from "@thinkrail/contracts";
+
+type FixtureMessage =
+	| { role: "user"; text: string; timestamp: number }
+	| {
+			role: "assistant";
+			text: string;
+			timestamp: number;
+			stopReason?: StopReason;
+			errorMessage?: string;
+	  };
 
 export function writeFixtureSession(
 	dir: string,
@@ -8,7 +19,7 @@ export function writeFixtureSession(
 		id?: string;
 		cwd: string;
 		name?: string;
-		messages: Array<{ role: "user" | "assistant"; text: string; timestamp: number }>;
+		messages: FixtureMessage[];
 	},
 ): { id: string; path: string } {
 	mkdirSync(dir, { recursive: true });
@@ -49,7 +60,17 @@ export function writeFixtureSession(
 				id,
 				parentId,
 				timestamp: new Date(m.timestamp).toISOString(),
-				message: { role: m.role, content, timestamp: m.timestamp },
+				message: {
+					role: m.role,
+					content,
+					timestamp: m.timestamp,
+					...(m.role === "assistant" && m.stopReason
+						? { stopReason: m.stopReason }
+						: {}),
+					...(m.role === "assistant" && m.errorMessage !== undefined
+						? { errorMessage: m.errorMessage }
+						: {}),
+				},
 			}),
 		);
 		parentId = id;

--- a/packages/server/src/history/testFixtures.ts
+++ b/packages/server/src/history/testFixtures.ts
@@ -64,9 +64,7 @@ export function writeFixtureSession(
 					role: m.role,
 					content,
 					timestamp: m.timestamp,
-					...(m.role === "assistant" && m.stopReason
-						? { stopReason: m.stopReason }
-						: {}),
+					...(m.role === "assistant" && m.stopReason ? { stopReason: m.stopReason } : {}),
 					...(m.role === "assistant" && m.errorMessage !== undefined
 						? { errorMessage: m.errorMessage }
 						: {}),


### PR DESCRIPTION
## Summary

Add a **Try again** recovery action to the current final agent failure or unrecovered truncation, so users can continue without manually composing a follow-up.

The action sends one visible ordinary `Try again.` user message through the existing immediate-send path. It does not replay the original prompt or change Pi's automatic retry behavior.

## Changes

- Mark only settlement-derived final failures and unrecovered truncations as recoverable in live and hydrated transcripts.
- Render a **Try again** button on the actionable error turn and consume the marker when local or remote follow-up work starts.
- Keep rejected sends and generic application errors non-actionable.
- Add unit coverage for hydration, row propagation, trigger behavior, and cross-session isolation.
- Add browser coverage proving the retry is visible, sent once, and contains no attachment field.

No Pi runtime, server handler, wire-contract, or persistence behavior changes are included.

## Testing

- `bun run check:deps` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed with 6 pre-existing unused-suppression warnings
- `bun run typecheck` — 12/12 packages passed
- `bun run test` — 1,992 passed
- `bun run e2e` — 299 passed
- `git diff --check origin/main...HEAD` — clean

## Screenshots

| Before | After |
| --- | --- |
| ![Agent failure before Try again](https://github.com/JetBrains/thinkrail/blob/6b7acbf18a7411ed63bdafe896e7cf0c49ceaac9/try-again-before.png?raw=true) | ![Agent failure with Try again action](https://github.com/JetBrains/thinkrail/blob/6b7acbf18a7411ed63bdafe896e7cf0c49ceaac9/try-again-after.png?raw=true) |
