### PR TITLE
perf(e2e): record local run timings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ playwright-report/
 blob-report/
 playwright/.cache/
 e2e/screenshots/
-# Workflow-test run log — local evidence, deliberately not a committed record (see e2e/workflows/SPEC.md).
+# Local test-run evidence, deliberately not committed (see e2e/SPEC.md and e2e/workflows/SPEC.md).
+e2e/.run-timings.jsonl
 e2e/.workflow-runs.jsonl
 
 docs/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,10 @@ HOME, pi-agent dir, fixture repo, and control files; reports merge into one resu
 paths derive in `e2e/fixtures/paths.ts`, never touch `~/.thinkrail`, and parallel runs from different
 worktrees never collide. Two complete invocations in the same worktree remain sequential. Every public
 browser E2E runner holds one macOS idle-system-sleep assertion for its lifetime while still allowing display
-sleep; composed full-run phases inherit the parent's assertion. Focused
+sleep; composed full-run phases inherit the parent's assertion. Completed non-list runs append versioned,
+local-only timing records to gitignored `e2e/.run-timings.jsonl` (redirectable with
+`THINKRAIL_E2E_TIMING_FILE`); full-run child records carry their parent run id, and timing I/O never changes
+the gate result. This is diagnostic evidence, not product analytics. Focused
 `e2e:full` runs preflight both modes and skips a mode with no selected tests; selecting nothing fails, while
 an argument-free run and `--list` retain both phases. Cancellation in the no-agent, agent, and full runners
 signals their complete child trees (POSIX snapshot; Windows tree-aware termination), then force-kills

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,10 @@ bun run e2e:agent                                   # only @agent; remains seria
 
 Use focused or last-failed runs while iterating, then run the complete `bun run e2e`
 once before handoff. On macOS, every public browser E2E command prevents idle system sleep for the
