### PR TITLE
fix(desktop): treat loopback address variants on the same port as internal

### DIFF
--- a/apps/desktop/SPEC.md
+++ b/apps/desktop/SPEC.md
@@ -92,8 +92,9 @@ pins production wiring.
 
 ## Navigation and window security
 
-The native window permits navigation only within its exact loopback origin. User-requested external URLs
-open through the OS instead of replacing the app surface.
+The native window permits navigation only within its loopback origin. All loopback addresses
+(`127.0.0.1`, `localhost`, `[::1]`) on the same port and protocol are treated as internal; any other host
+opens through the OS instead of replacing the app surface.
 
 A desktop preload sends typed, one-way route and local-preference messages. It wraps
 `history.replaceState` and `history.pushState` before page scripts and also reports initial/hash/pop

--- a/apps/desktop/src/externalNavigation.test.ts
+++ b/apps/desktop/src/externalNavigation.test.ts
@@ -8,6 +8,25 @@ test("keeps same-origin navigation inside the webview", () => {
 	expect(externalNavigationUrl({ url: `${origin}/files/a/b` }, origin)).toBeNull();
 });
 
+test("treats localhost on the same port as internal", () => {
+	expect(externalNavigationUrl("http://localhost:24242/page", origin)).toBeNull();
+});
+
+test("treats [::1] on the same port as internal", () => {
+	expect(externalNavigationUrl("http://[::1]:24242/page", origin)).toBeNull();
+});
+
+test("treats 127.0.0.1 on the same port as internal when origin is localhost", () => {
+	const localhostOrigin = "http://localhost:24242";
+	expect(externalNavigationUrl("http://127.0.0.1:24242/page", localhostOrigin)).toBeNull();
+});
+
+test("opens a real external host in the OS browser", () => {
+	expect(externalNavigationUrl("https://example.com/docs", origin)).toBe(
+		"https://example.com/docs",
+	);
+});
+
 test("opens reviewed external protocols only", () => {
 	expect(externalNavigationUrl("https://example.com/docs", origin)).toBe(
 		"https://example.com/docs",

--- a/apps/desktop/src/externalNavigation.test.ts
+++ b/apps/desktop/src/externalNavigation.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { externalNavigationUrl } from "./externalNavigation";
+import { externalNavigationUrl, loopbackNavigationRules } from "./externalNavigation";
 
 const origin = "http://127.0.0.1:24242";
 
@@ -41,4 +41,24 @@ test("opens reviewed external protocols only", () => {
 test("rejects malformed event detail", () => {
 	expect(externalNavigationUrl(null, origin)).toBeNull();
 	expect(externalNavigationUrl({}, origin)).toBeNull();
+});
+
+test("loopbackNavigationRules includes all three loopback origins", () => {
+	const rules = loopbackNavigationRules(24242);
+	expect(rules).toContain("http://127.0.0.1:24242/*");
+	expect(rules).toContain("http://localhost:24242/*");
+	expect(rules).toContain("http://[::1]:24242/*");
+});
+
+test("loopbackNavigationRules starts with deny-all", () => {
+	const rules = loopbackNavigationRules(24242);
+	expect(rules[0]).toBe("^*");
+});
+
+test("loopbackNavigationRules does not allow external hosts", () => {
+	const rules = loopbackNavigationRules(24242);
+	const allowPatterns = rules.slice(1);
+	for (const pattern of allowPatterns) {
+		expect(pattern).toMatch(/^http:\/\/(127\.0\.0\.1|localhost|\[::1\]):\d+\/\*$/);
+	}
 });

--- a/apps/desktop/src/externalNavigation.ts
+++ b/apps/desktop/src/externalNavigation.ts
@@ -1,3 +1,15 @@
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+function isSameLoopbackOrigin(a: URL, b: URL): boolean {
+	if (a.origin === b.origin) return true;
+	return (
+		a.protocol === b.protocol &&
+		a.port === b.port &&
+		LOOPBACK_HOSTS.has(a.hostname) &&
+		LOOPBACK_HOSTS.has(b.hostname)
+	);
+}
+
 export function externalNavigationUrl(value: unknown, origin: string): string | null {
 	const raw =
 		typeof value === "string"
@@ -8,7 +20,8 @@ export function externalNavigationUrl(value: unknown, origin: string): string | 
 	if (!raw) return null;
 	try {
 		const url = new URL(raw, origin);
-		if (url.origin === origin) return null;
+		const base = new URL(origin);
+		if (isSameLoopbackOrigin(url, base)) return null;
 		return ["https:", "http:", "mailto:"].includes(url.protocol) ? url.href : null;
 	} catch {
 		return null;

--- a/apps/desktop/src/externalNavigation.ts
+++ b/apps/desktop/src/externalNavigation.ts
@@ -1,13 +1,18 @@
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
+const LOOPBACK_HOSTS: readonly string[] = ["127.0.0.1", "localhost", "[::1]"];
+const LOOPBACK_HOST_SET = new Set(LOOPBACK_HOSTS);
 
 function isSameLoopbackOrigin(a: URL, b: URL): boolean {
 	if (a.origin === b.origin) return true;
 	return (
 		a.protocol === b.protocol &&
 		a.port === b.port &&
-		LOOPBACK_HOSTS.has(a.hostname) &&
-		LOOPBACK_HOSTS.has(b.hostname)
+		LOOPBACK_HOST_SET.has(a.hostname) &&
+		LOOPBACK_HOST_SET.has(b.hostname)
 	);
+}
+
+export function loopbackNavigationRules(port: number): string[] {
+	return ["^*", ...LOOPBACK_HOSTS.map((host) => `http://${host}:${port}/*`)];
 }
 
 export function externalNavigationUrl(value: unknown, origin: string): string | null {

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -10,7 +10,7 @@ import Electrobun, {
 	Utils,
 } from "electrobun/bun";
 import { installDesktopApplicationMenu } from "./applicationMenu";
-import { externalNavigationUrl } from "./externalNavigation";
+import { externalNavigationUrl, loopbackNavigationRules } from "./externalNavigation";
 import {
 	injectInitialDesktopPreferences,
 	readDesktopPreferenceRemove,
@@ -95,7 +95,7 @@ async function start(): Promise<void> {
 		hidden:
 			process.env.THINKRAIL_DESKTOP_HIDDEN === "1" ||
 			process.env.THINKRAIL_DESKTOP_E2E_HOST === "1",
-		navigationRules: neutral ? null : JSON.stringify(["^*", `${origin}/*`]),
+		navigationRules: neutral ? null : JSON.stringify(loopbackNavigationRules(host.port)),
 		frame: { x: 80, y: 60, width: 1440, height: 920 },
 	});
 	const openExternal = (detail: unknown) => {


### PR DESCRIPTION
## Summary

Desktop external-navigation treated any origin-string mismatch as external. When the desktop loads
`http://127.0.0.1:<port>`, a markdown link pointing to `http://localhost:<port>` or `http://[::1]:<port>`
opened the OS browser instead of staying in the webview. Two layers needed fixing:

1. **`externalNavigationUrl`** compared `url.origin === origin` as a strict string. A `LOOPBACK_HOSTS` set
   (`127.0.0.1`, `localhost`, `[::1]`) and `isSameLoopbackOrigin` helper now treat any two loopback hosts
   on the same port and protocol as equivalent.

2. **Electrobun `navigationRules`** only allowed the exact `http://127.0.0.1:<port>/*` pattern, so the
   window silently denied `localhost` and `[::1]` before the `will-navigate` handler could run. A new
   exported `loopbackNavigationRules(port)` builds the deny-all + three-origin allow list from the shared
   host array.

Non-loopback external hosts are unaffected — they are still denied by the rule list and still open
through the OS via `openExternal`.

## Related issues

Fixes JetBrains/thinkrail#372

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [ ] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)