### PR TITLE
tests: fixture repos do not inherit the developer's signing config

### DIFF
--- a/e2e/ask-restart.live.spec.ts
+++ b/e2e/ask-restart.live.spec.ts
@@ -63,6 +63,7 @@ function seedState(): void {
 	gitQuiet(REPO, "init", "-b", "main");
 	gitQuiet(REPO, "config", "user.email", "e2e@thinkrail.test");
 	gitQuiet(REPO, "config", "user.name", "ThinkRail E2E");
+	gitQuiet(REPO, "config", "commit.gpgsign", "false");
 	writeFileSync(join(REPO, "README.md"), "# restart fixture\n");
 	gitQuiet(REPO, "add", "-A");
 	gitQuiet(REPO, "commit", "-m", "init");

--- a/e2e/fixtures/repo.ts
+++ b/e2e/fixtures/repo.ts
@@ -18,6 +18,7 @@ export function seedFixtureRepo(): void {
 	git("init", "-b", "main");
 	git("config", "user.email", "e2e@thinkrail.test");
 	git("config", "user.name", "ThinkRail E2E");
+	git("config", "commit.gpgsign", "false");
 	writeFileSync(join(E2E_FIXTURE_REPO, "README.md"), "# sample-project\n");
 	writeFileSync(join(E2E_FIXTURE_REPO, "notes.txt"), "plain-text-fixture\n");
 	writeFileSync(

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -103,6 +103,7 @@ function seedSecondRepo(): string {
 	git(repo, "init", "-b", "main");
 	git(repo, "config", "user.email", "e2e@thinkrail.test");
 	git(repo, "config", "user.name", "ThinkRail E2E");
+	git(repo, "config", "commit.gpgsign", "false");
 	writeFileSync(join(repo, "README.md"), "# second project\n");
 	git(repo, "add", "-A");
 	git(repo, "commit", "-m", "seed");

--- a/e2e/workflows/harness/workspace.ts
+++ b/e2e/workflows/harness/workspace.ts
@@ -14,6 +14,7 @@ export function seedWorkspace(seed: WorkspaceSeed): string {
 	gitQuiet(cwd, "init", "-b", "main");
 	gitQuiet(cwd, "config", "user.email", "workflow-tests@thinkrail.test");
 	gitQuiet(cwd, "config", "user.name", "ThinkRail Workflow Tests");
+	gitQuiet(cwd, "config", "commit.gpgsign", "false");
 	if (typeof seed === "function") seed(cwd);
 	else seedKind(cwd, seed);
 	gitQuiet(cwd, "add", "-A");

--- a/packages/server/src/artifactProbes.ts
+++ b/packages/server/src/artifactProbes.ts
@@ -254,6 +254,8 @@ export default function syntheticExternalExtension(pi) {
 			"user.name=ThinkRail Smoke",
 			"-c",
 			"user.email=smoke@thinkrail.invalid",
+			"-c",
+			"commit.gpgsign=false",
 			"commit",
 			"--quiet",
 			"-m",

--- a/packages/server/src/git/git.test.ts
+++ b/packages/server/src/git/git.test.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
 	git(repo, "init", "-b", "main");
 	git(repo, "config", "user.email", "t@thinkrail.test");
 	git(repo, "config", "user.name", "test");
+	git(repo, "config", "commit.gpgsign", "false");
 	writeFileSync(join(repo, "README.md"), "# repo\n");
 	git(repo, "add", "-A");
 	git(repo, "commit", "-m", "init");
@@ -233,6 +234,7 @@ test("prefetchBranch fetches a remote ref and no-ops on a local ref or unknown p
 	git(clone, "checkout", "-B", "main", "origin/main");
 	git(clone, "config", "user.email", "t@thinkrail.test");
 	git(clone, "config", "user.name", "test");
+	git(clone, "config", "commit.gpgsign", "false");
 	writeFileSync(join(clone, "remote-only.txt"), "remote\n");
 	git(clone, "add", "-A");
 	git(clone, "commit", "-m", "remote-only");
@@ -736,6 +738,7 @@ test("a failed commit restores the index — the user's staging area is never le
 	writeFileSync(join(repo, "impl.ts"), "export {};\n");
 	writeFileSync(join(repo, "mine.ts"), "export const mine = 1;\n");
 	git(repo, "add", "--", "mine.ts");
+	git(repo, "config", "gpg.format", "openpgp");
 	git(repo, "config", "commit.gpgsign", "true");
 	git(repo, "config", "gpg.program", join(dataDir, "no-such-gpg"));
 
@@ -750,6 +753,7 @@ test("a failed commit preserves index-only state — an intent-to-add entry surv
 	writeFileSync(join(repo, "impl.ts"), "export {};\n");
 	writeFileSync(join(repo, "intent.txt"), "later\n");
 	git(repo, "add", "-N", "--", "intent.txt");
+	git(repo, "config", "gpg.format", "openpgp");
 	git(repo, "config", "commit.gpgsign", "true");
 	git(repo, "config", "gpg.program", join(dataDir, "no-such-gpg"));
 

--- a/packages/server/src/host/autoRename.test.ts
+++ b/packages/server/src/host/autoRename.test.ts
@@ -41,6 +41,8 @@ beforeEach(() => {
 		"user.email=t@thinkrail.test",
 		"-c",
 		"user.name=ThinkRail Test",
+		"-c",
+		"commit.gpgsign=false",
 		"commit",
 		"--allow-empty",
 		"-m",

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
 	git(repo, "init", "-b", "main");
 	git(repo, "config", "user.email", "t@thinkrail.test");
 	git(repo, "config", "user.name", "test");
+	git(repo, "config", "commit.gpgsign", "false");
 	writeFileSync(join(repo, "README.md"), "# repo\n");
 	git(repo, "add", "-A");
 	git(repo, "commit", "-m", "init");

--- a/packages/server/src/pr/pr.test.ts
+++ b/packages/server/src/pr/pr.test.ts
@@ -398,6 +398,7 @@ describe("openPr — invalidates the open-review cache", () => {
 		sh(repo, "init", "-q", "-b", "main");
 		sh(repo, "config", "user.email", "t@thinkrail.test");
 		sh(repo, "config", "user.name", "test");
+		sh(repo, "config", "commit.gpgsign", "false");
 		writeFileSync(join(repo, "README.md"), "# repo\n");
 		sh(repo, "add", "-A");
 		sh(repo, "commit", "-q", "-m", "init");
@@ -610,6 +611,7 @@ describe("openPr — rejects when the branch is its own base (never push straigh
 		sh("init", "-b", "main");
 		sh("config", "user.email", "t@thinkrail.test");
 		sh("config", "user.name", "test");
+		sh("config", "commit.gpgsign", "false");
 		writeFileSync(join(repo, "README.md"), "# repo\n");
 		sh("add", "-A");
 		sh("commit", "-m", "init");

--- a/packages/server/src/projects/projects.test.ts
+++ b/packages/server/src/projects/projects.test.ts
@@ -37,6 +37,7 @@ function makeRepo(path: string): void {
 	git(path, "init", "-b", "main");
 	git(path, "config", "user.email", "t@thinkrail.test");
 	git(path, "config", "user.name", "test");
+	git(path, "config", "commit.gpgsign", "false");
 	writeFileSync(join(path, "README.md"), "# repo\n");
 	git(path, "add", "-A");
 	git(path, "commit", "-m", "init");

--- a/packages/server/src/projects/projects.test.ts
+++ b/packages/server/src/projects/projects.test.ts
@@ -43,6 +43,21 @@ function makeRepo(path: string): void {
 	git(path, "commit", "-m", "init");
 }
 
+function withoutUserGitConfig<T>(run: () => T): T {
+	const savedGlobal = process.env.GIT_CONFIG_GLOBAL;
+	const savedSystem = process.env.GIT_CONFIG_SYSTEM;
+	process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+	process.env.GIT_CONFIG_SYSTEM = "/dev/null";
+	try {
+		return run();
+	} finally {
+		if (savedGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+		else process.env.GIT_CONFIG_GLOBAL = savedGlobal;
+		if (savedSystem === undefined) delete process.env.GIT_CONFIG_SYSTEM;
+		else process.env.GIT_CONFIG_SYSTEM = savedSystem;
+	}
+}
+
 let dataDir: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
 
@@ -147,7 +162,7 @@ test("host-home paths resolve consistently across inspect, open, and init", () =
 		expect(inspectProjectPath("~/repo")).toEqual({ kind: "repo" });
 		expect(openProject("~/repo").path).toBe(realpathSync(repo));
 		expect(inspectProjectPath("~/plain")).toEqual({ kind: "initable" });
-		expect(initProject("~/plain").path).toBe(realpathSync(plain));
+		expect(withoutUserGitConfig(() => initProject("~/plain")).path).toBe(realpathSync(plain));
 	} finally {
 		if (savedHome === undefined) delete process.env.HOME;
 		else process.env.HOME = savedHome;
@@ -167,7 +182,7 @@ test("initProject: initialises a plain folder, commits its contents, and opens i
 	mkdirSync(dir);
 	writeFileSync(join(dir, "hello.txt"), "hi\n");
 
-	const project = initProject(dir);
+	const project = withoutUserGitConfig(() => initProject(dir));
 	expect(project.path).toBe(realpathSync(dir));
 	expect(existsSync(join(dir, ".git"))).toBe(true);
 	expect(gitOut(dir, "rev-parse", "HEAD")).not.toBe("");
@@ -179,7 +194,7 @@ test("initProject: an empty folder gets an empty initial commit (a HEAD), so wor
 	const dir = join(dataDir, "empty");
 	mkdirSync(dir);
 
-	initProject(dir);
+	withoutUserGitConfig(() => initProject(dir));
 	expect(gitOut(dir, "rev-parse", "HEAD")).not.toBe("");
 	expect(gitOut(dir, "ls-tree", "-r", "HEAD", "--name-only")).toBe("");
 	const wt = join(dataDir, "wt");
@@ -192,20 +207,9 @@ test("initProject: commits even with no configured git identity (the -c fallback
 	mkdirSync(dir);
 	writeFileSync(join(dir, "file.txt"), "x\n");
 
-	const savedGlobal = process.env.GIT_CONFIG_GLOBAL;
-	const savedSystem = process.env.GIT_CONFIG_SYSTEM;
-	process.env.GIT_CONFIG_GLOBAL = "/dev/null";
-	process.env.GIT_CONFIG_SYSTEM = "/dev/null";
-	try {
-		initProject(dir);
-		expect(gitOut(dir, "rev-parse", "HEAD")).not.toBe("");
-		expect(gitOut(dir, "log", "-1", "--format=%an")).toBe("ThinkRail");
-	} finally {
-		if (savedGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
-		else process.env.GIT_CONFIG_GLOBAL = savedGlobal;
-		if (savedSystem === undefined) delete process.env.GIT_CONFIG_SYSTEM;
-		else process.env.GIT_CONFIG_SYSTEM = savedSystem;
-	}
+	withoutUserGitConfig(() => initProject(dir));
+	expect(gitOut(dir, "rev-parse", "HEAD")).not.toBe("");
+	expect(gitOut(dir, "log", "-1", "--format=%an")).toBe("ThinkRail");
 });
 
 test("initProject: an existing repo is opened, not re-initialised (dedupe, history preserved)", () => {

--- a/packages/server/src/reviews/reviews.test.ts
+++ b/packages/server/src/reviews/reviews.test.ts
@@ -51,6 +51,7 @@ beforeEach(() => {
 	worktree = mkdtempSync(join(tmpdir(), "reviews-wt-"));
 	process.env.THINKRAIL_DATA_DIR = dataDir;
 	gitIn(worktree, ["init", "-b", "main"]);
+	gitIn(worktree, ["config", "commit.gpgsign", "false"]);
 	gitIn(worktree, [
 		"-c",
 		"user.email=t@t",

--- a/packages/server/src/todos/artifacts.test.ts
+++ b/packages/server/src/todos/artifacts.test.ts
@@ -54,6 +54,7 @@ test("a newly active window is captured before a held queue or an earlier done i
 	process.env.THINKRAIL_DATA_DIR = dataDir;
 	try {
 		execFileSync("git", ["init", "-b", "main"], { cwd: worktree, stdio: "ignore" });
+		execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: worktree, stdio: "ignore" });
 		execFileSync(
 			"git",
 			["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"],
@@ -675,6 +676,7 @@ test("a UI removal landing during an in-flight reconcile leaves no orphan window
 	process.env.THINKRAIL_DATA_DIR = dataDir;
 	try {
 		execFileSync("git", ["init", "-b", "main"], { cwd: worktree, stdio: "ignore" });
+		execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: worktree, stdio: "ignore" });
 		execFileSync(
 			"git",
 			["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"],

--- a/packages/server/src/todos/decoration.test.ts
+++ b/packages/server/src/todos/decoration.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
 	sh(repo, "init", "-b", "main");
 	sh(repo, "config", "user.email", "t@thinkrail.test");
 	sh(repo, "config", "user.name", "test");
+	sh(repo, "config", "commit.gpgsign", "false");
 	writeFileSync(join(repo, "README.md"), "# repo\n");
 	sh(repo, "add", "-A");
 	sh(repo, "commit", "-m", "init");

--- a/packages/server/src/todos/reviewFlow.test.ts
+++ b/packages/server/src/todos/reviewFlow.test.ts
@@ -45,6 +45,7 @@ beforeEach(() => {
 	sh(repo, "init", "-b", "main");
 	sh(repo, "config", "user.email", "t@thinkrail.test");
 	sh(repo, "config", "user.name", "test");
+	sh(repo, "config", "commit.gpgsign", "false");
 	writeFileSync(join(repo, "README.md"), "# repo\n");
 	sh(repo, "add", "-A");
 	sh(repo, "commit", "-m", "init");

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -57,6 +57,7 @@ beforeEach(() => {
 	git(repo, "init", "-b", "main");
 	git(repo, "config", "user.email", "t@thinkrail.test");
 	git(repo, "config", "user.name", "test");
+	git(repo, "config", "commit.gpgsign", "false");
 	writeFileSync(join(repo, "README.md"), "# repo\n");
 	git(repo, "add", "-A");
 	git(repo, "commit", "-m", "init");


### PR DESCRIPTION
# Problem

Two git tests set `commit.gpgsign` with `gpg.program` pointed at a binary that does not exist and expect the commit to fail. On a machine that signs with `gpg.format=ssh` (my case: 1Password signing) the bogus program is never consulted: git reaches for the ssh signer instead, the commit succeeds, and the tests fail.

That uncovered the larger half. Every fixture repo inherits the developer's global git config, so with `commit.gpgsign=true` globally the whole suite was signing each seed commit for real. That is an agent round-trip per fixture, and with a hardware-backed key it is a prompt in the middle of a test run. The e2e spec helpers and the artifact smoke probe run with the developer's real HOME (only the host under test gets the isolated one), so they inherit the same way the unit-test fixtures do.

# Change

- The two failing-commit tests pin `gpg.format=openpgp` alongside `gpg.program`, so the program they broke is the one git uses.
- The `initProject` tests cannot pre-seed repo config, since `initProject` runs `git init` and `git commit` itself. Every call now goes through a `withoutUserGitConfig` helper that points `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at `/dev/null`, the isolation the no-identity test already used.
- Every fixture seed sets `commit.gpgsign=false`: the unit-test repos under `packages/server`, the e2e fixture repo and the workflow-harness workspace, the second-project seed in the projects e2e spec, the ask-restart live seed, and the artifact smoke probe's fixture project. Nothing in these repos is ever pushed, and a test repository in a temp directory has nothing to attest.

# Verification

- `bun run check:deps`, `check:boundaries`, `check:seams`, `lint`, `typecheck`: green.
- `packages/server` unit suite: 925 pass, 0 fail, on a machine with `commit.gpgsign=true` and `gpg.format=ssh`.
- `packages/server` unit suite with `GIT_CONFIG_GLOBAL` pointed at an unsignable config (`commit.gpgsign=true`, `gpg.program=/nonexistent`): 925 pass, 0 fail.
- `bun run e2e` (full no-agent suite): 344 passed. A first run had one failure in the `projects` spec at the `welcome-title` assertion; it passed on rerun, both alone and in a full clean run, and the seed it follows had already completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
