### PR TITLE
perf(e2e): add focused repair commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,8 +155,8 @@ reusable by any pi UI (extraction-ready as a future `packages/chat-ui`).
 
 Every change that touches the app is verified by the **complete e2e suite once before it is considered
 done**. During implementation, iterate with the affected spec
-(`bun run e2e -- e2e/<feature>.spec.ts`) or `bun run e2e -- --last-failed`; do not rerun the full gate
-after every edit.
+(`bun run e2e:focused -- e2e/<feature>.spec.ts`) or `bun run e2e:repair`; do not rerun the full gate after
+every edit. Focused runs stop after the first failure; repair runs every failure remembered by Playwright.
 
 `bun run e2e` is **fully self-contained and machine-adaptive**: it builds the web app once, then runs the
 no-agent tests across isolated Playwright shard processes (automatic count = half the available CPUs,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,16 +48,17 @@ shards (half the available CPUs, capped at eight):
 ```bash
 bunx playwright install chromium                    # one-time
 bun run e2e                                         # complete no-agent gate
-bun run e2e -- e2e/changes.spec.ts                  # focused iteration
-bun run e2e -- --last-failed                        # repair loop
+bun run e2e:focused -- e2e/changes.spec.ts          # serial; stop after first failure
+bun run e2e:repair                                  # serial; run every remembered failure
 bun run e2e:serial                                  # one-host debugging fallback
 bun run e2e -- --shards=12                          # explicit 1–16 override
 bun run e2e:full                                    # everything; needs pi auth
 bun run e2e:agent                                   # only @agent; remains serial
 ```
 
-Use focused or last-failed runs while iterating, then run the complete `bun run e2e`
-once before handoff. On macOS, every public browser E2E command prevents idle system sleep for the
+Use `e2e:focused` or `e2e:repair` while iterating, then run the complete `bun run e2e` once before
+handoff. Repair revisits the complete remembered failure set rather than stopping after its first failure.
+On macOS, every public browser E2E command prevents idle system sleep for the
 runner's lifetime while allowing the display to sleep normally. Completed runs append local timing evidence
 to the gitignored `e2e/.run-timings.jsonl`; `THINKRAIL_E2E_TIMING_FILE` redirects it for automation, and it
 is always safe to delete. Agent-driven specs are tagged `@agent` and run against a real provider on an

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ uses a machine-adaptive number of independent shards (half the available CPUs, c
 ```bash
 bunx playwright install chromium                    # one-time
 bun run e2e                                         # complete no-agent gate
-bun run e2e -- e2e/changes.spec.ts                  # focused iteration
-bun run e2e -- --last-failed                        # repair loop
+bun run e2e:focused -- e2e/changes.spec.ts          # serial; stop after first failure
+bun run e2e:repair                                  # serial; run every remembered failure
 bun run e2e:serial                                  # one-host debugging fallback
 bun run e2e -- --shards=12                          # explicit 1–16 override
 bun run e2e:binary                                  # packaged CLI host (build first)
@@ -167,7 +167,9 @@ bun run e2e:full                                    # everything; needs pi auth
 bun run e2e:agent                                   # only @agent; remains serial
 ```
 
-On macOS, every public browser E2E command prevents idle system sleep while its runner is alive; the
+`e2e:repair` intentionally does not stop on its first failure, so every failure from the prior run is
+revisited before Playwright replaces its last-run file. On macOS, every public browser E2E command prevents
+idle system sleep while its runner is alive; the
 display may still sleep normally. Completed runs append local timing evidence to the gitignored
 `e2e/.run-timings.jsonl`; set `THINKRAIL_E2E_TIMING_FILE` to redirect it, or delete it at any time.
 

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -29,6 +29,9 @@ is one or many.
 The automatic count is half the available CPU parallelism, clamped to 1–8. Developers may explicitly
 select 1–16 lanes; `e2e:serial` is the stable debugging fallback. A focused invocation carrying Playwright
 arguments defaults to one lane unless its shard count is explicit, so an iteration on one spec stays cheap.
+`e2e:focused` makes that one-lane loop explicit and stops after the first failure. `e2e:repair` runs
+Playwright's complete remembered failure set serially and deliberately does not inherit focused fail-fast
+behavior, because an early stop could replace the last-run file before every remembered failure is revisited.
 Every public browser E2E runner owns one process-lifetime idle-sleep assertion on macOS before setup or
 build work begins; source, agent, full, binary, and desktop modes all receive it. The assertion uses the
 system `caffeinate` executable with idle-system-sleep scope and the owning runner pid, so display sleep stays
@@ -222,7 +225,8 @@ Windows lane into the real profile (see `module-shared`).
 
 ## Verification policy
 
-During iteration, run the affected specs and use Playwright's last-failed mode. Flake repairs replace
+During iteration, use `e2e:focused` for affected specs and `e2e:repair` for Playwright's complete
+last-failed set. Flake repairs replace
 irrelevant expensive setup with equivalent fixture state and wait for observable readiness; blanket retries,
 arbitrary sleeps, and assertion weakening are not synchronization policy. Live-provider completion waits on
 the session's streaming state after response evidence appears; the optional rendered `Done` row is not a

--- a/e2e/shard-runner.spec.ts
+++ b/e2e/shard-runner.spec.ts
@@ -9,6 +9,14 @@ import {
 	resolveShardCount,
 } from "./shardPlan";
 
+function rootScripts(): Record<string, string> {
+	return (
+		JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+			scripts: Record<string, string>;
+		}
+	).scripts;
+}
+
 test("one macOS runner owns one pid-scoped idle-sleep assertion", async () => {
 	const env: NodeJS.ProcessEnv = {};
 	const commands: string[][] = [];
@@ -54,12 +62,12 @@ test("a macOS assertion that exits during startup fails the runner", async () =>
 });
 
 test("every public browser E2E command preloads the idle-sleep assertion", () => {
-	const rootPackage = JSON.parse(
-		readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-	) as { scripts: Record<string, string> };
+	const scripts = rootScripts();
 	for (const name of [
 		"e2e",
 		"e2e:serial",
+		"e2e:focused",
+		"e2e:repair",
 		"e2e:binary",
 		"e2e:desktop",
 		"e2e:full",
@@ -69,8 +77,20 @@ test("every public browser E2E command preloads the idle-sleep assertion", () =>
 		"e2e:headed",
 		"e2e:ui",
 	]) {
-		expect(rootPackage.scripts[name]).toContain("bun --preload ./e2e/idleSleepPreload.ts");
+		expect(scripts[name]).toContain("bun --preload ./e2e/idleSleepPreload.ts");
 	}
+});
+
+test("iteration commands separate first-failure focus from complete remembered repair", () => {
+	const scripts = rootScripts();
+	expect(scripts.e2e).toBe("bun --preload ./e2e/idleSleepPreload.ts e2e/run.ts");
+	expect(scripts["e2e:focused"]).toBe(
+		"bun --preload ./e2e/idleSleepPreload.ts e2e/run.ts --serial --max-failures=1",
+	);
+	expect(scripts["e2e:repair"]).toBe(
+		"bun --preload ./e2e/idleSleepPreload.ts e2e/run.ts --serial --last-failed",
+	);
+	expect(scripts["e2e:repair"]).not.toContain("max-failures");
 });
 
 test("automatic shard count budgets two CPUs per browser/host pair and stays bounded", () => {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
 		"prepare": "husky",
 		"e2e": "bun --preload ./e2e/idleSleepPreload.ts e2e/run.ts",
 		"e2e:serial": "bun --preload ./e2e/idleSleepPreload.ts e2e/run.ts --serial",
+		"e2e:focused": "bun --preload ./e2e/idleSleepPreload.ts e2e/run.ts --serial --max-failures=1",
+		"e2e:repair": "bun --preload ./e2e/idleSleepPreload.ts e2e/run.ts --serial --last-failed",
 		"e2e:binary": "bun --preload ./e2e/idleSleepPreload.ts e2e/run-binary.ts",
 		"e2e:desktop": "bun --preload ./e2e/idleSleepPreload.ts e2e/run-desktop.ts",
 		"test:workflows": "playwright test -c playwright.workflows.config.ts",


### PR DESCRIPTION
## Summary

Make the cheap repair loop explicit without weakening or changing the complete `bun run e2e` handoff gate. This PR is stacked directly on #390.

## Changes

- Add `e2e:focused` for one-host, one-worker iteration that stops after the first failure.
- Add `e2e:repair` for a serial `--last-failed` run that deliberately omits fail-fast, ensuring every remembered failure is revisited before Playwright replaces its last-run file.
- Keep the existing `e2e` script byte-for-byte unchanged as the complete machine-adaptive no-agent gate.
- Pin the command semantics in runner coverage and update the E2E contract and contributor guidance.

## Stack

1. #389 — macOS idle-sleep guard
2. #390 — local JSONL timing records
3. **focused and repair commands (this PR)**

Land bottom-up in this order.

## Testing

- `bun run e2e` — 351 passed across 8 shards
- `bun run check:deps && bun run check:boundaries && bun run check:seams && bun run lint && bun run typecheck && bun run test` — passed
- `bun run e2e:focused -- e2e/shard-runner.spec.ts` — 8 passed; timing confirmed one shard plus `--max-failures=1`
- Synthetic two-failure run followed by `bun run e2e:repair` — both remembered failures executed
- Post-rebase focused cumulative runner coverage — 26 passed
