### PR TITLE
fix(subprocess): hide bounded child windows on Windows

### DIFF
--- a/packages/server/src/subprocess/SPEC.md
+++ b/packages/server/src/subprocess/SPEC.md
@@ -103,7 +103,8 @@ never what a particular child's output means.
   stays unbuilt and needs the cancellation seam `dialog` wants above.
 - **Windows has no process groups.** `detached` maps to `UV_PROCESS_DETACHED` and the kill falls back to
   the direct child, so a grandchild there survives the timeout as before. The group-kill test is skipped
-  there rather than pretending otherwise.
+  there rather than pretending otherwise. Bounded children use `windowsHide` on Windows: background
+  lookups must not create a visible console window or steal focus from the browser client.
 - **The env defaults to the live `process.env`, not Bun's launch-time snapshot** — `boot`'s
   `resolveShellEnv()` repairs `PATH`/`LANG` by mutating `process.env` *after* startup, and a child spawned
   from the snapshot silently misses that repair. Both halves are pinned separately — a caller's `env`/`cwd`

--- a/packages/server/src/subprocess/runBounded.ts
+++ b/packages/server/src/subprocess/runBounded.ts
@@ -78,6 +78,7 @@ export async function runBounded(argv: string[], opts: BoundedRunOptions): Promi
 			stdout: "pipe",
 			stderr: "pipe",
 			detached: true,
+			windowsHide: process.platform === "win32",
 		});
 	} catch (cause) {
 		const err = cause instanceof Error ? cause.message : String(cause);


### PR DESCRIPTION
## Problem

On Windows, opening a project workspace can run bounded background lookups such as `gh pr list`. `gh.exe` currently creates a visible console window. When that window exits, focus returns to the browser, whose `window.focus` handler refreshes the pull request data and launches `gh.exe` again. This creates a loop of visible windows opening and closing while repeatedly taking focus, even when no agent is working.

## Fix

Set Bun's `windowsHide` spawn option for bounded subprocesses on Windows. Background lookups no longer create a visible console window or steal browser focus, while the existing detached-process and timeout behavior remains unchanged on every platform.

## Verification

- `bun test packages/server/src/subprocess`
- `bun run check:deps`
- `bun run check:boundaries`
- `bun run check:seams`
- `bun run lint` (passes with 6 existing warnings)
- `bun run typecheck`
- `bun run e2e` starts after temporarily accounting for the runner's Windows-only `bun.exe` lookup issue, but the existing POSIX fixtures fail on Windows (`spawnSync mv ENOENT` and the project picker fixture cannot seed a project), causing unrelated cascading failures
