### PR TITLE
fix(web): open relative Markdown links in-app

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -1186,8 +1186,10 @@ own section. The kebab menu (`plan-menu`, a
   the **preview** tab through the shared **`openFileInTab`** (the same flow `FileTree` uses) — following a
   link is browsing, so the slot is reused rather than promoting the source doc the way VS Code does; an
   accepted file target is a button styled as document-link text, never an anchor with a raw relative
-  `href`, because that URL is not a ThinkRail route and native navigation would escape to the Main page; the
-  slot is the slot, whatever the open came from — an **in-doc `#` link**
+  `href`, because that URL is not a ThinkRail route and native navigation would escape to the Main page;
+  URL pathnames are decoded once before resolution, while malformed encoding and traversal above the
+  worktree root produce an inert control instead of opening the wrong file; the slot is the slot, whatever
+  the open came from — an **in-doc `#` link**
   scrolls the preview (headings carry slug ids from the in-repo `remarkHeadingIds` transform), an
   **external** link opens a new tab, and a **relative image** rewrites to the host **`/files/…`** route
   (built from `transport.httpBase()`). A cross-file link's `#fragment` is not yet followed (opens the

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -1187,8 +1187,9 @@ own section. The kebab menu (`plan-menu`, a
   link is browsing, so the slot is reused rather than promoting the source doc the way VS Code does; an
   accepted file target is a button styled as document-link text, never an anchor with a raw relative
   `href`, because that URL is not a ThinkRail route and native navigation would escape to the Main page;
-  URL pathnames are decoded once before resolution, while malformed encoding and traversal above the
-  worktree root produce an inert control instead of opening the wrong file; the slot is the slot, whatever
+  URL pathnames are decoded once and both path-separator forms are normalized before resolution, while
+  malformed encoding and traversal above the worktree root produce an inert control instead of opening the
+  wrong file; the slot is the slot, whatever
   the open came from — an **in-doc `#` link**
   scrolls the preview (headings carry slug ids from the in-repo `remarkHeadingIds` transform), an
   **external** link opens a new tab, and a **relative image** rewrites to the host **`/files/…`** route

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -1184,7 +1184,9 @@ own section. The kebab menu (`plan-menu`, a
 - **Rendered markdown navigates.** In the preview, links + images resolve against the file's own path
   (via `markdownLinks`, passed as the `a`/`img` renderers): a **relative link** opens the target file in
   the **preview** tab through the shared **`openFileInTab`** (the same flow `FileTree` uses) — following a
-  link is browsing, so the slot is reused rather than promoting the source doc the way VS Code does; the
+  link is browsing, so the slot is reused rather than promoting the source doc the way VS Code does; an
+  accepted file target is a button styled as document-link text, never an anchor with a raw relative
+  `href`, because that URL is not a ThinkRail route and native navigation would escape to the Main page; the
   slot is the slot, whatever the open came from — an **in-doc `#` link**
   scrolls the preview (headings carry slug ids from the in-repo `remarkHeadingIds` transform), an
   **external** link opens a new tab, and a **relative image** rewrites to the host **`/files/…`** route

--- a/apps/web/src/panels/markdownLinks.test.ts
+++ b/apps/web/src/panels/markdownLinks.test.ts
@@ -32,6 +32,8 @@ test("resolveRelativePath resolves against the source file's directory (posix)",
 	expect(resolveRelativePath("docs/guide.md", "../themes/%E2%9C%93.md")).toBe("themes/✓.md");
 	expect(resolveRelativePath("docs/guide.md", "../../README.md")).toBeNull();
 	expect(resolveRelativePath("docs/guide.md", "%2e%2e/%2e%2e/README.md")).toBeNull();
+	expect(resolveRelativePath("docs/guide.md", "..%5cthemes%5cSPEC.md")).toBe("themes/SPEC.md");
+	expect(resolveRelativePath("docs/guide.md", "..%5c..%5coutside.md")).toBeNull();
 	expect(resolveRelativePath("docs/guide.md", "%E0%A4%A.md")).toBeNull();
 });
 

--- a/apps/web/src/panels/markdownLinks.test.ts
+++ b/apps/web/src/panels/markdownLinks.test.ts
@@ -2,12 +2,7 @@ import { expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { Markdown } from "../chat/Markdown";
-import {
-	classifyHref,
-	documentComponents,
-	resolveRelativePath,
-	slugify,
-} from "./markdownLinks";
+import { classifyHref, documentComponents, resolveRelativePath, slugify } from "./markdownLinks";
 
 test("classifyHref distinguishes anchors, external, and relative targets", () => {
 	expect(classifyHref(undefined)).toBe("empty");

--- a/apps/web/src/panels/markdownLinks.test.ts
+++ b/apps/web/src/panels/markdownLinks.test.ts
@@ -26,6 +26,13 @@ test("resolveRelativePath resolves against the source file's directory (posix)",
 	expect(resolveRelativePath("README.md", "architecture.md")).toBe("architecture.md");
 	expect(resolveRelativePath("docs/guide.md", "./img/logo.png")).toBe("docs/img/logo.png");
 	expect(resolveRelativePath("a/b/c.md", "/root.md")).toBe("root.md");
+	expect(resolveRelativePath("docs/guide.md", "../themes/My%20Theme.md")).toBe(
+		"themes/My Theme.md",
+	);
+	expect(resolveRelativePath("docs/guide.md", "../themes/%E2%9C%93.md")).toBe("themes/✓.md");
+	expect(resolveRelativePath("docs/guide.md", "../../README.md")).toBeNull();
+	expect(resolveRelativePath("docs/guide.md", "%2e%2e/%2e%2e/README.md")).toBeNull();
+	expect(resolveRelativePath("docs/guide.md", "%E0%A4%A.md")).toBeNull();
 });
 
 test("relative document targets have no browser-navigable href", () => {

--- a/apps/web/src/panels/markdownLinks.test.ts
+++ b/apps/web/src/panels/markdownLinks.test.ts
@@ -1,5 +1,13 @@
 import { expect, test } from "bun:test";
-import { classifyHref, resolveRelativePath, slugify } from "./markdownLinks";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Markdown } from "../chat/Markdown";
+import {
+	classifyHref,
+	documentComponents,
+	resolveRelativePath,
+	slugify,
+} from "./markdownLinks";
 
 test("classifyHref distinguishes anchors, external, and relative targets", () => {
 	expect(classifyHref(undefined)).toBe("empty");
@@ -23,6 +31,22 @@ test("resolveRelativePath resolves against the source file's directory (posix)",
 	expect(resolveRelativePath("README.md", "architecture.md")).toBe("architecture.md");
 	expect(resolveRelativePath("docs/guide.md", "./img/logo.png")).toBe("docs/img/logo.png");
 	expect(resolveRelativePath("a/b/c.md", "/root.md")).toBe("root.md");
+});
+
+test("relative document targets have no browser-navigable href", () => {
+	const html = renderToStaticMarkup(
+		createElement(Markdown, {
+			text: "[`themes/SPEC.md`](../themes/SPEC.md)",
+			components: documentComponents({
+				workspaceId: "workspace-1",
+				path: "apps/web/src/styles/COLOR.md",
+			}),
+		}),
+	);
+
+	expect(html).toContain('<button type="button" data-testid="markdown-file-link"');
+	expect(html).toContain('data-path="apps/web/src/themes/SPEC.md"');
+	expect(html).not.toContain('href="../themes/SPEC.md"');
 });
 
 test("slugify matches GitHub-style heading anchors", () => {

--- a/apps/web/src/panels/markdownLinks.tsx
+++ b/apps/web/src/panels/markdownLinks.tsx
@@ -95,17 +95,20 @@ export function documentComponents(ctx: { workspaceId: string; path: string }): 
 			);
 		}
 		if (kind === "relative" && href) {
+			const target = resolveRelativePath(ctx.path, splitHash(href).path);
 			return (
-				<a
-					href={href}
-					onClick={(e) => {
-						e.preventDefault();
-						const target = resolveRelativePath(ctx.path, splitHash(href).path);
+				<button
+					type="button"
+					data-testid="markdown-file-link"
+					data-path={target}
+					disabled={!target}
+					onClick={() => {
 						if (target) void openFileInTab(ctx.workspaceId, target, "preview");
 					}}
+					className="cursor-pointer text-left text-primary underline decoration-primary-muted underline-offset-2 hover:decoration-primary disabled:cursor-default"
 				>
 					{children}
-				</a>
+				</button>
 			);
 		}
 		return (

--- a/apps/web/src/panels/markdownLinks.tsx
+++ b/apps/web/src/panels/markdownLinks.tsx
@@ -15,7 +15,7 @@ export function classifyHref(href: string | undefined): HrefKind {
 export function resolveRelativePath(fromFile: string, href: string): string | null {
 	let decoded: string;
 	try {
-		decoded = decodeURIComponent(href);
+		decoded = decodeURIComponent(href).replaceAll("\\", "/");
 	} catch {
 		return null;
 	}

--- a/apps/web/src/panels/markdownLinks.tsx
+++ b/apps/web/src/panels/markdownLinks.tsx
@@ -12,15 +12,24 @@ export function classifyHref(href: string | undefined): HrefKind {
 	return "relative";
 }
 
-export function resolveRelativePath(fromFile: string, href: string): string {
-	const dir = fromFile.includes("/") ? fromFile.slice(0, fromFile.lastIndexOf("/")) : "";
-	const segs = href.startsWith("/") || dir === "" ? [] : dir.split("/");
-	for (const seg of href.split("/")) {
-		if (seg === "" || seg === ".") continue;
-		if (seg === "..") segs.pop();
-		else segs.push(seg);
+export function resolveRelativePath(fromFile: string, href: string): string | null {
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(href);
+	} catch {
+		return null;
 	}
-	return segs.join("/");
+	if (!decoded) return null;
+	const dir = fromFile.includes("/") ? fromFile.slice(0, fromFile.lastIndexOf("/")) : "";
+	const segs = decoded.startsWith("/") || dir === "" ? [] : dir.split("/");
+	for (const seg of decoded.split("/")) {
+		if (seg === "" || seg === ".") continue;
+		if (seg === "..") {
+			if (segs.length === 0) return null;
+			segs.pop();
+		} else segs.push(seg);
+	}
+	return segs.join("/") || null;
 }
 
 export function slugify(text: string): string {
@@ -31,9 +40,9 @@ export function slugify(text: string): string {
 		.replace(/\s+/g, "-");
 }
 
-function splitHash(href: string): { path: string; hash: string } {
-	const i = href.indexOf("#");
-	return i < 0 ? { path: href, hash: "" } : { path: href.slice(0, i), hash: href.slice(i + 1) };
+function relativePathname(href: string): string {
+	const i = href.search(/[?#]/);
+	return i < 0 ? href : href.slice(0, i);
 }
 
 function encodePath(path: string): string {
@@ -95,12 +104,12 @@ export function documentComponents(ctx: { workspaceId: string; path: string }): 
 			);
 		}
 		if (kind === "relative" && href) {
-			const target = resolveRelativePath(ctx.path, splitHash(href).path);
+			const target = resolveRelativePath(ctx.path, relativePathname(href));
 			return (
 				<button
 					type="button"
 					data-testid="markdown-file-link"
-					data-path={target}
+					data-path={target ?? undefined}
 					disabled={!target}
 					onClick={() => {
 						if (target) void openFileInTab(ctx.workspaceId, target, "preview");
@@ -119,12 +128,13 @@ export function documentComponents(ctx: { workspaceId: string; path: string }): 
 	}
 
 	function DocumentImage({ src, alt, title }: { src?: string; alt?: string; title?: string }) {
-		const resolved =
-			classifyHref(src) === "relative" && src
-				? `${getTransport().httpBase()}/files/${encodeURIComponent(ctx.workspaceId)}/${encodePath(
-						resolveRelativePath(ctx.path, src),
-					)}`
-				: src;
+		const isRelative = classifyHref(src) === "relative" && src !== undefined;
+		const target = isRelative ? resolveRelativePath(ctx.path, relativePathname(src)) : null;
+		const resolved = isRelative
+			? target
+				? `${getTransport().httpBase()}/files/${encodeURIComponent(ctx.workspaceId)}/${encodePath(target)}`
+				: undefined
+			: src;
 		return <img src={resolved} alt={alt ?? ""} title={title} />;
 	}
 

--- a/e2e/fixtures/repo.ts
+++ b/e2e/fixtures/repo.ts
@@ -79,6 +79,16 @@ export function seedFixtureRepo(): void {
 			"",
 		].join("\n"),
 	);
+	mkdirSync(join(E2E_FIXTURE_REPO, "styles"), { recursive: true });
+	writeFileSync(
+		join(E2E_FIXTURE_REPO, "styles", "COLOR.md"),
+		"# Colour system\n\nSee [`themes/SPEC.md`](../themes/SPEC.md).\n",
+	);
+	mkdirSync(join(E2E_FIXTURE_REPO, "themes"), { recursive: true });
+	writeFileSync(
+		join(E2E_FIXTURE_REPO, "themes", "SPEC.md"),
+		"# Theme spec target\n\nReached through a parent-relative Markdown link.\n",
+	);
 	writeFileSync(
 		join(E2E_FIXTURE_REPO, "logo.png"),
 		Buffer.from(

--- a/e2e/markdown-links.spec.ts
+++ b/e2e/markdown-links.spec.ts
@@ -11,6 +11,11 @@ test("a parent-relative file link cannot escape into browser navigation", async 
 	const preview = page.getByTestId("markdown-preview");
 	await expect(preview).toBeVisible();
 
+	await page.getByTestId("file-node").filter({ hasText: "LINKS.md" }).click();
+	await expect(page.getByTestId("editor-tab")).toHaveCount(2);
+	await page.getByTestId("editor-tab").filter({ hasText: "COLOR.md" }).click();
+	await expect(preview.getByRole("heading", { name: "Colour system" })).toBeVisible();
+
 	const link = preview.getByTestId("markdown-file-link");
 	await expect(link).toHaveAttribute("data-path", "themes/SPEC.md");
 	await expect(link).not.toHaveAttribute("href", /.+/);
@@ -20,6 +25,9 @@ test("a parent-relative file link cannot escape into browser navigation", async 
 	await link.click();
 
 	await expect(preview.getByRole("heading", { name: "Theme spec target" })).toBeVisible();
+	const targetTab = page.getByTestId("editor-tab").filter({ hasText: "SPEC.md" });
+	await expect(targetTab).toHaveAttribute("data-preview", "true");
+	await expect(page.getByTestId("editor-tab")).toHaveCount(2);
 	expect(page.url()).toBe(urlBefore);
 	expect(page.context().pages()).toHaveLength(pagesBefore);
 });

--- a/e2e/markdown-links.spec.ts
+++ b/e2e/markdown-links.spec.ts
@@ -1,6 +1,29 @@
 import { expect, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
 
+test("a parent-relative file link cannot escape into browser navigation", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await page.getByTestId("tab-files").click();
+
+	await page.getByTestId("file-node").filter({ hasText: "styles" }).click();
+	await page.getByTestId("file-node").filter({ hasText: "COLOR.md" }).dblclick();
+	const preview = page.getByTestId("markdown-preview");
+	await expect(preview).toBeVisible();
+
+	const link = preview.getByTestId("markdown-file-link");
+	await expect(link).toHaveAttribute("data-path", "themes/SPEC.md");
+	await expect(link).not.toHaveAttribute("href", /.+/);
+	const urlBefore = page.url();
+	const pagesBefore = page.context().pages().length;
+
+	await link.click();
+
+	await expect(preview.getByRole("heading", { name: "Theme spec target" })).toBeVisible();
+	expect(page.url()).toBe(urlBefore);
+	expect(page.context().pages()).toHaveLength(pagesBefore);
+});
+
 test("relative links, images, and heading anchors work in the rendered markdown view", async ({
 	page,
 }) => {

--- a/e2e/markdown-links.spec.ts
+++ b/e2e/markdown-links.spec.ts
@@ -12,7 +12,8 @@ test("a parent-relative file link cannot escape into browser navigation", async 
 	await expect(preview).toBeVisible();
 
 	await page.getByTestId("file-node").filter({ hasText: "LINKS.md" }).click();
-	await expect(page.getByTestId("editor-tab")).toHaveCount(2);
+	const priorPreview = page.getByTestId("editor-tab").filter({ hasText: "LINKS.md" });
+	await expect(priorPreview).toHaveAttribute("data-preview", "true");
 	await page.getByTestId("editor-tab").filter({ hasText: "COLOR.md" }).click();
 	await expect(preview.getByRole("heading", { name: "Colour system" })).toBeVisible();
 
@@ -27,7 +28,7 @@ test("a parent-relative file link cannot escape into browser navigation", async 
 	await expect(preview.getByRole("heading", { name: "Theme spec target" })).toBeVisible();
 	const targetTab = page.getByTestId("editor-tab").filter({ hasText: "SPEC.md" });
 	await expect(targetTab).toHaveAttribute("data-preview", "true");
-	await expect(page.getByTestId("editor-tab")).toHaveCount(2);
+	await expect(priorPreview).toHaveCount(0);
 	expect(page.url()).toBe(urlBefore);
 	expect(page.context().pages()).toHaveLength(pagesBefore);
 });

--- a/e2e/markdown-links.spec.ts
+++ b/e2e/markdown-links.spec.ts
@@ -47,6 +47,6 @@ test("relative links, images, and heading anchors work in the rendered markdown 
 	await expect(page.getByTestId("editor-tab")).toHaveCount(2);
 	await expect(preview).toBeVisible();
 
-	await preview.getByRole("link", { name: "the spec" }).click();
+	await preview.getByTestId("markdown-file-link").click();
 	await expect(page.getByTestId("editor-tab").filter({ hasText: "SPEC.md" })).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Fix rendered Markdown relative-file links so they open their resolved worktree target inside ThinkRail instead of allowing native browser navigation to escape to the empty Main page.

## Changes

- render accepted relative file targets as in-app controls that browse through the shared preview slot
- decode URL pathnames once, normalize slash forms, and reject malformed encodings or traversal above the worktree root
- preserve normal behavior for external URLs, same-document anchors, and valid relative images
- add unit and end-to-end coverage for the nested `styles/COLOR.md` → `../themes/SPEC.md` regression
- document the navigation and path-safety contract in the panels spec

Exact-file browser URLs and cross-file fragment navigation remain deliberately out of scope.

## Testing

- `bun run check:deps && bun run check:boundaries && bun run check:seams && bun run lint && bun run typecheck && bun run test` — 14/14 tasks passed
- `bun run e2e` — 337 passed across 8 shards


## Screenshots

| Before — the raw relative URL escapes to project home | After — the target opens inside the preview area |
| --- | --- |
| ![Before: relative Markdown link leaves the file view](https://github.com/JetBrains/thinkrail/blob/b186c825cf7e805f226579ed7bc043b473e93058/markdown-link-before-browser-escape.png?raw=true) | ![After: resolved Markdown target opens in ThinkRail](https://github.com/JetBrains/thinkrail/blob/b186c825cf7e805f226579ed7bc043b473e93058/markdown-link-after-target-opens.png?raw=true) |
