### PR TITLE
ci: run checks for merge groups

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -17,7 +17,7 @@ workflows and composite actions.
 
 ## CI vs release
 
-- **CI** (`ci.yml`, on PRs to `main`): dependency/module-boundary checks, lint+typecheck (incl.
+- **CI** (`ci.yml`, on PRs to `main` and merge-queue check requests): dependency/module-boundary checks, lint+typecheck (incl.
   `check:seams` — the pi binary-seam canary, see `scripts/check-binary-seams.ts`), unit tests, no-agent e2e,
   and a **host-target** binary
   build+smoke+**e2e-vs-binary** (`bun run e2e:binary`: the same no-agent suite against the compiled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 # Supersede in-flight runs when a PR is updated.
 concurrency:


### PR DESCRIPTION
## Summary

- Run the existing CI workflow for GitHub merge-group check requests so required checks attach to queue commits.
- Keep the CI module spec aligned with that trigger.

## Testing

- `bun run check:deps` — passed
- `bun run check:boundaries` — 2 tests passed; boundary scan passed
- `bun run check:seams` — passed
- `bun run lint` — passed with 6 existing warnings in untouched files
- `bun run typecheck` — 14 tasks passed
- Ruby YAML parse of `.github/workflows/ci.yml` — passed
- E2E not run, per request
