### PR TITLE
[Design] Improve drag-and-drop of Panels

### DIFF
--- a/apps/web/src/shell/layout/SPEC.md
+++ b/apps/web/src/shell/layout/SPEC.md
@@ -50,14 +50,19 @@ Frame groups may remain empty in any workspace. Closing a final resource therefo
 - **Left/right:** ordered vertical frame stacks. Dragging an outer separator through its minimum hides that side, retains the last expanded width, and exposes its full-height restore rail. Broad upper/lower targets create groups before/after each row, including folded or currently empty rows. Expanded bodies have a 120 px normal minimum; folded groups occupy 27 px and retain normalized expanded weights. An empty frame group remains available across workspaces until explicit removal and renders a named
   Add/Reveal surface rather than disappearing; a region with groups may stay hidden.
 - **Bottom:** ordered left-to-right frame groups resize on vertical separators. A group may fold to a 27 px
-  vertical rail; the region hides to a 27 px-high horizontal restore rail over its selected span. Height starts
-  at 30%, has a 120 px body minimum, and caps at 70%. Alignment is center, center+left, center+right, or full
-  workbench. A side excluded from that span owns its lower corner and continues to the workbench bottom; an
-  included side ends above it. Hidden restore geometry follows the same ownership. Alignment follows actual
-  browser-local side projection during resize and narrow compression while persisted workbench-wide frame
-  ratios remain the target and are converted through nested panel groups. A separator gesture commits only
-  the ratio of the side that owns it; compression of an untouched neighbor remains runtime-local. Hidden
-  sides contribute no phantom width. Empty bottom slots render terminal creation/reveal affordances.
+  vertical rail. When the region is hidden or the frame has no bottom groups, the workbench renders no bottom
+  chrome and reserves no bottom height; there is no persistent restore rail. While a bottom-eligible tab is
+  dragged and the bottom is not rendered, a 24 px-high horizontal Primary drop zone appears over the span
+  selected by bottom alignment; dropping there reveals the region. With no drag active, `Mod+Shift+J` remains
+  the direct chrome-free restore path. Height starts at 30%, has a 120 px body minimum, and caps at 70%.
+  Alignment is center, center+left, center+right, or full workbench. A side excluded from that span owns its
+  lower corner and continues to the workbench bottom; an included side ends above it; the drag-time drop zone
+  follows the same ownership. Alignment follows actual browser-local side projection during resize and narrow
+  compression while persisted workbench-wide frame ratios remain the target and are converted through nested
+  panel groups. A separator gesture commits only the ratio of the side that owns it; compression of an
+  untouched neighbor remains runtime-local. Hidden sides contribute no phantom width. A visible empty bottom
+  frame slot remains available across workspaces until explicit removal and renders terminal creation/reveal
+  affordances.
 - **Limits:** left/right share a local setting defaulting to six groups per side; bottom has an independent local setting defaulting to three. Both accept 1–32, with closed hard safety bounds enforced even for untrusted local state or shared presets. Existing overages survive; creation is unavailable until below the configured limit, while reorder/join/reducing moves remain legal. Stable-id uniqueness, one canonical resource placement per workspace view, normalized geometry, and the final-center-leaf invariant are enforced by every mutation.
 - **Small viewports:** restoring onto less space may compress below operation minimums locally. Content scrolls/clips; bottom alignment projects from actual compressed side spans, while frame topology, alignment choice, and ratios are never rewritten merely because this viewport is narrow.
 
@@ -67,7 +72,27 @@ Async completion reroutes from a removed group to current last focus and advance
 
 ## Arrangement and accessibility
 
