### PR TITLE
fix(web): remove redundant Specs refresh row

### DIFF
--- a/apps/web/UI-TERMINOLOGY.md
+++ b/apps/web/UI-TERMINOLOGY.md
@@ -337,7 +337,7 @@ joins that last group. This is startup behavior, not a fixed hierarchy.
 | Canonical name | `data-testid` | Implementation / responsibility |
 |---|---|---|
 | Projects | `tab-projects`, body `left-nav` | `panels/ProjectTree.tsx`; projects and workspaces |
-| Specs | `tab-specs` | `panels/SpecsPanel.tsx`; read-only spec graph, with `specs-refresh` |
+| Specs | `tab-specs` | `panels/SpecsPanel.tsx`; automatically refreshed read-only spec graph, with error-only `specs-retry` |
 | Files | `tab-files` | `panels/FileTree.tsx`; worktree file tree |
 | Changes | `tab-changes` | `panels/ChangesPanel.tsx`; scoped git changes and diff opens |
 | Review | `tab-review` | `panels/ReviewPanel.tsx`; review accordion and send actions |

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -953,8 +953,8 @@ own section. The kebab menu (`plan-menu`, a
   stale — stamp, so neither effect sees any drift and the pane keeps the old target's diff under the new
   target's label indefinitely. Dropping the superseded read costs nothing: the read that superseded it is
   the one the user is waiting for. Panels are mounted only for the active workspace,
-  so scoping is natural; a degraded watcher just means back to read-on-demand. Editable-file conflict
-  handling waits for `fs.writeFile` (the viewer is read-only today).
+  so scoping is natural. A degraded host watcher pauses automatic invalidations until the next workspace
+  read re-establishes it; editable-file conflict handling waits for `fs.writeFile` (the viewer is read-only today).
 - **`useWorkspaceSpecs` owns the `spec.graph` read** (one fetcher, one definition of "this file is a spec"):
   the snapshot lands in the store (`specsByWorkspace`), not panel state, because the chat's turn divider
   needs the same answer to route its chips. It is called by **the workbench tool integration**, not by `SpecsPanel` — the
@@ -963,12 +963,13 @@ own section. The kebab menu (`plan-menu`, a
   file (the split silently undone by a tab selection). Being keyed per workspace, a switch shows that
   workspace's last known tree while the re-read is in flight (there is nothing to reset), and the failed-read
   flag is workspace-scoped so it can't leak a hint over a sibling's good tree. It returns `{ failed, reload }`
-  — the header's Refresh calls `reload` directly, so no refresh counter has to be held in panel state.
+  — `SpecsPanel`'s error-only Retry calls `reload` directly, so no retry counter has to be held in panel state.
 - `SpecsPanel` is the read-only spec-graph viewer — a pure reader of that snapshot. One fetch per
-  workspace-activation, refetched on the fs tick, plus a header **Refresh** button re-fetching on demand (the
-  manual escape hatch if the host's watcher degraded; the host side revalidates per read), rendered as
-  the **`parent` tree** (roots = no/dangling parent; default-expanded). A fetch **failure renders a distinct error hint** (pointing at Refresh), never the
-  "No specs" empty state — offline and empty are different answers. The tree build (`specTree.ts`)
+  workspace activation, refetched automatically on the fs tick, rendered as the **`parent` tree** (roots =
+  no/dangling parent; default-expanded). There is **no persistent Refresh control or panel toolbar row**:
+  routine synchronization is automatic. A fetch **failure renders a distinct inline error hint with Retry**,
+  never the "No specs" empty state — offline and empty are different answers. With a previous snapshot, the
+  hint sits above the retained tree; without one, it replaces the loading state. The tree build (`specTree.ts`)
   assumes a well-formed graph — **parent cycles are `spec_validate`'s problem, not the viewer's** (cycle
   members are unreachable from any root and simply don't render) — but the walk is **visited-guarded**,
   so a malformed graph can never hang or loop the UI. Tree only in this slice — no cross-edge display,

--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -56,7 +56,9 @@ export function SpecsPanel({
 				<LoadingRegion rows={6} className="px-4 py-4" />
 			)
 		) : nodes.length === 0 ? (
-			<p className="px-4 py-4 tr-text-metadata text-text-muted">No specs</p>
+			failed ? null : (
+				<p className="px-4 py-4 tr-text-metadata text-text-muted">No specs</p>
+			)
 		) : (
 			<ul className="flex flex-col motion-safe:animate-reveal">
 				{roots.map((root) => (
@@ -76,18 +78,12 @@ export function SpecsPanel({
 				<div
 					role="alert"
 					data-testid="specs-error"
-					className="flex items-center gap-8 rounded-[var(--radius-sm)] bg-feedback-error-subtle px-8 py-4 tr-text-metadata text-feedback-error"
+					className="flex items-center gap-8 rounded-[var(--radius-sm)] border border-feedback-error-muted bg-feedback-error-subtle px-8 py-4 tr-text-metadata text-text-default"
 				>
 					<span className="min-w-0 flex-1">
 						{nodes === null ? "Couldn't load specs." : "Couldn't update specs."}
 					</span>
-					<Button
-						variant="ghost"
-						size="sm"
-						data-testid="specs-retry"
-						onClick={onRetry}
-						className="text-feedback-error hover:text-feedback-error"
-					>
+					<Button variant="ghost" size="sm" data-testid="specs-retry" onClick={onRetry}>
 						<RefreshCw className="size-14" />
 						Retry
 					</Button>

--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -16,7 +16,7 @@ import {
 } from "@remixicon/react";
 import { useEffect, useMemo, useState } from "react";
 import { LoadingRegion } from "../components/Skeleton";
-import { IconTooltip } from "../components/ui/tooltip";
+import { Button } from "../components/ui/button";
 import { cn } from "../lib";
 import { selectActiveEditorTab, useAppStore } from "../store";
 import { openFileInTab } from "./openTabs";
@@ -31,11 +31,11 @@ import {
 export function SpecsPanel({
 	workspaceId,
 	failed = false,
-	onRefresh,
+	onRetry,
 }: {
 	workspaceId: string;
 	failed?: boolean;
-	onRefresh?: () => void;
+	onRetry: () => void;
 }) {
 	const nodes = useAppStore((s) => s.specsByWorkspace[workspaceId]) ?? null;
 	const activeTab = useAppStore((state) => selectActiveEditorTab(state, workspaceId));
@@ -51,12 +51,10 @@ export function SpecsPanel({
 	const roots = useMemo(() => (nodes ? buildSpecTree(nodes) : null), [nodes]);
 
 	const content =
-		failed && !nodes ? (
-			<p data-testid="specs-error" className="px-4 py-4 tr-text-metadata text-text-muted">
-				Couldn't load specs — Refresh to retry.
-			</p>
-		) : nodes === null || roots === null ? (
-			<LoadingRegion rows={6} className="px-4 py-4" />
+		nodes === null || roots === null ? (
+			failed ? null : (
+				<LoadingRegion rows={6} className="px-4 py-4" />
+			)
 		) : nodes.length === 0 ? (
 			<p className="px-4 py-4 tr-text-metadata text-text-muted">No specs</p>
 		) : (
@@ -74,19 +72,25 @@ export function SpecsPanel({
 		);
 	return (
 		<div className="flex min-h-0 flex-col">
-			{onRefresh ? (
-				<div className="flex h-panel-header-row shrink-0 items-center justify-end border-border-muted border-b px-12">
-					<IconTooltip label="Refresh specs">
-						<button
-							type="button"
-							data-testid="specs-refresh"
-							aria-label="Refresh specs"
-							onClick={onRefresh}
-							className="flex size-24 items-center justify-center rounded-[var(--radius-sm)] text-text-muted hover:bg-control-bg-hovered hover:text-text-default"
-						>
-							<RefreshCw className="size-14" />
-						</button>
-					</IconTooltip>
+			{failed ? (
+				<div
+					role="alert"
+					data-testid="specs-error"
+					className="flex items-center gap-8 rounded-[var(--radius-sm)] bg-feedback-error-subtle px-8 py-4 tr-text-metadata text-feedback-error"
+				>
+					<span className="min-w-0 flex-1">
+						{nodes === null ? "Couldn't load specs." : "Couldn't update specs."}
+					</span>
+					<Button
+						variant="ghost"
+						size="sm"
+						data-testid="specs-retry"
+						onClick={onRetry}
+						className="text-feedback-error hover:text-feedback-error"
+					>
+						<RefreshCw className="size-14" />
+						Retry
+					</Button>
 				</div>
 			) : null}
 			{content}

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -488,11 +488,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 				case "specs":
 					body = (
 						<QuietScrollArea className="h-full" viewportClassName="p-12">
-							<SpecsPanel
-								workspaceId={workspaceId}
-								failed={specs.failed}
-								onRetry={specs.reload}
-							/>
+							<SpecsPanel workspaceId={workspaceId} failed={specs.failed} onRetry={specs.reload} />
 						</QuietScrollArea>
 					);
 					break;

--- a/apps/web/src/shell/WorkspaceWorkbench.tsx
+++ b/apps/web/src/shell/WorkspaceWorkbench.tsx
@@ -491,7 +491,7 @@ export function WorkspaceWorkbench({ workspaceId }: { workspaceId: string }) {
 							<SpecsPanel
 								workspaceId={workspaceId}
 								failed={specs.failed}
-								onRefresh={specs.reload}
+								onRetry={specs.reload}
 							/>
 						</QuietScrollArea>
 					);

--- a/e2e/setting-up-a-project.live.spec.ts
+++ b/e2e/setting-up-a-project.live.spec.ts
@@ -77,7 +77,10 @@ test("`/skill:setting-up-a-project` routes an existing codebase to import and dr
 
 	await page.getByTestId("tab-specs").click();
 	await expect(page.getByRole("button", { name: "Refresh specs" })).toHaveCount(0);
+	await expect(page.locator('[data-testid="spec-node"][data-spec-id="sample-root"]')).toHaveCount(
+		0,
+	);
 	await expect(
-		page.locator('[data-testid="spec-node"][title*="goal-and-requirements"]').first(),
+		page.locator('[data-testid="spec-node"][data-spec-type="goal-and-requirements"]').first(),
 	).toBeVisible();
 });

--- a/e2e/setting-up-a-project.live.spec.ts
+++ b/e2e/setting-up-a-project.live.spec.ts
@@ -76,7 +76,7 @@ test("`/skill:setting-up-a-project` routes an existing codebase to import and dr
 	expect(hasGoalSpec(worktree)).toBe(true);
 
 	await page.getByTestId("tab-specs").click();
-	await page.getByTestId("specs-refresh").click();
+	await expect(page.getByRole("button", { name: "Refresh specs" })).toHaveCount(0);
 	await expect(
 		page.locator('[data-testid="spec-node"][title*="goal-and-requirements"]').first(),
 	).toBeVisible();

--- a/e2e/specs-panel.spec.ts
+++ b/e2e/specs-panel.spec.ts
@@ -72,23 +72,66 @@ test("Specs tab renders the worktree's spec tree and opens a spec as an editor t
 	const submodule = page.locator('[data-testid="spec-node"][data-spec-id="sample-submodule"]');
 	await expect(moduleB).toBeVisible();
 	await expect(submodule).toBeVisible();
-	await expect(page.getByTestId("specs-refresh")).toBeVisible();
-	await page.getByTestId("specs-refresh").click();
-	await expect(moduleB).toBeVisible();
-	await expect(submodule).toBeVisible();
+	await expect(page.getByRole("button", { name: "Refresh specs" })).toHaveCount(0);
+	await expect(page.getByTestId("specs-retry")).toHaveCount(0);
+	const stripBottom = await page
+		.getByTestId("right-tab-strip")
+		.evaluate((element) => element.getBoundingClientRect().bottom);
+	const rootTop = await root.evaluate((element) => element.getBoundingClientRect().top);
+	expect(rootTop - stripBottom).toBeLessThanOrEqual(24);
 	await expect(submodule).toHaveAttribute("data-depth", "2");
 	await expect(submodule).toHaveAttribute("data-spec-role", "SUBMODULE");
 	await expect(submodule.getByTestId("spec-role")).toBeHidden();
 	await submodule.hover();
 	await expect(submodule.getByTestId("spec-role")).toBeVisible();
 	await expect(submodule.getByTestId("spec-role")).toHaveText("SUBMODULE");
-	const childLeftAfterRefresh = await child.evaluate(
+	const childLeftAfterUpdate = await child.evaluate(
 		(element) => element.getBoundingClientRect().left,
 	);
 	const moduleBLeft = await moduleB.evaluate((element) => element.getBoundingClientRect().left);
 	const submoduleLeft = await submodule.evaluate((element) => element.getBoundingClientRect().left);
-	expect(Math.abs(moduleBLeft - childLeftAfterRefresh)).toBeLessThanOrEqual(1);
-	expect(submoduleLeft - childLeftAfterRefresh).toBeGreaterThanOrEqual(10);
+	expect(Math.abs(moduleBLeft - childLeftAfterUpdate)).toBeLessThanOrEqual(1);
+	expect(submoduleLeft - childLeftAfterUpdate).toBeGreaterThanOrEqual(10);
 	await expect(page.getByTestId("spec-tree-branch")).toHaveCount(0);
 	await expect(page.getByTestId("spec-tree-rail")).toHaveCount(0);
+});
+
+test("Specs offers Retry only after its automatic graph read fails", async ({ page }) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+
+	const root = page.locator('[data-testid="spec-node"][data-spec-id="sample-root"]');
+	await expect(root).toBeVisible();
+
+	let injected = false;
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			let frame: { id?: string; method?: string };
+			try {
+				frame = JSON.parse(raw) as typeof frame;
+			} catch {
+				server.send(message);
+				return;
+			}
+			if (!injected && frame.id && frame.method === "spec.graph") {
+				injected = true;
+				ws.send(JSON.stringify({ id: frame.id, ok: false, error: "injected spec failure" }));
+				return;
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(page.getByTestId("specs-error")).toContainText("Couldn't load specs.");
+	await expect(page.getByRole("button", { name: "Refresh specs" })).toHaveCount(0);
+	await expect(page.getByTestId("skeleton-rows")).toHaveCount(0);
+	await page.getByTestId("specs-retry").click();
+	await expect(page.getByTestId("specs-error")).toHaveCount(0);
+	await expect(root).toBeVisible();
+	expect(injected).toBe(true);
 });

--- a/e2e/specs-panel.spec.ts
+++ b/e2e/specs-panel.spec.ts
@@ -1,7 +1,44 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
+import { E2eWire } from "./fixtures/wire";
+
+async function proxyOneSpecGraphFailure(page: Page) {
+	let armed = false;
+	let injected = false;
+	let readCount = 0;
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			const raw = typeof message === "string" ? message : message.toString();
+			let frame: { id?: string; method?: string };
+			try {
+				frame = JSON.parse(raw) as typeof frame;
+			} catch {
+				server.send(message);
+				return;
+			}
+			if (frame.id && frame.method === "spec.graph") {
+				readCount += 1;
+				if (armed && !injected) {
+					injected = true;
+					ws.send(JSON.stringify({ id: frame.id, ok: false, error: "injected spec failure" }));
+					return;
+				}
+			}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+	return {
+		arm: () => {
+			armed = true;
+		},
+		readCount: () => readCount,
+		wasInjected: () => injected,
+	};
+}
 
 test("Specs tab renders the worktree's spec tree and opens a spec as an editor tab", async ({
 	page,
@@ -103,35 +140,60 @@ test("Specs offers Retry only after its automatic graph read fails", async ({ pa
 	const root = page.locator('[data-testid="spec-node"][data-spec-id="sample-root"]');
 	await expect(root).toBeVisible();
 
-	let injected = false;
-	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
-		const server = ws.connectToServer();
-		ws.onMessage((message) => {
-			const raw = typeof message === "string" ? message : message.toString();
-			let frame: { id?: string; method?: string };
-			try {
-				frame = JSON.parse(raw) as typeof frame;
-			} catch {
-				server.send(message);
-				return;
-			}
-			if (!injected && frame.id && frame.method === "spec.graph") {
-				injected = true;
-				ws.send(JSON.stringify({ id: frame.id, ok: false, error: "injected spec failure" }));
-				return;
-			}
-			server.send(message);
-		});
-		server.onMessage((message) => ws.send(message));
-	});
-
+	const failure = await proxyOneSpecGraphFailure(page);
+	failure.arm();
 	await page.reload();
 	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
-	await expect(page.getByTestId("specs-error")).toContainText("Couldn't load specs.");
+	const error = page.getByTestId("specs-error");
+	const retry = error.getByRole("button", { name: "Retry", exact: true });
+	await expect(error).toContainText("Couldn't load specs.");
 	await expect(page.getByRole("button", { name: "Refresh specs" })).toHaveCount(0);
-	await expect(page.getByTestId("skeleton-rows")).toHaveCount(0);
-	await page.getByTestId("specs-retry").click();
+	await expect(page.getByTestId("right-panel").getByTestId("skeleton-rows")).toHaveCount(0);
+	const failedReadCount = failure.readCount();
+	await retry.click();
+	await expect.poll(failure.readCount).toBeGreaterThan(failedReadCount);
 	await expect(page.getByTestId("specs-error")).toHaveCount(0);
 	await expect(root).toBeVisible();
-	expect(injected).toBe(true);
+	expect(failure.wasInjected()).toBe(true);
+});
+
+test("a failed automatic Specs update keeps the previous tree until Retry succeeds", async ({
+	page,
+}) => {
+	const failure = await proxyOneSpecGraphFailure(page);
+	await openFixtureProject(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	const root = page.locator('[data-testid="spec-node"][data-spec-id="sample-root"]');
+	await expect(root).toBeVisible();
+
+	const wire = await E2eWire.connect();
+	const readsBeforeReady = failure.readCount();
+	const readiness = await wire
+		.request("workspace.watchReady", { workspaceId: workspace.id })
+		.finally(() => wire.close());
+	if (readiness.startupNudge) {
+		await expect.poll(failure.readCount).toBeGreaterThan(readsBeforeReady);
+	}
+
+	const added = page.locator('[data-testid="spec-node"][data-spec-id="sample-retry"]');
+	failure.arm();
+	writeFileSync(
+		join(workspace.worktreePath, "module-a", "retry.md"),
+		"---\nid: sample-retry\ntype: module-design\ntitle: Retry Sample\nparent: sample-root\n---\n\n## Responsibility\n\nAdded after the initial graph read.\n",
+	);
+
+	const error = page.getByTestId("specs-error");
+	const retry = error.getByRole("button", { name: "Retry", exact: true });
+	await expect(error).toContainText("Couldn't update specs.");
+	await expect(retry).toBeVisible();
+	await expect(root).toBeVisible();
+	await expect(added).toHaveCount(0);
+	await expect(page.getByTestId("right-panel").getByTestId("skeleton-rows")).toHaveCount(0);
+	const failedReadCount = failure.readCount();
+	await retry.click();
+	await expect.poll(failure.readCount).toBeGreaterThan(failedReadCount);
+	await expect(page.getByTestId("specs-error")).toHaveCount(0);
+	await expect(root).toBeVisible();
+	await expect(added).toBeVisible();
+	expect(failure.wasInjected()).toBe(true);
 });

--- a/e2e/specs-panel.spec.ts
+++ b/e2e/specs-panel.spec.ts
@@ -2,7 +2,6 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
-import { E2eWire } from "./fixtures/wire";
 
 async function proxyOneSpecGraphFailure(page: Page) {
 	let armed = false;
@@ -165,15 +164,6 @@ test("a failed automatic Specs update keeps the previous tree until Retry succee
 	const workspace = await createWorkspaceViaDialog(page);
 	const root = page.locator('[data-testid="spec-node"][data-spec-id="sample-root"]');
 	await expect(root).toBeVisible();
-
-	const wire = await E2eWire.connect();
-	const readsBeforeReady = failure.readCount();
-	const readiness = await wire
-		.request("workspace.watchReady", { workspaceId: workspace.id })
-		.finally(() => wire.close());
-	if (readiness.startupNudge) {
-		await expect.poll(failure.readCount).toBeGreaterThan(readsBeforeReady);
-	}
 
 	const added = page.locator('[data-testid="spec-node"][data-spec-id="sample-retry"]');
 	failure.arm();

--- a/packages/server/src/spec/SPEC.md
+++ b/packages/server/src/spec/SPEC.md
@@ -20,8 +20,8 @@ durable* spec (any node whose `type` is not the ephemeral `task-spec`) — which
 requested only for the one project the Welcome screen renders, never eagerly for every project).
 
 The read is **synchronous** (core's walk is sync-fs, O(worktree dirs) per call). That's acceptable —
-fetches are on-demand (tab-visit / Refresh / a `workspace.fsChanged` nudge, no polling) and the
-per-file parse cache skips re-reads. If
+fetches are on-demand (workspace activation / a `workspace.fsChanged` nudge / an error-state Retry, no
+polling) and the per-file parse cache skips re-reads. If
 the walk ever dominates, the escalation is core's **watcher-as-dirty-flag** (see `pi-spec-graph`
 core/SPEC.md), not an async wrapper — that would still block the loop in one piece.
 


### PR DESCRIPTION
## Summary

- Remove the persistent Specs refresh button and empty toolbar row.
- Keep automatic sync; show Retry only after failed reads while preserving the previous tree.

## Testing

- `bun run test` — passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- dependency, boundary, and seam checks — passed
- local e2e intentionally not rerun
