### PR TITLE
fix(web): mark the device and theme halves of the current-theme row

### DIFF
--- a/apps/web/src/panels/AppearanceSettings.tsx
+++ b/apps/web/src/panels/AppearanceSettings.tsx
@@ -1,4 +1,10 @@
-import { RiCheckLine as Check, RiArrowDownSLine as ChevronDown } from "@remixicon/react";
+import {
+	RiArrowRightLine as ArrowRight,
+	RiCheckLine as Check,
+	RiArrowDownSLine as ChevronDown,
+	RiComputerLine as Device,
+	RiPaletteLine as Palette,
+} from "@remixicon/react";
 import {
 	type AppConfigUpdate,
 	type SystemThemePair,
@@ -206,8 +212,12 @@ export function AppearanceSettings() {
 						className="flex items-center justify-between gap-8"
 					>
 						<span className="tr-text-metadata text-text-muted">Current on this device</span>
-						<span className="tr-text-ui text-text-default">
-							{systemAppearance === "light" ? "Light" : "Dark"} · {current.theme.label}
+						<span className="flex items-center gap-4 tr-text-ui text-text-default">
+							<Device className="size-14 shrink-0 text-text-muted" />
+							{systemAppearance === "light" ? "Light" : "Dark"}
+							<ArrowRight className="size-14 shrink-0 text-text-muted" />
+							<Palette className="size-14 shrink-0 text-text-muted" />
+							{current.theme.label}
 						</span>
 					</div>
 					<ThemeSelector

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -383,7 +383,9 @@ a project picker, the prompt hero, and the reused
   cards. Mode is deliberately separate from the manifest list: making System another theme row nests configuration in a
   radio-like option, while always showing all three choices gives inactive values equal visual weight. Fixed
   mode shows the existing manifest list and retained fixed choice. System mode shows appearance-filtered
-  `Light theme` / `Dark theme` selectors plus `Current on this device: <Light|Dark> · <resolved label>`;
+  `Light theme` / `Dark theme` selectors plus a `Current on this device` row reading
+  `<device icon> <Light|Dark> → <palette icon> <resolved label>` — the icons carry which half is the device
+  appearance and which is the theme, since both halves are often the same word;
   either slot may independently be normal or high contrast. First enable sends mode + the themes-derived
   same-contrast pair atomically; later slot edits replace the complete pair, and returning to fixed changes
   only mode, preserving both choices. Exactly one theme mutation may be in flight from this panel; its


### PR DESCRIPTION
`Current on this device` read `Dark · Dark` — no clue which half is the device appearance and which is the resolved theme. A monitor icon and a palette icon now label the two halves: `🖥 Dark → 🎨 Dark`.

<img width="513" height="362" alt="image" src="https://github.com/user-attachments/assets/1cffb4b9-2e23-4ba5-988b-6d7d6822aaf7" />

Verified: lint, typecheck, `check:boundaries`, `check:deps`, `check:spec-surface`, and the full `bun run e2e` (one pre-existing `projects.spec.ts` flake, green on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)