### PR TITLE
feat(subagents): add global and workspace controls

### DIFF
--- a/apps/web/src/panels/ChatSettings.test.tsx
+++ b/apps/web/src/panels/ChatSettings.test.tsx
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test";
+import {
+	SUBAGENT_SETTINGS_PROTOCOL_VERSION,
+	type SubagentOverride,
+	type Workspace,
+} from "@thinkrail/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
-import { ChatSettings } from "./ChatSettings";
+import { ChatSettings, SubagentSettings } from "./ChatSettings";
 
 test("Chat settings renders one two-handle streaming movement control", () => {
 	const markup = renderToStaticMarkup(<ChatSettings />);
@@ -16,4 +21,68 @@ test("Chat settings renders one two-handle streaming movement control", () => {
 	);
 	expect(markup).toContain('aria-valuetext="100% from the top"');
 	expect(markup.match(/type="range"/g)).toHaveLength(2);
+});
+
+function workspace(subagentsOverride?: SubagentOverride): Workspace {
+	return {
+		id: "ws1",
+		projectId: "p1",
+		name: "Checkout flow",
+		branch: "checkout-flow",
+		worktreePath: "/tmp/checkout-flow",
+		baseBranch: "main",
+		...(subagentsOverride ? { subagentsOverride } : {}),
+	};
+}
+
+function renderSettings({
+	protocolVersion = SUBAGENT_SETTINGS_PROTOCOL_VERSION,
+	globalEnabled = true,
+	activeWorkspace,
+}: {
+	protocolVersion?: number;
+	globalEnabled?: boolean;
+	activeWorkspace?: Workspace;
+} = {}): string {
+	return renderToStaticMarkup(
+		<SubagentSettings
+			protocolVersion={protocolVersion}
+			globalEnabled={globalEnabled}
+			workspace={activeWorkspace ?? null}
+			onGlobalChange={() => {}}
+			onWorkspaceChange={() => {}}
+		/>,
+	);
+}
+
+test("subagent controls stay hidden against hosts older than their protocol", () => {
+	const markup = renderSettings({
+		protocolVersion: SUBAGENT_SETTINGS_PROTOCOL_VERSION - 1,
+		activeWorkspace: workspace("off"),
+	});
+
+	expect(markup).not.toContain('data-testid="settings-subagents"');
+});
+
+test("subagent settings show the global default without inventing a local control", () => {
+	const markup = renderSettings({ globalEnabled: true });
+
+	expect(markup).toContain('data-testid="settings-subagents"');
+	expect(markup).toContain('data-testid="subagents-global-toggle"');
+	expect(markup).toContain('aria-checked="true"');
+	expect(markup).not.toContain('data-testid="subagents-workspace-options"');
+});
+
+test("an active workspace shows its named three-state override", () => {
+	const markup = renderSettings({
+		globalEnabled: true,
+		activeWorkspace: workspace("off"),
+	});
+
+	expect(markup).toContain("This workspace — Checkout flow");
+	expect(markup).toContain('data-testid="subagents-workspace-options"');
+	expect(markup).toContain('data-testid="subagents-workspace-inherit"');
+	expect(markup).toContain('data-testid="subagents-workspace-on"');
+	expect(markup).toContain('data-testid="subagents-workspace-off"');
+	expect(markup).toContain('data-testid="subagents-workspace-off" data-active="true"');
 });

--- a/apps/web/src/panels/ChatSettings.tsx
+++ b/apps/web/src/panels/ChatSettings.tsx
@@ -1,5 +1,11 @@
 import { RiCheckLine as Check } from "@remixicon/react";
-import type { AppConfigUpdate, ComposerGrowthLimit } from "@thinkrail/contracts";
+import {
+	type AppConfigUpdate,
+	type ComposerGrowthLimit,
+	SUBAGENT_SETTINGS_PROTOCOL_VERSION,
+	type SubagentOverride,
+	type Workspace,
+} from "@thinkrail/contracts";
 import {
 	type ChatMessageOrder,
 	moveStreamingResponseHandle,
@@ -7,8 +13,9 @@ import {
 	type StreamingResponseMovement,
 } from "@/chat/chatPreferences";
 import { cn } from "@/lib";
-import { toast, useAppStore } from "@/store";
+import { selectActiveWorkspace, toast, useAppStore } from "@/store";
 import { getTransport } from "@/transport";
+import { SettingsSwitch } from "./SettingsSwitch";
 
 interface RadioChoice<T extends string> {
 	id: T;
@@ -37,6 +44,7 @@ const MESSAGE_ORDER_CHOICES: RadioChoice<ChatMessageOrder>[] = [
 ];
 
 const MOVEMENT_TRACK_SEGMENTS = Array.from({ length: 20 }, (_, index) => index * 5);
+type WorkspaceSubagentChoice = "inherit" | SubagentOverride;
 
 const GROWTH_CHOICES: RadioChoice<ComposerGrowthLimit>[] = [
 	{
@@ -61,6 +69,32 @@ const GROWTH_CHOICES: RadioChoice<ComposerGrowthLimit>[] = [
 		testId: "composer-growth-half-chat",
 	},
 ];
+
+function subagentChoices(globalEnabled: boolean): RadioChoice<WorkspaceSubagentChoice>[] {
+	return [
+		{
+			id: "inherit",
+			label: "Use global",
+			hint: globalEnabled ? "Currently on" : "Currently off",
+			description: "Follows the global default, including later changes.",
+			testId: "subagents-workspace-inherit",
+		},
+		{
+			id: "on",
+			label: "On",
+			hint: "Override",
+			description: "Always allow delegation in this workspace.",
+			testId: "subagents-workspace-on",
+		},
+		{
+			id: "off",
+			label: "Off",
+			hint: "Override",
+			description: "Prevent new subagents in this workspace.",
+			testId: "subagents-workspace-off",
+		},
+	];
+}
 
 function RadioCards<T extends string>({
 	name,
@@ -201,10 +235,83 @@ function saveSetting(config: AppConfigUpdate, errorMessage: string): void {
 		.catch(() => toast.error(errorMessage));
 }
 
+export function SubagentSettings({
+	protocolVersion,
+	globalEnabled,
+	workspace,
+	onGlobalChange,
+	onWorkspaceChange,
+}: {
+	protocolVersion: number | null;
+	globalEnabled: boolean;
+	workspace: Workspace | null;
+	onGlobalChange: (enabled: boolean) => void;
+	onWorkspaceChange: (choice: WorkspaceSubagentChoice) => void;
+}) {
+	if (protocolVersion === null || protocolVersion < SUBAGENT_SETTINGS_PROTOCOL_VERSION) {
+		return null;
+	}
+	return (
+		<div
+			data-testid="settings-subagents"
+			className="flex flex-col gap-8 border-border-default border-t pt-16"
+		>
+			<div className="flex flex-col gap-4">
+				<h3 className="tr-title-section text-text-default">Subagents</h3>
+				<p className="text-text-muted tr-text-metadata">
+					Choose whether chats may delegate work to specialized agents. Turning this off prevents
+					new subagents; work already running finishes.
+				</p>
+			</div>
+			<div className="flex items-center justify-between gap-12 rounded-[var(--radius-sm)] border border-border-default bg-control-bg px-12 py-8">
+				<div className="flex flex-col gap-2">
+					<span className="tr-title-compact text-text-default">Global default</span>
+					<span className="text-text-muted tr-text-metadata">
+						{globalEnabled
+							? "On — workspaces may delegate unless they override it."
+							: "Off — workspaces cannot delegate unless they override it."}
+					</span>
+				</div>
+				<SettingsSwitch
+					checked={globalEnabled}
+					label="Enable subagents by default"
+					testId="subagents-global-toggle"
+					onChange={onGlobalChange}
+				/>
+			</div>
+
+			{workspace ? (
+				<div className="flex flex-col gap-8 border-border-default border-t pt-16">
+					<div className="flex flex-col gap-4">
+						<h4 className="min-w-0 break-words tr-title-compact text-text-default">
+							This workspace — {workspace.name}
+						</h4>
+						<p className="text-text-muted tr-text-metadata">
+							Override the global default only for this workspace.
+						</p>
+					</div>
+					<div data-testid="subagents-workspace-options">
+						<RadioCards
+							name="workspace-subagents"
+							label={`Subagents in ${workspace.name}`}
+							choices={subagentChoices(globalEnabled)}
+							value={workspace.subagentsOverride ?? "inherit"}
+							onSelect={onWorkspaceChange}
+						/>
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
 export function ChatSettings() {
 	const messageOrder = useAppStore((state) => state.chatMessageOrder);
 	const growthLimit = useAppStore((state) => state.composerGrowthLimit);
 	const streamingResponseMovement = useAppStore((state) => state.streamingResponseMovement);
+	const protocolVersion = useAppStore((state) => state.protocolVersion);
+	const subagentsEnabled = useAppStore((state) => state.subagentsEnabled);
+	const activeWorkspace = useAppStore(selectActiveWorkspace);
 	const setChatMessageOrder = useAppStore((state) => state.setChatMessageOrder);
 	const setStreamingResponseMovement = useAppStore((state) => state.setStreamingResponseMovement);
 
@@ -216,6 +323,18 @@ export function ChatSettings() {
 	const selectGrowthLimit = (composerGrowthLimit: ComposerGrowthLimit) => {
 		if (composerGrowthLimit === growthLimit) return;
 		saveSetting({ composerGrowthLimit }, "Couldn't change message box growth");
+	};
+
+	const selectWorkspaceSubagents = (choice: WorkspaceSubagentChoice) => {
+		if (!activeWorkspace) return;
+		const current = activeWorkspace.subagentsOverride ?? "inherit";
+		if (choice === current) return;
+		getTransport()
+			.request("workspace.setSubagentsOverride", {
+				id: activeWorkspace.id,
+				override: choice === "inherit" ? null : choice,
+			})
+			.catch(() => toast.error("Couldn't change subagents for this workspace"));
 	};
 
 	return (
@@ -267,6 +386,16 @@ export function ChatSettings() {
 					onSelect={selectGrowthLimit}
 				/>
 			</div>
+
+			<SubagentSettings
+				protocolVersion={protocolVersion}
+				globalEnabled={subagentsEnabled}
+				workspace={activeWorkspace}
+				onGlobalChange={(enabled) =>
+					saveSetting({ subagentsEnabled: enabled }, "Couldn't change the global subagent default")
+				}
+				onWorkspaceChange={selectWorkspaceSubagents}
+			/>
 		</section>
 	);
 }

--- a/apps/web/src/panels/PrivacySettings.tsx
+++ b/apps/web/src/panels/PrivacySettings.tsx
@@ -1,13 +1,13 @@
-import { cn } from "@/lib";
 import { toast, useAppStore } from "@/store";
 import { getTransport } from "@/transport";
+import { SettingsSwitch } from "./SettingsSwitch";
 
 export function PrivacySettings() {
 	const enabled = useAppStore((s) => s.analyticsEnabled);
 
-	const toggle = () => {
+	const setEnabled = (analyticsEnabled: boolean) => {
 		getTransport()
-			.request("settings.update", { config: { analyticsEnabled: !enabled } })
+			.request("settings.update", { config: { analyticsEnabled } })
 			.catch(() => toast.error("Couldn't change the analytics setting"));
 	};
 
@@ -30,26 +30,12 @@ export function PrivacySettings() {
 						{enabled ? "On — thank you for helping improve ThinkRail." : "Off — nothing is sent."}
 					</span>
 				</div>
-				<button
-					type="button"
-					role="switch"
-					aria-checked={enabled}
-					aria-label="Share anonymous usage analytics"
-					data-testid="analytics-toggle"
-					data-active={enabled}
-					onClick={toggle}
-					className={cn(
-						"relative h-20 w-36 shrink-0 rounded-full outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
-						enabled ? "bg-primary" : "bg-border-default",
-					)}
-				>
-					<span
-						className={cn(
-							"absolute top-2 left-2 size-16 rounded-full bg-container-workspace-bg transition-transform",
-							enabled && "translate-x-16",
-						)}
-					/>
-				</button>
+				<SettingsSwitch
+					checked={enabled}
+					label="Share anonymous usage analytics"
+					testId="analytics-toggle"
+					onChange={setEnabled}
+				/>
 			</div>
 
 			<div className="flex flex-col gap-4 tr-text-metadata">

--- a/apps/web/src/panels/ReviewSettings.tsx
+++ b/apps/web/src/panels/ReviewSettings.tsx
@@ -3,9 +3,9 @@ import { useEffect, useState } from "react";
 import { ModelSelector } from "@/chat/ModelSelector";
 import { ThinkingSelector } from "@/chat/ThinkingSelector";
 import { useModelCatalog } from "@/chat/useModelCatalog";
-import { cn } from "@/lib";
 import { toast, useAppStore } from "@/store";
 import { getTransport } from "@/transport";
+import { SettingsSwitch } from "./SettingsSwitch";
 
 export function ReviewSettings() {
 	const reviewModel = useAppStore((s) => s.reviewModel);
@@ -39,9 +39,9 @@ export function ReviewSettings() {
 	const defaultLabel = fallback?.model
 		? `Your default model (${fallback.model.name})`
 		: "Your default model";
-	const toggleAutoFix = () => {
+	const setAutoFix = (reviewAutoFix: boolean) => {
 		getTransport()
-			.request("settings.update", { config: { reviewAutoFix: !autoFix } })
+			.request("settings.update", { config: { reviewAutoFix } })
 			.catch(() => toast.error("Couldn't change the auto-fix setting"));
 	};
 
@@ -89,26 +89,12 @@ export function ReviewSettings() {
 							: "Off — findings wait for you; nothing is auto-sent."}
 					</span>
 				</div>
-				<button
-					type="button"
-					role="switch"
-					aria-checked={autoFix}
-					aria-label="Auto-fix requested changes"
-					data-testid="review-autofix-toggle"
-					data-active={autoFix}
-					onClick={toggleAutoFix}
-					className={cn(
-						"relative h-20 w-36 shrink-0 rounded-full outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
-						autoFix ? "bg-primary" : "bg-border-default",
-					)}
-				>
-					<span
-						className={cn(
-							"absolute top-2 left-2 size-16 rounded-full bg-container-workspace-bg transition-transform",
-							autoFix && "translate-x-16",
-						)}
-					/>
-				</button>
+				<SettingsSwitch
+					checked={autoFix}
+					label="Auto-fix requested changes"
+					testId="review-autofix-toggle"
+					onChange={setAutoFix}
+				/>
 			</div>
 		</section>
 	);

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -383,7 +383,11 @@ a project picker, the prompt hero, and the reused
   browsers use current-host-qualified keys, while a native shell may inject its stable
   backend-profile/window adapter. Another browser, native window, or host is unaffected. Composer growth
   remains a top-level `AppConfig` field and converges on `settings.changed`, with a toast on rejection.
-  Labels use “message box” rather than the internal “composer” name when explaining where the user types);
+  Labels use “message box” rather than the internal “composer” name when explaining where the user types.
+  The final **Subagents** block pairs the host-wide `subagentsEnabled` switch with a named **This workspace**
+  `Use global` / `On` / `Off` control when a workspace is active; no workspace means no local block.
+  Global mutation converges through `settings.changed`, local mutation through `workspace.updated`, and
+  neither is optimistic. `Use global` sends `null`, so later global changes continue to flow through);
   the
   **shell-owned injected Layout
   section** (Balanced/Focus/Review

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -385,7 +385,9 @@ a project picker, the prompt hero, and the reused
   remains a top-level `AppConfig` field and converges on `settings.changed`, with a toast on rejection.
   Labels use “message box” rather than the internal “composer” name when explaining where the user types.
   The final **Subagents** block pairs the host-wide `subagentsEnabled` switch with a named **This workspace**
-  `Use global` / `On` / `Off` control when a workspace is active; no workspace means no local block.
+  `Use global` / `On` / `Off` control when a workspace is active; no workspace means no local block. The
+  whole block requires `protocolVersion >= SUBAGENT_SETTINGS_PROTOCOL_VERSION`, so an independently shipped
+  client never offers unsupported mutations against an older host.
   Global mutation converges through `settings.changed`, local mutation through `workspace.updated`, and
   neither is optimistic. `Use global` sends `null`, so later global changes continue to flow through);
   the

--- a/apps/web/src/panels/SettingsSwitch.test.tsx
+++ b/apps/web/src/panels/SettingsSwitch.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SettingsSwitch } from "./SettingsSwitch";
+
+test("settings switches expose one accessible checked-state contract", () => {
+	const on = renderToStaticMarkup(
+		<SettingsSwitch checked label="Enable feature" testId="feature-toggle" onChange={() => {}} />,
+	);
+	const off = renderToStaticMarkup(
+		<SettingsSwitch
+			checked={false}
+			label="Enable feature"
+			testId="feature-toggle"
+			onChange={() => {}}
+		/>,
+	);
+
+	expect(on).toContain('role="switch"');
+	expect(on).toContain('aria-checked="true"');
+	expect(on).toContain('data-testid="feature-toggle"');
+	expect(on).toContain('data-active="true"');
+	expect(on).toContain("translate-x-16");
+	expect(off).toContain('aria-checked="false"');
+	expect(off).toContain('data-active="false"');
+	expect(off).not.toContain("translate-x-16");
+});

--- a/apps/web/src/panels/SettingsSwitch.tsx
+++ b/apps/web/src/panels/SettingsSwitch.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib";
+
+export function SettingsSwitch({
+	checked,
+	label,
+	testId,
+	onChange,
+}: {
+	checked: boolean;
+	label: string;
+	testId: string;
+	onChange: (checked: boolean) => void;
+}) {
+	return (
+		<button
+			type="button"
+			role="switch"
+			aria-checked={checked}
+			aria-label={label}
+			data-testid={testId}
+			data-active={checked}
+			onClick={() => onChange(!checked)}
+			className={cn(
+				"relative h-20 w-36 shrink-0 rounded-full outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+				checked ? "bg-primary" : "bg-border-default",
+			)}
+		>
+			<span
+				className={cn(
+					"absolute top-2 left-2 size-16 rounded-full bg-container-workspace-bg transition-transform",
+					checked && "translate-x-16",
+				)}
+			/>
+		</button>
+	);
+}

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -70,7 +70,8 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   `workspace.updated` snapshot in: **replace** the record by `id` in `workspaces[ws.projectId]`, carrying
   over only the list-computed `diffStats` aggregate (the snapshot is the persisted record, which has none).
   The push is authoritative, so a *replace* — never a merge: a merge could not clear an **optional field the
-  host dropped** (`diffBase` re-pointed back to the creation base, the last `skillOverrides` entry removed),
+  host dropped** (`diffBase` re-pointed back to the creation base, the last `skillOverrides` entry removed,
+  or `subagentsOverride` returned to inherited),
   leaving the client labelling and keying reads off a value the host no longer has; a project never fetched or an id absent from its list is a **no-op** — the next
   `workspace.list` reconciles; **`applyWorkspaceRemoved(projectId, id)`** is the **entire** removal
   reaction (`removeWorkspace` drops the row + `clearWorkspaceState` drops its
@@ -329,9 +330,10 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   `server.welcome` / the `settings.changed` broadcast) — lives here too; it's a **pure value only** (the
   theme-application side-effect is the shell's, keyed off `theme`), and defaults to
   `DEFAULT_CONFIG.theme` until the welcome arrives. **`composerGrowthLimit: ComposerGrowthLimit`**,
-  **`customLayoutPresets: LayoutPreset[]`**, and **`analyticsEnabled: boolean`** ride the same `applyConfig`
-  fold (host-owned, defaulted from `DEFAULT_CONFIG`) — the Chat, shared Layout catalog, and Privacy read
-  sides. **`chatMessageOrder: ChatMessageOrder`** and **`streamingResponseMovement:
+  **`customLayoutPresets: LayoutPreset[]`**, **`analyticsEnabled: boolean`**, and
+  **`subagentsEnabled: boolean`** ride the same `applyConfig` fold (host-owned, defaulted from
+  `DEFAULT_CONFIG`) — the Chat, shared Layout catalog, and Privacy read sides.
+  **`chatMessageOrder: ChatMessageOrder`** and **`streamingResponseMovement:
   StreamingResponseMovement`** are instead client-local presentation preferences, hydrated together by
   the chat preference seam from host-qualified browser localStorage or the native shell's injected
   backend-profile/window-scoped adapter. Message order defaults oldest-first; movement defaults to

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -2209,6 +2209,7 @@ test("updateWorkspace applies a pushed snapshot authoritatively: dropped fields 
 					...pushedWorkspace(),
 					diffBase: "release",
 					skillOverrides: { "spec-graph": "off" },
+					subagentsOverride: "off",
 					diffStats: { added: 3, removed: 1 },
 				},
 			],
@@ -2219,6 +2220,7 @@ test("updateWorkspace applies a pushed snapshot authoritatively: dropped fields 
 	const ws = useAppStore.getState().workspaces.p1?.[0];
 	expect(ws?.diffBase).toBeUndefined();
 	expect(ws?.skillOverrides).toBeUndefined();
+	expect(ws?.subagentsOverride).toBeUndefined();
 	expect(ws?.diffStats).toEqual({ added: 3, removed: 1 });
 });
 
@@ -2956,6 +2958,19 @@ test("applyConfig projects the composer growth limit", () => {
 		composerGrowthLimit: "roomy",
 	});
 	expect(useAppStore.getState()).toHaveProperty("composerGrowthLimit", "roomy");
+});
+
+test("applyConfig projects the host-wide subagent default", () => {
+	useAppStore.getState().applyConfig({
+		...DEFAULT_CONFIG,
+		subagentsEnabled: false,
+	});
+	expect(useAppStore.getState()).toHaveProperty("subagentsEnabled", false);
+	useAppStore.getState().applyConfig({
+		...DEFAULT_CONFIG,
+		subagentsEnabled: true,
+	});
+	expect(useAppStore.getState()).toHaveProperty("subagentsEnabled", true);
 });
 
 test("chat presentation preferences are client-local and cannot be overwritten by host config", () => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -772,6 +772,7 @@ interface AppState {
 	interviewPromptOpen: boolean;
 	theme: ThemeId;
 	analyticsEnabled: boolean;
+	subagentsEnabled: boolean;
 	terminalReplayKb: number;
 	composerGrowthLimit: ComposerGrowthLimit;
 	chatMessageOrder: ChatMessageOrder;
@@ -982,6 +983,7 @@ function configPatch(config: AppConfig) {
 	return {
 		theme: config.theme,
 		analyticsEnabled: config.analyticsEnabled,
+		subagentsEnabled: config.subagentsEnabled ?? DEFAULT_CONFIG.subagentsEnabled,
 		terminalReplayKb: config.terminalReplayKb,
 		composerGrowthLimit: config.composerGrowthLimit ?? DEFAULT_CONFIG.composerGrowthLimit,
 		customLayoutPresets: config.customLayoutPresets ?? DEFAULT_CONFIG.customLayoutPresets,
@@ -1577,6 +1579,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	interviewPromptOpen: false,
 	theme: DEFAULT_CONFIG.theme,
 	analyticsEnabled: DEFAULT_CONFIG.analyticsEnabled,
+	subagentsEnabled: DEFAULT_CONFIG.subagentsEnabled,
 	terminalReplayKb: DEFAULT_CONFIG.terminalReplayKb,
 	composerGrowthLimit: DEFAULT_CONFIG.composerGrowthLimit,
 	chatMessageOrder: "oldest-first",

--- a/e2e/subagent-settings.spec.ts
+++ b/e2e/subagent-settings.spec.ts
@@ -1,0 +1,188 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+	createWorkspaceViaDialog,
+	enterDefaultWorkspace,
+	openFixtureProject,
+	openWorkspaceMenu,
+	waitTerminalReady,
+	worktreeRows,
+} from "./fixtures/app";
+
+function parseFrame(message: unknown): Record<string, unknown> | null {
+	if (typeof message !== "string") return null;
+	try {
+		const value: unknown = JSON.parse(message);
+		return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : null;
+	} catch {
+		return null;
+	}
+}
+
+function signal() {
+	let send = () => {};
+	const received = new Promise<void>((resolve) => {
+		send = resolve;
+	});
+	return { received, send };
+}
+
+async function installChannelHold(page: Page) {
+	let armed:
+		| {
+				channel: "settings.changed" | "workspace.updated";
+				held: ReturnType<typeof signal>;
+				release: ReturnType<typeof signal>;
+		  }
+		| undefined;
+	await page.routeWebSocket(/\/ws(\?|$)/, (browserSocket) => {
+		const serverSocket = browserSocket.connectToServer();
+		browserSocket.onMessage((message) => serverSocket.send(message));
+		serverSocket.onMessage((message) => {
+			const pending = armed;
+			if (pending && parseFrame(message)?.channel === pending.channel) {
+				armed = undefined;
+				pending.held.send();
+				void pending.release.received.then(() => browserSocket.send(message));
+				return;
+			}
+			browserSocket.send(message);
+		});
+	});
+	return {
+		arm(channel: "settings.changed" | "workspace.updated") {
+			if (armed) throw new Error(`Already holding ${armed.channel}`);
+			const held = signal();
+			const release = signal();
+			armed = { channel, held, release };
+			return { held: held.received, release: release.send };
+		},
+	};
+}
+
+async function openChatSettings(page: Page): Promise<void> {
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	await expect(page.getByTestId("settings-subagents")).toBeVisible();
+}
+
+function controls(page: Page) {
+	return {
+		global: page.getByTestId("subagents-global-toggle"),
+		inherit: page.getByTestId("subagents-workspace-inherit"),
+		on: page.getByTestId("subagents-workspace-on"),
+		off: page.getByTestId("subagents-workspace-off"),
+	};
+}
+
+async function restoreSubagentBaseline(page: Page): Promise<void> {
+	if (page.isClosed()) return;
+	if (await page.getByTestId("settings-dialog").isVisible()) await page.keyboard.press("Escape");
+	await openChatSettings(page);
+	const current = controls(page);
+	if ((await current.global.getAttribute("data-active")) !== "true") {
+		await current.global.click();
+		await expect(current.global).toHaveAttribute("data-active", "true");
+	}
+	if (
+		(await current.inherit.count()) > 0 &&
+		(await current.inherit.getAttribute("data-active")) !== "true"
+	) {
+		await current.inherit.click();
+		await expect(current.inherit).toHaveAttribute("data-active", "true");
+	}
+	await page.keyboard.press("Escape");
+}
+
+test("a maximal unbroken workspace name stays contained on a phone-sized settings pane", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+	const row = worktreeRows(page).first();
+	const longName = "W".repeat(60);
+	await openWorkspaceMenu(row);
+	await page.getByTestId("workspace-rename").click();
+	const input = row.getByRole("textbox", { name: "Workspace name" });
+	await input.fill(longName);
+	await input.press("Enter");
+	await expect(row.getByTestId("workspace-name")).toHaveText(longName);
+
+	await page.setViewportSize({ width: 390, height: 780 });
+	await openChatSettings(page);
+	const heading = page.getByRole("heading", { name: `This workspace — ${longName}` });
+	await expect(heading).toBeVisible();
+	expect(await heading.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+		true,
+	);
+});
+
+test("global and workspace subagent choices converge from authoritative pushes", async ({
+	page,
+	context,
+}) => {
+	const channelHold = await installChannelHold(page);
+	let releaseGlobal = () => {};
+	let releaseWorkspace = () => {};
+	let peer: Page | undefined;
+	try {
+		await openFixtureProject(page);
+		await enterDefaultWorkspace(page);
+		await restoreSubagentBaseline(page);
+
+		peer = await context.newPage();
+		await peer.goto(page.url());
+		await expect(peer.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+		await openChatSettings(page);
+		await openChatSettings(peer);
+		const source = controls(page);
+		const observer = controls(peer);
+		await expect(source.global).toHaveAttribute("data-active", "true");
+		await expect(source.inherit).toHaveAttribute("data-active", "true");
+
+		const globalFrame = channelHold.arm("settings.changed");
+		releaseGlobal = globalFrame.release;
+		await source.global.click();
+		await globalFrame.held;
+		await expect(source.global).toHaveAttribute("data-active", "true");
+		await expect(observer.global).toHaveAttribute("data-active", "false");
+		releaseGlobal();
+		await expect(source.global).toHaveAttribute("data-active", "false");
+		await expect(source.inherit).toContainText("Currently off");
+
+		const workspaceFrame = channelHold.arm("workspace.updated");
+		releaseWorkspace = workspaceFrame.release;
+		await source.on.click();
+		await workspaceFrame.held;
+		await expect(source.inherit).toHaveAttribute("data-active", "true");
+		await expect(observer.on).toHaveAttribute("data-active", "true");
+		releaseWorkspace();
+		await expect(source.on).toHaveAttribute("data-active", "true");
+
+		await source.global.click();
+		for (const current of [source, observer]) {
+			await expect(current.global).toHaveAttribute("data-active", "true");
+			await expect(current.on).toHaveAttribute("data-active", "true");
+		}
+
+		await source.off.click();
+		for (const current of [source, observer]) {
+			await expect(current.off).toHaveAttribute("data-active", "true");
+		}
+
+		await page.reload();
+		await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+		await openChatSettings(page);
+		await expect(source.global).toHaveAttribute("data-active", "true");
+		await expect(source.off).toHaveAttribute("data-active", "true");
+
+		await source.inherit.click();
+		await expect(source.inherit).toHaveAttribute("data-active", "true");
+		await expect(source.inherit).toContainText("Currently on");
+	} finally {
+		releaseGlobal();
+		releaseWorkspace();
+		await restoreSubagentBaseline(page).catch(() => {});
+		await peer?.close();
+	}
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -138,6 +138,8 @@ of the host.
   **`disabledSkills`** / **`disabledGroups`** (project-baseline per-skill and per-group off — a group is a
   plugin, a source tier, or the special `@plugins`), which gate what its skills contribute; a workspace layers
   **`Workspace.skillOverrides`** (per-skill on/off) over that baseline;
+  **`SubagentOverride`** (`"on" | "off"`) + optional **`Workspace.subagentsOverride`** let a workspace
+  force subagents on/off, while absence inherits the host's `AppConfig.subagentsEnabled` default;
   "does it have specs?" is **not** a field — it's the lazy `project.hasSpecs` query, since it's a full-tree
   walk), **`ProjectPathStatus`** (a
   candidate path's kind — `repo` / `initable` / `missing` / `notDirectory` — so the UI opens, offers a
@@ -201,8 +203,9 @@ of the host.
   height preference: 6 visual lines, 10 visual lines, or 50% of the mounted chat panel respectively;
   `"half-chat"` is the default, and the web owns translating these semantic ids into geometry;
   **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, composerGrowthLimit,
-  customLayoutPresets, reviewModel?, reviewEffort?, reviewAutoFix }` — an extensible bag;
-  `customLayoutPresets` is the bounded resource-free catalog and is the **only** layout value synchronized
+  customLayoutPresets, reviewModel?, reviewEffort?, reviewAutoFix, subagentsEnabled }` — an extensible bag;
+  `subagentsEnabled` is the host-wide subagent default (`true` for current behavior), overridden only by
+  `Workspace.subagentsOverride`; `customLayoutPresets` is the bounded resource-free catalog and is the **only** layout value synchronized
   by the host; current/default preset and group limits are web-local); `analyticsEnabled` is the anonymous
   usage-analytics switch, default `true`
   — it is the **only** analytics fact on the wire:
@@ -344,7 +347,8 @@ of the host.
   names, for the presence-gated notice's count) / **`project.acknowledgeSkills`** (confirm skills that
   appeared after trust) / **`project.setSkillEnabled`** (project baseline) / **`project.setGroupEnabled`**
   (turn a plugin / source tier / `@plugins` on/off at the baseline) / **`workspace.setSkillOverride`**
-  (per-workspace on/off/clear → the `Workspace`) / **`workspace.setDiffBase`** (re-point the diff target,
+  (per-workspace on/off/clear → the `Workspace`) / **`workspace.setSubagentsOverride`**
+  (`"on"` / `"off"` / `null`-to-inherit → the updated `Workspace`) / **`workspace.setDiffBase`** (re-point the diff target,
   `null` clears it back to the creation base — echoes the updated `Workspace` **and** broadcasts
   `workspace.updated`, so every client converges on the push) / **`workspace.watchReady`** (await the
   fresh watcher's conservative startup nudge before a skill-loading client captures its freshness baseline;

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -202,7 +202,9 @@ of the host.
   **`ComposerGrowthLimit`** (`"compact" | "roomy" | "half-chat"`) is the closed, server-synced composer
   height preference: 6 visual lines, 10 visual lines, or 50% of the mounted chat panel respectively;
   `"half-chat"` is the default, and the web owns translating these semantic ids into geometry;
-  **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, composerGrowthLimit,
+  **`SUBAGENT_SETTINGS_PROTOCOL_VERSION`** pins the global/workspace controls to their v57 wire
+  introduction so a later web client hides them against an older host without comparing against the moving
+  latest protocol; **`AppConfig`** (`{ theme, analyticsEnabled, terminalReplayKb, composerGrowthLimit,
   customLayoutPresets, reviewModel?, reviewEffort?, reviewAutoFix, subagentsEnabled }` — an extensible bag;
   `subagentsEnabled` is the host-wide subagent default (`true` for current behavior), overridden only by
   `Workspace.subagentsOverride`; `customLayoutPresets` is the bounded resource-free catalog and is the **only** layout value synchronized

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -22,6 +22,8 @@ export interface DiffStats {
 	removed: number;
 }
 
+export type SubagentOverride = "on" | "off";
+
 export interface Workspace {
 	id: string;
 	projectId: string;
@@ -35,6 +37,7 @@ export interface Workspace {
 	initialTerminalPending?: true;
 	diffStats?: DiffStats;
 	skillOverrides?: Record<string, "on" | "off">;
+	subagentsOverride?: SubagentOverride;
 }
 
 export interface OpenBranchReview {
@@ -458,6 +461,7 @@ export interface AppConfig {
 	reviewEffort?: ThinkingLevel;
 	/** When false, a `request_changes` verdict records findings and waits — no automated fix cycle. */
 	reviewAutoFix: boolean;
+	subagentsEnabled: boolean;
 }
 
 /** The `settings.update` payload: `null` clears an optional override back to unset (⇒ the default). */
@@ -477,6 +481,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	composerGrowthLimit: "half-chat",
 	customLayoutPresets: [],
 	reviewAutoFix: true,
+	subagentsEnabled: true,
 };
 
 export const TODO_NUDGE_PREFIX = "[thinkrail:todo-nudge] ";

--- a/packages/contracts/src/wsProtocol.test.ts
+++ b/packages/contracts/src/wsProtocol.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+import { PROTOCOL_VERSION, SUBAGENT_SETTINGS_PROTOCOL_VERSION, WS_METHODS } from "./wsProtocol";
+
+test("subagent settings advance the protocol and name the workspace override mutation", () => {
+	expect(PROTOCOL_VERSION).toBe(57);
+	expect(SUBAGENT_SETTINGS_PROTOCOL_VERSION).toBe(57);
+	expect(WS_METHODS.workspaceSetSubagentsOverride).toBe("workspace.setSubagentsOverride");
+});

--- a/packages/contracts/src/wsProtocol.test.ts
+++ b/packages/contracts/src/wsProtocol.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { PROTOCOL_VERSION, SUBAGENT_SETTINGS_PROTOCOL_VERSION, WS_METHODS } from "./wsProtocol";
 
 test("subagent settings advance the protocol and name the workspace override mutation", () => {
-	expect(PROTOCOL_VERSION).toBe(57);
 	expect(SUBAGENT_SETTINGS_PROTOCOL_VERSION).toBe(57);
+	expect(PROTOCOL_VERSION).toBeGreaterThanOrEqual(SUBAGENT_SETTINGS_PROTOCOL_VERSION);
 	expect(WS_METHODS.workspaceSetSubagentsOverride).toBe("workspace.setSubagentsOverride");
 });

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -31,6 +31,7 @@ import type {
 	ReviewCommentStatus,
 	ReviewSnapshot,
 	SpecGraphSnapshot,
+	SubagentOverride,
 	Template,
 	TemplateInfo,
 	TemplateScope,
@@ -87,7 +88,8 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 56;
+export const PROTOCOL_VERSION = 57;
+export const SUBAGENT_SETTINGS_PROTOCOL_VERSION = 57;
 export const WORKSPACE_RENAME_PROTOCOL_VERSION = 55;
 export const FEEDBACK_INTERVIEW_PROTOCOL_VERSION = 56;
 
@@ -136,6 +138,7 @@ export const WS_METHODS = {
 	workspaceRemove: "workspace.remove",
 	workspaceDiffStats: "workspace.diffStats",
 	workspaceSetSkillOverride: "workspace.setSkillOverride",
+	workspaceSetSubagentsOverride: "workspace.setSubagentsOverride",
 	workspaceSetDiffBase: "workspace.setDiffBase",
 	workspaceWatchReady: "workspace.watchReady",
 	workspaceOpenIn: "workspace.openIn",
@@ -349,6 +352,10 @@ export interface WsMethodMap {
 	"workspace.diffStats": { params: { id: string }; result: DiffStats };
 	"workspace.setSkillOverride": {
 		params: { id: string; name: string; override: "on" | "off" | null };
+		result: Workspace;
+	};
+	"workspace.setSubagentsOverride": {
+		params: { id: string; override: SubagentOverride | null };
 		result: Workspace;
 	};
 	"workspace.setDiffBase": { params: { id: string; ref: string | null }; result: Workspace };

--- a/packages/pi-subagents/SPEC.md
+++ b/packages/pi-subagents/SPEC.md
@@ -43,8 +43,9 @@ choice was settled: the decision log below.
 - `createSubagentsExtension({ service?, delegationRoot?, scope?, isEnabled? })` — the embedder entry:
   ThinkRail passes its host-bound service, matching storage bindings (used for restart-loss error
   messages), and a live availability predicate. The predicate defaults to enabled for vanilla pi; it
-  removes both tools from the active set at `session_start` when false and is rechecked immediately
-  before `Agent` creates a child, closing an embedder-policy change race without unloading the extension.
+  removes both tools from the active set at `session_start` when false and is rechecked before child
+  assembly and again after its asynchronous setup, immediately before `runQueued`. A late disable disposes
+  that unstarted child before rejecting, closing both launch races without unloading the extension.
 - `SUBAGENT_COMPLETION_MESSAGE` — the custom-message type the web's completion card keys on.
 - Definitions: `AgentDefinition`, `discoverAgentDefinitions`, `parseAgentDefinition`,
   `BUILTIN_AGENTS`.

--- a/packages/pi-subagents/SPEC.md
+++ b/packages/pi-subagents/SPEC.md
@@ -40,9 +40,11 @@ choice was settled: the decision log below.
   `session_shutdown` emitted through pi's public extension runner in the package suite). The
   detached run's late `onUpdate` calls need no such guard: pi-agent-core drops updates after the
   tool call resolves (`acceptingUpdates`), so they are a no-op by construction.
-- `createSubagentsExtension({ service?, delegationRoot?, scope? })` — the embedder entry: ThinkRail
-  passes its host-bound service (and the matching storage bindings, used for restart-loss error
-  messages).
+- `createSubagentsExtension({ service?, delegationRoot?, scope?, isEnabled? })` — the embedder entry:
+  ThinkRail passes its host-bound service, matching storage bindings (used for restart-loss error
+  messages), and a live availability predicate. The predicate defaults to enabled for vanilla pi; it
+  removes both tools from the active set at `session_start` when false and is rechecked immediately
+  before `Agent` creates a child, closing an embedder-policy change race without unloading the extension.
 - `SUBAGENT_COMPLETION_MESSAGE` — the custom-message type the web's completion card keys on.
 - Definitions: `AgentDefinition`, `discoverAgentDefinitions`, `parseAgentDefinition`,
   `BUILTIN_AGENTS`.
@@ -58,7 +60,9 @@ choice was settled: the decision log below.
 Both tools register inside `session_start` (emitted by `bindExtensions`). `Agent` additionally
 re-registers in `before_agent_start` for the first provider turn and at each `turn_end` for the next
 one; pi replaces the same-name tool immediately, so each turn receives one definition snapshot for
-both its description and execution while edits remain live without `/reload`.
+both its description and execution while edits remain live without `/reload`. Registration remains
+intact while an embedder deactivates the tools: same-session re-enable and detached completion delivery
+do not require extension reload or replacement.
 
 ## Definitions: discovery, precedence, trust
 

--- a/packages/pi-subagents/src/extension.test.ts
+++ b/packages/pi-subagents/src/extension.test.ts
@@ -181,14 +181,20 @@ function lastToolResultText(session: AgentSession = parent): string {
 		.join("\n");
 }
 
-async function makeSession(isEnabled?: () => boolean): Promise<AgentSession> {
+async function makeSession(
+	isEnabled?: () => boolean,
+	boundService: DelegationService = service,
+): Promise<AgentSession> {
 	const settingsManager = SettingsManager.inMemory({});
 	const resourceLoader = new DefaultResourceLoader({
 		cwd: parentCwd,
 		agentDir: getAgentDir(),
 		settingsManager,
 		extensionFactories: [
-			createSubagentsExtension({ service, ...(isEnabled ? { isEnabled } : {}) }),
+			createSubagentsExtension({
+				service: boundService,
+				...(isEnabled ? { isEnabled } : {}),
+			}),
 		],
 		noPromptTemplates: true,
 		noThemes: true,
@@ -249,6 +255,55 @@ test("the live enabled predicate rejects a launch selected before embedder polic
 		expect(lastToolResultText(session)).toContain("Subagents are disabled");
 		expect(service.childrenOf(session.sessionId)).toEqual([]);
 	} finally {
+		await service.disposeChildrenOf(session.sessionId);
+		liveParents.delete(session.sessionId);
+		session.dispose();
+	}
+});
+
+test("a disable during asynchronous child creation disposes it before provider work starts", async () => {
+	let enabled = true;
+	let releaseChild = () => {};
+	const childGate = new Promise<void>((resolve) => {
+		releaseChild = resolve;
+	});
+	let signalChildCreated = () => {};
+	const childCreated = new Promise<void>((resolve) => {
+		signalChildCreated = resolve;
+	});
+	const gatedService: DelegationService = {
+		async createChild(spec) {
+			const child = await service.createChild(spec);
+			signalChildCreated();
+			await childGate;
+			return child;
+		},
+		findChild: (sessionId) => service.findChild(sessionId),
+		childrenOf: (parentSessionId) => service.childrenOf(parentSessionId),
+		onLifecycle: (listener) => service.onLifecycle(listener),
+		disposeChildrenOf: (parentSessionId) => service.disposeChildrenOf(parentSessionId),
+	};
+	const session = await makeSession(() => enabled, gatedService);
+	const childCallsBefore = fauxB.state.callCount;
+	try {
+		fauxA.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("Agent", { subagent_type: "bg-runner", task: "Do not start." }),
+			),
+			fauxAssistantMessage("PARENT_RECOVERED"),
+		]);
+		fauxB.setResponses([fauxAssistantMessage("CHILD_SHOULD_NOT_RUN")]);
+		const turn = session.prompt("Try to delegate during a policy change.");
+		await childCreated;
+		enabled = false;
+		releaseChild();
+		await turn;
+
+		expect(lastToolResultText(session)).toContain("Subagents are disabled");
+		expect(fauxB.state.callCount).toBe(childCallsBefore);
+		expect(service.childrenOf(session.sessionId)).toEqual([]);
+	} finally {
+		releaseChild();
 		await service.disposeChildrenOf(session.sessionId);
 		liveParents.delete(session.sessionId);
 		session.dispose();

--- a/packages/pi-subagents/src/extension.test.ts
+++ b/packages/pi-subagents/src/extension.test.ts
@@ -181,13 +181,15 @@ function lastToolResultText(session: AgentSession = parent): string {
 		.join("\n");
 }
 
-async function makeSession(): Promise<AgentSession> {
+async function makeSession(isEnabled?: () => boolean): Promise<AgentSession> {
 	const settingsManager = SettingsManager.inMemory({});
 	const resourceLoader = new DefaultResourceLoader({
 		cwd: parentCwd,
 		agentDir: getAgentDir(),
 		settingsManager,
-		extensionFactories: [createSubagentsExtension({ service })],
+		extensionFactories: [
+			createSubagentsExtension({ service, ...(isEnabled ? { isEnabled } : {}) }),
+		],
 		noPromptTemplates: true,
 		noThemes: true,
 		noContextFiles: true,
@@ -215,6 +217,43 @@ async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<vo
 		await Bun.sleep(20);
 	}
 }
+
+test("an embedder can keep subagent tools registered but inactive at session start", async () => {
+	const session = await makeSession(() => false);
+	try {
+		const configured = session.getAllTools().map((tool) => tool.name);
+		expect(configured).toContain("Agent");
+		expect(configured).toContain("get_subagent_result");
+		expect(session.getActiveToolNames()).not.toContain("Agent");
+		expect(session.getActiveToolNames()).not.toContain("get_subagent_result");
+	} finally {
+		liveParents.delete(session.sessionId);
+		session.dispose();
+	}
+});
+
+test("the live enabled predicate rejects a launch selected before embedder policy changed", async () => {
+	let enabled = true;
+	const session = await makeSession(() => enabled);
+	try {
+		enabled = false;
+		fauxA.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("Agent", { subagent_type: "scout", task: "Should not start." }),
+			),
+			fauxAssistantMessage("PARENT_RECOVERED"),
+		]);
+
+		await session.prompt("Try to delegate.");
+
+		expect(lastToolResultText(session)).toContain("Subagents are disabled");
+		expect(service.childrenOf(session.sessionId)).toEqual([]);
+	} finally {
+		await service.disposeChildrenOf(session.sessionId);
+		liveParents.delete(session.sessionId);
+		session.dispose();
+	}
+});
 
 test("foreground: one Agent call runs a builtin scout and returns its report to the parent", async () => {
 	fauxA.setResponses([

--- a/packages/pi-subagents/src/extension.ts
+++ b/packages/pi-subagents/src/extension.ts
@@ -15,7 +15,7 @@ import {
 } from "pi-delegation";
 import { Type } from "typebox";
 import { type AgentDefinition, discoverAgentDefinitions } from "./definitions";
-import { toSpawnMapping } from "./mapping";
+import { RECURSION_GUARD_TOOLS, toSpawnMapping } from "./mapping";
 
 export const SUBAGENT_COMPLETION_MESSAGE = "subagent-completion";
 
@@ -25,6 +25,7 @@ export interface SubagentsExtensionOptions {
 	service?: DelegationService;
 	delegationRoot?: string;
 	scope?: string;
+	isEnabled?: () => boolean;
 }
 
 function discoverFor(ctx: ExtensionContext): AgentDefinition[] {
@@ -63,6 +64,7 @@ export function createSubagentsExtension(
 	return (pi: ExtensionAPI) => {
 		const delegationRoot = options.delegationRoot ?? defaultDelegationRoot();
 		const scope = options.scope ?? DEFAULT_SCOPE;
+		const isEnabled = () => options.isEnabled?.() ?? true;
 
 		let shuttingDown = false;
 		const erroredRunDetails = new Map<string, DelegationRunDetails>();
@@ -138,6 +140,7 @@ ${known}`,
 					),
 				}),
 				async execute(toolCallId, params, signal, onUpdate, ctx) {
+					if (!isEnabled()) throw new Error("Subagents are disabled in this session.");
 					const definition = definitions.find((d) => d.name === params.subagent_type);
 					if (!definition) {
 						throw new Error(
@@ -278,6 +281,14 @@ ${known}`,
 					};
 				},
 			});
+
+			if (!isEnabled()) {
+				pi.setActiveTools(
+					pi
+						.getActiveTools()
+						.filter((name) => !RECURSION_GUARD_TOOLS.some((toolName) => toolName === name)),
+				);
+			}
 		});
 	};
 }

--- a/packages/pi-subagents/src/extension.ts
+++ b/packages/pi-subagents/src/extension.ts
@@ -164,6 +164,11 @@ ${known}`,
 						session: mapping.session,
 					});
 
+					if (!isEnabled()) {
+						await child.dispose();
+						throw new Error("Subagents are disabled in this session.");
+					}
+
 					const run = child.runQueued(params.task, {
 						...(mapping.maxTurns !== undefined ? { maxTurns: mapping.maxTurns } : {}),
 						...(!params.run_in_background && signal !== undefined ? { signal } : {}),

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -151,6 +151,10 @@ Analytics is host-mediated the same way: **every `track()` call site lives in `h
 session-create, login-success observation), and `host` syncs `setAnalyticsSending` off the settings
 broadcast — `analytics` has no `settings` edge and no feature module knows analytics exists.
 
+Subagent availability is also host-mediated: `settings` owns the global default, `workspaces` owns the
+optional local override, and `host` injects their effective value into `agent` plus requests live-session
+reevaluation after either mutation. No feature imports a sibling to derive the policy.
+
 ## Get right
 
 - **No process isolation** — a fatal agent/provider fault takes the whole host down (accepted tradeoff).

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -362,14 +362,17 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     while parents created afterward project the new generation. The host-wide `getPiRuntime` resolver
     is passed as the core's dynamic fallback rather than captured at service creation. One
     `DelegationService` per workspace is cached (`delegationServiceFor`, synchronous — nothing awaits
-    at bind time); `subagentsExtensionFor(workspaceId)` hands the bound service to the
-    extension factory each session loads. A host-injected `setSubagentsEnabledResolver` maps that
+    at bind time); `subagentsExtensionFor(workspaceId, isEnabled)` hands the bound service and live
+    availability callback to the extension factory each session loads. A host-injected
+    `setSubagentsEnabledResolver` maps that
     workspace id to its current effective policy without creating an `agent` → settings/workspaces edge.
     The predicate reaches the extension's launch-time guard and initial/reload activation. For live
     policy changes, `refreshSubagentTools(workspaceId?)` removes/adds `Agent` +
     `get_subagent_result` through pi's active-tool API: idle sessions update synchronously, streaming
     sessions retain only a pending reevaluation applied at `agent_settled`, and repeated changes resolve
-    the latest policy then. The extension instance is never replaced, so already-running detached children
+    the latest policy then. Session registration re-resolves once after async extension binding and before
+    creation is published, so a policy mutation cannot fall into the bind-before-registry gap. The extension
+    instance is never replaced, so already-running detached children
     finish and retain completion delivery; a disabled launch is still rejected immediately by the live
     predicate even before a streaming parent's tool set can be refreshed.
     Cascades: `removeSession`/`disposeAllSessions` fire

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -363,7 +363,16 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     is passed as the core's dynamic fallback rather than captured at service creation. One
     `DelegationService` per workspace is cached (`delegationServiceFor`, synchronous — nothing awaits
     at bind time); `subagentsExtensionFor(workspaceId)` hands the bound service to the
-    extension factory each session loads. Cascades: `removeSession`/`disposeAllSessions` fire
+    extension factory each session loads. A host-injected `setSubagentsEnabledResolver` maps that
+    workspace id to its current effective policy without creating an `agent` → settings/workspaces edge.
+    The predicate reaches the extension's launch-time guard and initial/reload activation. For live
+    policy changes, `refreshSubagentTools(workspaceId?)` removes/adds `Agent` +
+    `get_subagent_result` through pi's active-tool API: idle sessions update synchronously, streaming
+    sessions retain only a pending reevaluation applied at `agent_settled`, and repeated changes resolve
+    the latest policy then. The extension instance is never replaced, so already-running detached children
+    finish and retain completion delivery; a disabled launch is still rejected immediately by the live
+    predicate even before a streaming parent's tool set can be refreshed.
+    Cascades: `removeSession`/`disposeAllSessions` fire
     `disposeSessionChildren` — `removeSession` returns that cascade, the **delete transaction
     awaits it before `publishDeleted`/resolving** (safe: the cascade carries its own swallow, so a
     failing child abort can never fail a delete whose transcript is already trashed), and workspace
@@ -514,7 +523,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count) /
   `isProjectSkillPath(relativePath)` (watch-classification predicate);
   `reloadSessionResources(sessionId)` (active-chat reload); the **`setSkillAdmissionResolver`** seam (host
-  wires `workspaceId` → the admission context);
+  wires `workspaceId` → the admission context); the subagent-policy seams
+  **`setSubagentsEnabledResolver`** + **`refreshSubagentTools`** (host resolves the effective global default
+  plus workspace override; manager owns live-session activation timing);
   the bundled-artifact seam (`registerBundledRuntime` +
   `BundledExtensions`/`BundledExtensionFactory`).
 - **Allowed deps:** `@earendil-works/pi-coding-agent` (runtime); `@earendil-works/pi-ai` (types + test

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -7,8 +7,12 @@ import {
 	type Model,
 	type ModelsRefreshResult,
 } from "@earendil-works/pi-ai";
-import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
-import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
+import {
+	createFauxCore,
+	fauxAssistantMessage,
+	fauxToolCall,
+} from "@earendil-works/pi-ai/providers/faux";
+import { AgentSession, ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type {
 	AgentSettlement,
 	ExtUiRequest,
@@ -35,6 +39,8 @@ import {
 	listSessions,
 	promptSession,
 	refreshAvailableModels,
+	refreshSubagentTools,
+	reloadSessionResources,
 	removeQueuedSession,
 	removeSession,
 	removeWorkspaceSessions,
@@ -42,6 +48,7 @@ import {
 	setSessionDeletedPublisher,
 	setSessionManagerFactory,
 	setSessionPublisher,
+	setSubagentsEnabledResolver,
 	steerSession,
 	toWireModel,
 } from "./agentSessionManager";
@@ -90,6 +97,11 @@ const cfg = (faux: typeof fauxA, id: string) => ({
 
 const events = new Map<string, unknown[]>();
 const seen = (id: string) => JSON.stringify(events.get(id) ?? []);
+
+function subagentToolState(context: { tools?: ReadonlyArray<{ name: string }> }): string {
+	const names = new Set((context.tools ?? []).map((tool) => tool.name));
+	return names.has("Agent") && names.has("get_subagent_result") ? "SUBAGENTS_ON" : "SUBAGENTS_OFF";
+}
 
 const tmpDirs: string[] = [];
 function tmpCwd(prefix: string): string {
@@ -225,6 +237,291 @@ test("agent_settled carries the final attempt's terminal metadata", async () => 
 	});
 	const hydrated = await getSessionMessages(session.sessionId, "ws-settled", cwd);
 	expect(hydrated.summary.lastSettlement).toEqual(settled?.terminal);
+});
+
+test("a disabled workspace creates chats without active subagent tools", async () => {
+	const workspaceId = "ws-subagents-initial-off";
+	setSubagentsEnabledResolver((id) => id !== workspaceId);
+	let sessionId: string | undefined;
+	try {
+		const session = await createSession({
+			cwd: tmpCwd("trpi-subagents-initial-off-"),
+			workspaceId,
+			model: toWireModel(fauxA.getModel()),
+		});
+		sessionId = session.sessionId;
+		fauxA.setResponses([(context) => fauxAssistantMessage(subagentToolState(context))]);
+
+		await promptSession(sessionId, "Which tools are active?");
+
+		expect(seen(sessionId)).toContain("SUBAGENTS_OFF");
+	} finally {
+		setSubagentsEnabledResolver(() => true);
+		if (sessionId) removeSession(sessionId);
+	}
+});
+
+test("session registration reconciles a policy change that lands after extension binding", async () => {
+	const workspaceId = "ws-subagents-bind-race";
+	let enabled = false;
+	setSubagentsEnabledResolver((id) => id !== workspaceId || enabled);
+	const originalBind = AgentSession.prototype.bindExtensions;
+	let signalBound = () => {};
+	const bound = new Promise<void>((resolve) => {
+		signalBound = resolve;
+	});
+	let releaseRegistration = () => {};
+	const registrationGate = new Promise<void>((resolve) => {
+		releaseRegistration = resolve;
+	});
+	AgentSession.prototype.bindExtensions = async function (bindings) {
+		await originalBind.call(this, bindings);
+		signalBound();
+		await registrationGate;
+	};
+	let sessionId: string | undefined;
+	try {
+		const creating = createSession({
+			cwd: tmpCwd("trpi-subagents-bind-race-"),
+			workspaceId,
+			model: toWireModel(fauxA.getModel()),
+		});
+		await bound;
+		enabled = true;
+		refreshSubagentTools(workspaceId);
+		releaseRegistration();
+		const session = await creating;
+		sessionId = session.sessionId;
+		fauxA.setResponses([(context) => fauxAssistantMessage(subagentToolState(context))]);
+
+		await promptSession(sessionId, "Check post-registration tools.");
+
+		expect(seen(sessionId)).toContain("SUBAGENTS_ON");
+	} finally {
+		releaseRegistration();
+		AgentSession.prototype.bindExtensions = originalBind;
+		setSubagentsEnabledResolver(() => true);
+		if (sessionId) await removeSession(sessionId);
+	}
+});
+
+test("an idle chat adopts subagent policy changes, survives resource reload, and re-enables", async () => {
+	const workspaceId = "ws-subagents-idle-toggle";
+	let enabled = true;
+	setSubagentsEnabledResolver((id) => id !== workspaceId || enabled);
+	let sessionId: string | undefined;
+	try {
+		const session = await createSession({
+			cwd: tmpCwd("trpi-subagents-idle-toggle-"),
+			workspaceId,
+			model: toWireModel(fauxA.getModel()),
+		});
+		sessionId = session.sessionId;
+
+		enabled = false;
+		refreshSubagentTools(workspaceId);
+		await reloadSessionResources(sessionId);
+		fauxA.setResponses([(context) => fauxAssistantMessage(subagentToolState(context))]);
+		await promptSession(sessionId, "Check disabled tools.");
+		expect(seen(sessionId)).toContain("SUBAGENTS_OFF");
+
+		enabled = true;
+		refreshSubagentTools(workspaceId);
+		fauxA.setResponses([(context) => fauxAssistantMessage(subagentToolState(context))]);
+		await promptSession(sessionId, "Check enabled tools.");
+		expect(seen(sessionId)).toContain("SUBAGENTS_ON");
+	} finally {
+		setSubagentsEnabledResolver(() => true);
+		if (sessionId) removeSession(sessionId);
+	}
+});
+
+test("a streaming chat defers its tool-set change until agent_settled", async () => {
+	const slow = createFauxCore({
+		provider: "faux-subagent-policy",
+		api: "faux-subagent-policy",
+		models: [modelDef("faux-subagent-policy")],
+		tokensPerSecond: 2000,
+	});
+	runtime.registerProvider("faux-subagent-policy", cfg(slow, "faux-subagent-policy"));
+	const workspaceId = "ws-subagents-streaming-toggle";
+	let enabled = true;
+	setSubagentsEnabledResolver((id) => id !== workspaceId || enabled);
+	let release = () => {};
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let started = () => {};
+	const requestStarted = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	let firstState = "";
+	let automaticContinuationState = "";
+	let sessionId: string | undefined;
+	try {
+		const cwd = tmpCwd("trpi-subagents-streaming-toggle-");
+		writeFileSync(join(cwd, "probe.txt"), "probe\n");
+		slow.setResponses([
+			async (context) => {
+				firstState = subagentToolState(context);
+				started();
+				await gate;
+				return fauxAssistantMessage(fauxToolCall("read", { path: join(cwd, "probe.txt") }));
+			},
+			(context) => {
+				automaticContinuationState = subagentToolState(context);
+				return fauxAssistantMessage("AUTOMATIC_WORK_DONE");
+			},
+			(context) => fauxAssistantMessage(`NEXT_TURN_${subagentToolState(context)}`),
+		]);
+		const session = await createSession({
+			cwd,
+			workspaceId,
+			model: toWireModel(slow.getModel()),
+		});
+		sessionId = session.sessionId;
+		const firstTurn = promptSession(sessionId, "Start the gated turn.");
+		await requestStarted;
+
+		enabled = false;
+		refreshSubagentTools(workspaceId);
+		expect(firstState).toBe("SUBAGENTS_ON");
+		release();
+		await firstTurn;
+		expect(automaticContinuationState).toBe("SUBAGENTS_ON");
+		await promptSession(sessionId, "Check the next turn.");
+
+		expect(seen(sessionId)).toContain("NEXT_TURN_SUBAGENTS_OFF");
+	} finally {
+		release();
+		setSubagentsEnabledResolver(() => true);
+		if (sessionId) removeSession(sessionId);
+		runtime.unregisterProvider("faux-subagent-policy");
+	}
+});
+
+test("repeated streaming policy changes resolve only the latest value at settlement", async () => {
+	const slow = createFauxCore({
+		provider: "faux-subagent-policy-latest",
+		api: "faux-subagent-policy-latest",
+		models: [modelDef("faux-subagent-policy-latest")],
+		tokensPerSecond: 2000,
+	});
+	runtime.registerProvider("faux-subagent-policy-latest", cfg(slow, "faux-subagent-policy-latest"));
+	const workspaceId = "ws-subagents-streaming-latest";
+	let enabled = true;
+	const resolvedValues: boolean[] = [];
+	setSubagentsEnabledResolver((id) => {
+		if (id !== workspaceId) return true;
+		resolvedValues.push(enabled);
+		return enabled;
+	});
+	let release = () => {};
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let started = () => {};
+	const requestStarted = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	let sessionId: string | undefined;
+	try {
+		slow.setResponses([
+			async () => {
+				started();
+				await gate;
+				return fauxAssistantMessage("LATEST_POLICY_TURN_DONE");
+			},
+		]);
+		const session = await createSession({
+			cwd: tmpCwd("trpi-subagents-streaming-latest-"),
+			workspaceId,
+			model: toWireModel(slow.getModel()),
+		});
+		sessionId = session.sessionId;
+		resolvedValues.length = 0;
+		const turn = promptSession(sessionId, "Start another gated turn.");
+		await requestStarted;
+
+		enabled = false;
+		refreshSubagentTools(workspaceId);
+		enabled = true;
+		refreshSubagentTools(workspaceId);
+		expect(resolvedValues).toEqual([]);
+		release();
+		await turn;
+
+		expect(resolvedValues).toEqual([true]);
+	} finally {
+		release();
+		setSubagentsEnabledResolver(() => true);
+		if (sessionId) await removeSession(sessionId);
+		runtime.unregisterProvider("faux-subagent-policy-latest");
+	}
+});
+
+test("disabling an idle parent lets its running background child finish and deliver", async () => {
+	const workspaceId = "ws-subagents-running-child";
+	let enabled = true;
+	setSubagentsEnabledResolver((id) => id !== workspaceId || enabled);
+	let releaseChild = () => {};
+	const childGate = new Promise<void>((resolve) => {
+		releaseChild = resolve;
+	});
+	let signalChildStarted = () => {};
+	const childStarted = new Promise<void>((resolve) => {
+		signalChildStarted = resolve;
+	});
+	let sessionId: string | undefined;
+	try {
+		const cwd = tmpCwd("trpi-subagents-running-child-");
+		mkdirSync(join(cwd, ".pi", "agents"), { recursive: true });
+		writeFileSync(
+			join(cwd, ".pi", "agents", "policy-bg.md"),
+			"---\nname: policy-bg\ndescription: Policy background runner\nmodel: fauxb\n---\n\nFinish the task.\n",
+		);
+		fauxB.setResponses([
+			async () => {
+				signalChildStarted();
+				await childGate;
+				return fauxAssistantMessage("BACKGROUND_FINISHED");
+			},
+		]);
+		fauxA.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("Agent", {
+					subagent_type: "policy-bg",
+					task: "Wait, then finish.",
+					run_in_background: true,
+				}),
+			),
+			fauxAssistantMessage("BACKGROUND_STARTED"),
+			(context) => fauxAssistantMessage(`${subagentToolState(context)}_AT_COMPLETION`),
+		]);
+		const session = await createSession({
+			cwd,
+			workspaceId,
+			model: toWireModel(fauxA.getModel()),
+		});
+		sessionId = session.sessionId;
+		await Promise.all([promptSession(sessionId, "Start background work."), childStarted]);
+
+		enabled = false;
+		refreshSubagentTools(workspaceId);
+		releaseChild();
+		const deadline = Date.now() + 5000;
+		while (!seen(sessionId).includes("SUBAGENTS_OFF_AT_COMPLETION")) {
+			if (Date.now() > deadline) throw new Error("background completion was not delivered");
+			await Bun.sleep(20);
+		}
+
+		expect(seen(sessionId)).toContain("BACKGROUND_FINISHED");
+		expect(seen(sessionId)).toContain("subagent-completion");
+	} finally {
+		releaseChild();
+		setSubagentsEnabledResolver(() => true);
+		if (sessionId) await removeSession(sessionId);
+	}
 });
 
 test("buildSessionSettings disables image autoResize (in-memory, so the read tool sends images raw)", () => {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -35,6 +35,7 @@ import type {
 } from "@thinkrail/contracts";
 import { isTranscriptMessageRole } from "@thinkrail/contracts";
 import type { ParentContext } from "pi-delegation";
+import { RECURSION_GUARD_TOOLS } from "pi-subagents";
 import { logger } from "../log";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import {
@@ -75,6 +76,7 @@ interface Entry {
 	manualCompactionInProgress: boolean;
 	piCompactionInProgress: boolean;
 	registered: boolean;
+	subagentToolsRefreshPending: boolean;
 }
 
 const sessions = new Map<string, Entry>();
@@ -130,6 +132,43 @@ export function setSkillAdmissionResolver(
 	resolver: (workspaceId: string) => SkillAdmissionContext,
 ): void {
 	skillAdmissionResolver = resolver;
+}
+
+let subagentsEnabledResolver: (workspaceId: string) => boolean = () => true;
+export function setSubagentsEnabledResolver(resolver: (workspaceId: string) => boolean): void {
+	subagentsEnabledResolver = resolver;
+}
+
+function subagentsEnabled(workspaceId: string): boolean {
+	try {
+		return subagentsEnabledResolver(workspaceId);
+	} catch {
+		return false;
+	}
+}
+
+function isSubagentTool(name: string): boolean {
+	return RECURSION_GUARD_TOOLS.some((toolName) => toolName === name);
+}
+
+function applySubagentTools(entry: Entry): void {
+	const withoutSubagents = entry.session
+		.getActiveToolNames()
+		.filter((name) => !isSubagentTool(name));
+	entry.session.setActiveToolsByName(
+		subagentsEnabled(entry.workspaceId)
+			? [...withoutSubagents, ...RECURSION_GUARD_TOOLS]
+			: withoutSubagents,
+	);
+	entry.subagentToolsRefreshPending = false;
+}
+
+export function refreshSubagentTools(workspaceId?: string): void {
+	for (const entry of sessions.values()) {
+		if (workspaceId !== undefined && entry.workspaceId !== workspaceId) continue;
+		if (entry.session.isStreaming) entry.subagentToolsRefreshPending = true;
+		else applySubagentTools(entry);
+	}
 }
 
 function hasDeletionTombstone(sessionId: string): boolean {
@@ -231,6 +270,7 @@ async function prepareSessionEntry(
 		manualCompactionInProgress: false,
 		piCompactionInProgress: false,
 		registered: false,
+		subagentToolsRefreshPending: false,
 	};
 	entry.unsubscribe = session.subscribe((event) => {
 		if (event.type === "queue_update") {
@@ -260,7 +300,10 @@ async function prepareSessionEntry(
 			baseEvent.type === "queue_update" && hasQueuedImages(entry)
 				? { ...baseEvent, hasImages: true as const }
 				: baseEvent;
-		if (event.type === "agent_settled") entry.lastSettlement = terminal;
+		if (event.type === "agent_settled") {
+			entry.lastSettlement = terminal;
+			if (entry.subagentToolsRefreshPending) applySubagentTools(entry);
+		}
 		if (sessions.get(sessionId) === entry) publish({ sessionId, event: projected });
 		if (event.type === "agent_settled") terminal = null;
 	});
@@ -311,6 +354,7 @@ async function registerSession(
 	const prepared = await prepareSessionEntry(session, workspaceId, generation);
 	prepared.entry.registered = true;
 	sessions.set(session.sessionId, prepared.entry);
+	applySubagentTools(prepared.entry);
 	log.debug(`session ${session.sessionId} attached (workspace ${workspaceId})`);
 	if (announceCreation) publishCreated(summaryOf(session.sessionId, prepared.entry));
 	return prepared.result;
@@ -337,7 +381,7 @@ export async function createSession(input: CreateSessionInput): Promise<CreateSe
 			settingsManager,
 			() => skillAdmissionResolver(input.workspaceId),
 			generation.excludedSessionExtensionPaths,
-			[subagentsExtensionFor(input.workspaceId)],
+			[subagentsExtensionFor(input.workspaceId, () => subagentsEnabled(input.workspaceId))],
 		),
 		...(model ? { model } : {}),
 		...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
@@ -552,7 +596,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 			settingsManager,
 			() => skillAdmissionResolver(workspaceId),
 			generation.excludedSessionExtensionPaths,
-			[subagentsExtensionFor(workspaceId)],
+			[subagentsExtensionFor(workspaceId, () => subagentsEnabled(workspaceId))],
 		),
 		...(exactModel ? { model: exactModel } : {}),
 	});

--- a/packages/server/src/agent/delegation.ts
+++ b/packages/server/src/agent/delegation.ts
@@ -39,11 +39,15 @@ export function delegationServiceFor(workspaceId: string): DelegationService {
 	return service;
 }
 
-export function subagentsExtensionFor(workspaceId: string): BundledExtensionFactory {
+export function subagentsExtensionFor(
+	workspaceId: string,
+	isEnabled: () => boolean,
+): BundledExtensionFactory {
 	return createSubagentsExtension({
 		service: delegationServiceFor(workspaceId),
 		delegationRoot: delegationRootDir(),
 		scope: workspaceId,
+		isEnabled,
 	});
 }
 

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -266,7 +266,14 @@ channel fan-out, and the process-boot wrapper both launchers share.
   toggles; `session.reloadResources` re-scans a running session — the composition stays here; `agent` never
   imports its sibling. `createServer` also wires **`setSkillAdmissionResolver`**, mapping a session's
   `workspaceId` → its project's trust/acknowledged/disabled + that workspace's overrides (fail-closed), so
-  `agent` gates skills without importing `projects`/`workspaces`);
+  `agent` gates skills without importing `projects`/`workspaces`). The sibling subagent policy is composed
+  here the same way: `createServer` wires `setSubagentsEnabledResolver` to map an explicit
+  `Workspace.subagentsOverride` when present and otherwise use `AppConfig.subagentsEnabled` (unknown
+  workspace fails closed), the settings
+  publisher asks `refreshSubagentTools()` to reevaluate all live sessions after any global update, and
+  `workspace.setSubagentsOverride` persists through `workspaces` then refreshes only that workspace. The
+  two authoritative publishers remain the clients' convergence path; the host-to-agent refresh changes
+  runtime capability, not frontend state;
   **`reviewerSessionMonitor.ts`** (safety for stuck reviewer sessions) — when a reviewer session crashes/times out
   without sending a verdict, the item's `pending` review flag (the UI's `reviewing: true` spinner) previously
   persisted forever, deadlocking the Review All queue. The monitor subscribes to session settled events

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -107,6 +107,31 @@ test("workspace.rename locks the display name without changing Git or the worktr
 	expect(listed.find((workspace) => workspace.id === created.id)).toMatchObject(renamed);
 });
 
+test("workspace.setSubagentsOverride persists on/off and null restores the global default", async () => {
+	const created = (await handleRequest("workspace.create", { projectId: "p1" }, CTX)) as Workspace;
+
+	const enabled = (await handleRequest(
+		"workspace.setSubagentsOverride",
+		{ id: created.id, override: "on" },
+		CTX,
+	)) as Workspace;
+	expect(enabled.subagentsOverride).toBe("on");
+
+	const disabled = (await handleRequest(
+		"workspace.setSubagentsOverride",
+		{ id: created.id, override: "off" },
+		CTX,
+	)) as Workspace;
+	expect(disabled.subagentsOverride).toBe("off");
+
+	const inherited = (await handleRequest(
+		"workspace.setSubagentsOverride",
+		{ id: created.id, override: null },
+		CTX,
+	)) as Workspace;
+	expect(inherited.subagentsOverride).toBeUndefined();
+});
+
 test("workspace.watchReady waits for startup once, then reports an already-ready watcher", async () => {
 	const rows = (await handleRequest("workspace.list", { projectId: "p1" }, CTX)) as Workspace[];
 	const workspace = rows[0];

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -13,6 +13,7 @@ import type {
 	ReviewCommentKind,
 	ReviewCommentStatus,
 	ReviewSendResult,
+	SubagentOverride,
 	TemplateScope,
 	ThinkingLevel,
 	TodoStatus,
@@ -45,6 +46,7 @@ import {
 	promptSession,
 	readChildTranscript,
 	refreshAvailableModels,
+	refreshSubagentTools,
 	reloadSessionResources,
 	removeQueuedSession,
 	removeSession,
@@ -156,6 +158,7 @@ import {
 	renameWorkspace,
 	setWorkspaceDiffBase,
 	setWorkspaceSkillOverride,
+	setWorkspaceSubagentsOverride,
 	workspaceDiffStats,
 } from "../workspaces";
 import { ackSend } from "./ackSend";
@@ -569,6 +572,12 @@ const handlers: Record<string, Handler> = {
 	"workspace.setSkillOverride": (params) => {
 		const p = params as { id: string; name: string; override: "on" | "off" | null };
 		return setWorkspaceSkillOverride(p.id, p.name, p.override);
+	},
+	"workspace.setSubagentsOverride": (params) => {
+		const p = params as { id: string; override: SubagentOverride | null };
+		const workspace = setWorkspaceSubagentsOverride(p.id, p.override);
+		refreshSubagentTools(p.id);
+		return workspace;
 	},
 	"workspace.setDiffBase": (params) => {
 		const p = params as { id: string; ref: string | null };

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -18,12 +18,14 @@ import {
 	disposeAllSessions,
 	getSessionWorkspaceId,
 	isProjectSkillPath,
+	refreshSubagentTools,
 	setExtUiPublisher,
 	setReviewCommentHandler,
 	setSessionCreatedPublisher,
 	setSessionDeletedPublisher,
 	setSessionPublisher,
 	setSkillAdmissionResolver,
+	setSubagentsEnabledResolver,
 	settleSessionsForShutdown,
 } from "../agent";
 import {
@@ -81,6 +83,7 @@ import { handleRequest, requestMethodDiagnostic } from "./handlers";
 import { provisionInitialTerminal } from "./initialTerminal";
 import { trackLoginOutcome } from "./loginAnalytics";
 import { RequestReplayCache } from "./requestReplayCache";
+import { resolveSubagentsEnabled } from "./subagentPolicy";
 import { terminalDeliveryForSendStatus } from "./terminalSend";
 import {
 	handleReviewerSettled,
@@ -357,6 +360,14 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 		}
 	});
 
+	setSubagentsEnabledResolver((workspaceId) => {
+		try {
+			return resolveSubagentsEnabled(getConfig().subagentsEnabled, getWorkspace(workspaceId));
+		} catch {
+			return false;
+		}
+	});
+
 	setProjectPublisher((project) => {
 		server.publish(
 			WS_CHANNELS.projectUpdated,
@@ -421,6 +432,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 			JSON.stringify({ channel: WS_CHANNELS.settingsChanged, data: config }),
 		);
 		setAnalyticsSending(config.analyticsEnabled);
+		refreshSubagentTools();
 	});
 
 	setSessionCreatedPublisher((payload: SessionCreatedPayload) => {

--- a/packages/server/src/host/subagentPolicy.test.ts
+++ b/packages/server/src/host/subagentPolicy.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { resolveSubagentsEnabled } from "./subagentPolicy";
+
+test("workspace subagent overrides take precedence over the global default", () => {
+	expect(resolveSubagentsEnabled(true, { subagentsOverride: "off" })).toBe(false);
+	expect(resolveSubagentsEnabled(false, { subagentsOverride: "on" })).toBe(true);
+});
+
+test("an absent override inherits the global default and an unknown workspace fails closed", () => {
+	expect(resolveSubagentsEnabled(true, {})).toBe(true);
+	expect(resolveSubagentsEnabled(false, {})).toBe(false);
+	expect(resolveSubagentsEnabled(true, undefined)).toBe(false);
+});

--- a/packages/server/src/host/subagentPolicy.ts
+++ b/packages/server/src/host/subagentPolicy.ts
@@ -1,0 +1,11 @@
+import type { Workspace } from "@thinkrail/contracts";
+
+export function resolveSubagentsEnabled(
+	globalDefault: boolean,
+	workspace: Pick<Workspace, "subagentsOverride"> | undefined,
+): boolean {
+	if (!workspace) return false;
+	if (workspace.subagentsOverride === "on") return true;
+	if (workspace.subagentsOverride === "off") return false;
+	return globalDefault;
+}

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -82,6 +82,10 @@ export function loadConfig(): AppConfig {
 			: DEFAULT_CONFIG.composerGrowthLimit,
 		reviewAutoFix:
 			typeof value.reviewAutoFix === "boolean" ? value.reviewAutoFix : DEFAULT_CONFIG.reviewAutoFix,
+		subagentsEnabled:
+			typeof value.subagentsEnabled === "boolean"
+				? value.subagentsEnabled
+				: DEFAULT_CONFIG.subagentsEnabled,
 		customLayoutPresets: Array.isArray(value.customLayoutPresets)
 			? value.customLayoutPresets
 			: DEFAULT_CONFIG.customLayoutPresets,

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -33,7 +33,7 @@ layout presets because it owns their cross-frontend storage contract.
 ## Get right
 
 - **Converge on broadcast, no client optimism.** `updateConfig` persists before publishing; every frontend, including the initiator, adopts `settings.changed`. `server.welcome` seeds the same cached value.
-- `subagentsEnabled` defaults to `true` when absent so old config preserves current behavior. Settings owns only that global default; workspace override and effective-value resolution stay outside this module.
+- `subagentsEnabled` defaults to `true` when absent so old config preserves current behavior; a present non-boolean update is rejected before cache, persistence, or broadcast changes. Settings owns only that global default; workspace override and effective-value resolution stay outside this module.
 - Theme availability/labels/palettes are not server concerns. Unknown theme ids remain persisted; each independently shipped frontend resolves visual fallback.
 - Retired host-layout and chat-message-order fields are ignored rather than persisted or broadcast. Layout instantiation and transcript order are frontend-local preferences.
 - Custom layout presets are a complete top-level catalog replacement, not a nested per-item patch. Each value is bounded, resource-free, uniquely identified, uses only the current preset schema, and contains no workspace/tab/session/terminal identity. A malformed persisted member is isolated during config validation; a wire mutation with any malformed member is rejected as a whole. No alternate config key or old preset schema is read or upgraded.

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -32,7 +32,7 @@ layout presets because it owns their cross-frontend storage contract.
 
 ## Get right
 
-- **Converge on broadcast, no client optimism.** `updateConfig` persists before publishing; every frontend, including the initiator, adopts `settings.changed`. `server.welcome` seeds the same cached value.
+- **Converge on broadcast, no client optimism.** `updateConfig` persists before replacing the live cache or publishing; a failed write changes neither runtime reads nor frontends. Every frontend, including the initiator, adopts `settings.changed`. `server.welcome` seeds the same cached value.
 - `subagentsEnabled` defaults to `true` when absent so old config preserves current behavior; a present non-boolean update is rejected before cache, persistence, or broadcast changes. Settings owns only that global default; workspace override and effective-value resolution stay outside this module.
 - Theme availability/labels/palettes are not server concerns. Unknown theme ids remain persisted; each independently shipped frontend resolves visual fallback.
 - Retired host-layout and chat-message-order fields are ignored rather than persisted or broadcast. Layout instantiation and transcript order are frontend-local preferences.

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -11,7 +11,7 @@ tags: [v1]
 ## Responsibility
 
 The server-synchronized app config: opaque theme selection, analytics switch, terminal replay budget, chat
-composer growth preset, bounded custom layout-preset catalog, and plan-review policy. `reviewModel` /
+composer growth preset, bounded custom layout-preset catalog, the host-wide subagent default, and plan-review policy. `reviewModel` /
 `reviewEffort` select the reviewer/reflector runtime (unset means pi
 default); `reviewAutoFix: false` records a `request_changes` verdict and waits instead of auto-sending a fix.
 The module reads, normalizes, persists, caches, and broadcasts values that intentionally follow the owner
@@ -33,6 +33,7 @@ layout presets because it owns their cross-frontend storage contract.
 ## Get right
 
 - **Converge on broadcast, no client optimism.** `updateConfig` persists before publishing; every frontend, including the initiator, adopts `settings.changed`. `server.welcome` seeds the same cached value.
+- `subagentsEnabled` defaults to `true` when absent so old config preserves current behavior. Settings owns only that global default; workspace override and effective-value resolution stay outside this module.
 - Theme availability/labels/palettes are not server concerns. Unknown theme ids remain persisted; each independently shipped frontend resolves visual fallback.
 - Retired host-layout and chat-message-order fields are ignored rather than persisted or broadcast. Layout instantiation and transcript order are frontend-local preferences.
 - Custom layout presets are a complete top-level catalog replacement, not a nested per-item patch. Each value is bounded, resource-free, uniquely identified, uses only the current preset schema, and contains no workspace/tab/session/terminal identity. A malformed persisted member is isolated during config validation; a wire mutation with any malformed member is rejected as a whole. No alternate config key or old preset schema is read or upgraded.

--- a/packages/server/src/settings/settings.test.ts
+++ b/packages/server/src/settings/settings.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -151,6 +151,17 @@ test("a non-boolean subagents update is rejected before persistence or broadcast
 	expect(getConfig()).toEqual(before);
 	expect(published).toEqual([]);
 	expect(existsSync(join(dataDir, "config.json"))).toBe(false);
+});
+
+test("a failed config write leaves the live cache and publisher unchanged", () => {
+	const published: AppConfig[] = [];
+	setSettingsPublisher((config) => published.push(config));
+	expect(getConfig().subagentsEnabled).toBe(true);
+	mkdirSync(join(dataDir, "config.json"));
+
+	expect(() => updateConfig({ subagentsEnabled: false })).toThrow();
+	expect(getConfig().subagentsEnabled).toBe(true);
+	expect(published).toEqual([]);
 });
 
 test("reviewModel/reviewEffort persist through the top-level partial merge", () => {

--- a/packages/server/src/settings/settings.test.ts
+++ b/packages/server/src/settings/settings.test.ts
@@ -130,6 +130,29 @@ test("reviewAutoFix defaults on; an old config without it loads the default; tog
 	expect(getConfig().reviewAutoFix).toBe(false);
 });
 
+test("subagents default on; an old config inherits that default; toggling off round-trips", () => {
+	expect(DEFAULT_CONFIG.subagentsEnabled).toBe(true);
+	writeFileSync(join(dataDir, "config.json"), JSON.stringify({ theme: "dark" }));
+	resetConfigCache();
+	expect(getConfig().subagentsEnabled).toBe(true);
+	const next = updateConfig({ subagentsEnabled: false });
+	expect(next.subagentsEnabled).toBe(false);
+	resetConfigCache();
+	expect(getConfig().subagentsEnabled).toBe(false);
+});
+
+test("a non-boolean subagents update is rejected before persistence or broadcast", () => {
+	const published: AppConfig[] = [];
+	setSettingsPublisher((config) => published.push(config));
+	const before = getConfig();
+	const invalid = { subagentsEnabled: "false" } as unknown as AppConfigUpdate;
+
+	expect(() => updateConfig(invalid)).toThrow("subagentsEnabled must be a boolean");
+	expect(getConfig()).toEqual(before);
+	expect(published).toEqual([]);
+	expect(existsSync(join(dataDir, "config.json"))).toBe(false);
+});
+
 test("reviewModel/reviewEffort persist through the top-level partial merge", () => {
 	const model = {
 		id: "m",

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -52,8 +52,8 @@ export function updateConfig(partial: AppConfigUpdate): AppConfig {
 		if (reviewEffort === null) delete next.reviewEffort;
 		else next.reviewEffort = reviewEffort;
 	}
-	cached = next;
 	saveConfig(next);
+	cached = next;
 	publishSettings?.(next);
 	return next;
 }

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -31,10 +31,15 @@ export function updateConfig(partial: AppConfigUpdate): AppConfig {
 	const runtimeUpdate: RuntimeAppConfigUpdate = { ...partial };
 	delete runtimeUpdate.chatMessageOrder;
 	delete runtimeUpdate.layout;
-	const { reviewModel, reviewEffort, customLayoutPresets, ...rest } = runtimeUpdate;
+	const { reviewModel, reviewEffort, customLayoutPresets, subagentsEnabled, ...rest } =
+		runtimeUpdate;
+	if (subagentsEnabled !== undefined && typeof subagentsEnabled !== "boolean") {
+		throw new Error("subagentsEnabled must be a boolean");
+	}
 	const next: AppConfig = {
 		...getConfig(),
 		...rest,
+		...(subagentsEnabled === undefined ? {} : { subagentsEnabled }),
 		...(customLayoutPresets === undefined
 			? {}
 			: { customLayoutPresets: validateCustomLayoutPresets(customLayoutPresets) }),

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -108,7 +108,11 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   `listWorkspaceRecords`
   (raw registry records without Default ensure, folder-truth reconciliation, or per-workspace git diffStats —
   for internal read-only paths like history scope mapping that must not block on git spawns),
-  `workspaceDiffStats`, **`setWorkspaceDiffBase(id, ref | null)`** — re-point the ref this workspace's diff is
+  `workspaceDiffStats`, **`setWorkspaceSubagentsOverride(id, override)`** — persist `"on"` / `"off"`,
+  or delete `Workspace.subagentsOverride` for `null` (inherit), then emit the authoritative full
+  `workspace.updated` snapshot. It validates the closed value but never reads the global default or
+  resolves effective agent policy; the host composes that across sibling boundaries;
+  **`setWorkspaceDiffBase(id, ref | null)`** — re-point the ref this workspace's diff is
   measured against (`Workspace.diffBase`), `null` (or the creation base itself, which would be a redundant
   override) clearing it; persists + **broadcasts the updated record** so every client converges on the push,
   never optimistically (modelled exactly on `setWorkspaceSkillOverride`). Both **ref doors** — this one and
@@ -204,7 +208,8 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`, `reclaimWorktree`, `removeWorkspace`,
   `workspaceDiffStats`, `workspaceDiffKey`, `getWorkspace`, `renameWorkspace`, `refreshUserOwnedWorkspace`,
   `completeInitialTerminalReservation`, `ensureWorkspaceScratchDir`, `setWorkspacePublisher`,
-  `WorkspaceLifecycleEvent`, `setWorkspaceDiffBase`, `setWorkspaceSkillOverride`.
+  `WorkspaceLifecycleEvent`, `setWorkspaceDiffBase`, `setWorkspaceSkillOverride`,
+  `setWorkspaceSubagentsOverride`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`, `log`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -27,6 +27,7 @@ import {
 	renameWorkspace,
 	setWorkspaceDiffBase,
 	setWorkspacePublisher,
+	setWorkspaceSubagentsOverride,
 	type WorkspaceLifecycleEvent,
 } from "./workspaces";
 
@@ -459,6 +460,35 @@ test("renameWorkspace re-points siblings basing their diff on the old branch", a
 	const after = await listWorkspaces("p1");
 	expect(after.find((w) => w.id === dependent.id)?.baseBranch).toBe("core-work");
 	expect(after.find((w) => w.id === first.id)?.branch).toBe("core-work");
+});
+
+test("setWorkspaceSubagentsOverride persists explicit values and null restores inheritance", async () => {
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((event) => events.push(event));
+	const ws = await createWorkspace("p1");
+
+	expect(ws.subagentsOverride).toBeUndefined();
+	expect(setWorkspaceSubagentsOverride(ws.id, "on").subagentsOverride).toBe("on");
+	expect(listWorkspaceRecords("p1").find((row) => row.id === ws.id)?.subagentsOverride).toBe("on");
+	expect(events.at(-1)).toMatchObject({
+		kind: "updated",
+		workspace: { id: ws.id, subagentsOverride: "on" },
+	});
+	expect(setWorkspaceSubagentsOverride(ws.id, "off").subagentsOverride).toBe("off");
+	expect(setWorkspaceSubagentsOverride(ws.id, null).subagentsOverride).toBeUndefined();
+	expect(
+		listWorkspaceRecords("p1").find((row) => row.id === ws.id)?.subagentsOverride,
+	).toBeUndefined();
+});
+
+test("setWorkspaceSubagentsOverride rejects unknown workspaces and values outside the wire union", async () => {
+	const ws = await createWorkspace("p1");
+	expect(() => setWorkspaceSubagentsOverride("missing", "on")).toThrow(
+		"Unknown workspace: missing",
+	);
+	expect(() => setWorkspaceSubagentsOverride(ws.id, "sometimes" as "on")).toThrow(
+		"Invalid subagent override",
+	);
 });
 
 test("setWorkspaceDiffBase re-points the diff target, leaving creation provenance alone", async () => {

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -5,6 +5,7 @@ import type {
 	DiffStats,
 	ExistingWorktreeCandidate,
 	Project,
+	SubagentOverride,
 	Workspace,
 } from "@thinkrail/contracts";
 import { WORKSPACE_CONTEXT_DIR } from "@thinkrail/shared/paths";
@@ -438,6 +439,23 @@ export function setWorkspaceSkillOverride(
 	else overrides[name] = override;
 	if (Object.keys(overrides).length > 0) ws.skillOverrides = overrides;
 	else delete ws.skillOverrides;
+	saveWorkspaces(all);
+	emit({ kind: "updated", workspace: ws });
+	return ws;
+}
+
+export function setWorkspaceSubagentsOverride(
+	id: string,
+	override: SubagentOverride | null,
+): Workspace {
+	const all = loadWorkspaces();
+	const ws = all.find((workspace) => workspace.id === id);
+	if (!ws) throw new Error(`Unknown workspace: ${id}`);
+	if (override !== null && override !== "on" && override !== "off") {
+		throw new Error("Invalid subagent override");
+	}
+	if (override === null) delete ws.subagentsOverride;
+	else ws.subagentsOverride = override;
 	saveWorkspaces(all);
 	emit({ kind: "updated", workspace: ws });
 	return ws;


### PR DESCRIPTION
## Summary

- Add a default-on global subagent switch and per-workspace `Use global` / `On` / `Off` overrides.
- Apply changes to live chats without interrupting running child agents.
- Gate the controls on protocol v57 and keep state authoritative across clients.

## Screenshots

| Before | After |
| --- | --- |
| ![Chat settings before](https://github.com/JetBrains/thinkrail/blob/74f8ac1b45c4c00f972475f3fed26ba0ba3d1d2a/subagent-settings-before.png?raw=true) | ![Chat settings after](https://github.com/JetBrains/thinkrail/blob/74f8ac1b45c4c00f972475f3fed26ba0ba3d1d2a/subagent-settings-after.png?raw=true) |

## Testing

- Pre-rebase repository gates passed, including 922 server tests.
- Pre-rebase `bun run e2e` — 342 passed across 8 shards.
- No post-rebase local tests run, as requested; CI validates the rebased head.