-runner's lifetime while allowing the display to sleep normally. Agent-driven specs are tagged `@agent`
-and run against a real provider on an **isolated** `pi` agent dir — never your real `~/.pi/agent`.
+runner's lifetime while allowing the display to sleep normally. Completed runs append local timing evidence
+to the gitignored `e2e/.run-timings.jsonl`; `THINKRAIL_E2E_TIMING_FILE` redirects it for automation, and it
+is always safe to delete. Agent-driven specs are tagged `@agent` and run against a real provider on an
+**isolated** `pi` agent dir — never your real `~/.pi/agent`.
 
 ## Module boundaries
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ bun run e2e:agent                                   # only @agent; remains seria
 ```
 
 On macOS, every public browser E2E command prevents idle system sleep while its runner is alive; the
-display may still sleep normally.
+display may still sleep normally. Completed runs append local timing evidence to the gitignored
+`e2e/.run-timings.jsonl`; set `THINKRAIL_E2E_TIMING_FILE` to redirect it, or delete it at any time.
 
 ## Specification-driven development
 

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -35,6 +35,20 @@ system `caffeinate` executable with idle-system-sleep scope and the owning runne
 available and abrupt owner exit releases it. A private inherited owner marker makes composed full-run phases
 reuse the parent's assertion rather than multiplying helper processes. Other operating systems are a no-op,
 and a macOS host that cannot establish the assertion fails before spending test time.
+
+Every completed, non-list public browser run appends one compact versioned timing record to the worktree's
+gitignored `e2e/.run-timings.jsonl`; `THINKRAIL_E2E_TIMING_FILE` redirects that local evidence. Timing
+begins in the shared preload before the macOS assertion, so assertion failures are recorded and successful
+totals include that startup. The five modes are `no-agent`, `agent`, `full`, `binary`, and `desktop`. A record
+carries its raw and effective
+selection, UTC start, monotonic total/build/shard-or-phase durations, outcome, and exit code; inapplicable
+measurements are absent rather than zero. Managed interrupted runs finish their timing only after the
+existing bounded descendant cleanup drains. A full run records its own phase timings and gives each selected
+child phase its run id as lineage, so both the whole gate and its source can be analysed without counting
+internal Playwright list preflights as runs. Parallel shard durations overlap and therefore do not sum to the
+parent wall time. Timing writes are best-effort local diagnostics, never product analytics: inability to
+append warns but cannot change the test result, and abrupt process death may leave no final record.
+
 Direct no-agent use of the Playwright config remains self-contained and builds the web app when the shard
 runner has not already done so. Real-Central execution enters through the public `e2e:agent` or `e2e:full`
 runner; direct Central-mode test execution is rejected (while `--list` remains available), because the public

--- a/e2e/agent-harness.spec.ts
+++ b/e2e/agent-harness.spec.ts
@@ -31,8 +31,13 @@ import {
 	writeE2eAgentSettings,
 } from "./fixtures/centralAgent";
 import { resolveBunExecutable } from "./fixtures/executables";
-import { countSelectedPlaywrightTests, selectFocusedFullRunPhases } from "./fullRunPlan";
+import {
+	countSelectedPlaywrightTests,
+	createPlaywrightListArgs,
+	selectFocusedFullRunPhases,
+} from "./fullRunPlan";
 import { signalExitCode } from "./processRunner";
+import { E2E_TIMING_FILE_ENV, E2E_TIMING_PARENT_RUN_ID_ENV } from "./runTiming";
 
 function temporaryDirectory(): string {
 	return mkdtempSync(join(tmpdir(), "thinkrail-agent-harness-"));
@@ -133,6 +138,12 @@ test("Central Playwright execution requires the public runner authorization and 
 	const plan = createAgentRunPlan("bun", [], centralEnv);
 	expect(() => assertCentralPlaywrightRunner(plan.env, [])).not.toThrow();
 	expect(() => assertCentralPlaywrightRunner(centralEnv, ["--list"])).not.toThrow();
+	expect(() => assertCentralPlaywrightRunner(centralEnv, ["--output", "--list"])).toThrow(
+		/e2e:agent.*e2e:full/,
+	);
+	expect(() => assertCentralPlaywrightRunner(centralEnv, ["--", "--list"])).toThrow(
+		/e2e:agent.*e2e:full/,
+	);
 	expect(() => assertCentralPlaywrightRunner({}, [])).not.toThrow();
 });
 
@@ -147,6 +158,8 @@ test("agent run plan ignores ambient skip, trusts only internal build readiness,
 		THINKRAIL_E2E_SKIP_BUILD: "1",
 		THINKRAIL_E2E_LANE: "4",
 		PLAYWRIGHT_BLOB_OUTPUT_FILE: "/tmp/report.zip",
+		[E2E_TIMING_FILE_ENV]: "/tmp/e2e-timings.jsonl",
+		[E2E_TIMING_PARENT_RUN_ID_ENV]: "full-run",
 	};
 	const plan = createAgentRunPlan("/developer/bin/bun", ["e2e/agent.live.spec.ts"], sourceEnv);
 	expect(plan.buildCommand).toEqual(["/developer/bin/bun", "run", "build:web"]);
@@ -169,6 +182,9 @@ test("agent run plan ignores ambient skip, trusts only internal build readiness,
 	expect(plan.env[REAL_CENTRAL_E2E_ENV]).toBe("1");
 	expect(plan.env.THINKRAIL_E2E_LANE).toBeUndefined();
 	expect(plan.env.PLAYWRIGHT_BLOB_OUTPUT_FILE).toBeUndefined();
+	expect(plan.env[E2E_TIMING_FILE_ENV]).toBe("/tmp/e2e-timings.jsonl");
+	expect(plan.env[E2E_TIMING_PARENT_RUN_ID_ENV]).toBeUndefined();
+	expect(sourceEnv[E2E_TIMING_PARENT_RUN_ID_ENV]).toBe("full-run");
 	expect(plan.env[WEB_BUILD_READY_ENV]).toBeUndefined();
 	expect(isRealCentralE2e(plan.env)).toBe(true);
 	expect(
@@ -177,6 +193,34 @@ test("agent run plan ignores ambient skip, trusts only internal build readiness,
 		}).buildCommand,
 	).toBeNull();
 	expect(createAgentRunPlan("bun", ["--list"], sourceEnv).buildCommand).toBeNull();
+});
+
+test("focused full-run preflights force list and reporter options before separators", () => {
+	expect(createPlaywrightListArgs(["e2e/host.spec.ts"])).toEqual([
+		"--list",
+		"--reporter=json",
+		"--workers=1",
+		"e2e/host.spec.ts",
+		"--reporter=json",
+		"--workers=1",
+	]);
+	expect(createPlaywrightListArgs(["--output"])).toEqual([
+		"--list",
+		"--reporter=json",
+		"--workers=1",
+		"--output",
+		"--reporter=json",
+		"--workers=1",
+	]);
+	expect(createPlaywrightListArgs(["--", "--list"])).toEqual([
+		"--list",
+		"--reporter=json",
+		"--workers=1",
+		"--reporter=json",
+		"--workers=1",
+		"--",
+		"--list",
+	]);
 });
 
 test("focused full-run planning skips empty phases and rejects an empty selection", () => {
@@ -236,9 +280,10 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
 		const root = temporaryDirectory();
 		const statePath = join(root, `signal-tree-${signal}.json`);
 		const cleanupPath = join(root, `signal-tree-${signal}.cleaned`);
+		const timingPath = join(root, `signal-tree-${signal}.jsonl`);
 		const runner = spawn(
 			resolveBunExecutable(),
-			["e2e/fixtures/nested-signal-runner.ts", statePath, cleanupPath],
+			["e2e/fixtures/nested-signal-runner.ts", statePath, cleanupPath, timingPath],
 			{
 				cwd: fileURLToPath(new URL("..", import.meta.url)),
 				stdio: "ignore",
@@ -265,6 +310,9 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
 			expect(processExists(runningState.grandchild)).toBe(true);
 			expect(await exited).toBe(signalExitCode(signal));
 			expect(Date.now() - startedAt).toBeLessThan(3_000);
+			const timing = JSON.parse(readFileSync(timingPath, "utf8"));
+			expect(timing).toMatchObject({ outcome: "interrupted", exitCode: signalExitCode(signal) });
+			expect(timing.durationMs).toBeGreaterThanOrEqual(450);
 			await expect
 				.poll(
 					() =>

--- a/e2e/agentRunPlan.ts
+++ b/e2e/agentRunPlan.ts
@@ -1,5 +1,6 @@
 import { stripAmbientPiCredentials } from "./ambientCredentials";
 import { isRealCentralE2e, REAL_CENTRAL_E2E_ENV } from "./fixtures/centralAgent";
+import { E2E_TIMING_PARENT_RUN_ID_ENV, isPlaywrightListRun } from "./runTiming";
 
 export const CENTRAL_PLAYWRIGHT_RUNNER_AUTH_ENV = "THINKRAIL_E2E_CENTRAL_RUNNER_AUTHORIZED";
 export const WEB_BUILD_READY_ENV = "THINKRAIL_E2E_WEB_BUILD_READY";
@@ -16,7 +17,7 @@ export function assertCentralPlaywrightRunner(
 ): void {
 	const authorized =
 		env.THINKRAIL_E2E_SKIP_BUILD === "1" && env[CENTRAL_PLAYWRIGHT_RUNNER_AUTH_ENV] === "1";
-	if (isRealCentralE2e(env) && !authorized && !args.includes("--list")) {
+	if (isRealCentralE2e(env) && !authorized && !isPlaywrightListRun(args)) {
 		throw new Error(
 			"Real-Central Playwright execution must use `bun run e2e:agent` or `bun run e2e:full`",
 		);
@@ -29,7 +30,7 @@ export function createAgentRunPlan(
 	env: NodeJS.ProcessEnv = process.env,
 	options: { webBuildReady?: boolean } = {},
 ): AgentRunPlan {
-	const listOnly = playwrightArgs.includes("--list");
+	const listOnly = isPlaywrightListRun(playwrightArgs);
 	const buildCommand =
 		listOnly || options.webBuildReady === true ? null : [bun, "run", "build:web"];
 	const childEnv = stripAmbientPiCredentials({
@@ -41,6 +42,7 @@ export function createAgentRunPlan(
 	delete childEnv[WEB_BUILD_READY_ENV];
 	delete childEnv.THINKRAIL_E2E_LANE;
 	delete childEnv.PLAYWRIGHT_BLOB_OUTPUT_FILE;
+	delete childEnv[E2E_TIMING_PARENT_RUN_ID_ENV];
 	return {
 		buildCommand,
 		playwrightCommand: [bun, "x", "playwright", "test", ...playwrightArgs, "--workers=1"],

--- a/e2e/fixtures/nested-signal-runner.ts
+++ b/e2e/fixtures/nested-signal-runner.ts
@@ -1,11 +1,23 @@
-import { PARENT_SIGNAL_OWNER_ENV, runE2eProcess } from "../processRunner";
+import {
+	PARENT_SIGNAL_OWNER_ENV,
+	processRunnerInterruption,
+	runE2eProcess,
+	waitForE2eProcessDrain,
+} from "../processRunner";
+import { E2E_TIMING_FILE_ENV, startE2eRunTiming } from "../runTiming";
 
 const statePath = process.argv[2];
 const cleanupPath = process.argv[3];
+const timingPath = process.argv[4];
 if (!statePath || !cleanupPath) {
 	throw new Error("Nested signal runner state and cleanup paths are required");
 }
 
+const timing = timingPath
+	? startE2eRunTiming("no-agent", [], {
+			env: { ...process.env, [E2E_TIMING_FILE_ENV]: timingPath },
+		})
+	: null;
 const result = await runE2eProcess(
 	[process.execPath, "e2e/fixtures/signal-runner.ts", statePath, cleanupPath],
 	{
@@ -13,4 +25,6 @@ const result = await runE2eProcess(
 		terminationGraceMs: 500,
 	},
 );
+await waitForE2eProcessDrain();
+timing?.finish(result.exitCode, { interrupted: processRunnerInterruption() !== null });
 process.exitCode = result.exitCode;

--- a/e2e/fullRunPlan.ts
+++ b/e2e/fullRunPlan.ts
@@ -1,5 +1,7 @@
 export type FullRunPhase = "no-agent" | "agent";
 
+const forcedListArgs = ["--list", "--reporter=json", "--workers=1"];
+
 type JsonRecord = Record<string, unknown>;
 
 function record(value: unknown): JsonRecord | null {
@@ -20,6 +22,13 @@ function countSuiteTests(value: unknown): number {
 		for (const child of suite.suites) count += countSuiteTests(child);
 	}
 	return count;
+}
+
+export function createPlaywrightListArgs(args: readonly string[]): string[] {
+	const separator = args.indexOf("--");
+	const options = separator === -1 ? args : args.slice(0, separator);
+	const positionals = separator === -1 ? [] : args.slice(separator);
+	return [...forcedListArgs, ...options, "--reporter=json", "--workers=1", ...positionals];
 }
 
 export function countSelectedPlaywrightTests(output: string): number {

--- a/e2e/idleSleepPreload.ts
+++ b/e2e/idleSleepPreload.ts
@@ -1,3 +1,10 @@
 import { holdE2eIdleSleep } from "./idleSleep";
+import { preloadE2eRunTiming } from "./runTiming";
 
-await holdE2eIdleSleep();
+const timing = preloadE2eRunTiming(process.argv[1], process.argv.slice(2));
+try {
+	await holdE2eIdleSleep();
+} catch (error) {
+	timing?.finish(1);
+	throw error;
+}

--- a/e2e/processRunner.ts
+++ b/e2e/processRunner.ts
@@ -40,6 +40,7 @@ interface ActiveProcess {
 }
 
 const activeProcesses = new Set<ActiveProcess>();
+const processDrainWaiters = new Set<() => void>();
 let interruptedBy: NodeJS.Signals | null = null;
 let listening = false;
 
@@ -49,6 +50,11 @@ export function signalExitCode(signal: NodeJS.Signals): number {
 
 export function processRunnerInterruption(): NodeJS.Signals | null {
 	return interruptedBy;
+}
+
+export async function waitForE2eProcessDrain(): Promise<void> {
+	if (activeProcesses.size === 0) return;
+	await new Promise<void>((resolve) => processDrainWaiters.add(resolve));
 }
 
 function readPosixProcessSnapshot(): PosixProcessSnapshot[] {
@@ -208,6 +214,10 @@ function finishActiveProcess(active: ActiveProcess): void {
 	active.forceTimer = null;
 	activeProcesses.delete(active);
 	stopListeningWhenIdle();
+	if (activeProcesses.size === 0) {
+		for (const resolve of processDrainWaiters) resolve();
+		processDrainWaiters.clear();
+	}
 }
 
 function forceActiveProcess(active: ActiveProcess): void {

--- a/e2e/run-agent.ts
+++ b/e2e/run-agent.ts
@@ -2,28 +2,44 @@ import { rmSync } from "node:fs";
 import { createAgentRunPlan, WEB_BUILD_READY_ENV } from "./agentRunPlan";
 import { E2E_DATA_DIR } from "./fixtures/paths";
 import { holdE2eIdleSleep } from "./idleSleep";
-import { PARENT_SIGNAL_OWNER_ENV, runE2eProcess } from "./processRunner";
+import {
+	PARENT_SIGNAL_OWNER_ENV,
+	processRunnerInterruption,
+	runE2eProcess,
+	waitForE2eProcessDrain,
+} from "./processRunner";
+import { type E2eRunTiming, isPlaywrightListRun, startE2eRunTiming } from "./runTiming";
 
 const bun = process.execPath;
 
-async function main(): Promise<number> {
+async function main(playwrightArgs: string[], timing: E2eRunTiming): Promise<number> {
 	await holdE2eIdleSleep();
-	const playwrightArgs = process.argv.slice(2);
+	timing.setSelection({ playwrightArgs });
 	const plan = createAgentRunPlan(bun, playwrightArgs, process.env, {
 		webBuildReady: process.env[WEB_BUILD_READY_ENV] === "1",
 	});
 	if (plan.buildCommand) {
-		const { exitCode } = await runE2eProcess(plan.buildCommand);
+		const { exitCode } = await timing.timeBuild(() => runE2eProcess(plan.buildCommand));
 		if (exitCode !== 0) return exitCode;
 	}
-	if (!playwrightArgs.includes("--list")) rmSync(E2E_DATA_DIR, { recursive: true, force: true });
+	if (!isPlaywrightListRun(playwrightArgs)) rmSync(E2E_DATA_DIR, { recursive: true, force: true });
 	delete plan.env[PARENT_SIGNAL_OWNER_ENV];
-	return (await runE2eProcess(plan.playwrightCommand, { env: plan.env })).exitCode;
+	return (
+		await timing.timePhase("playwright", () =>
+			runE2eProcess(plan.playwrightCommand, { env: plan.env }),
+		)
+	).exitCode;
 }
 
+const playwrightArgs = process.argv.slice(2);
+const timing = startE2eRunTiming("agent", playwrightArgs);
+let exitCode = 1;
 try {
-	process.exitCode = await main();
+	exitCode = await main(playwrightArgs, timing);
 } catch (error) {
 	console.error(error instanceof Error ? error.message : error);
-	process.exitCode = 1;
 }
+const interruption = processRunnerInterruption();
+if (interruption) await waitForE2eProcessDrain();
+timing.finish(exitCode, { interrupted: interruption !== null });
+process.exitCode = exitCode;

--- a/e2e/run-binary.ts
+++ b/e2e/run-binary.ts
@@ -1,31 +1,29 @@
 #!/usr/bin/env bun
 
 import { holdE2eIdleSleep } from "./idleSleep";
+import { type E2eRunTiming, startE2eRunTiming } from "./runTiming";
 
-async function main(): Promise<number> {
+async function main(args: string[], timing: E2eRunTiming): Promise<number> {
 	await holdE2eIdleSleep();
+	timing.setSelection({ playwrightArgs: args });
 	const playwright = Bun.spawn(
-		[
-			process.execPath,
-			"x",
-			"playwright",
-			"test",
-			"-c",
-			"playwright.binary.config.ts",
-			...process.argv.slice(2),
-		],
+		[process.execPath, "x", "playwright", "test", "-c", "playwright.binary.config.ts", ...args],
 		{
 			stdin: "inherit",
 			stdout: "inherit",
 			stderr: "inherit",
 		},
 	);
-	return playwright.exited;
+	return timing.timePhase("playwright", () => playwright.exited);
 }
 
+const args = process.argv.slice(2);
+const timing = startE2eRunTiming("binary", args);
+let exitCode = 1;
 try {
-	process.exitCode = await main();
+	exitCode = await main(args, timing);
 } catch (error) {
 	console.error(error instanceof Error ? error.message : error);
-	process.exitCode = 1;
 }
+timing.finish(exitCode);
+process.exitCode = exitCode;

--- a/e2e/run-desktop.ts
+++ b/e2e/run-desktop.ts
@@ -13,33 +13,43 @@ import {
 import globalSetup from "./global-setup";
 import globalTeardown from "./global-teardown";
 import { holdE2eIdleSleep } from "./idleSleep";
+import { type E2eRunTiming, startE2eRunTiming } from "./runTiming";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const desktopDir = fileURLToPath(new URL("../apps/desktop", import.meta.url));
-const launcher = locateDesktopLauncher(desktopDir, process.env.THINKRAIL_E2E_DESKTOP);
 
 function within<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
-	return Promise.race([
-		promise,
-		new Promise<never>((_, reject) =>
-			setTimeout(() => reject(new Error(`timed out after ${ms}ms: ${what}`)), ms),
-		),
-	]);
+	return new Promise<T>((resolve, reject) => {
+		const timeout = setTimeout(() => reject(new Error(`timed out after ${ms}ms: ${what}`)), ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timeout);
+				resolve(value);
+			},
+			(error) => {
+				clearTimeout(timeout);
+				reject(error);
+			},
+		);
+	});
 }
 
 async function waitForReady(exited: Promise<number>): Promise<string> {
-	await within(
-		Promise.race([
-			(async () => {
-				while (!existsSync(E2E_DESKTOP_READY_FILE)) await Bun.sleep(50);
-			})(),
-			exited.then((code) => {
-				throw new Error(`desktop host exited before ready with ${code}`);
-			}),
-		]),
-		30_000,
-		"desktop host ready",
-	);
+	let desktopExit: number | undefined;
+	void exited.then((code) => {
+		desktopExit = code;
+	});
+	const startedAt = performance.now();
+	while (!existsSync(E2E_DESKTOP_READY_FILE)) {
+		if (desktopExit !== undefined)
+			throw new Error(`desktop host exited before ready with ${desktopExit}`);
+		if (performance.now() - startedAt >= 30_000) {
+			throw new Error("timed out after 30000ms: desktop host ready");
+		}
+		await Bun.sleep(50);
+	}
+	if (desktopExit !== undefined)
+		throw new Error(`desktop host exited before ready with ${desktopExit}`);
 	const ready = JSON.parse(readFileSync(E2E_DESKTOP_READY_FILE, "utf8")) as {
 		origin?: unknown;
 		mode?: unknown;
@@ -50,50 +60,60 @@ async function waitForReady(exited: Promise<number>): Promise<string> {
 	return ready.origin;
 }
 
-await holdE2eIdleSleep();
-globalSetup();
-const desktop = Bun.spawn([launcher], {
-	cwd: repoRoot,
-	env: {
-		...process.env,
-		...artifactHostEnvironment(E2E_DESKTOP_CACHE),
-		THINKRAIL_DESKTOP_READY_FILE: E2E_DESKTOP_READY_FILE,
-		THINKRAIL_DESKTOP_CONTROL_FILE: E2E_DESKTOP_CONTROL_FILE,
-		THINKRAIL_DESKTOP_USER_DATA: E2E_DESKTOP_USER_DATA,
-		THINKRAIL_DESKTOP_E2E_HOST: "1",
-		THINKRAIL_DESKTOP_HIDDEN: "1",
-	},
-	stdout: "inherit",
-	stderr: "inherit",
-});
-
-try {
-	const origin = await waitForReady(desktop.exited);
-	const playwright = Bun.spawn(
-		[
-			process.execPath,
-			"x",
-			"playwright",
-			"test",
-			"-c",
-			"playwright.desktop.config.ts",
-			...process.argv.slice(2),
-		],
-		{
-			cwd: repoRoot,
-			env: { ...process.env, THINKRAIL_E2E_DESKTOP_ORIGIN: origin },
-			stdout: "inherit",
-			stderr: "inherit",
+async function main(args: string[], timing: E2eRunTiming): Promise<number> {
+	await holdE2eIdleSleep();
+	timing.setSelection({ playwrightArgs: args });
+	const launcher = locateDesktopLauncher(desktopDir, process.env.THINKRAIL_E2E_DESKTOP);
+	await timing.timePhase("fixture-setup", () => globalSetup());
+	const desktop = Bun.spawn([launcher], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			...artifactHostEnvironment(E2E_DESKTOP_CACHE),
+			THINKRAIL_DESKTOP_READY_FILE: E2E_DESKTOP_READY_FILE,
+			THINKRAIL_DESKTOP_CONTROL_FILE: E2E_DESKTOP_CONTROL_FILE,
+			THINKRAIL_DESKTOP_USER_DATA: E2E_DESKTOP_USER_DATA,
+			THINKRAIL_DESKTOP_E2E_HOST: "1",
+			THINKRAIL_DESKTOP_HIDDEN: "1",
 		},
-	);
-	const testExit = await playwright.exited;
-	writeFileSync(E2E_DESKTOP_CONTROL_FILE, "stop");
-	const desktopExit = await within(desktop.exited, 20_000, "desktop graceful shutdown");
-	if (desktopExit !== 0) throw new Error(`desktop shutdown exited ${desktopExit}`);
-	if (testExit !== 0) process.exitCode = testExit;
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+
+	try {
+		const origin = await timing.timePhase("host-ready", () => waitForReady(desktop.exited));
+		const playwright = Bun.spawn(
+			[process.execPath, "x", "playwright", "test", "-c", "playwright.desktop.config.ts", ...args],
+			{
+				cwd: repoRoot,
+				env: { ...process.env, THINKRAIL_E2E_DESKTOP_ORIGIN: origin },
+				stdout: "inherit",
+				stderr: "inherit",
+			},
+		);
+		const testExit = await timing.timePhase("playwright", () => playwright.exited);
+		await timing.timePhase("host-shutdown", async () => {
+			writeFileSync(E2E_DESKTOP_CONTROL_FILE, "stop");
+			const desktopExit = await within(desktop.exited, 20_000, "desktop graceful shutdown");
+			if (desktopExit !== 0) throw new Error(`desktop shutdown exited ${desktopExit}`);
+		});
+		return testExit;
+	} catch (error) {
+		desktop.kill("SIGKILL");
+		await desktop.exited;
+		throw error;
+	} finally {
+		await timing.timePhase("fixture-teardown", () => globalTeardown());
+	}
+}
+
+const args = process.argv.slice(2);
+const timing = startE2eRunTiming("desktop", args);
+try {
+	const exitCode = await main(args, timing);
+	timing.finish(exitCode);
+	process.exitCode = exitCode;
 } catch (error) {
-	desktop.kill("SIGKILL");
+	timing.finish(1);
 	throw error;
-} finally {
-	globalTeardown();
 }

--- a/e2e/run-full.ts
+++ b/e2e/run-full.ts
@@ -7,6 +7,7 @@ import {
 import { REAL_CENTRAL_E2E_ENV } from "./fixtures/centralAgent";
 import {
 	countSelectedPlaywrightTests,
+	createPlaywrightListArgs,
 	type FullRunPhase,
 	selectFocusedFullRunPhases,
 } from "./fullRunPlan";
@@ -16,7 +17,14 @@ import {
 	processRunnerInterruption,
 	runE2eProcess,
 	signalExitCode,
+	waitForE2eProcessDrain,
 } from "./processRunner";
+import {
+	type E2eRunTiming,
+	isPlaywrightListRun,
+	startE2eRunTiming,
+	withE2eTimingParent,
+} from "./runTiming";
 
 const bun = process.execPath;
 
@@ -33,8 +41,12 @@ function agentEnv(): NodeJS.ProcessEnv {
 	return createAgentRunPlan(bun, ["--list"], process.env).env;
 }
 
-function phaseRunnerEnv(phase: FullRunPhase, webBuildReady: boolean): NodeJS.ProcessEnv {
-	const env = phase === "agent" ? agentEnv() : noAgentEnv();
+function phaseRunnerEnv(
+	phase: FullRunPhase,
+	webBuildReady: boolean,
+	parentRunId: string,
+): NodeJS.ProcessEnv {
+	const env = withE2eTimingParent(phase === "agent" ? agentEnv() : noAgentEnv(), parentRunId);
 	env[PARENT_SIGNAL_OWNER_ENV] = "1";
 	if (phase === "agent" && webBuildReady) env[WEB_BUILD_READY_ENV] = "1";
 	return env;
@@ -42,7 +54,7 @@ function phaseRunnerEnv(phase: FullRunPhase, webBuildReady: boolean): NodeJS.Pro
 
 async function countSelectedTests(phase: FullRunPhase, args: readonly string[]): Promise<number> {
 	const result = await runE2eProcess(
-		[bun, "x", "playwright", "test", ...args, "--list", "--reporter=json", "--workers=1"],
+		[bun, "x", "playwright", "test", ...createPlaywrightListArgs(args)],
 		{ env: phase === "agent" ? agentEnv() : noAgentEnv(), stdout: "pipe" },
 	);
 	const count = countSelectedPlaywrightTests(result.stdout);
@@ -56,45 +68,52 @@ async function runPhase(
 	phase: FullRunPhase,
 	args: readonly string[],
 	webBuildReady: boolean,
+	timing: E2eRunTiming,
 ): Promise<number> {
 	const runner = phase === "agent" ? "run-agent.ts" : "run.ts";
 	return (
-		await runE2eProcess([bun, join("e2e", runner), ...args], {
-			env: phaseRunnerEnv(phase, webBuildReady),
-		})
+		await timing.timePhase(phase, () =>
+			runE2eProcess([bun, "--preload", "./e2e/idleSleepPreload.ts", join("e2e", runner), ...args], {
+				env: phaseRunnerEnv(phase, webBuildReady, timing.runId),
+			}),
+		)
 	).exitCode;
 }
 
-async function main(): Promise<number> {
+async function main(args: string[], timing: E2eRunTiming): Promise<number> {
 	await holdE2eIdleSleep();
-	const args = process.argv.slice(2);
-	const listOnly = args.includes("--list");
+	const listOnly = isPlaywrightListRun(args);
 	let phases: FullRunPhase[] = ["no-agent", "agent"];
 	if (args.length > 0 && !listOnly) {
 		const noAgentTests = await countSelectedTests("no-agent", args);
 		const agentTests = await countSelectedTests("agent", args);
 		phases = selectFocusedFullRunPhases(noAgentTests, agentTests);
 	}
+	timing.setSelection({ playwrightArgs: args, phases });
 	let webBuildReady = false;
 	if (!listOnly) {
-		const { exitCode } = await runE2eProcess([bun, "run", "build:web"]);
+		const { exitCode } = await timing.timeBuild(() => runE2eProcess([bun, "run", "build:web"]));
 		if (exitCode !== 0) return exitCode;
 		webBuildReady = true;
 	}
 	for (const phase of phases) {
-		const exitCode = await runPhase(phase, args, webBuildReady);
+		const exitCode = await runPhase(phase, args, webBuildReady, timing);
 		if (exitCode !== 0) return exitCode;
 	}
 	return 0;
 }
 
+const args = process.argv.slice(2);
+const timing = startE2eRunTiming("full", args);
+let exitCode = 1;
 try {
-	process.exitCode = await main();
+	exitCode = await main(args, timing);
 } catch (error) {
 	const interruption = processRunnerInterruption();
-	if (interruption) process.exitCode = signalExitCode(interruption);
-	else {
-		console.error(error instanceof Error ? error.message : error);
-		process.exitCode = 1;
-	}
+	if (interruption) exitCode = signalExitCode(interruption);
+	else console.error(error instanceof Error ? error.message : error);
 }
+const interruption = processRunnerInterruption();
+if (interruption) await waitForE2eProcessDrain();
+timing.finish(exitCode, { interrupted: interruption !== null });
+process.exitCode = exitCode;

--- a/e2e/run-timing.spec.ts
+++ b/e2e/run-timing.spec.ts
@@ -1,0 +1,186 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+	E2E_TIMING_FILE_ENV,
+	E2E_TIMING_PARENT_RUN_ID_ENV,
+	type E2eRunTimingRecordV1,
+	e2eRunModeForEntrypoint,
+	isPlaywrightListRun,
+	preloadE2eRunTiming,
+	startE2eRunTiming,
+	withE2eTimingParent,
+} from "./runTiming";
+
+test("a completed run records stable v1 selection, lineage, and monotonic timings", async () => {
+	let now = 100;
+	const lines: string[] = [];
+	const selection = { playwrightArgs: ["e2e/host.spec.ts"], shardCount: 2, phases: ["no-agent"] };
+	const timing = startE2eRunTiming("no-agent", ["--serial", "e2e/host.spec.ts"], {
+		env: { [E2E_TIMING_PARENT_RUN_ID_ENV]: "parent-run" },
+		now: () => now,
+		wallNow: () => new Date("2026-09-03T12:00:00.000Z"),
+		runId: () => "run-1",
+		append: (_path, line) => lines.push(line),
+	});
+	timing.setSelection(selection);
+	selection.playwrightArgs.push("mutated");
+	selection.phases.push("mutated");
+
+	now = 110;
+	await timing.timeBuild(() => {
+		now = 125;
+	});
+	now = 130;
+	await timing.timeShard(2, 2, () => {
+		now = 160;
+	});
+	now = 165;
+	await timing.timeShard(1, 2, () => {
+		now = 175;
+	});
+	now = 180;
+	await timing.timePhase("report-merge", () => {
+		now = 190;
+	});
+	now = 200;
+
+	expect(timing.finish(0)).toBe(0);
+	expect(timing.finish(9)).toBe(9);
+	expect(lines).toHaveLength(1);
+	expect(JSON.parse(lines[0] ?? "") as E2eRunTimingRecordV1).toEqual({
+		version: 1,
+		runId: "run-1",
+		parentRunId: "parent-run",
+		mode: "no-agent",
+		args: ["--serial", "e2e/host.spec.ts"],
+		selection: {
+			playwrightArgs: ["e2e/host.spec.ts"],
+			shardCount: 2,
+			phases: ["no-agent"],
+		},
+		startedAt: "2026-09-03T12:00:00.000Z",
+		durationMs: 100,
+		buildDurationMs: 15,
+		shards: [
+			{ index: 1, count: 2, durationMs: 10 },
+			{ index: 2, count: 2, durationMs: 30 },
+		],
+		phases: [{ name: "report-merge", durationMs: 10 }],
+		outcome: "passed",
+		exitCode: 0,
+	});
+});
+
+test("the default writer creates an overridden path and appends compact records", () => {
+	const directory = mkdtempSync(join(tmpdir(), "thinkrail-e2e-timing-"));
+	const path = join(directory, "nested", "runs.jsonl");
+	try {
+		for (const [runId, exitCode] of [
+			["run-a", 0],
+			["run-b", 2],
+		] as const) {
+			startE2eRunTiming("binary", [], {
+				env: { [E2E_TIMING_FILE_ENV]: path },
+				now: () => 5,
+				wallNow: () => new Date("2026-09-03T12:00:00.000Z"),
+				runId: () => runId,
+			}).finish(exitCode);
+		}
+		const content = readFileSync(path, "utf8");
+		expect(content.endsWith("\n")).toBe(true);
+		expect(
+			content
+				.trimEnd()
+				.split("\n")
+				.map((line) => JSON.parse(line)),
+		).toMatchObject([
+			{ runId: "run-a", outcome: "passed", exitCode: 0 },
+			{ runId: "run-b", outcome: "failed", exitCode: 2 },
+		]);
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("the preload starts total timing before the runner module claims it", () => {
+	let now = 10;
+	const lines: string[] = [];
+	const preloaded = preloadE2eRunTiming("/repo/e2e/run-binary.ts", ["e2e/host.spec.ts"], {
+		now: () => now,
+		append: (_path, line) => lines.push(line),
+	});
+	now = 25;
+	const claimed = startE2eRunTiming("binary", ["e2e/host.spec.ts"]);
+	expect(claimed).toBe(preloaded);
+	now = 50;
+	claimed.finish(0);
+	expect(JSON.parse(lines[0] ?? "").durationMs).toBe(40);
+});
+
+test("early failures retain an effective fallback selection and runner modes are explicit", () => {
+	const lines: string[] = [];
+	startE2eRunTiming("agent", ["--invalid"], {
+		append: (_path, line) => lines.push(line),
+	}).finish(1);
+	expect(JSON.parse(lines[0] ?? "")).toMatchObject({
+		mode: "agent",
+		selection: { playwrightArgs: ["--invalid"] },
+		outcome: "failed",
+	});
+	expect(e2eRunModeForEntrypoint("/repo/e2e/run.ts")).toBe("no-agent");
+	expect(e2eRunModeForEntrypoint("run-agent.ts")).toBe("agent");
+	expect(e2eRunModeForEntrypoint("/repo/e2e/run-full.ts")).toBe("full");
+	expect(e2eRunModeForEntrypoint("/repo/e2e/run-binary.ts")).toBe("binary");
+	expect(e2eRunModeForEntrypoint("/repo/e2e/run-desktop.ts")).toBe("desktop");
+	expect(e2eRunModeForEntrypoint("/repo/e2e/unknown.ts")).toBeNull();
+});
+
+test("list-only runs produce no record or filesystem path", () => {
+	const directory = mkdtempSync(join(tmpdir(), "thinkrail-e2e-timing-list-"));
+	const path = join(directory, "missing", "runs.jsonl");
+	try {
+		expect(isPlaywrightListRun(["e2e/host.spec.ts", "--list"])).toBe(true);
+		expect(isPlaywrightListRun(["--grep", "--list"])).toBe(false);
+		expect(isPlaywrightListRun(["--grep", "--list", "--list"])).toBe(true);
+		expect(isPlaywrightListRun(["--", "--list"])).toBe(false);
+		const timing = startE2eRunTiming("full", ["--list"], {
+			env: { [E2E_TIMING_FILE_ENV]: path },
+		});
+		timing.setSelection({ playwrightArgs: ["--list"], phases: ["no-agent", "agent"] });
+		expect(timing.finish(0)).toBe(0);
+		expect(existsSync(join(directory, "missing"))).toBe(false);
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+test("timing failures warn without changing results and parent environments stay immutable", () => {
+	const lines: string[] = [];
+	const interrupted = startE2eRunTiming("desktop", [], {
+		append: (_path, line) => lines.push(line),
+	});
+	expect(interrupted.finish(130, { interrupted: true })).toBe(130);
+	expect(JSON.parse(lines[0] ?? "")).toMatchObject({ outcome: "interrupted", exitCode: 130 });
+
+	const warnings: string[] = [];
+	const blockedPath = join(tmpdir(), "thinkrail-blocked", "runs.jsonl");
+	const failedWrite = startE2eRunTiming("desktop", [], {
+		env: { [E2E_TIMING_FILE_ENV]: blockedPath },
+		append: () => {
+			throw new Error("disk denied");
+		},
+		warn: (warning) => warnings.push(warning),
+	});
+	expect(failedWrite.finish(7)).toBe(7);
+	expect(warnings).toEqual([`E2E: could not append timing record to ${blockedPath}: disk denied`]);
+
+	const env = { KEEP: "yes" };
+	const childEnv = withE2eTimingParent(env, "parent-run");
+	expect(env).toEqual({ KEEP: "yes" });
+	expect(childEnv).toEqual({
+		KEEP: "yes",
+		[E2E_TIMING_PARENT_RUN_ID_ENV]: "parent-run",
+	});
+});

--- a/e2e/run.ts
+++ b/e2e/run.ts
@@ -9,7 +9,14 @@ import {
 	processRunnerInterruption,
 	runE2eProcess,
 	signalExitCode,
+	waitForE2eProcessDrain,
 } from "./processRunner";
+import {
+	E2E_TIMING_PARENT_RUN_ID_ENV,
+	type E2eRunTiming,
+	isPlaywrightListRun,
+	startE2eRunTiming,
+} from "./runTiming";
 import { parseRunnerArgs, resolveShardCount } from "./shardPlan";
 
 const rootDir = E2E_ROOT_DIR;
@@ -33,6 +40,7 @@ function childEnv(): NodeJS.ProcessEnv {
 	delete env.PLAYWRIGHT_BLOB_OUTPUT_FILE;
 	delete env[REAL_CENTRAL_E2E_ENV];
 	delete env[PARENT_SIGNAL_OWNER_ENV];
+	delete env[E2E_TIMING_PARENT_RUN_ID_ENV];
 	return env;
 }
 
@@ -65,12 +73,16 @@ function mergeLastRunFiles(reportDir: string, shardCount: number, failed: boolea
 	writeFileSync(join(outputDir, ".last-run.json"), `${JSON.stringify(lastRun, null, 2)}\n`);
 }
 
-async function runSerial(playwrightArgs: string[]): Promise<number> {
+async function runSerial(playwrightArgs: string[], timing: E2eRunTiming): Promise<number> {
 	console.log("E2E: running serially (one host, one worker)");
-	return run(playwrightCommand(playwrightArgs), childEnv());
+	return timing.timeShard(1, 1, () => run(playwrightCommand(playwrightArgs), childEnv()));
 }
 
-async function runShards(shardCount: number, playwrightArgs: string[]): Promise<number> {
+async function runShards(
+	shardCount: number,
+	playwrightArgs: string[],
+	timing: E2eRunTiming,
+): Promise<number> {
 	const startedAt = performance.now();
 	const reportDir = mkdtempSync(join(tmpdir(), "thinkrail-e2e-blobs-"));
 	const children: Promise<number>[] = [];
@@ -93,14 +105,16 @@ async function runShards(shardCount: number, playwrightArgs: string[]): Promise<
 		]);
 		const shardStartedAt = performance.now();
 		children.push(
-			runE2eProcess(command, { env }).then(({ exitCode }) => {
-				console.log(
-					`E2E: shard ${shard}/${shardCount} ${
-						exitCode === 0 ? "passed" : `failed (${exitCode})`
-					} in ${elapsed(shardStartedAt)}`,
-				);
-				return exitCode;
-			}),
+			timing
+				.timeShard(shard, shardCount, () => runE2eProcess(command, { env }))
+				.then(({ exitCode }) => {
+					console.log(
+						`E2E: shard ${shard}/${shardCount} ${
+							exitCode === 0 ? "passed" : `failed (${exitCode})`
+						} in ${elapsed(shardStartedAt)}`,
+					);
+					return exitCode;
+				}),
 		);
 	}
 
@@ -114,14 +128,9 @@ async function runShards(shardCount: number, playwrightArgs: string[]): Promise<
 	let mergeCode = 1;
 	if (reports.length > 0) {
 		const reporters = process.env.CI ? "github,html" : "dot";
-		mergeCode = await run([
-			bun,
-			"x",
-			"playwright",
-			"merge-reports",
-			`--reporter=${reporters}`,
-			reportDir,
-		]);
+		mergeCode = await timing.timePhase("report-merge", () =>
+			run([bun, "x", "playwright", "merge-reports", `--reporter=${reporters}`, reportDir]),
+		);
 	} else {
 		console.error(`E2E: no shard reports were produced; temporary output retained at ${reportDir}`);
 	}
@@ -138,30 +147,39 @@ async function runShards(shardCount: number, playwrightArgs: string[]): Promise<
 	return failed ? 1 : 0;
 }
 
-async function main(): Promise<number> {
+async function main(rawArgs: string[], timing: E2eRunTiming): Promise<number> {
 	await holdE2eIdleSleep();
-	const { playwrightArgs, shardOverride } = parseRunnerArgs(process.argv.slice(2));
+	const { playwrightArgs, shardOverride } = parseRunnerArgs(rawArgs);
 	const shardCount = resolveShardCount({
 		shardOverride,
 		envValue: process.env.THINKRAIL_E2E_SHARDS,
 		availableCpuCount: availableParallelism(),
 		hasPlaywrightArgs: playwrightArgs.length > 0,
 	});
+	timing.setSelection({ playwrightArgs, shardCount });
 
-	if (!playwrightArgs.includes("--list") && process.env.THINKRAIL_E2E_SKIP_BUILD !== "1") {
+	if (!isPlaywrightListRun(playwrightArgs) && process.env.THINKRAIL_E2E_SKIP_BUILD !== "1") {
 		const buildStartedAt = performance.now();
 		console.log("E2E: building web once before host startup");
-		const buildCode = await run([bun, "run", "build:web"]);
+		const buildCode = await timing.timeBuild(() => run([bun, "run", "build:web"]));
 		if (buildCode !== 0) return buildCode;
 		console.log(`E2E: web build ready in ${elapsed(buildStartedAt)}`);
 	}
 
-	return shardCount === 1 ? runSerial(playwrightArgs) : runShards(shardCount, playwrightArgs);
+	return shardCount === 1
+		? runSerial(playwrightArgs, timing)
+		: runShards(shardCount, playwrightArgs, timing);
 }
 
+const rawArgs = process.argv.slice(2);
+const timing = startE2eRunTiming("no-agent", rawArgs);
+let exitCode = 1;
 try {
-	process.exitCode = await main();
+	exitCode = await main(rawArgs, timing);
 } catch (error) {
 	console.error(error instanceof Error ? error.message : error);
-	process.exitCode = 1;
 }
+const interruption = processRunnerInterruption();
+if (interruption) await waitForE2eProcessDrain();
+timing.finish(exitCode, { interrupted: interruption !== null });
+process.exitCode = exitCode;

--- a/e2e/runTiming.ts
+++ b/e2e/runTiming.ts
@@ -1,0 +1,262 @@
+import { randomUUID } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const E2E_TIMING_FILE_ENV = "THINKRAIL_E2E_TIMING_FILE";
+export const E2E_TIMING_PARENT_RUN_ID_ENV = "THINKRAIL_E2E_TIMING_PARENT_RUN_ID";
+
+export type E2eRunMode = "no-agent" | "agent" | "full" | "binary" | "desktop";
+export type E2eRunOutcome = "passed" | "failed" | "interrupted";
+
+export interface E2eRunSelection {
+	playwrightArgs: string[];
+	shardCount?: number;
+	phases?: string[];
+}
+
+export interface E2eRunShardTiming {
+	index: number;
+	count: number;
+	durationMs: number;
+}
+
+export interface E2eRunPhaseTiming {
+	name: string;
+	durationMs: number;
+}
+
+export interface E2eRunTimingRecordV1 {
+	version: 1;
+	runId: string;
+	parentRunId?: string;
+	mode: E2eRunMode;
+	args: string[];
+	selection: E2eRunSelection;
+	startedAt: string;
+	durationMs: number;
+	buildDurationMs?: number;
+	shards?: E2eRunShardTiming[];
+	phases?: E2eRunPhaseTiming[];
+	outcome: E2eRunOutcome;
+	exitCode: number;
+}
+
+export interface E2eRunTimingDependencies {
+	env?: NodeJS.ProcessEnv;
+	now?: () => number;
+	wallNow?: () => Date;
+	runId?: () => string;
+	append?: (path: string, line: string) => void;
+	warn?: (message: string) => void;
+}
+
+export interface E2eRunTiming {
+	readonly runId: string;
+	setSelection(selection: E2eRunSelection): void;
+	timeBuild<T>(run: () => T | Promise<T>): Promise<T>;
+	timeShard<T>(index: number, count: number, run: () => T | Promise<T>): Promise<T>;
+	timePhase<T>(name: string, run: () => T | Promise<T>): Promise<T>;
+	finish(exitCode: number, options?: { interrupted?: boolean }): number;
+}
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const defaultTimingFile = fileURLToPath(new URL("./.run-timings.jsonl", import.meta.url));
+let preloadedTiming: { mode: E2eRunMode; args: string[]; timing: E2eRunTiming } | undefined;
+
+function appendTimingLine(path: string, line: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	appendFileSync(path, line);
+}
+
+function timingFile(env: NodeJS.ProcessEnv): string {
+	const configured = env[E2E_TIMING_FILE_ENV];
+	return configured ? resolve(repoRoot, configured) : defaultTimingFile;
+}
+
+function duration(startedAt: number, now: () => number): number {
+	return Math.max(0, Math.round(now() - startedAt));
+}
+
+function message(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export function withE2eTimingParent(env: NodeJS.ProcessEnv, runId: string): NodeJS.ProcessEnv {
+	return { ...env, [E2E_TIMING_PARENT_RUN_ID_ENV]: runId };
+}
+
+const optionsWithRequiredValues = new Set([
+	"--browser",
+	"-c",
+	"--config",
+	"-g",
+	"--grep",
+	"-G",
+	"--grep-invert",
+	"--global-timeout",
+	"-j",
+	"--workers",
+	"--last-failed-file",
+	"--max-failures",
+	"--output",
+	"--project",
+	"--repeat-each",
+	"--reporter",
+	"--retries",
+	"--run-agents",
+	"--shard",
+	"--shards",
+	"--test-list",
+	"--test-list-invert",
+	"--timeout",
+	"--trace",
+	"--tsconfig",
+	"--ui-host",
+	"--ui-port",
+	"--update-source-method",
+]);
+
+export function isPlaywrightListRun(args: readonly string[]): boolean {
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--") return false;
+		if (arg === "--list") return true;
+		if (optionsWithRequiredValues.has(arg)) index += 1;
+	}
+	return false;
+}
+
+export function e2eRunModeForEntrypoint(entrypoint: string | undefined): E2eRunMode | null {
+	switch (basename(entrypoint ?? "")) {
+		case "run.ts":
+			return "no-agent";
+		case "run-agent.ts":
+			return "agent";
+		case "run-full.ts":
+			return "full";
+		case "run-binary.ts":
+			return "binary";
+		case "run-desktop.ts":
+			return "desktop";
+		default:
+			return null;
+	}
+}
+
+function createE2eRunTiming(
+	mode: E2eRunMode,
+	args: readonly string[],
+	dependencies: E2eRunTimingDependencies = {},
+): E2eRunTiming {
+	const env = dependencies.env ?? process.env;
+	const now = dependencies.now ?? performance.now.bind(performance);
+	const wallNow = dependencies.wallNow ?? (() => new Date());
+	const append = dependencies.append ?? appendTimingLine;
+	const warn = dependencies.warn ?? ((warning: string) => console.error(warning));
+	const runId = (dependencies.runId ?? randomUUID)();
+	const parentRunId = env[E2E_TIMING_PARENT_RUN_ID_ENV] || undefined;
+	const startedAt = wallNow().toISOString();
+	const monotonicStartedAt = now();
+	const suppressed = isPlaywrightListRun(args);
+	const rawArgs = [...args];
+	let selection: E2eRunSelection = { playwrightArgs: [...args] };
+	let buildDurationMs: number | undefined;
+	const shards: E2eRunShardTiming[] = [];
+	const phases: E2eRunPhaseTiming[] = [];
+	let finished = false;
+
+	const measure = async <T>(run: () => T | Promise<T>, measured: (value: number) => void) => {
+		const measurementStartedAt = now();
+		try {
+			return await run();
+		} finally {
+			measured(duration(measurementStartedAt, now));
+		}
+	};
+
+	return {
+		runId,
+		setSelection(nextSelection) {
+			selection = {
+				...nextSelection,
+				playwrightArgs: [...nextSelection.playwrightArgs],
+				...(nextSelection.phases ? { phases: [...nextSelection.phases] } : {}),
+			};
+		},
+		timeBuild(run) {
+			return measure(run, (value) => {
+				buildDurationMs = value;
+			});
+		},
+		timeShard(index, count, run) {
+			return measure(run, (durationMs) => {
+				shards.push({ index, count, durationMs });
+			});
+		},
+		timePhase(name, run) {
+			return measure(run, (durationMs) => {
+				phases.push({ name, durationMs });
+			});
+		},
+		finish(exitCode, options = {}) {
+			if (finished) return exitCode;
+			finished = true;
+			if (suppressed) return exitCode;
+			const record: E2eRunTimingRecordV1 = {
+				version: 1,
+				runId,
+				...(parentRunId ? { parentRunId } : {}),
+				mode,
+				args: rawArgs,
+				selection,
+				startedAt,
+				durationMs: duration(monotonicStartedAt, now),
+				...(buildDurationMs === undefined ? {} : { buildDurationMs }),
+				...(shards.length === 0
+					? {}
+					: { shards: [...shards].sort((left, right) => left.index - right.index) }),
+				...(phases.length === 0 ? {} : { phases: [...phases] }),
+				outcome: options.interrupted ? "interrupted" : exitCode === 0 ? "passed" : "failed",
+				exitCode,
+			};
+			const path = timingFile(env);
+			try {
+				append(path, `${JSON.stringify(record)}\n`);
+			} catch (error) {
+				warn(`E2E: could not append timing record to ${path}: ${message(error)}`);
+			}
+			return exitCode;
+		},
+	};
+}
+
+export function preloadE2eRunTiming(
+	entrypoint: string | undefined,
+	args: readonly string[],
+	dependencies: E2eRunTimingDependencies = {},
+): E2eRunTiming | null {
+	const mode = e2eRunModeForEntrypoint(entrypoint);
+	if (!mode) return null;
+	const timing = createE2eRunTiming(mode, args, dependencies);
+	preloadedTiming = { mode, args: [...args], timing };
+	return timing;
+}
+
+export function startE2eRunTiming(
+	mode: E2eRunMode,
+	args: readonly string[],
+	dependencies: E2eRunTimingDependencies = {},
+): E2eRunTiming {
+	if (
+		Object.keys(dependencies).length === 0 &&
+		preloadedTiming?.mode === mode &&
+		preloadedTiming.args.length === args.length &&
+		preloadedTiming.args.every((arg, index) => arg === args[index])
+	) {
+		const timing = preloadedTiming.timing;
+		preloadedTiming = undefined;
+		return timing;
+	}
+	return createE2eRunTiming(mode, args, dependencies);
+}


### PR DESCRIPTION
## Summary

Add durable, local timing evidence for browser E2E runs so slow, skewed, failed, and interrupted executions can be diagnosed from real history instead of anecdotes. This PR is stacked directly on #389.

## Changes

- Append compact versioned JSONL records to gitignored `e2e/.run-timings.jsonl`, with `THINKRAIL_E2E_TIMING_FILE` as a test/automation override.
- Record mode, raw/effective selection, UTC start, monotonic total/build/shard/phase durations, outcome, exit code, and full-run parent lineage across source, agent, full, binary, and desktop modes.
- Start timing in the shared preload so idle-sleep setup is included and its failures are captured; suppress true list/preflight commands with option-aware parsing.
- Keep writes best-effort and ensure managed interruptions include bounded descendant cleanup before finalization.
- Harden full/Central list preflights and clear desktop timeout/readiness losers so diagnostics cannot alter or underreport the runner lifecycle.
- Add focused timing, lineage, interruption, and environment tests plus spec/docs updates.

## Stack

1. #389 — macOS idle-sleep guard
2. **local JSONL timing records (this PR)**
3. #391 — focused and repair commands

Land bottom-up in this order.

## Testing

- `bun run e2e` — 350 passed across 8 shards
- `bun run check:deps && bun run check:boundaries && bun run check:seams && bun run lint && bun run typecheck && bun run test` — passed
- Focused timing/agent/signal coverage — 18 passed
- Focused `e2e:full` lineage run — 6 passed with linked parent/child records
- True `--list` runs produced no timing file; `--grep --list` remained a recorded non-list failure

