### PR TITLE
Git/GitHub cleanup: naming collision, sync-block hazard, e2e fixture duplication

### DIFF
--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -186,6 +186,9 @@ Windows lane into the real profile (see `module-shared`).
 
 - **Owns:** browser scenarios and fixtures under `e2e/`, their Playwright configuration/runner entrypoints,
   isolation and port-allocation rules, report orchestration, and the public `e2e*` package commands.
+  `e2e/fixtures/git.ts` is the one place specs shell out to `git` (`git`, `gitQuiet`, `gitText`, `gitAs`,
+  `commitFile`); `gitAs`/`commitFile` pin a throwaway e2e identity so a seeded commit's authorship never
+  depends on the developer machine's real git config.
 - **Consumes:** the built web artifact, the host's public boot/wire behavior, sanctioned server test-fixture
   exports, CLI binary, packaged desktop adapter, shared retrying teardown helper, git, Chromium, and
   Playwright.

--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import {
 	chmodSync,
 	copyFileSync,
@@ -25,6 +25,7 @@ import {
 	waitForCentralTarget,
 } from "./fixtures/centralAgent";
 import { hermeticE2ePath, resolveBunExecutable } from "./fixtures/executables";
+import { gitQuiet } from "./fixtures/git";
 import {
 	E2E_CENTRAL_BAD_EXTENSION_SOURCE,
 	E2E_CENTRAL_EXTENSION_SOURCE,
@@ -59,14 +60,12 @@ function seedState(): void {
 	rmSync(HOST_LOG, { force: true });
 	mkdirSync(REPO, { recursive: true });
 	mkdirSync(HOME_DIR, { recursive: true });
-	const git = (...args: string[]) =>
-		execFileSync("git", ["-C", REPO, ...args], { stdio: "ignore" });
-	git("init", "-b", "main");
-	git("config", "user.email", "e2e@thinkrail.test");
-	git("config", "user.name", "ThinkRail E2E");
+	gitQuiet(REPO, "init", "-b", "main");
+	gitQuiet(REPO, "config", "user.email", "e2e@thinkrail.test");
+	gitQuiet(REPO, "config", "user.name", "ThinkRail E2E");
 	writeFileSync(join(REPO, "README.md"), "# restart fixture\n");
-	git("add", "-A");
-	git("commit", "-m", "init");
+	gitQuiet(REPO, "add", "-A");
+	gitQuiet(REPO, "commit", "-m", "init");
 
 	mkdirSync(AGENT_DIR, { recursive: true });
 	const settingsSource = join(E2E_PI_AGENT_DIR, "settings.json");

--- a/e2e/auto-rename.live.spec.ts
+++ b/e2e/auto-rename.live.spec.ts
@@ -1,9 +1,9 @@
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import type { Workspace } from "@thinkrail/contracts";
 import { createWorkspaceViaDialog, openWorkspaceChat } from "./fixtures/app";
+import { gitText } from "./fixtures/git";
 import { E2E_DATA_DIR, E2E_FIXTURE_REPO } from "./fixtures/paths";
 
 function persistedWorkspaces(): Workspace[] {
@@ -58,16 +58,15 @@ test("turn start names the workspace instantly, then the settled turn refines it
 	await expect(name).toHaveText(displayName, { timeout: 20_000 });
 	await expect(branchLine).toHaveText(branch, { timeout: 20_000 });
 
-	const branches = execFileSync(
-		"git",
-		["-C", E2E_FIXTURE_REPO, "for-each-ref", "--format=%(refname:short)", "refs/heads"],
-		{ encoding: "utf8" },
+	const branches = gitText(
+		E2E_FIXTURE_REPO,
+		"for-each-ref",
+		"--format=%(refname:short)",
+		"refs/heads",
 	);
 	expect(branches.split("\n")).not.toContain(initialName);
 	expect(branches.split("\n")).toContain(branch);
-	const worktrees = execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "list"], {
-		encoding: "utf8",
-	});
+	const worktrees = gitText(E2E_FIXTURE_REPO, "worktree", "list");
 	expect(worktrees).toContain(before.worktreePath);
 
 	const second = await createWorkspaceViaDialog(page);

--- a/e2e/changes.spec.ts
+++ b/e2e/changes.spec.ts
@@ -1,8 +1,8 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Locator, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject, worktreeRows } from "./fixtures/app";
+import { gitQuiet } from "./fixtures/git";
 import { E2E_DATA_DIR, E2E_FIXTURE_REPO } from "./fixtures/paths";
 import { largeRepetitiveMarkdownEdited } from "./fixtures/repo";
 
@@ -173,10 +173,6 @@ test("Changes has a List|Tree toggle; Tree groups files into folders with +/- co
 	await expect(page.getByTestId("changes-toggle-tree")).toHaveAttribute("data-active", "true");
 });
 
-function gitIn(cwd: string, ...args: string[]): void {
-	execFileSync("git", ["-C", cwd, ...args], { stdio: "ignore" });
-}
-
 function worktreeDir(): string {
 	return join(E2E_DATA_DIR, "worktrees", "sample-project", "workspace-1");
 }
@@ -184,8 +180,8 @@ function worktreeDir(): string {
 function seedCommitAndDirtyEdit(): string {
 	const worktree = worktreeDir();
 	writeFileSync(join(worktree, "committed.txt"), "committed by e2e\n");
-	gitIn(worktree, "add", "committed.txt");
-	gitIn(
+	gitQuiet(worktree, "add", "committed.txt");
+	gitQuiet(
 		worktree,
 		"-c",
 		"user.email=e2e@thinkrail.test",
@@ -260,8 +256,8 @@ test("Uncommitted scope converges when HEAD moves out-of-band (a commit in a ter
 
 	await new Promise((r) => setTimeout(r, 1500));
 
-	gitIn(worktree, "add", "-A");
-	gitIn(
+	gitQuiet(worktree, "add", "-A");
+	gitQuiet(
 		worktree,
 		"-c",
 		"user.email=e2e@thinkrail.test",
@@ -307,10 +303,10 @@ test("A target that advanced past the fork point adds no phantom changes (merge-
 	seedCommitAndDirtyEdit();
 
 	const upstreamWt = join(E2E_DATA_DIR, "worktrees", "e2e-upstream");
-	gitIn(E2E_FIXTURE_REPO, "worktree", "add", upstreamWt, "-b", "future-main", "main");
+	gitQuiet(E2E_FIXTURE_REPO, "worktree", "add", upstreamWt, "-b", "future-main", "main");
 	writeFileSync(join(upstreamWt, "upstream.txt"), "landed on the base after the fork\n");
-	gitIn(upstreamWt, "add", "upstream.txt");
-	gitIn(
+	gitQuiet(upstreamWt, "add", "upstream.txt");
+	gitQuiet(
 		upstreamWt,
 		"-c",
 		"user.email=e2e@thinkrail.test",
@@ -385,8 +381,8 @@ test("The diff viewer collapses unchanged context and has a per-tab hide-whitesp
 	const worktree = worktreeDir();
 	const lines = Array.from({ length: 120 }, (_, i) => `export const v${i} = ${i};`);
 	writeFileSync(join(worktree, "long.ts"), `${lines.join("\n")}\n`);
-	gitIn(worktree, "add", "long.ts");
-	gitIn(
+	gitQuiet(worktree, "add", "long.ts");
+	gitQuiet(
 		worktree,
 		"-c",
 		"user.email=e2e@thinkrail.test",
@@ -571,8 +567,8 @@ test("Re-pointing the target branch re-reads an open branch-scope diff tab — a
 	await createWorkspaceViaDialog(page);
 	const worktree = seedCommitAndDirtyEdit();
 	writeFileSync(join(worktree, "committed.txt"), "revised by the workspace\n");
-	gitIn(worktree, "add", "committed.txt");
-	gitIn(
+	gitQuiet(worktree, "add", "committed.txt");
+	gitQuiet(
 		worktree,
 		"-c",
 		"user.email=e2e@thinkrail.test",
@@ -582,7 +578,7 @@ test("Re-pointing the target branch re-reads an open branch-scope diff tab — a
 		"-m",
 		"e2e revise commit",
 	);
-	gitIn(worktree, "branch", "e2e-target", "HEAD~1");
+	gitQuiet(worktree, "branch", "e2e-target", "HEAD~1");
 
 	await page.getByTestId("tab-changes").click();
 	const committedRow = page.getByTestId("change-item").filter({ hasText: "committed.txt" });
@@ -618,9 +614,9 @@ test("A commit scope whose commit is rewritten away falls back to All changes wi
 	await page.getByTestId("changes-scope-commit").filter({ hasText: "e2e scope commit" }).click();
 	await expect(page.getByTestId("changes-scope-label")).toHaveText(/^[0-9a-f]{7,}$/);
 
-	gitIn(worktree, "reset", "--hard", "HEAD~1");
-	gitIn(worktree, "reflog", "expire", "--expire=now", "--all");
-	gitIn(worktree, "gc", "--prune=now");
+	gitQuiet(worktree, "reset", "--hard", "HEAD~1");
+	gitQuiet(worktree, "reflog", "expire", "--expire=now", "--all");
+	gitQuiet(worktree, "gc", "--prune=now");
 	writeFileSync(join(worktree, "nudge.txt"), "nudge the watcher\n");
 
 	await expect(page.getByTestId("changes-scope-label")).toHaveText("All changes", {
@@ -638,13 +634,13 @@ test("A failed read says so — it never renders as an empty (clean) change set"
 	await createWorkspaceViaDialog(page);
 	const worktree = worktreeDir();
 	writeFileSync(join(worktree, "README.md"), "# sample-project\n\nedited by e2e\n");
-	gitIn(worktree, "branch", "doomed");
+	gitQuiet(worktree, "branch", "doomed");
 
 	await page.getByTestId("tab-changes").click();
 	await page.getByTestId("changes-target-picker").click();
 	await page.locator('[data-testid="branch-option"][data-branch="doomed"]').click();
 	await expect(page.getByTestId("change-item").filter({ hasText: "README.md" })).toHaveCount(1);
-	gitIn(worktree, "branch", "-D", "doomed");
+	gitQuiet(worktree, "branch", "-D", "doomed");
 
 	await page.getByTestId("changes-scope-trigger").click();
 	await page.getByTestId("changes-scope-uncommitted").click();

--- a/e2e/fixtures/app.ts
+++ b/e2e/fixtures/app.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Locator, Page } from "@playwright/test";
@@ -11,6 +10,7 @@ import {
 	removeCentralModeLocalSeeds,
 	writeE2eAgentSettings,
 } from "./centralAgent";
+import { git, gitQuiet, gitText } from "./git";
 import {
 	E2E_CENTRAL_ARTIFACT,
 	E2E_CENTRAL_LOG,
@@ -65,20 +65,19 @@ function resetState(): void {
 	if (!fixtureRepoHealthy()) seedFixtureRepo();
 
 	try {
-		const head = execFileSync("git", ["-C", E2E_FIXTURE_REPO, "symbolic-ref", "--short", "HEAD"], {
-			encoding: "utf8",
-		}).trim();
+		const head = gitText(E2E_FIXTURE_REPO, "symbolic-ref", "--short", "HEAD").trim();
 		if (head !== "main") {
-			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "checkout", "-f", "main"], { stdio: "ignore" });
+			gitQuiet(E2E_FIXTURE_REPO, "checkout", "-f", "main");
 		}
 	} catch {}
 
-	execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "prune"]);
+	git(E2E_FIXTURE_REPO, "worktree", "prune");
 	for (let sweep = 0; sweep < 2; sweep += 1) {
-		const branches = execFileSync(
-			"git",
-			["-C", E2E_FIXTURE_REPO, "for-each-ref", "--format=%(refname:short)", "refs/heads"],
-			{ encoding: "utf8" },
+		const branches = gitText(
+			E2E_FIXTURE_REPO,
+			"for-each-ref",
+			"--format=%(refname:short)",
+			"refs/heads",
 		)
 			.split("\n")
 			.map((b) => b.trim())
@@ -86,7 +85,7 @@ function resetState(): void {
 		if (branches.length === 0) break;
 		for (const branch of branches) {
 			try {
-				execFileSync("git", ["-C", E2E_FIXTURE_REPO, "branch", "-D", branch], { stdio: "ignore" });
+				gitQuiet(E2E_FIXTURE_REPO, "branch", "-D", branch);
 			} catch {}
 		}
 	}

--- a/e2e/fixtures/git.ts
+++ b/e2e/fixtures/git.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Runs git in `cwd`; on failure, the thrown error carries git's captured stderr. */
+export function git(cwd: string, ...args: string[]): void {
+	execFileSync("git", ["-C", cwd, ...args]);
+}
+
+/** Runs git in `cwd`, discarding its output entirely — for calls a caller expects may fail. */
+export function gitQuiet(cwd: string, ...args: string[]): void {
+	execFileSync("git", ["-C", cwd, ...args], { stdio: "ignore" });
+}
+
+/** Runs git in `cwd`, returning its raw utf8 stdout. */
+export function gitText(cwd: string, ...args: string[]): string {
+	return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+}
+
+/** Runs git in `cwd` under a throwaway e2e identity, returning trimmed utf8 stdout. */
+export function gitAs(cwd: string, ...args: string[]): string {
+	return execFileSync(
+		"git",
+		["-C", cwd, "-c", "user.email=e2e@thinkrail.test", "-c", "user.name=e2e", ...args],
+		{ encoding: "utf8" },
+	).trim();
+}
+
+/** One real commit in the worktree (the shape artifacts.ts leaves), returning its sha. */
+export function commitFile(
+	worktree: string,
+	path: string,
+	content: string,
+	subject: string,
+): string {
+	writeFileSync(join(worktree, path), content);
+	gitAs(worktree, "add", "--", path);
+	gitAs(worktree, "commit", "--no-verify", "-m", subject);
+	return gitAs(worktree, "rev-parse", "HEAD");
+}

--- a/e2e/fixtures/git.ts
+++ b/e2e/fixtures/git.ts
@@ -2,22 +2,18 @@ import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-/** Runs git in `cwd`; on failure, the thrown error carries git's captured stderr. */
 export function git(cwd: string, ...args: string[]): void {
 	execFileSync("git", ["-C", cwd, ...args]);
 }
 
-/** Runs git in `cwd`, discarding its output entirely — for calls a caller expects may fail. */
 export function gitQuiet(cwd: string, ...args: string[]): void {
 	execFileSync("git", ["-C", cwd, ...args], { stdio: "ignore" });
 }
 
-/** Runs git in `cwd`, returning its raw utf8 stdout. */
 export function gitText(cwd: string, ...args: string[]): string {
 	return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
 }
 
-/** Runs git in `cwd` under a throwaway e2e identity, returning trimmed utf8 stdout. */
 export function gitAs(cwd: string, ...args: string[]): string {
 	return execFileSync(
 		"git",
@@ -26,7 +22,6 @@ export function gitAs(cwd: string, ...args: string[]): string {
 	).trim();
 }
 
-/** One real commit in the worktree (the shape artifacts.ts leaves), returning its sha. */
 export function commitFile(
 	worktree: string,
 	path: string,

--- a/e2e/fixtures/repo.ts
+++ b/e2e/fixtures/repo.ts
@@ -1,11 +1,11 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { gitQuiet } from "./git";
 import { E2E_FIXTURE_REPO } from "./paths";
 
 export function fixtureRepoHealthy(): boolean {
 	try {
-		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "rev-parse", "--git-dir"], { stdio: "ignore" });
+		gitQuiet(E2E_FIXTURE_REPO, "rev-parse", "--git-dir");
 		return true;
 	} catch {
 		return false;
@@ -14,8 +14,7 @@ export function fixtureRepoHealthy(): boolean {
 
 export function seedFixtureRepo(): void {
 	mkdirSync(E2E_FIXTURE_REPO, { recursive: true });
-	const git = (...args: string[]) =>
-		execFileSync("git", ["-C", E2E_FIXTURE_REPO, ...args], { stdio: "ignore" });
+	const git = (...args: string[]) => gitQuiet(E2E_FIXTURE_REPO, ...args);
 	git("init", "-b", "main");
 	git("config", "user.email", "e2e@thinkrail.test");
 	git("config", "user.name", "ThinkRail E2E");

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -1,8 +1,8 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { openAppFresh, openFixtureProject, worktreeRows } from "./fixtures/app";
+import { git } from "./fixtures/git";
 import { E2E_DATA_DIR, E2E_FIXTURE_REPO, E2E_PICK_DIR_POINTER } from "./fixtures/paths";
 
 test("the dialog lists local branches (no stray origin) and creates a worktree", async ({
@@ -177,7 +177,6 @@ test("Enter in the prompt creates; Shift+Enter inserts a newline", async ({ page
 test("a base whose fetch fails reports git's error, not a request timeout", async ({ page }) => {
 	const remote = join(E2E_DATA_DIR, "dangling-head-remote.git");
 	const repo = join(E2E_DATA_DIR, "dangling-head-fixture");
-	const git = (cwd: string, ...args: string[]) => execFileSync("git", ["-C", cwd, ...args]);
 	for (const path of [remote, repo]) rmSync(path, { recursive: true, force: true });
 	mkdirSync(remote, { recursive: true });
 	git(remote, "init", "--bare", "-b", "main");

--- a/e2e/plan-open-pr.spec.ts
+++ b/e2e/plan-open-pr.spec.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,6 +7,7 @@ import {
 	enterDefaultWorkspace,
 	openFixtureProject,
 } from "./fixtures/app";
+import { gitAs } from "./fixtures/git";
 
 // The plan page's finish line, no agent and no GitHub: Open PR in the header opens the compose
 // dialog (pr.preview prefills title + body) and submitting runs the deterministic host-side
@@ -18,14 +18,6 @@ import {
 // success), and pressing again re-pushes new commits to the SAME branch (the anti-Codex
 // invariant). gh never runs here (non-GitHub remote + the THINKRAIL_GH_OFFLINE seam); the
 // created/updated/compare arms are pinned by unit tests (packages/server/src/pr/pr.test.ts).
-
-function gitIn(cwd: string, ...args: string[]): string {
-	return execFileSync(
-		"git",
-		["-C", cwd, "-c", "user.email=e2e@thinkrail.test", "-c", "user.name=e2e", ...args],
-		{ encoding: "utf8" },
-	).trim();
-}
 
 test("Open PR: no origin errors, with origin pushes, re-press follows the same branch", async ({
 	page,
@@ -53,31 +45,31 @@ test("Open PR: no origin errors, with origin pushes, re-press follows the same b
 	await expect(compose).not.toBeVisible();
 
 	const bare = mkdtempSync(join(tmpdir(), "thinkrail-pr-origin-"));
-	gitIn(bare, "init", "--bare");
-	gitIn(workspace.worktreePath, "remote", "add", "origin", bare);
+	gitAs(bare, "init", "--bare");
+	gitAs(workspace.worktreePath, "remote", "add", "origin", bare);
 	writeFileSync(join(workspace.worktreePath, "flood.ts"), "export const wait = 1;\n");
-	gitIn(workspace.worktreePath, "add", "--", "flood.ts");
-	gitIn(workspace.worktreePath, "commit", "--no-verify", "-m", "todo: implement FloodWait");
-	const firstSha = gitIn(workspace.worktreePath, "rev-parse", "HEAD");
-	const branch = gitIn(workspace.worktreePath, "rev-parse", "--abbrev-ref", "HEAD");
+	gitAs(workspace.worktreePath, "add", "--", "flood.ts");
+	gitAs(workspace.worktreePath, "commit", "--no-verify", "-m", "todo: implement FloodWait");
+	const firstSha = gitAs(workspace.worktreePath, "rev-parse", "HEAD");
+	const branch = gitAs(workspace.worktreePath, "rev-parse", "--abbrev-ref", "HEAD");
 
 	await openPr.click();
 	await expect(compose).toBeVisible();
 	await submit.click();
 	await expect(page.getByText("Branch pushed").first()).toBeVisible();
 	await expect(compose).not.toBeVisible();
-	expect(gitIn(bare, "rev-parse", `refs/heads/${branch}`)).toBe(firstSha);
+	expect(gitAs(bare, "rev-parse", `refs/heads/${branch}`)).toBe(firstSha);
 
 	writeFileSync(join(workspace.worktreePath, "flood.ts"), "export const wait = 2;\n");
-	gitIn(workspace.worktreePath, "add", "--", "flood.ts");
-	gitIn(workspace.worktreePath, "commit", "--no-verify", "-m", "todo: tune FloodWait");
-	const secondSha = gitIn(workspace.worktreePath, "rev-parse", "HEAD");
+	gitAs(workspace.worktreePath, "add", "--", "flood.ts");
+	gitAs(workspace.worktreePath, "commit", "--no-verify", "-m", "todo: tune FloodWait");
+	const secondSha = gitAs(workspace.worktreePath, "rev-parse", "HEAD");
 
 	await openPr.click();
 	await expect(compose).toBeVisible();
 	await submit.click();
 	await expect
-		.poll(() => gitIn(bare, "rev-parse", `refs/heads/${branch}`), { timeout: 10_000 })
+		.poll(() => gitAs(bare, "rev-parse", `refs/heads/${branch}`), { timeout: 10_000 })
 		.toBe(secondSha);
 });
 

--- a/e2e/plan-review.spec.ts
+++ b/e2e/plan-review.spec.ts
@@ -1,8 +1,8 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { commitFile } from "./fixtures/git";
 
 // The TODO → review workflow's user-visible half, no agent: a seeded plan whose done steps carry
 // completion summaries + real commit artifacts (the host's change-set shape) renders on the plan page
@@ -13,20 +13,6 @@ import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 // mode" page (task-plan-review-kebab): findings live in the right-panel Review tab, header actions are
 // a kebab menu. Actually settling a review (the reviewer chat, verdicts, ask-to-fix's fix cycle,
 // Review All's queue) is @agent territory; the seeded JSON here is exactly the shape those leave behind.
-
-/** One real commit in the worktree (the shape artifacts.ts leaves), returning its sha. */
-function commitFile(worktree: string, path: string, content: string, subject: string): string {
-	writeFileSync(join(worktree, path), content);
-	const git = (...args: string[]) =>
-		execFileSync(
-			"git",
-			["-C", worktree, "-c", "user.email=e2e@thinkrail.test", "-c", "user.name=e2e", ...args],
-			{ encoding: "utf8" },
-		);
-	git("add", "--", path);
-	git("commit", "--no-verify", "-m", subject);
-	return git("rev-parse", "HEAD").trim();
-}
 
 test("reviewable steps show the reviewed counter, Start review, and the settled Verified state", async ({
 	page,

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { expect, type Locator, type Page, test } from "@playwright/test";
@@ -10,6 +9,7 @@ import {
 	stagePlainFolder,
 	worktreeRows,
 } from "./fixtures/app";
+import { git } from "./fixtures/git";
 import {
 	E2E_DATA_DIR,
 	E2E_FIXTURE_REPO,
@@ -28,12 +28,12 @@ function seedSecondRepo(): string {
 	const repo = join(E2E_DATA_DIR, "second-project");
 	rmSync(repo, { recursive: true, force: true });
 	mkdirSync(repo, { recursive: true });
-	execFileSync("git", ["-C", repo, "init", "-b", "main"]);
-	execFileSync("git", ["-C", repo, "config", "user.email", "e2e@thinkrail.test"]);
-	execFileSync("git", ["-C", repo, "config", "user.name", "ThinkRail E2E"]);
+	git(repo, "init", "-b", "main");
+	git(repo, "config", "user.email", "e2e@thinkrail.test");
+	git(repo, "config", "user.name", "ThinkRail E2E");
 	writeFileSync(join(repo, "README.md"), "# second project\n");
-	execFileSync("git", ["-C", repo, "add", "-A"]);
-	execFileSync("git", ["-C", repo, "commit", "-m", "seed"]);
+	git(repo, "add", "-A");
+	git(repo, "commit", "-m", "seed");
 	writeFileSync(E2E_PICK_DIR_POINTER, repo);
 	return repo;
 }

--- a/e2e/reflection.live.spec.ts
+++ b/e2e/reflection.live.spec.ts
@@ -1,8 +1,8 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { commitFile } from "./fixtures/git";
 
 // The agent-reviewer's reflection pass, end to end (@agent, real provider): Start review on a step whose
 // committed change carries a blatant problem (a hallucinated import + inverted logic under a "tests pass"
@@ -11,19 +11,6 @@ import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 // that reflection RAN (a comment carries a `reflection` verdict) — never a specific kept/refuted outcome,
 // which a live model decides. Inherently slower + less deterministic than the no-agent badge test in
 // review.spec.ts; on-demand only (real tokens), never a commit/CI gate.
-
-function commitFile(worktree: string, path: string, content: string, subject: string): string {
-	writeFileSync(join(worktree, path), content);
-	const git = (...args: string[]) =>
-		execFileSync(
-			"git",
-			["-C", worktree, "-c", "user.email=e2e@thinkrail.test", "-c", "user.name=e2e", ...args],
-			{ encoding: "utf8" },
-		);
-	git("add", "--", path);
-	git("commit", "--no-verify", "-m", subject);
-	return git("rev-parse", "HEAD").trim();
-}
 
 /** Poll review.get over a throwaway socket until at least one comment carries a reflection verdict. */
 async function reflectionLanded(page: Page): Promise<boolean> {

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import { expect, test } from "@playwright/test";
@@ -9,6 +8,7 @@ import {
 	stagePlainFolder,
 	worktreeRows,
 } from "./fixtures/app";
+import { git } from "./fixtures/git";
 import { E2E_FIXTURE_REPO, E2E_PLAIN_DIR } from "./fixtures/paths";
 
 const FIXTURE_SPECS = ["SPEC.md", join("module-a", "SPEC.md")];
@@ -197,7 +197,7 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 		).toHaveAttribute("data-active", "true");
 		await expect(worktreeRows(page)).toHaveCount(0);
 	} finally {
-		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "checkout", "--", ...FIXTURE_SPECS]);
+		git(E2E_FIXTURE_REPO, "checkout", "--", ...FIXTURE_SPECS);
 	}
 });
 

--- a/e2e/workflows/harness/workspace.ts
+++ b/e2e/workflows/harness/workspace.ts
@@ -1,6 +1,6 @@
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { gitQuiet } from "../../fixtures/git";
 import { E2E_DATA_DIR } from "../../fixtures/paths";
 
 export type WorkspaceKind = "empty" | "code-only" | "specced";
@@ -11,14 +11,13 @@ let counter = 0;
 export function seedWorkspace(seed: WorkspaceSeed): string {
 	const cwd = join(E2E_DATA_DIR, `workflow-ws-${process.pid}-${++counter}`);
 	mkdirSync(cwd, { recursive: true });
-	const git = (...args: string[]) => execFileSync("git", ["-C", cwd, ...args], { stdio: "ignore" });
-	git("init", "-b", "main");
-	git("config", "user.email", "workflow-tests@thinkrail.test");
-	git("config", "user.name", "ThinkRail Workflow Tests");
+	gitQuiet(cwd, "init", "-b", "main");
+	gitQuiet(cwd, "config", "user.email", "workflow-tests@thinkrail.test");
+	gitQuiet(cwd, "config", "user.name", "ThinkRail Workflow Tests");
 	if (typeof seed === "function") seed(cwd);
 	else seedKind(cwd, seed);
-	git("add", "-A");
-	git("commit", "-m", "seed", "--allow-empty");
+	gitQuiet(cwd, "add", "-A");
+	gitQuiet(cwd, "commit", "-m", "seed", "--allow-empty");
 	return cwd;
 }
 

--- a/e2e/workspaces.spec.ts
+++ b/e2e/workspaces.spec.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
@@ -9,6 +8,7 @@ import {
 	openWorkspaceMenu,
 	worktreeRows,
 } from "./fixtures/app";
+import { git, gitText } from "./fixtures/git";
 import { E2E_DATA_DIR, E2E_FIXTURE_REPO, E2E_PICK_DIR_POINTER } from "./fixtures/paths";
 
 test("opens and safely forgets an existing user-owned worktree", async ({ page }) => {
@@ -17,27 +17,16 @@ test("opens and safely forgets an existing user-owned worktree", async ({ page }
 	const detached = join(E2E_DATA_DIR, "detached-worktree-fixture");
 	rmSync(external, { recursive: true, force: true });
 	rmSync(detached, { recursive: true, force: true });
-	execFileSync("git", [
-		"-C",
-		E2E_FIXTURE_REPO,
-		"worktree",
-		"add",
-		external,
-		"-b",
-		"feature/existing",
-		"main",
-	]);
-	execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "add", "--detach", detached, "main"]);
+	git(E2E_FIXTURE_REPO, "worktree", "add", external, "-b", "feature/existing", "main");
+	git(E2E_FIXTURE_REPO, "worktree", "add", "--detach", detached, "main");
 	writeFileSync(join(external, "staged.txt"), "preserve this staged addition\n");
-	execFileSync("git", ["-C", external, "add", "staged.txt"]);
+	git(external, "add", "staged.txt");
 	writeFileSync(
 		join(external, "README.md"),
 		`${readFileSync(join(external, "README.md"), "utf8")}preserve this unstaged edit\n`,
 	);
 	writeFileSync(join(external, "uncommitted.txt"), "preserve this untracked file\n");
 
-	const gitText = (cwd: string, ...args: string[]) =>
-		execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
 	const before = {
 		status: gitText(external, "status", "--porcelain=v1", "-z"),
 		branch: gitText(external, "symbolic-ref", "--short", "HEAD"),
@@ -120,15 +109,15 @@ test("opens and safely forgets an existing user-owned worktree", async ({ page }
 	} finally {
 		for (const path of [external, detached]) {
 			try {
-				execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "remove", "--force", path]);
+				git(E2E_FIXTURE_REPO, "worktree", "remove", "--force", path);
 			} catch {
 				rmSync(path, { recursive: true, force: true });
 			}
 		}
 		try {
-			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "branch", "-D", "feature/existing"]);
+			git(E2E_FIXTURE_REPO, "branch", "-D", "feature/existing");
 		} catch {}
-		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "prune"]);
+		git(E2E_FIXTURE_REPO, "worktree", "prune");
 	}
 });
 
@@ -136,16 +125,7 @@ test("an attached worktree cannot also be opened as a project", async ({ page })
 	await openFixtureProject(page);
 	const external = join(E2E_DATA_DIR, "claimed-worktree-fixture");
 	rmSync(external, { recursive: true, force: true });
-	execFileSync("git", [
-		"-C",
-		E2E_FIXTURE_REPO,
-		"worktree",
-		"add",
-		external,
-		"-b",
-		"feature/claimed",
-		"main",
-	]);
+	git(E2E_FIXTURE_REPO, "worktree", "add", external, "-b", "feature/claimed", "main");
 
 	try {
 		const projectRow = page.getByTestId("project-item").filter({ hasText: "sample-project" });
@@ -172,14 +152,14 @@ test("an attached worktree cannot also be opened as a project", async ({ page })
 	} finally {
 		writeFileSync(E2E_PICK_DIR_POINTER, E2E_FIXTURE_REPO);
 		try {
-			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "remove", "--force", external]);
+			git(E2E_FIXTURE_REPO, "worktree", "remove", "--force", external);
 		} catch {
 			rmSync(external, { recursive: true, force: true });
 		}
 		try {
-			execFileSync("git", ["-C", E2E_FIXTURE_REPO, "branch", "-D", "feature/claimed"]);
+			git(E2E_FIXTURE_REPO, "branch", "-D", "feature/claimed");
 		} catch {}
-		execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "prune"]);
+		git(E2E_FIXTURE_REPO, "worktree", "prune");
 	}
 });
 
@@ -191,9 +171,7 @@ test("creates, removes, and re-creates worktree workspaces (no branch collision)
 
 	await createWorkspaceViaDialog(page);
 	await expect(items).toHaveCount(1);
-	const worktrees = execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "list"], {
-		encoding: "utf8",
-	});
+	const worktrees = gitText(E2E_FIXTURE_REPO, "worktree", "list");
 	expect(worktrees.trim().split("\n").length).toBeGreaterThanOrEqual(2);
 	expect(worktrees).toContain("/worktrees/sample-project/");
 
@@ -206,12 +184,7 @@ test("creates, removes, and re-creates worktree workspaces (no branch collision)
 	await expect(page.getByTestId("welcome")).toBeVisible();
 	await expect(page.getByTestId("center-tabs")).toHaveCount(0);
 	await expect
-		.poll(
-			() =>
-				execFileSync("git", ["-C", E2E_FIXTURE_REPO, "worktree", "list"], { encoding: "utf8" })
-					.trim()
-					.split("\n").length,
-		)
+		.poll(() => gitText(E2E_FIXTURE_REPO, "worktree", "list").trim().split("\n").length)
 		.toBe(1);
 
 	await createWorkspaceViaDialog(page);

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -105,6 +105,7 @@ the host from env via `bootHost` for dev/e2e.
 - `pr` → `workspaces`, `git`, `todos`, `branch-review` (provider detection + gh-output parsing + the shared CLI runner), `github` (`ghSetupProblem` — the named compare-fallback reason)
 - `projects` → `git` (shared runner), `persistence`
 - `git` → `subprocess` (every child that talks to a network or another CLI)
+- `github` → `subprocess` (both `gh auth status` probes run under the same bounded runner as `git`/`branch-review`)
 - `git`, `fs`, `spec`, `watch`, `terminal`, `settings`, `analytics` → `persistence` (`spec` also → `pi-spec-graph/core`, external; `analytics` also → the pi-ai built-in provider/model catalog + `posthog-node`, external—the identity-bucketing vocabulary and delivery SDK)
 - `log` → `persistence` (`dataDir`) — and **any feature module (+ `host`) may → `log`**: it is the one
   cross-cutting edge, like `persistence`, exempt from the never-each-other rule (today: `host`,
@@ -123,7 +124,7 @@ the host from env via `bootHost` for dev/e2e.
 - `agent` → `log`, `persistence` (`dataDir` — the static state-root resolver; the delegation store lives at
   `<dataDir>/delegation`, bound in the agent's delegation embedding) — otherwise the pi runtime alone; auth
   passes desired opaque Central paths through its public generation seam
-- `persistence`, `dialog`, `github`, `history`, `templates`, `subprocess` → (leaves)
+- `persistence`, `dialog`, `history`, `templates`, `subprocess` → (leaves)
 
 Rules: features never import `host`, and never each other except the edges above. The graph is acyclic.
 `agent`'s WS surface (`session.*` + `pi.event` forwarding) attaches to `host`. Features that push on their

--- a/packages/server/src/github/SPEC.md
+++ b/packages/server/src/github/SPEC.md
@@ -15,19 +15,21 @@ Read-only local GitHub CLI (`gh`) auth status for the New-Workspace dialog's "Co
 
 ## Boundary
 
-- **Owns:** `githubAuthStatus()` → `{ connected, login?, scopes? }` by shelling `gh auth status` (parsing
-  its report for the account + token scopes); `githubRefresh()` (re-shells the same check). Degrades
-  gracefully — a missing / un-authed `gh` returns `{ connected: false }` so the dialog works fully offline.
-  `THINKRAIL_GH_OFFLINE=1` forces the disconnected result without shelling (e2e drives the offline path).
-  Also `ghSetupProblem()` → `Promise<GhSetupProblem | null>` — the *named* reason the direct gh path is
-  unavailable (`missing` when `Bun.which("gh")` finds no binary, `unauthenticated` when a **non-blocking**
-  `gh auth status` probe exits non-zero, `null` when gh is usable or the offline seam is on). The probe is
-  async with an 8s TERM + 2s KILL escalation: `gh auth status` does a network round-trip, and the host is
-  one event loop — a spawnSync here would freeze every session for the probe's duration. A probe that
-  TIMED OUT reports `null` (a transient network stall is not "signed out" — the silent compare fallback,
-  never the sign-in dialog). `pr` consumes it (after a failed gh
-  flow only) so the client can show setup guidance instead of silently degrading to the compare page.
+- **Owns:** `githubAuthStatus()` → `Promise<{ connected, login?, scopes? }>` by shelling `gh auth status`
+  (parsing its report for the account + token scopes); `githubRefresh()` (re-shells the same check).
+  Degrades gracefully — a missing / un-authed / non-responding `gh` all resolve to `{ connected: false }`
+  so the dialog works fully offline. `THINKRAIL_GH_OFFLINE=1` forces the disconnected result without
+  shelling (e2e drives the offline path). Also `ghSetupProblem()` → `Promise<GhSetupProblem | null>` — the
+  *named* reason the direct gh path is unavailable (`missing` when `Bun.which("gh")` finds no binary or the
+  probe never launched, `unauthenticated` when the probe exits non-zero, `null` when gh is usable or the
+  offline seam is on). Both probes run the same `gh auth status` under `subprocess`' `runBounded` at an 8s
+  budget (`GH_PROBE_TIMEOUT_MS`): `gh auth status` does a network round-trip, and the host is one event
+  loop — a `spawnSync` here would freeze every session for the probe's duration, which is exactly the
+  failure `runBounded` exists to rule out (see `subprocess/SPEC.md`). A probe that TIMED OUT reports `null`/
+  `{ connected: false }` (a transient network stall is not "signed out" — the silent compare fallback,
+  never the sign-in dialog). `pr` consumes `ghSetupProblem` (after a failed gh flow only) so the client can
+  show setup guidance instead of silently degrading to the compare page.
 - **Public surface (barrel):** `githubAuthStatus`, `githubRefresh`, `ghSetupProblem`.
-- **Allowed deps:** `contracts` (`GithubAuthStatus`); Bun (spawn). No `git`/`projects` reach — it's a pure
-  `gh` probe.
+- **Allowed deps:** `contracts` (`GithubAuthStatus`); `subprocess` (`runBounded`, the bounded child both
+  probes spawn under); Bun (`which`). No `git`/`projects` reach — it's a pure `gh` probe.
 - **Forbidden:** `host`; sibling features; being bundled into the browser (`gh` is shelled, never bundled).

--- a/packages/server/src/github/github.test.ts
+++ b/packages/server/src/github/github.test.ts
@@ -7,9 +7,9 @@ afterEach(() => {
 	else process.env.THINKRAIL_GH_OFFLINE = saved;
 });
 
-test("THINKRAIL_GH_OFFLINE forces a disconnected status without shelling out", () => {
+test("THINKRAIL_GH_OFFLINE forces a disconnected status without shelling out", async () => {
 	process.env.THINKRAIL_GH_OFFLINE = "1";
-	expect(githubAuthStatus()).toEqual({ connected: false });
+	expect(await githubAuthStatus()).toEqual({ connected: false });
 });
 
 test("ghSetupProblemFrom names the missing piece: no binary, then a failed auth probe, then nothing", () => {

--- a/packages/server/src/github/github.ts
+++ b/packages/server/src/github/github.ts
@@ -1,19 +1,15 @@
 import type { GhSetupProblem, GithubAuthStatus } from "@thinkrail/contracts";
+import { runBounded } from "../subprocess";
 
-export function githubAuthStatus(): GithubAuthStatus {
+const GH_PROBE_TIMEOUT_MS = 8_000;
+
+export async function githubAuthStatus(): Promise<GithubAuthStatus> {
 	if (process.env.THINKRAIL_GH_OFFLINE === "1") return { connected: false };
 
-	let result: { success: boolean; stdout: Uint8Array; stderr: Uint8Array };
-	try {
-		result = Bun.spawnSync(["gh", "auth", "status"], { stdout: "pipe", stderr: "pipe" });
-	} catch {
-		return { connected: false };
-	}
-	if (!result.success) return { connected: false };
+	const result = await runBounded(["gh", "auth", "status"], { timeoutMs: GH_PROBE_TIMEOUT_MS });
+	if (!result.ok) return { connected: false };
 
-	return parseGhAuthStatus(
-		`${new TextDecoder().decode(result.stdout)}\n${new TextDecoder().decode(result.stderr)}`,
-	);
+	return parseGhAuthStatus(`${result.out}\n${result.err}`);
 }
 
 export function parseGhAuthStatus(text: string): GithubAuthStatus {
@@ -31,7 +27,7 @@ export function parseGhAuthStatus(text: string): GithubAuthStatus {
 	return status;
 }
 
-export function githubRefresh(): GithubAuthStatus {
+export function githubRefresh(): Promise<GithubAuthStatus> {
 	return githubAuthStatus();
 }
 
@@ -40,29 +36,12 @@ export function ghSetupProblemFrom(ghPath: string | null, authOk: boolean): GhSe
 	return authOk ? null : "unauthenticated";
 }
 
-const GH_PROBE_TIMEOUT_MS = 8_000;
-
 export async function ghSetupProblem(): Promise<GhSetupProblem | null> {
 	if (process.env.THINKRAIL_GH_OFFLINE === "1") return null;
 	const ghPath = Bun.which("gh");
 	if (ghPath === null) return "missing";
-	try {
-		const proc = Bun.spawn(["gh", "auth", "status"], { stdout: "ignore", stderr: "ignore" });
-		let timedOut = false;
-		const term = setTimeout(() => {
-			timedOut = true;
-			proc.kill();
-		}, GH_PROBE_TIMEOUT_MS);
-		const kill = setTimeout(() => proc.kill(9), GH_PROBE_TIMEOUT_MS + 2_000);
-		try {
-			const exitCode = await proc.exited;
-			if (timedOut) return null;
-			return ghSetupProblemFrom(ghPath, exitCode === 0);
-		} finally {
-			clearTimeout(term);
-			clearTimeout(kill);
-		}
-	} catch {
-		return "missing";
-	}
+	const result = await runBounded(["gh", "auth", "status"], { timeoutMs: GH_PROBE_TIMEOUT_MS });
+	if (result.timedOut) return null;
+	if (result.launchFailed) return "missing";
+	return ghSetupProblemFrom(ghPath, result.ok);
 }

--- a/packages/server/src/pr/SPEC.md
+++ b/packages/server/src/pr/SPEC.md
@@ -54,7 +54,7 @@ value. Then:
    the client answers with setup guidance rather than a raw-stderr toast.
 2. Always pushes `--set-upstream origin <branch>` first — the branch is workspace-owned, so a plain
    push is correct; re-invocations push follow-up commits to the SAME branch (never a second PR).
-   The push runs with a **non-interactive env** (`nonInteractiveGitEnv`): `GIT_TERMINAL_PROMPT=0`;
+   The push runs with a **non-interactive env** (`pushGitEnv`): `GIT_TERMINAL_PROMPT=0`;
    **`LC_MESSAGES=C` with `LC_ALL` demoted to `LC_CTYPE`** (dropped, its value preserved as
    `LC_CTYPE` when none was set) so git's stderr stays English for the PUSH_AUTH_FAILED patterns on
    any host locale — while hooks and helpers spawned by the push keep their character encoding

--- a/packages/server/src/pr/pr.test.ts
+++ b/packages/server/src/pr/pr.test.ts
@@ -8,9 +8,9 @@ import {
 	ghPrFlow,
 	githubSlug,
 	isPushAuthFailure,
-	nonInteractiveGitEnv,
 	openPr,
 	type PrCommandRunner,
+	pushGitEnv,
 } from "./pr";
 import { renderPrBody } from "./prBody";
 
@@ -94,27 +94,25 @@ describe("isPushAuthFailure", () => {
 	});
 });
 
-describe("nonInteractiveGitEnv", () => {
+describe("pushGitEnv", () => {
 	test("forces prompt-free git, English git messages without touching hook encoding, batch-mode ssh", () => {
-		const env = nonInteractiveGitEnv({ PATH: "/bin", LC_ALL: "ru_RU.UTF-8" }, false);
+		const env = pushGitEnv({ PATH: "/bin", LC_ALL: "ru_RU.UTF-8" }, false);
 		expect(env.GIT_TERMINAL_PROMPT).toBe("0");
 		expect(env.LC_MESSAGES).toBe("C");
 		expect("LC_ALL" in env).toBe(false);
 		expect(env.LC_CTYPE).toBe("ru_RU.UTF-8");
-		expect(nonInteractiveGitEnv({ LC_ALL: "C", LC_CTYPE: "en_US.UTF-8" }, false).LC_CTYPE).toBe(
+		expect(pushGitEnv({ LC_ALL: "C", LC_CTYPE: "en_US.UTF-8" }, false).LC_CTYPE).toBe(
 			"en_US.UTF-8",
 		);
 		expect(env.GIT_SSH_COMMAND).toBe("ssh -oBatchMode=yes");
 	});
 
 	test("never overrides the user's own ssh command — env vars or core.sshCommand config", () => {
-		expect(nonInteractiveGitEnv({ GIT_SSH_COMMAND: "ssh -i /key" }, false).GIT_SSH_COMMAND).toBe(
+		expect(pushGitEnv({ GIT_SSH_COMMAND: "ssh -i /key" }, false).GIT_SSH_COMMAND).toBe(
 			"ssh -i /key",
 		);
-		expect(
-			nonInteractiveGitEnv({ GIT_SSH: "/usr/bin/myssh" }, false).GIT_SSH_COMMAND,
-		).toBeUndefined();
-		expect(nonInteractiveGitEnv({}, true).GIT_SSH_COMMAND).toBeUndefined();
+		expect(pushGitEnv({ GIT_SSH: "/usr/bin/myssh" }, false).GIT_SSH_COMMAND).toBeUndefined();
+		expect(pushGitEnv({}, true).GIT_SSH_COMMAND).toBeUndefined();
 	});
 });
 

--- a/packages/server/src/pr/pr.ts
+++ b/packages/server/src/pr/pr.ts
@@ -50,7 +50,7 @@ export function isPushAuthFailure(stderr: string): boolean {
 	return PUSH_AUTH_PATTERNS.some((p) => p.test(stderr));
 }
 
-export function nonInteractiveGitEnv(
+export function pushGitEnv(
 	base: Record<string, string | undefined>,
 	hasSshCommandConfig: boolean,
 ): Record<string, string | undefined> {
@@ -212,7 +212,7 @@ export async function openPr(
 	if (!origin.ok) throw new Error("This workspace's repository has no 'origin' remote to push to.");
 	const hasSshCommandConfig = git(cwd, ["config", "core.sshCommand"]).ok;
 	const pushed = await gitAsync(cwd, ["push", "--set-upstream", "origin", ws.branch], {
-		env: nonInteractiveGitEnv(process.env, hasSshCommandConfig),
+		env: pushGitEnv(process.env, hasSshCommandConfig),
 		network: true,
 	});
 	if (!pushed.ok) {

--- a/packages/server/src/subprocess/SPEC.md
+++ b/packages/server/src/subprocess/SPEC.md
@@ -26,7 +26,7 @@ never what a particular child's output means.
   persistence.
 - **Forbidden:** message wording, retry, truncation, or any policy about a specific program. `git`'s
   stalled/stderr text and `branch-review`'s degrade-to-`null` are the callers' business.
-- **Known non-consumers.** Three callers spawn something that can outlast a human's patience and still do
+- **Known non-consumers.** Two callers spawn something that can outlast a human's patience and still do
   it themselves, each deliberately and each a standing debt rather than a settled design:
   - `@thinkrail/shared/jbcentral` — already deadline-first, and a different contract (bounded-byte reads, a
     closed outcome vocabulary, an injectable `run` seam, Central's confidentiality rules). Folding it in
@@ -34,9 +34,11 @@ never what a particular child's output means.
   - `dialog`'s `selectDirectory` (`dialog.ts`) — still the EOF-gated shape this module replaces, around
     `zenity`/`kdialog`/`osascript`, whose forked helpers inherit stdio. Unmigrated because a picker's real
     budget is a human at a dialog: it needs a cancellation seam, which `runBounded` does not offer.
-  - `github`'s `githubAuthStatus` (`github.ts`) — a `spawnSync` HTTPS call on the single event loop, so it
-    also caps this module's guarantee: while it blocks, no `runBounded` deadline can fire. Migrating it
-    means making the call async first, which changes its handler on the wire side.
+
+  `github`'s `githubAuthStatus` (`github.ts`) used to be a third — a `spawnSync` HTTPS call on the single
+  event loop — until it moved onto `runBounded`, which is also why `ghSetupProblem` no longer hand-rolls its
+  own TERM+KILL escalation: both `gh auth status` probes now share this module's timeout mechanics instead
+  of duplicating them.
 
   The census above is about *unbounded waits*, not about every spawn in the repo — the rest are already
   bounded or cannot wait on anything: `git`'s sync `git()` and `shared/shellEnv` pass their own


### PR DESCRIPTION
Three small, independent fixes found while auditing how git/GitHub plumbing is used across the codebase.                                                                                                       
                                                                                                                                                                                                                 
  1. Resolve a name collision in the git env builders                                                                                                                                                            
  packages/server/src/pr/pr.ts defined its own nonInteractiveGitEnv(base, hasSshCommandConfig) — a different function, with a different signature, from the git module's barrel-exported nonInteractiveGitEnv()  
  (packages/server/src/git/gitExec.ts) that pr.ts already imports. Renamed the local one to pushGitEnv to remove the ambiguity.                                                                                  
                                                                                                                                                                                                                 
  2. Move gh auth status off spawnSync onto the shared bounded runner                                                                                                                                            
  github.ts's githubAuthStatus() ran gh auth status via a synchronous, unbounded Bun.spawnSync — capable of freezing the entire single-threaded host if gh ever hangs. Its sibling ghSetupProblem(), in the same 
  file, already worked around this with a hand-rolled async TERM+KILL timeout — and subprocess/SPEC.md explicitly listed githubAuthStatus as known debt to migrate onto runBounded. Both probes now share        
  runBounded at the same 8s budget; the hand-rolled escalation logic is gone. Wire handler and web client needed no changes (already promise-based).                                                             
                                                                                                                                                                                                                 
  3. Centralize the duplicated raw-git e2e fixture helper                                                                                                                                                        
  ~10 e2e spec files each reimplemented their own execFileSync("git", ["-C", cwd, ...args]) wrapper (six near-identical local git(...) closures, plus two byte-identical commitFile helpers). Extracted a shared 
  e2e/fixtures/git.ts (git, gitQuiet, gitText, gitAs, commitFile) and migrated every call site.  