### PR TITLE
[Design] Workspace renaming

### DIFF
--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -7,6 +7,7 @@ import {
 	RiGitBranchLine as GitBranch,
 	RiHome2Line as House,
 	RiMore2Line as MoreVertical,
+	RiPencilLine as Pencil,
 	RiAddLine as Plus,
 	RiFolderFill,
 	RiFolderLine,
@@ -17,7 +18,14 @@ import {
 	RiCloseLine as X,
 } from "@remixicon/react";
 import type { EditorInfo, Project, Workspace } from "@thinkrail/contracts";
-import { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
+import {
+	type KeyboardEvent,
+	type MouseEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { Button } from "@/components/ui/button";
 import {
 	ContextMenu,
@@ -189,6 +197,17 @@ export function ProjectTree() {
 			.catch((err) => toast.error(errorText(err, "Failed to reveal workspace")));
 	};
 
+	// Event-driven like remove/reveal: fire the RPC and let the host's `workspace.updated` push drive
+	// convergence (`applyWorkspaceUpdated` replaces the record). No client-side optimism — the server owns
+	// the display name and derives the branch from it, so the echo is the source of truth.
+	const renameWorkspace = (workspace: Workspace, name: string) => {
+		void getTransport()
+			.request("workspace.rename", { id: workspace.id, name })
+			.catch((err) => toast.error(errorText(err, "Failed to rename workspace")));
+	};
+
+	// Lossless and event-driven: the host marks the stable project record closed, then project.updated
+	// removes it from every client's rail. A rejected request emits no event, so the row stays and we toast.
 	const closeProject = (project: Project) => {
 		pendingCloseFocusProjectIdRef.current = project.id;
 		void getTransport()
@@ -265,6 +284,7 @@ export function ProjectTree() {
 											onOpenIn={(editor) => openWorkspaceIn(ws, editor)}
 											onCopyPath={() => void copyText(ws.worktreePath)}
 											onReveal={() => revealWorkspace(ws)}
+											onRename={(name) => renameWorkspace(ws, name)}
 											onRemove={() => removeWorkspace(ws.id)}
 										/>
 									))}
@@ -489,6 +509,7 @@ function WorkspaceRow({
 	onOpenIn,
 	onCopyPath,
 	onReveal,
+	onRename,
 	onRemove,
 }: {
 	workspace: Workspace;
@@ -498,6 +519,7 @@ function WorkspaceRow({
 	onOpenIn: (editor: EditorInfo) => void;
 	onCopyPath: () => void;
 	onReveal: () => void;
+	onRename: (name: string) => void;
 	onRemove: () => void;
 }) {
 	const isDefault = isDefaultWorkspace(workspace);
@@ -520,6 +542,55 @@ function WorkspaceRow({
 		setMenuOpen(true);
 	};
 	const [confirmOpen, setConfirmOpen] = useState(false);
+
+	// Inline rename is client-owned *editing* state; the name itself stays server-owned (the row re-renders
+	// from `workspace.name` the moment editing ends, and a successful rename converges via the
+	// `workspace.updated` push). Only worktree workspaces are renamable — default/external throw server-side.
+	const nameRef = useRef<HTMLInputElement>(null);
+	const [editing, setEditing] = useState(false);
+	// Set when Escape cancels, so the ensuing blur restores the previous name instead of saving.
+	const cancelNextBlurRef = useRef(false);
+	// Set when the menu closes *into* rename, so `onCloseAutoFocus` skips returning focus to the kebab —
+	// otherwise Radix's focus-return fires after our rAF and immediately blurs (thus commits) the input.
+	const enterRenameRef = useRef(false);
+
+	// Enter edit mode: focus + select-all so the current name can be replaced immediately (the input is
+	// uncontrolled, seeded via `defaultValue`). Focus in a rAF so it lands after Radix returns focus to the
+	// (now-closed) menu trigger.
+	useEffect(() => {
+		if (!editing) return;
+		const el = nameRef.current;
+		if (!el) return;
+		const raf = requestAnimationFrame(() => {
+			el.focus();
+			el.select();
+		});
+		return () => cancelAnimationFrame(raf);
+	}, [editing]);
+
+	// Blur = clicking outside the editable name (including outside the row) commits. Empty/whitespace or an
+	// unchanged value sends nothing — the server-owned name restored by the `!editing` render stands.
+	const commitRename = () => {
+		if (cancelNextBlurRef.current) {
+			cancelNextBlurRef.current = false;
+			setEditing(false);
+			return;
+		}
+		const next = (nameRef.current?.value ?? "").trim();
+		setEditing(false);
+		if (next && next !== workspace.name) onRename(next);
+	};
+
+	const onNameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key === "Enter") {
+			event.preventDefault(); // single line: commit rather than insert a newline
+			nameRef.current?.blur();
+		} else if (event.key === "Escape") {
+			event.preventDefault();
+			cancelNextBlurRef.current = true;
+			nameRef.current?.blur();
+		}
+	};
 	return (
 		<li>
 			<fieldset
@@ -541,12 +612,34 @@ function WorkspaceRow({
 						className={`${isTwoLine ? "mt-2 " : ""}size-14 shrink-0 ${isActive ? "text-primary" : "text-text-muted"}`}
 					/>
 					<span className="flex min-w-0 flex-1 flex-col">
-						<span
-							data-testid="workspace-name"
-							className={`truncate tr-text-ui leading-tight ${isActive ? "text-primary" : "text-text-muted"}`}
-						>
-							{workspace.name}
-						</span>
+						{editing ? (
+							// A bare, chrome-less input so the row keeps the label's exact typography token, color, and
+							// metrics in place: no border/background/ring/padding/extra container (`border-0
+							// bg-transparent p-0 outline-none`) — only the caret/selection signals editability. Seeded
+							// uncontrolled via `defaultValue`, focused + selected by the ref effect. Clicks stopPropagation
+							// so the caret lands instead of the row selecting.
+							<input
+								ref={nameRef}
+								data-testid="workspace-name"
+								data-editing
+								type="text"
+								spellCheck={false}
+								aria-label="Workspace name"
+								defaultValue={workspace.name}
+								onMouseDown={(event) => event.stopPropagation()}
+								onClick={(event) => event.stopPropagation()}
+								onKeyDown={onNameKeyDown}
+								onBlur={commitRename}
+								className={`w-full min-w-0 truncate border-0 bg-transparent p-0 tr-text-ui leading-tight outline-none ${isActive ? "text-primary" : "text-text-muted"}`}
+							/>
+						) : (
+							<span
+								data-testid="workspace-name"
+								className={`truncate tr-text-ui leading-tight ${isActive ? "text-primary" : "text-text-muted"}`}
+							>
+								{workspace.name}
+							</span>
+						)}
 						{isTwoLine && (
 							<span
 								data-testid="workspace-branch"
@@ -565,7 +658,15 @@ function WorkspaceRow({
 					>
 						<MoreVertical className="size-14" />
 					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" data-testid="workspace-actions">
+					<DropdownMenuContent
+						align="end"
+						data-testid="workspace-actions"
+						onCloseAutoFocus={(event) => {
+							if (!enterRenameRef.current) return;
+							enterRenameRef.current = false;
+							event.preventDefault(); // let the inline input keep focus instead of the kebab
+						}}
+					>
 						{editors.length > 0 && (
 							<DropdownMenuSub>
 								<DropdownMenuSubTrigger data-testid="workspace-open-in">
@@ -584,6 +685,18 @@ function WorkspaceRow({
 									))}
 								</DropdownMenuSubContent>
 							</DropdownMenuSub>
+						)}
+						{!isDefault && !isExternal && (
+							<DropdownMenuItem
+								data-testid="workspace-rename"
+								onSelect={() => {
+									enterRenameRef.current = true;
+									setEditing(true);
+								}}
+							>
+								<Pencil />
+								Rename
+							</DropdownMenuItem>
 						)}
 						<DropdownMenuItem data-testid="workspace-copy-path" onSelect={onCopyPath}>
 							<Copy />

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -53,12 +53,23 @@ treatment.
   workspace row's hover-revealed **kebab menu** (`MoreVertical`, controlled `DropdownMenu`) — right-clicking
   anywhere on the row opens that exact menu at the kebab without selecting/activating the workspace, while
   the kebab remains the touch and keyboard-focus path. Its actions are a `DropdownMenuSub` **"Open in"**
-  (rendered only when at least one editor was detected), **Copy path**, **Reveal in file manager**, and
+  (rendered only when at least one editor was detected), (worktrees only) **Rename**, **Copy path**,
+  **Reveal in file manager**, and
   (worktrees only) **Remove workspace** — worded **Remove from ThinkRail** on an external row, whose
   confirm promises the checkout and its branch stay untouched. "Open in" comes from the
   host-wide `editor.list`;
   GUI entries call `workspace.openIn`, while terminal-kind Vim activates the workspace and runs through
   `addTerminal`'s one-shot `initialCommand`. Copy writes `worktreePath`; Reveal calls `workspace.reveal`.
+  **Rename** (worktrees only — hidden for default/external, which the server refuses) edits the name
+  **inline in the row**, not in a dialog: it swaps the `workspace-name` label for a bare, chrome-less
+  `<input>` in the same slot — same typography token / semantic color / row height, no
+  border/background/focus-ring/padding/extra container (`border-0 bg-transparent p-0 outline-none`), only
+  the caret/selection signals editability. Seeded uncontrolled from the current name and selected on
+  entry. Blur (clicking outside the input) commits; Enter commits, Escape cancels; an empty/whitespace or
+  unchanged value sends nothing and the server-owned name returns with the non-editing re-render. A
+  committed change fires `workspace.rename` and converges via the host's `workspace.updated` push (no
+  client-side optimism, same discipline as Remove); a rejected request toasts and the row keeps the
+  server's name.
   Remove is styled destructive and opens a centered `ConfirmDialog`; confirming fires
   `workspace.remove` and lets every client react to the host's `workspace.removed` push via the store's
   `applyWorkspaceRemoved`; a rejected request (no event will come) surfaces an error toast, leaving the row

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -105,7 +105,7 @@ export function stagePlainFolder(): string {
 	return E2E_PLAIN_DIR;
 }
 
-function loadPersistedWorkspaces(): Workspace[] {
+export function loadPersistedWorkspaces(): Workspace[] {
 	try {
 		return JSON.parse(readFileSync(join(E2E_DATA_DIR, "workspaces.json"), "utf8")) as Workspace[];
 	} catch {

--- a/e2e/workspace-actions.spec.ts
+++ b/e2e/workspace-actions.spec.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 import {
 	createWorkspaceViaDialog,
+	loadPersistedWorkspaces,
 	openFixtureProject,
 	openWorkspaceMenu,
 	waitTerminalReady,
@@ -50,7 +51,7 @@ test("Copy path copies the worktree's absolute path to the clipboard", async ({
 	expect(copied).toContain("/worktrees/sample-project/");
 });
 
-test("the Default workspace's kebab menu offers Open in / Copy path but no Remove", async ({
+test("the Default workspace's kebab menu offers Open in / Copy path but no Rename or Remove", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
@@ -58,7 +59,61 @@ test("the Default workspace's kebab menu offers Open in / Copy path but no Remov
 	await openWorkspaceMenu(row);
 	await expect(page.getByTestId("workspace-open-in")).toBeVisible();
 	await expect(page.getByTestId("workspace-copy-path")).toBeVisible();
+	// Default is non-renamable server-side, so the row hides Rename to match.
+	await expect(page.getByTestId("workspace-rename")).toHaveCount(0);
 	await expect(page.getByTestId("workspace-remove")).toHaveCount(0);
+});
+
+test("Rename edits the workspace name inline and persists via workspace.rename", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const created = await createWorkspaceViaDialog(page);
+	await settleAfterCreate(page);
+	const row = worktreeRows(page).first();
+
+	await openWorkspaceMenu(row);
+	await page.getByTestId("workspace-rename").click();
+
+	// The name becomes editable in place (same testid), prefilled with the current name and selected so it
+	// can be replaced immediately — no dialog, and the input carries no chrome of its own.
+	const input = row.getByTestId("workspace-name");
+	await expect(input).toBeFocused();
+	await expect(input).toHaveValue(created.name);
+	const selectedAll = await input.evaluate(
+		(el: HTMLInputElement) => el.selectionStart === 0 && el.selectionEnd === el.value.length,
+	);
+	expect(selectedAll).toBe(true);
+
+	await input.fill("Renamed Space");
+	// Clicking anywhere outside the row item saves.
+	await page.getByTestId("project-name").first().click();
+
+	// No client optimism: the label only reflects the host's `workspace.updated` echo, so a changed label
+	// already proves the round-trip. The persisted record confirms the server actually renamed.
+	await expect(row.getByTestId("workspace-name")).toHaveText("Renamed Space");
+	await expect
+		.poll(() => loadPersistedWorkspaces().find((w) => w.id === created.id)?.name)
+		.toBe("Renamed Space");
+});
+
+test("Rename with an empty value restores the previous name and sends nothing", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const created = await createWorkspaceViaDialog(page);
+	await settleAfterCreate(page);
+	const row = worktreeRows(page).first();
+
+	await openWorkspaceMenu(row);
+	await page.getByTestId("workspace-rename").click();
+	const input = row.getByTestId("workspace-name");
+	await expect(input).toBeFocused();
+	await input.fill("   "); // whitespace only → treated as empty
+	await page.getByTestId("project-name").first().click();
+
+	await expect(row.getByTestId("workspace-name")).toHaveText(created.name);
+	expect(loadPersistedWorkspaces().find((w) => w.id === created.id)?.name).toBe(created.name);
 });
 
 test("right-click opens the workspace's kebab menu without activating it", async ({ page }) => {

--- a/e2e/workspace-actions.spec.ts
+++ b/e2e/workspace-actions.spec.ts
@@ -95,6 +95,11 @@ test("Rename edits the workspace name inline and persists via workspace.rename",
 	await expect
 		.poll(() => loadPersistedWorkspaces().find((w) => w.id === created.id)?.name)
 		.toBe("Renamed Space");
+	// A user rename edits the display label only — the git branch is decoupled and must be KEPT, not
+	// renamed to a slug of the new name. So the branch stays `workspace-1` and, now differing from the
+	// name, surfaces on the row's second line.
+	expect(loadPersistedWorkspaces().find((w) => w.id === created.id)?.branch).toBe(created.branch);
+	await expect(row.getByTestId("workspace-branch")).toHaveText(created.branch);
 });
 
 test("Rename with an empty value restores the previous name and sends nothing", async ({

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -338,7 +338,11 @@ of the host.
   (turn a plugin / source tier / `@plugins` on/off at the baseline) / **`workspace.setSkillOverride`**
   (per-workspace on/off/clear → the `Workspace`) / **`workspace.setDiffBase`** (re-point the diff target,
   `null` clears it back to the creation base — echoes the updated `Workspace` **and** broadcasts
-  `workspace.updated`, so every client converges on the push) / **`workspace.watchReady`** (await the
+  `workspace.updated`, so every client converges on the push) / **`workspace.rename`** (deliberate user
+  rename of a worktree workspace — sets the display `name`, derives its branch, and **locks** it
+  (`renamed: true`) so the auto-namer never overrides it; echoes the updated `Workspace` **and**
+  broadcasts `workspace.updated`, same convergence as `setDiffBase`; throws for a `default`/`external`
+  kind or an empty name) / **`workspace.watchReady`** (await the
   fresh watcher's conservative startup nudge before a skill-loading client captures its freshness baseline;
   `{ startupNudge }` is true unless the watcher was already known ready, so a replayed response can supply
   the client's conservative fallback when the event push was lost or startup failed; an optional

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -339,7 +339,8 @@ of the host.
   (per-workspace on/off/clear → the `Workspace`) / **`workspace.setDiffBase`** (re-point the diff target,
   `null` clears it back to the creation base — echoes the updated `Workspace` **and** broadcasts
   `workspace.updated`, so every client converges on the push) / **`workspace.rename`** (deliberate user
-  rename of a worktree workspace — sets the display `name`, derives its branch, and **locks** it
+  rename of a worktree workspace — sets the display `name` **only** (the git `branch` is kept: name and
+  branch are decoupled, so editing the label never renames the user's branch) and **locks** it
   (`renamed: true`) so the auto-namer never overrides it; echoes the updated `Workspace` **and**
   broadcasts `workspace.updated`, same convergence as `setDiffBase`; throws for a `default`/`external`
   kind or an empty name) / **`workspace.watchReady`** (await the

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -130,6 +130,9 @@ export const WS_METHODS = {
 	workspaceList: "workspace.list",
 	workspaceOpenReview: "workspace.openReview",
 	workspaceRemove: "workspace.remove",
+	// Deliberate user rename of a worktree workspace — sets the display name + derives its branch and locks
+	// it (`renamed: true`) so the auto-namer never overrides it. Broadcasts `workspace.updated`.
+	workspaceRename: "workspace.rename",
 	workspaceDiffStats: "workspace.diffStats",
 	workspaceSetSkillOverride: "workspace.setSkillOverride",
 	workspaceSetDiffBase: "workspace.setDiffBase",
@@ -339,6 +342,11 @@ export interface WsMethodMap {
 		result: OpenBranchReview | null;
 	};
 	"workspace.remove": { params: { id: string }; result: Ack };
+	// Deliberate user rename: sets the display `name` and derives the branch, locking it (`renamed: true`)
+	// so the auto-namer leaves it alone. Echoes the updated `Workspace` **and** broadcasts
+	// `workspace.updated`, so every client converges on the push (like `workspace.setDiffBase`). Throws for
+	// an unknown id, a non-worktree kind (default/external), or an empty name.
+	"workspace.rename": { params: { id: string; name: string }; result: Workspace };
 	"workspace.diffStats": { params: { id: string }; result: DiffStats };
 	"workspace.setSkillOverride": {
 		params: { id: string; name: string; override: "on" | "off" | null };

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -130,8 +130,8 @@ export const WS_METHODS = {
 	workspaceList: "workspace.list",
 	workspaceOpenReview: "workspace.openReview",
 	workspaceRemove: "workspace.remove",
-	// Deliberate user rename of a worktree workspace — sets the display name + derives its branch and locks
-	// it (`renamed: true`) so the auto-namer never overrides it. Broadcasts `workspace.updated`.
+	// Deliberate user rename of a worktree workspace — sets the display name only (the git branch is kept:
+	// name and branch are decoupled) and locks it (`renamed: true`). Broadcasts `workspace.updated`.
 	workspaceRename: "workspace.rename",
 	workspaceDiffStats: "workspace.diffStats",
 	workspaceSetSkillOverride: "workspace.setSkillOverride",
@@ -342,8 +342,9 @@ export interface WsMethodMap {
 		result: OpenBranchReview | null;
 	};
 	"workspace.remove": { params: { id: string }; result: Ack };
-	// Deliberate user rename: sets the display `name` and derives the branch, locking it (`renamed: true`)
-	// so the auto-namer leaves it alone. Echoes the updated `Workspace` **and** broadcasts
+	// Deliberate user rename: sets the display `name` only — the git `branch` is **kept** (name and branch
+	// are decoupled, so editing the label never `git branch -m`s the user's branch away) — and locks it
+	// (`renamed: true`) so the auto-namer leaves it alone. Echoes the updated `Workspace` **and** broadcasts
 	// `workspace.updated`, so every client converges on the push (like `workspace.setDiffBase`). Throws for
 	// an unknown id, a non-worktree kind (default/external), or an empty name.
 	"workspace.rename": { params: { id: string; name: string }; result: Workspace };

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -150,6 +150,7 @@ import {
 	listWorkspaces,
 	openExistingWorktree,
 	reclaimWorktree,
+	renameWorkspace,
 	setWorkspaceDiffBase,
 	setWorkspaceSkillOverride,
 	workspaceDiffStats,
@@ -333,6 +334,12 @@ const handlers: Record<string, Handler> = {
 			void archiveTeardown(ws);
 		}
 		return { ok: true } as const;
+	},
+	// Deliberate user rename. `renameWorkspace` self-emits `workspace.updated` (it locks `renamed: true`
+	// so the auto-namer leaves the name alone) and throws for an unknown id / non-worktree kind / empty name.
+	"workspace.rename": (params) => {
+		const p = params as { id: string; name: string };
+		return renameWorkspace(p.id, p.name, { lock: true });
 	},
 	"workspace.diffStats": (params) => workspaceDiffStats((params as { id: string }).id),
 	"workspace.openIn": (params) => {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -335,11 +335,13 @@ const handlers: Record<string, Handler> = {
 		}
 		return { ok: true } as const;
 	},
-	// Deliberate user rename. `renameWorkspace` self-emits `workspace.updated` (it locks `renamed: true`
-	// so the auto-namer leaves the name alone) and throws for an unknown id / non-worktree kind / empty name.
+	// Deliberate user rename of the *display label only* — `renameBranch: false` keeps the git branch
+	// (name and branch are decoupled; editing the label must not `git branch -m` the user's branch away).
+	// `renameWorkspace` self-emits `workspace.updated` and locks `renamed: true` so the auto-namer leaves it
+	// alone; it throws for an unknown id / non-worktree kind / empty name.
 	"workspace.rename": (params) => {
 		const p = params as { id: string; name: string };
-		return renameWorkspace(p.id, p.name, { lock: true });
+		return renameWorkspace(p.id, p.name, { lock: true, renameBranch: false });
 	},
 	"workspace.diffStats": (params) => workspaceDiffStats((params as { id: string }).id),
 	"workspace.openIn": (params) => {

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -74,7 +74,8 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   where `name === branch`; **re-reads the registry after the awaited fallback fetch** before appending —
   the pre-await snapshot is stale by then, and saving it would clobber a concurrent list's Default-ensure
   (same discipline as `renameWorkspace`'s re-load after its git subprocess)),
-  `renameWorkspace` (**sync**; sets the **display `name`** (sanitized, casing preserved) and derives the
+  `renameWorkspace` (**sync**; sets the **display `name`** (sanitized, casing preserved) and — **only when
+  `opts.renameBranch` (default `true`)** — derives the
   **git branch** from it via `toBranch`, uniqued against refs + worktree dirs, `git branch -m` from the
   project repo — the branch ref moves and the worktree's HEAD follows, but the **worktree dir never moves**
   (pi keys sessions by exact cwd; terminals/tabs are cwd'd there — the stale dir name is the accepted cost);
@@ -90,7 +91,11 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   the auto-rename hook treats it as best-effort. `opts.lock` (default `true`) sets `renamed: true`,
   marking the name deliberate so the auto-namer never touches it again — what a user rename and the
   agentic auto-rename want; the host's **provisional naive rename** passes `lock: false` to rename name +
-  branch while leaving `renamed` unset, so the settled-turn agentic pass still refines it),
+  branch while leaving `renamed` unset, so the settled-turn agentic pass still refines it. `opts.renameBranch`
+  (default `true`) is what the auto-rename passes want — a pristine workspace's branch should track its
+  derived name; the **user-facing `workspace.rename`** passes `renameBranch: false` so editing the display
+  label changes only `name` and **keeps the git branch** (decoupled; a label edit must never `git branch -m`
+  the user's — possibly pushed — branch away, and with no ref moved there is nothing to re-point)),
   `listWorkspaces(projectId, { includeDiffStats? })` (complete authoritative membership/order after Default
   ensure + user-owned folder-truth reconciliation; diff stats default **on** for compatibility, while
   `includeDiffStats: false` skips the per-workspace `git diff --shortstat` fan-out for cold navigation —

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -391,6 +391,25 @@ test("renameWorkspace moves the branch in place: record + git follow, the worktr
 	expect(worktrees()[0]?.branch).toBe("add-login-flow");
 });
 
+test("renameWorkspace with renameBranch:false renames the display name only, keeping the git branch", async () => {
+	const ws = await createWorkspace("p1");
+	const renamed = renameWorkspace(ws.id, "work3", { lock: true, renameBranch: false });
+
+	// Display label changed; the git branch is decoupled and KEPT (no `git branch -m`).
+	expect(renamed.name).toBe("work3");
+	expect(renamed.branch).toBe(ws.branch);
+	expect(renamed.renamed).toBe(true);
+	expect(renamed.worktreePath).toBe(ws.worktreePath);
+	// The worktree stays on its original branch, and that branch still exists in the repo.
+	expect(gitOut(ws.worktreePath, "rev-parse", "--abbrev-ref", "HEAD")).toBe(ws.branch);
+	expect(gitOut(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads")).toContain(
+		ws.branch,
+	);
+	// And the record on disk agrees: name moved, branch kept.
+	expect(worktrees()[0]?.name).toBe("work3");
+	expect(worktrees()[0]?.branch).toBe(ws.branch);
+});
+
 test("renameWorkspace with lock:false renames name + branch but leaves renamed unset (provisional)", async () => {
 	const ws = await createWorkspace("p1");
 	const renamed = renameWorkspace(ws.id, "add login flow", { lock: false });

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -369,9 +369,10 @@ export function refreshUserOwnedWorkspace(workspaceId: string): void {
 export function renameWorkspace(
 	id: string,
 	requestedName: string,
-	opts: { lock?: boolean } = {},
+	opts: { lock?: boolean; renameBranch?: boolean } = {},
 ): Workspace {
 	const lock = opts.lock ?? true;
+	const renameBranch = opts.renameBranch ?? true;
 	const ws = loadWorkspaces().find((w) => w.id === id);
 	if (!ws) throw new Error(`Unknown workspace: ${id}`);
 	const project = getProjects().find((p) => p.id === ws.projectId);
@@ -382,7 +383,8 @@ export function renameWorkspace(
 		throw new Error("An existing worktree cannot be renamed by ThinkRail");
 	const displayName = toDisplayName(requestedName);
 	if (!displayName) throw new Error(`Invalid workspace name: ${requestedName}`);
-	const wanted = toBranch(displayName);
+	// A user rename keeps the existing branch (decoupled from the label); the auto-rename passes derive it.
+	const wanted = renameBranch ? toBranch(displayName) : ws.branch;
 	const branch = wanted === ws.branch ? ws.branch : uniqueBranch(project, wanted);
 	if (branch !== ws.branch) {
 		const moved = git(project.path, ["branch", "-m", ws.branch, branch]);
@@ -392,16 +394,20 @@ export function renameWorkspace(
 	const all = loadWorkspaces();
 	const target = all.find((w) => w.id === id);
 	if (!target) throw new Error(`Unknown workspace: ${id}`);
+	// Re-point siblings only when the branch actually moved — a display-only rename (renameBranch:false)
+	// touches no ref, so there is nothing to re-point.
 	const repointed: Workspace[] = [];
-	for (const w of all) {
-		if (w.projectId !== target.projectId || w.id === target.id) continue;
-		const changed = w.baseBranch === ws.branch || w.diffBase === ws.branch;
-		if (w.baseBranch === ws.branch) w.baseBranch = branch;
-		if (w.diffBase === ws.branch) w.diffBase = branch;
-		if (changed) repointed.push(w);
+	if (branch !== ws.branch) {
+		for (const w of all) {
+			if (w.projectId !== target.projectId || w.id === target.id) continue;
+			const changed = w.baseBranch === ws.branch || w.diffBase === ws.branch;
+			if (w.baseBranch === ws.branch) w.baseBranch = branch;
+			if (w.diffBase === ws.branch) w.diffBase = branch;
+			if (changed) repointed.push(w);
+		}
+		if (target.baseBranch === ws.branch) target.baseBranch = branch;
+		if (target.diffBase === ws.branch) target.diffBase = branch;
 	}
-	if (target.baseBranch === ws.branch) target.baseBranch = branch;
-	if (target.diffBase === ws.branch) target.diffBase = branch;
 	target.name = displayName;
 	target.branch = branch;
 	if (lock) target.renamed = true;


### PR DESCRIPTION
## Summary

Workspace naming is currently unreliable: even when the agent is explicitly asked to rename a
workspace — including when the desired name is provided in the initial task prompt — it often doesn't
update it correctly.

Clear workspace names are important for keeping parallel tasks organized and easy to scan, especially
as the number of workspaces grows. Renaming is also an expected interaction in modern editors, so it
should be simple and dependable.

This PR makes renaming dependable by giving the user a first-class, direct way to rename a workspace —
an **inline rename** in the workspace row — backed by a real server capability, instead of relying on
the agent to name it for you.

## Demo

Inline rename in the workspace row: open the ⋮ menu → **Rename**, edit the name in place (no dialog), then click away to save. The git branch is **kept** and — now differing from the display name — surfaces on the row's second line.

![Inline workspace rename](https://github.com/JetBrains/thinkrail/blob/5bc82ae6d4068245846c0bd33729ffd76e086084/rename-demo.gif?raw=true)

▶️ [Full-resolution MP4](https://github.com/JetBrains/thinkrail/blob/5bc82ae6d4068245846c0bd33729ffd76e086084/rename-demo.mp4?raw=true)

## Changes

**Wire (`packages/contracts`)** — new RPC `workspace.rename` `{ id, name } → Workspace`, added to
`WS_METHODS` + `WsMethodMap`. Echoes the updated `Workspace` and broadcasts `workspace.updated`, the
same convergence contract as `workspace.setDiffBase`.

**Server (`packages/server`)** — a `workspace.rename` handler that reuses the existing
`renameWorkspace()` (no rename logic duplicated). It passes a new option `renameBranch: false`:

- A **user** rename edits the **display name only** and **keeps the git branch**. Display name and
  branch are decoupled (`Workspace.name` is display-only), so editing the label must never
  `git branch -m` the user's — possibly pushed — branch out from under them.
- The existing **auto-rename** passes are unchanged (`renameBranch` defaults to `true`), so a pristine
  workspace's branch still tracks its derived name.
- `renameWorkspace` self-emits `workspace.updated`; the handler adds no extra push. It still throws for
  an unknown id, a `default`/`external` kind, or an empty name.

**Web (`apps/web`)** — a `Rename` action in the workspace row's More menu (worktree-only; hidden for
default/external, which the server refuses). Selecting it edits the name **inline in the row**, not in a
dialog: the label becomes a bare, chrome-less `<input>` in the same slot — same typography token,
color, and row metrics, no border/background/focus-ring/padding. It's seeded with the current name and
selected on entry; blur (click outside) or Enter saves, Escape cancels, and an empty/whitespace or
unchanged value sends nothing. There is no client-side optimism — the row converges on the host's
`workspace.updated` push (`updateWorkspace`), so domain state stays server-owned.

Specs updated alongside the code: `packages/contracts/SPEC.md`, `packages/server/src/workspaces/SPEC.md`,
`apps/web/src/panels/SPEC.md`.

**Out of scope:** the agent's auto-naming heuristics are untouched — this PR adds a reliable *manual*
path rather than changing when/how the agent auto-renames.

## Testing

- `bun run test` (server + contracts + web unit) — **847 pass, 0 fail**, incl. a new
  `renameWorkspace with renameBranch:false renames the display name only, keeping the git branch` case.
- `bun run e2e` (full no-agent suite, 6 shards) — **all shards passed**. New `e2e/workspace-actions.spec.ts`
  cases: inline rename persists via `workspace.rename` **and keeps the branch** (it now surfaces on the
  row's second line); empty value restores the previous name; the Default row hides `Rename`.
- `bun run typecheck` — clean for `@thinkrail/contracts` / `@thinkrail/server` / `@thinkrail/web`.
  (`@thinkrail/website`'s `astro check` requires Node ≥ 22.12 and the local shell has an older Node —
  environmental, and the website is untouched by this PR.)
- `bun run lint` — clean.

