### PR TITLE
feat(subagents): strengthen built-in reviewer guidance

### DIFF
--- a/packages/pi-subagents/SPEC.md
+++ b/packages/pi-subagents/SPEC.md
@@ -70,7 +70,11 @@ typechecked; user-authored definitions keep the community `.md` + frontmatter co
 `skills`, `extensions`; body = system prompt). Malformed files are skipped, never fatal. All four
 builtins set `extensions: true` (the embedder's curated child set — inert under pure-pi
 zero-config) with the spec READ tools (`spec_grep`/`spec_get`/`spec_graph`) allowlisted for the
-read-only roles and web tools (`web_search`/`fetch_content`) for the scout.
+read-only roles and web tools (`web_search`/`fetch_content`) for the scout. The reviewer alone opts
+into project context: its judgment depends on repository guidance, and its prompt admits only
+material, reachable, unmitigated findings attributed to the named target. It must falsify candidate
+findings, complete the target, deduplicate by root cause, and end with one explicit verdict; GitHub
+review and thread semantics stay outside this portable role.
 
 ## The mapping (policy, not mechanism)
 

--- a/packages/pi-subagents/src/builtins.ts
+++ b/packages/pi-subagents/src/builtins.ts
@@ -69,16 +69,49 @@ Final report format: what changed (files + one line each), how it was verified, 
 	{
 		name: "reviewer",
 		description:
-			"Read-only code review of a diff or area: correctness, boundaries, and quality findings as file:line items.",
+			"Read-only code review of an exact diff or area. The task should name the review target and intended behavior; returns material, deduplicated findings with a verdict.",
 		source: "builtin",
 		tools: ["read", "grep", "find", "ls", "bash", ...SPEC_READ_TOOLS],
 		extensions: true,
-		systemPrompt: `You are a reviewer: a read-only code-review agent (bash is for read-only
-inspection — git diff/log, test runs — never for modifying anything).
+		inheritProjectContext: true,
+		systemPrompt: `You are a reviewer: a read-only code-review agent. You may use bash for
+inspection, git history/diffs, and targeted checks, but never edit source files or history.
 
-Judge each finding against the surrounding design, not just the quoted lines. ${SPEC_FIRST}
+Review the exact diff, commits, or area named in the delegated task. If the target is ambiguous,
+state the assumption you used. For a diff review, report only problems introduced or materially
+worsened by that diff.
 
-Report format: findings as \`path:line\` items, each with severity (blocker / should-fix / nit),
-what is wrong, and a concrete fix. End with a one-line verdict.`,
+Investigate before judging:
+- Read applicable repository guidance before the code. ${SPEC_FIRST}
+- Inspect every file in the review target and enough callers, tests, types, contracts, and
+  surrounding code to trace the changed behavior end to end.
+- Form your own model of the correct solution. Judge whether the implementation solves the right
+  problem, at the right layer, within the repository's boundaries.
+- Verify claims about dependencies and frameworks against the exact installed implementation, not
+  type declarations, README text, or recollection.
+- Try to disprove every candidate finding by checking existing guards, cleanup, ordering, state
+  semantics, error handling, tests, and other mitigations.
+- Complete the entire review target before reporting. Search for other occurrences of the same
+  defect class and consolidate symptoms that share one root cause.
+
+Report a finding only when:
+1. It is introduced or materially worsened by the target, when reviewing a diff.
+2. It is a concrete correctness, security, privacy, data-loss, broken-contract, or material
+   maintainability problem.
+3. It has a reachable failure scenario under supported use.
+4. No existing mitigation prevents that scenario.
+5. You can suggest a minimal safe fix consistent with repository boundaries.
+
+Drop style preferences, nits, optional hardening, speculative future problems, and issues outside
+of the named target.
+
+Report each finding as:
+- Blocking or Non-blocking — \`path:line\`
+  Problem: …
+  Failure scenario: …
+  Suggested fix: …
+
+Deduplicate by root cause. End with exactly one verdict: \`Verdict: Approve\` or
+\`Verdict: Request changes\`. Request changes only when at least one blocking finding remains.`,
 	},
 ];

--- a/packages/pi-subagents/src/definitions.test.ts
+++ b/packages/pi-subagents/src/definitions.test.ts
@@ -126,3 +126,21 @@ test("the builtin set is the settled four, all with prompts and descriptions", (
 	expect(BUILTIN_AGENTS.find((d) => d.name === "scout")?.tools).toContain("web_search");
 	expect(BUILTIN_AGENTS.find((d) => d.name === "planner")?.tools).not.toContain("web_search");
 });
+
+test("the builtin reviewer carries the portable review contract", () => {
+	const reviewer = BUILTIN_AGENTS.find((definition) => definition.name === "reviewer");
+	expect(reviewer?.inheritProjectContext).toBe(true);
+	for (const phrase of [
+		"introduced or materially worsened",
+		"exact installed implementation",
+		"Try to disprove every candidate finding",
+		"reachable failure scenario",
+		"No existing mitigation",
+		"Deduplicate by root cause",
+		"Verdict: Approve",
+		"Verdict: Request changes",
+	]) {
+		expect(reviewer?.systemPrompt).toContain(phrase);
+	}
+	expect(reviewer?.systemPrompt).not.toContain("should-fix");
+});


### PR DESCRIPTION
## Summary

Strengthen the portable built-in reviewer sub-agent so delegated reviews prioritize material, reproducible findings over broad quality commentary.

## Changes

- scope reviews to the exact delegated diff, commits, or area and require target assumptions to be explicit
- load project context and inspect repository guidance, specs, callers, tests, types, and contracts
- require reachable, unmitigated failure scenarios with minimal boundary-compatible fixes
- add active falsification, whole-target completion, same-class searching, root-cause deduplication, and installed-dependency verification
- replace nit-oriented output with structured Blocking/Non-blocking findings and one explicit verdict
- document and test the portable reviewer contract without coupling it to ThinkRail's plan-review or GitHub-specific tools

## Testing

- `bun --filter pi-subagents test` — 25 passed
- `bun run check:deps` — passed
- `bun run check:boundaries` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed with 6 pre-existing unused-suppression warnings
- `bun run typecheck` — 14/14 tasks passed
- `bun run test` — 14/14 tasks passed
- `bun run e2e` — 339 passed
