### PR TITLE
fix(web): guard IME composition so Enter commits candidates, not sends

### DIFF
--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -475,6 +475,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+		// IME composition guard: while the input method is composing (e.g. pinyin
+		// candidates not yet committed), Enter/other keys must be handed back to
+		// the IME (commit the candidate), not treated as chat shortcuts. Without
+		// this, pressing Enter to confirm a candidate sends the raw pinyin.
+		if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
 		if (slots && !menuOpen) {
 			if (e.key === "Tab") {
 				e.preventDefault();

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -53,6 +53,8 @@ export type SubmitBehavior = "send" | "steer" | "followUp" | "interrupt";
 
 export type ComposerSubmitDisposition = { accepted: true } | { accepted: false; reason: string };
 
+const IME_SENTINEL_KEYCODE = 229;
+
 const COMPOSER_EDITOR_LIMIT_CLASS = {
 	compact: "max-h-[calc(6lh+var(--space-8)+var(--space-8))]",
 	roomy: "max-h-[calc(10lh+var(--space-8)+var(--space-8))]",
@@ -475,11 +477,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	};
 
 	const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-		// IME composition guard: while the input method is composing (e.g. pinyin
-		// candidates not yet committed), Enter/other keys must be handed back to
-		// the IME (commit the candidate), not treated as chat shortcuts. Without
-		// this, pressing Enter to confirm a candidate sends the raw pinyin.
-		if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+		if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === IME_SENTINEL_KEYCODE) return;
 		if (slots && !menuOpen) {
 			if (e.key === "Tab") {
 				e.preventDefault();

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -512,6 +512,11 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   `send-mode-steer` / `send-mode-queue` / `send-mode-interrupt`) names each mode with a one-line
   meaning + shortcut. Menu rows are **actions** (send the current draft with that mode), never a
   sticky mode switch — a persistent mode would make the next plain Enter silently obey hidden state.
+  `Composer` yields every keydown to an active IME before slot, menu, recall, or send handling. It uses
+  `KeyboardEvent.isComposing` plus the legacy `keyCode` 229 sentinel because `compositionend` may precede
+  the final keydown, making `isComposing` false while the IME still owns that event. The guard does not
+  cancel the event, so candidate-confirming Enter commits; only a later ordinary Enter invokes send
+  semantics.
   **Interrupt** (`SubmitBehavior: "interrupt"`, Cmd/Ctrl+Shift+Enter while streaming; plain send when
   idle; Shift+Enter alone stays newline) is the "take my message NOW" gesture pi lacks: `ChatView`
   awaits `session.abort` (the ack means idle) then performs an ordinary idle send — the partial reply

--- a/e2e/composer-ime.spec.ts
+++ b/e2e/composer-ime.spec.ts
@@ -1,0 +1,85 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { openWorkspaceChat } from "./fixtures/app";
+
+const ENTER_KEYCODE = 13;
+const IME_SENTINEL_KEYCODE = 229;
+
+interface ClientFrame {
+	method?: string;
+	params?: { text?: unknown };
+}
+
+function capturePromptTexts(page: Page): string[] {
+	const prompts: string[] = [];
+	page.on("websocket", (socket) => {
+		socket.on("framesent", ({ payload }) => {
+			try {
+				const frame = JSON.parse(
+					typeof payload === "string" ? payload : payload.toString(),
+				) as ClientFrame;
+				if (frame.method === "session.prompt" && typeof frame.params?.text === "string") {
+					prompts.push(frame.params.text);
+				}
+			} catch {}
+		});
+	});
+	return prompts;
+}
+
+async function dispatchEnter(
+	input: Locator,
+	init: { isComposing: boolean; keyCode: number },
+): Promise<{ defaultPrevented: boolean; isComposing: boolean; keyCode: number }> {
+	return input.evaluate((element, keyboard) => {
+		const event = new KeyboardEvent("keydown", {
+			bubbles: true,
+			cancelable: true,
+			code: "Enter",
+			isComposing: keyboard.isComposing,
+			key: "Enter",
+		});
+		Object.defineProperty(event, "keyCode", { value: keyboard.keyCode });
+		element.dispatchEvent(event);
+		return {
+			defaultPrevented: event.defaultPrevented,
+			isComposing: event.isComposing,
+			keyCode: event.keyCode,
+		};
+	}, init);
+}
+
+test("composer yields IME Enter events before applying send shortcuts", async ({ page }) => {
+	const sentPromptTexts = capturePromptTexts(page);
+	await openWorkspaceChat(page);
+
+	const input = page.getByTestId("chat-input");
+	const userMessages = page.locator('[data-testid="chat-message"][data-role="user"]');
+	await input.fill("ni hao ma");
+
+	expect(await dispatchEnter(input, { isComposing: true, keyCode: ENTER_KEYCODE })).toEqual({
+		defaultPrevented: false,
+		isComposing: true,
+		keyCode: ENTER_KEYCODE,
+	});
+	await expect(input).toHaveValue("ni hao ma");
+	await expect(userMessages).toHaveCount(0);
+
+	expect(await dispatchEnter(input, { isComposing: false, keyCode: IME_SENTINEL_KEYCODE })).toEqual(
+		{
+			defaultPrevented: false,
+			isComposing: false,
+			keyCode: IME_SENTINEL_KEYCODE,
+		},
+	);
+	await expect(input).toHaveValue("ni hao ma");
+	await expect(userMessages).toHaveCount(0);
+
+	await input.fill("你好吗");
+	expect(await dispatchEnter(input, { isComposing: false, keyCode: ENTER_KEYCODE })).toEqual({
+		defaultPrevented: true,
+		isComposing: false,
+		keyCode: ENTER_KEYCODE,
+	});
+	await expect(input).toHaveValue("");
+	await expect.poll(() => sentPromptTexts).toEqual(["你好吗"]);
+});


### PR DESCRIPTION
Fixes #339

## Problem

While a Chinese/Japanese/Korean IME is composing (pinyin/candidates not yet committed), pressing **Enter** should commit the current candidate to the input — but ThinkRail's chat composer instead treats it as a send shortcut and submits the unfinished raw pinyin as a message.

This is the classic web-chat IME pitfall: the `keydown` handler in `Composer.tsx` checks `e.key === "Enter"` without checking whether an IME composition is in progress.

## Fix

Yield every composer keydown to an active IME before slot, completion, recall, or send shortcuts run:

```ts
const IME_SENTINEL_KEYCODE = 229;

if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === IME_SENTINEL_KEYCODE) return;
```

Returning without cancelling the event lets Enter commit the current candidate. The named `229` fallback is the legacy browser sentinel for an IME-processed keydown; it covers event ordering where `compositionend` precedes the final keydown and leaves `isComposing` false. Only a later ordinary Enter reaches the send shortcuts.

The chat spec now records that compatibility invariant instead of carrying the rationale as a source comment.

## Verification

- `bun run e2e -- e2e/composer-ime.spec.ts` — 1 passed; the same regression test fails against the parent implementation
- The browser test asserts both IME event shapes emit no `session.prompt`, then an ordinary Enter emits exactly one committed `你好吗` prompt
- `bun run check:deps`, `bun run check:boundaries`, `bun run check:seams`, `bun run lint`, `bun run typecheck`, and `bun run test` — passed
- `bun run e2e` — 340 passed across 8 shards
