### PR TITLE
[Design] Add copy actions and show more/less for long messages 

### DIFF
--- a/apps/web/src/chat/ActivityGroup.test.ts
+++ b/apps/web/src/chat/ActivityGroup.test.ts
@@ -55,7 +55,9 @@ describe("activity disclosure summaries", () => {
 			live: false,
 		};
 
-		const markup = renderToStaticMarkup(ChatTurnView({ row }));
+		const markup = renderToStaticMarkup(
+			ChatTurnView({ row, agentResponded: false, isFinalAnswer: false }),
+		);
 
 		expect(markup).toContain('data-testid="activity-group"');
 		expect(markup).toContain('data-activity-node-id="activity:a"');
@@ -65,7 +67,13 @@ describe("activity disclosure summaries", () => {
 		expect(markup).not.toContain(">Activity<");
 		expect(markup).not.toContain("inspect first");
 
-		const liveMarkup = renderToStaticMarkup(ChatTurnView({ row: { ...row, live: true } }));
+		const liveMarkup = renderToStaticMarkup(
+			ChatTurnView({
+				row: { ...row, live: true },
+				agentResponded: false,
+				isFinalAnswer: false,
+			}),
+		);
 		expect(liveMarkup).toContain('data-activity-node-label="4 steps"');
 	});
 });

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -817,7 +817,6 @@ export default function ChatView({
 							totalListHeightChanged={handleContentHeight}
 							atBottomThreshold={50}
 							atTopThreshold={50}
-							increaseViewportBy={{ top: 1600, bottom: 1600 }}
 							computeItemKey={(_, row) => row.id}
 							itemContent={(index, row) => (
 								<div

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -38,6 +38,7 @@ import {
 } from "./Composer";
 import { ExtUiDialog } from "./ExtUiDialog";
 import { HistoryOverlay } from "./HistoryOverlay";
+import { deriveMessageActions } from "./messageActions";
 import type { ChatMessageOrder } from "./messageOrder";
 import {
 	compactSubmissionError,
@@ -247,43 +248,10 @@ export default function ChatView({
 	}
 	const firstItemIndex = virtualRows.firstItemIndex;
 
-	const userResponded = useMemo(() => {
-		const map = new Map<string, boolean>();
-		let sawQualifying = false;
-		let sawUserAfter = false;
-		for (let i = chronologicalRows.length - 1; i >= 0; i--) {
-			const kind = chronologicalRows[i]?.kind;
-			if (kind === "user") {
-				map.set(chronologicalRows[i]?.id ?? "", sawQualifying || (!sawUserAfter && isStreaming));
-				sawUserAfter = true;
-			} else if (
-				kind === "markdown" ||
-				kind === "tool" ||
-				kind === "activity" ||
-				kind === "divider"
-			) {
-				sawQualifying = true;
-			}
-		}
-		return map;
-	}, [chronologicalRows, isStreaming]);
-
-	const finalAnswerRowIds = useMemo(() => {
-		const ids = new Set<string>();
-		let dirtySinceUser = false;
-		for (let i = chronologicalRows.length - 1; i >= 0; i--) {
-			const kind = chronologicalRows[i]?.kind;
-			if (kind === "user") {
-				dirtySinceUser = false;
-			} else if (kind === "markdown") {
-				if (!dirtySinceUser) ids.add(chronologicalRows[i]?.id ?? "");
-				dirtySinceUser = true;
-			} else if (kind === "tool" || kind === "activity") {
-				dirtySinceUser = true;
-			}
-		}
-		return ids;
-	}, [chronologicalRows]);
+	const messageActions = useMemo(
+		() => deriveMessageActions(chronologicalRows, isStreaming),
+		[chronologicalRows, isStreaming],
+	);
 
 	const currentStreamStatus = useMemo<StreamStatus | null>(() => {
 		const last = turns[turns.length - 1];
@@ -835,10 +803,8 @@ export default function ChatView({
 										row={row}
 										workspaceRoot={workspaceRoot}
 										onOpenFile={onOpenFile}
-										agentResponded={row.kind === "user" ? userResponded.get(row.id) : undefined}
-										isFinalAnswer={
-											row.kind === "markdown" ? finalAnswerRowIds.has(row.id) : undefined
-										}
+										agentResponded={messageActions.agentRespondedByUserId.get(row.id) ?? false}
+										isFinalAnswer={messageActions.finalAnswerRowIds.has(row.id)}
 										onOpenSpec={onOpenSpec}
 										onOpenChange={onOpenChange}
 										onReveal={onReveal}

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -824,8 +824,6 @@ export default function ChatView({
 							totalListHeightChanged={handleContentHeight}
 							atBottomThreshold={50}
 							atTopThreshold={50}
-							// Keep a generous off-screen render buffer so a short transcript stays fully mounted
-							// even when opened scrolled to the bottom (rows now carry a per-message copy action).
 							increaseViewportBy={{ top: 1600, bottom: 1600 }}
 							computeItemKey={(_, row) => row.id}
 							itemContent={(index, row) => (

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -247,48 +247,43 @@ export default function ChatView({
 	}
 	const firstItemIndex = virtualRows.firstItemIndex;
 
-	// Per user row: has the agent started responding to it? Drives the large-user-message auto-collapse
-	// (client view state only — no wire). "Responded" = a later assistant-derived row exists after it,
-	// or it is the trailing user row while the session is still streaming (covers the pre-content gap).
 	const userResponded = useMemo(() => {
 		const map = new Map<string, boolean>();
-		for (let i = 0; i < rows.length; i++) {
-			if (rows[i]?.kind !== "user") continue;
-			let responded = false;
-			let hasUserAfter = false;
-			for (let j = i + 1; j < rows.length; j++) {
-				const k = rows[j]?.kind;
-				if (k === "markdown" || k === "tool" || k === "activity" || k === "divider")
-					responded = true;
-				if (k === "user") hasUserAfter = true;
+		let sawQualifying = false;
+		let sawUserAfter = false;
+		for (let i = chronologicalRows.length - 1; i >= 0; i--) {
+			const kind = chronologicalRows[i]?.kind;
+			if (kind === "user") {
+				map.set(chronologicalRows[i]?.id ?? "", sawQualifying || (!sawUserAfter && isStreaming));
+				sawUserAfter = true;
+			} else if (
+				kind === "markdown" ||
+				kind === "tool" ||
+				kind === "activity" ||
+				kind === "divider"
+			) {
+				sawQualifying = true;
 			}
-			if (!responded && !hasUserAfter && isStreaming) responded = true;
-			map.set(rows[i]?.id ?? "", responded);
 		}
 		return map;
-	}, [rows, isStreaming]);
+	}, [chronologicalRows, isStreaming]);
 
-	// The concluding answer of each round — the only `markdown` row that carries the Copy action, so it
-	// rides the work summary rather than the intermediate narration the agent emits between tool steps. A
-	// markdown row is "final" when no further assistant-content row (`markdown`/`tool`/`activity`) follows
-	// it before the next user turn (a `divider`/`system`/`retry` in between doesn't disqualify it).
 	const finalAnswerRowIds = useMemo(() => {
 		const ids = new Set<string>();
-		for (let i = 0; i < rows.length; i++) {
-			if (rows[i]?.kind !== "markdown") continue;
-			let isFinal = true;
-			for (let j = i + 1; j < rows.length; j++) {
-				const k = rows[j]?.kind;
-				if (k === "user") break;
-				if (k === "markdown" || k === "tool" || k === "activity") {
-					isFinal = false;
-					break;
-				}
+		let dirtySinceUser = false;
+		for (let i = chronologicalRows.length - 1; i >= 0; i--) {
+			const kind = chronologicalRows[i]?.kind;
+			if (kind === "user") {
+				dirtySinceUser = false;
+			} else if (kind === "markdown") {
+				if (!dirtySinceUser) ids.add(chronologicalRows[i]?.id ?? "");
+				dirtySinceUser = true;
+			} else if (kind === "tool" || kind === "activity") {
+				dirtySinceUser = true;
 			}
-			if (isFinal) ids.add(rows[i]?.id ?? "");
 		}
 		return ids;
-	}, [rows]);
+	}, [chronologicalRows]);
 
 	const currentStreamStatus = useMemo<StreamStatus | null>(() => {
 		const last = turns[turns.length - 1];

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -247,6 +247,49 @@ export default function ChatView({
 	}
 	const firstItemIndex = virtualRows.firstItemIndex;
 
+	// Per user row: has the agent started responding to it? Drives the large-user-message auto-collapse
+	// (client view state only — no wire). "Responded" = a later assistant-derived row exists after it,
+	// or it is the trailing user row while the session is still streaming (covers the pre-content gap).
+	const userResponded = useMemo(() => {
+		const map = new Map<string, boolean>();
+		for (let i = 0; i < rows.length; i++) {
+			if (rows[i]?.kind !== "user") continue;
+			let responded = false;
+			let hasUserAfter = false;
+			for (let j = i + 1; j < rows.length; j++) {
+				const k = rows[j]?.kind;
+				if (k === "markdown" || k === "tool" || k === "activity" || k === "divider")
+					responded = true;
+				if (k === "user") hasUserAfter = true;
+			}
+			if (!responded && !hasUserAfter && isStreaming) responded = true;
+			map.set(rows[i]?.id ?? "", responded);
+		}
+		return map;
+	}, [rows, isStreaming]);
+
+	// The concluding answer of each round — the only `markdown` row that carries the Copy action, so it
+	// rides the work summary rather than the intermediate narration the agent emits between tool steps. A
+	// markdown row is "final" when no further assistant-content row (`markdown`/`tool`/`activity`) follows
+	// it before the next user turn (a `divider`/`system`/`retry` in between doesn't disqualify it).
+	const finalAnswerRowIds = useMemo(() => {
+		const ids = new Set<string>();
+		for (let i = 0; i < rows.length; i++) {
+			if (rows[i]?.kind !== "markdown") continue;
+			let isFinal = true;
+			for (let j = i + 1; j < rows.length; j++) {
+				const k = rows[j]?.kind;
+				if (k === "user") break;
+				if (k === "markdown" || k === "tool" || k === "activity") {
+					isFinal = false;
+					break;
+				}
+			}
+			if (isFinal) ids.add(rows[i]?.id ?? "");
+		}
+		return ids;
+	}, [rows]);
+
 	const currentStreamStatus = useMemo<StreamStatus | null>(() => {
 		const last = turns[turns.length - 1];
 		return isStreaming && last?.kind !== "retry" ? streamStatus(turns, currentAssistantId) : null;
@@ -786,6 +829,9 @@ export default function ChatView({
 							totalListHeightChanged={handleContentHeight}
 							atBottomThreshold={50}
 							atTopThreshold={50}
+							// Keep a generous off-screen render buffer so a short transcript stays fully mounted
+							// even when opened scrolled to the bottom (rows now carry a per-message copy action).
+							increaseViewportBy={{ top: 1600, bottom: 1600 }}
 							computeItemKey={(_, row) => row.id}
 							itemContent={(index, row) => (
 								<div
@@ -796,6 +842,10 @@ export default function ChatView({
 										row={row}
 										workspaceRoot={workspaceRoot}
 										onOpenFile={onOpenFile}
+										agentResponded={row.kind === "user" ? userResponded.get(row.id) : undefined}
+										isFinalAnswer={
+											row.kind === "markdown" ? finalAnswerRowIds.has(row.id) : undefined
+										}
 										onOpenSpec={onOpenSpec}
 										onOpenChange={onOpenChange}
 										onReveal={onReveal}

--- a/apps/web/src/chat/CopyButton.tsx
+++ b/apps/web/src/chat/CopyButton.tsx
@@ -1,0 +1,47 @@
+import { RiCheckLine as Check, RiFileCopyLine as Copy } from "@remixicon/react";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib";
+
+/**
+ * A hover-revealed copy affordance for a chat message. Self-contained and presentational (no
+ * store/transport): it writes `getText()` to the clipboard and flips its icon to a check for ~1.2s as
+ * confirmation, rather than reaching the store toast `panels/PlanPane` uses — that keeps the message
+ * renderers props-driven and reusable. `getText` is a thunk so the caller supplies the full message
+ * source (never a collapsed preview) at click time.
+ */
+export function CopyButton({
+	getText,
+	label = "Copy message",
+	className,
+}: {
+	getText: () => string;
+	label?: string;
+	className?: string | undefined;
+}) {
+	const [copied, setCopied] = useState(false);
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(() => () => (timer.current ? clearTimeout(timer.current) : undefined), []);
+
+	return (
+		<button
+			type="button"
+			data-testid="chat-copy"
+			data-copied={copied || undefined}
+			aria-label={label}
+			title={label}
+			onClick={() => {
+				void navigator.clipboard.writeText(getText()).then(() => {
+					setCopied(true);
+					if (timer.current) clearTimeout(timer.current);
+					timer.current = setTimeout(() => setCopied(false), 1200);
+				});
+			}}
+			className={cn(
+				"flex size-24 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-text-muted opacity-0 transition hover:bg-control-bg-hovered hover:text-text-default focus-visible:opacity-100 group-hover:opacity-100 data-[copied]:opacity-100",
+				className,
+			)}
+		>
+			{copied ? <Check className="size-14" /> : <Copy className="size-14" />}
+		</button>
+	);
+}

--- a/apps/web/src/chat/CopyButton.tsx
+++ b/apps/web/src/chat/CopyButton.tsx
@@ -1,6 +1,6 @@
 import { RiCheckLine as Check, RiFileCopyLine as Copy } from "@remixicon/react";
 import { useEffect, useRef, useState } from "react";
-import { cn } from "@/lib";
+import { cn, copyText } from "@/lib";
 
 export function CopyButton({
 	getText,
@@ -23,11 +23,12 @@ export function CopyButton({
 			aria-label={label}
 			title={label}
 			onClick={() => {
-				void navigator.clipboard.writeText(getText()).then(() => {
+				void (async () => {
+					if (!(await copyText(getText()))) return;
 					setCopied(true);
 					if (timer.current) clearTimeout(timer.current);
 					timer.current = setTimeout(() => setCopied(false), 1200);
-				});
+				})();
 			}}
 			className={cn(
 				"flex size-24 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-text-muted opacity-0 transition hover:bg-control-bg-hovered hover:text-text-default focus-visible:opacity-100 group-hover:opacity-100 data-[copied]:opacity-100",

--- a/apps/web/src/chat/CopyButton.tsx
+++ b/apps/web/src/chat/CopyButton.tsx
@@ -2,13 +2,6 @@ import { RiCheckLine as Check, RiFileCopyLine as Copy } from "@remixicon/react";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib";
 
-/**
- * A hover-revealed copy affordance for a chat message. Self-contained and presentational (no
- * store/transport): it writes `getText()` to the clipboard and flips its icon to a check for ~1.2s as
- * confirmation, rather than reaching the store toast `panels/PlanPane` uses — that keeps the message
- * renderers props-driven and reusable. `getText` is a thunk so the caller supplies the full message
- * source (never a collapsed preview) at click time.
- */
 export function CopyButton({
 	getText,
 	label = "Copy message",

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -118,15 +118,17 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   precedes the next user turn (`finalAnswerRowIds`, passed down as `isFinalAnswer`); a non-final markdown
   row renders plain, without the action.
   Both go through **one shared layout**, `MessageWithCopy` (in `turns.tsx`): a `relative` wrapper that
-  overlays the action on the message's own **bottom-right corner** (`absolute right-4 bottom-4` on the
+  overlays the action on the message's own **bottom-right corner** (`absolute right-4 bottom-0` on the
   `CopyButton`) — for both roles alike, agent and user — rather than a row below the content. The user
   bubble stays content-only: the button is positioned against the outer wrapper, not injected into the
   bubble markup, and lands on the bubble's own corner because the bubble is the wrapper's only (and so
   bottom-most, right-aligned) child. Both message content wrappers (the user bubble, the final-answer
-  markdown wrapper) carry `pb-32` — clearance for the button's 24px hit target plus its inset — so the
-  overlay's hit area is reserved padding, never the text's own last line, no matter how close that line
-  runs to the right edge. `MessageWithCopy` also carries the `data-testid="chat-message"`/`data-role`
-  hooks the jump/flash + tests rely on. `CopyButton` is a self-contained presentational primitive
+  markdown wrapper) carry `pb-24` — exactly the button's own `size-24` hit target, flush against the
+  wrapper's bottom edge (`bottom-0`, no extra inset, so the reserved band and the button's footprint
+  match exactly) — so the overlay's hit area is reserved padding, never the text's own last line, no
+  matter how close that line runs to the right edge. `MessageWithCopy` also carries the
+  `data-testid="chat-message"`/`data-role` hooks the jump/flash + tests rely on. `CopyButton` is a
+  self-contained presentational primitive
   (`navigator.clipboard.writeText` + a local ~1.2s `Copy`→`Check` icon flip); it does **not** reach the
   store toast the way `panels/PlanPane` does, keeping the message renderers props-driven.
   Skill-invocation and review-package cards keep their own disclosure UI and carry no copy affordance.

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -125,9 +125,10 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   content-only: the button is positioned against the outer wrapper, not injected into the bubble markup.
   The message content reserves one horizontal `size-24` band on the action's side (`pl-24` for the final
   assistant Markdown wrapper, `pr-24` for the user bubble) instead of a vertical band, so text and the
-  large-message toggle cannot sit beneath the hit target. The assistant wrapper removes only its final
-  Markdown block's trailing margin to align the action with the actual final line; inter-block and leading
-  margins stay unchanged. `MessageWithCopy` also carries the
+  large-message toggle cannot sit beneath the hit target. Final-answer list markers stay inside their
+  content box rather than painting back into the assistant's action band. The assistant wrapper removes
+  only its final Markdown block's trailing margin to align the action with the actual final line;
+  inter-block and leading margins stay unchanged. `MessageWithCopy` also carries the
   `data-testid="chat-message"`/`data-role` hooks the jump/flash + tests rely on. `CopyButton` is a
   self-contained presentational primitive that copies through the shared `copyText()` (`@/lib`) — the
   one clipboard-write path with its degradation baked in — flipping to a local ~1.2s `Copy`→`Check` icon

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -44,7 +44,18 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   the quoted `<fragment>` verbatim (monospace, height-capped). Everything is parsed from the MESSAGE
   itself — never the review snapshot, which the next review replaces — so any transcript answers
   "what was sent" forever, on any client; the comment-row folds ride the shared fold cache (keyed
-  `rowId:<content-key>`), surviving virtualization. The retry countdown carries a `source` (`turn` =
+  `rowId:<content-key>`), surviving virtualization. A **plain** user bubble (not a skill/review card)
+  whose text exceeds **500 characters** collapses to a `line-clamp` preview + a `Show more`/`Show less`
+  toggle **inside the card** (within its padding, directly below the message body, so line-clamp truncates
+  only the body's own element — never the control) once the agent has started responding to it: `UserTurn`
+  folds on `useFold(`${id}:user-collapse`,
+  agentResponded)`, so the fallback is *expanded* until the agent responds and *collapsed* after — with
+  the shared cache's "a manual toggle always wins over a fallback flip" giving exactly the required
+  behavior (shown expanded right after send; auto-collapses the instant the agent produces anything;
+  a manual `Show more` then survives continued streaming). `agentResponded` is derived in `ChatView`
+  (a later `markdown`/`tool`/`activity`/`divider` row exists after this user row, **or** it is the
+  trailing user row while `isStreaming`) — client view state only, no wire. Below 500 chars the bubble
+  is unchanged. The retry countdown carries a `source` (`turn` =
   pi `auto_retry_*`; `summarization` = compaction/branch-summary `summarization_retry_*`, pi ≥0.81.1) —
   the flows can overlap mid-run, each keeps exactly one indicator (re-scheduling replaces, each source's
   end event clears only its own), and `RetryIndicator` labels them apart ("Retrying" vs "Retrying
@@ -98,6 +109,23 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   pan-zoom, error → source fallback) — uniform across every `Markdown` surface (chat, file/specs
   preview); until mounted it renders as highlighted source, so static contexts (`RenderedDiff`'s
   `renderToStaticMarkup`) degrade to code exactly like shiki blocks do.
+- **Message copy** — plain user bubbles and the **round's concluding assistant answer** carry a
+  hover-revealed (`group`/`opacity-0 group-hover:opacity-100`) **`CopyButton`** (`chat/CopyButton.tsx`,
+  `data-testid="chat-copy"`) that copies the full message **source** — `userText(message.content)` for a
+  user bubble, the markdown `text` for an assistant row — never the collapsed preview or any UI chrome.
+  Only the **final** `markdown` row of a round is copyable, not the intermediate narration the agent emits
+  between tool steps: `ChatView` marks a markdown row final when no later `markdown`/`tool`/`activity` row
+  precedes the next user turn (`finalAnswerRowIds`, passed down as `isFinalAnswer`); a non-final markdown
+  row renders plain, without the action.
+  Both go through **one shared layout**, `MessageWithCopy` (in `turns.tsx`): a `flex-col` that places the
+  action **below** the message content, aligned to the message's own side — bottom-**left** under an
+  assistant row, bottom-**right** under a user bubble — never an overlay on the text, so long/multiline
+  messages can't collide with it. The user bubble stays content-only (the action moved out of it).
+  `MessageWithCopy` also carries the `data-testid="chat-message"`/`data-role` hooks the jump/flash + tests
+  rely on. `CopyButton` is a self-contained presentational primitive (`navigator.clipboard.writeText` + a local ~1.2s
+  `Copy`→`Check` icon flip); it does **not** reach the store toast the way `panels/PlanPane` does,
+  keeping the message renderers props-driven. Skill-invocation and review-package cards keep their own
+  disclosure UI and carry no copy affordance.
 - `tool` — a **primary** tool call: the collapsible `ToolCard` frame (collapsed unless registered
   `defaultExpanded`; errors auto-expand; a manual toggle wins), or a `"bare"` renderer that owns its
   frame. A `"bare"` call on a dead message (`stopReason` aborted/error — pi never executes those calls)

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -49,7 +49,7 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   toggle **inside the card** (within its padding, directly below the message body, so line-clamp truncates
   only the body's own element — never the control) once the agent has started responding to it: `UserTurn`
   folds on `useFold(`${id}:user-collapse`,
-  agentResponded)`, so the fallback is *expanded* until the agent responds and *collapsed* after — with
+  !agentResponded)`, so the fallback is *expanded* until the agent responds and *collapsed* after — with
   the shared cache's "a manual toggle always wins over a fallback flip" giving exactly the required
   behavior (shown expanded right after send; auto-collapses the instant the agent produces anything;
   a manual `Show more` then survives continued streaming). `agentResponded` is derived in `ChatView`
@@ -128,10 +128,14 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   match exactly) — so the overlay's hit area is reserved padding, never the text's own last line, no
   matter how close that line runs to the right edge. `MessageWithCopy` also carries the
   `data-testid="chat-message"`/`data-role` hooks the jump/flash + tests rely on. `CopyButton` is a
-  self-contained presentational primitive
-  (`navigator.clipboard.writeText` + a local ~1.2s `Copy`→`Check` icon flip); it does **not** reach the
-  store toast the way `panels/PlanPane` does, keeping the message renderers props-driven.
+  self-contained presentational primitive that copies through the shared `copyText()` (`@/lib`) — the
+  one clipboard-write path with its degradation baked in — flipping to a local ~1.2s `Copy`→`Check` icon
+  only when it reports success; it does **not** reach the store toast the way `panels/PlanPane` does,
+  keeping the message renderers props-driven.
   Skill-invocation and review-package cards keep their own disclosure UI and carry no copy affordance.
+  The transcript's Virtuoso list carries a 1600px `increaseViewportBy` on both edges so a short transcript
+  stays fully mounted even opened scrolled to the bottom — every row's hover-revealed copy action needs to
+  be in the DOM, not virtualized away, for it to be reachable at all.
 - `tool` — a **primary** tool call: the collapsible `ToolCard` frame (collapsed unless registered
   `defaultExpanded`; errors auto-expand; a manual toggle wins), or a `"bare"` renderer that owns its
   frame. A `"bare"` call on a dead message (`stopReason` aborted/error — pi never executes those calls)

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -117,19 +117,16 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   between tool steps: `ChatView` marks a markdown row final when no later `markdown`/`tool`/`activity` row
   precedes the next user turn (`finalAnswerRowIds`, passed down as `isFinalAnswer`); a non-final markdown
   row renders plain, without the action.
-  Both go through **one shared layout**, `MessageWithCopy` (in `turns.tsx`): a `flex-col` that places the
-  action **below** the message content, aligned to the message's own side — bottom-**left** under an
-  assistant row, bottom-**right** under a user bubble — never an overlay on the text, so long/multiline
-  messages can't collide with it. The `flex-col` gap is the **single source** of the message→copy spacing
-  (2px), so the action sits the same distance from an agent answer as from a user bubble; the agent
-  answer's content wrapper zeroes only its **last** markdown block's trailing margin
-  (`[&>div>*:last-child]:mb-0`) so the prose's 8px bottom margin doesn't add to that gap (inter-block and
-  leading prose margins are untouched). The user bubble stays content-only (the action moved out of it).
-  `MessageWithCopy` also carries the `data-testid="chat-message"`/`data-role` hooks the jump/flash + tests
-  rely on. `CopyButton` is a self-contained presentational primitive (`navigator.clipboard.writeText` + a local ~1.2s
-  `Copy`→`Check` icon flip); it does **not** reach the store toast the way `panels/PlanPane` does,
-  keeping the message renderers props-driven. Skill-invocation and review-package cards keep their own
-  disclosure UI and carry no copy affordance.
+  Both go through **one shared layout**, `MessageWithCopy` (in `turns.tsx`): a `relative` wrapper that
+  overlays the action on the message's own **bottom-right corner** (`absolute right-4 bottom-4` on the
+  `CopyButton`) — for both roles alike, agent and user — rather than a row below the content. The user
+  bubble stays content-only: the button is positioned against the outer wrapper, not injected into the
+  bubble markup, and lands on the bubble's own corner because the bubble is the wrapper's only (and so
+  bottom-most, right-aligned) child. `MessageWithCopy` also carries the `data-testid="chat-message"`/
+  `data-role` hooks the jump/flash + tests rely on. `CopyButton` is a self-contained presentational
+  primitive (`navigator.clipboard.writeText` + a local ~1.2s `Copy`→`Check` icon flip); it does **not**
+  reach the store toast the way `panels/PlanPane` does, keeping the message renderers props-driven.
+  Skill-invocation and review-package cards keep their own disclosure UI and carry no copy affordance.
 - `tool` — a **primary** tool call: the collapsible `ToolCard` frame (collapsed unless registered
   `defaultExpanded`; errors auto-expand; a manual toggle wins), or a `"bare"` renderer that owns its
   frame. A `"bare"` call on a dead message (`stopReason` aborted/error — pi never executes those calls)

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -119,15 +119,15 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   `markdown`/`tool`/`activity` row precedes the next user turn (`finalAnswerRowIds`, supplied by every
   transcript integration as `isFinalAnswer`); a non-final markdown row renders plain, without the action.
   Both go through **one shared layout**, `MessageWithCopy` (in `turns.tsx`): a `relative` wrapper that
-  overlays the action on the message's own **bottom-right corner** (`absolute right-4 bottom-0` on the
-  `CopyButton`) — for both roles alike, agent and user — rather than a row below the content. The user
-  bubble stays content-only: the button is positioned against the outer wrapper, not injected into the
-  bubble markup, and lands on the bubble's own corner because the bubble is the wrapper's only (and so
-  bottom-most, right-aligned) child. Both message content wrappers (the user bubble, the final-answer
-  markdown wrapper) carry `pb-24` — exactly the button's own `size-24` hit target, flush against the
-  wrapper's bottom edge (`bottom-0`, no extra inset, so the reserved band and the button's footprint
-  match exactly) — so the overlay's hit area is reserved padding, never the text's own last line, no
-  matter how close that line runs to the right edge. `MessageWithCopy` also carries the
+  overlays the action **inside the role's bottom corner on the same line as content** — bottom-left for
+  an assistant answer (`left-0 bottom-0`), bottom-right for a user bubble (`right-0 bottom-8`, aligned
+  within the bubble's existing vertical padding) — never in a row below it. The user bubble stays
+  content-only: the button is positioned against the outer wrapper, not injected into the bubble markup.
+  The message content reserves one horizontal `size-24` band on the action's side (`pl-24` for the final
+  assistant Markdown wrapper, `pr-24` for the user bubble) instead of a vertical band, so text and the
+  large-message toggle cannot sit beneath the hit target. The assistant wrapper removes only its final
+  Markdown block's trailing margin to align the action with the actual final line; inter-block and leading
+  margins stay unchanged. `MessageWithCopy` also carries the
   `data-testid="chat-message"`/`data-role` hooks the jump/flash + tests rely on. `CopyButton` is a
   self-contained presentational primitive that copies through the shared `copyText()` (`@/lib`) — the
   one clipboard-write path with its degradation baked in — flipping to a local ~1.2s `Copy`→`Check` icon

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -122,10 +122,13 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   `CopyButton`) — for both roles alike, agent and user — rather than a row below the content. The user
   bubble stays content-only: the button is positioned against the outer wrapper, not injected into the
   bubble markup, and lands on the bubble's own corner because the bubble is the wrapper's only (and so
-  bottom-most, right-aligned) child. `MessageWithCopy` also carries the `data-testid="chat-message"`/
-  `data-role` hooks the jump/flash + tests rely on. `CopyButton` is a self-contained presentational
-  primitive (`navigator.clipboard.writeText` + a local ~1.2s `Copy`→`Check` icon flip); it does **not**
-  reach the store toast the way `panels/PlanPane` does, keeping the message renderers props-driven.
+  bottom-most, right-aligned) child. Both message content wrappers (the user bubble, the final-answer
+  markdown wrapper) carry `pb-32` — clearance for the button's 24px hit target plus its inset — so the
+  overlay's hit area is reserved padding, never the text's own last line, no matter how close that line
+  runs to the right edge. `MessageWithCopy` also carries the `data-testid="chat-message"`/`data-role`
+  hooks the jump/flash + tests rely on. `CopyButton` is a self-contained presentational primitive
+  (`navigator.clipboard.writeText` + a local ~1.2s `Copy`→`Check` icon flip); it does **not** reach the
+  store toast the way `panels/PlanPane` does, keeping the message renderers props-driven.
   Skill-invocation and review-package cards keep their own disclosure UI and carry no copy affordance.
 - `tool` — a **primary** tool call: the collapsible `ToolCard` frame (collapsed unless registered
   `defaultExpanded`; errors auto-expand; a manual toggle wins), or a `"bare"` renderer that owns its

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -52,10 +52,11 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   !agentResponded)`, so the fallback is *expanded* until the agent responds and *collapsed* after — with
   the shared cache's "a manual toggle always wins over a fallback flip" giving exactly the required
   behavior (shown expanded right after send; auto-collapses the instant the agent produces anything;
-  a manual `Show more` then survives continued streaming). `agentResponded` is derived in `ChatView`
-  (a later `markdown`/`tool`/`activity`/`divider` row exists after this user row, **or** it is the
-  trailing user row while `isStreaming`) — client view state only, no wire. Below 500 chars the bubble
-  is unchanged. The retry countdown carries a `source` (`turn` =
+  a manual `Show more` then survives continued streaming). The shared `deriveMessageActions` classifier
+  derives `agentResponded` from chronological rows (a later `markdown`/`tool`/`activity`/`divider` row
+  exists after this user row, **or** it is the trailing user row while `isStreaming`) and every transcript
+  integration supplies that state to the renderer. It remains client view state only, with no wire impact.
+  Below 500 chars the bubble is unchanged. The retry countdown carries a `source` (`turn` =
   pi `auto_retry_*`; `summarization` = compaction/branch-summary `summarization_retry_*`, pi ≥0.81.1) —
   the flows can overlap mid-run, each keeps exactly one indicator (re-scheduling replaces, each source's
   end event clears only its own), and `RetryIndicator` labels them apart ("Retrying" vs "Retrying
@@ -114,9 +115,9 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   `data-testid="chat-copy"`) that copies the full message **source** — `userText(message.content)` for a
   user bubble, the markdown `text` for an assistant row — never the collapsed preview or any UI chrome.
   Only the **final** `markdown` row of a round is copyable, not the intermediate narration the agent emits
-  between tool steps: `ChatView` marks a markdown row final when no later `markdown`/`tool`/`activity` row
-  precedes the next user turn (`finalAnswerRowIds`, passed down as `isFinalAnswer`); a non-final markdown
-  row renders plain, without the action.
+  between tool steps: `deriveMessageActions` marks a markdown row final when no later
+  `markdown`/`tool`/`activity` row precedes the next user turn (`finalAnswerRowIds`, supplied by every
+  transcript integration as `isFinalAnswer`); a non-final markdown row renders plain, without the action.
   Both go through **one shared layout**, `MessageWithCopy` (in `turns.tsx`): a `relative` wrapper that
   overlays the action on the message's own **bottom-right corner** (`absolute right-4 bottom-0` on the
   `CopyButton`) — for both roles alike, agent and user — rather than a row below the content. The user

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -120,7 +120,11 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   Both go through **one shared layout**, `MessageWithCopy` (in `turns.tsx`): a `flex-col` that places the
   action **below** the message content, aligned to the message's own side — bottom-**left** under an
   assistant row, bottom-**right** under a user bubble — never an overlay on the text, so long/multiline
-  messages can't collide with it. The user bubble stays content-only (the action moved out of it).
+  messages can't collide with it. The `flex-col` gap is the **single source** of the message→copy spacing
+  (2px), so the action sits the same distance from an agent answer as from a user bubble; the agent
+  answer's content wrapper zeroes only its **last** markdown block's trailing margin
+  (`[&>div>*:last-child]:mb-0`) so the prose's 8px bottom margin doesn't add to that gap (inter-block and
+  leading prose margins are untouched). The user bubble stays content-only (the action moved out of it).
   `MessageWithCopy` also carries the `data-testid="chat-message"`/`data-role` hooks the jump/flash + tests
   rely on. `CopyButton` is a self-contained presentational primitive (`navigator.clipboard.writeText` + a local ~1.2s
   `Copy`→`Check` icon flip); it does **not** reach the store toast the way `panels/PlanPane` does,

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -135,9 +135,6 @@ blocks in order into rows; `ChatTurnView` dispatches on row kind:
   only when it reports success; it does **not** reach the store toast the way `panels/PlanPane` does,
   keeping the message renderers props-driven.
   Skill-invocation and review-package cards keep their own disclosure UI and carry no copy affordance.
-  The transcript's Virtuoso list carries a 1600px `increaseViewportBy` on both edges so a short transcript
-  stays fully mounted even opened scrolled to the bottom — every row's hover-revealed copy action needs to
-  be in the DOM, not virtualized away, for it to be reachable at all.
 - `tool` — a **primary** tool call: the collapsible `ToolCard` frame (collapsed unless registered
   `defaultExpanded`; errors auto-expand; a manual toggle wins), or a `"bare"` renderer that owns its
   frame. A `"bare"` call on a dead message (`stopReason` aborted/error — pi never executes those calls)

--- a/apps/web/src/chat/SubagentTranscriptDialog.tsx
+++ b/apps/web/src/chat/SubagentTranscriptDialog.tsx
@@ -5,6 +5,7 @@ import { errorText, getTransport, wsErrorCode } from "@/transport";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { ChatActionsContext } from "./ChatActions";
 import { messagesToRuntime } from "./hydrate";
+import { deriveMessageActions } from "./messageActions";
 import { deriveRows } from "./rows";
 import { startSubagentTranscriptPolling } from "./subagentTranscriptPolling";
 import { ChatTurnView } from "./turns";
@@ -67,6 +68,7 @@ export function SubagentTranscriptDialog({
 		() => (runtime ? deriveRows(runtime.turns, runtime.toolResults, live) : []),
 		[runtime, live],
 	);
+	const messageActions = useMemo(() => deriveMessageActions(rows, live), [rows, live]);
 	const askContext = useMemo(
 		() => ({
 			states: runtime ? deriveAskStates(runtime.turns, runtime.askAnswers) : {},
@@ -107,7 +109,11 @@ export function SubagentTranscriptDialog({
 							) : (
 								rows.map((row) => (
 									<div key={row.id}>
-										<ChatTurnView row={row} />
+										<ChatTurnView
+											row={row}
+											agentResponded={messageActions.agentRespondedByUserId.get(row.id) ?? false}
+											isFinalAnswer={messageActions.finalAnswerRowIds.has(row.id)}
+										/>
 									</div>
 								))
 							)}

--- a/apps/web/src/chat/messageActions.test.ts
+++ b/apps/web/src/chat/messageActions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { deriveMessageActions } from "./messageActions";
+import type { ChatRow } from "./rows";
+
+function user(id: string): ChatRow {
+	return { kind: "user", id, message: { role: "user", content: id, timestamp: 0 } };
+}
+
+function markdown(id: string): ChatRow {
+	return { kind: "markdown", id, text: id };
+}
+
+describe("deriveMessageActions", () => {
+	test("classifies answered prompts and concluding answers across completed rounds", () => {
+		const rows: ChatRow[] = [
+			user("user-1"),
+			markdown("narration-1"),
+			{ kind: "activity", id: "activity-1", steps: [], live: false },
+			markdown("answer-1"),
+			{
+				kind: "divider",
+				id: "divider-1",
+				data: { elapsedMs: 1, toolCount: 0, specs: [], changedFiles: [] },
+			},
+			user("user-2"),
+			markdown("answer-2"),
+			user("user-3"),
+		];
+
+		const state = deriveMessageActions(rows, false);
+
+		expect(Object.fromEntries(state.agentRespondedByUserId)).toEqual({
+			"user-1": true,
+			"user-2": true,
+			"user-3": false,
+		});
+		expect([...state.finalAnswerRowIds].sort()).toEqual(["answer-1", "answer-2"]);
+	});
+
+	test("marks only the trailing unanswered prompt as responded while streaming", () => {
+		const state = deriveMessageActions([user("user-1"), user("user-2")], true);
+
+		expect(state.agentRespondedByUserId.get("user-1")).toBe(false);
+		expect(state.agentRespondedByUserId.get("user-2")).toBe(true);
+	});
+
+	test("does not expose narration as final when later activity has no answer yet", () => {
+		const state = deriveMessageActions(
+			[
+				user("user-1"),
+				markdown("narration-1"),
+				{ kind: "activity", id: "activity-1", steps: [], live: true },
+			],
+			true,
+		);
+
+		expect(state.finalAnswerRowIds.size).toBe(0);
+	});
+});

--- a/apps/web/src/chat/messageActions.ts
+++ b/apps/web/src/chat/messageActions.ts
@@ -1,0 +1,45 @@
+import type { ChatRow } from "./rows";
+
+export interface MessageActionState {
+	agentRespondedByUserId: ReadonlyMap<string, boolean>;
+	finalAnswerRowIds: ReadonlySet<string>;
+}
+
+export function deriveMessageActions(
+	chronologicalRows: readonly ChatRow[],
+	isStreaming: boolean,
+): MessageActionState {
+	const agentRespondedByUserId = new Map<string, boolean>();
+	const finalAnswerRowIds = new Set<string>();
+	let sawRespondingRow = false;
+	let sawLaterUser = false;
+	let roundHasLaterContent = false;
+
+	for (let index = chronologicalRows.length - 1; index >= 0; index -= 1) {
+		const row = chronologicalRows[index];
+		if (!row) continue;
+
+		switch (row.kind) {
+			case "user":
+				agentRespondedByUserId.set(row.id, sawRespondingRow || (!sawLaterUser && isStreaming));
+				sawLaterUser = true;
+				roundHasLaterContent = false;
+				break;
+			case "markdown":
+				sawRespondingRow = true;
+				if (!roundHasLaterContent) finalAnswerRowIds.add(row.id);
+				roundHasLaterContent = true;
+				break;
+			case "tool":
+			case "activity":
+				sawRespondingRow = true;
+				roundHasLaterContent = true;
+				break;
+			case "divider":
+				sawRespondingRow = true;
+				break;
+		}
+	}
+
+	return { agentRespondedByUserId, finalAnswerRowIds };
+}

--- a/apps/web/src/chat/turns.test.tsx
+++ b/apps/web/src/chat/turns.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ChatRow } from "./rows";
+import { ChatTurnView } from "./turns";
+
+function renderRow(row: ChatRow, isFinalAnswer: boolean): string {
+	return renderToStaticMarkup(
+		<ChatTurnView row={row} agentResponded isFinalAnswer={isFinalAnswer} />,
+	);
+}
+
+describe("message copy layout", () => {
+	test("places an assistant copy action inside the bottom-left content band", () => {
+		const html = renderRow({ kind: "markdown", id: "answer", text: "100. Final answer" }, true);
+
+		expect(html).toContain("pl-24");
+		expect(html).toContain("list-inside");
+		expect(html).toContain("bottom-0 left-0");
+		expect(html).not.toContain("pb-24");
+	});
+
+	test("places a user copy action inside the bottom-right content band", () => {
+		const html = renderRow(
+			{
+				kind: "user",
+				id: "prompt",
+				message: { role: "user", content: "User prompt", timestamp: 0 },
+			},
+			false,
+		);
+
+		expect(html).toContain("pr-24");
+		expect(html).toContain("right-0 bottom-8");
+		expect(html).not.toContain("pb-24");
+	});
+});

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -51,9 +51,7 @@ export function ChatTurnView({
 	row: ChatRow;
 	workspaceRoot?: string | undefined;
 	onOpenFile?: ((path: string) => void) | undefined;
-	/** For a `user` row: has the agent started responding to it yet (drives large-message auto-collapse). */
 	agentResponded?: boolean | undefined;
-	/** For a `markdown` row: is it the round's concluding answer (only that one carries the Copy action). */
 	isFinalAnswer?: boolean | undefined;
 	onOpenSpec?: ((path: string) => void) | undefined;
 	onOpenChange?: ((path: string) => void) | undefined;
@@ -101,8 +99,6 @@ export function ChatTurnView({
 				/>
 			);
 		case "markdown":
-			// Copy rides only the round's concluding answer (the work summary) — not the intermediate
-			// narration the agent emits between tool steps.
 			return isFinalAnswer ? (
 				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
 					<div className="w-full min-w-0 tr-text-reading text-text-default">
@@ -200,14 +196,6 @@ function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
 		</>
 	);
 }
-/**
- * Shared message + Copy layout, so both message types position the action the same way instead of each
- * carrying its own hack. The Copy overlays the message's own **bottom-right corner** — for both agent and
- * user messages alike — absolutely positioned against this `relative` wrapper rather than sitting in a row
- * below the content. Hover-reveal (the button's own styling) keeps it visually secondary. The
- * `data-testid`/`data-role` hooks stay on this outer element, where the transcript's jump/flash and tests
- * expect them.
- */
 function MessageWithCopy({
 	messageRole,
 	side,
@@ -231,13 +219,6 @@ function MessageWithCopy({
 	);
 }
 
-/** The user bubble. Pi's canonical expanded skill block renders as a compact, collapsed invocation with
- * any user-supplied request kept visible beneath it. A review send's context package renders as a compact
- * card — the "Sent N review comments on <file>" line with the COMMENT rows right under it (a send is one
- * message per file, so a file level would always hold exactly one entry — the summary already names the
- * file); each comment unfolds to its full text + the quoted fragment — instead of the structured XML the
- * agent needs. Everything is parsed from the message itself (the transcript IS the history), so any old
- * chat unfolds the same way; the folds survive virtualization via the shared cache. */
 const LARGE_USER_MESSAGE = 500;
 
 function UserTurn({
@@ -249,7 +230,6 @@ function UserTurn({
 	id: string;
 	message: UserMessage;
 	attachmentNames?: string[] | undefined;
-	/** Once the agent has started responding, a large (>500-char) plain message auto-collapses. */
 	agentResponded: boolean;
 }) {
 	const text = userText(message.content);
@@ -302,14 +282,6 @@ function UserTurn({
 	);
 }
 
-/**
- * A plain user message bubble (its Copy action lives in the enclosing {@link MessageWithCopy}, overlaid on
- * the bubble's bottom-right corner) — and, only above {@link LARGE_USER_MESSAGE} chars, auto-collapse. The fold's fallback is
- * `agentResponded` (expanded until the agent starts responding, collapsed after), so the shared cache's
- * "a manual toggle always wins over a fallback flip" gives the required behavior for free: shown
- * expanded right after send, auto-collapsed the instant the agent produces anything, and a manual
- * `Show more` then survives continued streaming. Copy always yields the full text, never the preview.
- */
 function PlainUserTurn({
 	id,
 	text,
@@ -326,8 +298,6 @@ function PlainUserTurn({
 	const collapsed = large && !expanded;
 	return (
 		<MessageWithCopy messageRole="user" side="right" getText={() => text}>
-			{/* w-fit so the bubble still hugs its content (up to 85%) and is the wrapper's only, right-aligned
-			    child — so the overlaid Copy button's corner coincides with the bubble's own corner. */}
 			<div className="flex w-fit max-w-[85%] flex-col items-end">
 				<div className={USER_BUBBLE_BASE}>
 					{attachments.length > 0 ? (
@@ -337,8 +307,6 @@ function PlainUserTurn({
 							))}
 						</div>
 					) : null}
-					{/* The Show more/less control lives INSIDE the card, within its padding, below the text — so
-					    line-clamp truncates only the message body (its own element), never the control. */}
 					<div
 						data-testid="user-message-body"
 						data-collapsed={collapsed || undefined}

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -105,10 +105,7 @@ export function ChatTurnView({
 			// narration the agent emits between tool steps.
 			return isFinalAnswer ? (
 				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
-					{/* Zero the trailing block margin of the answer's LAST child only, so the message ends flush
-					    against the copy-action gap (its own owning layout) — inter-block + leading spacing keep
-					    the shared prose margins. */}
-					<div className="w-full min-w-0 tr-text-reading text-text-default [&>div>*:last-child]:mb-0">
+					<div className="w-full min-w-0 tr-text-reading text-text-default">
 						<Markdown text={row.text} />
 					</div>
 				</MessageWithCopy>
@@ -205,9 +202,9 @@ function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
 }
 /**
  * Shared message + Copy layout, so both message types position the action the same way instead of each
- * carrying its own hack. The Copy sits **below** the message content (never an overlay on the text),
- * aligned to the message's own side: agent = bottom-**left** under the message, user = bottom-**right**
- * under the bubble. Hover-reveal (the button's own styling) keeps it visually secondary. The
+ * carrying its own hack. The Copy overlays the message's own **bottom-right corner** — for both agent and
+ * user messages alike — absolutely positioned against this `relative` wrapper rather than sitting in a row
+ * below the content. Hover-reveal (the button's own styling) keeps it visually secondary. The
  * `data-testid`/`data-role` hooks stay on this outer element, where the transcript's jump/flash and tests
  * expect them.
  */
@@ -226,10 +223,10 @@ function MessageWithCopy({
 		<div
 			data-testid="chat-message"
 			data-role={messageRole}
-			className={cn("group flex flex-col gap-2", side === "right" ? "items-end" : "items-start")}
+			className={cn("group relative flex flex-col", side === "right" ? "items-end" : "items-start")}
 		>
 			{children}
-			<CopyButton getText={getText} />
+			<CopyButton getText={getText} className="absolute right-4 bottom-4 z-10" />
 		</div>
 	);
 }
@@ -306,8 +303,8 @@ function UserTurn({
 }
 
 /**
- * A plain user message bubble (its Copy action lives in the enclosing {@link MessageWithCopy}, below the
- * bubble on the right) — and, only above {@link LARGE_USER_MESSAGE} chars, auto-collapse. The fold's fallback is
+ * A plain user message bubble (its Copy action lives in the enclosing {@link MessageWithCopy}, overlaid on
+ * the bubble's bottom-right corner) — and, only above {@link LARGE_USER_MESSAGE} chars, auto-collapse. The fold's fallback is
  * `agentResponded` (expanded until the agent starts responding, collapsed after), so the shared cache's
  * "a manual toggle always wins over a fallback flip" gives the required behavior for free: shown
  * expanded right after send, auto-collapsed the instant the agent produces anything, and a manual
@@ -329,8 +326,8 @@ function PlainUserTurn({
 	const collapsed = large && !expanded;
 	return (
 		<MessageWithCopy messageRole="user" side="right" getText={() => text}>
-			{/* w-fit so the bubble still hugs its content (up to 85%). Copy lives OUTSIDE this bubble column
-			    (in MessageWithCopy's gutter); the bubble holds message content only. */}
+			{/* w-fit so the bubble still hugs its content (up to 85%) and is the wrapper's only, right-aligned
+			    child — so the overlaid Copy button's corner coincides with the bubble's own corner. */}
 			<div className="flex w-fit max-w-[85%] flex-col items-end">
 				<div className={USER_BUBBLE_BASE}>
 					{attachments.length > 0 ? (

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -102,7 +102,11 @@ export function ChatTurnView({
 			return isFinalAnswer ? (
 				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
 					<div className="w-full min-w-0 pb-24 tr-text-reading text-text-default">
-						<Markdown text={row.text} />
+						<AssistantMarkdown
+							text={row.text}
+							workspaceRoot={workspaceRoot}
+							onOpenFile={onOpenFile}
+						/>
 					</div>
 				</MessageWithCopy>
 			) : (

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -101,7 +101,7 @@ export function ChatTurnView({
 		case "markdown":
 			return isFinalAnswer ? (
 				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
-					<div className="w-full min-w-0 tr-text-reading text-text-default">
+					<div className="w-full min-w-0 pb-32 tr-text-reading text-text-default">
 						<Markdown text={row.text} />
 					</div>
 				</MessageWithCopy>
@@ -299,7 +299,7 @@ function PlainUserTurn({
 	return (
 		<MessageWithCopy messageRole="user" side="right" getText={() => text}>
 			<div className="flex w-fit max-w-[85%] flex-col items-end">
-				<div className={USER_BUBBLE_BASE}>
+				<div className={cn(USER_BUBBLE_BASE, "pb-32")}>
 					{attachments.length > 0 ? (
 						<div className="flex flex-wrap gap-4 pb-4" data-testid="chat-message-images">
 							{attachments.map(({ key, label, img }) => (

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -101,7 +101,7 @@ export function ChatTurnView({
 		case "markdown":
 			return isFinalAnswer ? (
 				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
-					<div className="w-full min-w-0 pb-32 tr-text-reading text-text-default">
+					<div className="w-full min-w-0 pb-24 tr-text-reading text-text-default">
 						<Markdown text={row.text} />
 					</div>
 				</MessageWithCopy>
@@ -214,7 +214,7 @@ function MessageWithCopy({
 			className={cn("group relative flex flex-col", side === "right" ? "items-end" : "items-start")}
 		>
 			{children}
-			<CopyButton getText={getText} className="absolute right-4 bottom-4 z-10" />
+			<CopyButton getText={getText} className="absolute right-4 bottom-0 z-10" />
 		</div>
 	);
 }
@@ -299,7 +299,7 @@ function PlainUserTurn({
 	return (
 		<MessageWithCopy messageRole="user" side="right" getText={() => text}>
 			<div className="flex w-fit max-w-[85%] flex-col items-end">
-				<div className={cn(USER_BUBBLE_BASE, "pb-32")}>
+				<div className={cn(USER_BUBBLE_BASE, "pb-24")}>
 					{attachments.length > 0 ? (
 						<div className="flex flex-wrap gap-4 pb-4" data-testid="chat-message-images">
 							{attachments.map(({ key, label, img }) => (

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -51,8 +51,8 @@ export function ChatTurnView({
 	row: ChatRow;
 	workspaceRoot?: string | undefined;
 	onOpenFile?: ((path: string) => void) | undefined;
-	agentResponded?: boolean | undefined;
-	isFinalAnswer?: boolean | undefined;
+	agentResponded: boolean;
+	isFinalAnswer: boolean;
 	onOpenSpec?: ((path: string) => void) | undefined;
 	onOpenChange?: ((path: string) => void) | undefined;
 	onReveal?: ((tab: "specs" | "changes") => void) | undefined;
@@ -65,7 +65,7 @@ export function ChatTurnView({
 					id={row.id}
 					message={row.message}
 					attachmentNames={row.attachmentNames}
-					agentResponded={agentResponded ?? false}
+					agentResponded={agentResponded}
 				/>
 			);
 		case "system":

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -101,7 +101,7 @@ export function ChatTurnView({
 		case "markdown":
 			return isFinalAnswer ? (
 				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
-					<div className="w-full min-w-0 pb-24 tr-text-reading text-text-default">
+					<div className="w-full min-w-0 pl-24 tr-text-reading text-text-default [&>div>*:last-child]:mb-0 [&_ol]:list-inside [&_ul]:list-inside">
 						<AssistantMarkdown
 							text={row.text}
 							workspaceRoot={workspaceRoot}
@@ -218,7 +218,10 @@ function MessageWithCopy({
 			className={cn("group relative flex flex-col", side === "right" ? "items-end" : "items-start")}
 		>
 			{children}
-			<CopyButton getText={getText} className="absolute right-4 bottom-0 z-10" />
+			<CopyButton
+				getText={getText}
+				className={cn("absolute z-10", side === "right" ? "right-0 bottom-8" : "bottom-0 left-0")}
+			/>
 		</div>
 	);
 }
@@ -303,7 +306,7 @@ function PlainUserTurn({
 	return (
 		<MessageWithCopy messageRole="user" side="right" getText={() => text}>
 			<div className="flex w-fit max-w-[85%] flex-col items-end">
-				<div className={cn(USER_BUBBLE_BASE, "pb-24")}>
+				<div className={cn(USER_BUBBLE_BASE, "pr-24")}>
 					{attachments.length > 0 ? (
 						<div className="flex flex-wrap gap-4 pb-4" data-testid="chat-message-images">
 							{attachments.map(({ key, label, img }) => (

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -327,9 +327,9 @@ function PlainUserTurn({
 							className="mt-4 flex items-center gap-4 tr-text-metadata text-text-subtle hover:text-text-default"
 						>
 							{expanded ? (
-								<ChevronUp className="size-12 shrink-0" />
+								<ChevronUp className="size-16 shrink-0" />
 							) : (
-								<ChevronDown className="size-12 shrink-0" />
+								<ChevronDown className="size-16 shrink-0" />
 							)}
 							{expanded ? "Show less" : "Show more"}
 						</button>

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -105,7 +105,10 @@ export function ChatTurnView({
 			// narration the agent emits between tool steps.
 			return isFinalAnswer ? (
 				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
-					<div className="w-full min-w-0 tr-text-reading text-text-default">
+					{/* Zero the trailing block margin of the answer's LAST child only, so the message ends flush
+					    against the copy-action gap (its own owning layout) — inter-block + leading spacing keep
+					    the shared prose margins. */}
+					<div className="w-full min-w-0 tr-text-reading text-text-default [&>div>*:last-child]:mb-0">
 						<Markdown text={row.text} />
 					</div>
 				</MessageWithCopy>
@@ -223,7 +226,7 @@ function MessageWithCopy({
 		<div
 			data-testid="chat-message"
 			data-role={messageRole}
-			className={cn("group flex flex-col gap-4", side === "right" ? "items-end" : "items-start")}
+			className={cn("group flex flex-col gap-2", side === "right" ? "items-end" : "items-start")}
 		>
 			{children}
 			<CopyButton getText={getText} />

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -2,6 +2,7 @@ import {
 	RiBookOpenLine as BookOpen,
 	RiArrowDownSLine as ChevronDown,
 	RiArrowRightSLine as ChevronRight,
+	RiArrowUpSLine as ChevronUp,
 	RiTimeLine as Clock,
 	RiFileTextLine as FileText,
 	RiContractUpDownLine as FoldVertical,
@@ -23,6 +24,7 @@ import {
 } from "@/lib";
 import { ActivityGroup } from "./ActivityGroup";
 import { AssistantMarkdown } from "./assistantLinks";
+import { CopyButton } from "./CopyButton";
 import { FileChip } from "./FileChip";
 import { useFold, useSelection } from "./foldState";
 import { Markdown } from "./Markdown";
@@ -39,6 +41,8 @@ export function ChatTurnView({
 	row,
 	workspaceRoot,
 	onOpenFile,
+	agentResponded,
+	isFinalAnswer,
 	onOpenSpec,
 	onOpenChange,
 	onReveal,
@@ -47,6 +51,10 @@ export function ChatTurnView({
 	row: ChatRow;
 	workspaceRoot?: string | undefined;
 	onOpenFile?: ((path: string) => void) | undefined;
+	/** For a `user` row: has the agent started responding to it yet (drives large-message auto-collapse). */
+	agentResponded?: boolean | undefined;
+	/** For a `markdown` row: is it the round's concluding answer (only that one carries the Copy action). */
+	isFinalAnswer?: boolean | undefined;
 	onOpenSpec?: ((path: string) => void) | undefined;
 	onOpenChange?: ((path: string) => void) | undefined;
 	onReveal?: ((tab: "specs" | "changes") => void) | undefined;
@@ -54,7 +62,14 @@ export function ChatTurnView({
 }) {
 	switch (row.kind) {
 		case "user":
-			return <UserTurn id={row.id} message={row.message} attachmentNames={row.attachmentNames} />;
+			return (
+				<UserTurn
+					id={row.id}
+					message={row.message}
+					attachmentNames={row.attachmentNames}
+					agentResponded={agentResponded ?? false}
+				/>
+			);
 		case "system":
 			return <SystemTurn text={row.text} />;
 		case "error":
@@ -86,7 +101,15 @@ export function ChatTurnView({
 				/>
 			);
 		case "markdown":
-			return (
+			// Copy rides only the round's concluding answer (the work summary) — not the intermediate
+			// narration the agent emits between tool steps.
+			return isFinalAnswer ? (
+				<MessageWithCopy messageRole="assistant" side="left" getText={() => row.text}>
+					<div className="w-full min-w-0 tr-text-reading text-text-default">
+						<Markdown text={row.text} />
+					</div>
+				</MessageWithCopy>
+			) : (
 				<div
 					data-testid="chat-message"
 					data-role="assistant"
@@ -142,8 +165,9 @@ function userAttachments(content: UserMessage["content"], names?: string[]) {
 		});
 }
 
-const USER_BUBBLE =
-	"max-w-[85%] whitespace-pre-wrap break-words rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-12 py-8 tr-text-reading text-text-muted";
+const USER_BUBBLE_BASE =
+	"whitespace-pre-wrap break-words rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg px-12 py-8 tr-text-reading text-text-muted";
+const USER_BUBBLE = cn("max-w-[85%]", USER_BUBBLE_BASE);
 
 function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
 	const [open, setOpen] = useState(false);
@@ -176,15 +200,57 @@ function AttachmentChip({ label, img }: { label: string; img: ImageContent }) {
 		</>
 	);
 }
+/**
+ * Shared message + Copy layout, so both message types position the action the same way instead of each
+ * carrying its own hack. The Copy sits **below** the message content (never an overlay on the text),
+ * aligned to the message's own side: agent = bottom-**left** under the message, user = bottom-**right**
+ * under the bubble. Hover-reveal (the button's own styling) keeps it visually secondary. The
+ * `data-testid`/`data-role` hooks stay on this outer element, where the transcript's jump/flash and tests
+ * expect them.
+ */
+function MessageWithCopy({
+	messageRole,
+	side,
+	getText,
+	children,
+}: {
+	messageRole: "user" | "assistant";
+	side: "left" | "right";
+	getText: () => string;
+	children: ReactNode;
+}) {
+	return (
+		<div
+			data-testid="chat-message"
+			data-role={messageRole}
+			className={cn("group flex flex-col gap-4", side === "right" ? "items-end" : "items-start")}
+		>
+			{children}
+			<CopyButton getText={getText} />
+		</div>
+	);
+}
+
+/** The user bubble. Pi's canonical expanded skill block renders as a compact, collapsed invocation with
+ * any user-supplied request kept visible beneath it. A review send's context package renders as a compact
+ * card — the "Sent N review comments on <file>" line with the COMMENT rows right under it (a send is one
+ * message per file, so a file level would always hold exactly one entry — the summary already names the
+ * file); each comment unfolds to its full text + the quoted fragment — instead of the structured XML the
+ * agent needs. Everything is parsed from the message itself (the transcript IS the history), so any old
+ * chat unfolds the same way; the folds survive virtualization via the shared cache. */
+const LARGE_USER_MESSAGE = 500;
 
 function UserTurn({
 	id,
 	message,
 	attachmentNames,
+	agentResponded,
 }: {
 	id: string;
 	message: UserMessage;
 	attachmentNames?: string[] | undefined;
+	/** Once the agent has started responding, a large (>500-char) plain message auto-collapses. */
+	agentResponded: boolean;
 }) {
 	const text = userText(message.content);
 	const attachments = userAttachments(message.content, attachmentNames);
@@ -205,17 +271,17 @@ function UserTurn({
 	}
 
 	const review = parseReviewPackage(text);
-	return (
-		<div data-testid="chat-message" data-role="user" className="flex justify-end">
-			<div className={USER_BUBBLE}>
-				{attachments.length > 0 ? (
-					<div className="flex flex-wrap gap-4 pb-4" data-testid="chat-message-images">
-						{attachments.map(({ key, label, img }) => (
-							<AttachmentChip key={key} label={label} img={img} />
-						))}
-					</div>
-				) : null}
-				{review ? (
+	if (review) {
+		return (
+			<div data-testid="chat-message" data-role="user" className="flex justify-end">
+				<div className={USER_BUBBLE}>
+					{attachments.length > 0 ? (
+						<div className="flex flex-wrap gap-4 pb-4" data-testid="chat-message-images">
+							{attachments.map(({ key, label, img }) => (
+								<AttachmentChip key={key} label={label} img={img} />
+							))}
+						</div>
+					) : null}
 					<div data-testid="review-package-card" className="whitespace-normal">
 						<span data-testid="review-package-summary" className="block text-text-default">
 							{reviewPackageLabel(review)}
@@ -226,11 +292,79 @@ function UserTurn({
 							))}
 						</ul>
 					</div>
-				) : (
-					text
-				)}
+				</div>
 			</div>
-		</div>
+		);
+	}
+
+	return (
+		<PlainUserTurn id={id} text={text} attachments={attachments} agentResponded={agentResponded} />
+	);
+}
+
+/**
+ * A plain user message bubble (its Copy action lives in the enclosing {@link MessageWithCopy}, below the
+ * bubble on the right) — and, only above {@link LARGE_USER_MESSAGE} chars, auto-collapse. The fold's fallback is
+ * `agentResponded` (expanded until the agent starts responding, collapsed after), so the shared cache's
+ * "a manual toggle always wins over a fallback flip" gives the required behavior for free: shown
+ * expanded right after send, auto-collapsed the instant the agent produces anything, and a manual
+ * `Show more` then survives continued streaming. Copy always yields the full text, never the preview.
+ */
+function PlainUserTurn({
+	id,
+	text,
+	attachments,
+	agentResponded,
+}: {
+	id: string;
+	text: string;
+	attachments: ReturnType<typeof userAttachments>;
+	agentResponded: boolean;
+}) {
+	const large = text.length > LARGE_USER_MESSAGE;
+	const [expanded, toggle] = useFold(`${id}:user-collapse`, !agentResponded);
+	const collapsed = large && !expanded;
+	return (
+		<MessageWithCopy messageRole="user" side="right" getText={() => text}>
+			{/* w-fit so the bubble still hugs its content (up to 85%). Copy lives OUTSIDE this bubble column
+			    (in MessageWithCopy's gutter); the bubble holds message content only. */}
+			<div className="flex w-fit max-w-[85%] flex-col items-end">
+				<div className={USER_BUBBLE_BASE}>
+					{attachments.length > 0 ? (
+						<div className="flex flex-wrap gap-4 pb-4" data-testid="chat-message-images">
+							{attachments.map(({ key, label, img }) => (
+								<AttachmentChip key={key} label={label} img={img} />
+							))}
+						</div>
+					) : null}
+					{/* The Show more/less control lives INSIDE the card, within its padding, below the text — so
+					    line-clamp truncates only the message body (its own element), never the control. */}
+					<div
+						data-testid="user-message-body"
+						data-collapsed={collapsed || undefined}
+						className={cn(collapsed && "line-clamp-3")}
+					>
+						{text}
+					</div>
+					{large ? (
+						<button
+							type="button"
+							data-testid="user-message-toggle"
+							aria-expanded={expanded}
+							onClick={toggle}
+							className="mt-4 flex items-center gap-4 tr-text-metadata text-text-subtle hover:text-text-default"
+						>
+							{expanded ? (
+								<ChevronUp className="size-12 shrink-0" />
+							) : (
+								<ChevronDown className="size-12 shrink-0" />
+							)}
+							{expanded ? "Show less" : "Show more"}
+						</button>
+					) : null}
+				</div>
+			</div>
+		</MessageWithCopy>
 	);
 }
 

--- a/e2e/chat-order.spec.ts
+++ b/e2e/chat-order.spec.ts
@@ -189,3 +189,44 @@ test("newest-first scrolls down into history and returns upward to the latest gr
 		rmSync(session.path, { force: true });
 	}
 });
+
+test("in newest-first order, auto-collapse and the final-answer copy action still track chronological order", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const largeText = `Please refactor the transport layer. ${"Investigate the reconnect path and reducer ordering carefully. ".repeat(12)}`;
+	const session = seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "newest-first round chat",
+		messages: [
+			{ role: "user", text: largeText, timestamp: BASE_TS },
+			{ role: "assistant", text: "First, let me inspect the files.", timestamp: BASE_TS + 1_000 },
+			{
+				role: "assistant",
+				text: "Done — I refactored the module and updated its tests.",
+				timestamp: BASE_TS + 2_000,
+			},
+			{ role: "user", text: "any follow-up needed?", timestamp: BASE_TS + 3_000 },
+			{ role: "assistant", text: "All set.", timestamp: BASE_TS + 4_000 },
+		],
+	});
+	utimesSync(session.path, new Date(BASE_TS + 10_000), new Date(BASE_TS + 10_000));
+
+	try {
+		await selectMessageOrder(page, "newest-first");
+		await enterDefaultWorkspace(page);
+		await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
+
+		const largeBody = page
+			.getByTestId("user-message-body")
+			.filter({ hasText: "Please refactor the transport layer" });
+		await expect(largeBody).toHaveAttribute("data-collapsed", "true");
+
+		const assistantMessages = page.locator('[data-testid="chat-message"][data-role="assistant"]');
+		const intermediate = assistantMessages.filter({ hasText: "let me inspect" });
+		const final = assistantMessages.filter({ hasText: "Done — I refactored" });
+		await expect(intermediate.getByTestId("chat-copy")).toHaveCount(0);
+		await expect(final.getByTestId("chat-copy")).toHaveCount(1);
+	} finally {
+		rmSync(session.path, { force: true });
+	}
+});

--- a/e2e/history-search.spec.ts
+++ b/e2e/history-search.spec.ts
@@ -62,7 +62,8 @@ async function openSeededClosedChat(page: Page, messages: SeededMessages) {
 		await expect(
 			page
 				.locator('[data-testid="chat-message"][data-role="user"]')
-				.filter({ hasText: latestUserMessage.text }),
+				.filter({ hasText: latestUserMessage.text })
+				.last(),
 		).toBeVisible({ timeout: 20_000 });
 	}
 	const input = page.getByTestId("chat-input");

--- a/e2e/message-actions.spec.ts
+++ b/e2e/message-actions.spec.ts
@@ -1,0 +1,155 @@
+import { realpathSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+	defaultWorkspaceRow,
+	enterDefaultWorkspace,
+	openChatFromHistory,
+	openFixtureProject,
+} from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_910_000_000;
+
+// A plain user message comfortably over the 500-char collapse threshold.
+const LARGE_TEXT = `Please refactor the transport layer. ${"Investigate the reconnect path and reducer ordering carefully. ".repeat(
+	12,
+)}`;
+const SHORT_TEXT = "Quick question: does the reducer append or replace?";
+
+test("a large user message with an agent reply collapses, and Show more re-expands it", async ({
+	page,
+}) => {
+	expect(LARGE_TEXT.length).toBeGreaterThan(500);
+	await openFixtureProject(page); // resets state — seed after
+	seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "large message chat",
+		messages: [
+			{ role: "user", text: LARGE_TEXT, timestamp: BASE_TS },
+			{ role: "assistant", text: "On it — starting with the reducer.", timestamp: BASE_TS + 1_000 },
+		],
+	});
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+	await openChatFromHistory(page, "large message chat");
+
+	const body = page.getByTestId("user-message-body");
+	const toggle = page.getByTestId("user-message-toggle");
+	// Agent has replied, so the large message is collapsed by default.
+	await expect(body).toHaveAttribute("data-collapsed", "true");
+	await expect(toggle).toHaveText("Show more");
+
+	await toggle.click();
+	await expect(body).not.toHaveAttribute("data-collapsed", "true");
+	await expect(toggle).toHaveText("Show less");
+	await expect(body).toContainText("Please refactor the transport layer.");
+
+	await toggle.click();
+	await expect(body).toHaveAttribute("data-collapsed", "true");
+});
+
+test("a large user message with no agent reply stays expanded", async ({ page }) => {
+	await openFixtureProject(page);
+	seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "unanswered large message chat",
+		messages: [{ role: "user", text: LARGE_TEXT, timestamp: BASE_TS }],
+	});
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+	await openChatFromHistory(page, "unanswered large message chat");
+
+	const body = page.getByTestId("user-message-body");
+	await expect(body).toBeVisible();
+	await expect(body).not.toHaveAttribute("data-collapsed", "true");
+	await expect(page.getByTestId("user-message-toggle")).toHaveText("Show less");
+});
+
+test("a short user message has no collapse controls", async ({ page }) => {
+	await openFixtureProject(page);
+	seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "short message chat",
+		messages: [
+			{ role: "user", text: SHORT_TEXT, timestamp: BASE_TS },
+			{ role: "assistant", text: "It appends.", timestamp: BASE_TS + 1_000 },
+		],
+	});
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+	await openChatFromHistory(page, "short message chat");
+
+	const body = page.getByTestId("user-message-body");
+	await expect(body).toBeVisible();
+	await expect(body).not.toHaveAttribute("data-collapsed", "true");
+	await expect(page.getByTestId("user-message-toggle")).toHaveCount(0);
+});
+
+test("only the round's final agent answer carries a copy action, not intermediate narration", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "intermediate vs final chat",
+		messages: [
+			{ role: "user", text: "refactor the module", timestamp: BASE_TS },
+			{ role: "assistant", text: "First, let me inspect the files.", timestamp: BASE_TS + 1_000 },
+			{
+				role: "assistant",
+				text: "Done — I refactored the module and updated its tests.",
+				timestamp: BASE_TS + 2_000,
+			},
+		],
+	});
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+	await openChatFromHistory(page, "intermediate vs final chat");
+
+	const assistantMessages = page.locator('[data-testid="chat-message"][data-role="assistant"]');
+	await expect(assistantMessages).toHaveCount(2);
+	const intermediate = assistantMessages.filter({ hasText: "let me inspect" });
+	const final = assistantMessages.filter({ hasText: "Done — I refactored" });
+	// The intermediate narration has no copy affordance at all; only the concluding answer does.
+	await expect(intermediate.getByTestId("chat-copy")).toHaveCount(0);
+	await expect(final.getByTestId("chat-copy")).toHaveCount(1);
+});
+
+test("copy actions copy the full source of both user and agent messages", async ({ page }) => {
+	await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+	await openFixtureProject(page);
+	seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "copy chat",
+		messages: [
+			{ role: "user", text: LARGE_TEXT, timestamp: BASE_TS },
+			{
+				role: "assistant",
+				text: "Here is the **plan** with `code`.",
+				timestamp: BASE_TS + 1_000,
+			},
+		],
+	});
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+	await openChatFromHistory(page, "copy chat");
+
+	// User copy — full source, not the collapsed preview.
+	const userMessage = page.locator('[data-testid="chat-message"][data-role="user"]');
+	await userMessage.hover();
+	await userMessage.getByTestId("chat-copy").click();
+	await expect(async () => {
+		expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(LARGE_TEXT);
+	}).toPass();
+
+	// Agent copy — the markdown source.
+	const assistantMessage = page.locator('[data-testid="chat-message"][data-role="assistant"]');
+	await assistantMessage.hover();
+	await assistantMessage.getByTestId("chat-copy").click();
+	await expect(async () => {
+		expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(
+			"Here is the **plan** with `code`.",
+		);
+	}).toPass();
+});

--- a/e2e/message-actions.spec.ts
+++ b/e2e/message-actions.spec.ts
@@ -11,6 +11,19 @@ const LARGE_TEXT = `Please refactor the transport layer. ${"Investigate the reco
 )}`;
 const SHORT_TEXT = "Quick question: does the reducer append or replace?";
 
+type Box = { x: number; y: number; width: number; height: number };
+
+function boxBottom(box: Box): number {
+	return box.y + box.height;
+}
+
+function expectContained(inner: Box, outer: Box): void {
+	expect(inner.x).toBeGreaterThanOrEqual(outer.x - 1);
+	expect(inner.y).toBeGreaterThanOrEqual(outer.y - 1);
+	expect(inner.x + inner.width).toBeLessThanOrEqual(outer.x + outer.width + 1);
+	expect(boxBottom(inner)).toBeLessThanOrEqual(boxBottom(outer) + 1);
+}
+
 test("a large user message with an agent reply collapses, and Show more re-expands it", async ({
 	page,
 }) => {
@@ -108,7 +121,7 @@ test("only the round's final agent answer carries a copy action, not intermediat
 	await expect(final.getByTestId("chat-copy")).toHaveCount(1);
 });
 
-test("the copy action overlays the bottom-right corner of the message, for both agent and user", async ({
+test("copy actions share the content line at the assistant left and user right without overlap", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
@@ -132,15 +145,42 @@ test("the copy action overlays the bottom-right corner of the message, for both 
 	const assistantMessage = page.locator('[data-testid="chat-message"][data-role="assistant"]');
 	await expect(assistantMessage).toBeVisible();
 
-	for (const message of [userMessage, assistantMessage]) {
-		const [messageBox, copyBox] = await Promise.all([
-			message.boundingBox(),
-			message.getByTestId("chat-copy").boundingBox(),
-		]);
-		if (!messageBox || !copyBox) throw new Error("expected both bounding boxes to be visible");
-		expect(messageBox.x + messageBox.width - (copyBox.x + copyBox.width)).toBeLessThan(8);
-		expect(messageBox.y + messageBox.height - (copyBox.y + copyBox.height)).toBeLessThan(8);
+	const [
+		userBox,
+		userCopyBox,
+		userContentBox,
+		assistantBox,
+		assistantCopyBox,
+		assistantContentBox,
+	] = await Promise.all([
+		userMessage.boundingBox(),
+		userMessage.getByTestId("chat-copy").boundingBox(),
+		userMessage.getByTestId("user-message-body").boundingBox(),
+		assistantMessage.boundingBox(),
+		assistantMessage.getByTestId("chat-copy").boundingBox(),
+		assistantMessage.locator("p").last().boundingBox(),
+	]);
+	if (
+		!userBox ||
+		!userCopyBox ||
+		!userContentBox ||
+		!assistantBox ||
+		!assistantCopyBox ||
+		!assistantContentBox
+	) {
+		throw new Error("expected message, content, and copy-action boxes to be visible");
 	}
+
+	expectContained(assistantCopyBox, assistantBox);
+	expectContained(userCopyBox, userBox);
+	expect(Math.abs(assistantCopyBox.x - assistantBox.x)).toBeLessThan(2);
+	expect(Math.abs(userBox.x + userBox.width - (userCopyBox.x + userCopyBox.width))).toBeLessThan(2);
+	expect(assistantCopyBox.x + assistantCopyBox.width).toBeLessThanOrEqual(
+		assistantContentBox.x + 1,
+	);
+	expect(userContentBox.x + userContentBox.width).toBeLessThanOrEqual(userCopyBox.x + 1);
+	expect(Math.abs(boxBottom(assistantCopyBox) - boxBottom(assistantContentBox))).toBeLessThan(2);
+	expect(Math.abs(boxBottom(userCopyBox) - boxBottom(userContentBox))).toBeLessThan(2);
 });
 
 test("copy actions copy the full source of both user and agent messages", async ({ page }) => {

--- a/e2e/message-actions.spec.ts
+++ b/e2e/message-actions.spec.ts
@@ -6,7 +6,6 @@ import { seedWorkspaceSession } from "./fixtures/sessions";
 
 const BASE_TS = 1_700_910_000_000;
 
-// A plain user message comfortably over the 500-char collapse threshold.
 const LARGE_TEXT = `Please refactor the transport layer. ${"Investigate the reconnect path and reducer ordering carefully. ".repeat(
 	12,
 )}`;
@@ -16,7 +15,7 @@ test("a large user message with an agent reply collapses, and Show more re-expan
 	page,
 }) => {
 	expect(LARGE_TEXT.length).toBeGreaterThan(500);
-	await openFixtureProject(page); // resets state — seed after
+	await openFixtureProject(page);
 	seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
 		name: "large message chat",
 		messages: [
@@ -31,7 +30,6 @@ test("a large user message with an agent reply collapses, and Show more re-expan
 
 	const body = page.getByTestId("user-message-body");
 	const toggle = page.getByTestId("user-message-toggle");
-	// Agent has replied, so the large message is collapsed by default.
 	await expect(body).toHaveAttribute("data-collapsed", "true");
 	await expect(toggle).toHaveText("Show more");
 
@@ -106,7 +104,6 @@ test("only the round's final agent answer carries a copy action, not intermediat
 	await expect(assistantMessages).toHaveCount(2);
 	const intermediate = assistantMessages.filter({ hasText: "let me inspect" });
 	const final = assistantMessages.filter({ hasText: "Done — I refactored" });
-	// The intermediate narration has no copy affordance at all; only the concluding answer does.
 	await expect(intermediate.getByTestId("chat-copy")).toHaveCount(0);
 	await expect(final.getByTestId("chat-copy")).toHaveCount(1);
 });
@@ -135,8 +132,6 @@ test("the copy action overlays the bottom-right corner of the message, for both 
 	const assistantMessage = page.locator('[data-testid="chat-message"][data-role="assistant"]');
 	await expect(assistantMessage).toBeVisible();
 
-	// The copy action is an overlay pinned to its message's own bottom-right corner — for both roles —
-	// not a row below the content, so its edges track the message's own bounding box.
 	for (const message of [userMessage, assistantMessage]) {
 		const [messageBox, copyBox] = await Promise.all([
 			message.boundingBox(),
@@ -167,7 +162,6 @@ test("copy actions copy the full source of both user and agent messages", async 
 	await enterDefaultWorkspace(page);
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
-	// User copy — full source, not the collapsed preview.
 	const userMessage = page.locator('[data-testid="chat-message"][data-role="user"]');
 	await userMessage.hover();
 	await userMessage.getByTestId("chat-copy").click();
@@ -175,7 +169,6 @@ test("copy actions copy the full source of both user and agent messages", async 
 		expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(LARGE_TEXT);
 	}).toPass();
 
-	// Agent copy — the markdown source.
 	const assistantMessage = page.locator('[data-testid="chat-message"][data-role="assistant"]');
 	await assistantMessage.hover();
 	await assistantMessage.getByTestId("chat-copy").click();

--- a/e2e/message-actions.spec.ts
+++ b/e2e/message-actions.spec.ts
@@ -116,7 +116,7 @@ test("only the round's final agent answer carries a copy action, not intermediat
 	await expect(final.getByTestId("chat-copy")).toHaveCount(1);
 });
 
-test("the copy action sits 2px below the content, consistent for agent and user messages", async ({
+test("the copy action overlays the bottom-right corner of the message, for both agent and user", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
@@ -140,22 +140,17 @@ test("the copy action sits 2px below the content, consistent for agent and user 
 	const assistantMessage = page.locator('[data-testid="chat-message"][data-role="assistant"]');
 	await expect(assistantMessage).toBeVisible();
 
-	// The shared copy-action gap is exactly 2px on both roles (single source of truth in MessageWithCopy).
-	const gapOf = (loc: import("@playwright/test").Locator) =>
-		loc.evaluate((el) => getComputedStyle(el).rowGap);
-	await expect.poll(() => gapOf(userMessage)).toBe("2px");
-	await expect.poll(() => gapOf(assistantMessage)).toBe("2px");
-
-	// The agent answer ends flush: its last markdown block carries no trailing bottom margin, so the copy
-	// action is not pushed farther away than on a user bubble.
-	const lastBlockMb = await assistantMessage
-		.locator("[data-testid='chat-copy']")
-		.evaluate((copy) => {
-			const content = copy.previousElementSibling;
-			const block = content?.firstElementChild?.lastElementChild;
-			return block ? getComputedStyle(block).marginBottom : null;
-		});
-	expect(lastBlockMb).toBe("0px");
+	// The copy action is an overlay pinned to its message's own bottom-right corner — for both roles —
+	// not a row below the content, so its edges track the message's own bounding box.
+	for (const message of [userMessage, assistantMessage]) {
+		const [messageBox, copyBox] = await Promise.all([
+			message.boundingBox(),
+			message.getByTestId("chat-copy").boundingBox(),
+		]);
+		if (!messageBox || !copyBox) throw new Error("expected both bounding boxes to be visible");
+		expect(messageBox.x + messageBox.width - (copyBox.x + copyBox.width)).toBeLessThan(8);
+		expect(messageBox.y + messageBox.height - (copyBox.y + copyBox.height)).toBeLessThan(8);
+	}
 });
 
 test("copy actions copy the full source of both user and agent messages", async ({ page }) => {

--- a/e2e/message-actions.spec.ts
+++ b/e2e/message-actions.spec.ts
@@ -116,6 +116,48 @@ test("only the round's final agent answer carries a copy action, not intermediat
 	await expect(final.getByTestId("chat-copy")).toHaveCount(1);
 });
 
+test("the copy action sits 2px below the content, consistent for agent and user messages", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name: "copy spacing chat",
+		messages: [
+			{ role: "user", text: "Summarize the transport module.", timestamp: BASE_TS },
+			{
+				role: "assistant",
+				text: "Reworked reconnect and made ordering deterministic.",
+				timestamp: BASE_TS + 1_000,
+			},
+		],
+	});
+
+	await expect(defaultWorkspaceRow(page)).toBeVisible();
+	await enterDefaultWorkspace(page);
+	await openChatFromHistory(page, "copy spacing chat");
+
+	const userMessage = page.locator('[data-testid="chat-message"][data-role="user"]');
+	const assistantMessage = page.locator('[data-testid="chat-message"][data-role="assistant"]');
+	await expect(assistantMessage).toBeVisible();
+
+	// The shared copy-action gap is exactly 2px on both roles (single source of truth in MessageWithCopy).
+	const gapOf = (loc: import("@playwright/test").Locator) =>
+		loc.evaluate((el) => getComputedStyle(el).rowGap);
+	await expect.poll(() => gapOf(userMessage)).toBe("2px");
+	await expect.poll(() => gapOf(assistantMessage)).toBe("2px");
+
+	// The agent answer ends flush: its last markdown block carries no trailing bottom margin, so the copy
+	// action is not pushed farther away than on a user bubble.
+	const lastBlockMb = await assistantMessage
+		.locator("[data-testid='chat-copy']")
+		.evaluate((copy) => {
+			const content = copy.previousElementSibling;
+			const block = content?.firstElementChild?.lastElementChild;
+			return block ? getComputedStyle(block).marginBottom : null;
+		});
+	expect(lastBlockMb).toBe("0px");
+});
+
 test("copy actions copy the full source of both user and agent messages", async ({ page }) => {
 	await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
 	await openFixtureProject(page);

--- a/e2e/message-actions.spec.ts
+++ b/e2e/message-actions.spec.ts
@@ -1,11 +1,6 @@
 import { realpathSync } from "node:fs";
 import { expect, test } from "@playwright/test";
-import {
-	defaultWorkspaceRow,
-	enterDefaultWorkspace,
-	openChatFromHistory,
-	openFixtureProject,
-} from "./fixtures/app";
+import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
 import { seedWorkspaceSession } from "./fixtures/sessions";
 
@@ -32,7 +27,7 @@ test("a large user message with an agent reply collapses, and Show more re-expan
 
 	await expect(defaultWorkspaceRow(page)).toBeVisible();
 	await enterDefaultWorkspace(page);
-	await openChatFromHistory(page, "large message chat");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	const body = page.getByTestId("user-message-body");
 	const toggle = page.getByTestId("user-message-toggle");
@@ -58,7 +53,7 @@ test("a large user message with no agent reply stays expanded", async ({ page })
 
 	await expect(defaultWorkspaceRow(page)).toBeVisible();
 	await enterDefaultWorkspace(page);
-	await openChatFromHistory(page, "unanswered large message chat");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	const body = page.getByTestId("user-message-body");
 	await expect(body).toBeVisible();
@@ -78,7 +73,7 @@ test("a short user message has no collapse controls", async ({ page }) => {
 
 	await expect(defaultWorkspaceRow(page)).toBeVisible();
 	await enterDefaultWorkspace(page);
-	await openChatFromHistory(page, "short message chat");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	const body = page.getByTestId("user-message-body");
 	await expect(body).toBeVisible();
@@ -105,7 +100,7 @@ test("only the round's final agent answer carries a copy action, not intermediat
 
 	await expect(defaultWorkspaceRow(page)).toBeVisible();
 	await enterDefaultWorkspace(page);
-	await openChatFromHistory(page, "intermediate vs final chat");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	const assistantMessages = page.locator('[data-testid="chat-message"][data-role="assistant"]');
 	await expect(assistantMessages).toHaveCount(2);
@@ -134,7 +129,7 @@ test("the copy action overlays the bottom-right corner of the message, for both 
 
 	await expect(defaultWorkspaceRow(page)).toBeVisible();
 	await enterDefaultWorkspace(page);
-	await openChatFromHistory(page, "copy spacing chat");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	const userMessage = page.locator('[data-testid="chat-message"][data-role="user"]');
 	const assistantMessage = page.locator('[data-testid="chat-message"][data-role="assistant"]');
@@ -170,7 +165,7 @@ test("copy actions copy the full source of both user and agent messages", async 
 
 	await expect(defaultWorkspaceRow(page)).toBeVisible();
 	await enterDefaultWorkspace(page);
-	await openChatFromHistory(page, "copy chat");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
 	// User copy — full source, not the collapsed preview.
 	const userMessage = page.locator('[data-testid="chat-message"][data-role="user"]');


### PR DESCRIPTION
## Summary

Add copy actions to chat messages and collapse very long user messages so transcripts stay scannable.
The behavior is shared by the main chat and read-only subagent transcripts, while all state remains
client-side presentation state.

## Changes

- **Copy actions** (`apps/web/src/chat/CopyButton.tsx`, `turns.tsx`) — plain user bubbles and each
  round's concluding assistant answer get a hover-revealed copy affordance through one shared
  `MessageWithCopy` layout. The 24px action sits inside a same-line horizontal reserve at the
  bottom-left of assistant answers and bottom-right of user bubbles, with final-answer list markers
  contained on the content side; there is no dedicated action row and no text overlap. It copies the
  full source (`userText(...)` / markdown text), never a collapsed preview or UI chrome, through the shared
  `copyText()` degradation path and shows success feedback only after a successful write.
- **Collapse large user messages** (`turns.tsx`) — a plain user message over 500 characters stays
  expanded until the agent starts responding, then collapses to a `line-clamp` preview with an in-card
  `Show more` / `Show less` toggle. Manual choices survive streaming and virtualization through the
  shared fold-state cache; short messages are unchanged.
- **Shared chronological classification** (`messageActions.ts`) — one linear backward pass determines
  answered user rows and final assistant-answer rows from canonical chronological rows. Both
  `ChatView` and `SubagentTranscriptDialog` supply the result to `ChatTurnView`; required renderer props
  prevent another transcript integration from silently omitting the behavior.
- **Reused, not reinvented** — Remix icons, existing hover-reveal conventions, the shared clipboard
  helper, fold state, and semantic typography/color/spacing tokens; no parallel styling or state owner.
- **Spec and tests** — `apps/web/src/chat/SPEC.md` owns the behavior. Focused unit coverage pins the
  shared classifier and role-specific layout classes; `e2e/message-actions.spec.ts` checks containment,
  edge placement, non-overlap, and final-line alignment, while `e2e/chat-order.spec.ts` covers projection.
  The history-search seed helper selects its latest matching row.

State ownership is unchanged: chat/session state stays server-owned, collapse/expand is client-side view
state, hydrate-then-stream is untouched, and closing a tab remains a view action.

## Testing

- `bun test apps/web/src/chat/turns.test.tsx apps/web/src/chat/messageActions.test.ts` — 5 passed
- `bun test apps/web/src/styles/spacingUsage.test.ts` — 14 passed
- `bun run test` — 14/14 package tasks successful
- `bun run typecheck` — 14/14 package tasks successful
- `bun run check:deps && bun run check:boundaries && bun run check:seams` — passed
- `bun --filter @thinkrail/web build` — passed with existing CSS/chunk-size warnings
- `bun run lint` — passed with 6 pre-existing unused-suppression warnings
- Local e2e was not run for this follow-up, per request; PR CI is the e2e authority

