### PR TITLE
Make todo_write an identity-preserving reconcile

### DIFF
--- a/e2e/plan-open-pr.spec.ts
+++ b/e2e/plan-open-pr.spec.ts
@@ -49,7 +49,7 @@ test("Open PR: no origin errors, with origin pushes, re-press follows the same b
 	gitAs(workspace.worktreePath, "remote", "add", "origin", bare);
 	writeFileSync(join(workspace.worktreePath, "flood.ts"), "export const wait = 1;\n");
 	gitAs(workspace.worktreePath, "add", "--", "flood.ts");
-	gitAs(workspace.worktreePath, "commit", "--no-verify", "-m", "todo: implement FloodWait");
+	gitAs(workspace.worktreePath, "commit", "--no-verify", "-m", "fix(sender): handle FloodWait");
 	const firstSha = gitAs(workspace.worktreePath, "rev-parse", "HEAD");
 	const branch = gitAs(workspace.worktreePath, "rev-parse", "--abbrev-ref", "HEAD");
 
@@ -62,7 +62,13 @@ test("Open PR: no origin errors, with origin pushes, re-press follows the same b
 
 	writeFileSync(join(workspace.worktreePath, "flood.ts"), "export const wait = 2;\n");
 	gitAs(workspace.worktreePath, "add", "--", "flood.ts");
-	gitAs(workspace.worktreePath, "commit", "--no-verify", "-m", "todo: tune FloodWait");
+	gitAs(
+		workspace.worktreePath,
+		"commit",
+		"--no-verify",
+		"-m",
+		"fix(sender): tune the FloodWait backoff",
+	);
 	const secondSha = gitAs(workspace.worktreePath, "rev-parse", "HEAD");
 
 	await openPr.click();

--- a/e2e/plan-review.spec.ts
+++ b/e2e/plan-review.spec.ts
@@ -33,32 +33,32 @@ test("reviewable steps show the reviewed counter, Start review, and the settled 
 		workspace.worktreePath,
 		"flood.ts",
 		"export const wait = 1;\n",
-		"todo: implement FloodWait handling",
+		"fix(sender): handle FloodWait",
 	);
 	const shaFlagged = commitFile(
 		workspace.worktreePath,
 		"parse.ts",
 		"export const parse = 1;\n",
-		"todo: implement parser",
+		"feat(parser): implement the parser",
 	);
 	const shaFlaggedFix = commitFile(
 		workspace.worktreePath,
 		"parse.ts",
 		"export const parse = 2;\n",
-		"todo: fix parser edge case",
+		"fix(parser): handle the empty-input edge case",
 	);
 	const shaDone = commitFile(
 		workspace.worktreePath,
 		"retry.ts",
 		"export const retries = 3;\n",
-		"todo: implement retry policy",
+		"feat(sender): add the retry policy",
 	);
 	const todosDir = join(workspace.worktreePath, ".thinkrail", "context", "todos");
 	mkdirSync(todosDir, { recursive: true });
 	writeFileSync(
 		join(todosDir, `${sessionId}.json`),
 		JSON.stringify({
-			version: 5,
+			version: 6,
 			todos: [],
 			summary: "FloodWait handling shipped end to end; suite green.",
 			groups: [

--- a/e2e/reflection.live.spec.ts
+++ b/e2e/reflection.live.spec.ts
@@ -64,14 +64,14 @@ test("Start review → reviewer requests changes → an independent reflector ju
 		workspace.worktreePath,
 		"sum.ts",
 		'import { helper } from "./does-not-exist";\n\nexport const sum = (a: number, b: number): number => helper(a) - b;\n',
-		"todo: add sum helper",
+		"feat(math): add a sum helper",
 	);
 	const todosDir = join(workspace.worktreePath, ".thinkrail", "context", "todos");
 	mkdirSync(todosDir, { recursive: true });
 	writeFileSync(
 		join(todosDir, `${sessionId}.json`),
 		JSON.stringify({
-			version: 5,
+			version: 6,
 			todos: [
 				{
 					id: "t_sum",

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -227,7 +227,11 @@ of the host.
   (same one-home rationale), never stored; absent = the sha no longer resolves, degrade silently.
   `TodoItem.summary` / `TodoPlan.summary` are the agent's completion notes (per step / whole plan, as
   stored) and `TodoItem.verification` the separate self-reported check line (exact command + result, or
-  "not verified" — clients render it as a badge labeled as the agent's own claim, never a host gate); **`TodoItem.review?: TodoReviewInfo`** (+ the **`TodoReviewState`** union) is the host-derived
+  "not verified" — clients render it as a badge labeled as the agent's own claim, never a host gate).
+  `TodoItem.commitSubject` is the third stored done-time field: the git subject the host commits the
+  item's delta under (the `title` is the plan step for the panel, this is the line that lands in the
+  repository's history — see [[submodule-server-todos]]). It is on the wire because the DTO mirrors the
+  stored item, not because any client renders it today; **`TodoItem.review?: TodoReviewInfo`** (+ the **`TodoReviewState`** union) is the host-derived
   review decoration, present only on reviewable items (those with a host change set): `state`
   (`unreviewed`/`reviewed`/`changes_requested` — `unreviewed` = no stored record), `revision` (commit
   count — 1 TODO = N commits), `unreviewedShas` (commits since the user's watermark — the "changed since

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -139,6 +139,7 @@ export interface TodoItem {
 	note?: string;
 	summary?: string;
 	verification?: string;
+	commitSubject?: string;
 	artifacts?: TodoArtifact[];
 	/**
 	 * The item's review decoration — **host-derived on `todo.list`, present only on reviewable items**

--- a/packages/pi-todos/SPEC.md
+++ b/packages/pi-todos/SPEC.md
@@ -13,9 +13,9 @@ tags: [pi-extension, todos, v2]
 
 `pi-todos` is a portable pi-package that gives the `pi` agent a **chat-scoped TODO list** — its working
 plan for the conversation, which the user can also add to. It is the *engine* behind the chat's TODO
-plan UX ([[submodule-web-chat]]'s "Chat TODO plan"), modeled on [[module-spec-graph]]: a skill, five `todo_*` custom tools, and one `before_agent_start` rule.
+plan UX ([[submodule-web-chat]]'s "Chat TODO plan"), modeled on [[module-spec-graph]]: a skill, six `todo_*` custom tools, and one `before_agent_start` rule.
 
-- **`index.ts`** — an `ExtensionFactory` registering the five tools and one always-on `before_agent_start`
+- **`index.ts`** — an `ExtensionFactory` registering the six tools and one always-on `before_agent_start`
   rule. The rule is deliberately **short and byte-stable** — awareness that a shared list + `todo_*` tools
   exist, plus a pointer to the todos skill. The lever is *understanding*, not prompt volume: **how to work
   with the list lives in the skill; each tool's invariants live in its own description.** (We tried
@@ -24,7 +24,7 @@ plan UX ([[submodule-web-chat]]'s "Chat TODO plan"), modeled on [[module-spec-gr
   `TodoStore` (read-modify-write `.thinkrail/context/todos/<sessionId>.json`). No `@earendil-works/*` imports, so
   the host can value-import `pi-todos/core` to power the plan viewer — reading the plan and writing the
   user's own edits (the `spec/` → `spec.graph` pattern).
-- **`tools/`** — the five `todo_*` custom tools ([[submodule-pi-todos-tools]]), thin wrappers over `core/`.
+- **`tools/`** — the six `todo_*` custom tools ([[submodule-pi-todos-tools]]), thin wrappers over `core/`.
 - **`skills/todos/SKILL.md`** — the bundled skill: the chat-plan discipline — group = task (one user
   ask, outcome-titled; 1–7 verifiable, ≈commit-sized steps), work tasks strictly in order with one step
   `in_progress` (blocked task = note why, tell the user, move on), fold in the user's mid-conversation
@@ -38,7 +38,8 @@ plan UX ([[submodule-web-chat]]'s "Chat TODO plan"), modeled on [[module-spec-gr
 | `todo_add` | Add one item — into a `group`, or `after` an existing item (**one of the two is required**: the agent can't author loose items). |
 | `todo_update` | Change an item's status / title / note / artifacts — how the agent flips `pending → in_progress → done`. Reports auto-demoted (`paused`) items; a `done` flip suggests the group's next open step. |
 | `todo_remove` | Drop an item. |
-| `todo_write` | Replace the agent's plan with fresh **groups only** — one group per task, steps inside (the plan-first pattern). |
+| `todo_write` | **Reconcile** the agent's plan from fresh **groups only** — one group per task, steps inside (the plan-first pattern). Identity-preserving, not a destructive replace: see below. |
+| `todo_plan_summary` | Set/clear the plan-level completion summary (`TodoFile.summary`) — the overall handoff note written when the whole plan is done. |
 
 **Group = task.** The plan's model is two-level: a group is one user ask (title = the outcome), its
 items are the steps. A group's own status is **derived, never stored** (`groupStatus` in `core/`:
@@ -75,10 +76,16 @@ wire method exists and accepts a status, but no UI path calls it today; it's res
 lever.)
 
 Each item carries an **`origin`** (`agent` | `user`) — UI adds are `user`, the agent's tools write
-`agent`. This is a **structural guard, not just guidance**: `todo_write` (the agent re-laying its plan)
-**preserves `user` items and any `done` item**, replacing only the agent's own open items — so a re-plan
-can never drop the user's requests or the completed history. The UI marks `user` items so the human sees
-which are theirs.
+`agent`. This is a **structural guard, not just guidance**: `todo_write` is an **identity-preserving
+reconcile, not a replace** — written steps are matched to existing ones by `(group title, step title)` and
+keep their id/status/summary/verification/commitSubject/artifacts (only `note` is refreshed; a written
+status on a match is ignored — status advances via `todo_update`). Unmatched written steps are created;
+omitted **agent-open** steps are dropped; **`user` items and any `done` item are always preserved** — so a
+re-plan can never drop the user's requests or the completed history, and re-running it is lossless. The
+**loose lane is user-only**: `WritePlan` has no `todos` field (writes are groups-only), so the agent never
+mints a loose item; the UI marks `user` items so the human sees which are theirs. See
+[[submodule-pi-todos-core]] for the full reconcile contract (title-matching is the accepted limit — a
+rename reads as a new step).
 
 ## Artifacts
 
@@ -89,8 +96,11 @@ the tools (a `spec` from `spec_create`'s `{path,id}`); **`change` and `commit` a
 agent marks an item `done`, the host commits the item's work and records just the `sha` (one `commit`
 artifact — the file list is derived from git at read time, never denormalized); `change` path-lists are
 the host's **no-commit fallback** only, see [[submodule-server-todos]]. The pi-free `core`/`tools`
-never touch git — they just store whatever artifacts they're handed. The on-disk file `version` is `4`
-(`3` added artifacts, `4` added the `commit` kind); an older file with no artifacts upgrades on write.
+never touch git — they just store whatever artifacts they're handed. Beyond artifacts, a done item may
+carry a **`summary`** + **`verification`** (the review trail) and a **`commitSubject`** (the git-facing
+title the host commits with); all three clear when the item leaves `done`, see [[submodule-pi-todos-core]].
+The on-disk file `version` is `6` (`3` added artifacts, `4` added the `commit` kind, `5` added the
+`summary` fields, `6` added `commitSubject`); an older file upgrades on the next write.
 
 ## Boundary
 

--- a/packages/pi-todos/core/SPEC.md
+++ b/packages/pi-todos/core/SPEC.md
@@ -59,6 +59,35 @@ fresh plan is new work. Review *state* is never stored here: it is user-owned an
 ships the result on the wire DTO (`TodoGroupItem.status`, see [[submodule-server-todos]]), so `apps/web` —
 which may import `contracts` only — renders it rather than keeping a second copy of the truth table.
 
+**`replaceAll` is an identity-preserving reconcile, not a replace.** `todo_write` sends a *desired*
+plan; the model reaches for it to say "make the plan look like this, keep the progress", so
+`replaceAll(plan)` reconciles rather than rebuilding from scratch:
+
+- Each written grouped item is **matched** to an existing **agent** item by the key
+  `(group title, item title)` — both compared *decoded*; the first unconsumed match wins (duplicate
+  titles reconcile positionally). A **match reuses the existing item**: its `id`, `createdAt`, `status`,
+  `summary`, `verification`, `commitSubject`, and `artifacts` are kept; only `note` is updated from the
+  write. A `status` in the write is **ignored for a matched item** — status advances only through
+  `update`, so a re-listed `in_progress`/`done` step is never knocked back to `pending`. An **unmatched**
+  written item is created fresh.
+- **Leftovers** (existing items no written item matched): `origin: "user"` items are preserved into the
+  loose lane; `done` items are preserved (rejoin a fresh group of the same title, else carried over under
+  their original group, appended after the fresh groups); **agent + open** items are **dropped** — that is
+  the legitimate "removed a step". Consequence: re-writing the same plan is a **no-op on progress** (no
+  status reset, no duplicates, no orphaning).
+
+**Loose lane = user-only** (held structurally): `TodoPlan.todos` (the lane the UI renders as "Other")
+carries **only `origin: "user"` items** — agent-authored items always live in a group. Only user items
+ever reach `resultLoose`; the tools also refuse a direct loose agent write (`todo_add` needs
+`group`/`after`; `todo_write` takes `groups` only). The invariant is robust by construction, not
+dependent on the agent's tool discipline.
+
+**Matching is title-based, by design's current increment.** Because the key is `(group title, item
+title)`, a **group rename** or a **step rename** is not followed: the old item's done work is preserved
+(carried under the old name), its open work is dropped, and the renamed item appears fresh. This is the
+accepted cost of title matching; an optional per-item `id` in the `todo_write` schema is the planned next
+increment that makes matching rename-proof.
+
 **Linearity invariants** (held structurally): `update` setting `in_progress` auto-demotes every other
 `in_progress` item back to `pending` in the same write and returns them (`TodoUpdateResult.paused`) so
 the change stays visible; `replaceAll` re-establishes it over its **merged** result (fresh plan + the kept

--- a/packages/pi-todos/core/SPEC.md
+++ b/packages/pi-todos/core/SPEC.md
@@ -24,9 +24,9 @@ stores them; it does not resolve paths, compute diffs, or touch git. `file`/`spe
 agent (a `spec` naturally from `spec_create`'s `{path,id}`); `change` **and** `commit` are attached by the
 host when an item reaches `done` — the host commits the item's work and records just the sha, or falls
 back to a `change` path-list when it couldn't commit (see `server/src/todos` — the store stays git-free). `sanitize` drops an entry lacking its key (a `commit` with
-no `sha`, any other kind with no `path`). The on-disk `version` is `5` (`3` added `artifacts`, `4` added
-the `commit` kind, `5` added the `summary` fields); an older file reads cleanly and is upgraded on the
-next write.
+no `sha`, any other kind with no `path`). The on-disk `version` is `6` (`3` added `artifacts`, `4` added
+the `commit` kind, `5` added the `summary` fields, `6` added `commitSubject`); an older file reads cleanly
+and is upgraded on the next write.
 
 **Summaries (the review trail).** An item may carry `summary` — the agent's completion note (what/why,
 the decisions the diff can't show) — and **`verification`**, a separate field for the exact check run +
@@ -36,7 +36,18 @@ plan-level `summary` (`TodoFile.summary`, written by `TodoStore.setSummary`) —
 the agent writes when the whole plan completes. Both are stored verbatim across later edits, with one
 invalidation rule: `update` clears an item's `summary`/`verification`, and drops the plan-level `summary`
 with it, the moment that item's `status` leaves `done` — unless the same patch also supplies fresh values
-for them, which win. A UI reader can gate display on "everything done", but a non-UI consumer (a generated
+for them, which win.
+
+**`commitSubject` (the git-facing title).** A third done-time field, same family and the same
+invalidation rule: the subject line the host uses verbatim when it commits the item's delta (see
+[[submodule-server-todos]]). It exists because `title` and a commit subject are **different texts for
+different readers** — `title` is a plan step in the user's status panel ("Newest-first chat order"),
+while the subject lands in the repository's permanent history next to human commits and must match that
+history's own convention ("feat(web): add newest-first chat order"). Deriving one from the other is not
+possible (the change's type/scope is knowable only from the change), so the agent authors both and the
+store just carries them. The model stays git-free: it never validates the style, never reads `git log` —
+the tool description and the todos skill carry the "match this repo's history" instruction, and the host
+falls back to `title` when the field is absent. A UI reader can gate display on "everything done", but a non-UI consumer (a generated
 PR body, a work report) has no such gate, so a reopened item's stale completion story must not survive on
 disk, not merely be hidden. `replaceAll` deliberately does **not** carry the plan summary over — a
 fresh plan is new work. Review *state* is never stored here: it is user-owned and lives in a host sidecar

--- a/packages/pi-todos/core/SPEC.md
+++ b/packages/pi-todos/core/SPEC.md
@@ -73,13 +73,17 @@ plan; the model reaches for it to say "make the plan look like this, keep the pr
 - **Leftovers** (existing items no written item matched): `origin: "user"` items are preserved into the
   loose lane; `done` items are preserved (rejoin a fresh group of the same title, else carried over under
   their original group, appended after the fresh groups); **agent + open** items are **dropped** — that is
-  the legitimate "removed a step". Consequence: re-writing the same plan is a **no-op on progress** (no
+  the legitimate "removed a step". A leftover **agent `done` item in the loose lane** (only reachable from a
+  legacy/hand-edited file — no live path writes an agent loose item) is carried into a `"Completed"` group
+  rather than left in the user's lane, so the loose-lane invariant below holds after every reconcile. Consequence: re-writing the same plan is a **no-op on progress** (no
   status reset, no duplicates, no orphaning).
 
 **Loose lane = user-only** (held structurally): `TodoPlan.todos` (the lane the UI renders as "Other")
-carries **only `origin: "user"` items** — agent-authored items always live in a group. Only user items
-ever reach `resultLoose`; the tools also refuse a direct loose agent write (`todo_add` needs
-`group`/`after`; `todo_write` takes `groups` only). The invariant is robust by construction, not
+carries **only `origin: "user"` items** — agent-authored items always live in a group. `WritePlan` has
+**no `todos` field** (`todo_write` reconciles `groups` only), so a write can never mint a loose agent item,
+and `replaceAll` only ever admits `origin: "user"` items to `resultLoose` — a leftover agent `done` loose
+item (a legacy stray) is carried into a `"Completed"` group, an open one dropped. The tools also refuse a
+direct loose agent write (`todo_add` needs `group`/`after`). The invariant is robust by construction, not
 dependent on the agent's tool discipline.
 
 **Matching is title-based, by design's current increment.** Because the key is `(group title, item

--- a/packages/pi-todos/core/core.test.ts
+++ b/packages/pi-todos/core/core.test.ts
@@ -142,7 +142,7 @@ test("add places an item into a named group (created if new) or loose", () => {
 	}
 });
 
-test("done items in a group rejoin it across a re-plan; a dropped group's done items fall to loose", () => {
+test("across a re-plan done items rejoin a matching group and a dropped group's done items stay grouped, never loose", () => {
 	const root = tempRoot();
 	try {
 		const s = store(root);
@@ -154,8 +154,92 @@ test("done items in a group rejoin it across a re-plan; a dropped group's done i
 		const plan = s.replaceAll({ groups: [{ title: "Import", todos: [{ title: "next step" }] }] });
 		const importGroup = plan.groups.find((g) => g.title === "Import");
 		expect(importGroup?.todos.map((t) => t.title)).toContain("kept done");
-		expect(plan.groups.find((g) => g.title === "Gone")).toBeUndefined();
-		expect(plan.todos.map((t) => t.title)).toContain("orphan done");
+		const goneGroup = plan.groups.find((g) => g.title === "Gone");
+		expect(goneGroup?.todos.map((t) => t.title)).toEqual(["orphan done"]);
+		expect(plan.groups.map((g) => g.title)).toEqual(["Import", "Gone"]);
+		expect(plan.todos.map((t) => t.title)).not.toContain("orphan done");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("re-plan keeps the loose lane user-only: agent items never leak into it", () => {
+	const root = tempRoot();
+	try {
+		const s = store(root);
+		const userLoose = s.add({ title: "user request", origin: "user" });
+		const agentDone = s.add({ title: "agent done", group: "Gone" });
+		s.update(agentDone.id, { status: "done" });
+
+		const plan = s.replaceAll({ groups: [{ title: "Fresh", todos: [{ title: "step" }] }] });
+		expect(plan.todos.map((t) => t.id)).toEqual([userLoose.id]);
+		expect(plan.todos.every((t) => t.origin === "user")).toBe(true);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("reconcile: re-listing a step keeps its id, in_progress status and summary (no reset, no dup)", () => {
+	const root = tempRoot();
+	try {
+		const s = store(root);
+		const a = s.add({ title: "step a", group: "Task" });
+		s.add({ title: "step b", group: "Task" });
+		s.update(a.id, { status: "in_progress", summary: "halfway" });
+
+		const plan = s.replaceAll({
+			groups: [
+				{
+					title: "Task",
+					todos: [{ title: "step a", status: "done" }, { title: "step b" }, { title: "step c" }],
+				},
+			],
+		});
+		const task = plan.groups.find((g) => g.title === "Task");
+		const reA = task?.todos.find((t) => t.title === "step a");
+		expect(reA?.id).toBe(a.id);
+		expect(reA?.status).toBe("in_progress");
+		expect(reA?.summary).toBe("halfway");
+		expect(task?.todos.filter((t) => t.title === "step a")).toHaveLength(1);
+		expect(task?.todos.map((t) => t.title)).toEqual(["step a", "step b", "step c"]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("reconcile: an agent-open step omitted from the re-plan is dropped; a done one is preserved", () => {
+	const root = tempRoot();
+	try {
+		const s = store(root);
+		s.add({ title: "open step", group: "Task" });
+		const done = s.add({ title: "done step", group: "Task" });
+		s.update(done.id, { status: "done" });
+
+		const plan = s.replaceAll({ groups: [{ title: "Task", todos: [{ title: "new step" }] }] });
+		const task = plan.groups.find((g) => g.title === "Task");
+		expect(task?.todos.map((t) => t.title)).toContain("new step");
+		expect(task?.todos.map((t) => t.title)).toContain("done step");
+		expect(task?.todos.map((t) => t.title)).not.toContain("open step");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("reconcile: duplicate step titles in a group are matched positionally", () => {
+	const root = tempRoot();
+	try {
+		const s = store(root);
+		const first = s.add({ title: "dup", group: "Task" });
+		const second = s.add({ title: "dup", group: "Task" });
+		s.update(first.id, { status: "in_progress" });
+		s.update(second.id, { status: "done" });
+
+		const plan = s.replaceAll({
+			groups: [{ title: "Task", todos: [{ title: "dup" }, { title: "dup" }] }],
+		});
+		const task = plan.groups.find((g) => g.title === "Task");
+		expect(task?.todos.map((t) => t.id)).toEqual([first.id, second.id]);
+		expect(task?.todos.map((t) => t.status)).toEqual(["in_progress", "done"]);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/packages/pi-todos/core/core.test.ts
+++ b/packages/pi-todos/core/core.test.ts
@@ -92,13 +92,16 @@ test("replaceAll overwrites the agent's open items with fresh ones", () => {
 	const root = tempRoot();
 	try {
 		const s = store(root);
-		s.add({ title: "old" });
+		s.add({ title: "old", group: "Task" });
 		const plan = s.replaceAll({
-			todos: [{ title: "step 1", status: "done" }, { title: "step 2" }],
+			groups: [
+				{ title: "Task", todos: [{ title: "step 1", status: "done" }, { title: "step 2" }] },
+			],
 		});
-		expect(plan.todos).toHaveLength(2);
-		expect(plan.todos[0]?.status).toBe("done");
-		expect(plan.todos[1]?.status).toBe("pending");
+		const task = plan.groups.find((g) => g.title === "Task");
+		expect(task?.todos).toHaveLength(2);
+		expect(task?.todos[0]?.status).toBe("done");
+		expect(task?.todos[1]?.status).toBe("pending");
 		expect(s.list()).toHaveLength(2);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
@@ -110,10 +113,9 @@ test("replaceAll lays out named groups (created with fresh ids), preserving item
 	try {
 		const s = store(root);
 		const plan = s.replaceAll({
-			todos: [{ title: "loose one" }],
 			groups: [{ title: "Import", todos: [{ title: "parse" }, { title: "validate" }] }],
 		});
-		expect(plan.todos.map((t) => t.title)).toEqual(["loose one"]);
+		expect(plan.todos).toHaveLength(0);
 		expect(plan.groups).toHaveLength(1);
 		expect(plan.groups[0]?.id).toMatch(/^g_/);
 		expect(plan.groups[0]?.title).toBe("Import");
@@ -174,6 +176,35 @@ test("re-plan keeps the loose lane user-only: agent items never leak into it", (
 		const plan = s.replaceAll({ groups: [{ title: "Fresh", todos: [{ title: "step" }] }] });
 		expect(plan.todos.map((t) => t.id)).toEqual([userLoose.id]);
 		expect(plan.todos.every((t) => t.origin === "user")).toBe(true);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("re-plan carries a legacy agent done loose item into a group, never leaving it in the user lane", () => {
+	const root = tempRoot();
+	try {
+		const file = join(root, storeRel(SESSION));
+		mkdirSync(dirname(file), { recursive: true });
+		writeFileSync(
+			file,
+			JSON.stringify({
+				version: 6,
+				todos: [
+					{ id: "t_legacy_done", title: "legacy agent done", status: "done", origin: "agent" },
+					{ id: "t_legacy_open", title: "legacy agent open", status: "pending", origin: "agent" },
+				],
+				groups: [],
+			}),
+			"utf8",
+		);
+		const plan = store(root).replaceAll({
+			groups: [{ title: "Fresh", todos: [{ title: "step" }] }],
+		});
+		expect(plan.todos).toHaveLength(0);
+		const completed = plan.groups.find((g) => g.title === "Completed");
+		expect(completed?.todos.map((t) => t.title)).toEqual(["legacy agent done"]);
+		expect(flatItems(plan).map((t) => t.title)).not.toContain("legacy agent open");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -363,15 +394,19 @@ test("replaceAll preserves user items and done items, replacing only the agent's
 	try {
 		const s = store(root);
 		s.add({ title: "user task", origin: "user" });
-		s.add({ title: "agent open" });
-		const done = s.add({ title: "agent finished" });
+		s.add({ title: "agent open", group: "Task" });
+		const done = s.add({ title: "agent finished", group: "Task" });
 		s.update(done.id, { status: "done" });
 
-		const titles = s.replaceAll({ todos: [{ title: "new plan item" }] }).todos.map((t) => t.title);
+		const plan = s.replaceAll({
+			groups: [{ title: "Fresh", todos: [{ title: "new plan item" }] }],
+		});
+		const titles = flatItems(plan).map((t) => t.title);
 		expect(titles).toContain("new plan item");
 		expect(titles).toContain("user task");
 		expect(titles).toContain("agent finished");
 		expect(titles).not.toContain("agent open");
+		expect(plan.todos.map((t) => t.title)).toEqual(["user task"]);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
@@ -517,7 +552,6 @@ test("replaceAll keeps only the first in_progress of a fresh plan (direct API: `
 	try {
 		const s = store(root);
 		const plan = s.replaceAll({
-			todos: [{ title: "loose", status: "in_progress" }],
 			groups: [
 				{
 					title: "Task",
@@ -529,7 +563,7 @@ test("replaceAll keeps only the first in_progress of a fresh plan (direct API: `
 			],
 		});
 		const statuses = flatItems(plan).map((t) => t.status);
-		expect(statuses).toEqual(["in_progress", "pending", "pending"]);
+		expect(statuses).toEqual(["in_progress", "pending"]);
 		expect(flatItems(plan)[0]?.title).toBe("one");
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/packages/pi-todos/core/core.test.ts
+++ b/packages/pi-todos/core/core.test.ts
@@ -498,13 +498,13 @@ test("a version-3 file (pre-commit-kind) reads cleanly and upgrades to the curre
 		);
 		expect(store(root).get("t_old")?.artifacts).toEqual([{ kind: "change", path: "a.ts" }]);
 		store(root).add({ title: "new" }); // any write upgrades the file version
-		expect(JSON.parse(readFileSync(file, "utf8")).version).toBe(5);
+		expect(JSON.parse(readFileSync(file, "utf8")).version).toBe(6);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
 
-test("item summary: set with done, cleared by empty string, sanitized on read", () => {
+test("item summary/verification/commitSubject: set with done, cleared by empty string, sanitized on read", () => {
 	const root = tempRoot();
 	try {
 		const todo = store(root).add({ title: "Implement FloodWait handling" });
@@ -512,20 +512,25 @@ test("item summary: set with done, cleared by empty string, sanitized on read", 
 			status: "done",
 			summary: "Added throttling and fallback for failed batch sends.",
 			verification: "bun test src/todos — 34 pass",
+			commitSubject: "fix(sender): back off and retry on FloodWait",
 		});
 		expect(store(root).get(todo.id)?.summary).toBe(
 			"Added throttling and fallback for failed batch sends.",
 		);
 		expect(store(root).get(todo.id)?.verification).toBe("bun test src/todos — 34 pass");
-		store(root).update(todo.id, { summary: "", verification: "" });
+		expect(store(root).get(todo.id)?.commitSubject).toBe(
+			"fix(sender): back off and retry on FloodWait",
+		);
+		store(root).update(todo.id, { summary: "", verification: "", commitSubject: "" });
 		expect(store(root).get(todo.id)?.summary).toBeUndefined();
 		expect(store(root).get(todo.id)?.verification).toBeUndefined();
+		expect(store(root).get(todo.id)?.commitSubject).toBeUndefined();
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
 
-test("reopening a done item clears its stale completion summary/verification and the plan summary", () => {
+test("reopening a done item clears its stale completion fields and the plan summary", () => {
 	const root = tempRoot();
 	try {
 		const s = store(root);
@@ -534,6 +539,7 @@ test("reopening a done item clears its stale completion summary/verification and
 			status: "done",
 			summary: "Added throttling and fallback for failed batch sends.",
 			verification: "bun test src/todos — 34 pass",
+			commitSubject: "fix(sender): back off and retry on FloodWait",
 		});
 		s.setSummary("All tasks landed; e2e suite green.");
 
@@ -541,15 +547,18 @@ test("reopening a done item clears its stale completion summary/verification and
 
 		expect(s.get(todo.id)?.summary).toBeUndefined();
 		expect(s.get(todo.id)?.verification).toBeUndefined();
+		expect(s.get(todo.id)?.commitSubject).toBeUndefined();
 		expect(s.read().summary).toBeUndefined();
 
 		s.update(todo.id, {
 			status: "done",
 			summary: "Retried with the corrected backoff window.",
 			verification: "bun test src/todos — 35 pass",
+			commitSubject: "fix(sender): widen the FloodWait backoff window",
 		});
 		expect(s.get(todo.id)?.summary).toBe("Retried with the corrected backoff window.");
 		expect(s.get(todo.id)?.verification).toBe("bun test src/todos — 35 pass");
+		expect(s.get(todo.id)?.commitSubject).toBe("fix(sender): widen the FloodWait backoff window");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/packages/pi-todos/core/store.ts
+++ b/packages/pi-todos/core/store.ts
@@ -16,6 +16,7 @@ import {
 	type TodoPlan,
 	type TodoStatus,
 	type TodoUpdateResult,
+	type WriteItem,
 	type WritePlan,
 } from "./types.ts";
 
@@ -333,11 +334,24 @@ export class TodoStore {
 				w.verification,
 			),
 		);
-		const freshGroups: TodoGroup[] = (plan.groups ?? []).map((g) => ({
-			id: freshId("g"),
-			title: decodeEscapes(g.title),
-			todos: g.todos.map((w) =>
-				makeTodo(
+		const current = this.read();
+		const existingByKey = new Map<string, Todo[]>();
+		for (const g of current.groups) {
+			for (const t of g.todos) {
+				if (t.origin !== "agent") continue;
+				const key = `${g.title}\u0000${t.title}`;
+				const bucket = existingByKey.get(key);
+				if (bucket) bucket.push(t);
+				else existingByKey.set(key, [t]);
+			}
+		}
+		const consumed = new Set<string>();
+		const reconcile = (groupTitle: string, w: WriteItem): Todo => {
+			const hit = existingByKey
+				.get(`${groupTitle}\u0000${decodeEscapes(w.title)}`)
+				?.find((t) => !consumed.has(t.id));
+			if (!hit) {
+				return makeTodo(
 					w.title,
 					w.status ?? "pending",
 					"agent",
@@ -345,25 +359,43 @@ export class TodoStore {
 					w.artifacts,
 					w.summary,
 					w.verification,
-				),
-			),
-		}));
-		const current = this.read();
+				);
+			}
+			consumed.add(hit.id);
+			const merged: Todo = { ...hit };
+			if (w.note !== undefined) {
+				const note = decodeEscapes(w.note);
+				if (note) merged.note = note;
+				else delete merged.note;
+				merged.updatedAt = nowIso();
+			}
+			return merged;
+		};
+		const freshGroups: TodoGroup[] = (plan.groups ?? []).map((g) => {
+			const title = decodeEscapes(g.title);
+			return { id: freshId("g"), title, todos: g.todos.map((w) => reconcile(title, w)) };
+		});
 		const keptLoose = current.todos.filter((t) => t.origin === "user" || t.status === "done");
 		const resultLoose = [...freshLoose, ...keptLoose];
+		const carriedGroups: TodoGroup[] = [];
 		for (const old of current.groups) {
+			const carriedDone: Todo[] = [];
 			for (const t of old.todos) {
+				if (consumed.has(t.id)) continue;
 				if (t.origin === "user") {
 					resultLoose.push(t);
 				} else if (t.status === "done") {
 					const match = freshGroups.find((g) => g.title === old.title);
 					if (match) match.todos.push(t);
-					else resultLoose.push(t);
+					else carriedDone.push(t);
 				}
+			}
+			if (carriedDone.length > 0) {
+				carriedGroups.push({ id: freshId("g"), title: old.title, todos: carriedDone });
 			}
 		}
 
-		const next: TodoPlan = { todos: resultLoose, groups: freshGroups };
+		const next: TodoPlan = { todos: resultLoose, groups: [...freshGroups, ...carriedGroups] };
 		this.keepOneInProgress(next);
 		this.write(next);
 		return next;

--- a/packages/pi-todos/core/store.ts
+++ b/packages/pi-todos/core/store.ts
@@ -52,6 +52,9 @@ export function groupStatus(group: TodoGroup): TodoGroupStatus {
 
 const CURRENT_VERSION = 6 as const;
 
+// Home for a legacy stray: an agent `done` item found in the (user-only) loose lane on re-plan (see core/SPEC.md).
+const CARRIED_LOOSE_GROUP = "Completed";
+
 const STATUS_SET: ReadonlySet<string> = new Set(TODO_STATUSES);
 const ORIGIN_SET: ReadonlySet<string> = new Set(TODO_ORIGINS);
 const ARTIFACT_KIND_SET: ReadonlySet<string> = new Set(TODO_ARTIFACT_KINDS);
@@ -323,17 +326,6 @@ export class TodoStore {
 	}
 
 	replaceAll(plan: WritePlan): TodoPlan {
-		const freshLoose = (plan.todos ?? []).map((w) =>
-			makeTodo(
-				w.title,
-				w.status ?? "pending",
-				"agent",
-				w.note,
-				w.artifacts,
-				w.summary,
-				w.verification,
-			),
-		);
 		const current = this.read();
 		const existingByKey = new Map<string, Todo[]>();
 		for (const g of current.groups) {
@@ -375,9 +367,9 @@ export class TodoStore {
 			const title = decodeEscapes(g.title);
 			return { id: freshId("g"), title, todos: g.todos.map((w) => reconcile(title, w)) };
 		});
-		const keptLoose = current.todos.filter((t) => t.origin === "user" || t.status === "done");
-		const resultLoose = [...freshLoose, ...keptLoose];
+		const resultLoose = current.todos.filter((t) => t.origin === "user");
 		const carriedGroups: TodoGroup[] = [];
+		const carriedLooseDone: Todo[] = [];
 		for (const old of current.groups) {
 			const carriedDone: Todo[] = [];
 			for (const t of old.todos) {
@@ -393,6 +385,19 @@ export class TodoStore {
 			if (carriedDone.length > 0) {
 				carriedGroups.push({ id: freshId("g"), title: old.title, todos: carriedDone });
 			}
+		}
+		for (const t of current.todos) {
+			if (t.origin === "agent" && t.status === "done") carriedLooseDone.push(t);
+		}
+		if (carriedLooseDone.length > 0) {
+			const match = freshGroups.find((g) => g.title === CARRIED_LOOSE_GROUP);
+			if (match) match.todos.push(...carriedLooseDone);
+			else
+				carriedGroups.push({
+					id: freshId("g"),
+					title: CARRIED_LOOSE_GROUP,
+					todos: carriedLooseDone,
+				});
 		}
 
 		const next: TodoPlan = { todos: resultLoose, groups: [...freshGroups, ...carriedGroups] };

--- a/packages/pi-todos/core/store.ts
+++ b/packages/pi-todos/core/store.ts
@@ -49,7 +49,7 @@ export function groupStatus(group: TodoGroup): TodoGroupStatus {
 	return "pending";
 }
 
-const CURRENT_VERSION = 5 as const;
+const CURRENT_VERSION = 6 as const;
 
 const STATUS_SET: ReadonlySet<string> = new Set(TODO_STATUSES);
 const ORIGIN_SET: ReadonlySet<string> = new Set(TODO_ORIGINS);
@@ -115,6 +115,8 @@ function sanitize(raw: unknown): Todo | null {
 	if (typeof o.summary === "string" && o.summary) todo.summary = decodeIfAgent(o.summary, origin);
 	if (typeof o.verification === "string" && o.verification)
 		todo.verification = decodeIfAgent(o.verification, origin);
+	if (typeof o.commitSubject === "string" && o.commitSubject)
+		todo.commitSubject = decodeIfAgent(o.commitSubject, origin);
 	const artifacts = sanitizeArtifacts(o.artifacts, origin);
 	if (artifacts) todo.artifacts = artifacts;
 	return todo;
@@ -279,6 +281,7 @@ export class TodoStore {
 			if (wasDone && patch.status !== "done") {
 				delete todo.summary;
 				delete todo.verification;
+				delete todo.commitSubject;
 				delete plan.summary;
 			}
 		}
@@ -293,6 +296,10 @@ export class TodoStore {
 		if (patch.verification !== undefined) {
 			if (patch.verification) todo.verification = decodeIfAgent(patch.verification, todo.origin);
 			else delete todo.verification;
+		}
+		if (patch.commitSubject !== undefined) {
+			if (patch.commitSubject) todo.commitSubject = decodeIfAgent(patch.commitSubject, todo.origin);
+			else delete todo.commitSubject;
 		}
 		if (patch.artifacts !== undefined) {
 			const clean = sanitizeArtifacts(patch.artifacts, todo.origin);

--- a/packages/pi-todos/core/types.ts
+++ b/packages/pi-todos/core/types.ts
@@ -23,6 +23,7 @@ export interface Todo {
 	note?: string;
 	summary?: string;
 	verification?: string;
+	commitSubject?: string;
 	artifacts?: TodoArtifact[];
 	createdAt: string;
 	updatedAt: string;
@@ -45,7 +46,7 @@ export interface TodoPlan {
 }
 
 export interface TodoFile {
-	version: 5;
+	version: 6;
 	todos: Todo[];
 	groups: TodoGroup[];
 	summary?: string;
@@ -71,6 +72,7 @@ export interface TodoPatch {
 	note?: string;
 	summary?: string;
 	verification?: string;
+	commitSubject?: string;
 	artifacts?: TodoArtifact[];
 }
 

--- a/packages/pi-todos/core/types.ts
+++ b/packages/pi-todos/core/types.ts
@@ -86,6 +86,5 @@ export interface WriteItem {
 }
 
 export interface WritePlan {
-	todos?: WriteItem[];
 	groups?: { title: string; todos: WriteItem[] }[];
 }

--- a/packages/pi-todos/skills/todos/SKILL.md
+++ b/packages/pi-todos/skills/todos/SKILL.md
@@ -110,13 +110,16 @@ reviewer, not for yourself.
 
 - **Done stays.** Completing a step = `todo_update` → `done`. **Never delete a done item** — it's the
   user's history. `todo_remove` is only for when the user explicitly asks to drop something.
-- **Edit surgically.** After the first plan, use `todo_update` / `todo_add` (they touch one item).
-  **Never `todo_write` to tweak** an existing list — it replaces everything; `todo_write` is only for
-  laying out a fresh plan.
+- **Edit surgically.** After the first plan, prefer `todo_update` / `todo_add` (they touch one item) for
+  a single change — cheaper than restating the whole plan. `todo_write` **reconciles** (it's not a
+  destructive replace): it matches your written steps to the existing ones by group + step title and
+  keeps their status/summary/id, so a re-plan is safe and lossless — reach for it when you're genuinely
+  restructuring, not to nudge one item. Status advances only via `todo_update`; a `status` you put in
+  `todo_write` on a step that already exists is ignored.
 - **Respect the user's edits.** The list is shared; treat their additions as new requests and their
   removals as cancellations. Loose items are theirs — do them, but don't rewrite or drop them when you
-  re-plan. (`todo_write` preserves user items and done items for you, but don't lean on that — reach
-  for `todo_add`/`todo_update` to edit, and keep `todo_write` for a genuinely fresh plan.)
+  re-plan. (`todo_write` never touches user items and keeps done items; but keep your steps' titles
+  stable across a re-plan — a reworded title reads as a new step, so the old one's progress won't carry.)
 
 ## Tools
 
@@ -125,7 +128,7 @@ reviewer, not for yourself.
 - `todo_update` — progress one step (`in_progress` on start, `done` when finished — with a `summary`
   when the step changed code; done stays).
 - `todo_remove` — delete one item (only when the user asks).
-- `todo_write` — lay out a fresh plan (groups only — one per task; replaces your open items; use once,
-  at the start).
+- `todo_write` — lay out or reconcile the plan (groups only — one per task; matches steps by title and
+  keeps their progress; prefer `todo_add`/`todo_update` for a single change).
 - `todo_plan_summary` — after the last item is done: a short overall summary of what the plan
   accomplished.

--- a/packages/pi-todos/skills/todos/SKILL.md
+++ b/packages/pi-todos/skills/todos/SKILL.md
@@ -80,6 +80,13 @@ reviewer, not for yourself.
    check pass by weakening it — if you changed, skipped, or deleted a test as part of the step, the
    summary must say so explicitly: a reviewer who finds it themselves stops trusting every other
    summary.
+- **A step that changed code also gets a `commitSubject`.** The host commits that step's delta on the
+   user's branch and uses this line as the commit subject verbatim, so write it as a **commit message,
+   not a plan step**: one imperative line about the *change*, and in **this repository's existing
+   style** — run `git log --oneline -20` and match what you see (Conventional Commits ⇒
+   `type(scope): subject`; a prose-subject repo ⇒ prose). It must be pushable as-is: no `todo:`
+   prefix, no item ids, no tool attribution. Omit it and the host falls back to the step title, which
+   reads as a plan step in `git log` — so don't rely on that.
 - **Disclose scope drift.** Anything you touched beyond the step's own ask — an adjacent refactor, a
    drive-by rename, a new dependency — goes in the summary ("also touched X because Y"). The
    signature failure of agent changes is solving the asked problem *plus* neighbors; undisclosed
@@ -93,9 +100,11 @@ reviewer, not for yourself.
    deferred — an omission here reads as "nothing left", so say it if something is.
 - **Fix requests re-open the SAME item.** When the user asks for a fix on a reviewed step (you'll
    receive the original step, its summary, its change set, and their feedback), flip **that exact item**
-   (by id) back to `in_progress`, make the fix, and mark it `done` with a **fresh summary** describing
-   the fix — the fix, not the original work (the user re-reviews only the new delta). Never open a new
-   item for a fix — the revision must attach to the step it revises.
+   (by id) back to `in_progress`, make the fix, and mark it `done` with a **fresh summary** and a
+   **fresh `commitSubject`** describing the fix — the fix, not the original work (the user re-reviews
+   only the new delta, and the revision lands as its own commit). Re-opening clears the previous
+   values, so supply both again. Never open a new item for a fix — the revision must attach to the step
+   it revises.
 
 ## Invariants
 

--- a/packages/pi-todos/tools/SPEC.md
+++ b/packages/pi-todos/tools/SPEC.md
@@ -25,6 +25,11 @@ the host wire still use loose items):
   or done items), making the step appear among the user's requests and then vanish on the next re-plan. The
   policy lives here, not in `core`: `TodoStore.add` stays permissive because the host writes the user's own
   lane through it.
+- **`todo_write` reconciles, it never destructively replaces:** the tool forwards its `groups` to
+  `TodoStore.replaceAll`, which matches written steps to existing ones by group + step title and keeps
+  their progress (see [[submodule-pi-todos-core]]). So a mid-task re-plan is safe and lossless — there is
+  **no runtime nudge** discouraging it; the todos skill carries the (efficiency-only) preference for
+  `todo_add`/`todo_update` on a single change.
 - **In-band nudges** (the status-discipline feedback): every mutating/list result appends
   `consistencyNudge` when open items exist but none is `in_progress`; a `todo_update` → `done` names
   the group's next open step instead (suggest-only, never auto-started); auto-demoted items are

--- a/packages/pi-todos/tools/SPEC.md
+++ b/packages/pi-todos/tools/SPEC.md
@@ -31,9 +31,12 @@ the host wire still use loose items):
   reported as `(paused: …)`. A `done` that leaves **no open item anywhere** additionally nudges
   `todo_plan_summary` — the overall completion summary is asked for at exactly the moment it becomes due.
 - **Completion summaries (the review trail):** `todo_update` takes optional `summary` (what/why — the
-  decisions the diff can't show, plus any scope drift) and **`verification`** (the exact check run +
+  decisions the diff can't show, plus any scope drift), **`commitSubject`** (the git-facing subject line
+  for the step's delta, written in the host repository's own commit style — the schema description is
+  where the "read `git log` and match it" instruction lives, since the tools are the agent's only
+  contact with this field) and **`verification`** (the exact check run +
   result, or "not verified" — a separate field so the UI renders it as a status badge and a vague or
-  missing line is visible at a glance), both set together with `status: done` (skill-mandated for
+  missing line is visible at a glance) — all three set together with `status: done` (skill-mandated for
   code-changing steps, never a tool gate: the tool can't know whether the step changed code — git
   lives host-side). `todo_plan_summary` sets the plan-level handoff note
   (`TodoStore.setSummary`); it accepts an early call but flags how many items are still open (the UI

--- a/packages/pi-todos/tools/tools.test.ts
+++ b/packages/pi-todos/tools/tools.test.ts
@@ -126,6 +126,45 @@ test("todo_write lays out a groups-only plan (no loose lane for the agent)", asy
 	}
 });
 
+test("todo_write reconciles a re-listed plan without resetting progress or nudging", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-todos-tools-"));
+	try {
+		await run(
+			"todo_write",
+			{ groups: [{ title: "Task", todos: [{ title: "step a" }, { title: "step b" }] }] },
+			cwd,
+		);
+		const listed = (await run("todo_list", {}, cwd)) as AgentToolResult<{
+			plan: { groups: { todos: { id: string; title: string }[] }[] };
+		}>;
+		const stepA = listed.details.plan.groups[0]?.todos.find((t) => t.title === "step a");
+		if (!stepA) throw new Error("step a not found");
+		await run("todo_update", { id: stepA.id, status: "in_progress" }, cwd);
+
+		const replan = (await run(
+			"todo_write",
+			{
+				groups: [
+					{
+						title: "Task",
+						todos: [{ title: "step a" }, { title: "step b" }, { title: "step c" }],
+					},
+				],
+			},
+			cwd,
+		)) as AgentToolResult<{
+			plan: { groups: { todos: { id: string; title: string; status: string }[] }[] };
+		}>;
+		const reconciled = replan.details.plan.groups[0]?.todos ?? [];
+		const reA = reconciled.find((t) => t.title === "step a");
+		expect(reA?.id).toBe(stepA.id);
+		expect(reA?.status).toBe("in_progress");
+		expect(reconciled.map((t) => t.title)).toEqual(["step a", "step b", "step c"]);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
 test("todo_add requires group or after — the agent cannot author loose items", async () => {
 	const cwd = mkdtempSync(join(tmpdir(), "pi-todos-tools-"));
 	try {

--- a/packages/pi-todos/tools/update.ts
+++ b/packages/pi-todos/tools/update.ts
@@ -33,6 +33,12 @@ const parameters = Type.Object({
 				'Verification line, set together with status=done: the EXACT check you ran and its result ("bun test src/todos — 34 pass", "typecheck green") — or "not verified" when you ran nothing. Never claim a check you did not run. Empty string clears it.',
 		}),
 	),
+	commitSubject: Type.Optional(
+		Type.String({
+			description:
+				"Commit subject for this step's code changes, set together with status=done when the step changed code — the host commits the step's delta under it verbatim. One line, imperative, describing the CHANGE (not the plan step), and written in THIS repository's existing commit style: read `git log --oneline -20` and match what you see (a Conventional-Commits repo gets `type(scope): subject`, a prose-subject repo gets prose). It lands on the user's branch and must be pushable as-is: no todo/plan markers, no ids, no tool attribution. Empty string clears it; omitted, the host falls back to the step title.",
+		}),
+	),
 });
 
 function nextOpenStep(plan: TodoPlan, id: string): Todo | undefined {
@@ -63,6 +69,7 @@ export function registerTodoUpdate(pi: ExtensionAPI): void {
 			if (params.note !== undefined) patch.note = params.note;
 			if (params.summary !== undefined) patch.summary = params.summary;
 			if (params.verification !== undefined) patch.verification = params.verification;
+			if (params.commitSubject !== undefined) patch.commitSubject = params.commitSubject;
 			const store = storeFor(ctx);
 			const result = store.update(params.id, patch);
 			if (!result) return errorResult(`No TODO with id "${params.id}".`);

--- a/packages/pi-todos/tools/write.ts
+++ b/packages/pi-todos/tools/write.ts
@@ -31,9 +31,9 @@ export function registerTodoWrite(pi: ExtensionAPI): void {
 		name: "todo_write",
 		label: "Todo Write",
 		description:
-			"Lay out a fresh plan: replace your own open items with these groups — one group per task (a user ask; title = the outcome), each with its ordered steps. Use it once, at the start of a multi-step task. The user's items and any completed (done) items are preserved — but don't use it to tweak an existing plan; for that use todo_update (progress an item) and todo_add (insert one).",
+			"Lay out or reconcile the plan as these groups — one group per task (a user ask; title = the outcome), each with its ordered steps. This RECONCILES, it does not destructively replace: written steps are matched to existing ones by group title + step title and keep their status/summary/id, so re-running it is safe and lossless (a re-listed in-progress or done step is NOT reset — status advances only via todo_update, and a status you pass here for an existing step is ignored). Unmatched written steps are created; your steps you omit are dropped; the user's items and completed (done) items are always preserved. Keep step titles stable across a re-plan — a reworded title reads as a new step. For a single change prefer todo_add/todo_update (cheaper than restating the whole plan).",
 		promptSnippet:
-			"todo_write — lay out a FRESH plan (groups only: one per task, steps inside; replaces your open items; keeps user items + done; use once at the start).",
+			"todo_write — lay out or reconcile the plan (groups only; matches steps by title, keeps their progress; prefer todo_add/todo_update for one change).",
 		parameters,
 		async execute(_callId, params, _signal, _onUpdate, ctx) {
 			const write: WritePlan = { groups: params.groups };

--- a/packages/server/src/git/git.test.ts
+++ b/packages/server/src/git/git.test.ts
@@ -665,7 +665,7 @@ test("gitCommitPaths commits EXACTLY the named paths and returns the sha; commit
 	writeFileSync(join(repo, ".thinkrail", "context", "todos.json"), "{}");
 
 	const before = gitHeadSha("w1");
-	const committed = gitCommitPaths("w1", "todo: step\n\nThinkRail-Todo: s/t1", ["impl.ts"]);
+	const committed = gitCommitPaths("w1", "feat: step", ["impl.ts"]);
 	expect(committed).not.toBeNull();
 	expect(committed?.sha).not.toBe(before);
 	expect(gitHeadSha("w1")).toBe(committed?.sha ?? "");
@@ -681,11 +681,11 @@ test("gitCommitPaths commits EXACTLY the named paths and returns the sha; commit
 
 test("gitCommitPaths stages a deletion, and returns null for an empty set or paths with nothing to commit", async () => {
 	seedWorkspace();
-	expect(gitCommitPaths("w1", "todo: nothing named", [])).toBeNull();
-	expect(gitCommitPaths("w1", "todo: clean path", ["README.md"])).toBeNull();
+	expect(gitCommitPaths("w1", "feat: nothing named", [])).toBeNull();
+	expect(gitCommitPaths("w1", "feat: clean path", ["README.md"])).toBeNull();
 
 	rmSync(join(repo, "README.md"));
-	const committed = gitCommitPaths("w1", "todo: drop the readme", ["README.md"]);
+	const committed = gitCommitPaths("w1", "chore: drop the readme", ["README.md"]);
 	expect(committed).not.toBeNull();
 	expect(
 		await (await gitStatus("w1", { kind: "commit", sha: committed?.sha ?? "" })).changes[0],
@@ -701,7 +701,7 @@ test("gitCommitPaths leaves the user's own staged work staged (never in the item
 	writeFileSync(join(repo, "mine.ts"), "export const mine = 1;\n");
 	git(repo, "add", "--", "mine.ts");
 
-	const committed = gitCommitPaths("w1", "todo: step", ["impl.ts"]);
+	const committed = gitCommitPaths("w1", "feat: step", ["impl.ts"]);
 	expect(
 		(await gitStatus("w1", { kind: "commit", sha: committed?.sha ?? "" })).changes.map(
 			(c) => c.path,
@@ -718,7 +718,7 @@ test("gitCommitPaths treats paths literally — a pathspec-magic filename never 
 	mkdirSync(join(repo, ".thinkrail", "context"), { recursive: true });
 	writeFileSync(join(repo, ".thinkrail", "context", "todos.json"), "{}");
 
-	const committed = gitCommitPaths("w1", "todo: magic name", [magic]);
+	const committed = gitCommitPaths("w1", "feat: magic name", [magic]);
 	expect(committed).not.toBeNull();
 	expect(
 		(await gitStatus("w1", { kind: "commit", sha: committed?.sha ?? "" })).changes.map(
@@ -740,7 +740,7 @@ test("a failed commit restores the index — the user's staging area is never le
 	git(repo, "config", "gpg.program", join(dataDir, "no-such-gpg"));
 
 	const head = gitHeadSha("w1");
-	expect(gitCommitPaths("w1", "todo: unsignable", ["impl.ts"])).toBeNull();
+	expect(gitCommitPaths("w1", "feat: unsignable", ["impl.ts"])).toBeNull();
 	expect(gitHeadSha("w1")).toBe(head ?? "");
 	expect(stagedPaths()).toEqual(["mine.ts"]);
 });
@@ -754,7 +754,7 @@ test("a failed commit preserves index-only state — an intent-to-add entry surv
 	git(repo, "config", "gpg.program", join(dataDir, "no-such-gpg"));
 
 	const head = gitHeadSha("w1");
-	expect(gitCommitPaths("w1", "todo: unsignable", ["impl.ts"])).toBeNull();
+	expect(gitCommitPaths("w1", "feat: unsignable", ["impl.ts"])).toBeNull();
 	expect(gitHeadSha("w1")).toBe(head ?? "");
 	const tracked = new TextDecoder()
 		.decode(
@@ -782,7 +782,7 @@ test("gitCommitPaths refuses to commit over a conflicted index (unmerged entries
 
 	writeFileSync(join(repo, "impl.ts"), "export {};\n");
 	const head = gitHeadSha("w1");
-	expect(gitCommitPaths("w1", "todo: mid-merge", ["impl.ts"])).toBeNull();
+	expect(gitCommitPaths("w1", "feat: mid-merge", ["impl.ts"])).toBeNull();
 	expect(gitHeadSha("w1")).toBe(head ?? "");
 });
 

--- a/packages/server/src/todos/SPEC.md
+++ b/packages/server/src/todos/SPEC.md
@@ -5,7 +5,7 @@ status: active
 title: todos — a chat's per-session TODO plan (read/write)
 parent: module-server
 depends-on: [module-contracts, submodule-server-git]
-references: [module-pi-todos, submodule-web-chat]
+references: [module-pi-todos, submodule-server-pr, submodule-web-chat]
 tags: [v2, todos]
 ---
 
@@ -71,13 +71,25 @@ and `session.delete` removes the chat's whole sidecar (`removeSessionTodoWindows
 as a permanently open foreign window and force every sibling chat into the fallback forever. On `done`:
 
 - **Commit the item's delta.** `git.gitCommitPaths` commits **exactly the delta paths** — the item's own
-  work, never "everything currently dirty" — `--no-verify` (the bookkeeping commit must not run/fail the
-  user's hooks; author/committer stay the user's own config — it's their branch) with a `todo: <title>`
-  subject + a `ThinkRail-Todo: <sessionId>/<todoId>` trailer (recoverable/squashable by tooling). It
+  work, never "everything currently dirty" — `--no-verify` (the commit must not run/fail the
+  user's hooks; author/committer stay the user's own config — it's their branch). It
   preserves the user's index across any failure (see [[submodule-server-git]]). The item gets **one
   `commit` artifact** (the sha, `label` = the item title) and **nothing else**: the commit is
   self-sufficient — its file list is *derived*, never denormalized into the JSON (see the `listTodos`
   decoration below).
+- **The message is a single subject line the user can push unedited.** These commits land on the user's
+  own branch, in the same history as their hand-written ones, and the branch ships straight to a PR
+  ([[submodule-server-pr]] pushes it) — so anything the user would have to reword before pushing is a
+  defect. The subject is the item's agent-authored **`commitSubject`** (see [[module-pi-todos]]: written
+  at `done` in the *host repository's* commit style, which the agent reads off `git log`), falling back
+  to the item `title` when absent. Nothing else: **no `todo:` prefix and no body/trailer.** An earlier
+  version wrote `todo: <title>` plus a `ThinkRail-Todo: <sessionId>/<todoId>` trailer; both are gone.
+  The prefix + a plan-step title read as a foreign artifact in a Conventional-Commits history (this
+  repo's own `todo: Get design sign-off, promote decisions into apps/website/SPEC.md` is the
+  specimen), and the trailer was **write-only** — item↔commit attribution is the `commit` artifact's
+  `sha`, nothing ever parsed the trailer back, so it bought only a leaked internal session UUID in
+  public history. The `CommitWindow` seam is correspondingly `{ subject, paths }`: choosing the
+  subject is the reconcile's job, and the git leaf only commits.
 - **Commit gate (safety on the user's branch).** A commit may only contain work the item can be *proven*
   to own, so all four must hold — else **no commit**, and the live-diff `change` path-list artifacts stand
   in (branch scope; `change` survives **only** as this fallback):

--- a/packages/server/src/todos/artifacts.test.ts
+++ b/packages/server/src/todos/artifacts.test.ts
@@ -367,7 +367,7 @@ test("done commits the window: one commit artifact (the sha), and only the item'
 	}
 });
 
-test("the agent's commitSubject is the commit subject verbatim; the title stays the artifact label", async () => {
+test("only the first commitSubject line is committed; the title stays the artifact label", async () => {
 	const { store, root } = tempStore();
 	try {
 		const todo = store.add({ title: "Newest-first chat order" });
@@ -375,7 +375,7 @@ test("the agent's commitSubject is the commit subject verbatim; the title stays 
 		await reconcileChangeArtifacts(store, root, SESSION, async () => []);
 		store.update(todo.id, {
 			status: "done",
-			commitSubject: "feat(web): add newest-first chat order",
+			commitSubject: "feat(web): add newest-first chat order\n\nGenerated explanation",
 		});
 		const subjects: string[] = [];
 		await reconcileChangeArtifacts(

--- a/packages/server/src/todos/artifacts.test.ts
+++ b/packages/server/src/todos/artifacts.test.ts
@@ -352,16 +352,45 @@ test("done commits the window: one commit artifact (the sha), and only the item'
 			root,
 			SESSION,
 			async () => ["src/foo.ts"],
-			({ paths, title, todoId }) => {
+			({ paths, subject }) => {
 				seen.push(paths);
-				expect(title).toBe("step");
-				expect(todoId).toBe(todo.id);
+				expect(subject).toBe("step");
 				return { sha: "abc1234def" };
 			},
 		);
 		expect(seen).toEqual([["src/foo.ts"]]);
 		expect(store.get(todo.id)?.artifacts).toEqual([
 			{ kind: "commit", sha: "abc1234def", label: "step" },
+		]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("the agent's commitSubject is the commit subject verbatim; the title stays the artifact label", async () => {
+	const { store, root } = tempStore();
+	try {
+		const todo = store.add({ title: "Newest-first chat order" });
+		store.update(todo.id, { status: "in_progress" });
+		await reconcileChangeArtifacts(store, root, SESSION, async () => []);
+		store.update(todo.id, {
+			status: "done",
+			commitSubject: "feat(web): add newest-first chat order",
+		});
+		const subjects: string[] = [];
+		await reconcileChangeArtifacts(
+			store,
+			root,
+			SESSION,
+			async () => ["src/foo.ts"],
+			({ subject }) => {
+				subjects.push(subject);
+				return { sha: "sha-subject" };
+			},
+		);
+		expect(subjects).toEqual(["feat(web): add newest-first chat order"]);
+		expect(store.get(todo.id)?.artifacts).toEqual([
+			{ kind: "commit", sha: "sha-subject", label: "Newest-first chat order" },
 		]);
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/packages/server/src/todos/artifacts.ts
+++ b/packages/server/src/todos/artifacts.ts
@@ -226,7 +226,10 @@ export async function reconcileChangeArtifacts(
 		const exclusive = base?.shared !== true && !otherChatWorking();
 		const committed =
 			commit && base?.paths.every((p) => !now.includes(p)) && exclusive
-				? commit({ subject: todo.commitSubject ?? todo.title, paths: deltaPaths })
+				? commit({
+						subject: (todo.commitSubject ?? todo.title).split(/[\r\n]/u, 1)[0] ?? "",
+						paths: deltaPaths,
+					})
 				: null;
 		if (committed) {
 			changed = null;

--- a/packages/server/src/todos/artifacts.ts
+++ b/packages/server/src/todos/artifacts.ts
@@ -15,12 +15,7 @@ import { dropReviewRecord } from "./reviews";
 
 const log = logger("todos");
 
-export type CommitWindow = (opts: {
-	title: string;
-	sessionId: string;
-	todoId: string;
-	paths: string[];
-}) => { sha: string } | null;
+export type CommitWindow = (opts: { subject: string; paths: string[] }) => { sha: string } | null;
 
 const isAppStatePath = (path: string): boolean =>
 	path === WORKSPACE_INTERNAL_DIR || path.startsWith(`${WORKSPACE_INTERNAL_DIR}/`);
@@ -35,10 +30,6 @@ export function isTodoToolEnd(event: PiEvent): boolean {
 
 function flatten(plan: TodoPlan): TodoPlan["todos"] {
 	return [...plan.todos, ...plan.groups.flatMap((g) => g.todos)];
-}
-
-function commitMessage(title: string, sessionId: string, todoId: string): string {
-	return `todo: ${title}\n\nThinkRail-Todo: ${sessionId}/${todoId}`;
 }
 
 const commitQueues = new Map<string, Promise<void>>();
@@ -116,8 +107,7 @@ async function runReconcile(workspaceId: string, sessionId: string): Promise<voi
 			sessionId,
 			async () =>
 				(await gitStatus(workspaceId, { kind: "uncommitted" })).changes.map((c) => c.path),
-			({ title, todoId, paths }) =>
-				gitCommitPaths(workspaceId, commitMessage(title, sessionId, todoId), paths),
+			({ subject, paths }) => gitCommitPaths(workspaceId, subject, paths),
 			() => gitHeadSha(workspaceId),
 			false,
 		);
@@ -236,7 +226,7 @@ export async function reconcileChangeArtifacts(
 		const exclusive = base?.shared !== true && !otherChatWorking();
 		const committed =
 			commit && base?.paths.every((p) => !now.includes(p)) && exclusive
-				? commit({ title: todo.title, sessionId, todoId: todo.id, paths: deltaPaths })
+				? commit({ subject: todo.commitSubject ?? todo.title, paths: deltaPaths })
 				: null;
 		if (committed) {
 			changed = null;

--- a/packages/server/src/todos/decoration.test.ts
+++ b/packages/server/src/todos/decoration.test.ts
@@ -57,7 +57,7 @@ afterEach(() => {
 test("listTodos decorates a commit artifact with the commit's derived files; a dead sha ships none", async () => {
 	const store = new TodoStore(repo, SESSION);
 	writeFileSync(join(repo, "impl.ts"), "export {};\n");
-	const committed = gitCommitPaths("w1", "todo: step", ["impl.ts"]);
+	const committed = gitCommitPaths("w1", "feat: step", ["impl.ts"]);
 	if (!committed) throw new Error("commit failed");
 	const good = store.add({
 		title: "committed step",

--- a/packages/server/src/todos/reviewFlow.test.ts
+++ b/packages/server/src/todos/reviewFlow.test.ts
@@ -77,7 +77,7 @@ afterEach(() => {
 /** A committed done item the way artifacts.ts leaves one, returning its id + sha. */
 function committedItem(store: TodoStore, title: string, file: string): { id: string; sha: string } {
 	writeFileSync(join(repo, file), "export {};\n");
-	const committed = gitCommitPaths("w1", `todo: ${title}`, [file]);
+	const committed = gitCommitPaths("w1", title, [file]);
 	if (!committed) throw new Error("commit failed");
 	const todo = store.add({
 		title,
@@ -154,7 +154,7 @@ test("approve records the watermark; a later revision commit reads as the unrevi
 
 	// A fix cycle appends a second commit — only IT is the unreviewed delta.
 	writeFileSync(join(repo, "impl2.ts"), "export {};\n");
-	const second = gitCommitPaths("w1", "todo: step", ["impl2.ts"]);
+	const second = gitCommitPaths("w1", "feat: step", ["impl2.ts"]);
 	if (!second) throw new Error("commit failed");
 	store.update(id, {
 		artifacts: [
@@ -177,7 +177,7 @@ test("an agent verdict watermarks the START-time shas — a commit landed mid-re
 
 	// The worker lands another commit WHILE the reviewer's turn is streaming.
 	writeFileSync(join(repo, "impl2.ts"), "export {};\n");
-	const second = gitCommitPaths("w1", "todo: step", ["impl2.ts"]);
+	const second = gitCommitPaths("w1", "feat: step", ["impl2.ts"]);
 	if (!second) throw new Error("commit failed");
 	store.update(id, {
 		artifacts: [

--- a/packages/server/src/todos/todos.ts
+++ b/packages/server/src/todos/todos.ts
@@ -466,7 +466,7 @@ export function renderFixPackage(item: StoredItem, feedback: string): string {
 		feedback,
 		'"""',
 		"",
-		`Address the feedback on THIS step: flip ${item.id} back to in_progress (todo_update), make the fix, then mark it done with a fresh summary describing the fix. Do not create a new item for it.`,
+		`Address the feedback on THIS step: flip ${item.id} back to in_progress (todo_update), make the fix, then mark it done with a fresh summary AND a fresh commitSubject describing the fix (the revision is its own commit). Do not create a new item for it.`,
 	];
 	return lines.join("\n");
 }


### PR DESCRIPTION
Problem: todo_write had replace semantics (TodoStore.replaceAll), but the model uses it as a reconcile. On re-plan, agent-authored items leaked into the loose "Other" lane and lost their progress (status/summary/verification/commitSubject/artifacts).

Fix: replaceAll now matches written steps to existing agent items by (group title, step title), reusing their id and progress. Unmatched steps are created; omitted open steps are dropped; done and user items are always preserved. Re-running todo_write is now lossless.

Loose lane is user-origin only — a re-planned-away group's done items are carried over under their group, never orphaned.
Removed the now-redundant mid-plan replan nudge.
Reconcile contract documented in core/SPEC.md, tools/SPEC.md, the todos skill, and the todo_write tool description. Known limit: title-matching (rename not followed); per-item id is the planned next step.
Tests: bun test packages/pi-todos — 49 pass; typecheck green; biome clean.