### PR TITLE
[Design] Compact agent activity in chat

### DIFF
--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -1,5 +1,6 @@
 import {
 	RiBrainLine as Brain,
+	RiChatQuoteLine as ChatQuote,
 	RiCheckLine as Check,
 	RiArrowRightSLine as ChevronRight,
 	RiStackLine as Layers,
@@ -9,7 +10,13 @@ import {
 import { cn } from "@/lib";
 import type { ActivityBreadcrumbKind } from "./activityBreadcrumbs";
 import { useFold } from "./foldState";
-import type { ActivityStep, RoutineToolStep, ThinkingStep } from "./rows";
+import type {
+	ActivityNode,
+	ActivityStep,
+	NarrationStep,
+	RoutineToolStep,
+	ThinkingStep,
+} from "./rows";
 import { ToolRendererBody } from "./ToolRendererBody";
 import { getToolSummary, type ToolRenderProps } from "./toolRegistry";
 import type { ToolStatus } from "./types";
@@ -22,14 +29,14 @@ export function ActivityGroup({
 	onOpenFile,
 }: {
 	id: string;
-	steps: ActivityStep[];
+	steps: ActivityNode[];
 	live: boolean;
 	workspaceRoot?: string | undefined;
 	onOpenFile?: ((path: string) => void) | undefined;
 }) {
 	const flatSteps = flattenActivitySteps(steps);
-	const single = flatSteps.length === 1 ? steps[0] : undefined;
-	if (single)
+	const single = flatSteps.length === 1 && steps.length === 1 ? steps[0] : undefined;
+	if (single && single.kind !== "narration")
 		return single.kind === "thinking" ? (
 			<ThinkingGroup
 				id={single.id}
@@ -59,7 +66,15 @@ export function ActivityGroup({
 			summary={summary}
 		>
 			{steps.map((step) =>
-				step.kind === "thinking" ? (
+				step.kind === "narration" ? (
+					<NarrationGroup
+						key={step.id}
+						parentId={id}
+						narration={step}
+						workspaceRoot={workspaceRoot}
+						onOpenFile={onOpenFile}
+					/>
+				) : step.kind === "thinking" ? (
 					<ThinkingGroup
 						key={step.id}
 						id={step.id}
@@ -141,6 +156,59 @@ export function ThinkingGroup({
 	);
 }
 
+export function NarrationGroup({
+	parentId,
+	narration,
+	workspaceRoot,
+	onOpenFile,
+}: {
+	parentId: string;
+	narration: NarrationStep;
+	workspaceRoot?: string | undefined;
+	onOpenFile?: ((path: string) => void) | undefined;
+}) {
+	const summary = narration.steps.length > 0 ? summarizeSteps(narration.steps) : "note";
+	return (
+		<GroupDisclosure
+			id={narration.id}
+			parentId={parentId}
+			kind="narration"
+			testId="narration-group"
+			live={false}
+			stepCount={narration.steps.length}
+			icon={<ChatQuote className="size-12 shrink-0" />}
+			headline={narration.text}
+			headlineAlways
+			breadcrumbLabel={narration.text}
+			breadcrumbMeta={summary}
+			summary={summary}
+		>
+			{narration.steps.map((step) =>
+				step.kind === "thinking" ? (
+					<ThinkingGroup
+						key={step.id}
+						id={step.id}
+						parentId={narration.id}
+						thought={step}
+						tools={step.tools}
+						live={false}
+						workspaceRoot={workspaceRoot}
+						onOpenFile={onOpenFile}
+					/>
+				) : (
+					<RoutineToolRow
+						key={step.id}
+						step={step}
+						parentId={narration.id}
+						workspaceRoot={workspaceRoot}
+						onOpenFile={onOpenFile}
+					/>
+				),
+			)}
+		</GroupDisclosure>
+	);
+}
+
 function GroupDisclosure({
 	id,
 	parentId,
@@ -151,6 +219,7 @@ function GroupDisclosure({
 	icon,
 	label,
 	headline,
+	headlineAlways,
 	breadcrumbLabel,
 	breadcrumbMeta,
 	summary,
@@ -159,18 +228,20 @@ function GroupDisclosure({
 	id: string;
 	parentId?: string;
 	kind: ActivityBreadcrumbKind;
-	testId: "activity-group" | "thinking-group";
+	testId: "activity-group" | "thinking-group" | "narration-group";
 	live: boolean;
 	stepCount: number;
 	icon: React.ReactNode;
 	label?: string;
 	headline?: string | undefined;
+	headlineAlways?: boolean;
 	breadcrumbLabel: string;
 	breadcrumbMeta: string;
 	summary: string;
 	children: React.ReactNode;
 }) {
 	const [expanded, toggle] = useFold(id);
+	const showHeadline = (headlineAlways || !expanded) && !!headline;
 	return (
 		<div
 			data-testid={testId}
@@ -201,11 +272,11 @@ function GroupDisclosure({
 					icon
 				)}
 				{label ? (
-					<span className={cn("shrink-0 text-text-default", !expanded && headline && "sr-only")}>
+					<span className={cn("shrink-0 text-text-default", showHeadline && "sr-only")}>
 						{label}
 					</span>
 				) : null}
-				{!expanded && headline ? (
+				{showHeadline ? (
 					<span
 						data-testid={`${testId}-headline`}
 						className="min-w-0 flex-1 truncate text-text-default"
@@ -249,11 +320,17 @@ function splitSummary(summary: string): { label: string; meta: string } {
 		: { label: summary.slice(0, separator), meta: summary.slice(separator + 3) };
 }
 
-function flattenActivitySteps(steps: ActivityStep[]): ActivityStep[] {
-	return steps.flatMap((step) => (step.kind === "thinking" ? [step, ...step.tools] : [step]));
+function flattenActivitySteps(steps: ActivityNode[]): ActivityStep[] {
+	return steps.flatMap((step) =>
+		step.kind === "narration"
+			? flattenActivitySteps(step.steps)
+			: step.kind === "thinking"
+				? [step, ...step.tools]
+				: [step],
+	);
 }
 
-export function summarizeSteps(steps: ActivityStep[]): string {
+export function summarizeSteps(steps: ActivityNode[]): string {
 	const flatSteps = flattenActivitySteps(steps);
 	const counts = new Map<string, number>();
 	for (const step of flatSteps) {
@@ -268,7 +345,7 @@ export function summarizeSteps(steps: ActivityStep[]): string {
 	return `${count} · ${shown}${more > 0 ? `, +${more} more` : ""}`;
 }
 
-function liveActivityTicker(steps: ActivityStep[], workspaceRoot: string | undefined): string {
+function liveActivityTicker(steps: ActivityNode[], workspaceRoot: string | undefined): string {
 	const flatSteps = flattenActivitySteps(steps);
 	const current = flatSteps[flatSteps.length - 1];
 	if (!current) return "Working…";

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -26,7 +26,45 @@ The transcript is pi-canonical turns (`ChatTurn` in `types.ts`: user/assistant a
 record pi leaves where it replaced earlier messages), but the list renders **derived rows, not raw turns** — folding
 spans assistant-message boundaries (pi emits one assistant message per tool round), so a per-turn item
 model can't group. The pure **`deriveRows(turns, toolResults, isStreaming, isSpec?)`** (`rows.ts`) walks
-blocks in order into rows; `ChatTurnView` dispatches on row kind:
+blocks in order into rows; `ChatTurnView` dispatches on row kind.
+
+**Turn hierarchy — three regions per round.** A *settled* agent round reads as exactly *opening prose →
+one compact activity block → final prose*, not a flat chronological transcript. `deriveRows` accumulates
+each round's assistant blocks into a **segment** as one ordered `events` list (`step` = thinking / routine
+tool; `prose` = a text block) so a narration fragment keeps its position relative to the steps that
+followed it, then emits region rows in a fixed non-reflowing order:
+
+1. **opening** prose (`markdown` `role: "opening"`) — the round's intent: the first prose block plus any
+   *contiguous continuation* prose (no step between them, normalized into the opening).
+2. ONE coalesced `activity` block holding *all* routine work of the segment. **Intermediate narration
+   lives here, not as region-3 prose:** each mid-round prose fragment becomes a `NarrationStep` section
+   whose `steps` are the thinking/tools that followed it (a leading run of steps before the first
+   narration stays top-level; inside every section routine tools still `nestRoutineRun`-fold under their
+   thinking). Chronology and grouping are preserved — narration is a contextual label over its own
+   execution, never all-narration-collected-at-the-top. Collapsed, the whole block reduces to the
+   `summarizeSteps` count ("N steps", counting thinking + tools only — narration labels are not steps).
+3. **final** prose (`markdown` `role: "final"`) — the terminal message's prose, the settled user-facing
+   result, visually prominent below Activity.
+
+A `primary` tool (interactive/result-bearing — see the `tool` bullet) is *not* mechanics: it flushes the
+current segment, renders as its own prominent row in place, and a fresh segment begins after it — so most
+rounds are exactly one segment (one clean three-region layout), and interactive cards/diagrams are never
+buried in the fold.
+
+**Streaming vs settled.** The boundary is the pi event model's own, not a timing/string heuristic: a
+round is `user` → next `user` (or end); a message's `stopReason` distinguishes a continuing round
+(`toolUse`) from a terminal one (`stop`/`length`/`error`/`aborted`); a prose block is `terminal` when its
+message is settled and non-`toolUse`. Only the **trailing live segment of a streaming transcript** uses a
+different projection — the **response model**: opening + a steps-only Activity block + region-3 prose
+(`role: "response"`), so the answer being streamed is never buried inside Activity. Every already-past
+segment, and the whole transcript once it settles, uses the **narration model** above; that re-derivation
+is the running → settled *normalization* the design calls for. Because both projections are pure and
+boundary-derived, a hydrated transcript reconstructs the identical settled grouping as the live stream
+once settled (`hydrate.ts` builds the same turns; `deriveRows` does the rest). The opening anchor is
+`safeOpening` (first prose not preceded by activity, OR preceded but in an already-completed `toolUse`
+message — `confirmedContinuing`, so its region can't change at settlement); the parallel work pi exposes
+is only block/message order (batched tool calls are an ordered list in one message), which is preserved
+as-is — no stricter linear chronology is invented. Row list:
 
 - `user` / `system` / `retry` — 1:1 renderers. A user message that is Pi's canonical expanded skill block (`<skill name="…" location="…">`) renders
   as one **collapsed skill-invocation card** rather than exposing the full `SKILL.md`: the skill name is
@@ -79,7 +117,12 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   summarized disappear immediately rather than only after reload. Its `summary` opens on click
   (`data-testid="chat-compaction"`). Hydration/reopen starts directly from that same durable form. Both forms
   share the **"Context compacted"** title; only facts unavailable after reload disappear.
-- `markdown` — a non-empty assistant text block (react-markdown + remark-gfm + shiki). A fenced
+- `markdown` — a non-empty assistant text block carrying a `role` (`opening` | `final`, plus `response`
+  only in the streaming response model; surfaced as `data-prose-role` on the `data-role="assistant"`
+  element, the region hook for tests). Intermediate narration is NOT a `markdown` row in a settled round —
+  it renders inside Activity as a `narration` node. All roles use the same assistant body typography
+  (`tr-text-reading text-text-default`) and semantic tokens — the hierarchy is region *order*, not
+  per-role font/colour. Rendered via react-markdown + remark-gfm + shiki. A fenced
   ```mermaid block renders as a themed diagram via `tools/visualize`'s `MermaidView` (fullscreen
   pan-zoom, error → source fallback) — uniform across every `Markdown` surface (chat, file/specs
   preview); until mounted it renders as highlighted source, so static contexts (`RenderedDiff`'s
@@ -95,8 +138,15 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   needs no host fetch and works for paths outside the workspace. Previewable blocks require non-empty data
   and one of `contracts`' shared raster media types (PNG/JPEG/GIF/WebP); malformed shapes and unsupported
   media types are ignored, while canonical content arrays are never serialized into base64 JSON.
-- `activity` — one contiguous run of routine work stays one **collapsed outer disclosure** whose header
-  summarizes every atomic step (thinking blocks + routine tool calls). Expanding it preserves tools before
+- `activity` — the round segment's execution (thinking, routine tool calls, and — settled — intermediate
+  **narration** sections) as one **collapsed outer disclosure** whose header summarizes every atomic step.
+  It is coalesced across assistant-message boundaries and across intervening narration, so a segment has
+  at most one activity block regardless of how prose and tools interleave. Its `steps` are
+  `ActivityNode[]` = `NarrationStep | ThinkingStep | RoutineToolStep`: a `NarrationStep` (`NarrationGroup`,
+  a disclosure whose always-visible header is the model's narration text over its nested
+  thinking/tools — `data-testid="narration-group"`, breadcrumb kind `narration`) groups the steps that
+  followed that fragment. Only a `primary` tool or a non-assistant turn (a new round, compaction, retry,
+  error) breaks it. Expanding it preserves tools before
   the first thought as direct rows, then renders each non-empty thinking block as a nested disclosure. When
   that block's first non-empty line is a complete standalone Markdown strong span (`**…**` or `__…__`),
   its folded header surfaces the model-authored inner text in place of the redundant visible `Thinking`
@@ -108,8 +158,9 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   tool call stays under that thought until the next thinking block or activity boundary. Those thinking
   groups are siblings **inside** the outer run, even across assistant-message
   boundaries; the hierarchy is presentational, never invented pi entry parentage. A single atomic step
-  still renders directly. Non-empty text, primary tools, and non-assistant turns break the outer run. Only
-  its trailing instance carries the live ticker. Errored routine tools get **no special treatment**
+  still renders directly. Only
+  its trailing instance carries the live ticker (live while the segment's most recent block was activity,
+  not while the agent is streaming response prose below it). Errored routine tools get **no special treatment**
   (deliberate — agents often recover; `ErrorTurn` and primary error-auto-expand are the safety nets).
 - `subagentCompletion` — a `subagent-completion` custom message: a detached (background) subagent run's
   terminal report, injected into the parent by `pi-subagents` when the run finishes. Rendered as a compact

--- a/apps/web/src/chat/ThinkingGroup.test.tsx
+++ b/apps/web/src/chat/ThinkingGroup.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { ThinkingGroup } from "./ActivityGroup";
+import { NarrationGroup, ThinkingGroup } from "./ActivityGroup";
 
 const tool = (id: string, toolName: string) => ({
 	kind: "tool" as const,
@@ -130,6 +130,26 @@ describe("ThinkingGroup", () => {
 
 		expect(markup).not.toContain("Not actually strong");
 		expect(markup).not.toContain("This is ordinary reasoning.");
+	});
+
+	test("NarrationGroup shows the narration text as an always-visible section header over its steps", () => {
+		const markup = renderToStaticMarkup(
+			<NarrationGroup
+				parentId="activity:a1"
+				narration={{
+					kind: "narration",
+					id: "a2:text:0",
+					text: "Now the CSS token system and structure.",
+					steps: [tool("c1", "read"), tool("c2", "grep")],
+				}}
+			/>,
+		);
+		expect(markup).toContain('data-testid="narration-group"');
+		expect(markup).toContain('data-activity-node-kind="narration"');
+		expect(markup).toContain('data-activity-parent-id="activity:a1"');
+		expect(markup).toContain('data-testid="narration-group-headline"');
+		expect(markup).toContain("Now the CSS token system and structure.");
+		expect(markup).toContain("2 steps · read, grep");
 	});
 
 	test("rejects triple-emphasis runs instead of exposing leftover Markdown", () => {

--- a/apps/web/src/chat/activityBreadcrumbs.tsx
+++ b/apps/web/src/chat/activityBreadcrumbs.tsx
@@ -1,12 +1,13 @@
 import {
 	RiBrainLine as Brain,
+	RiChatQuoteLine as ChatQuote,
 	RiArrowRightSLine as ChevronRight,
 	RiStackLine as Layers,
 	RiToolsLine as Tools,
 } from "@remixicon/react";
 import { useCallback, useEffect, useState } from "react";
 
-export type ActivityBreadcrumbKind = "activity" | "thinking" | "tool";
+export type ActivityBreadcrumbKind = "activity" | "thinking" | "tool" | "narration";
 
 export interface ActivityBreadcrumbDescriptor {
 	id: string;
@@ -81,7 +82,14 @@ export function compressBreadcrumbPath(
 }
 
 function SegmentIcon({ kind }: { kind: ActivityBreadcrumbKind }) {
-	const Icon = kind === "activity" ? Layers : kind === "thinking" ? Brain : Tools;
+	const Icon =
+		kind === "activity"
+			? Layers
+			: kind === "thinking"
+				? Brain
+				: kind === "narration"
+					? ChatQuote
+					: Tools;
 	return <Icon aria-hidden className="size-12 shrink-0 text-primary" />;
 }
 

--- a/apps/web/src/chat/rows.test.ts
+++ b/apps/web/src/chat/rows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AssistantMessage } from "@thinkrail/contracts";
+import { summarizeSteps } from "./ActivityGroup";
 import { type ChatRow, deriveRows, projectRows, turnDivider } from "./rows";
 import { registerToolRenderer } from "./toolRegistry";
 import type { ChatTurn, ToolResultState } from "./types";
@@ -133,26 +134,113 @@ describe("deriveRows grouping", () => {
 		]);
 	});
 
-	test("non-empty text splits the run; empty/whitespace text and empty thinking do not", () => {
+	test("intermediate narration becomes a section inside the one activity block; empty text/thinking dropped", () => {
 		const turns = [
 			user("u1"),
-			assistant("a1", [
-				tc("t1"),
-				text("  "),
-				think(""),
-				tc("t2"),
-				text("interim narration"),
-				tc("t3"),
-			]),
+			assistant(
+				"a1",
+				[
+					text("I'll start."),
+					tc("t1"),
+					text("  "),
+					think(""),
+					tc("t2"),
+					text("interim narration"),
+					tc("t3"),
+				],
+				{ stopReason: "toolUse" },
+			),
+			assistant("a2", [text("final answer")]),
 			done("s1"),
 		];
 		const rows = deriveRows(turns, {}, false);
-		expect(kinds(rows)).toEqual(["user", "activity", "markdown", "activity", "system", "divider"]);
-		const first = rows[1];
-		const second = rows[3];
-		if (first?.kind !== "activity" || second?.kind !== "activity") throw new Error("bad rows");
-		expect(first.steps.map((s) => s.id)).toEqual(["t1", "t2"]);
-		expect(second.steps.map((s) => s.id)).toEqual(["t3"]);
+		expect(kinds(rows)).toEqual(["user", "markdown", "activity", "markdown", "system", "divider"]);
+		expect(rows[1]).toMatchObject({ role: "opening", text: "I'll start." });
+		const activity = rows[2];
+		if (activity?.kind !== "activity") throw new Error("expected one coalesced activity block");
+		expect(activity.steps.map((s) => s.kind)).toEqual(["tool", "tool", "narration"]);
+		const narration = activity.steps[2];
+		if (narration?.kind !== "narration") throw new Error("expected a narration section");
+		expect(narration.text).toBe("interim narration");
+		expect(narration.steps.map((s) => s.id)).toEqual(["t3"]);
+		expect(rows[3]).toMatchObject({ role: "final", text: "final answer" });
+	});
+
+	test("three regions: opening prose, one activity block, then final prose (reference rhythm)", () => {
+		const turns = [
+			user("u1"),
+			assistant("a1", [text("I'll inspect and fix."), tc("t1", "read")], { stopReason: "toolUse" }),
+			assistant("a2", [tc("t2", "edit"), text("Fixed. Verification: ok.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		expect(kinds(rows)).toEqual(["user", "markdown", "activity", "markdown", "system", "divider"]);
+		expect(rows[1]).toMatchObject({ text: "I'll inspect and fix.", role: "opening" });
+		const activity = rows[2];
+		if (activity?.kind !== "activity") throw new Error("expected activity row");
+		expect(activity.steps.map((s) => s.id)).toEqual(["t1", "t2"]);
+		expect(rows[3]).toMatchObject({ text: "Fixed. Verification: ok.", role: "final" });
+	});
+
+	test("a completed tool-use message's prose is the opening even when thinking preceded it", () => {
+		const turns = [
+			user("u1"),
+			assistant("a1", [think("plan"), text("I'll do X."), tc("t1", "read")], {
+				stopReason: "toolUse",
+			}),
+			assistant("a2", [text("Done.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		expect(kinds(rows)).toEqual(["user", "markdown", "activity", "markdown", "system", "divider"]);
+		expect(rows[1]).toMatchObject({ text: "I'll do X.", role: "opening" });
+		expect(rows[3]).toMatchObject({ text: "Done.", role: "final" });
+	});
+
+	test("a single prose block after activity is the final answer (region 3), not an opening", () => {
+		const turns = [
+			user("u1"),
+			assistant("a1", [think("hmm"), tc("t1"), text("The answer.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		expect(kinds(rows)).toEqual(["user", "activity", "markdown", "system", "divider"]);
+		expect(rows[2]).toMatchObject({ text: "The answer.", role: "final" });
+	});
+
+	test("a plain Q&A round with no activity is one prominent final message", () => {
+		const rows = deriveRows(
+			[user("u1"), assistant("a1", [text("Hi there.")]), done("s1")],
+			{},
+			false,
+		);
+		expect(kinds(rows)).toEqual(["user", "markdown", "system", "divider"]);
+		expect(rows[1]).toMatchObject({ text: "Hi there.", role: "final" });
+	});
+
+	test("a primary tool starts a fresh three-region segment after it", () => {
+		const turns = [
+			user("u1"),
+			assistant("a1", [text("Let me ask."), tc("t1"), tc("q1", "bare-tool")], {
+				stopReason: "toolUse",
+			}),
+			assistant("a2", [tc("t2"), text("All set.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		expect(kinds(rows)).toEqual([
+			"user",
+			"markdown",
+			"activity",
+			"tool",
+			"activity",
+			"markdown",
+			"system",
+			"divider",
+		]);
+		expect(rows[1]).toMatchObject({ text: "Let me ask.", role: "opening" });
+		expect(rows[3]?.kind === "tool" && rows[3].toolCallId).toBe("q1");
+		expect(rows[5]).toMatchObject({ text: "All set.", role: "final" });
 	});
 
 	test("a primary tool escapes the fold as its own row and breaks the run (bare implies primary)", () => {
@@ -266,6 +354,128 @@ describe("deriveRows grouping", () => {
 		expect(s1?.kind === "tool" && s1.tool?.status).toBe("done");
 		expect(s2?.kind === "tool" && s2.tool?.status).toBe("error");
 		expect(s3?.kind === "tool" && s3.tool).toBeUndefined();
+	});
+});
+
+describe("deriveRows narration-in-activity (settled)", () => {
+	test("several narration groups each own the steps that followed them, in chronological order", () => {
+		const turns = [
+			user("u1"),
+			assistant("a1", [text("Opening."), think("plan"), tc("t1")], { stopReason: "toolUse" }),
+			assistant("a2", [text("Now HTML."), tc("h1"), tc("h2")], { stopReason: "toolUse" }),
+			assistant("a3", [text("Now CSS."), tc("c1")], { stopReason: "toolUse" }),
+			assistant("a4", [text("Here's the audit.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		expect(kinds(rows)).toEqual(["user", "markdown", "activity", "markdown", "system", "divider"]);
+		expect(rows[1]).toMatchObject({ role: "opening", text: "Opening." });
+		expect(rows[3]).toMatchObject({ role: "final", text: "Here's the audit." });
+		const activity = rows[2];
+		if (activity?.kind !== "activity") throw new Error("expected activity");
+		expect(activity.steps.map((s) => s.kind)).toEqual(["thinking", "narration", "narration"]);
+		const think1 = activity.steps[0];
+		const html = activity.steps[1];
+		const css = activity.steps[2];
+		if (think1?.kind !== "thinking") throw new Error("expected leading thinking");
+		expect(think1.tools.map((t) => t.id)).toEqual(["t1"]);
+		if (html?.kind !== "narration" || css?.kind !== "narration") throw new Error("bad narration");
+		expect(html.text).toBe("Now HTML.");
+		expect(html.steps.map((s) => s.id)).toEqual(["h1", "h2"]);
+		expect(css.text).toBe("Now CSS.");
+		expect(css.steps.map((s) => s.id)).toEqual(["c1"]);
+	});
+
+	test("a narration section nests routine tools under a thinking block that followed it", () => {
+		const turns = [
+			user("u1"),
+			assistant("a1", [text("Opening."), tc("t0")], { stopReason: "toolUse" }),
+			assistant("a2", [text("Now the tokens."), think("inspect"), tc("t1"), tc("t2")], {
+				stopReason: "toolUse",
+			}),
+			assistant("a3", [text("Result.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		const activity = rows[2];
+		if (activity?.kind !== "activity") throw new Error("expected activity");
+		expect(activity.steps.map((s) => s.kind)).toEqual(["tool", "narration"]);
+		const narration = activity.steps[1];
+		if (narration?.kind !== "narration") throw new Error("expected narration");
+		const nestedThinking = narration.steps[0];
+		if (nestedThinking?.kind !== "thinking") throw new Error("expected nested thinking");
+		expect(nestedThinking.tools.map((t) => t.id)).toEqual(["t1", "t2"]);
+	});
+
+	test("a long run collapses to one activity block; the summary counts steps, not narration labels", () => {
+		const tools = Array.from({ length: 12 }, (_, i) => tc(`x${i}`, "read"));
+		const turns = [
+			user("u1"),
+			assistant("a1", [text("Opening."), ...tools.slice(0, 6)], { stopReason: "toolUse" }),
+			assistant("a2", [text("Halfway note."), ...tools.slice(6)], { stopReason: "toolUse" }),
+			assistant("a3", [text("Final.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		expect(rows.filter((r) => r.kind === "activity")).toHaveLength(1);
+		const activity = rows.find((r) => r.kind === "activity");
+		if (activity?.kind !== "activity") throw new Error("expected one activity block");
+		expect(summarizeSteps(activity.steps)).toBe("12 steps · read ×12");
+	});
+
+	test("streaming keeps narration as response prose; settling normalizes it into activity", () => {
+		const streaming = [
+			user("u1"),
+			assistant("a1", [text("Opening."), tc("t1"), text("Now HTML."), tc("h1")], {
+				stopReason: "toolUse",
+				streaming: true,
+			}),
+		];
+		const live = deriveRows(streaming, {}, true);
+		expect(kinds(live)).toEqual(["user", "markdown", "activity", "markdown"]);
+		expect(live[1]).toMatchObject({ role: "opening", text: "Opening." });
+		expect(live[3]).toMatchObject({ role: "response", text: "Now HTML." });
+		const liveActivity = live[2];
+		if (liveActivity?.kind !== "activity") throw new Error("expected activity");
+		expect(liveActivity.steps.every((s) => s.kind !== "narration")).toBe(true);
+
+		const settled = [
+			user("u1"),
+			assistant("a1", [text("Opening."), tc("t1"), text("Now HTML."), tc("h1")], {
+				stopReason: "toolUse",
+			}),
+			assistant("a2", [text("Final.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(settled, {}, false);
+		expect(kinds(rows)).toEqual(["user", "markdown", "activity", "markdown", "system", "divider"]);
+		expect(rows[3]).toMatchObject({ role: "final", text: "Final." });
+		const settledActivity = rows[2];
+		if (settledActivity?.kind !== "activity") throw new Error("expected activity");
+		const narration = settledActivity.steps.find((s) => s.kind === "narration");
+		if (narration?.kind !== "narration") throw new Error("narration should move into activity");
+		expect(narration.text).toBe("Now HTML.");
+		expect(narration.steps.map((s) => s.id)).toEqual(["h1"]);
+	});
+
+	test("contiguous continuation prose (no step between) normalizes into the opening", () => {
+		const turns = [
+			user("u1"),
+			assistant("a1", [text("I'll audit the page."), text("Let me gather source."), tc("t1")], {
+				stopReason: "toolUse",
+			}),
+			assistant("a2", [text("Done.")]),
+			done("s1"),
+		];
+		const rows = deriveRows(turns, {}, false);
+		const openings = rows.filter((r) => r.kind === "markdown" && r.role === "opening");
+		expect(openings.map((r) => (r.kind === "markdown" ? r.text : ""))).toEqual([
+			"I'll audit the page.",
+			"Let me gather source.",
+		]);
+		const activity = rows.find((r) => r.kind === "activity");
+		if (activity?.kind !== "activity") throw new Error("expected activity");
+		expect(activity.steps.every((s) => s.kind !== "narration")).toBe(true);
 	});
 });
 

--- a/apps/web/src/chat/rows.ts
+++ b/apps/web/src/chat/rows.ts
@@ -25,6 +25,17 @@ export interface ThinkingStep {
 
 export type ActivityStep = RoutineToolStep | ThinkingStep;
 
+export interface NarrationStep {
+	kind: "narration";
+	id: string;
+	text: string;
+	steps: ActivityStep[];
+}
+
+export type ActivityNode = NarrationStep | ThinkingStep | RoutineToolStep;
+
+export type ProseRole = "opening" | "response" | "final";
+
 export type ChatRow =
 	| { kind: "user"; id: string; message: UserMessage; attachmentNames?: string[] }
 	| { kind: "system"; id: string; text: string }
@@ -38,13 +49,13 @@ export type ChatRow =
 			maxAttempts: number;
 			delayMs: number;
 	  }
-	| { kind: "markdown"; id: string; text: string }
+	| { kind: "markdown"; id: string; text: string; role: ProseRole }
 	| { kind: "subagentCompletion"; id: string; details: DelegationRunDetails; text: string }
 	| ({ kind: "tool"; id: string } & ToolCallData)
 	| {
 			kind: "activity";
 			id: string;
-			steps: ActivityStep[];
+			steps: ActivityNode[];
 			live: boolean;
 	  }
 	| { kind: "divider"; id: string; data: TurnDividerData };
@@ -74,6 +85,23 @@ export function projectRows(rows: ChatRow[], messageOrder: ChatMessageOrder): Ch
 	return projected;
 }
 
+interface ProseEntry {
+	id: string;
+	text: string;
+	safeOpening: boolean;
+	afterStep: boolean;
+	terminal: boolean;
+}
+
+type SegEvent = { kind: "step"; step: ActivityStep } | { kind: "prose"; entry: ProseEntry };
+
+interface Segment {
+	events: SegEvent[];
+	sawActivity: boolean;
+	endedOnActivity: boolean;
+	stepSincePrevProse: boolean;
+}
+
 function nestRoutineRun(steps: ActivityStep[]): ActivityStep[] {
 	const nested: ActivityStep[] = [];
 	let currentThinking: ThinkingStep | undefined;
@@ -90,6 +118,33 @@ function nestRoutineRun(steps: ActivityStep[]): ActivityStep[] {
 	return nested;
 }
 
+function buildActivityTree(events: SegEvent[]): ActivityNode[] {
+	const top: ActivityNode[] = [];
+	let sectionSteps: ActivityStep[] = [];
+	let narration: NarrationStep | undefined;
+	const commit = () => {
+		const nested = nestRoutineRun(sectionSteps);
+		if (narration) narration.steps = nested;
+		else top.push(...nested);
+		sectionSteps = [];
+	};
+	for (const event of events) {
+		if (event.kind === "prose") {
+			commit();
+			narration = { kind: "narration", id: event.entry.id, text: event.entry.text, steps: [] };
+			top.push(narration);
+		} else {
+			sectionSteps.push(event.step);
+		}
+	}
+	commit();
+	return top;
+}
+
+function emptySegment(): Segment {
+	return { events: [], sawActivity: false, endedOnActivity: false, stepSincePrevProse: false };
+}
+
 export function deriveRows(
 	turns: ChatTurn[],
 	toolResults: Record<string, ToolResultState>,
@@ -97,37 +152,122 @@ export function deriveRows(
 	isSpec?: (path: string) => boolean,
 ): ChatRow[] {
 	const rows: ChatRow[] = [];
-	let run: ActivityStep[] = [];
+	let seg = emptySegment();
 
-	const flushRun = (live = false) => {
-		const first = run[0];
-		if (!first) return;
-		rows.push({ kind: "activity", id: `activity:${first.id}`, steps: nestRoutineRun(run), live });
-		run = [];
+	const pushProse = (entry: ProseEntry, role: ProseRole) => {
+		rows.push({ kind: "markdown", id: entry.id, text: entry.text, role });
+	};
+
+	const pushActivity = (events: SegEvent[], live: boolean) => {
+		const firstStep = events.find((event) => event.kind === "step");
+		if (firstStep?.kind !== "step") return false;
+		rows.push({
+			kind: "activity",
+			id: `activity:${firstStep.step.id}`,
+			steps: buildActivityTree(events),
+			live,
+		});
+		return true;
+	};
+
+	const flushSegment = (opts: { live: boolean; settled: boolean; roundEnd: boolean }) => {
+		const { events } = seg;
+		if (events.length === 0) {
+			seg = emptySegment();
+			return;
+		}
+		const prose = events.flatMap((event) => (event.kind === "prose" ? [event.entry] : []));
+		const anyStep = events.some((event) => event.kind === "step");
+		const first = prose[0];
+		const hasFollowing = anyStep || prose.length > 1;
+
+		if (!opts.settled) {
+			const opening = first?.safeOpening && hasFollowing ? first : undefined;
+			if (opening) pushProse(opening, "opening");
+			pushActivity(
+				events.filter((event) => event.kind === "step"),
+				opts.live,
+			);
+			const response = opening ? prose.slice(1) : prose;
+			response.forEach((entry, idx) => {
+				pushProse(entry, opts.roundEnd && idx === response.length - 1 ? "final" : "response");
+			});
+			seg = emptySegment();
+			return;
+		}
+
+		const openingIds = new Set<string>();
+		if (first?.safeOpening && hasFollowing && !first.terminal) {
+			openingIds.add(first.id);
+			for (let k = 1; k < prose.length; k++) {
+				const entry = prose[k];
+				const prev = prose[k - 1];
+				if (entry && prev && !entry.afterStep && !entry.terminal && openingIds.has(prev.id))
+					openingIds.add(entry.id);
+				else break;
+			}
+		}
+		const finalIds = new Set(
+			prose.filter((entry) => entry.terminal && !openingIds.has(entry.id)).map((entry) => entry.id),
+		);
+		const activityEvents = events.filter(
+			(event) =>
+				event.kind === "step" || (!openingIds.has(event.entry.id) && !finalIds.has(event.entry.id)),
+		);
+
+		for (const event of events)
+			if (event.kind === "prose" && openingIds.has(event.entry.id))
+				pushProse(event.entry, "opening");
+		if (!pushActivity(activityEvents, opts.live))
+			for (const event of activityEvents)
+				if (event.kind === "prose") pushProse(event.entry, "response");
+		for (const event of events)
+			if (event.kind === "prose" && finalIds.has(event.entry.id)) pushProse(event.entry, "final");
+		seg = emptySegment();
 	};
 
 	for (let i = 0; i < turns.length; i++) {
 		const turn = turns[i];
 		if (!turn) continue;
+		const endsRound =
+			turn.kind !== "user" &&
+			(turns[i + 1]?.kind === "user" || (i === turns.length - 1 && !isStreaming));
 		if (turn.kind === "assistant") {
 			const { message } = turn;
 			const dead = message.stopReason === "aborted" || message.stopReason === "error";
+			const confirmedContinuing = !turn.streaming && message.stopReason === "toolUse";
 			for (let b = 0; b < message.content.length; b++) {
 				const block = message.content[b];
 				if (!block) continue;
 				if (block.type === "thinking") {
 					if (block.thinking.trim().length === 0) continue;
-					run.push({
-						kind: "thinking",
-						id: `${turn.id}:thinking:${b}`,
-						text: block.thinking,
-						streaming: turn.streaming,
-						tools: [],
+					seg.events.push({
+						kind: "step",
+						step: {
+							kind: "thinking",
+							id: `${turn.id}:thinking:${b}`,
+							text: block.thinking,
+							streaming: turn.streaming,
+							tools: [],
+						},
 					});
+					seg.sawActivity = true;
+					seg.endedOnActivity = true;
+					seg.stepSincePrevProse = true;
 				} else if (block.type === "text") {
 					if (block.text.trim().length === 0) continue;
-					flushRun();
-					rows.push({ kind: "markdown", id: `${turn.id}:text:${b}`, text: block.text });
+					seg.events.push({
+						kind: "prose",
+						entry: {
+							id: `${turn.id}:text:${b}`,
+							text: block.text,
+							safeOpening: !seg.sawActivity || confirmedContinuing,
+							afterStep: seg.stepSincePrevProse,
+							terminal: !turn.streaming && message.stopReason !== "toolUse",
+						},
+					});
+					seg.endedOnActivity = false;
+					seg.stepSincePrevProse = false;
 				} else if (block.type === "toolCall") {
 					const data: ToolCallData = {
 						toolCallId: block.id,
@@ -138,15 +278,23 @@ export function deriveRows(
 						streaming: turn.streaming,
 					};
 					if (resolveProminence(block.name).prominence === "primary") {
-						flushRun();
+						flushSegment({ live: false, settled: true, roundEnd: false });
 						rows.push({ kind: "tool", id: block.id, ...data });
 					} else {
-						run.push({ kind: "tool", id: block.id, ...data });
+						seg.events.push({ kind: "step", step: { kind: "tool", id: block.id, ...data } });
+						seg.sawActivity = true;
+						seg.endedOnActivity = true;
+						seg.stepSincePrevProse = true;
 					}
 				}
 			}
+			if (endsRound) {
+				flushSegment({ live: false, settled: true, roundEnd: true });
+				const data = turnDivider(turns, i, isSpec);
+				if (data) rows.push({ kind: "divider", id: `${turn.id}:divider`, data });
+			}
 		} else {
-			flushRun();
+			flushSegment({ live: false, settled: true, roundEnd: endsRound });
 			switch (turn.kind) {
 				case "user":
 					rows.push({
@@ -189,17 +337,17 @@ export function deriveRows(
 					});
 					break;
 			}
-		}
-		const roundEnded =
-			turn.kind !== "user" &&
-			(turns[i + 1]?.kind === "user" || (i === turns.length - 1 && !isStreaming));
-		if (roundEnded) {
-			flushRun();
-			const data = turnDivider(turns, i, isSpec);
-			if (data) rows.push({ kind: "divider", id: `${turn.id}:divider`, data });
+			if (endsRound) {
+				const data = turnDivider(turns, i, isSpec);
+				if (data) rows.push({ kind: "divider", id: `${turn.id}:divider`, data });
+			}
 		}
 	}
-	flushRun(isStreaming);
+	flushSegment({
+		live: isStreaming && seg.endedOnActivity,
+		settled: !isStreaming,
+		roundEnd: !isStreaming,
+	});
 	return rows;
 }
 

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -89,6 +89,7 @@ export function ChatTurnView({
 				<div
 					data-testid="chat-message"
 					data-role="assistant"
+					data-prose-role={row.role}
 					className="tr-text-reading text-text-default"
 				>
 					<Markdown text={row.text} />

--- a/e2e/turn-hierarchy.spec.ts
+++ b/e2e/turn-hierarchy.spec.ts
@@ -1,0 +1,129 @@
+import { appendFileSync, realpathSync, utimesSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+	defaultWorkspaceRow,
+	enterDefaultWorkspace,
+	openChatFromHistory,
+	openFixtureProject,
+} from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_500_000_000;
+const repoCwd = () => realpathSync(E2E_FIXTURE_REPO);
+
+function appendMessage(path: string, id: string, parentId: string, message: object): string {
+	appendFileSync(
+		path,
+		`${JSON.stringify({ type: "message", id, parentId, timestamp: new Date(BASE_TS).toISOString(), message })}\n`,
+	);
+	return id;
+}
+const usage = {
+	input: 10,
+	output: 10,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 20,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+test("one round resolves to opening prose, one compact activity block, then the final answer", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const chat = seedWorkspaceSession(repoCwd(), {
+		name: "turn hierarchy",
+		messages: [{ role: "user", text: "Fix the rename flow.", timestamp: BASE_TS }],
+	});
+
+	// A round whose prose and tools interleave: opening → tool → intermediate → tool → final.
+	// The projection must not scatter this into four prose rows around two activity blocks.
+	const a1 = appendMessage(chat.path, `${chat.id}-a1`, `${chat.id}-m0`, {
+		role: "assistant",
+		content: [
+			{ type: "text", text: "I'll inspect the rename flow and fix the display-name behavior." },
+			{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "rename.ts" } },
+		],
+		usage,
+		stopReason: "toolUse",
+		timestamp: BASE_TS + 1_000,
+	});
+	const r1 = appendMessage(chat.path, `${chat.id}-read-1`, a1, {
+		role: "toolResult",
+		toolCallId: "read-1",
+		toolName: "read",
+		content: [{ type: "text", text: "ok" }],
+		isError: false,
+		timestamp: BASE_TS + 1_100,
+	});
+	const a2 = appendMessage(chat.path, `${chat.id}-a2`, r1, {
+		role: "assistant",
+		content: [
+			{ type: "text", text: "Found it: the branch was renamed alongside the label." },
+			{ type: "toolCall", id: "edit-1", name: "edit", arguments: { path: "rename.ts" } },
+		],
+		usage,
+		stopReason: "toolUse",
+		timestamp: BASE_TS + 2_000,
+	});
+	const r2 = appendMessage(chat.path, `${chat.id}-edit-1`, a2, {
+		role: "toolResult",
+		toolCallId: "edit-1",
+		toolName: "edit",
+		content: [{ type: "text", text: "ok" }],
+		isError: false,
+		timestamp: BASE_TS + 2_100,
+	});
+	appendMessage(chat.path, `${chat.id}-a3`, r2, {
+		role: "assistant",
+		content: [
+			{
+				type: "text",
+				text: "Fixed. Renaming now changes only the display name; the Git branch is untouched.",
+			},
+		],
+		usage,
+		stopReason: "stop",
+		timestamp: BASE_TS + 3_000,
+	});
+	utimesSync(chat.path, new Date(BASE_TS), new Date(BASE_TS));
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+	await openChatFromHistory(page, "turn hierarchy");
+
+	// Exactly one compact activity block for the whole round (two tools coalesced, not two blocks).
+	const activity = page.getByTestId("activity-group");
+	await expect(activity).toHaveCount(1);
+
+	// Only two prose regions survive settlement: opening and final. Intermediate narration is
+	// NOT a region-3 prose row any more — it moved into Activity.
+	const prose = page.locator('[data-testid="chat-message"][data-role="assistant"]');
+	await expect(prose).toHaveCount(2);
+	await expect(prose.nth(0)).toHaveAttribute("data-prose-role", "opening");
+	await expect(prose.nth(0)).toContainText("I'll inspect the rename flow");
+	await expect(prose.nth(1)).toHaveAttribute("data-prose-role", "final");
+	await expect(prose.nth(1)).toContainText("only the display name");
+	await expect(page.getByText("Found it", { exact: false })).toHaveCount(0);
+
+	// The opening leads the turn; the single activity block sits between opening and final.
+	const openingBox = await prose.nth(0).boundingBox();
+	const activityBox = await activity.boundingBox();
+	const finalBox = await prose.nth(1).boundingBox();
+	if (!openingBox || !activityBox || !finalBox) throw new Error("missing layout boxes");
+	expect(openingBox.y).toBeLessThan(activityBox.y);
+	expect(activityBox.y).toBeLessThan(finalBox.y);
+
+	// Mechanics stay compact-by-default but remain inspectable via disclosure. Expanding reveals the
+	// intermediate narration as a contextual section that groups the step that followed it.
+	await expect(activity).toHaveAttribute("data-expanded", "false");
+	await activity.getByTestId("activity-group-toggle").click();
+	await expect(activity).toHaveAttribute("data-expanded", "true");
+	await expect(activity.locator('[data-testid="activity-step"][data-tool="read"]')).toBeVisible();
+	const narration = activity.getByTestId("narration-group");
+	await expect(narration).toHaveCount(1);
+	await expect(narration).toContainText("Found it");
+	await narration.getByTestId("narration-group-toggle").click();
+	await expect(narration.locator('[data-testid="activity-step"][data-tool="edit"]')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

This PR redesigns how agent activity is presented in chat to make longer runs easier to scan and significantly more compact.

Previously, agent narration, thinking, skills, tool calls, file operations, and other execution steps appeared sequentially as separate items, creating a long stream that could quickly take over the conversation.

Now the hierarchy is simplified:

- The agent's opening message stays visible at the top.
- Intermediate execution activity — thinking, skills, tools, file operations, tests, and related narration — is grouped into a single compact, collapsible activity section while preserving the underlying sequence and context.
- Interactive/result tools remain prominent when user attention or input is required.
- The final response stays separate and visible below the activity.

The goal is to let users understand what the agent is doing at a glance, keep the actual conversation prominent, and avoid an endlessly growing sequence of execution steps.

### Before 
https://github.com/user-attachments/assets/3f392acd-d921-481b-b363-ba0713ea3a37 
### After
https://github.com/user-attachments/assets/563fcf30-53dd-4dbb-8800-cc8075dc41f2



### Before
<img width="1919" height="962" alt="Screenshot 2026-08-31 at 2 35 26 PM" src="https://github.com/user-attachments/assets/c696d638-4e0e-4d18-ba7e-b73e59fd3170" />

### After
<img width="1918" height="959" alt="Screenshot 2026-08-31 at 2 26 40 PM" src="https://github.com/user-attachments/assets/6d5db2dc-ec98-450b-b752-fe198b237ef5" />


