### PR TITLE
fix(server): let pi be the only pre-session model resolver so a new w…

### DIFF
--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -277,8 +277,7 @@ export function NewWorkspaceDialog({
 		try {
 			const { result: session, syncedTick } = await createSessionWithSkillBaseline({
 				workspaceId: workspace.id,
-				...(model ? { model } : {}),
-				thinkingLevel,
+				...(model ? { model, thinkingLevel } : {}),
 			});
 			store.openChatSession(
 				workspace.id,
@@ -477,6 +476,7 @@ export function NewWorkspaceDialog({
 							refreshing={modelsRefreshing}
 							onRefresh={onRefreshModels}
 							container={dialogEl}
+							placeholder="Default model"
 							onSelect={(m) => {
 								setModel(m);
 							}}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -283,9 +283,12 @@ empty by default); while the prompt is non-empty (worktree mode), a secondary hi
 and branch from the request. The rest stays compact: the base-branch combobox (`git.listBranches`,
 degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
 a project picker, the prompt hero, and the reused
-  `chat/ModelSelector`+`ThinkingSelector` in **pre-session** mode — preselected to the host's resolved
-  default via `model.default` so the exact model shows (values held in dialog state, applied at create
-  time). The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll
+  `chat/ModelSelector`+`ThinkingSelector` in **pre-session** mode — preselected to the host's **pinned**
+  default via `model.default` so the exact model shows when there is one (values held in dialog state,
+  applied at create time). With **no pinned default the host answers `model: null`** and the dialog holds
+  none: the picker reads **Default model**, the effort control is disabled (no model, no supported set), and
+  create sends neither — so pi resolves both exactly as it does for a new chat tab. The dialog must not
+  substitute a model of its own choosing here; one resolver, pi's, see `submodule-agent`. The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll
   lock). Their catalog is the shared one — `chat/useModelCatalog`, so the dialog and the chat composer
   cannot drift — which means it is **live**: the picker's Refresh row can replace the list underneath a
   held selection. The dialog therefore reconciles the held model against it on every change via the pure
@@ -296,7 +299,7 @@ a project picker, the prompt hero, and the reused
   current-but-unsettled list, which is no basis for a verdict), dropped by the next `model.list` install from any consumer (whose
   handler answers from before the detached refresh it starts) *and* dropped up front by any consumer
   activating. On a fresh catalog it returns **`"unavailable"`** — a verdict, not a replacement: the dialog
-  then asks **`model.default`** (pi's own `pinned ?? available[0]`, plus a consistent effort) exactly as it
+  then asks **`model.default`** (the host's pinned default or none, plus a consistent effort) exactly as it
   does for the preselect, through **one** `applyHostDefault` — so no client-side copy of the host's default
   policy exists here. Asked at most once per opening, so a still-missing model can't spin the effect. Effort is a separate concern: one effect keeps the held level
   runnable by the held model by asking the host for pi's clamp (**`model.clampThinking`**) rather than
@@ -313,8 +316,8 @@ a project picker, the prompt hero, and the reused
   updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter submits** (matching the submit button's
   `↵` affordance) and
   **Shift+Enter** inserts a newline. Worktree-mode submit = `workspace.create({ projectId, baseRef })` → set active → **always open a
-  fresh chat** (`session.create({ model, thinkingLevel })` — the picked model + effort apply even
-  without a prompt) → a typed prompt is additionally sent as the first message (fire-and-forget
+  fresh chat** (`session.create({ workspaceId, model?, thinkingLevel? })` — a held model + effort apply even
+  without a prompt, and travel together: with none held both are omitted and pi resolves them) → a typed prompt is additionally sent as the first message (fire-and-forget
   `prompt`); an **empty prompt leaves the just-opened composer ready** — submitting the start-working
   surface always lands the user in a chat, never on a bare receipt (folder mode: the same tail after
   entering Default). A **rejected** kick-off `prompt` (a bad model / missing API key — e.g. picking a

--- a/e2e/error-turn.live.spec.ts
+++ b/e2e/error-turn.live.spec.ts
@@ -41,7 +41,7 @@ test("a bad model surfaces a visible error toast, not a false ✓ Done", {
 	await page.getByTestId("add-workspace").first().click();
 	const dialog = page.getByTestId("new-workspace-dialog");
 	await expect(dialog).toBeVisible();
-	await expect(dialog.getByTestId("model-selector")).not.toContainText("Select model");
+	await expect(dialog.getByTestId("model-selector")).not.toContainText("Default model");
 	await page.getByTestId("ws-prompt").fill("Reply with the single word: pong");
 	await page.getByTestId("create-workspace").click();
 	await expect(dialog).toBeHidden();

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -52,7 +52,7 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	const effort = dialog.getByTestId("thinking-selector");
 	await expect(effort).toBeVisible();
 	const modelResolved = !(await dialog.getByTestId("model-selector").textContent())?.includes(
-		"Select model",
+		"Default model",
 	);
 	if (modelResolved) await expect(effort).toBeEnabled();
 	else await expect(effort).toBeDisabled();

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -141,9 +141,18 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     entry) / `getSessionStats` (+ contextUsage) / `getSessionCommands` /
     `listAvailableModels` / **`clampThinkingForModel`** (pi's `clampThinkingLevel` for a `{model, level}`
     pair — `model.clampThinking`; the host owns it so the pre-session picker, `getDefaultModel`, and a live
-    session all adjust effort identically) / `getDefaultModel` (the model + thinking a fresh session resolves to — settings
-    default if available, else first available — so the New-Workspace dialog shows the exact pre-session
-    model). **Models cross the wire as `WireModel` (never pi's raw `Model`):** `toWireModel` projects a
+    session all adjust effort identically) / `getDefaultModel` (the **pinned** default only — pi's settings
+    `defaultProvider`/`defaultModel` when that model is available, else `model: null` — plus the effort that
+    pairs with it). **The host never guesses a pre-session model:** pi's own resolver (settings pin →
+    provider default → first available) runs inside `createAgentSession`, so a caller without a pinned
+    default omits `model` and lets pi choose, and every creation path agrees by construction. The earlier
+    `pinned ?? available[0]` was a *second* resolver: with nothing pinned it answered `available[0]` while a
+    fresh session got pi's provider default, so the New-Workspace dialog pre-pinned a model no other path
+    would have picked — landing on `anthropic/claude-fable-5`, whose `compat.allowedFallbackModels` makes pi
+    send a `fallbacks` field, a 400 on an Anthropic proxy without the server-side-fallback beta, while a new
+    chat in the same worktree worked. Pi publishes no pre-session resolver (`findInitialModel` and
+    `defaultModelPerProvider` are not re-exported from the package root and its `exports` map blocks the deep
+    import), and copying its provider-default table here would recompute what `pi` owns. **Models cross the wire as `WireModel` (never pi's raw `Model`):** `toWireModel` projects a
     `Model` onto the wire's **allowlist** (see `WireModel`) — so `baseUrl`, `headers`, extension/provider
     routing data, and any other field are excluded by
     default — and the inbound side re-resolves the ref by `{provider,id}` via `resolveWireModel` against

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -356,15 +356,53 @@ test("model.clampThinking refuses a model ref the host can't resolve", async () 
 	);
 });
 
-test("model.default clamps the saved thinking level onto the resolved model's support set", async () => {
+test("model.default clamps the saved thinking level onto the pinned model's support set", async () => {
+	const agentDir = process.env.PI_CODING_AGENT_DIR;
+	if (!agentDir) throw new Error("agent dir not isolated");
+	const settingsPath = join(agentDir, "settings.json");
+	writeFileSync(
+		settingsPath,
+		`${JSON.stringify({
+			defaultProvider: "fauxa",
+			defaultModel: "fauxa",
+			defaultThinkingLevel: "high",
+		})}\n`,
+	);
+	try {
+		const d = await getDefaultModel();
+		expect(d.model?.id).toBe("fauxa");
+		expect(d.model?.thinkingLevels).toEqual(["off"]);
+		expect(d.thinkingLevel).toBe("off");
+	} finally {
+		rmSync(settingsPath, { force: true });
+	}
+});
+
+test("model.default names NO model when nothing is pinned — pi's resolver is the only one", async () => {
 	const agentDir = process.env.PI_CODING_AGENT_DIR;
 	if (!agentDir) throw new Error("agent dir not isolated");
 	const settingsPath = join(agentDir, "settings.json");
 	writeFileSync(settingsPath, `${JSON.stringify({ defaultThinkingLevel: "high" })}\n`);
 	try {
+		expect((await listAvailableModels()).length).toBeGreaterThan(0);
 		const d = await getDefaultModel();
-		expect(d.model?.thinkingLevels).toEqual(["off"]);
-		expect(d.thinkingLevel).toBe("off");
+		expect(d.model).toBeNull();
+		expect(d.thinkingLevel).toBe("high");
+	} finally {
+		rmSync(settingsPath, { force: true });
+	}
+});
+
+test("model.default names NO model when the pinned one is unavailable", async () => {
+	const agentDir = process.env.PI_CODING_AGENT_DIR;
+	if (!agentDir) throw new Error("agent dir not isolated");
+	const settingsPath = join(agentDir, "settings.json");
+	writeFileSync(
+		settingsPath,
+		`${JSON.stringify({ defaultProvider: "fauxa", defaultModel: "gone" })}\n`,
+	);
+	try {
+		expect((await getDefaultModel()).model).toBeNull();
 	} finally {
 		rmSync(settingsPath, { force: true });
 	}

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -904,7 +904,7 @@ export async function getDefaultModel(): Promise<DefaultModelResult> {
 		provider && modelId
 			? available.find((model) => model.provider === provider && model.id === modelId)
 			: undefined;
-	const resolved = (pinned ?? available[0] ?? null) as Model<string> | null;
+	const resolved = (pinned ?? null) as Model<string> | null;
 	const saved = settings.getDefaultThinkingLevel() ?? "medium";
 	const thinkingLevel = resolved ? clampThinkingLevel(resolved, saved) : saved;
 	return { model: resolved ? toWireModel(resolved) : null, thinkingLevel };


### PR DESCRIPTION
Problem                                                                                                                                                                                                      
                                                                                                                                                                                                             
getDefaultModel (the host's model.default) resolved pinned ?? available[0] — a second pre-session model resolver, competing with pi's own (settings pin → provider default → first available) that runs inside createAgentSession.                                                                                                                                                                                   
                                                                                                                                                                                                              
With nothing pinned the two disagreed. The New-Workspace dialog pre-pinned available[0] — anthropic/claude-fable-5 — while a new chat tab in the same worktree got pi's provider default. Fable's compat.allowedFallbackModels makes pi send a fallbacks field, which is a 400 on an Anthropic proxy without the server-side-fallback beta. So creating a worktree handed you a chat that couldn't talk, while opening a chat tab right next to it worked.