-A tab drag paints exactly one result: strip insertion, whole-group join, legal center half-split, side upper/lower boundary, or bottom left/right boundary. Expanded strips remain join/reorder targets while bodies create adjacent groups; folded rails divide their compact axis between the same two targets. Hidden restore rails are broad legal creation targets within local limits. Illegal domains, limits, exact-position no-ops, and minimum violations paint no target and commit nothing. Escape, pointer cancellation, outside drop, or a superseding local frame/view transition restores the source. Drag moves one workspace resource or one frame-owned tool; it never copies or crosses workspaces.
+A tab drag paints exactly one result: strip insertion, whole-group join, legal center half-split, side
+upper/lower boundary, or bottom left/right boundary. Expanded strips remain join/reorder targets while bodies
+create adjacent groups; folded rails divide their compact axis between the same two targets. The user never
+has to acquire a thin outer edge. Hidden left/right restore rails are broad legal creation targets within local
+limits. When bottom is not rendered, its drag-time zone reuses the active workspace's last-focused surviving
+bottom frame group, falls back to the trailing group, or creates one at the trailing boundary only when no
+group exists and the local bottom limit permits; either drop reveals the region. Illegal domains, limits,
+exact-position no-ops, and minimum violations paint no target and commit nothing. Escape, pointer
+cancellation, outside drop, or a superseding local frame/view transition restores the source. A drag moves one
+workspace resource or one frame-owned tool; it never copies or crosses workspaces.
+
+Drop-target styling has no resting treatment. As soon as a movable tab is picked up, every currently valid
+destination shows a subtle Primary hint, and the destination under the pointer strengthens. Both states derive
+from the existing drag state and each site's already-computed validity—there is no second drag-state
+machine—and use only semantic Primary roles, never `feedback-*`: `drop-hint` is a subtle Primary outline or
+translucent surface and `drop-active` is stronger. Tab-header targets outline the whole group header;
+individual before/after insertion markers remain the precise hover cue. Center-split targets show compact
+directional edge hints at drag start and fill the true resulting half on hover. The bottom drag-time zone is
+24 px high and takes collision priority within that band over overlapping lower-body targets. Active emphasis
+clears on pointer leave; all hints clear on drop or cancel; decorative layers never alter hit-testing or the
+committed result.
 
 Creating or deleting a group is visibly a frame command and therefore affects every workspace in this window. Moving a resource among existing groups affects only its workspace view. Moving a singleton tool changes frame placement globally within this window. Uncommitted drag/resize drafts stay runtime-local and commit once on drop/pointer-up; no host revision can cancel them. A local projection epoch invalidates drafts or delayed preview-settle timers only when another local transition replaces their base.
 

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -1,4 +1,5 @@
 import {
+	type CollisionDetection,
 	DndContext,
 	type DragEndEvent,
 	DragOverlay,
@@ -19,7 +20,6 @@ import {
 	RiListCheck3 as ListTodo,
 	RiChatNewLine as MessageSquarePlus,
 	RiMoreLine as MoreHorizontal,
-	RiLayoutBottomLine as PanelBottomOpen,
 	RiLayoutLeftLine as PanelLeftOpen,
 	RiLayoutRightLine as PanelRightOpen,
 	RiLayout2Line as PanelsTopLeft,
@@ -120,7 +120,6 @@ import {
 	setAuxiliaryGroupFolded,
 	setBottomAlignment,
 	setSideGroupFolded,
-	showBottom,
 	showSide,
 	splitCenterGroup,
 	toolTab,
@@ -188,6 +187,18 @@ type DropTarget =
 interface DragData {
 	tab: LayoutTab;
 }
+
+const HIDDEN_BOTTOM_DROP_ID = "dnd-hidden-bottom-edge";
+
+const workbenchCollisionDetection: CollisionDetection = (args) => {
+	const collisions = pointerWithin(args);
+	const bottomCollision = collisions.find((collision) => collision.id === HIDDEN_BOTTOM_DROP_ID);
+	if (!bottomCollision) return collisions;
+	return [
+		bottomCollision,
+		...collisions.filter((collision) => collision.id !== HIDDEN_BOTTOM_DROP_ID),
+	];
+};
 
 function sameSizes(first: readonly number[], second: readonly number[], tolerance = 0.15): boolean {
 	return (
@@ -529,9 +540,46 @@ function DropZone({
 			ref={setNodeRef}
 			aria-hidden="true"
 			data-drop-active={isOver || undefined}
+			data-drop-hint={!isOver || undefined}
 			data-drop-label={label}
-			className={`pointer-events-auto z-20 rounded-[var(--radius-sm)] border border-transparent transition-colors data-[drop-active]:border-primary data-[drop-active]:bg-primary-subtle ${className}`}
+			className={`pointer-events-auto z-20 rounded-[var(--radius-sm)] border border-transparent transition-colors data-[drop-hint]:border-primary-soft data-[drop-hint]:bg-primary-subtle data-[drop-active]:border-primary data-[drop-active]:bg-primary-soft ${className}`}
 		/>
+	);
+}
+
+function CenterSplitTarget({
+	groupId,
+	direction,
+	label,
+	edgeClassName,
+	halfClassName,
+}: {
+	groupId: string;
+	direction: CenterSplitDirection;
+	label: string;
+	edgeClassName: string;
+	halfClassName: string;
+}) {
+	const { setNodeRef, isOver } = useDroppable({
+		id: tupleKey("dnd-split", groupId, direction),
+		data: { target: { kind: "split", groupId, direction } satisfies DropTarget },
+	});
+	return (
+		<>
+			<div
+				aria-hidden="true"
+				data-drop-active={isOver || undefined}
+				className={`pointer-events-none absolute z-10 rounded-[var(--radius-sm)] border-2 border-transparent transition-colors data-[drop-active]:border-primary data-[drop-active]:bg-primary-soft ${halfClassName}`}
+			/>
+			<div
+				ref={setNodeRef}
+				aria-hidden="true"
+				data-drop-label={label}
+				data-drop-active={isOver || undefined}
+				data-drop-hint={!isOver || undefined}
+				className={`pointer-events-auto absolute z-20 rounded-[var(--radius-sm)] border border-transparent transition-colors data-[drop-hint]:border-primary-soft data-[drop-hint]:bg-primary-subtle ${edgeClassName}`}
+			/>
+		</>
 	);
 }
 
@@ -638,7 +686,8 @@ function TabStrip({
 			data-area={location.area}
 			data-group-id={location.groupId}
 			data-drop-active={groupDrop.isOver || undefined}
-			className="relative flex h-panel-header-row shrink-0 items-stretch border-border-default border-b bg-container-workspace-bg data-[drop-active]:bg-primary-subtle"
+			data-drop-hint={(acceptsAppend && !groupDrop.isOver) || undefined}
+			className="relative flex h-panel-header-row shrink-0 items-stretch border-border-default border-b bg-container-workspace-bg data-[drop-hint]:ring-1 data-[drop-hint]:ring-inset data-[drop-hint]:ring-primary-soft data-[drop-active]:bg-primary-subtle data-[drop-active]:ring-2 data-[drop-active]:ring-inset data-[drop-active]:ring-primary"
 		>
 			<div className="relative min-w-0 flex-1 overflow-hidden">
 				<div
@@ -1347,33 +1396,37 @@ function CenterGroupView({
 				<div className="pointer-events-none absolute inset-0 z-30">
 					{splitGeometry.horizontal ? (
 						<>
-							<DropZone
-								id={tupleKey("dnd-split", group.id, "left")}
-								target={{ kind: "split", groupId: group.id, direction: "left" }}
+							<CenterSplitTarget
+								groupId={group.id}
+								direction="left"
 								label="Split left"
-								className="absolute inset-y-1/4 left-4 w-1/5"
+								edgeClassName="inset-y-1/4 left-4 w-1/5"
+								halfClassName="inset-y-0 left-0 w-1/2"
 							/>
-							<DropZone
-								id={tupleKey("dnd-split", group.id, "right")}
-								target={{ kind: "split", groupId: group.id, direction: "right" }}
+							<CenterSplitTarget
+								groupId={group.id}
+								direction="right"
 								label="Split right"
-								className="absolute inset-y-1/4 right-4 w-1/5"
+								edgeClassName="inset-y-1/4 right-4 w-1/5"
+								halfClassName="inset-y-0 right-0 w-1/2"
 							/>
 						</>
 					) : null}
 					{splitGeometry.vertical ? (
 						<>
-							<DropZone
-								id={tupleKey("dnd-split", group.id, "up")}
-								target={{ kind: "split", groupId: group.id, direction: "up" }}
+							<CenterSplitTarget
+								groupId={group.id}
+								direction="up"
 								label="Split up"
-								className="absolute inset-x-1/4 top-32 h-1/5"
+								edgeClassName="inset-x-1/4 top-32 h-1/5"
+								halfClassName="inset-x-0 top-0 h-1/2"
 							/>
-							<DropZone
-								id={tupleKey("dnd-split", group.id, "down")}
-								target={{ kind: "split", groupId: group.id, direction: "down" }}
+							<CenterSplitTarget
+								groupId={group.id}
+								direction="down"
 								label="Split down"
-								className="absolute inset-x-1/4 bottom-4 h-1/5"
+								edgeClassName="inset-x-1/4 bottom-4 h-1/5"
+								halfClassName="inset-x-0 bottom-0 h-1/2"
 							/>
 						</>
 					) : null}
@@ -2078,10 +2131,11 @@ function BottomFoldedGroup({
 	const location: LayoutGroupLocation = { area: "bottom", groupId: group.id };
 	const restoreId = groupDomId(location);
 	const panelId = groupPanelId(location);
+	const dropEnabled = !!shared.draggingTab && canPlaceLayoutTab(shared.draggingTab, "bottom");
 	const drop = useDroppable({
 		id: tupleKey("dnd-bottom-folded", group.id),
 		data: { target: { kind: "group", location } satisfies DropTarget },
-		disabled: !shared.draggingTab || !canPlaceLayoutTab(shared.draggingTab, "bottom"),
+		disabled: !dropEnabled,
 	});
 	return (
 		<section
@@ -2090,10 +2144,11 @@ function BottomFoldedGroup({
 			data-group-id={group.id}
 			data-folded="true"
 			data-drop-active={drop.isOver || undefined}
+			data-drop-hint={(dropEnabled && !drop.isOver) || undefined}
 			aria-label={
 				selectedName ? `Folded bottom group: ${selectedName}` : "Folded empty bottom group"
 			}
-			className="relative flex h-full items-stretch overflow-hidden border-border-default border-r bg-container-sidebar-bg data-[drop-active]:bg-primary-subtle"
+			className="relative flex h-full items-stretch overflow-hidden border-border-default border-r bg-container-sidebar-bg data-[drop-hint]:bg-primary-subtle data-[drop-active]:bg-primary-soft"
 		>
 			<div className="flex min-h-0 w-full flex-col">
 				{showAlignmentMenu ? (
@@ -2277,19 +2332,15 @@ function BottomAlignedRow({
 	);
 }
 
-function HiddenBottomRail({
-	onShow,
-	dropEnabled,
+function BottomDropZone({
 	targetGroupId,
 	targetIndex,
 }: {
-	onShow: () => void;
-	dropEnabled: boolean;
 	targetGroupId: string | undefined;
 	targetIndex: number;
 }) {
 	const drop = useDroppable({
-		id: "dnd-hidden-bottom-edge",
+		id: HIDDEN_BOTTOM_DROP_ID,
 		data: {
 			target: targetGroupId
 				? ({
@@ -2298,26 +2349,19 @@ function HiddenBottomRail({
 					} satisfies DropTarget)
 				: ({ kind: "auxiliary-edge", region: "bottom", index: targetIndex } satisfies DropTarget),
 		},
-		disabled: !dropEnabled,
 	});
 	return (
 		<div
 			ref={drop.setNodeRef}
-			data-testid="bottom-layout-rail"
-			data-drop-label={dropEnabled ? "Create group in hidden bottom region" : undefined}
+			data-testid="bottom-drop-zone"
+			aria-hidden="true"
+			data-drop-label={
+				targetGroupId ? "Reveal hidden bottom group" : "Create group in hidden bottom region"
+			}
 			data-drop-active={drop.isOver || undefined}
-			className="flex h-28 shrink-0 items-center justify-center border-border-default border-t bg-container-sidebar-bg data-[drop-active]:bg-primary-subtle data-[drop-active]:ring-2 data-[drop-active]:ring-inset data-[drop-active]:ring-primary"
-		>
-			<button
-				type="button"
-				aria-label="Show bottom panel"
-				title="Show bottom panel (Mod+Shift+J)"
-				onClick={onShow}
-				className="flex h-24 items-center gap-4 rounded-[var(--radius-sm)] px-8 tr-text-metadata text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-			>
-				<PanelBottomOpen className="size-16" /> Bottom
-			</button>
-		</div>
+			data-drop-hint={!drop.isOver || undefined}
+			className="pointer-events-auto absolute inset-x-0 bottom-0 z-20 h-24 border-primary transition-colors data-[drop-hint]:border-t data-[drop-hint]:bg-primary-subtle data-[drop-active]:border-t-2 data-[drop-active]:bg-primary-soft"
+		/>
 	);
 }
 
@@ -2383,7 +2427,8 @@ function HiddenSideRail({
 			data-testid={`${side}-layout-rail`}
 			data-drop-label={dropEnabled ? `Create ${side} group in hidden side` : undefined}
 			data-drop-active={drop.isOver || undefined}
-			className="flex w-28 shrink-0 flex-col items-center border-border-default bg-container-sidebar-bg py-4 first:border-r last:border-l data-[drop-active]:bg-primary-subtle data-[drop-active]:ring-2 data-[drop-active]:ring-inset data-[drop-active]:ring-primary"
+			data-drop-hint={(dropEnabled && !drop.isOver) || undefined}
+			className="flex w-28 shrink-0 flex-col items-center border-border-default bg-container-sidebar-bg py-4 first:border-r last:border-l data-[drop-hint]:bg-primary-subtle data-[drop-hint]:ring-1 data-[drop-hint]:ring-inset data-[drop-hint]:ring-primary-soft data-[drop-active]:bg-primary-soft data-[drop-active]:ring-2 data-[drop-active]:ring-inset data-[drop-active]:ring-primary"
 		>
 			<IconTooltip
 				label={showEnabled ? `Show ${side} side` : `No ${side} groups to show`}
@@ -2944,15 +2989,6 @@ export function Workbench({
 			),
 		[apply, document],
 	);
-	const showBottomRegion = useCallback(() => {
-		const shown = showBottom(document, maxSideGroups, maxBottomGroups, attentionRef.current);
-		if (isLayoutUnavailable(shown)) return;
-		apply(shown);
-		if (shown.document.bottom.groups.every((group) => group.tabs.length === 0)) {
-			const groupId = shown.focusGroupId ?? shown.document.bottom.groups[0]?.id;
-			if (groupId) onNewTerminal(groupId, "bottom");
-		}
-	}, [apply, document, maxBottomGroups, maxSideGroups, onNewTerminal]);
 	const revealMissingTool = useCallback(
 		(tool: LayoutToolId) => {
 			const result = revealTool(document, tool, maxSideGroups, maxBottomGroups);
@@ -3113,29 +3149,23 @@ export function Workbench({
 			</ResizablePanel>
 		</ResizablePanelGroup>
 	) : (
-		<div className="flex h-full min-h-0 min-w-0 flex-col">
+		<div className="relative flex h-full min-h-0 min-w-0 flex-col">
 			<div className="min-h-0 min-w-0 flex-1">{alignedTopRow}</div>
-			<div className="h-28 shrink-0">
-				<BottomAlignedRow document={document}>
-					<HiddenBottomRail
-						onShow={showBottomRegion}
-						dropEnabled={
-							!!draggingTab &&
-							canPlaceLayoutTab(draggingTab, "bottom") &&
-							(hiddenBottomTargetGroupId !== undefined ||
-								canCreateAuxiliaryGroup(
-									document,
-									"bottom",
-									draggingTab,
-									maxBottomGroups,
-									document.bottom.groups.length,
-								))
-						}
-						targetGroupId={hiddenBottomTargetGroupId}
-						targetIndex={document.bottom.groups.length}
-					/>
-				</BottomAlignedRow>
-			</div>
+			{draggingTab &&
+			canPlaceLayoutTab(draggingTab, "bottom") &&
+			(hiddenBottomTargetGroupId !== undefined ||
+				canCreateAuxiliaryGroup(
+					document,
+					"bottom",
+					draggingTab,
+					maxBottomGroups,
+					document.bottom.groups.length,
+				)) ? (
+				<BottomDropZone
+					targetGroupId={hiddenBottomTargetGroupId}
+					targetIndex={document.bottom.groups.length}
+				/>
+			) : null}
 		</div>
 	);
 	const workbenchColumns = (
@@ -3202,7 +3232,7 @@ export function Workbench({
 	return (
 		<DndContext
 			sensors={sensors}
-			collisionDetection={pointerWithin}
+			collisionDetection={workbenchCollisionDetection}
 			measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
 			onDragStart={handleDragStart}
 			onDragCancel={() => setDraggingTab(null)}

--- a/apps/web/src/styles/colorUsage.test.ts
+++ b/apps/web/src/styles/colorUsage.test.ts
@@ -73,6 +73,7 @@ const NON_COLOR = new Set([
 	"b-0",
 	"l-2",
 	"r-2",
+	"t-2",
 	"l-4",
 	"collapse",
 	"separate",

--- a/e2e/bottom-panel.spec.ts
+++ b/e2e/bottom-panel.spec.ts
@@ -90,6 +90,19 @@ function bottomGroups(page: Page): Locator {
 	return page.getByTestId("bottom-group");
 }
 
+async function startTabDrag(page: Page, tab: Locator): Promise<void> {
+	const box = await tab.boundingBox();
+	if (!box) throw new Error("drag tab has no bounding box");
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width / 2 + 12, box.y + box.height / 2 + 8, { steps: 4 });
+}
+
+async function cancelTabDrag(page: Page): Promise<void> {
+	await page.keyboard.press("Escape");
+	await page.mouse.up();
+}
+
 async function setBottomAlignment(page: Page, name: string): Promise<void> {
 	await page.getByRole("button", { name: "Bottom panel alignment" }).click();
 	await page.getByRole("menuitemradio", { name, exact: true }).click();
@@ -269,13 +282,13 @@ test("a hidden local frame keeps the host terminal reserved without attaching un
 	await focusPreset.getByRole("button", { name: "Apply now…" }).click();
 	await page.getByTestId("layout-apply-confirm").click();
 	await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 
 	const workspace = await createWorkspaceWithoutOpening(page);
 	await pressPlatformShortcut(page, "b");
 	const workspaceRow = page.getByTestId("workspace-item").filter({ hasText: workspace.name });
 	await workspaceRow.getByRole("button").first().click();
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
 	const catalog = await requestOverWire<{ tabs: Array<{ tabKey: string }> }>(
 		page,
@@ -293,10 +306,12 @@ test("a hidden local frame keeps the host terminal reserved without attaching un
 	await expect(peer.getByTestId("terminal-tab")).toHaveCount(1);
 	await waitTerminalReady(peer);
 
-	await page.reload();
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await reloadDefaultWorkbench(page);
+	await waitForLayoutSettled(page);
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
-	await page.getByRole("button", { name: "Show bottom panel" }).click();
+	await pressPlatformShortcut(page, "Shift+j");
+	await waitTerminalReady(page);
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(1);
 	await peer.close();
 });
@@ -342,11 +357,11 @@ test("Mod+Shift+J works from xterm, preserves its PTY through hide and reload, a
 
 	await visibleTerminal(page).locator(".xterm-helper-textarea").focus();
 	await pressPlatformShortcut(page, "Shift+j");
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 	await expect(page.getByTestId("terminal-instance")).toHaveCount(0);
 
 	await reloadDefaultWorkbench(page);
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 	await pressPlatformShortcut(page, "Shift+j");
 	await waitTerminalReady(page);
 	await expect(visibleTerminalScreen(page)).toContainText(marker);
@@ -357,7 +372,7 @@ test("Mod+Shift+J works from xterm, preserves its PTY through hide and reload, a
 	await expect(page.getByTestId("bottom-panel")).toBeVisible();
 	await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
 	await pressPlatformShortcut(page, "Shift+j");
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 });
 
 test("bottom height, all alignments, and keyboard resizing persist across reload", async ({
@@ -429,7 +444,10 @@ test("bottom height, all alignments, and keyboard resizing persist across reload
 		.toBeGreaterThan(keyboardBefore);
 
 	await pressPlatformShortcut(page, "Shift+j");
-	await expectHorizontalSpan(page.getByTestId("bottom-layout-rail"), left, center);
+	await startTabDrag(page, page.getByTestId("tab-files"));
+	await expect(page.getByTestId("bottom-drop-zone")).toBeVisible();
+	await expectHorizontalSpan(page.getByTestId("bottom-drop-zone"), left, center);
+	await cancelTabDrag(page);
 	await pressPlatformShortcut(page, "Shift+j");
 	await expectHorizontalSpan(page.getByTestId("bottom-panel"), left, center);
 });
@@ -558,7 +576,8 @@ test("closing a final bottom resource retains its frame groups until explicit re
 	await bottomGroups(page).first().getByTestId("remove-layout-group").click();
 	await expect(bottomGroups(page)).toHaveCount(1);
 	await bottomGroups(page).first().getByTestId("remove-layout-group").click();
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
+	await expect(page.getByTestId("bottom-drop-zone")).toHaveCount(0);
 	await expect(page.getByTestId("center-group").first()).toBeFocused();
 });
 
@@ -717,7 +736,7 @@ test("bottom visibility and alignment stay local to each window and survive its 
 	await setBottomAlignment(page, "Full width");
 	await expect(peer.getByTestId("bottom-aligned-row")).toHaveAttribute("data-alignment", "center");
 	await pressPlatformShortcut(page, "Shift+j");
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 	await expect(peer.getByTestId("bottom-panel")).toBeVisible();
 
 	await setBottomAlignment(peer, "Below center and left");
@@ -726,7 +745,7 @@ test("bottom visibility and alignment stay local to each window and survive its 
 		"data-alignment",
 		"center-left",
 	);
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 	await peer.close();
 });
 

--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -349,17 +349,17 @@ test("one local frame survives workspace switches while resource tabs stay works
 	await dragHandle(page, handle, handleBox.x - 70, handleBox.y + handleBox.height / 2);
 	const resized = await width(page.getByTestId("right-stack"));
 	await pressPlatformShortcut(page, "Shift+j");
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 
 	await createWorkspaceViaDialog(page);
 	await expect(page.getByTestId("editor-tab").filter({ hasText: "README.md" })).toHaveCount(0);
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 	await expect.poll(() => width(page.getByTestId("right-stack"))).toBeCloseTo(resized, 0);
 
 	await defaultWorkspaceRow(page).getByRole("button").first().click();
 	await expect(page.getByTestId("editor-tab").filter({ hasText: "README.md" })).toHaveCount(1);
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
-	await expect(page.getByTestId("bottom-layout-rail")).toBeVisible();
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
 });
 
 test("a duplicated tab remints copied surface storage and preserves both layouts on reload", async ({
@@ -1183,4 +1183,89 @@ test("another window cannot cancel or adopt an active side resize", async ({ pag
 	await expect.poll(() => width(page.getByTestId("right-stack"))).not.toBeCloseTo(before, 0);
 	await expect(page2.getByTestId("right-layout-rail")).toBeVisible();
 	await page2.close();
+});
+
+test("a tab drag reveals every valid destination subtly, then emphasizes the one under the pointer", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	await openKeptFiles(page, ["README.md", "notes.txt"]);
+
+	const centerStrip = page.getByTestId("center-tab-strip");
+	const rightStrip = page.getByTestId("right-tab-strip");
+	const dragged = page.getByTestId("editor-tab").filter({ hasText: "README.md" });
+	const box = await dragged.boundingBox();
+	if (!box) throw new Error("drag tab has no box");
+
+	await expect(centerStrip).not.toHaveAttribute("data-drop-hint", "true");
+	await expect(page.locator('[data-drop-label="Split right"]')).toHaveCount(0);
+
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width / 2 + 12, box.y + box.height / 2 + 8, { steps: 4 });
+	const pane = await page.getByTestId("editor-pane").first().boundingBox();
+	if (!pane) throw new Error("editor pane has no box");
+	await page.mouse.move(pane.x + pane.width / 2, pane.y + pane.height / 2, { steps: 6 });
+
+	await expect(centerStrip).toHaveAttribute("data-drop-hint", "true");
+	await expect(centerStrip).not.toHaveAttribute("data-drop-active", "true");
+	await expect(rightStrip).not.toHaveAttribute("data-drop-hint", "true");
+	const splitTarget = page.locator('[data-drop-label="Split right"]');
+	await expect(splitTarget).toBeVisible();
+	await expect(splitTarget).toHaveAttribute("data-drop-hint", "true");
+	await expect(page.getByTestId("bottom-drop-zone")).toHaveCount(0);
+
+	const targetBox = await splitTarget.boundingBox();
+	if (!targetBox) throw new Error("split target has no box");
+	await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
+		steps: 8,
+	});
+	await expect(splitTarget).toHaveAttribute("data-drop-active", "true");
+	await expect(splitTarget).not.toHaveAttribute("data-drop-hint", "true");
+	await expect(centerStrip).toHaveAttribute("data-drop-hint", "true");
+
+	await page.keyboard.press("Escape");
+	await page.mouse.up();
+	await expect(centerStrip).not.toHaveAttribute("data-drop-hint", "true");
+	await expect(page.locator('[data-drop-label="Split right"]')).toHaveCount(0);
+});
+
+test("the hidden bottom drop zone wins overlapping terminal targets and reveals its frame group", async ({
+	page,
+}) => {
+	await openDefaultWorkbench(page);
+	await page.getByTestId("terminal-tab").click({ button: "right" });
+	await page.getByRole("menuitem", { name: /Move to center group/ }).click();
+	await waitForLayoutSettled(page);
+	const terminal = page.getByTestId("center-group").getByTestId("terminal-tab");
+	await expect(terminal).toBeVisible();
+
+	await pressPlatformShortcut(page, "Shift+j");
+	await expect(page.getByTestId("bottom-panel")).toHaveCount(0);
+	const box = await terminal.boundingBox();
+	if (!box) throw new Error("terminal tab has no box");
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width / 2 + 12, box.y + box.height / 2 + 8, { steps: 4 });
+
+	const dropZone = page.getByTestId("bottom-drop-zone");
+	await expect(dropZone).toBeVisible();
+	await expect(dropZone).toHaveAttribute("data-drop-hint", "true");
+	await expect(async () => {
+		const zoneBox = await dropZone.boundingBox();
+		if (!zoneBox) throw new Error("bottom drop zone has no box");
+		expect(Math.round(zoneBox.height)).toBe(24);
+	}).toPass();
+
+	const zoneBox = await dropZone.boundingBox();
+	if (!zoneBox) throw new Error("bottom drop zone has no box");
+	await page.mouse.move(zoneBox.x + zoneBox.width / 2, zoneBox.y + zoneBox.height / 2, {
+		steps: 8,
+	});
+	await expect(dropZone).toHaveAttribute("data-drop-active", "true");
+	await page.mouse.up();
+	await waitForLayoutSettled(page);
+	await expect(page.getByTestId("bottom-panel")).toBeVisible();
+	await expect(page.getByTestId("bottom-group").getByTestId("terminal-tab")).toHaveCount(1);
+	await expect(page.getByTestId("center-group").getByTestId("terminal-tab")).toHaveCount(0);
 });


### PR DESCRIPTION
Draft — still needs refinement. One known issue is that Terminal can currently only be opened by dragging it out of the bottom panel; when the bottom panel is absent, there is no other way to open Terminal yet.

This PR explores a more discoverable drag-and-drop model for the flexible panel layout. When a tab is picked up, available drop targets become visible. Hovering a target makes it more prominent and previews where the tab will be placed.

The goal is to make it clear that any tab can be moved to different areas of the layout without keeping the bottom panel permanently visible. When the bottom area is empty, it disappears completely and only appears as a drop target while dragging.

The interaction and drop-zone behavior follow the current Figma exploration and still need some visual/behavioral tuning before this is ready to merge.


## Demo

![Drag-and-drop discoverability demo](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/dnd-demo.gif?raw=true)

## Screenshots

| State | |
| --- | --- |
| Resting — no drop-zone chrome | ![resting](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/01-resting.png?raw=true) |
| Drag started — every valid destination revealed subtly | ![drag started](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/02-drag-started-subtle-hints.png?raw=true) |
| Hovering a center-split target — the true resulting half fills | ![hover split half](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/03-hover-split-right-half.png?raw=true) |
| After dropping — side-by-side split created | ![after split](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/04-after-split.png?raw=true) |
| Bottom hidden — no resting chrome, reserves no height | ![bottom hidden](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/05-bottom-hidden-no-chrome.png?raw=true) |
| Dragging a bottom-eligible tab — 24px drop zone (subtle) | ![bottom subtle](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/06-bottom-drop-zone-subtle.png?raw=true) |
| Hovering the bottom drop zone — stronger treatment | ![bottom strong](https://github.com/JetBrains/thinkrail/blob/283fe1d944e59ac5ba7eba013d079bb1b04054a3/07-bottom-drop-zone-strong.png?raw=true) |
