### PR TITLE
feat(web): show agent activity in the Projects rail

### DIFF
--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -936,7 +936,15 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   your answer" **even when every item is done** (the earlier strip hid it whenever there was no
   in-progress step, so an agent blocked on a question read as "finished"); "working" while it runs;
   "paused" only when it stopped with open steps left; and nothing extra on a clean finish (all done,
-  idle). `TodoList` stays props-driven — it receives the resolved glance, never reads the transport.
+  idle). The glance stays **chat-local and is not the Projects rail's authority**, even though the rail's
+  host-derived `ActivityStatus` overlaps it: `askStates` exists here for a job status cannot do —
+  `useAskState(toolCallId)` renders *which* questionnaire is awaiting — so `planGlance` is a one-line
+  reduction over a map this view already holds, and routing it through the wire would add a dependency to
+  remove nothing. They also answer different questions: "paused" (stopped with open steps) is a plan
+  concept the rail calls idle, and the glance has no `queued`/`failed`. What *is* shared is the meaning of
+  awaiting (unanswered, not superseded), single-sourced per process — `deriveAskStates` here,
+  `assessAnswerability` on the host; `contracts` is types-only, so no implementation can span both.
+  `TodoList` stays props-driven — it receives the resolved glance, never reads the transport.
   Its section label + pending/active/done status glyphs live in **`planKit.tsx`** — shared
   presentational atoms the Review panel (`panels/ReviewPanel`) reuses so both "work items in
   sections" surfaces read identically.

--- a/apps/web/src/panels/ActivityGlyph.test.tsx
+++ b/apps/web/src/panels/ActivityGlyph.test.tsx
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import type { ActivityStatus } from "@thinkrail/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { ActivityGlyph, activityBreakdown } from "./ActivityGlyph";
+import { ActivityGlyph, activityBreakdown, activityChatCount } from "./ActivityGlyph";
 
 function render(status: ActivityStatus, counts?: Partial<Record<ActivityStatus, number>>): string {
 	return renderToStaticMarkup(
@@ -52,4 +52,22 @@ test("the breakdown omits states nothing is in", () => {
 test("several busy chats surface the breakdown as the accessible name too", () => {
 	const markup = render("failed", { failed: 1, running: 2 });
 	expect(markup).toContain("1 chat failed, 2 chats working");
+});
+
+test("repeated statuses still show the breakdown — the count is what the row cannot say", () => {
+	const markup = render("running", { running: 2 });
+	expect(markup).toContain('aria-label="2 chats working"');
+	expect(markup).not.toContain('aria-label="Agent is working"');
+});
+
+test("the breakdown threshold counts CHATS, not distinct statuses", () => {
+	expect(activityChatCount({ running: 2 })).toBe(2);
+	expect(activityChatCount({ failed: 1, running: 3 })).toBe(4);
+	expect(activityChatCount({ running: 1 })).toBe(1);
+	expect(activityChatCount({})).toBe(0);
+});
+
+test("one chat keeps the plain label whichever status it is in", () => {
+	expect(render("failed", { failed: 1 })).toContain('aria-label="Last run failed"');
+	expect(render("queued", { queued: 1 })).toContain('aria-label="Message queued"');
 });

--- a/apps/web/src/panels/ActivityGlyph.test.tsx
+++ b/apps/web/src/panels/ActivityGlyph.test.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import type { ActivityStatus } from "@thinkrail/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ActivityGlyph, activityBreakdown } from "./ActivityGlyph";
+
+function render(status: ActivityStatus, counts?: Partial<Record<ActivityStatus, number>>): string {
+	return renderToStaticMarkup(
+		<TooltipProvider>
+			<ActivityGlyph status={status} counts={counts} />
+		</TooltipProvider>,
+	);
+}
+
+test("every status renders a glyph carrying its own accessible name", () => {
+	expect(render("running")).toContain('aria-label="Agent is working"');
+	expect(render("waiting")).toContain('aria-label="Waiting for your answer"');
+	expect(render("failed")).toContain('aria-label="Last run failed"');
+	expect(render("queued")).toContain('aria-label="Message queued"');
+});
+
+test("the accessible name never depends on the tooltip, which hover-only surfaces cannot give a phone", () => {
+	const markup = render("waiting");
+	expect(markup).toContain('role="img"');
+	expect(markup).toContain('data-testid="activity-glyph"');
+});
+
+test("each status uses its published semantic colour token, never a raw value", () => {
+	expect(render("running")).toContain("text-feedback-info");
+	expect(render("waiting")).toContain("text-feedback-warning");
+	expect(render("failed")).toContain("text-feedback-error");
+	expect(render("queued")).toContain("text-text-subtle");
+});
+
+test("a single busy chat keeps the plain label instead of a one-line breakdown", () => {
+	expect(render("running", { running: 1 })).toContain('aria-label="Agent is working"');
+});
+
+test("the breakdown reports counts in rollup order, so the glyph's own state reads first", () => {
+	expect(activityBreakdown({ running: 2, failed: 1, waiting: 1 })).toEqual([
+		"1 chat failed",
+		"1 chat waiting for your answer",
+		"2 chats working",
+	]);
+});
+
+test("the breakdown omits states nothing is in", () => {
+	expect(activityBreakdown({ queued: 3 })).toEqual(["3 chats queued"]);
+	expect(activityBreakdown({})).toEqual([]);
+});
+
+test("several busy chats surface the breakdown as the accessible name too", () => {
+	const markup = render("failed", { failed: 1, running: 2 });
+	expect(markup).toContain("1 chat failed, 2 chats working");
+});

--- a/apps/web/src/panels/ActivityGlyph.tsx
+++ b/apps/web/src/panels/ActivityGlyph.tsx
@@ -39,6 +39,10 @@ const PRESENTATION: Record<
 
 const BREAKDOWN_ORDER: readonly ActivityStatus[] = ["failed", "waiting", "running", "queued"];
 
+export function activityChatCount(counts: Partial<Record<ActivityStatus, number>>): number {
+	return BREAKDOWN_ORDER.reduce((total, status) => total + (counts[status] ?? 0), 0);
+}
+
 export function activityBreakdown(counts: Partial<Record<ActivityStatus, number>>): string[] {
 	return BREAKDOWN_ORDER.flatMap((status) => {
 		const count = counts[status] ?? 0;
@@ -56,7 +60,7 @@ export function ActivityGlyph({
 }) {
 	const { Icon, label, className } = PRESENTATION[status];
 	const lines = counts ? activityBreakdown(counts) : [];
-	const detailed = lines.length > 1;
+	const detailed = counts !== undefined && activityChatCount(counts) > 1;
 	return (
 		<IconTooltip
 			wrapTrigger

--- a/apps/web/src/panels/ActivityGlyph.tsx
+++ b/apps/web/src/panels/ActivityGlyph.tsx
@@ -1,0 +1,85 @@
+import {
+	RiErrorWarningLine as CircleAlert,
+	RiRecordCircleLine as CircleDot,
+	RiQuestionnaireLine as MessageCircleQuestion,
+	RiTimeLine as Timer,
+} from "@remixicon/react";
+import type { ActivityStatus } from "@thinkrail/contracts";
+import { IconTooltip } from "@/components/ui/tooltip";
+
+const PRESENTATION: Record<
+	ActivityStatus,
+	{ Icon: typeof CircleDot; label: string; plural: string; className: string }
+> = {
+	failed: {
+		Icon: CircleAlert,
+		label: "Last run failed",
+		plural: "failed",
+		className: "text-feedback-error",
+	},
+	waiting: {
+		Icon: MessageCircleQuestion,
+		label: "Waiting for your answer",
+		plural: "waiting for your answer",
+		className: "text-feedback-warning",
+	},
+	running: {
+		Icon: CircleDot,
+		label: "Agent is working",
+		plural: "working",
+		className: "text-feedback-info",
+	},
+	queued: {
+		Icon: Timer,
+		label: "Message queued",
+		plural: "queued",
+		className: "text-text-subtle",
+	},
+};
+
+const BREAKDOWN_ORDER: readonly ActivityStatus[] = ["failed", "waiting", "running", "queued"];
+
+export function activityBreakdown(counts: Partial<Record<ActivityStatus, number>>): string[] {
+	return BREAKDOWN_ORDER.flatMap((status) => {
+		const count = counts[status] ?? 0;
+		if (count === 0) return [];
+		return [`${count} ${count === 1 ? "chat" : "chats"} ${PRESENTATION[status].plural}`];
+	});
+}
+
+export function ActivityGlyph({
+	status,
+	counts,
+}: {
+	status: ActivityStatus;
+	counts?: Partial<Record<ActivityStatus, number>>;
+}) {
+	const { Icon, label, className } = PRESENTATION[status];
+	const lines = counts ? activityBreakdown(counts) : [];
+	const detailed = lines.length > 1;
+	return (
+		<IconTooltip
+			wrapTrigger
+			label={
+				detailed ? (
+					<span className="flex flex-col gap-2">
+						{lines.map((line) => (
+							<span key={line}>{line}</span>
+						))}
+					</span>
+				) : (
+					label
+				)
+			}
+		>
+			<span
+				data-testid="activity-glyph"
+				role="img"
+				aria-label={detailed ? lines.join(", ") : label}
+				className="flex size-20 shrink-0 items-center justify-center"
+			>
+				<Icon className={`size-14 ${className}`} />
+			</span>
+		</IconTooltip>
+	);
+}

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -397,6 +397,7 @@ function ProjectRow({
 		<div
 			data-testid="project-item"
 			data-menu-open={menuOpen}
+			{...(activity ? { "data-activity": activity.status } : {})}
 			className={`group flex h-28 items-center gap-4 rounded-[var(--radius-sm)] pr-4 pl-4 transition-colors ${
 				menuOpen ? "bg-control-bg-selected" : "hover:bg-control-bg-hovered"
 			}`}

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -48,13 +48,17 @@ import {
 import { copyText } from "@/lib";
 import { LoadingRegion } from "../components/Skeleton";
 import {
+	type ActivityRollup,
 	isDefaultWorkspace,
 	isExternalWorkspace,
+	projectActivityRollup,
 	selectActiveWorkspaceProjectId,
 	toast,
 	useAppStore,
+	workspaceActivityRollup,
 } from "../store";
 import { errorText, getTransport, prewarmWorkspaceSkillLoad } from "../transport";
+import { ActivityGlyph } from "./ActivityGlyph";
 import { AddProjectMenu } from "./AddProjectMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { ExistingWorktreeDialog } from "./ExistingWorktreeDialog";
@@ -71,6 +75,7 @@ export function ProjectTree() {
 	const workspaces = useAppStore((s) => s.workspaces);
 	const worktreeCreations = useAppStore((s) => s.worktreeCreationsByProject);
 	const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
+	const activityByWorkspace = useAppStore((s) => s.activityByWorkspace);
 	const protocolVersion = useAppStore((s) => s.protocolVersion);
 
 	const [editors, setEditors] = useState<EditorInfo[]>([]);
@@ -263,6 +268,11 @@ export function ProjectTree() {
 								project={project}
 								isSelected={selectedProjectId === project.id}
 								isExpanded={isExpanded}
+								activity={
+									isExpanded
+										? null
+										: projectActivityRollup(activityByWorkspace, workspaces, project.id)
+								}
 								workspaceCount={(list ?? []).filter((w) => !isDefaultWorkspace(w)).length}
 								onToggle={() => toggleExpand(project.id)}
 								onSelect={() => void selectProject(project.id)}
@@ -283,6 +293,7 @@ export function ProjectTree() {
 											key={ws.id}
 											workspace={ws}
 											isActive={activeWorkspaceId === ws.id}
+											activity={workspaceActivityRollup(activityByWorkspace, ws.id)}
 											canRename={canRenameWorkspace(protocolVersion, ws)}
 											editors={editors}
 											onSelect={() => selectWorkspace(ws)}
@@ -348,6 +359,7 @@ function ProjectRow({
 	project,
 	isSelected,
 	isExpanded,
+	activity,
 	workspaceCount,
 	onToggle,
 	onSelect,
@@ -361,6 +373,7 @@ function ProjectRow({
 	project: Project;
 	isSelected: boolean;
 	isExpanded: boolean;
+	activity: ActivityRollup | null;
 	workspaceCount: number;
 	onToggle: () => void;
 	onSelect: () => void;
@@ -414,6 +427,7 @@ function ProjectRow({
 					{project.name}
 				</span>
 			</button>
+			{activity && <ActivityGlyph status={activity.status} counts={activity.counts} />}
 			{!isExpanded && workspaceCount > 0 && (
 				<span
 					data-testid="project-workspace-count"
@@ -518,6 +532,7 @@ function ProjectRow({
 function WorkspaceRow({
 	workspace,
 	isActive,
+	activity,
 	canRename,
 	editors,
 	onSelect,
@@ -529,6 +544,7 @@ function WorkspaceRow({
 }: {
 	workspace: Workspace;
 	isActive: boolean;
+	activity: ActivityRollup | null;
 	canRename: boolean;
 	editors: EditorInfo[];
 	onSelect: () => void;
@@ -638,6 +654,7 @@ function WorkspaceRow({
 				data-testid="workspace-item"
 				data-active={isActive}
 				data-kind={workspace.kind ?? "worktree"}
+				{...(activity ? { "data-activity": activity.status } : {})}
 				onContextMenu={openMenuFromContext}
 				className={`group flex min-h-28 min-w-0 items-center gap-8 rounded-[var(--radius-sm)] border-0 py-4 pr-4 pl-24 transition-colors ${
 					isActive || menuOpen ? "bg-control-bg-selected" : "hover:bg-control-bg-hovered"
@@ -676,6 +693,7 @@ function WorkspaceRow({
 						</span>
 					</button>
 				)}
+				{activity && <ActivityGlyph status={activity.status} counts={activity.counts} />}
 				<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
 					<DropdownMenuTrigger
 						data-testid="workspace-menu"
@@ -754,6 +772,7 @@ function WorkspaceRow({
 					</DropdownMenuContent>
 				</DropdownMenu>
 			</fieldset>
+
 			{!isDefault && (
 				<ConfirmDialog
 					open={confirmOpen}

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -269,9 +269,7 @@ export function ProjectTree() {
 								isSelected={selectedProjectId === project.id}
 								isExpanded={isExpanded}
 								activity={
-									isExpanded
-										? null
-										: projectActivityRollup(activityByWorkspace, workspaces, project.id)
+									isExpanded ? null : projectActivityRollup(activityByWorkspace, project.id)
 								}
 								workspaceCount={(list ?? []).filter((w) => !isDefaultWorkspace(w)).length}
 								onToggle={() => toggleExpand(project.id)}

--- a/apps/web/src/panels/ProjectTree.tsx
+++ b/apps/web/src/panels/ProjectTree.tsx
@@ -237,7 +237,7 @@ export function ProjectTree() {
 	};
 
 	return (
-		<nav className="flex flex-col gap-8">
+		<nav data-testid="project-tree" className="flex flex-col gap-8">
 			<header className="flex h-28 items-center justify-between pr-4 pl-8">
 				<span className="tr-text-eyebrow text-text-muted">Projects</span>
 				<AddProjectMenu

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -104,11 +104,14 @@ treatment.
     kebab never covers it (a trailing overlay would).
   - **Hover explains it**, via `IconTooltip` (`wrapTrigger` — a bare glyph is not focusable). One busy
     chat shows the plain label; several show a per-state breakdown with counts in rollup order — which is
-    where the counts the row itself refuses to carry actually live. The tooltip is an *enhancement*: the
+    where the counts the row itself refuses to carry actually live. "Several" counts **chats**
+    (`activityChatCount`), not distinct statuses: two chats both working must read "2 chats working", so a
+    threshold on the number of breakdown *lines* would silently drop the count in exactly the
+    single-status case. The tooltip is an *enhancement*: the
     same text is always the glyph's `aria-label`, because Radix tooltips are hover/focus-only and a phone
     has neither.
-  - Rows carry **`data-activity`** (absent when idle) as the e2e hook — on the row, not the glyph, so the
-    status has one home in the DOM.
+  - **Both** row kinds carry **`data-activity`** (absent when idle) as the e2e hook — workspace rows and
+    collapsed project rows alike, on the row rather than the glyph, so the status has one home in the DOM.
 
   **Project rows carry the rollup only while collapsed**, matching the collapsed-only workspace count;
   expanded, their workspace rows already say it. The **Default workspace**

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -74,9 +74,44 @@ treatment.
   come) surfaces an error toast, leaving the row in place. Each **workspace row** is **two-line**: the display
   `name` on top with the git **branch on a second line beneath it** (muted, monospace), rendered only when
   it differs from the name (so pristine/legacy `workspace-N` rows stay a single compact line) — the display
-  name is decoupled from the git branch (see [[submodule-server-workspaces]]). Workspace rows deliberately
-  show **no `+N −M` change badge**: the Projects view is for navigation and identity; change detail stays in
-  the dedicated Changes views. The **Default workspace**
+  name is decoupled from the git branch (see [[submodule-server-workspaces]]).
+
+  **One decoration class, and only one.** Workspace rows deliberately show **no `+N −M` change badge**:
+  the Projects view is for navigation and identity, and change detail stays in the dedicated Changes
+  views. The single admitted exception is the **activity glyph** — live agent state — because it is the
+  answer to a question the rail is the *only* place to ask: "what is happening in the workspaces I do not
+  have open?" Without it the user must open every workspace to find out, which is navigation, not detail.
+  A `+N −M` badge fails that test (the Changes view answers it better and the rail cannot show it
+  truthfully without watching every worktree), so the rule stands for everything else.
+
+  **`ActivityGlyph`** renders it: a `size-14` Remix line icon in a `size-20` box, keyed by
+  `ActivityStatus` — `RiRecordCircleLine`/`text-feedback-info` (running),
+  `RiQuestionnaireLine`/`text-feedback-warning` (waiting), `RiErrorWarningLine`/`text-feedback-error`
+  (failed), `RiTimeLine`/`text-text-subtle` (queued). Presentational and props-driven; the rollup arrives
+  as an `ActivityRollup` from the store's pure `workspaceActivityRollup`/`projectActivityRollup`, which
+  `ProjectTree` calls against its one stable `activityByWorkspace` subscription — a rollup returned *from*
+  a Zustand selector would be a fresh object every store change and re-render the whole rail.
+  - **Icons, not coloured dots** (`.review-thread-dot`'s 6px circle was the alternative): five states
+    encoded purely in hue fail colour-blind users and the shipped high-contrast themes. Shape carries the
+    meaning; colour reinforces it.
+  - **`running` is `feedback-info`, never the accent.** The active workspace's icon and name already
+    render `text-primary` on these very rows, so an accent-green glyph would read as selection.
+  - **No motion.** The rail is permanently in peripheral vision, and several concurrent runs pulsing out
+    of phase read as flicker. The chat plan pane keeps its pulse — that surface is actively read.
+  - **Idle draws nothing at all** (`ActivityRollup` is `null`), so a quiet rail is byte-identical to the
+    pre-feature one; twenty idle workspaces wearing twenty glyphs would destroy the signal.
+  - It sits in **its own flex column between the identity button and the kebab**, so the hover-revealed
+    kebab never covers it (a trailing overlay would).
+  - **Hover explains it**, via `IconTooltip` (`wrapTrigger` — a bare glyph is not focusable). One busy
+    chat shows the plain label; several show a per-state breakdown with counts in rollup order — which is
+    where the counts the row itself refuses to carry actually live. The tooltip is an *enhancement*: the
+    same text is always the glyph's `aria-label`, because Radix tooltips are hover/focus-only and a phone
+    has neither.
+  - Rows carry **`data-activity`** (absent when idle) as the e2e hook — on the row, not the glyph, so the
+    status has one home in the DOM.
+
+  **Project rows carry the rollup only while collapsed**, matching the collapsed-only workspace count;
+  expanded, their workspace rows already say it. The **Default workspace**
   (`kind === "default"` — the project folder itself) renders **pinned first** (the server pins it in
   `workspace.list`; `addWorkspace` appends created worktree rows after it), with a **`House` icon** in
   place of the `GitBranch` glyph and **no Rename or Remove item** (non-renamable/non-removable — the server

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -75,7 +75,7 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   leaving the client labelling and keying reads off a value the host no longer has; a project never fetched or an id absent from its list is a **no-op** — the next
   `workspace.list` reconciles; **`applyWorkspaceRemoved(projectId, id)`** is the **entire** removal
   reaction (`removeWorkspace` drops the row + `clearWorkspaceState` drops its
-  local view/attention/terminal maps and chat runtimes + recency drops the dead id,
+  local view/attention/terminal/activity maps and chat runtimes + recency drops the dead id,
   and **if it was this client's active workspace** → activate the most recently selected loaded workspace
   whose project remains open, even across projects; when none remains, `selectProject(projectId)` falls back
   to the removed workspace's Project Home; either active fallback gets the same neutral toast that reads right
@@ -191,7 +191,22 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   otherwise the client renders the reply twice (frozen failed partial + retried copy). Hydration applies
   the same presentation rule to the persisted copy (`chat/hydrate.ts` hides retried attempts — an
   errored assistant followed by another assistant before any user message), so live and reloaded clients
-  agree. Closed
+  agree.
+- **Workspace activity** (`activityByWorkspace`) is the host's cross-workspace agent-state signal, the one
+  thing here that describes chats **nobody has open** — the Projects rail's glyphs. Keyed workspace →
+  session → `ActivityStatus`, and **idle is absence at every level**: a retraction deletes the session key
+  and then the workspace key once it empties, so "quiet" is an empty map rather than a map full of nulls.
+  A status that did not move is not a state write at all (the reducer returns the identical object), which
+  is what keeps an always-mounted rail from re-rendering on every event of every session.
+  **`applySessionActivity`** folds one `session.activity` push; **`hydrateSessionActivity`** **replaces**
+  the whole map from the `session.activityList` snapshot — replacement, not merge, because a reconnect must
+  not leave a glyph behind for a session that settled while the socket was down. Both refuse removed
+  workspaces and tombstoned sessions, so a late push cannot resurrect a deleted chat's glyph.
+  The rollup is **not** stored: `selectWorkspaceActivity`/`selectProjectActivity` derive it on read with a
+  single shared precedence, **`failed` > `waiting` > `running` > `queued`** — a rare fault must never be
+  masked by routine work, and both are "needs you" anyway. Note this is deliberately *not* the host's
+  per-session derivation order (see `packages/server/src/agent/SPEC.md`): there the question is "what is
+  this one chat doing", here it is "which of several chats should this row speak for". Closed
   chats are reopenable: the workbench close command atomically removes local placement and invokes
   **`closeChatToHistory`**, which **keeps the runtime + host session alive**, records it in
   **`closedChatsByWorkspace`** (`ClosedChat[]`, per workspace, most-recent-first), and clears pending
@@ -207,7 +222,7 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   gaining local placement. **`deleteChat(workspaceId, sessionId)`** is the idempotent
   fold for both a confirmed local `session.delete` and the `session.deleted` broadcast: it atomically drops
   every tab the chat owns — its transcript, live plan page, and any dependent legacy document cache — plus
-  its history row/runtime + skill baseline, records a page-lifetime tombstone, removes queued opens for the
+  its history row/runtime + skill baseline + activity row, records a page-lifetime tombstone, removes queued opens for the
   chat or its dependent documents, and queues a resource-removal intent. The shell layout integration
   removes every matching chat placement and session-backed plan reference through its pure mutation path,
   then reconciles local attention in the same transition. Until then the tombstone renders no body, so a
@@ -496,7 +511,9 @@ branch's review — a commit sha means nothing in another worktree — and dropp
   (that ref *as an open diff tab's live dimension*: the target for a branch-scope tab, `""` for a
   commit/uncommitted one whose sides can't move — derived here, never re-assembled in a panel),
   `selectWorkspaceTick` (the sync-baseline snapshot), `selectWorkspaceSessionIds` (deduplicated local chat
-  placement + history membership used as a reconnect-reconciliation baseline);
+  placement + history membership used as a reconnect-reconciliation baseline),
+  **`selectWorkspaceActivity` / `selectProjectActivity`** (the Projects rail's agent-state rollup — see the
+  activity section);
   `matchesWorktreePath` (line an agent-reported path — relative or absolute — up against a worktree-relative
   one; shared by the Changes deep link and the spec classifier. The suffix rule is for **absolute reports
   only** and is anchored at a separator: unanchored, `/wt/src/a-foo.ts` would match `src/foo.ts`; applied to

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -194,8 +194,12 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   agree.
 - **Workspace activity** (`activityByWorkspace`) is the host's cross-workspace agent-state signal, the one
   thing here that describes chats **nobody has open** — the Projects rail's glyphs. Keyed workspace →
-  session → `ActivityStatus`, and **idle is absence at every level**: a retraction deletes the session key
-  and then the workspace key once it empties, so "quiet" is an empty map rather than a map full of nulls.
+  **`WorkspaceActivity`** (`{ projectId, sessions }`), and **idle is absence at every level**: a retraction
+  deletes the session key and then the workspace key once it empties, so "quiet" is an empty map rather
+  than a map full of nulls. Each entry carries its **own `projectId`** rather than looking one up in
+  `workspaces`: that list is fetched only for *expanded* projects, so a rollup that depended on it would
+  return nothing for the collapsed, never-opened project whose activity the rail most needs to show. A
+  workspace re-attributed to another project replaces its entry, so it is never counted under both.
   A status that did not move is not a state write at all (the reducer returns the identical object), which
   is what keeps an always-mounted rail from re-rendering on every event of every session.
   **`applySessionActivity`** folds one `session.activity` push; **`hydrateSessionActivity`** **replaces**
@@ -207,8 +211,8 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   clear. Hydration is equally a no-op when the computed map matches the current one, so a reconnect that
   changes nothing does not re-render the rail. Both refuse removed
   workspaces and tombstoned sessions, so a late push cannot resurrect a deleted chat's glyph.
-  The rollup is **not** stored: `workspaceActivityRollup`/`projectActivityRollup` derive it on read with a
-  single shared precedence, **`failed` > `waiting` > `running` > `queued`** — a rare fault must never be
+  The rollup is **not** stored: `workspaceActivityRollup`/`projectActivityRollup` derive it on read from
+  the map alone — no workspace list, no second store slice — with a single shared precedence, **`failed` > `waiting` > `running` > `queued`** — a rare fault must never be
   masked by routine work, and both are "needs you" anyway. Note this is deliberately *not* the host's
   per-session derivation order (see `packages/server/src/agent/SPEC.md`): there the question is "what is
   this one chat doing", here it is "which of several chats should this row speak for". Closed

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -202,7 +202,7 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   the whole map from the `session.activityList` snapshot — replacement, not merge, because a reconnect must
   not leave a glyph behind for a session that settled while the socket was down. Both refuse removed
   workspaces and tombstoned sessions, so a late push cannot resurrect a deleted chat's glyph.
-  The rollup is **not** stored: `selectWorkspaceActivity`/`selectProjectActivity` derive it on read with a
+  The rollup is **not** stored: `workspaceActivityRollup`/`projectActivityRollup` derive it on read with a
   single shared precedence, **`failed` > `waiting` > `running` > `queued`** — a rare fault must never be
   masked by routine work, and both are "needs you" anyway. Note this is deliberately *not* the host's
   per-session derivation order (see `packages/server/src/agent/SPEC.md`): there the question is "what is
@@ -512,8 +512,9 @@ branch's review — a commit sha means nothing in another worktree — and dropp
   commit/uncommitted one whose sides can't move — derived here, never re-assembled in a panel),
   `selectWorkspaceTick` (the sync-baseline snapshot), `selectWorkspaceSessionIds` (deduplicated local chat
   placement + history membership used as a reconnect-reconciliation baseline),
-  **`selectWorkspaceActivity` / `selectProjectActivity`** (the Projects rail's agent-state rollup — see the
-  activity section);
+  **`workspaceActivityRollup` / `projectActivityRollup`** (the Projects rail's agent-state rollup — pure
+  functions *over* the slice rather than Zustand selectors, since a fresh rollup object returned from a
+  selector would re-render the rail on every store change; see the activity section);
   `matchesWorktreePath` (line an agent-reported path — relative or absolute — up against a worktree-relative
   one; shared by the Changes deep link and the spec classifier. The suffix rule is for **absolute reports
   only** and is anchored at a separator: unanchored, `/wt/src/a-foo.ts` would match `src/foo.ts`; applied to

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -192,31 +192,31 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   the same presentation rule to the persisted copy (`chat/hydrate.ts` hides retried attempts — an
   errored assistant followed by another assistant before any user message), so live and reloaded clients
   agree.
-- **Workspace activity** (`activityByWorkspace`) is the host's cross-workspace agent-state signal, the one
-  thing here that describes chats **nobody has open** — the Projects rail's glyphs. Keyed workspace →
-  **`WorkspaceActivity`** (`{ projectId, sessions }`), and **idle is absence at every level**: a retraction
-  deletes the session key and then the workspace key once it empties, so "quiet" is an empty map rather
-  than a map full of nulls. Each entry carries its **own `projectId`** rather than looking one up in
-  `workspaces`: that list is fetched only for *expanded* projects, so a rollup that depended on it would
-  return nothing for the collapsed, never-opened project whose activity the rail most needs to show. A
-  workspace re-attributed to another project replaces its entry, so it is never counted under both.
-  A status that did not move is not a state write at all (the reducer returns the identical object), which
-  is what keeps an always-mounted rail from re-rendering on every event of every session.
-  **`applySessionActivity`** folds one `session.activity` push; **`hydrateSessionActivity`** **replaces**
-  the whole map from the `session.activityList` snapshot — replacement, not merge, because a reconnect must
-  not leave a glyph behind for a session that settled while the socket was down. Replacement is also what
-  makes an **empty** snapshot the retirement path: a client that has seen a v59 host and then reconnects
-  to a pre-activity one hydrates `[]` rather than skipping the read, because that host can send neither a
-  replacement snapshot nor a retraction, and the alternative is stale `running`/`failed` glyphs that never
-  clear. Hydration is equally a no-op when the computed map matches the current one, so a reconnect that
-  changes nothing does not re-render the rail. Both refuse removed
-  workspaces and tombstoned sessions, so a late push cannot resurrect a deleted chat's glyph.
-  The rollup is **not** stored: `workspaceActivityRollup`/`projectActivityRollup` derive it on read from
-  the map alone — no workspace list, no second store slice — with a single shared precedence, **`failed` > `waiting` > `running` > `queued`** — a rare fault must never be
-  masked by routine work, and both are "needs you" anyway. Note this is deliberately *not* the host's
-  per-session derivation order (see `packages/server/src/agent/SPEC.md`): there the question is "what is
-  this one chat doing", here it is "which of several chats should this row speak for". Closed
-  chats are reopenable: the workbench close command atomically removes local placement and invokes
+  - **Workspace activity** (`activityByWorkspace`) is the host's cross-workspace agent-state signal, the one
+    thing here that describes chats **nobody has open** — the Projects rail's glyphs. Keyed workspace →
+    **`WorkspaceActivity`** (`{ projectId, sessions }`), and **idle is absence at every level**: a retraction
+    deletes the session key and then the workspace key once it empties, so "quiet" is an empty map rather
+    than a map full of nulls. Each entry carries its **own `projectId`** rather than looking one up in
+    `workspaces`: that list is fetched only for *expanded* projects, so a rollup that depended on it would
+    return nothing for the collapsed, never-opened project whose activity the rail most needs to show. A
+    workspace re-attributed to another project replaces its entry, so it is never counted under both.
+    A status that did not move is not a state write at all (the reducer returns the identical object), which
+    is what keeps an always-mounted rail from re-rendering on every event of every session.
+    **`applySessionActivity`** folds one `session.activity` push; **`hydrateSessionActivity`** **replaces**
+    the whole map from the `session.activityList` snapshot — replacement, not merge, because a reconnect must
+    not leave a glyph behind for a session that settled while the socket was down. Replacement is also what
+    makes an **empty** snapshot the retirement path: a client that has seen a v59 host and then reconnects
+    to a pre-activity one hydrates `[]` rather than skipping the read, because that host can send neither a
+    replacement snapshot nor a retraction, and the alternative is stale `running`/`failed` glyphs that never
+    clear. Hydration is equally a no-op when the computed map matches the current one, so a reconnect that
+    changes nothing does not re-render the rail. Both refuse removed
+    workspaces and tombstoned sessions, so a late push cannot resurrect a deleted chat's glyph.
+    The rollup is **not** stored: `workspaceActivityRollup`/`projectActivityRollup` derive it on read from
+    the map alone — no workspace list, no second store slice — with a single shared precedence, **`failed` > `waiting` > `running` > `queued`** — a rare fault must never be
+    masked by routine work, and both are "needs you" anyway. Note this is deliberately *not* the host's
+    per-session derivation order (see `packages/server/src/agent/SPEC.md`): there the question is "what is
+    this one chat doing", here it is "which of several chats should this row speak for".
+  Closed chats are reopenable: the workbench close command atomically removes local placement and invokes
   **`closeChatToHistory`**, which **keeps the runtime + host session alive**, records it in
   **`closedChatsByWorkspace`** (`ClosedChat[]`, per workspace, most-recent-first), and clears pending
   jump/history-open requests—but never a newer `routeChatTarget`, whose lifecycle belongs to navigation

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -200,7 +200,12 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   is what keeps an always-mounted rail from re-rendering on every event of every session.
   **`applySessionActivity`** folds one `session.activity` push; **`hydrateSessionActivity`** **replaces**
   the whole map from the `session.activityList` snapshot — replacement, not merge, because a reconnect must
-  not leave a glyph behind for a session that settled while the socket was down. Both refuse removed
+  not leave a glyph behind for a session that settled while the socket was down. Replacement is also what
+  makes an **empty** snapshot the retirement path: a client that has seen a v59 host and then reconnects
+  to a pre-activity one hydrates `[]` rather than skipping the read, because that host can send neither a
+  replacement snapshot nor a retraction, and the alternative is stale `running`/`failed` glyphs that never
+  clear. Hydration is equally a no-op when the computed map matches the current one, so a reconnect that
+  changes nothing does not re-render the rail. Both refuse removed
   workspaces and tombstoned sessions, so a late push cannot resurrect a deleted chat's glyph.
   The rollup is **not** stored: `workspaceActivityRollup`/`projectActivityRollup` derive it on read with a
   single shared precedence, **`failed` > `waiting` > `running` > `queued`** — a rare fault must never be

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -3884,3 +3884,41 @@ test("deleting a chat drops its activity row", () => {
 	store.deleteChat("w1", "s1", false);
 	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s2: "running" } });
 });
+
+test("hydrating an empty snapshot clears the map — how a pre-activity host retires stale glyphs", () => {
+	const store = useAppStore.getState();
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	store.hydrateSessionActivity([]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({});
+});
+
+test("hydrating an unchanged snapshot is not a state write, so a reconnect never churns the rail", () => {
+	const store = useAppStore.getState();
+	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "waiting" }]);
+	const before = useAppStore.getState().activityByWorkspace;
+	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "waiting" }]);
+	expect(useAppStore.getState().activityByWorkspace).toBe(before);
+
+	store.hydrateSessionActivity([]);
+	const empty = useAppStore.getState().activityByWorkspace;
+	store.hydrateSessionActivity([]);
+	expect(useAppStore.getState().activityByWorkspace).toBe(empty);
+});
+
+test("hydration notices a changed status, an added chat, and a dropped chat", () => {
+	const store = useAppStore.getState();
+	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "running" }]);
+	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "failed" }]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s1: "failed" } });
+
+	store.hydrateSessionActivity([
+		{ workspaceId: "w1", sessionId: "s1", status: "failed" },
+		{ workspaceId: "w1", sessionId: "s2", status: "queued" },
+	]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { s1: "failed", s2: "queued" },
+	});
+
+	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s2", status: "queued" }]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s2: "queued" } });
+});

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -28,6 +28,7 @@ import {
 	useAppStore,
 } from "./appStore";
 import {
+	projectActivityRollup,
 	selectCompactionTurnIds,
 	selectCurrentRouteChatTarget,
 	selectDiffScope,
@@ -3806,32 +3807,68 @@ test("authority can be given up without replacing the list (a consumer activatin
 
 test("an activity push installs a status, and a null push retracts it", () => {
 	const store = useAppStore.getState();
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s1: "running" } });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "running",
+	});
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { projectId: "p1", sessions: { s1: "running" } },
+	});
 
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "failed" });
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s1: "failed" } });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "failed",
+	});
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { projectId: "p1", sessions: { s1: "failed" } },
+	});
 
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: null });
+	store.applySessionActivity({ workspaceId: "w1", projectId: "p1", sessionId: "s1", status: null });
 	expect(useAppStore.getState().activityByWorkspace).toEqual({});
 });
 
 test("retracting one chat keeps its siblings and prunes the workspace only when it empties", () => {
 	const store = useAppStore.getState();
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s2", status: "waiting" });
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: null });
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s2: "waiting" } });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "running",
+	});
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s2",
+		status: "waiting",
+	});
+	store.applySessionActivity({ workspaceId: "w1", projectId: "p1", sessionId: "s1", status: null });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { projectId: "p1", sessions: { s2: "waiting" } },
+	});
 
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s2", status: null });
+	store.applySessionActivity({ workspaceId: "w1", projectId: "p1", sessionId: "s2", status: null });
 	expect(useAppStore.getState().activityByWorkspace).toEqual({});
 });
 
 test("an unchanged status is not a state write, so a quiet rail never re-renders", () => {
 	const store = useAppStore.getState();
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "running",
+	});
 	const before = useAppStore.getState().activityByWorkspace;
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "running",
+	});
 	expect(useAppStore.getState().activityByWorkspace).toBe(before);
 });
 
@@ -3841,23 +3878,44 @@ test("activity for a removed workspace or a deleted chat is refused, live and on
 		deletedSessionsByWorkspace: { w1: { dead: true } },
 	});
 	const store = useAppStore.getState();
-	store.applySessionActivity({ workspaceId: "gone", sessionId: "s1", status: "running" });
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "dead", status: "running" });
+	store.applySessionActivity({
+		workspaceId: "gone",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "running",
+	});
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "dead",
+		status: "running",
+	});
 	expect(useAppStore.getState().activityByWorkspace).toEqual({});
 
 	store.hydrateSessionActivity([
-		{ workspaceId: "gone", sessionId: "s1", status: "running" },
-		{ workspaceId: "w1", sessionId: "dead", status: "failed" },
-		{ workspaceId: "w1", sessionId: "alive", status: "waiting" },
+		{ workspaceId: "gone", projectId: "p1", sessionId: "s1", status: "running" },
+		{ workspaceId: "w1", projectId: "p1", sessionId: "dead", status: "failed" },
+		{ workspaceId: "w1", projectId: "p1", sessionId: "alive", status: "waiting" },
 	]);
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { alive: "waiting" } });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { projectId: "p1", sessions: { alive: "waiting" } },
+	});
 });
 
 test("hydration REPLACES the map, so a reconnect cannot leave a stale glyph behind", () => {
 	const store = useAppStore.getState();
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "stale", status: "running" });
-	store.hydrateSessionActivity([{ workspaceId: "w2", sessionId: "fresh", status: "queued" }]);
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w2: { fresh: "queued" } });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "stale",
+		status: "running",
+	});
+	store.hydrateSessionActivity([
+		{ workspaceId: "w2", projectId: "p1", sessionId: "fresh", status: "queued" },
+	]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w2: { projectId: "p1", sessions: { fresh: "queued" } },
+	});
 });
 
 test("removing a workspace drops its activity along with its other local state", () => {
@@ -3870,33 +3928,57 @@ test("removing a workspace drops its activity along with its other local state",
 		baseBranch: "main",
 	};
 	useAppStore.setState({ projects: [], workspaces: { p1: [workspace] } });
-	useAppStore
-		.getState()
-		.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	useAppStore.getState().applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "running",
+	});
 	useAppStore.getState().applyWorkspaceRemoved("p1", "w1");
 	expect(useAppStore.getState().activityByWorkspace).toEqual({});
 });
 
 test("deleting a chat drops its activity row", () => {
 	const store = useAppStore.getState();
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "failed" });
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s2", status: "running" });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "failed",
+	});
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s2",
+		status: "running",
+	});
 	store.deleteChat("w1", "s1", false);
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s2: "running" } });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { projectId: "p1", sessions: { s2: "running" } },
+	});
 });
 
 test("hydrating an empty snapshot clears the map — how a pre-activity host retires stale glyphs", () => {
 	const store = useAppStore.getState();
-	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "p1",
+		sessionId: "s1",
+		status: "running",
+	});
 	store.hydrateSessionActivity([]);
 	expect(useAppStore.getState().activityByWorkspace).toEqual({});
 });
 
 test("hydrating an unchanged snapshot is not a state write, so a reconnect never churns the rail", () => {
 	const store = useAppStore.getState();
-	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "waiting" }]);
+	store.hydrateSessionActivity([
+		{ workspaceId: "w1", projectId: "p1", sessionId: "s1", status: "waiting" },
+	]);
 	const before = useAppStore.getState().activityByWorkspace;
-	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "waiting" }]);
+	store.hydrateSessionActivity([
+		{ workspaceId: "w1", projectId: "p1", sessionId: "s1", status: "waiting" },
+	]);
 	expect(useAppStore.getState().activityByWorkspace).toBe(before);
 
 	store.hydrateSessionActivity([]);
@@ -3907,18 +3989,60 @@ test("hydrating an unchanged snapshot is not a state write, so a reconnect never
 
 test("hydration notices a changed status, an added chat, and a dropped chat", () => {
 	const store = useAppStore.getState();
-	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "running" }]);
-	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s1", status: "failed" }]);
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s1: "failed" } });
-
 	store.hydrateSessionActivity([
-		{ workspaceId: "w1", sessionId: "s1", status: "failed" },
-		{ workspaceId: "w1", sessionId: "s2", status: "queued" },
+		{ workspaceId: "w1", projectId: "p1", sessionId: "s1", status: "running" },
+	]);
+	store.hydrateSessionActivity([
+		{ workspaceId: "w1", projectId: "p1", sessionId: "s1", status: "failed" },
 	]);
 	expect(useAppStore.getState().activityByWorkspace).toEqual({
-		w1: { s1: "failed", s2: "queued" },
+		w1: { projectId: "p1", sessions: { s1: "failed" } },
 	});
 
-	store.hydrateSessionActivity([{ workspaceId: "w1", sessionId: "s2", status: "queued" }]);
-	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s2: "queued" } });
+	store.hydrateSessionActivity([
+		{ workspaceId: "w1", projectId: "p1", sessionId: "s1", status: "failed" },
+		{ workspaceId: "w1", projectId: "p1", sessionId: "s2", status: "queued" },
+	]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { projectId: "p1", sessions: { s1: "failed", s2: "queued" } },
+	});
+
+	store.hydrateSessionActivity([
+		{ workspaceId: "w1", projectId: "p1", sessionId: "s2", status: "queued" },
+	]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({
+		w1: { projectId: "p1", sessions: { s2: "queued" } },
+	});
+});
+
+test("a project rollup works for a workspace whose project list was never loaded", () => {
+	useAppStore.getState().applySessionActivity({
+		workspaceId: "w9",
+		projectId: "never-loaded",
+		sessionId: "s1",
+		status: "running",
+	});
+	expect(
+		projectActivityRollup(useAppStore.getState().activityByWorkspace, "never-loaded")?.status,
+	).toBe("running");
+	expect(useAppStore.getState().workspaces["never-loaded"]).toBeUndefined();
+});
+
+test("a workspace that changes project is re-attributed rather than counted twice", () => {
+	const store = useAppStore.getState();
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "pa",
+		sessionId: "s1",
+		status: "running",
+	});
+	store.applySessionActivity({
+		workspaceId: "w1",
+		projectId: "pb",
+		sessionId: "s1",
+		status: "running",
+	});
+	const map = useAppStore.getState().activityByWorkspace;
+	expect(projectActivityRollup(map, "pa")).toBeNull();
+	expect(projectActivityRollup(map, "pb")?.status).toBe("running");
 });

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -131,6 +131,7 @@ beforeEach(() => {
 		navTickByWorkspace: {},
 		closedChatsByWorkspace: {},
 		deletedSessionsByWorkspace: {},
+		activityByWorkspace: {},
 		fsChangesByWorkspace: {},
 		skillChangeTickByWorkspace: {},
 		skillsSyncedTickBySession: {},
@@ -3801,4 +3802,85 @@ test("authority can be given up without replacing the list (a consumer activatin
 	s().dropModelsFreshness();
 	expect(s().modelsFresh).toBe(false);
 	expect(s().models).toBe(refreshed);
+});
+
+test("an activity push installs a status, and a null push retracts it", () => {
+	const store = useAppStore.getState();
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s1: "running" } });
+
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "failed" });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s1: "failed" } });
+
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: null });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({});
+});
+
+test("retracting one chat keeps its siblings and prunes the workspace only when it empties", () => {
+	const store = useAppStore.getState();
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s2", status: "waiting" });
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: null });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s2: "waiting" } });
+
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s2", status: null });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({});
+});
+
+test("an unchanged status is not a state write, so a quiet rail never re-renders", () => {
+	const store = useAppStore.getState();
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	const before = useAppStore.getState().activityByWorkspace;
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	expect(useAppStore.getState().activityByWorkspace).toBe(before);
+});
+
+test("activity for a removed workspace or a deleted chat is refused, live and on hydration", () => {
+	useAppStore.setState({
+		removedWorkspaceIds: { gone: true },
+		deletedSessionsByWorkspace: { w1: { dead: true } },
+	});
+	const store = useAppStore.getState();
+	store.applySessionActivity({ workspaceId: "gone", sessionId: "s1", status: "running" });
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "dead", status: "running" });
+	expect(useAppStore.getState().activityByWorkspace).toEqual({});
+
+	store.hydrateSessionActivity([
+		{ workspaceId: "gone", sessionId: "s1", status: "running" },
+		{ workspaceId: "w1", sessionId: "dead", status: "failed" },
+		{ workspaceId: "w1", sessionId: "alive", status: "waiting" },
+	]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { alive: "waiting" } });
+});
+
+test("hydration REPLACES the map, so a reconnect cannot leave a stale glyph behind", () => {
+	const store = useAppStore.getState();
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "stale", status: "running" });
+	store.hydrateSessionActivity([{ workspaceId: "w2", sessionId: "fresh", status: "queued" }]);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w2: { fresh: "queued" } });
+});
+
+test("removing a workspace drops its activity along with its other local state", () => {
+	const workspace: Workspace = {
+		id: "w1",
+		projectId: "p1",
+		name: "one",
+		branch: "one",
+		worktreePath: "/p/one",
+		baseBranch: "main",
+	};
+	useAppStore.setState({ projects: [], workspaces: { p1: [workspace] } });
+	useAppStore
+		.getState()
+		.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "running" });
+	useAppStore.getState().applyWorkspaceRemoved("p1", "w1");
+	expect(useAppStore.getState().activityByWorkspace).toEqual({});
+});
+
+test("deleting a chat drops its activity row", () => {
+	const store = useAppStore.getState();
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s1", status: "failed" });
+	store.applySessionActivity({ workspaceId: "w1", sessionId: "s2", status: "running" });
+	store.deleteChat("w1", "s1", false);
+	expect(useAppStore.getState().activityByWorkspace).toEqual({ w1: { s2: "running" } });
 });

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1,4 +1,5 @@
 import type {
+	ActivityStatus,
 	AppConfig,
 	AskUserQuestionResult,
 	ComposerGrowthLimit,
@@ -13,6 +14,8 @@ import type {
 	RefreshedModels,
 	ReviewChangedPayload,
 	ReviewSnapshot,
+	SessionActivity,
+	SessionActivityPayload,
 	SessionEventPayload,
 	SessionQueueState,
 	SessionStats,
@@ -741,6 +744,7 @@ interface AppState {
 	chatStartsByWorkspace: Record<string, number>;
 	worktreeCreationsByProject: Record<string, number>;
 	deletedSessionsByWorkspace: Record<string, Record<string, true>>;
+	activityByWorkspace: Record<string, Record<string, ActivityStatus>>;
 	terminalsByWorkspace: Record<string, TerminalTab[]>;
 	activeTerminalByWorkspace: Record<string, string | null>;
 	sessions: Record<string, SessionRuntime>;
@@ -916,6 +920,8 @@ interface AppState {
 		title: string,
 	) => void;
 	noteClosedChats: (workspaceId: string, entries: ClosedChat[]) => void;
+	hydrateSessionActivity: (rows: SessionActivity[]) => void;
+	applySessionActivity: (payload: SessionActivityPayload) => void;
 	hydrateSession: (
 		summary: SessionSummary,
 		hydrated: HydratedRuntime,
@@ -1068,6 +1074,20 @@ function reconcileProjectNavigation(
 function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
 	const { [key]: _dropped, ...rest } = record;
 	return rest;
+}
+
+function withoutSessionActivity(
+	s: AppState,
+	workspaceId: string,
+	sessionId: string,
+): Pick<AppState, "activityByWorkspace"> {
+	const remaining = omitKey(s.activityByWorkspace[workspaceId] ?? {}, sessionId);
+	return {
+		activityByWorkspace:
+			Object.keys(remaining).length === 0
+				? omitKey(s.activityByWorkspace, workspaceId)
+				: { ...s.activityByWorkspace, [workspaceId]: remaining },
+	};
 }
 
 function appendLayoutIntent(intents: LayoutIntent[], input: LayoutIntentInput): LayoutIntent[] {
@@ -1269,6 +1289,7 @@ function withoutChat(
 	const inHistory = closed.some((chat) => chat.sessionId === sessionId);
 	const hasRuntime = s.sessions[sessionId] !== undefined;
 	const hasSkillBaseline = Object.hasOwn(s.skillsSyncedTickBySession, sessionId);
+	const hasActivity = s.activityByWorkspace[workspaceId]?.[sessionId] !== undefined;
 	const targetsLocation =
 		s.chatLocationRequest?.workspaceId === workspaceId &&
 		s.chatLocationRequest.sessionId === sessionId;
@@ -1281,6 +1302,7 @@ function withoutChat(
 	if (
 		alreadyDeleted &&
 		sessionTabs.length === 0 &&
+		!hasActivity &&
 		!inHistory &&
 		!hasRuntime &&
 		!hasSkillBaseline &&
@@ -1348,6 +1370,7 @@ function withoutChat(
 				}
 			: {}),
 		...(hasRuntime ? { sessions: omitKey(s.sessions, sessionId) } : {}),
+		...(hasActivity ? withoutSessionActivity(s, workspaceId, sessionId) : {}),
 		...(hasSkillBaseline
 			? { skillsSyncedTickBySession: omitKey(s.skillsSyncedTickBySession, sessionId) }
 			: {}),
@@ -1542,6 +1565,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	recentProjects: [],
 	workspaces: {},
 	removedWorkspaceIds: Object.create(null) as Record<string, true>,
+	activityByWorkspace: Object.create(null) as Record<string, Record<string, ActivityStatus>>,
 	expandedProjectIds: Object.create(null) as Record<string, true>,
 	selectedProjectId: null,
 	activeWorkspaceId: null,
@@ -1708,6 +1732,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 					(id) => id !== workspaceId,
 				),
 				fsChangesByWorkspace: omitKey(state.fsChangesByWorkspace, workspaceId),
+				activityByWorkspace: omitKey(state.activityByWorkspace, workspaceId),
 				skillChangeTickByWorkspace: omitKey(state.skillChangeTickByWorkspace, workspaceId),
 				specsByWorkspace: omitKey(state.specsByWorkspace, workspaceId),
 				diffScopeByWorkspace: omitKey(state.diffScopeByWorkspace, workspaceId),
@@ -2626,6 +2651,34 @@ export const useAppStore = create<AppState>((set, get) => ({
 					retargeted && s.previewTabByWorkspace[workspaceId] === placed?.id
 						? { ...s.previewTabByWorkspace, [workspaceId]: id }
 						: s.previewTabByWorkspace,
+			};
+		}),
+	hydrateSessionActivity: (rows) =>
+		set((s) => {
+			const next: Record<string, Record<string, ActivityStatus>> = Object.create(null);
+			for (const row of rows) {
+				if (s.removedWorkspaceIds[row.workspaceId]) continue;
+				if (isSessionDeleted(s, row.workspaceId, row.sessionId)) continue;
+				const forWorkspace = next[row.workspaceId] ?? Object.create(null);
+				forWorkspace[row.sessionId] = row.status;
+				next[row.workspaceId] = forWorkspace;
+			}
+			return { activityByWorkspace: next };
+		}),
+	applySessionActivity: ({ workspaceId, sessionId, status }) =>
+		set((s) => {
+			if (s.removedWorkspaceIds[workspaceId]) return {};
+			const current = s.activityByWorkspace[workspaceId];
+			if (status === null || isSessionDeleted(s, workspaceId, sessionId)) {
+				if (current?.[sessionId] === undefined) return {};
+				return withoutSessionActivity(s, workspaceId, sessionId);
+			}
+			if (current?.[sessionId] === status) return {};
+			return {
+				activityByWorkspace: {
+					...s.activityByWorkspace,
+					[workspaceId]: { ...current, [sessionId]: status },
+				},
 			};
 		}),
 	noteClosedChats: (workspaceId, entries) =>

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -278,6 +278,11 @@ export const SettingsSection = {
 } as const;
 export type SettingsSection = (typeof SettingsSection)[keyof typeof SettingsSection];
 
+export interface WorkspaceActivity {
+	projectId: string;
+	sessions: Record<string, ActivityStatus>;
+}
+
 export interface Toast {
 	id: string;
 	variant: "error" | "success" | "info";
@@ -744,7 +749,7 @@ interface AppState {
 	chatStartsByWorkspace: Record<string, number>;
 	worktreeCreationsByProject: Record<string, number>;
 	deletedSessionsByWorkspace: Record<string, Record<string, true>>;
-	activityByWorkspace: Record<string, Record<string, ActivityStatus>>;
+	activityByWorkspace: Record<string, WorkspaceActivity>;
 	terminalsByWorkspace: Record<string, TerminalTab[]>;
 	activeTerminalByWorkspace: Record<string, string | null>;
 	sessions: Record<string, SessionRuntime>;
@@ -1077,19 +1082,19 @@ function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
 }
 
 function sameActivityMap(
-	prev: Record<string, Record<string, ActivityStatus>>,
-	next: Record<string, Record<string, ActivityStatus>>,
+	prev: Record<string, WorkspaceActivity>,
+	next: Record<string, WorkspaceActivity>,
 ): boolean {
 	const prevKeys = Object.keys(prev);
 	if (prevKeys.length !== Object.keys(next).length) return false;
 	return prevKeys.every((workspaceId) => {
 		const before = prev[workspaceId];
 		const after = next[workspaceId];
-		if (!before || !after) return false;
-		const sessionIds = Object.keys(before);
+		if (!before || !after || before.projectId !== after.projectId) return false;
+		const sessionIds = Object.keys(before.sessions);
 		return (
-			sessionIds.length === Object.keys(after).length &&
-			sessionIds.every((sessionId) => before[sessionId] === after[sessionId])
+			sessionIds.length === Object.keys(after.sessions).length &&
+			sessionIds.every((sessionId) => before.sessions[sessionId] === after.sessions[sessionId])
 		);
 	});
 }
@@ -1099,12 +1104,14 @@ function withoutSessionActivity(
 	workspaceId: string,
 	sessionId: string,
 ): Pick<AppState, "activityByWorkspace"> {
-	const remaining = omitKey(s.activityByWorkspace[workspaceId] ?? {}, sessionId);
+	const current = s.activityByWorkspace[workspaceId];
+	if (!current) return { activityByWorkspace: s.activityByWorkspace };
+	const sessions = omitKey(current.sessions, sessionId);
 	return {
 		activityByWorkspace:
-			Object.keys(remaining).length === 0
+			Object.keys(sessions).length === 0
 				? omitKey(s.activityByWorkspace, workspaceId)
-				: { ...s.activityByWorkspace, [workspaceId]: remaining },
+				: { ...s.activityByWorkspace, [workspaceId]: { ...current, sessions } },
 	};
 }
 
@@ -1307,7 +1314,7 @@ function withoutChat(
 	const inHistory = closed.some((chat) => chat.sessionId === sessionId);
 	const hasRuntime = s.sessions[sessionId] !== undefined;
 	const hasSkillBaseline = Object.hasOwn(s.skillsSyncedTickBySession, sessionId);
-	const hasActivity = s.activityByWorkspace[workspaceId]?.[sessionId] !== undefined;
+	const hasActivity = s.activityByWorkspace[workspaceId]?.sessions[sessionId] !== undefined;
 	const targetsLocation =
 		s.chatLocationRequest?.workspaceId === workspaceId &&
 		s.chatLocationRequest.sessionId === sessionId;
@@ -1583,7 +1590,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	recentProjects: [],
 	workspaces: {},
 	removedWorkspaceIds: Object.create(null) as Record<string, true>,
-	activityByWorkspace: Object.create(null) as Record<string, Record<string, ActivityStatus>>,
+	activityByWorkspace: Object.create(null) as Record<string, WorkspaceActivity>,
 	expandedProjectIds: Object.create(null) as Record<string, true>,
 	selectedProjectId: null,
 	activeWorkspaceId: null,
@@ -2673,29 +2680,34 @@ export const useAppStore = create<AppState>((set, get) => ({
 		}),
 	hydrateSessionActivity: (rows) =>
 		set((s) => {
-			const next: Record<string, Record<string, ActivityStatus>> = Object.create(null);
+			const next: Record<string, WorkspaceActivity> = Object.create(null);
 			for (const row of rows) {
 				if (s.removedWorkspaceIds[row.workspaceId]) continue;
 				if (isSessionDeleted(s, row.workspaceId, row.sessionId)) continue;
-				const forWorkspace = next[row.workspaceId] ?? Object.create(null);
-				forWorkspace[row.sessionId] = row.status;
+				const forWorkspace =
+					next[row.workspaceId] ??
+					({ projectId: row.projectId, sessions: Object.create(null) } as WorkspaceActivity);
+				forWorkspace.sessions[row.sessionId] = row.status;
 				next[row.workspaceId] = forWorkspace;
 			}
 			return sameActivityMap(s.activityByWorkspace, next) ? {} : { activityByWorkspace: next };
 		}),
-	applySessionActivity: ({ workspaceId, sessionId, status }) =>
+	applySessionActivity: ({ workspaceId, projectId, sessionId, status }) =>
 		set((s) => {
 			if (s.removedWorkspaceIds[workspaceId]) return {};
 			const current = s.activityByWorkspace[workspaceId];
 			if (status === null || isSessionDeleted(s, workspaceId, sessionId)) {
-				if (current?.[sessionId] === undefined) return {};
+				if (current?.sessions[sessionId] === undefined) return {};
 				return withoutSessionActivity(s, workspaceId, sessionId);
 			}
-			if (current?.[sessionId] === status) return {};
+			if (current?.sessions[sessionId] === status && current.projectId === projectId) return {};
 			return {
 				activityByWorkspace: {
 					...s.activityByWorkspace,
-					[workspaceId]: { ...current, [sessionId]: status },
+					[workspaceId]: {
+						projectId,
+						sessions: { ...current?.sessions, [sessionId]: status },
+					},
 				},
 			};
 		}),

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -1076,6 +1076,24 @@ function omitKey<T>(record: Record<string, T>, key: string): Record<string, T> {
 	return rest;
 }
 
+function sameActivityMap(
+	prev: Record<string, Record<string, ActivityStatus>>,
+	next: Record<string, Record<string, ActivityStatus>>,
+): boolean {
+	const prevKeys = Object.keys(prev);
+	if (prevKeys.length !== Object.keys(next).length) return false;
+	return prevKeys.every((workspaceId) => {
+		const before = prev[workspaceId];
+		const after = next[workspaceId];
+		if (!before || !after) return false;
+		const sessionIds = Object.keys(before);
+		return (
+			sessionIds.length === Object.keys(after).length &&
+			sessionIds.every((sessionId) => before[sessionId] === after[sessionId])
+		);
+	});
+}
+
 function withoutSessionActivity(
 	s: AppState,
 	workspaceId: string,
@@ -2663,7 +2681,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 				forWorkspace[row.sessionId] = row.status;
 				next[row.workspaceId] = forWorkspace;
 			}
-			return { activityByWorkspace: next };
+			return sameActivityMap(s.activityByWorkspace, next) ? {} : { activityByWorkspace: next };
 		}),
 	applySessionActivity: ({ workspaceId, sessionId, status }) =>
 		set((s) => {

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -22,7 +22,9 @@ import {
 	selectLayoutResourcePlacement,
 	selectLayoutTabPlaced,
 	selectLayoutTabPlacement,
+	selectProjectActivity,
 	selectSkillsStale,
+	selectWorkspaceActivity,
 	specPathMatcher,
 } from "./selectors";
 
@@ -453,4 +455,58 @@ test("selectAgentReviewCommentCount counts only OPEN agent-authored comments", (
 	expect(selectAgentReviewCommentCount(state, "w1")).toBe(2);
 	expect(selectAgentReviewCommentCount(state, "missing")).toBe(0);
 	expect(selectAgentReviewCommentCount(state, null)).toBe(0);
+});
+
+const activityWorkspaces: Record<string, Workspace[]> = {
+	p1: [
+		{ ...workspace, id: "wa", projectId: "p1", name: "a", branch: "a" },
+		{ ...workspace, id: "wb", projectId: "p1", name: "b", branch: "b" },
+	],
+};
+
+test("a workspace with no activity rows rolls up to null, so a quiet rail draws nothing", () => {
+	expect(selectWorkspaceActivity({ activityByWorkspace: {} }, "wa")).toBeNull();
+	expect(selectWorkspaceActivity({ activityByWorkspace: { wa: {} } }, "wa")).toBeNull();
+});
+
+test("a workspace rolls up to its single chat's status", () => {
+	expect(selectWorkspaceActivity({ activityByWorkspace: { wa: { s1: "running" } } }, "wa")).toBe(
+		"running",
+	);
+});
+
+test("failed outranks every other state — a rare fault is never masked by routine work", () => {
+	const activityByWorkspace = {
+		wa: {
+			s1: "running" as const,
+			s2: "waiting" as const,
+			s3: "failed" as const,
+			s4: "queued" as const,
+		},
+	};
+	expect(selectWorkspaceActivity({ activityByWorkspace }, "wa")).toBe("failed");
+});
+
+test("the rollup order is failed > waiting > running > queued", () => {
+	const at = (statuses: Record<string, "running" | "waiting" | "queued" | "failed">) =>
+		selectWorkspaceActivity({ activityByWorkspace: { wa: statuses } }, "wa");
+	expect(at({ s1: "waiting", s2: "running", s3: "queued" })).toBe("waiting");
+	expect(at({ s1: "running", s2: "queued" })).toBe("running");
+	expect(at({ s1: "queued" })).toBe("queued");
+});
+
+test("a project rolls up across its workspaces and ignores other projects", () => {
+	const activityByWorkspace = { wa: { s1: "running" as const }, wb: { s2: "failed" as const } };
+	expect(selectProjectActivity({ activityByWorkspace, workspaces: activityWorkspaces }, "p1")).toBe(
+		"failed",
+	);
+	expect(
+		selectProjectActivity({ activityByWorkspace, workspaces: activityWorkspaces }, "p2"),
+	).toBeNull();
+});
+
+test("a project with only quiet workspaces rolls up to null", () => {
+	expect(
+		selectProjectActivity({ activityByWorkspace: {}, workspaces: activityWorkspaces }, "p1"),
+	).toBeNull();
 });

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { Project, WireModel, Workspace } from "@thinkrail/contracts";
+import type { ActivityStatus, Project, WireModel, Workspace } from "@thinkrail/contracts";
 import type { WorkspaceLayoutDocument } from "../shell/layout";
 import type { EditorTab } from "./appStore";
 import {
@@ -8,6 +8,7 @@ import {
 	isExternalWorkspace,
 	isUserOwnedWorkspace,
 	matchesWorktreePath,
+	projectActivityRollup,
 	selectActiveEditorTab,
 	selectActiveWorkspace,
 	selectActiveWorkspaceProjectId,
@@ -22,10 +23,9 @@ import {
 	selectLayoutResourcePlacement,
 	selectLayoutTabPlaced,
 	selectLayoutTabPlacement,
-	selectProjectActivity,
 	selectSkillsStale,
-	selectWorkspaceActivity,
 	specPathMatcher,
+	workspaceActivityRollup,
 } from "./selectors";
 
 const projects: Project[] = [
@@ -465,48 +465,48 @@ const activityWorkspaces: Record<string, Workspace[]> = {
 };
 
 test("a workspace with no activity rows rolls up to null, so a quiet rail draws nothing", () => {
-	expect(selectWorkspaceActivity({ activityByWorkspace: {} }, "wa")).toBeNull();
-	expect(selectWorkspaceActivity({ activityByWorkspace: { wa: {} } }, "wa")).toBeNull();
+	expect(workspaceActivityRollup({}, "wa")).toBeNull();
+	expect(workspaceActivityRollup({ wa: {} }, "wa")).toBeNull();
 });
 
-test("a workspace rolls up to its single chat's status", () => {
-	expect(selectWorkspaceActivity({ activityByWorkspace: { wa: { s1: "running" } } }, "wa")).toBe(
-		"running",
-	);
+test("a workspace rolls up to its single chat's status and counts it", () => {
+	expect(workspaceActivityRollup({ wa: { s1: "running" } }, "wa")).toEqual({
+		status: "running",
+		counts: { running: 1 },
+	});
 });
 
 test("failed outranks every other state — a rare fault is never masked by routine work", () => {
-	const activityByWorkspace = {
-		wa: {
-			s1: "running" as const,
-			s2: "waiting" as const,
-			s3: "failed" as const,
-			s4: "queued" as const,
-		},
-	};
-	expect(selectWorkspaceActivity({ activityByWorkspace }, "wa")).toBe("failed");
+	const rollup = workspaceActivityRollup(
+		{ wa: { s1: "running", s2: "waiting", s3: "failed", s4: "queued" } },
+		"wa",
+	);
+	expect(rollup?.status).toBe("failed");
+	expect(rollup?.counts).toEqual({ running: 1, waiting: 1, failed: 1, queued: 1 });
 });
 
 test("the rollup order is failed > waiting > running > queued", () => {
-	const at = (statuses: Record<string, "running" | "waiting" | "queued" | "failed">) =>
-		selectWorkspaceActivity({ activityByWorkspace: { wa: statuses } }, "wa");
+	const at = (statuses: Record<string, ActivityStatus>) =>
+		workspaceActivityRollup({ wa: statuses }, "wa")?.status;
 	expect(at({ s1: "waiting", s2: "running", s3: "queued" })).toBe("waiting");
 	expect(at({ s1: "running", s2: "queued" })).toBe("running");
 	expect(at({ s1: "queued" })).toBe("queued");
 });
 
+test("counts tally repeats, which is what lets the tooltip say '2 chats working'", () => {
+	expect(workspaceActivityRollup({ wa: { s1: "running", s2: "running" } }, "wa")?.counts).toEqual({
+		running: 2,
+	});
+});
+
 test("a project rolls up across its workspaces and ignores other projects", () => {
-	const activityByWorkspace = { wa: { s1: "running" as const }, wb: { s2: "failed" as const } };
-	expect(selectProjectActivity({ activityByWorkspace, workspaces: activityWorkspaces }, "p1")).toBe(
-		"failed",
-	);
-	expect(
-		selectProjectActivity({ activityByWorkspace, workspaces: activityWorkspaces }, "p2"),
-	).toBeNull();
+	const map = { wa: { s1: "running" as const }, wb: { s2: "failed" as const } };
+	const rollup = projectActivityRollup(map, activityWorkspaces, "p1");
+	expect(rollup?.status).toBe("failed");
+	expect(rollup?.counts).toEqual({ running: 1, failed: 1 });
+	expect(projectActivityRollup(map, activityWorkspaces, "p2")).toBeNull();
 });
 
 test("a project with only quiet workspaces rolls up to null", () => {
-	expect(
-		selectProjectActivity({ activityByWorkspace: {}, workspaces: activityWorkspaces }, "p1"),
-	).toBeNull();
+	expect(projectActivityRollup({}, activityWorkspaces, "p1")).toBeNull();
 });

--- a/apps/web/src/store/selectors.test.ts
+++ b/apps/web/src/store/selectors.test.ts
@@ -457,20 +457,18 @@ test("selectAgentReviewCommentCount counts only OPEN agent-authored comments", (
 	expect(selectAgentReviewCommentCount(state, null)).toBe(0);
 });
 
-const activityWorkspaces: Record<string, Workspace[]> = {
-	p1: [
-		{ ...workspace, id: "wa", projectId: "p1", name: "a", branch: "a" },
-		{ ...workspace, id: "wb", projectId: "p1", name: "b", branch: "b" },
-	],
-};
+const wsActivity = (projectId: string, sessions: Record<string, ActivityStatus>) => ({
+	projectId,
+	sessions,
+});
 
 test("a workspace with no activity rows rolls up to null, so a quiet rail draws nothing", () => {
 	expect(workspaceActivityRollup({}, "wa")).toBeNull();
-	expect(workspaceActivityRollup({ wa: {} }, "wa")).toBeNull();
+	expect(workspaceActivityRollup({ wa: wsActivity("p1", {}) }, "wa")).toBeNull();
 });
 
 test("a workspace rolls up to its single chat's status and counts it", () => {
-	expect(workspaceActivityRollup({ wa: { s1: "running" } }, "wa")).toEqual({
+	expect(workspaceActivityRollup({ wa: wsActivity("p1", { s1: "running" }) }, "wa")).toEqual({
 		status: "running",
 		counts: { running: 1 },
 	});
@@ -478,7 +476,7 @@ test("a workspace rolls up to its single chat's status and counts it", () => {
 
 test("failed outranks every other state — a rare fault is never masked by routine work", () => {
 	const rollup = workspaceActivityRollup(
-		{ wa: { s1: "running", s2: "waiting", s3: "failed", s4: "queued" } },
+		{ wa: wsActivity("p1", { s1: "running", s2: "waiting", s3: "failed", s4: "queued" }) },
 		"wa",
 	);
 	expect(rollup?.status).toBe("failed");
@@ -486,27 +484,38 @@ test("failed outranks every other state — a rare fault is never masked by rout
 });
 
 test("the rollup order is failed > waiting > running > queued", () => {
-	const at = (statuses: Record<string, ActivityStatus>) =>
-		workspaceActivityRollup({ wa: statuses }, "wa")?.status;
+	const at = (sessions: Record<string, ActivityStatus>) =>
+		workspaceActivityRollup({ wa: wsActivity("p1", sessions) }, "wa")?.status;
 	expect(at({ s1: "waiting", s2: "running", s3: "queued" })).toBe("waiting");
 	expect(at({ s1: "running", s2: "queued" })).toBe("running");
 	expect(at({ s1: "queued" })).toBe("queued");
 });
 
 test("counts tally repeats, which is what lets the tooltip say '2 chats working'", () => {
-	expect(workspaceActivityRollup({ wa: { s1: "running", s2: "running" } }, "wa")?.counts).toEqual({
-		running: 2,
-	});
+	expect(
+		workspaceActivityRollup({ wa: wsActivity("p1", { s1: "running", s2: "running" }) }, "wa")
+			?.counts,
+	).toEqual({ running: 2 });
 });
 
 test("a project rolls up across its workspaces and ignores other projects", () => {
-	const map = { wa: { s1: "running" as const }, wb: { s2: "failed" as const } };
-	const rollup = projectActivityRollup(map, activityWorkspaces, "p1");
+	const map = {
+		wa: wsActivity("p1", { s1: "running" }),
+		wb: wsActivity("p1", { s2: "failed" }),
+		wc: wsActivity("p2", { s3: "waiting" }),
+	};
+	const rollup = projectActivityRollup(map, "p1");
 	expect(rollup?.status).toBe("failed");
 	expect(rollup?.counts).toEqual({ running: 1, failed: 1 });
-	expect(projectActivityRollup(map, activityWorkspaces, "p2")).toBeNull();
+	expect(projectActivityRollup(map, "p2")?.status).toBe("waiting");
+	expect(projectActivityRollup(map, "p3")).toBeNull();
+});
+
+test("a project rolls up with NO workspace list loaded — the collapsed, never-opened case", () => {
+	const map = { wa: wsActivity("never-opened", { s1: "running" }) };
+	expect(projectActivityRollup(map, "never-opened")?.status).toBe("running");
 });
 
 test("a project with only quiet workspaces rolls up to null", () => {
-	expect(projectActivityRollup({}, activityWorkspaces, "p1")).toBeNull();
+	expect(projectActivityRollup({}, "p1")).toBeNull();
 });

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -464,37 +464,41 @@ export function selectAgentReviewCommentCount(
 
 const ACTIVITY_ROLLUP_ORDER: readonly ActivityStatus[] = ["failed", "waiting", "running", "queued"];
 
-function rollUpActivity(statuses: Iterable<ActivityStatus>): ActivityStatus | null {
-	let best = ACTIVITY_ROLLUP_ORDER.length;
-	for (const status of statuses) {
-		const rank = ACTIVITY_ROLLUP_ORDER.indexOf(status);
-		if (rank >= 0 && rank < best) best = rank;
-		if (best === 0) break;
-	}
-	return ACTIVITY_ROLLUP_ORDER[best] ?? null;
+export type ActivityMap = Record<string, Record<string, ActivityStatus>>;
+
+export interface ActivityRollup {
+	status: ActivityStatus;
+	counts: Partial<Record<ActivityStatus, number>>;
 }
 
-export function selectWorkspaceActivity(
-	state: { activityByWorkspace: Record<string, Record<string, ActivityStatus>> },
+function rollUp(records: Iterable<Record<string, ActivityStatus>>): ActivityRollup | null {
+	const counts: Partial<Record<ActivityStatus, number>> = {};
+	for (const record of records) {
+		for (const status of Object.values(record)) counts[status] = (counts[status] ?? 0) + 1;
+	}
+	const status = ACTIVITY_ROLLUP_ORDER.find((candidate) => (counts[candidate] ?? 0) > 0);
+	return status ? { status, counts } : null;
+}
+
+export function workspaceActivityRollup(
+	activityByWorkspace: ActivityMap,
 	workspaceId: string,
-): ActivityStatus | null {
-	const forWorkspace = state.activityByWorkspace[workspaceId];
-	return forWorkspace ? rollUpActivity(Object.values(forWorkspace)) : null;
+): ActivityRollup | null {
+	const record = activityByWorkspace[workspaceId];
+	return record ? rollUp([record]) : null;
 }
 
-export function selectProjectActivity(
-	state: {
-		activityByWorkspace: Record<string, Record<string, ActivityStatus>>;
-		workspaces: Record<string, Workspace[]>;
-	},
+export function projectActivityRollup(
+	activityByWorkspace: ActivityMap,
+	workspaces: Record<string, Workspace[]>,
 	projectId: string,
-): ActivityStatus | null {
-	const list = state.workspaces[projectId];
+): ActivityRollup | null {
+	const list = workspaces[projectId];
 	if (!list) return null;
-	const statuses: ActivityStatus[] = [];
+	const records: Record<string, ActivityStatus>[] = [];
 	for (const workspace of list) {
-		const status = selectWorkspaceActivity(state, workspace.id);
-		if (status) statuses.push(status);
+		const record = activityByWorkspace[workspace.id];
+		if (record) records.push(record);
 	}
-	return rollUpActivity(statuses);
+	return rollUp(records);
 }

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -1,4 +1,5 @@
 import type {
+	ActivityStatus,
 	GitDiffScope,
 	Project,
 	SpecGraphNode,
@@ -459,4 +460,41 @@ export function selectAgentReviewCommentCount(
 	return snapshot.comments.filter(
 		(c) => c.author === "agent" && c.status !== "resolved" && c.status !== "dismissed",
 	).length;
+}
+
+const ACTIVITY_ROLLUP_ORDER: readonly ActivityStatus[] = ["failed", "waiting", "running", "queued"];
+
+function rollUpActivity(statuses: Iterable<ActivityStatus>): ActivityStatus | null {
+	let best = ACTIVITY_ROLLUP_ORDER.length;
+	for (const status of statuses) {
+		const rank = ACTIVITY_ROLLUP_ORDER.indexOf(status);
+		if (rank >= 0 && rank < best) best = rank;
+		if (best === 0) break;
+	}
+	return ACTIVITY_ROLLUP_ORDER[best] ?? null;
+}
+
+export function selectWorkspaceActivity(
+	state: { activityByWorkspace: Record<string, Record<string, ActivityStatus>> },
+	workspaceId: string,
+): ActivityStatus | null {
+	const forWorkspace = state.activityByWorkspace[workspaceId];
+	return forWorkspace ? rollUpActivity(Object.values(forWorkspace)) : null;
+}
+
+export function selectProjectActivity(
+	state: {
+		activityByWorkspace: Record<string, Record<string, ActivityStatus>>;
+		workspaces: Record<string, Workspace[]>;
+	},
+	projectId: string,
+): ActivityStatus | null {
+	const list = state.workspaces[projectId];
+	if (!list) return null;
+	const statuses: ActivityStatus[] = [];
+	for (const workspace of list) {
+		const status = selectWorkspaceActivity(state, workspace.id);
+		if (status) statuses.push(status);
+	}
+	return rollUpActivity(statuses);
 }

--- a/apps/web/src/store/selectors.ts
+++ b/apps/web/src/store/selectors.ts
@@ -25,6 +25,7 @@ import type {
 	RouteChatTarget,
 	SessionRuntime,
 	TerminalTab,
+	WorkspaceActivity,
 } from "./appStore";
 
 interface ConnectionGenerationState {
@@ -464,7 +465,7 @@ export function selectAgentReviewCommentCount(
 
 const ACTIVITY_ROLLUP_ORDER: readonly ActivityStatus[] = ["failed", "waiting", "running", "queued"];
 
-export type ActivityMap = Record<string, Record<string, ActivityStatus>>;
+export type ActivityMap = Record<string, WorkspaceActivity>;
 
 export interface ActivityRollup {
 	status: ActivityStatus;
@@ -484,21 +485,17 @@ export function workspaceActivityRollup(
 	activityByWorkspace: ActivityMap,
 	workspaceId: string,
 ): ActivityRollup | null {
-	const record = activityByWorkspace[workspaceId];
-	return record ? rollUp([record]) : null;
+	const entry = activityByWorkspace[workspaceId];
+	return entry ? rollUp([entry.sessions]) : null;
 }
 
 export function projectActivityRollup(
 	activityByWorkspace: ActivityMap,
-	workspaces: Record<string, Workspace[]>,
 	projectId: string,
 ): ActivityRollup | null {
-	const list = workspaces[projectId];
-	if (!list) return null;
 	const records: Record<string, ActivityStatus>[] = [];
-	for (const workspace of list) {
-		const record = activityByWorkspace[workspace.id];
-		if (record) records.push(record);
+	for (const entry of Object.values(activityByWorkspace)) {
+		if (entry.projectId === projectId) records.push(entry.sessions);
 	}
 	return rollUp(records);
 }

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -84,7 +84,15 @@ batches high-frequency Pi events without allowing later wire messages to overtak
   the store stays a plain fold. Reads are tokenized so a stale response cannot settle over a newer one; a
   **failed** read still replays its buffer (no snapshot arrived, so those pushes are the only truth left),
   while a **superseded generation** discards it (a fresh welcome is already re-reading, and replaying a
-  dead connection's pushes would resurrect stale rows). The capability gate is **`supportsSessionActivity(protocolVersion)`**
+  dead connection's pushes would resurrect stale rows). Both settle *and* failure are generation-fenced for
+  that reason — `WsTransport` **resends** pending requests across a reconnect, so an outcome can arrive
+  after the connection it was issued on is gone.
+
+  The unsupported-welcome path additionally **abandons** any in-flight hydration before clearing, and that
+  ordering is load-bearing: a v60 read can be in flight with pushes buffered when the endpoint reconnects
+  to a pre-activity host, whose rejection of the resent `session.activityList` would otherwise replay those
+  pushes *after* the clear — stranding a glyph the older host can never retract. `abandon` invalidates the
+  read's token, so its late settle or failure is inert. The capability gate is **`supportsSessionActivity(protocolVersion)`**
   (`ACTIVITY_PROTOCOL_VERSION`), and failing it does **not** skip the call: it hydrates `[]`, so a surface
   that has seen a newer host and then reconnects to an older one clears its glyphs rather than stranding
   them — that host can send neither a snapshot nor a retraction. Store semantics for the fold live in

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -74,7 +74,17 @@ batches high-frequency Pi events without allowing later wire messages to overtak
   **Activity hydrates on welcome, and retires there too.** Alongside the workspace re-read, every welcome
   runs `session.activityList` → `hydrateSessionActivity(rows)` under the same connection-generation fence,
   because `session.activity` pushes are never replayed and a reconnecting surface would otherwise render a
-  rail from before the outage. The capability gate is **`supportsSessionActivity(protocolVersion)`**
+  rail from before the outage.
+
+  A generation fence alone is **not** enough, because the collision is *within* one connection:
+  `activityHydration` therefore **buffers pushes for the duration of the read** and replays them, in
+  arrival order, immediately after the snapshot installs. Without it a push that lands while the request is
+  in flight is silently reverted by a snapshot the host computed before it — leaving a wrong glyph until
+  that session next changes. Same shape as the Pi-event batcher above: the transport owns push *ordering*,
+  the store stays a plain fold. Reads are tokenized so a stale response cannot settle over a newer one; a
+  **failed** read still replays its buffer (no snapshot arrived, so those pushes are the only truth left),
+  while a **superseded generation** discards it (a fresh welcome is already re-reading, and replaying a
+  dead connection's pushes would resurrect stale rows). The capability gate is **`supportsSessionActivity(protocolVersion)`**
   (`ACTIVITY_PROTOCOL_VERSION`), and failing it does **not** skip the call: it hydrates `[]`, so a surface
   that has seen a newer host and then reconnects to an older one clears its glyphs rather than stranding
   them — that host can send neither a snapshot nor a retraction. Store semantics for the fold live in

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -60,7 +60,8 @@ batches high-frequency Pi events without allowing later wire messages to overtak
   (peer-created domain state enters history only, never local placement), `session.deleted` via the idempotent
   `deleteChat(workspaceId, sessionId)` tombstone fold (an online fast path; because this event channel is
   deliberately not replayed, workbench hydration repairs any deletion missed while disconnected from the next
-  authoritative `session.list`), `provider.changed` via the atomic store invalidation
+  authoritative `session.list`), **`session.activity`** via `applySessionActivity(payload)`,
+  `provider.changed` via the atomic store invalidation
   `noteProviderChanged()` plus a `model.list` re-read installed through the store's monotonic provider-version
   guard (the model-catalog hook uses the same guarded write for every list/refresh, so an older reply cannot
   restore a removed generation's models; provider settings observes the same version and re-reads
@@ -68,7 +69,16 @@ batches high-frequency Pi events without allowing later wire messages to overtak
   then `feedback.interview` via the idempotent `showInterviewPrompt()` (a surviving host claim re-delivers the
   addressed event immediately after welcome),
   `workspace.fsChanged` via `noteFsChanged(payload)`, and **`settings.changed`** via `applyConfig(config)` — the post-startup server-synced app config broadcast;
-  welcome config lands in the atomic install above. Before `WsTransport` dispatches any response or non-Pi
+  welcome config lands in the atomic install above.
+
+  **Activity hydrates on welcome, and retires there too.** Alongside the workspace re-read, every welcome
+  runs `session.activityList` → `hydrateSessionActivity(rows)` under the same connection-generation fence,
+  because `session.activity` pushes are never replayed and a reconnecting surface would otherwise render a
+  rail from before the outage. The capability gate is **`supportsSessionActivity(protocolVersion)`**
+  (`ACTIVITY_PROTOCOL_VERSION`), and failing it does **not** skip the call: it hydrates `[]`, so a surface
+  that has seen a newer host and then reconnects to an older one clears its glyphs rather than stranding
+  them — that host can send neither a snapshot nor a retraction. Store semantics for the fold live in
+  [[submodule-web-store]]; the wire shape is [[module-contracts]]. Before `WsTransport` dispatches any response or non-Pi
   push, `wireTransport` flushes queued Pi events synchronously; connection-status transitions do the same.
   This dispatch barrier preserves cross-message order and the store's transcript-revision fence while still
   collapsing consecutive stream frames. All subscriptions happen once at init, never in component effects);
@@ -95,11 +105,13 @@ batches high-frequency Pi events without allowing later wire messages to overtak
   than a caller convention).
 - **Public surface (barrel):** `initTransport`, `getTransport`, `prewarmWorkspaceSkillLoad`, the three
   skill-load-safe session request wrappers, `errorText`, `RequestError`, `wsErrorCode`, `ConnectionStatus`,
-  `TransportOptions`.
+  `TransportOptions`. `supportsSessionActivity` stays module-internal (its own tests import the file
+  directly) — no sibling decides the activity capability, this module does.
 - **Allowed deps:** `contracts` (method maps, `WS_CHANNELS`, `Project` for welcome + `project.updated`, `SessionEventPayload`
   for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.created`/`updated`,
   `WorkspaceRemoved` for `workspace.removed`, `SessionCreatedPayload` for `session.created`,
-  `SessionDeletedPayload` for `session.deleted`, `provider.changed`, the empty addressed
+  `SessionDeletedPayload` for `session.deleted`, `SessionActivityPayload` +
+  `ACTIVITY_PROTOCOL_VERSION` for `session.activity` and its snapshot gate, `provider.changed`, the empty addressed
   `feedback.interview` invitation, `WorkspaceFsChangedPayload` for `workspace.fsChanged`, and `AppConfig` for
   `server.welcome`'s config + `settings.changed`); `store`
   (welcome + event routing — a runtime edge owned by the parent graph); `lib` (plain-HTTP-safe random page

--- a/apps/web/src/transport/activityHydration.test.ts
+++ b/apps/web/src/transport/activityHydration.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test";
+import type { SessionActivity, SessionActivityPayload } from "@thinkrail/contracts";
+import { createActivityHydration } from "./activityHydration";
+
+const payload = (sessionId: string, status: SessionActivityPayload["status"]) => ({
+	sessionId,
+	workspaceId: "w1",
+	projectId: "p1",
+	status,
+});
+
+const row = (sessionId: string, status: SessionActivity["status"]): SessionActivity => ({
+	sessionId,
+	workspaceId: "w1",
+	projectId: "p1",
+	status,
+});
+
+function harness() {
+	const log: string[] = [];
+	const hydration = createActivityHydration({
+		apply: (p) => log.push(`apply:${p.sessionId}=${p.status}`),
+		hydrate: (rows) => log.push(`hydrate:[${rows.map((r) => r.sessionId).join(",")}]`),
+	});
+	return { log, hydration };
+}
+
+test("with no read in flight a push applies straight through", () => {
+	const { log, hydration } = harness();
+	hydration.push(payload("s1", "running"));
+	expect(log).toEqual(["apply:s1=running"]);
+});
+
+test("a push arriving during the read is applied AFTER the snapshot, so it cannot be clobbered", () => {
+	const { log, hydration } = harness();
+	const token = hydration.begin();
+	hydration.push(payload("s1", "failed"));
+	expect(log).toEqual([]);
+	hydration.settle(token, [row("s1", "running"), row("s2", "queued")]);
+	expect(log).toEqual(["hydrate:[s1,s2]", "apply:s1=failed"]);
+});
+
+test("buffered pushes replay in arrival order", () => {
+	const { log, hydration } = harness();
+	const token = hydration.begin();
+	hydration.push(payload("s1", "running"));
+	hydration.push(payload("s2", "waiting"));
+	hydration.push(payload("s1", null));
+	hydration.settle(token, []);
+	expect(log).toEqual(["hydrate:[]", "apply:s1=running", "apply:s2=waiting", "apply:s1=null"]);
+});
+
+test("a failed read still replays its buffer — the pushes are the only truth left", () => {
+	const { log, hydration } = harness();
+	const token = hydration.begin();
+	hydration.push(payload("s1", "running"));
+	hydration.fail(token);
+	expect(log).toEqual(["apply:s1=running"]);
+});
+
+test("a superseded connection discards the buffer instead of replaying dead pushes", () => {
+	const { log, hydration } = harness();
+	const token = hydration.begin();
+	hydration.push(payload("s1", "running"));
+	hydration.discard(token);
+	expect(log).toEqual([]);
+	expect(hydration.buffered()).toBe(0);
+});
+
+test("a stale read cannot settle over a newer one", () => {
+	const { log, hydration } = harness();
+	const stale = hydration.begin();
+	const fresh = hydration.begin();
+	hydration.push(payload("s1", "running"));
+
+	hydration.settle(stale, [row("s9", "failed")]);
+	expect(log).toEqual([]);
+	expect(hydration.buffered()).toBe(1);
+
+	hydration.settle(fresh, [row("s2", "queued")]);
+	expect(log).toEqual(["hydrate:[s2]", "apply:s1=running"]);
+});
+
+test("buffering stops once a read settles, so later pushes apply immediately", () => {
+	const { log, hydration } = harness();
+	const token = hydration.begin();
+	hydration.settle(token, []);
+	hydration.push(payload("s1", "running"));
+	expect(log).toEqual(["hydrate:[]", "apply:s1=running"]);
+});

--- a/apps/web/src/transport/activityHydration.test.ts
+++ b/apps/web/src/transport/activityHydration.test.ts
@@ -88,3 +88,36 @@ test("buffering stops once a read settles, so later pushes apply immediately", (
 	hydration.push(payload("s1", "running"));
 	expect(log).toEqual(["hydrate:[]", "apply:s1=running"]);
 });
+
+test("abandon drops the buffer, so a downgraded host cannot inherit a newer host's pushes", () => {
+	const { log, hydration } = harness();
+	const token = hydration.begin();
+	hydration.push(payload("s1", "running"));
+
+	hydration.abandon();
+	expect(hydration.buffered()).toBe(0);
+
+	hydration.fail(token);
+	hydration.settle(token, [row("s9", "failed")]);
+	expect(log).toEqual([]);
+});
+
+test("after abandon, pushes apply straight through again", () => {
+	const { log, hydration } = harness();
+	hydration.begin();
+	hydration.abandon();
+	hydration.push(payload("s1", "waiting"));
+	expect(log).toEqual(["apply:s1=waiting"]);
+});
+
+test("a resent request rejected by an older host cannot replay its buffer once abandoned", () => {
+	const { log, hydration } = harness();
+	const token = hydration.begin();
+	hydration.push(payload("s1", "failed"));
+
+	hydration.abandon();
+	log.push("cleared");
+	hydration.fail(token);
+
+	expect(log).toEqual(["cleared"]);
+});

--- a/apps/web/src/transport/activityHydration.ts
+++ b/apps/web/src/transport/activityHydration.ts
@@ -1,0 +1,52 @@
+import type { SessionActivity, SessionActivityPayload } from "@thinkrail/contracts";
+
+export interface ActivityHydrationSink {
+	apply: (payload: SessionActivityPayload) => void;
+	hydrate: (rows: SessionActivity[]) => void;
+}
+
+export interface ActivityHydration {
+	push: (payload: SessionActivityPayload) => void;
+	begin: () => number;
+	settle: (token: number, rows: SessionActivity[]) => void;
+	fail: (token: number) => void;
+	discard: (token: number) => void;
+	buffered: () => number;
+}
+
+export function createActivityHydration(sink: ActivityHydrationSink): ActivityHydration {
+	let token = 0;
+	let buffer: SessionActivityPayload[] | null = null;
+
+	const drain = (): void => {
+		const pending = buffer ?? [];
+		buffer = null;
+		for (const payload of pending) sink.apply(payload);
+	};
+
+	return {
+		push: (payload) => {
+			if (buffer) buffer.push(payload);
+			else sink.apply(payload);
+		},
+		begin: () => {
+			token += 1;
+			buffer = [];
+			return token;
+		},
+		settle: (requestToken, rows) => {
+			if (requestToken !== token) return;
+			sink.hydrate(rows);
+			drain();
+		},
+		fail: (requestToken) => {
+			if (requestToken !== token) return;
+			drain();
+		},
+		discard: (requestToken) => {
+			if (requestToken !== token) return;
+			buffer = null;
+		},
+		buffered: () => buffer?.length ?? 0,
+	};
+}

--- a/apps/web/src/transport/activityHydration.ts
+++ b/apps/web/src/transport/activityHydration.ts
@@ -11,6 +11,7 @@ export interface ActivityHydration {
 	settle: (token: number, rows: SessionActivity[]) => void;
 	fail: (token: number) => void;
 	discard: (token: number) => void;
+	abandon: () => void;
 	buffered: () => number;
 }
 
@@ -45,6 +46,10 @@ export function createActivityHydration(sink: ActivityHydrationSink): ActivityHy
 		},
 		discard: (requestToken) => {
 			if (requestToken !== token) return;
+			buffer = null;
+		},
+		abandon: () => {
+			token += 1;
 			buffer = null;
 		},
 		buffered: () => buffer?.length ?? 0,

--- a/apps/web/src/transport/wireTransport.test.ts
+++ b/apps/web/src/transport/wireTransport.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { ACTIVITY_PROTOCOL_VERSION } from "@thinkrail/contracts";
+import { supportsSessionActivity } from "./wireTransport";
+
+test("a host at or beyond the activity version supports the layer", () => {
+	expect(supportsSessionActivity(ACTIVITY_PROTOCOL_VERSION)).toBe(true);
+	expect(supportsSessionActivity(ACTIVITY_PROTOCOL_VERSION + 1)).toBe(true);
+});
+
+test("an older host and a pre-welcome connection do not, so the client clears rather than keeps glyphs", () => {
+	expect(supportsSessionActivity(ACTIVITY_PROTOCOL_VERSION - 1)).toBe(false);
+	expect(supportsSessionActivity(null)).toBe(false);
+});

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -5,6 +5,7 @@ import type {
 	Project,
 	ReviewChangedPayload,
 	ServerWelcome,
+	SessionActivityPayload,
 	SessionCreatedPayload,
 	SessionDeletedPayload,
 	SessionEventPayload,
@@ -12,12 +13,25 @@ import type {
 	WorkspaceFsChangedPayload,
 	WorkspaceRemoved,
 } from "@thinkrail/contracts";
-import { WS_CHANNELS } from "@thinkrail/contracts";
+import { ACTIVITY_PROTOCOL_VERSION, WS_CHANNELS } from "@thinkrail/contracts";
 import { isConnectedGeneration, useAppStore } from "../store";
 import { createPiEventBatcher, shouldFlushPiEventsBefore } from "./piEventBatcher";
 import { WsTransport } from "./transport";
 
 let transport: WsTransport | null = null;
+
+function refreshSessionActivity(connectionGeneration: number): void {
+	const { protocolVersion } = useAppStore.getState();
+	if (protocolVersion === null || protocolVersion < ACTIVITY_PROTOCOL_VERSION) return;
+	void getTransport()
+		.request("session.activityList", {})
+		.then((rows) => {
+			const current = useAppStore.getState();
+			if (!isConnectedGeneration(current, connectionGeneration)) return;
+			current.hydrateSessionActivity(rows);
+		})
+		.catch(() => {});
+}
 
 function refreshLoadedWorkspaceLists(connectionGeneration: number): void {
 	const snapshot = useAppStore.getState();
@@ -74,6 +88,7 @@ export function initTransport(): WsTransport {
 					: undefined,
 			);
 		refreshLoadedWorkspaceLists(useAppStore.getState().connectionGeneration);
+		refreshSessionActivity(useAppStore.getState().connectionGeneration);
 	});
 
 	transport.subscribe(WS_CHANNELS.projectUpdated, (data) => {
@@ -100,6 +115,10 @@ export function initTransport(): WsTransport {
 	transport.subscribe(WS_CHANNELS.sessionDeleted, (data) => {
 		const { workspaceId, sessionId } = data as SessionDeletedPayload;
 		useAppStore.getState().deleteChat(workspaceId, sessionId, false);
+	});
+
+	transport.subscribe(WS_CHANNELS.sessionActivity, (data) => {
+		useAppStore.getState().applySessionActivity(data as SessionActivityPayload);
 	});
 
 	transport.subscribe(WS_CHANNELS.providerLogin, (data) => {

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -15,6 +15,7 @@ import type {
 } from "@thinkrail/contracts";
 import { ACTIVITY_PROTOCOL_VERSION, WS_CHANNELS } from "@thinkrail/contracts";
 import { isConnectedGeneration, useAppStore } from "../store";
+import { createActivityHydration } from "./activityHydration";
 import { createPiEventBatcher, shouldFlushPiEventsBefore } from "./piEventBatcher";
 import { WsTransport } from "./transport";
 
@@ -24,20 +25,28 @@ export function supportsSessionActivity(protocolVersion: number | null): boolean
 	return protocolVersion !== null && protocolVersion >= ACTIVITY_PROTOCOL_VERSION;
 }
 
+const activityHydration = createActivityHydration({
+	apply: (payload) => useAppStore.getState().applySessionActivity(payload),
+	hydrate: (rows) => useAppStore.getState().hydrateSessionActivity(rows),
+});
+
 function refreshSessionActivity(connectionGeneration: number): void {
 	const state = useAppStore.getState();
 	if (!supportsSessionActivity(state.protocolVersion)) {
 		state.hydrateSessionActivity([]);
 		return;
 	}
+	const token = activityHydration.begin();
 	void getTransport()
 		.request("session.activityList", {})
 		.then((rows) => {
-			const current = useAppStore.getState();
-			if (!isConnectedGeneration(current, connectionGeneration)) return;
-			current.hydrateSessionActivity(rows);
+			if (!isConnectedGeneration(useAppStore.getState(), connectionGeneration)) {
+				activityHydration.discard(token);
+				return;
+			}
+			activityHydration.settle(token, rows);
 		})
-		.catch(() => {});
+		.catch(() => activityHydration.fail(token));
 }
 
 function refreshLoadedWorkspaceLists(connectionGeneration: number): void {
@@ -125,7 +134,7 @@ export function initTransport(): WsTransport {
 	});
 
 	transport.subscribe(WS_CHANNELS.sessionActivity, (data) => {
-		useAppStore.getState().applySessionActivity(data as SessionActivityPayload);
+		activityHydration.push(data as SessionActivityPayload);
 	});
 
 	transport.subscribe(WS_CHANNELS.providerLogin, (data) => {

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -33,20 +33,23 @@ const activityHydration = createActivityHydration({
 function refreshSessionActivity(connectionGeneration: number): void {
 	const state = useAppStore.getState();
 	if (!supportsSessionActivity(state.protocolVersion)) {
+		activityHydration.abandon();
 		state.hydrateSessionActivity([]);
 		return;
 	}
 	const token = activityHydration.begin();
+	const current = (): boolean =>
+		isConnectedGeneration(useAppStore.getState(), connectionGeneration);
 	void getTransport()
 		.request("session.activityList", {})
 		.then((rows) => {
-			if (!isConnectedGeneration(useAppStore.getState(), connectionGeneration)) {
-				activityHydration.discard(token);
-				return;
-			}
-			activityHydration.settle(token, rows);
+			if (current()) activityHydration.settle(token, rows);
+			else activityHydration.discard(token);
 		})
-		.catch(() => activityHydration.fail(token));
+		.catch(() => {
+			if (current()) activityHydration.fail(token);
+			else activityHydration.discard(token);
+		});
 }
 
 function refreshLoadedWorkspaceLists(connectionGeneration: number): void {

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -20,9 +20,16 @@ import { WsTransport } from "./transport";
 
 let transport: WsTransport | null = null;
 
+export function supportsSessionActivity(protocolVersion: number | null): boolean {
+	return protocolVersion !== null && protocolVersion >= ACTIVITY_PROTOCOL_VERSION;
+}
+
 function refreshSessionActivity(connectionGeneration: number): void {
-	const { protocolVersion } = useAppStore.getState();
-	if (protocolVersion === null || protocolVersion < ACTIVITY_PROTOCOL_VERSION) return;
+	const state = useAppStore.getState();
+	if (!supportsSessionActivity(state.protocolVersion)) {
+		state.hydrateSessionActivity([]);
+		return;
+	}
 	void getTransport()
 		.request("session.activityList", {})
 		.then((rows) => {

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -158,6 +158,16 @@ used when the variable is absent). A missing artifact, failed generation, or una
 before any provider turn; PI's ordinary first-available fallback is never accepted as test configuration.
 The same copy and hermetic environment seed the private restart host.
 
+**Workspace activity** (`workspace-activity.spec.ts`) covers the Projects rail's agent-state glyphs without
+an agent, and is the reason the host's `failed`/`waiting` derivations fall back to the transcript: a seeded
+fixture transcript (an assistant with `stopReason: "error"`, or an `ask_user_question` call plus its `ack`
+tool result) becomes real activity the moment opening the chat attaches the session, so the whole chain —
+host derivation, `session.activity` push, store fold, rollup, render — runs for real on the no-agent lane.
+It asserts the row's `data-activity` and the glyph's `aria-label` (never the tooltip, which needs hover),
+including the rollup breakdown when one workspace holds both states. Note that **seeding must happen after
+`openFixtureProject`**: `openAppFresh` calls `resetState`, which deletes the isolated agent dir's `sessions`
+tree, so anything seeded earlier is wiped.
+
 Workbench scenarios exercise the normalized frontend-local frame rather than only the pure model: frame
 geometry/tool placement survives workspace switches while resource tabs and attention differ; closing a final
 resource retains its empty group; explicit group removal rehomes hidden-workspace resources; reload restores

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -159,14 +159,18 @@ before any provider turn; PI's ordinary first-available fallback is never accept
 The same copy and hermetic environment seed the private restart host.
 
 **Workspace activity** (`workspace-activity.spec.ts`) covers the Projects rail's agent-state glyphs without
-an agent, and is the reason the host's `failed`/`waiting` derivations fall back to the transcript: a seeded
-fixture transcript (an assistant with `stopReason: "error"`, or an `ask_user_question` call plus its `ack`
-tool result) becomes real activity the moment opening the chat attaches the session, so the whole chain —
-host derivation, `session.activity` push, store fold, rollup, render — runs for real on the no-agent lane.
-It asserts the row's `data-activity` and the glyph's `aria-label` (never the tooltip, which needs hover),
-including the rollup breakdown when one workspace holds both states. Note that **seeding must happen after
-`openFixtureProject`**: `openAppFresh` calls `resetState`, which deletes the isolated agent dir's `sessions`
-tree, so anything seeded earlier is wiped.
+an agent, and is the reason the host's `failed`/`waiting` derivations read the transcript: a seeded fixture
+transcript (an assistant with `stopReason: "error"`, or an `ask_user_question` call plus its `ack` tool
+result) becomes real activity, so the whole chain — host derivation, `session.activity` push, store fold,
+rollup, render — runs for real on the no-agent lane. It asserts the row's `data-activity` and the glyph's
+`aria-label` (never the tooltip, which needs hover), the rollup breakdown when one workspace holds both
+states, and the collapsed-project rollup.
+
+Two entry paths are covered on purpose. Opening the chat attaches the session and exercises the **live**
+path; a **reload after seeding** exercises the **disk** path — the snapshot union — by asserting the glyph
+appears while the workspace is never activated and no chat tab exists, which is the reviewer scenario a
+host restart produces. Note that **seeding must happen after `openFixtureProject`**: `openAppFresh` calls
+`resetState`, which deletes the isolated agent dir's `sessions` tree, so anything seeded earlier is wiped.
 
 Workbench scenarios exercise the normalized frontend-local frame rather than only the pure model: frame
 geometry/tool placement survives workspace switches while resource tabs and attention differ; closing a final

--- a/e2e/workspace-activity.spec.ts
+++ b/e2e/workspace-activity.spec.ts
@@ -1,0 +1,159 @@
+import { realpathSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+	defaultWorkspaceRow,
+	enterDefaultWorkspace,
+	goProjectHome,
+	openFixtureProject,
+	openPersistedChat,
+} from "./fixtures/app";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { shot } from "./fixtures/screenshots";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_800_000_000;
+
+const FAILED_CHAT = "activity failed chat";
+const WAITING_CHAT = "activity waiting chat";
+
+function seedFailedChat(worktree: string): void {
+	seedWorkspaceSession(worktree, {
+		name: FAILED_CHAT,
+		messages: [
+			{ role: "user", text: "ship the release", timestamp: BASE_TS },
+			{
+				role: "assistant",
+				text: "I was preparing the release",
+				timestamp: BASE_TS + 1_000,
+				stopReason: "error",
+				errorMessage: "provider unreachable",
+			},
+		],
+	});
+}
+
+function seedWaitingChat(worktree: string): void {
+	seedWorkspaceSession(worktree, {
+		name: WAITING_CHAT,
+		messages: [
+			{ role: "user", text: "pick a database", timestamp: BASE_TS + 10_000 },
+			{
+				role: "assistant",
+				text: "",
+				timestamp: BASE_TS + 11_000,
+				stopReason: "toolUse",
+				content: [
+					{
+						type: "toolCall",
+						id: "tc-activity-1",
+						name: "ask_user_question",
+						arguments: {
+							questions: [
+								{
+									question: "Which database should we use?",
+									header: "DB",
+									options: [
+										{ label: "Postgres", description: "relational" },
+										{ label: "SQLite", description: "embedded" },
+									],
+								},
+							],
+						},
+					},
+				],
+			},
+			{
+				role: "toolResult",
+				text: "",
+				timestamp: BASE_TS + 12_000,
+				toolCallId: "tc-activity-1",
+				toolName: "ask_user_question",
+				content: [{ type: "text", text: "Questions shown to the user." }],
+				details: { kind: "ack" },
+				isError: false,
+			},
+		],
+	});
+}
+
+test("a failed run marks its workspace row, and the mark outlives both the tab and the workspace", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const row = defaultWorkspaceRow(page);
+	await expect(row).not.toHaveAttribute("data-activity", /.+/);
+
+	seedFailedChat(realpathSync(E2E_FIXTURE_REPO));
+	await enterDefaultWorkspace(page);
+	await openPersistedChat(page, FAILED_CHAT);
+
+	await expect(row).toHaveAttribute("data-activity", "failed");
+	await expect(row.getByTestId("activity-glyph")).toHaveAttribute("aria-label", "Last run failed");
+	await shot(page.getByTestId("project-tree"), "activity", "workspace-failed");
+
+	const chatTab = page
+		.locator('[data-testid="editor-tab"][data-kind="chat"]')
+		.filter({ hasText: FAILED_CHAT });
+	await chatTab.getByTestId("editor-tab-close").click();
+	await expect(chatTab).toHaveCount(0);
+	await expect(row).toHaveAttribute("data-activity", "failed");
+
+	await goProjectHome(page);
+	await expect(row).toHaveAttribute("data-activity", "failed");
+});
+
+test("an unanswered question marks the row as waiting for you", async ({ page }) => {
+	await openFixtureProject(page);
+	seedWaitingChat(realpathSync(E2E_FIXTURE_REPO));
+	await enterDefaultWorkspace(page);
+	await openPersistedChat(page, WAITING_CHAT);
+
+	const row = defaultWorkspaceRow(page);
+	await expect(row).toHaveAttribute("data-activity", "waiting");
+	await expect(row.getByTestId("activity-glyph")).toHaveAttribute(
+		"aria-label",
+		"Waiting for your answer",
+	);
+	await shot(page.getByTestId("project-tree"), "activity", "workspace-waiting");
+});
+
+test("failed outranks waiting in one workspace, and the glyph names the whole breakdown", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	const worktree = realpathSync(E2E_FIXTURE_REPO);
+	seedFailedChat(worktree);
+	seedWaitingChat(worktree);
+
+	await enterDefaultWorkspace(page);
+	await openPersistedChat(page, WAITING_CHAT);
+	await openPersistedChat(page, FAILED_CHAT);
+
+	const row = defaultWorkspaceRow(page);
+	await expect(row).toHaveAttribute("data-activity", "failed");
+	await expect(row.getByTestId("activity-glyph")).toHaveAttribute(
+		"aria-label",
+		"1 chat failed, 1 chat waiting for your answer",
+	);
+	await shot(page.getByTestId("project-tree"), "activity", "workspace-rollup");
+});
+
+test("deleting the marked chat clears the row", async ({ page }) => {
+	await openFixtureProject(page);
+	seedFailedChat(realpathSync(E2E_FIXTURE_REPO));
+	await enterDefaultWorkspace(page);
+	await openPersistedChat(page, FAILED_CHAT);
+
+	const row = defaultWorkspaceRow(page);
+	await expect(row).toHaveAttribute("data-activity", "failed");
+
+	const chatTab = page
+		.locator('[data-testid="editor-tab"][data-kind="chat"]')
+		.filter({ hasText: FAILED_CHAT });
+	await chatTab.getByTestId("editor-tab-close").click();
+	await page.getByTestId("chat-history").first().click();
+	const historyRow = page.getByTestId("closed-chat-row").filter({ hasText: FAILED_CHAT });
+	await historyRow.getByTestId("closed-chat-delete").click();
+
+	await expect(row).not.toHaveAttribute("data-activity", /.+/);
+});

--- a/e2e/workspace-activity.spec.ts
+++ b/e2e/workspace-activity.spec.ts
@@ -183,3 +183,20 @@ test("a collapsed project row carries the rollup, so activity survives folding t
 	await expand.click();
 	await expect(project).not.toHaveAttribute("data-activity", /.+/);
 });
+
+test("a never-opened chat's failure reaches the rail from disk, without entering its workspace", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	seedFailedChat(realpathSync(E2E_FIXTURE_REPO));
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+
+	const row = defaultWorkspaceRow(page);
+	await expect(row).toHaveAttribute("data-activity", "failed");
+	await expect(row.getByTestId("activity-glyph")).toHaveAttribute("aria-label", "Last run failed");
+	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(0);
+	await expect(row).not.toHaveAttribute("data-active", "true");
+	await shot(page.getByTestId("project-tree"), "activity", "workspace-from-disk");
+});

--- a/e2e/workspace-activity.spec.ts
+++ b/e2e/workspace-activity.spec.ts
@@ -157,3 +157,29 @@ test("deleting the marked chat clears the row", async ({ page }) => {
 
 	await expect(row).not.toHaveAttribute("data-activity", /.+/);
 });
+
+test("a collapsed project row carries the rollup, so activity survives folding the project away", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	seedFailedChat(realpathSync(E2E_FIXTURE_REPO));
+	await enterDefaultWorkspace(page);
+	await openPersistedChat(page, FAILED_CHAT);
+
+	const project = page.getByTestId("project-item").first();
+	const expand = project.getByTestId("project-expand");
+	await expect(expand).toHaveAttribute("data-expanded", "true");
+	await expect(project).not.toHaveAttribute("data-activity", /.+/);
+
+	await expand.click();
+	await expect(expand).toHaveAttribute("data-expanded", "false");
+	await expect(project).toHaveAttribute("data-activity", "failed");
+	await expect(project.getByTestId("activity-glyph")).toHaveAttribute(
+		"aria-label",
+		"Last run failed",
+	);
+	await shot(page.getByTestId("project-tree"), "activity", "project-collapsed");
+
+	await expand.click();
+	await expect(project).not.toHaveAttribute("data-activity", /.+/);
+});

--- a/e2e/workspace-activity.spec.ts
+++ b/e2e/workspace-activity.spec.ts
@@ -39,7 +39,6 @@ function seedWaitingChat(worktree: string): void {
 			{ role: "user", text: "pick a database", timestamp: BASE_TS + 10_000 },
 			{
 				role: "assistant",
-				text: "",
 				timestamp: BASE_TS + 11_000,
 				stopReason: "toolUse",
 				content: [
@@ -64,7 +63,6 @@ function seedWaitingChat(worktree: string): void {
 			},
 			{
 				role: "toolResult",
-				text: "",
 				timestamp: BASE_TS + 12_000,
 				toolCallId: "tc-activity-1",
 				toolName: "ask_user_question",

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -502,9 +502,14 @@ gets for free rather than a value each one must remember to special-case, and th
 workspaces that have something to say. The single place idleness is spelled out is the push's
 `status: null`, because a *removal* has to be transmitted.
 
-- **`SessionActivity`** = `{ sessionId, workspaceId, status }` — a snapshot row.
-- **`session.activity`** push = `{ sessionId, workspaceId, status: ActivityStatus | null }`, emitted when a
-  session's derived status changes.
+- **`SessionActivity`** = `{ sessionId, workspaceId, projectId, status }` — a snapshot row.
+- **`session.activity`** push = `{ sessionId, workspaceId, projectId, status: ActivityStatus | null }`,
+  emitted when a session's derived status changes.
+- **`projectId` rides every row deliberately, even though it is derivable from `workspaceId`.** The client
+  can only make that derivation for projects whose `workspace.list` it has read, and it reads that list
+  only for *expanded* projects — so a collapsed, never-opened project would roll up to nothing, which is
+  exactly the state this feature exists to reveal. Attribution therefore travels with the row rather than
+  depending on unrelated data being loaded first.
 - **`session.activityList`** (no params) → `SessionActivity[]` for every workspace. A snapshot request
   exists because pushes are **not** replayed on reconnect (the dedup cache covers requests only), so
   without it a client that reconnected mid-run would show a stale or empty rail until the next transition.

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -99,7 +99,10 @@ of the host.
     only when non-empty — the hydration seed for the client's pending strip, since `queue_update` fires only
     on changes and a client attaching mid-run would otherwise never learn of messages queued before it
     connected. The same aggregate enriches projected `queue_update` events; image bytes never ride this
-    read-side queue state. Destructive operations use the separate **`SessionQueueContent`** /
+    read-side queue state. `SessionSummary` is a *hydration* read and says nothing about background work:
+  `session.list` is issued for one workspace at a time, so the cross-workspace "what is happening in there"
+  signal is the separate `ActivityStatus` layer, not a field here.
+  Destructive operations use the separate **`SessionQueueContent`** /
     **`QueuedMessageContent`** shapes, which return each drained message's text and optional images exactly
     once so the composer can restore complete content without making ordinary queue broadcasts heavy.
     `session.getMessages` returns `{ summary, messages }` (the transcript is
@@ -159,8 +162,9 @@ of the host.
   conventions),
   **`OpenBranchReview`** (the optional open review reference for the active branch: PR vs MR + number; no status/actions),
   **`ExistingWorktreeCandidate`** (a `workspace.listExisting` row: absolute `path` + `branch`, or a
-  `detached` row the chooser disables), `Session` (chat tab),
-  `FileNode` (file-tree node), `TabStatus`, `Git*`/diff types — incl. **`GitDiffScope`** (what the Changes
+  `detached` row the chooser disables),
+  `FileNode` (file-tree node), **`ActivityStatus`** + **`SessionActivity`** (see below),
+  `Git*`/diff types — incl. **`GitDiffScope`** (what the Changes
   panel is diffing: `branch` → the workspace's work since diverging from its diff base (the range starts at
   their merge-base, never the base's tip) / `uncommitted` → worktree vs `HEAD` /
   `commit` → one commit, `sha^` vs `sha`; omitted on the wire = `branch`, so an older client is unchanged)
@@ -442,7 +446,7 @@ of the host.
   **`session.created`** (the initial `SessionSummary`, broadcast when a new host-owned session registers so
   other frontends can list it in history without opening local placement) / **`session.deleted`** (workspace +
   session id; a non-replayable domain event broadcast after permanent deletion so every client removes the chat
-  and blocks stale hydration) /
+  and blocks stale hydration) / **`session.activity`** (see the activity layer below) /
   **`settings.changed`** (the full `AppConfig`, including custom preset definitions, broadcast so every
   client converges) / **`feedback.interview`** (an empty, addressed invitation sent only to the host-claimed
   frontend; not broadcast, subscribed, or replayed) / **`provider.login`** — the session-less
@@ -485,6 +489,34 @@ of the host.
   as reliable as the socket carrying it and nothing would ever re-send a lost one: restating the live set beats
   confirming the confirmations. This behavior is protocol-versioned — a replaying UI must never run against a
   pre-dedup host.
+
+## The activity layer
+
+`ActivityStatus` = `"running" | "waiting" | "queued" | "failed"` answers one question the hydration reads
+cannot: *what is happening in a workspace I do not have open?* `SessionSummary` is per-workspace and read
+on demand; activity is cross-workspace and pushed.
+
+**`idle` is not a member of the union.** It is represented by absence everywhere: omitted from the
+snapshot, deleted from the client's map, and drawn as nothing. Quiet is therefore the default a consumer
+gets for free rather than a value each one must remember to special-case, and the wire carries only the
+workspaces that have something to say. The single place idleness is spelled out is the push's
+`status: null`, because a *removal* has to be transmitted.
+
+- **`SessionActivity`** = `{ sessionId, workspaceId, status }` — a snapshot row.
+- **`session.activity`** push = `{ sessionId, workspaceId, status: ActivityStatus | null }`, emitted when a
+  session's derived status changes.
+- **`session.activityList`** (no params) → `SessionActivity[]` for every workspace. A snapshot request
+  exists because pushes are **not** replayed on reconnect (the dedup cache covers requests only), so
+  without it a client that reconnected mid-run would show a stale or empty rail until the next transition.
+
+The status is **per session, deliberately not pre-rolled per workspace**: how several chats collapse into
+one row is presentation policy that belongs to the client's selectors, and the host has no business
+encoding a UI precedence order. Deriving it is the host's job because only the host holds every
+workspace's sessions at once — see the `agent` module SPEC for the derivation and its two precedence
+orders.
+
+`ACTIVITY_PROTOCOL_VERSION` pins the layer, so a UI shipped ahead of its host renders no glyphs instead of
+an empty rail that looks like "nothing is running".
 
 ## Get right
 

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -510,9 +510,12 @@ workspaces that have something to say. The single place idleness is spelled out 
   only for *expanded* projects — so a collapsed, never-opened project would roll up to nothing, which is
   exactly the state this feature exists to reveal. Attribution therefore travels with the row rather than
   depending on unrelated data being loaded first.
-- **`session.activityList`** (no params) → `SessionActivity[]` for every workspace. A snapshot request
+- **`session.activityList`** (no params) → `SessionActivity[]` for every workspace, **unioning live and
+  on-disk sessions** exactly as `session.list` does, so a host restart rebuilds the rail (architecture #8)
+  rather than hiding a waiting question in a workspace nobody has opened yet. A snapshot request
   exists because pushes are **not** replayed on reconnect (the dedup cache covers requests only), so
   without it a client that reconnected mid-run would show a stale or empty rail until the next transition.
+  Only `waiting`/`failed` can arrive from disk — `running` and `queued` describe a live process.
 
 The status is **per session, deliberately not pre-rolled per workspace**: how several chats collapse into
 one row is presentation policy that belongs to the client's selectors, and the host has no business

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -516,7 +516,10 @@ workspace's sessions at once — see the `agent` module SPEC for the derivation 
 orders.
 
 `ACTIVITY_PROTOCOL_VERSION` pins the layer, so a UI shipped ahead of its host renders no glyphs instead of
-an empty rail that looks like "nothing is running".
+an empty rail that looks like "nothing is running". The gate is **not** a plain early return: an older host
+can send neither a snapshot nor a retraction, so a client that has already seen a v59 host must actively
+*clear* what it holds when it reconnects to a pre-activity one — otherwise a downgraded or re-pointed
+endpoint strands glyphs that nothing can ever retire (see `apps/web/src/store/SPEC.md`).
 
 ## Get right
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -1,6 +1,12 @@
 import type { ThinkingLevel, WireModel } from "./piProtocol";
 
-export type TabStatus = "idle" | "running" | "waiting" | "error";
+export type ActivityStatus = "running" | "waiting" | "queued" | "failed";
+
+export interface SessionActivity {
+	sessionId: string;
+	workspaceId: string;
+	status: ActivityStatus;
+}
 
 export interface Project {
 	id: string;
@@ -83,14 +89,6 @@ export interface WorkspaceFsChangedPayload {
 	paths: string[];
 	truncated: boolean;
 	skillChange: WorkspaceSkillChange;
-}
-
-export interface Session {
-	id: string;
-	workspaceId: string;
-	sessionId: string;
-	title: string;
-	status: TabStatus;
 }
 
 export type FileKind = "file" | "dir";

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -5,6 +5,7 @@ export type ActivityStatus = "running" | "waiting" | "queued" | "failed";
 export interface SessionActivity {
 	sessionId: string;
 	workspaceId: string;
+	projectId: string;
 	status: ActivityStatus;
 }
 

--- a/packages/contracts/src/wsProtocol.test.ts
+++ b/packages/contracts/src/wsProtocol.test.ts
@@ -1,11 +1,20 @@
 import { expect, test } from "bun:test";
 import {
+	ACTIVITY_PROTOCOL_VERSION,
 	JBCENTRAL_QUOTA_PROTOCOL_VERSION,
 	PROTOCOL_VERSION,
 	SUBAGENT_SETTINGS_PROTOCOL_VERSION,
 	THEME_SYSTEM_PROTOCOL_VERSION,
+	WS_CHANNELS,
 	WS_METHODS,
 } from "./wsProtocol";
+
+test("workspace activity advances the protocol and names its channel and snapshot read", () => {
+	expect(ACTIVITY_PROTOCOL_VERSION).toBe(60);
+	expect(PROTOCOL_VERSION).toBeGreaterThanOrEqual(ACTIVITY_PROTOCOL_VERSION);
+	expect(WS_CHANNELS.sessionActivity).toBe("session.activity");
+	expect(WS_METHODS.sessionActivityList).toBe("session.activityList");
+});
 
 test("system theme settings advance the protocol", () => {
 	expect(THEME_SYSTEM_PROTOCOL_VERSION).toBe(58);

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -1,4 +1,5 @@
 import type {
+	ActivityStatus,
 	AppConfig,
 	AppConfigUpdate,
 	BranchList,
@@ -31,6 +32,7 @@ import type {
 	ReviewCommentKind,
 	ReviewCommentStatus,
 	ReviewSnapshot,
+	SessionActivity,
 	SpecGraphSnapshot,
 	SubagentOverride,
 	Template,
@@ -95,6 +97,7 @@ export const SUBAGENT_SETTINGS_PROTOCOL_VERSION = 57;
 export const JBCENTRAL_QUOTA_PROTOCOL_VERSION = 59;
 export const WORKSPACE_RENAME_PROTOCOL_VERSION = 55;
 export const FEEDBACK_INTERVIEW_PROTOCOL_VERSION = 56;
+export const ACTIVITY_PROTOCOL_VERSION = 59;
 
 export type HostPlatform = "darwin" | "linux" | "win32";
 
@@ -117,6 +120,12 @@ export type SessionCreatedPayload = SessionSummary;
 export interface SessionDeletedPayload {
 	workspaceId: string;
 	sessionId: string;
+}
+
+export interface SessionActivityPayload {
+	workspaceId: string;
+	sessionId: string;
+	status: ActivityStatus | null;
 }
 
 export const WS_METHODS = {
@@ -194,6 +203,7 @@ export const WS_METHODS = {
 	sessionExtUiReply: "session.extUiReply",
 	sessionAnswerQuestion: "session.answerQuestion",
 	sessionList: "session.list",
+	sessionActivityList: "session.activityList",
 	sessionGetMessages: "session.getMessages",
 	subagentGetTranscript: "subagent.getTranscript",
 	modelList: "model.list",
@@ -235,6 +245,7 @@ export const WS_CHANNELS = {
 	piExtensionUi: "pi.extensionUi",
 	sessionCreated: "session.created",
 	sessionDeleted: "session.deleted",
+	sessionActivity: "session.activity",
 	providerLogin: "provider.login",
 	providerChanged: "provider.changed",
 	terminalData: "terminal.data",
@@ -494,6 +505,7 @@ export interface WsMethodMap {
 		result: Ack;
 	};
 	"session.list": { params: { workspaceId: string }; result: SessionSummary[] };
+	"session.activityList": { params: Record<string, never>; result: SessionActivity[] };
 	"session.getMessages": {
 		params: { sessionId: string; workspaceId: string };
 		result: { summary: SessionSummary; messages: TranscriptMessage[] };

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -124,6 +124,7 @@ export interface SessionDeletedPayload {
 
 export interface SessionActivityPayload {
 	workspaceId: string;
+	projectId: string;
 	sessionId: string;
 	status: ActivityStatus | null;
 }

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -91,13 +91,13 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 59;
+export const PROTOCOL_VERSION = 60;
 export const THEME_SYSTEM_PROTOCOL_VERSION = 58;
 export const SUBAGENT_SETTINGS_PROTOCOL_VERSION = 57;
 export const JBCENTRAL_QUOTA_PROTOCOL_VERSION = 59;
 export const WORKSPACE_RENAME_PROTOCOL_VERSION = 55;
 export const FEEDBACK_INTERVIEW_PROTOCOL_VERSION = 56;
-export const ACTIVITY_PROTOCOL_VERSION = 59;
+export const ACTIVITY_PROTOCOL_VERSION = 60;
 
 export type HostPlatform = "darwin" | "linux" | "win32";
 

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -125,8 +125,18 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   | 2 | `session.isStreaming` | `running` |
   | 3 | `session.pendingMessageCount > 0` | `queued` |
   | 4 | an unanswered `ask_user_question` | `waiting` |
-  | 5 | `lastSettlement.stopReason === "error"` | `failed` |
+  | 5 | the run failed (see below) | `failed` |
   | — | otherwise | idle, i.e. `null` |
+
+  **`failed` reads the settlement when there is one and the transcript otherwise**, mirroring exactly what
+  `lastSettlement`'s three states already mean: a value decides it outright; explicit **`null`** (run
+  active, or settled with no assistant) means *not failed* and must **not** consult the transcript, or a
+  new `agent_start` would let an older persisted failure reappear mid-run; **`undefined`** means this host
+  process observed nothing, so the persisted transcript is authoritative and the trailing assistant's
+  `stopReason` decides. "Trailing" stops at the next user message and takes the last assistant, so a
+  retried failure followed by a successful attempt is not failed — the same rule `chat/hydrate.ts` uses to
+  hide retried attempts, and the reason a re-attached session keeps its glyph across a host restart
+  instead of silently reading idle while the chat itself shows the failure.
 
   Every rung of that order is load-bearing and pinned by `activity.test.ts`:
   - **A dialog outranks streaming** because pi is technically mid-turn while blocked on it, yet the person
@@ -148,10 +158,12 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   is presentation policy owned by the client's selectors (see `apps/web/src/store/SPEC.md`), and a
   precedence order baked in here would be a UI decision escaping into the host.
 
-  **Lifetime:** in-memory, for this host process. Entries are never idle-evicted, so a `failed`/`waiting`
-  status survives client reconnects, but a host restart resets un-reattached sessions to idle; the
-  transcript stays authoritative and shows the failure once the chat is opened. Deriving those two states
-  from the disk-session scan is the deliberate follow-up, not V1.
+  **Lifetime:** entries are never idle-evicted, so every status survives client reconnects. Because
+  `waiting` and `failed` both fall back to the transcript, they also survive a **host restart** for any
+  session that gets attached. What no status survives is a session this process has never loaded:
+  `listSessionActivity` walks live entries only, so a disk-only chat contributes nothing. Extending the
+  snapshot to derive those two from the disk-session scan (`listSessionInfosStrict`) is the deliberate
+  follow-up, not V1.
     New-session and pre-session entrypoints capture the current generation; operations on a live session use
     that session's retained runtime. `abort` remains available as the cancellation control path.
     `prompt`/`steer`/`followUp` (with images) /

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -173,12 +173,28 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     the client's own workspace-removal fold has already dropped its activity. See `packages/contracts/SPEC.md`
     for why attribution travels on the wire instead of being derived client-side.
 
-    **Lifetime:** entries are never idle-evicted, so every status survives client reconnects. Because
-    `waiting` and `failed` both fall back to the transcript, they also survive a **host restart** for any
-    session that gets attached. What no status survives is a session this process has never loaded:
-    `listSessionActivity` walks live entries only, so a disk-only chat contributes nothing. Extending the
-    snapshot to derive those two from the disk-session scan (`listSessionInfosStrict`) is the deliberate
-    follow-up, not V1.
+    **Lifetime:** entries are never idle-evicted, so every status survives client reconnects, and
+    `listSessionActivity` **unions live entries with on-disk sessions** for each workspace the host passes
+    in (`cwd` stays an input, never a persistence lookup) — so a chat this process never loaded still
+    reports its durable state. That mirrors `session.list`, which already unions the two, and honours
+    architecture decision #8: a host restart rebuilds the same state.
+
+    A disk row runs the **same** `deriveActivityStatus` through `deriveDiskActivityStatus`, which pins
+    `isStreaming: false`, `pendingMessageCount: 0`, `hasPendingDialog: false` and an `undefined`
+    settlement. `running` and `queued` are therefore *structurally unreachable* from disk rather than
+    filtered out afterwards — both describe a live process, and a persisted one would be a permanent lie
+    after a crash.
+
+    **The transcript is the only durable store, deliberately.** Both durable states are already functions
+    of it, so a status file would cache a derivation rather than record new knowledge — and it would have a
+    second writer, since sessions live in pi's own cwd-keyed directory and plain `pi` reads and writes the
+    same files. A sidecar would then claim "waiting for your answer" after the user answered in the
+    terminal: a *wrong* signal, which is worse than a missing one. Only signals at the transcript's **tail**
+    are needed (a trailing assistant's `stopReason`; an `ask_user_question` plus its `ack`), so a bounded
+    `TRANSCRIPT_TAIL_BYTES` window suffices, with the partial leading line dropped. Repeat reads are
+    memoized per file on `(mtime, messageCount)` — **in memory only**, so a fresh process re-derives and no
+    stale verdict can outlive a crash. An unreadable workspace is logged and skipped, never fatal to the
+    snapshot.
     New-session and pre-session entrypoints capture the current generation; operations on a live session use
     that session's retained runtime. `abort` remains available as the cancellation control path.
     `prompt`/`steer`/`followUp` (with images) /

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -191,7 +191,14 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     same files. A sidecar would then claim "waiting for your answer" after the user answered in the
     terminal: a *wrong* signal, which is worse than a missing one. Only signals at the transcript's **tail**
     are needed (a trailing assistant's `stopReason`; an `ask_user_question` plus its `ack`), so a bounded
-    `TRANSCRIPT_TAIL_BYTES` window suffices, with the partial leading line dropped. Repeat reads are
+    `TRANSCRIPT_TAIL_BYTES` window suffices — but the window must **start at a record boundary**, not merely
+    drop its partial first line. Pi writes each message as one unbounded `JSON.stringify` line, so a
+    decisive record can exceed the window: dropping the fragment would then discard the very assistant that
+    failed, and — subtler — a huge questionnaire record followed by its small `ack` yields a *non-empty*
+    parse that is still missing the tool call, so "retry when empty" would not catch it either. The reader
+    therefore probes the byte before the window and grows (×8, to `TRANSCRIPT_TAIL_MAX_BYTES`) until that
+    byte is a newline; only a single record beyond that cap degrades to the best-effort fragment drop.
+    Repeat reads are
     memoized per file on `(mtime, messageCount)` — **in memory only**, so a fresh process re-derives and no
     stale verdict can outlive a crash. An unreadable workspace is logged and skipped, never fatal to the
     snapshot.

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -113,6 +113,45 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     destructive queue API returns text but drops image blocks; Pi's queue events remain authoritative for
     membership/order. The host projects only a conservative `hasImages` aggregate into summaries/events, so
     image bytes do not ride the ordinary read stream.
+- **Activity projection** (`activity.ts`) answers "what is happening in a workspace nobody has open?" —
+  the signal the Projects rail draws. `deriveActivityStatus` is a **pure function** of one session's
+  observable state; the manager owns only the publish-on-change bookkeeping (`publishedActivity` per
+  entry, so a status that did not move emits nothing), the `session.activityList` snapshot, and retraction
+  on disposal.
+
+  | # | condition | status |
+  |---|---|---|
+  | 1 | a pending blocking extension dialog | `waiting` |
+  | 2 | `session.isStreaming` | `running` |
+  | 3 | `session.pendingMessageCount > 0` | `queued` |
+  | 4 | an unanswered `ask_user_question` | `waiting` |
+  | 5 | `lastSettlement.stopReason === "error"` | `failed` |
+  | — | otherwise | idle, i.e. `null` |
+
+  Every rung of that order is load-bearing and pinned by `activity.test.ts`:
+  - **A dialog outranks streaming** because pi is technically mid-turn while blocked on it, yet the person
+    is the blocker. Reporting `running` would hide a prompt waiting for an answer.
+  - **`queued` outranks `failed`** (you already sent the follow-up, so the failure is handled and nagging
+    would be wrong) **and outranks `waiting`** — a queued message supersedes a pending questionnaire, but
+    it is still in pi's queue and *not yet in the transcript*, so `assessAnswerability` cannot see it.
+    This is why supersession is not modelled as mutable "awaiting" state on the entry: `waiting` is
+    **derived from the transcript** via `awaitingQuestionToolCallId`, which reuses `assessAnswerability`
+    rather than duplicating its already-answered/superseded rules. One authority, nothing to keep in sync.
+  - **`aborted` is idle, not `failed`** — cancelling is a choice, not a fault, and a red row for every
+    Escape would teach the user to ignore the signal.
+
+  The hot path costs nothing: rungs 1–2 return before the transcript scan, so the per-event sync that
+  fires during streaming never walks messages. The scan runs only at rest, and stops at the latest user
+  message.
+
+  The status is **per session and never pre-rolled per workspace** — collapsing several chats into one row
+  is presentation policy owned by the client's selectors (see `apps/web/src/store/SPEC.md`), and a
+  precedence order baked in here would be a UI decision escaping into the host.
+
+  **Lifetime:** in-memory, for this host process. Entries are never idle-evicted, so a `failed`/`waiting`
+  status survives client reconnects, but a host restart resets un-reattached sessions to idle; the
+  transcript stays authoritative and shows the failure once the chat is opened. Deriving those two states
+  from the disk-session scan is the deliberate follow-up, not V1.
     New-session and pre-session entrypoints capture the current generation; operations on a live session use
     that session's retained runtime. `abort` remains available as the cancellation control path.
     `prompt`/`steer`/`followUp` (with images) /
@@ -536,7 +575,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   `completeOnce`/`pickModel` +
   `OneShotRequest`/`OneShotResult`/`ModelTier`; the `webUiContext` seams; the `askUserQuestion` pure
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
-  `buildAnswersMessage`); `repairDanglingToolCalls`; `liveParentContext` + `readChildTranscript`
+  `buildAnswersMessage`/`awaitingQuestionToolCallId`); the activity layer
+  (`deriveActivityStatus`/`ActivityInputs` + `listSessionActivity`/`syncSessionActivity`/
+  `setSessionActivityPublisher`); `repairDanglingToolCalls`; `liveParentContext` + `readChildTranscript`
   (the delegation embedding); the skill catalog helpers
   `listSkillCommands(cwd, admission)` (filtered, pre-session autocomplete) / `listSkillCatalog(cwd, admission)`
   (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count) /

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -158,6 +158,12 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   is presentation policy owned by the client's selectors (see `apps/web/src/store/SPEC.md`), and a
   precedence order baked in here would be a UI decision escaping into the host.
 
+  Every row and push carries its **`projectId`**, resolved through the **`setActivityProjectResolver`**
+  seam (the host owns the workspace registry; this module stays ignorant of projects, as with
+  `setSkillAdmissionResolver`). An unresolvable workspace — one being torn down — publishes nothing, since
+  the client's own workspace-removal fold has already dropped its activity. See `packages/contracts/SPEC.md`
+  for why attribution travels on the wire instead of being derived client-side.
+
   **Lifetime:** entries are never idle-evicted, so every status survives client reconnects. Because
   `waiting` and `failed` both fall back to the transcript, they also survive a **host restart** for any
   session that gets attached. What no status survives is a session this process has never loaded:
@@ -589,7 +595,7 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   helpers (`validateQuestionnaire`/`buildQuestionnaireResponse`/`assessAnswerability`/
   `buildAnswersMessage`/`awaitingQuestionToolCallId`); the activity layer
   (`deriveActivityStatus`/`ActivityInputs` + `listSessionActivity`/`syncSessionActivity`/
-  `setSessionActivityPublisher`); `repairDanglingToolCalls`; `liveParentContext` + `readChildTranscript`
+  `setSessionActivityPublisher`/`setActivityProjectResolver`); `repairDanglingToolCalls`; `liveParentContext` + `readChildTranscript`
   (the delegation embedding); the skill catalog helpers
   `listSkillCommands(cwd, admission)` (filtered, pre-session autocomplete) / `listSkillCatalog(cwd, admission)`
   (unfiltered, the manager's `skills.state`) / `listProjectAliasSkillNames(cwd)` (present-alias count) /

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -113,63 +113,72 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     destructive queue API returns text but drops image blocks; Pi's queue events remain authoritative for
     membership/order. The host projects only a conservative `hasImages` aggregate into summaries/events, so
     image bytes do not ride the ordinary read stream.
-- **Activity projection** (`activity.ts`) answers "what is happening in a workspace nobody has open?" —
-  the signal the Projects rail draws. `deriveActivityStatus` is a **pure function** of one session's
-  observable state; the manager owns only the publish-on-change bookkeeping (`publishedActivity` per
-  entry, so a status that did not move emits nothing), the `session.activityList` snapshot, and retraction
-  on disposal.
+  - **Activity projection** (`activity.ts`) answers "what is happening in a workspace nobody has open?" —
+    the signal the Projects rail draws. `deriveActivityStatus` is a **pure function** of one session's
+    observable state; the manager owns only the publish-on-change bookkeeping (`publishedActivity` per
+    entry, so a status that did not move emits nothing), the `session.activityList` snapshot, and retraction
+    on disposal. A delete that **fails and rolls its tombstone back** re-syncs, because the retraction
+    published while the tombstone stood has already set `publishedActivity` to null: without that
+    republish the change-detector would suppress the session's real status until its next event, leaving a
+    live failed chat with no glyph.
 
-  | # | condition | status |
-  |---|---|---|
-  | 1 | a pending blocking extension dialog | `waiting` |
-  | 2 | `session.isStreaming` | `running` |
-  | 3 | `session.pendingMessageCount > 0` | `queued` |
-  | 4 | an unanswered `ask_user_question` | `waiting` |
-  | 5 | the run failed (see below) | `failed` |
-  | — | otherwise | idle, i.e. `null` |
+    | # | condition | status |
+    |---|---|---|
+    | 1 | a pending blocking extension dialog | `waiting` |
+    | 2 | `session.isStreaming` | `running` |
+    | 3 | `session.pendingMessageCount > 0` | `queued` |
+    | 4 | an unanswered `ask_user_question` | `waiting` |
+    | 5 | the run failed (see below) | `failed` |
+    | — | otherwise | idle, i.e. `null` |
 
-  **`failed` reads the settlement when there is one and the transcript otherwise**, mirroring exactly what
-  `lastSettlement`'s three states already mean: a value decides it outright; explicit **`null`** (run
-  active, or settled with no assistant) means *not failed* and must **not** consult the transcript, or a
-  new `agent_start` would let an older persisted failure reappear mid-run; **`undefined`** means this host
-  process observed nothing, so the persisted transcript is authoritative and the trailing assistant's
-  `stopReason` decides. "Trailing" stops at the next user message and takes the last assistant, so a
-  retried failure followed by a successful attempt is not failed — the same rule `chat/hydrate.ts` uses to
-  hide retried attempts, and the reason a re-attached session keeps its glyph across a host restart
-  instead of silently reading idle while the chat itself shows the failure.
+    **A failure is `stopReason` `error` *or* `length`.** Both are actionable faults the chat already renders
+    as such (`apps/web/src/store/SPEC.md`: a length stop "becomes an actionable truncation error — neither
+    may become '✓ Done'"), so the rail must not disagree with the transcript by calling a truncated run
+    idle. The set is one constant consulted by both the settlement and transcript paths, so the two can
+    never classify differently.
 
-  Every rung of that order is load-bearing and pinned by `activity.test.ts`:
-  - **A dialog outranks streaming** because pi is technically mid-turn while blocked on it, yet the person
-    is the blocker. Reporting `running` would hide a prompt waiting for an answer.
-  - **`queued` outranks `failed`** (you already sent the follow-up, so the failure is handled and nagging
-    would be wrong) **and outranks `waiting`** — a queued message supersedes a pending questionnaire, but
-    it is still in pi's queue and *not yet in the transcript*, so `assessAnswerability` cannot see it.
-    This is why supersession is not modelled as mutable "awaiting" state on the entry: `waiting` is
-    **derived from the transcript** via `awaitingQuestionToolCallId`, which reuses `assessAnswerability`
-    rather than duplicating its already-answered/superseded rules. One authority, nothing to keep in sync.
-  - **`aborted` is idle, not `failed`** — cancelling is a choice, not a fault, and a red row for every
-    Escape would teach the user to ignore the signal.
+    **`failed` reads the settlement when there is one and the transcript otherwise**, mirroring exactly what
+    `lastSettlement`'s three states already mean: a value decides it outright; explicit **`null`** (run
+    active, or settled with no assistant) means *not failed* and must **not** consult the transcript, or a
+    new `agent_start` would let an older persisted failure reappear mid-run; **`undefined`** means this host
+    process observed nothing, so the persisted transcript is authoritative and the trailing assistant's
+    `stopReason` decides. "Trailing" stops at the next user message and takes the last assistant, so a
+    retried failure followed by a successful attempt is not failed — the same rule `chat/hydrate.ts` uses to
+    hide retried attempts, and the reason a re-attached session keeps its glyph across a host restart
+    instead of silently reading idle while the chat itself shows the failure.
 
-  The hot path costs nothing: rungs 1–2 return before the transcript scan, so the per-event sync that
-  fires during streaming never walks messages. The scan runs only at rest, and stops at the latest user
-  message.
+    Every rung of that order is load-bearing and pinned by `activity.test.ts`:
+    - **A dialog outranks streaming** because pi is technically mid-turn while blocked on it, yet the person
+      is the blocker. Reporting `running` would hide a prompt waiting for an answer.
+    - **`queued` outranks `failed`** (you already sent the follow-up, so the failure is handled and nagging
+      would be wrong) **and outranks `waiting`** — a queued message supersedes a pending questionnaire, but
+      it is still in pi's queue and *not yet in the transcript*, so `assessAnswerability` cannot see it.
+      This is why supersession is not modelled as mutable "awaiting" state on the entry: `waiting` is
+      **derived from the transcript** via `awaitingQuestionToolCallId`, which reuses `assessAnswerability`
+      rather than duplicating its already-answered/superseded rules. One authority, nothing to keep in sync.
+    - **`aborted` is idle, not `failed`** — cancelling is a choice, not a fault, and a red row for every
+      Escape would teach the user to ignore the signal.
 
-  The status is **per session and never pre-rolled per workspace** — collapsing several chats into one row
-  is presentation policy owned by the client's selectors (see `apps/web/src/store/SPEC.md`), and a
-  precedence order baked in here would be a UI decision escaping into the host.
+    The hot path costs nothing: rungs 1–2 return before the transcript scan, so the per-event sync that
+    fires during streaming never walks messages. The scan runs only at rest, and stops at the latest user
+    message.
 
-  Every row and push carries its **`projectId`**, resolved through the **`setActivityProjectResolver`**
-  seam (the host owns the workspace registry; this module stays ignorant of projects, as with
-  `setSkillAdmissionResolver`). An unresolvable workspace — one being torn down — publishes nothing, since
-  the client's own workspace-removal fold has already dropped its activity. See `packages/contracts/SPEC.md`
-  for why attribution travels on the wire instead of being derived client-side.
+    The status is **per session and never pre-rolled per workspace** — collapsing several chats into one row
+    is presentation policy owned by the client's selectors (see `apps/web/src/store/SPEC.md`), and a
+    precedence order baked in here would be a UI decision escaping into the host.
 
-  **Lifetime:** entries are never idle-evicted, so every status survives client reconnects. Because
-  `waiting` and `failed` both fall back to the transcript, they also survive a **host restart** for any
-  session that gets attached. What no status survives is a session this process has never loaded:
-  `listSessionActivity` walks live entries only, so a disk-only chat contributes nothing. Extending the
-  snapshot to derive those two from the disk-session scan (`listSessionInfosStrict`) is the deliberate
-  follow-up, not V1.
+    Every row and push carries its **`projectId`**, resolved through the **`setActivityProjectResolver`**
+    seam (the host owns the workspace registry; this module stays ignorant of projects, as with
+    `setSkillAdmissionResolver`). An unresolvable workspace — one being torn down — publishes nothing, since
+    the client's own workspace-removal fold has already dropped its activity. See `packages/contracts/SPEC.md`
+    for why attribution travels on the wire instead of being derived client-side.
+
+    **Lifetime:** entries are never idle-evicted, so every status survives client reconnects. Because
+    `waiting` and `failed` both fall back to the transcript, they also survive a **host restart** for any
+    session that gets attached. What no status survives is a session this process has never loaded:
+    `listSessionActivity` walks live entries only, so a disk-only chat contributes nothing. Extending the
+    snapshot to derive those two from the disk-session scan (`listSessionInfosStrict`) is the deliberate
+    follow-up, not V1.
     New-session and pre-session entrypoints capture the current generation; operations on a live session use
     that session's retained runtime. `abort` remains available as the cancellation control path.
     `prompt`/`steer`/`followUp` (with images) /

--- a/packages/server/src/agent/activity.test.ts
+++ b/packages/server/src/agent/activity.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "bun:test";
+import type { AgentMessage } from "@thinkrail/contracts";
+import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
+import { type ActivityInputs, deriveActivityStatus } from "./activity";
+import { ASK_ACK_TEXT, awaitingQuestionToolCallId } from "./askUserQuestion";
+
+const askCall = (toolCallId: string) =>
+	({
+		role: "assistant",
+		content: [
+			{ type: "toolCall", id: toolCallId, name: "ask_user_question", arguments: { questions: [] } },
+		],
+	}) as unknown as AgentMessage;
+
+const ackResult = (toolCallId: string) =>
+	({
+		role: "toolResult",
+		toolCallId,
+		toolName: "ask_user_question",
+		content: [{ type: "text", text: ASK_ACK_TEXT }],
+		details: { kind: "ack" },
+		isError: false,
+	}) as unknown as AgentMessage;
+
+const answersMessage = (toolCallId: string) =>
+	({
+		role: "custom",
+		customType: ASK_USER_ANSWERS_CUSTOM_TYPE,
+		content: "User has answered your questions: …",
+		display: true,
+		details: { toolCallId, result: { answers: [], cancelled: false } },
+	}) as unknown as AgentMessage;
+
+const userMessage = () =>
+	({
+		role: "user",
+		content: [{ type: "text", text: "do this instead" }],
+	}) as unknown as AgentMessage;
+
+const awaiting = [askCall("tc-1"), ackResult("tc-1")];
+
+const inputs = (over: Partial<ActivityInputs> = {}): ActivityInputs => ({
+	isStreaming: false,
+	pendingMessageCount: 0,
+	messages: [],
+	lastSettlement: undefined,
+	hasPendingDialog: false,
+	...over,
+});
+
+test("a session at rest with nothing to report is idle, expressed as null", () => {
+	expect(deriveActivityStatus(inputs())).toBeNull();
+});
+
+test("a streaming session is running", () => {
+	expect(deriveActivityStatus(inputs({ isStreaming: true }))).toBe("running");
+});
+
+test("a blocking extension dialog outranks streaming — the user is the blocker, not pi", () => {
+	expect(deriveActivityStatus(inputs({ isStreaming: true, hasPendingDialog: true }))).toBe(
+		"waiting",
+	);
+});
+
+test("an unanswered ask_user_question is waiting", () => {
+	expect(deriveActivityStatus(inputs({ messages: awaiting }))).toBe("waiting");
+});
+
+test("an answered questionnaire is no longer waiting", () => {
+	expect(
+		deriveActivityStatus(inputs({ messages: [...awaiting, answersMessage("tc-1")] })),
+	).toBeNull();
+});
+
+test("a later user message supersedes the questionnaire", () => {
+	expect(deriveActivityStatus(inputs({ messages: [...awaiting, userMessage()] }))).toBeNull();
+});
+
+test("an errored settlement is failed", () => {
+	expect(deriveActivityStatus(inputs({ lastSettlement: { stopReason: "error" } }))).toBe("failed");
+});
+
+test("a cancelled run is idle, not failed — aborting is not a fault", () => {
+	expect(deriveActivityStatus(inputs({ lastSettlement: { stopReason: "aborted" } }))).toBeNull();
+});
+
+test("queued outranks failed: a follow-up you already sent means the failure is handled", () => {
+	expect(
+		deriveActivityStatus(
+			inputs({ pendingMessageCount: 1, lastSettlement: { stopReason: "error" } }),
+		),
+	).toBe("queued");
+});
+
+test("queued outranks waiting: a queued message supersedes the question before it lands in the transcript", () => {
+	expect(deriveActivityStatus(inputs({ pendingMessageCount: 1, messages: awaiting }))).toBe(
+		"queued",
+	);
+});
+
+test("running outranks queued: a message queued mid-run does not mask the run", () => {
+	expect(deriveActivityStatus(inputs({ isStreaming: true, pendingMessageCount: 2 }))).toBe(
+		"running",
+	);
+});
+
+test("awaitingQuestionToolCallId names the call, so waiting is never guessed from a bare count", () => {
+	expect(awaitingQuestionToolCallId(awaiting)).toBe("tc-1");
+	expect(awaitingQuestionToolCallId([...awaiting, answersMessage("tc-1")])).toBeNull();
+	expect(awaitingQuestionToolCallId([])).toBeNull();
+});
+
+test("only the most recent questionnaire decides — an old answered one does not linger", () => {
+	const messages = [
+		askCall("tc-1"),
+		ackResult("tc-1"),
+		answersMessage("tc-1"),
+		askCall("tc-2"),
+		ackResult("tc-2"),
+	];
+	expect(awaitingQuestionToolCallId(messages)).toBe("tc-2");
+	expect(deriveActivityStatus(inputs({ messages }))).toBe("waiting");
+});

--- a/packages/server/src/agent/activity.test.ts
+++ b/packages/server/src/agent/activity.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from "bun:test";
 import type { AgentMessage, StopReason } from "@thinkrail/contracts";
 import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
-import { type ActivityInputs, deriveActivityStatus } from "./activity";
+import {
+	type ActivityInputs,
+	deriveActivityStatus,
+	deriveDiskActivityStatus,
+	parseTranscriptTail,
+} from "./activity";
 import { ASK_ACK_TEXT, awaitingQuestionToolCallId } from "./askUserQuestion";
 
 const askCall = (toolCallId: string) =>
@@ -204,4 +209,42 @@ test("error and length are classified identically on both the settlement and tra
 			deriveActivityStatus(inputs({ messages: [userMessage(), assistant(stopReason)] })),
 		).toBeNull();
 	}
+});
+
+const entry = (message: unknown) => JSON.stringify({ type: "message", id: "e", message });
+
+test("a transcript tail parses only message entries, ignoring session headers and junk", () => {
+	const text = [
+		JSON.stringify({ type: "session", id: "s1", cwd: "/w" }),
+		entry({ role: "user", content: [{ type: "text", text: "go" }] }),
+		"not json at all",
+		JSON.stringify({ type: "summary", id: "x" }),
+		entry({ role: "assistant", content: [], stopReason: "error" }),
+		"",
+	].join("\n");
+	const messages = parseTranscriptTail(text, false);
+	expect(messages.map((m) => (m as { role: string }).role)).toEqual(["user", "assistant"]);
+});
+
+test("a truncated window drops its partial first line rather than parsing half an entry", () => {
+	const text = ['e": "hal', entry({ role: "assistant", content: [], stopReason: "error" })].join(
+		"\n",
+	);
+	expect(parseTranscriptTail(text, true)).toHaveLength(1);
+	expect(parseTranscriptTail(text, false)).toHaveLength(1);
+});
+
+test("a disk session can only ever be waiting, failed, or idle — never running or queued", () => {
+	expect(deriveDiskActivityStatus([userMessage(), assistant("error")])).toBe("failed");
+	expect(deriveDiskActivityStatus([userMessage(), assistant("length")])).toBe("failed");
+	expect(deriveDiskActivityStatus(awaiting)).toBe("waiting");
+	expect(deriveDiskActivityStatus([userMessage(), assistant("stop")])).toBeNull();
+	expect(deriveDiskActivityStatus([])).toBeNull();
+});
+
+test("the disk derivation runs the SAME precedence as a live session, not a copy of it", () => {
+	const messages = [...awaiting];
+	expect(deriveDiskActivityStatus(messages)).toBe(
+		deriveActivityStatus(inputs({ messages, lastSettlement: undefined })),
+	);
 });

--- a/packages/server/src/agent/activity.test.ts
+++ b/packages/server/src/agent/activity.test.ts
@@ -121,3 +121,47 @@ test("only the most recent questionnaire decides — an old answered one does no
 	expect(awaitingQuestionToolCallId(messages)).toBe("tc-2");
 	expect(deriveActivityStatus(inputs({ messages }))).toBe("waiting");
 });
+
+const assistant = (stopReason: string) =>
+	({ role: "assistant", content: [{ type: "text", text: "…" }], stopReason }) as unknown as AgentMessage;
+
+test("an attached session whose transcript ends in a failure is failed, so a restart keeps the glyph", () => {
+	expect(deriveActivityStatus(inputs({ messages: [userMessage(), assistant("error")] }))).toBe(
+		"failed",
+	);
+});
+
+test("a transcript ending in a clean stop is idle", () => {
+	expect(deriveActivityStatus(inputs({ messages: [userMessage(), assistant("stop")] }))).toBeNull();
+});
+
+test("a retried failure is not failed — the succeeding attempt is the trailing assistant", () => {
+	expect(
+		deriveActivityStatus(inputs({ messages: [userMessage(), assistant("error"), assistant("stop")] })),
+	).toBeNull();
+});
+
+test("a user message after a failure clears it — asking again is not still-broken", () => {
+	expect(
+		deriveActivityStatus(inputs({ messages: [assistant("error"), userMessage()] })),
+	).toBeNull();
+});
+
+test("an explicit null settlement outranks the transcript, so an old failure cannot reappear mid-run", () => {
+	expect(
+		deriveActivityStatus(inputs({ lastSettlement: null, messages: [userMessage(), assistant("error")] })),
+	).toBeNull();
+});
+
+test("an observed settlement always wins over the transcript, in both directions", () => {
+	expect(
+		deriveActivityStatus(
+			inputs({ lastSettlement: { stopReason: "error" }, messages: [userMessage(), assistant("stop")] }),
+		),
+	).toBe("failed");
+	expect(
+		deriveActivityStatus(
+			inputs({ lastSettlement: { stopReason: "stop" }, messages: [userMessage(), assistant("error")] }),
+		),
+	).toBeNull();
+});

--- a/packages/server/src/agent/activity.test.ts
+++ b/packages/server/src/agent/activity.test.ts
@@ -123,7 +123,11 @@ test("only the most recent questionnaire decides — an old answered one does no
 });
 
 const assistant = (stopReason: string) =>
-	({ role: "assistant", content: [{ type: "text", text: "…" }], stopReason }) as unknown as AgentMessage;
+	({
+		role: "assistant",
+		content: [{ type: "text", text: "…" }],
+		stopReason,
+	}) as unknown as AgentMessage;
 
 test("an attached session whose transcript ends in a failure is failed, so a restart keeps the glyph", () => {
 	expect(deriveActivityStatus(inputs({ messages: [userMessage(), assistant("error")] }))).toBe(
@@ -137,7 +141,9 @@ test("a transcript ending in a clean stop is idle", () => {
 
 test("a retried failure is not failed — the succeeding attempt is the trailing assistant", () => {
 	expect(
-		deriveActivityStatus(inputs({ messages: [userMessage(), assistant("error"), assistant("stop")] })),
+		deriveActivityStatus(
+			inputs({ messages: [userMessage(), assistant("error"), assistant("stop")] }),
+		),
 	).toBeNull();
 });
 
@@ -149,19 +155,27 @@ test("a user message after a failure clears it — asking again is not still-bro
 
 test("an explicit null settlement outranks the transcript, so an old failure cannot reappear mid-run", () => {
 	expect(
-		deriveActivityStatus(inputs({ lastSettlement: null, messages: [userMessage(), assistant("error")] })),
+		deriveActivityStatus(
+			inputs({ lastSettlement: null, messages: [userMessage(), assistant("error")] }),
+		),
 	).toBeNull();
 });
 
 test("an observed settlement always wins over the transcript, in both directions", () => {
 	expect(
 		deriveActivityStatus(
-			inputs({ lastSettlement: { stopReason: "error" }, messages: [userMessage(), assistant("stop")] }),
+			inputs({
+				lastSettlement: { stopReason: "error" },
+				messages: [userMessage(), assistant("stop")],
+			}),
 		),
 	).toBe("failed");
 	expect(
 		deriveActivityStatus(
-			inputs({ lastSettlement: { stopReason: "stop" }, messages: [userMessage(), assistant("error")] }),
+			inputs({
+				lastSettlement: { stopReason: "stop" },
+				messages: [userMessage(), assistant("error")],
+			}),
 		),
 	).toBeNull();
 });

--- a/packages/server/src/agent/activity.test.ts
+++ b/packages/server/src/agent/activity.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { AgentMessage } from "@thinkrail/contracts";
+import type { AgentMessage, StopReason } from "@thinkrail/contracts";
 import { ASK_USER_ANSWERS_CUSTOM_TYPE } from "@thinkrail/contracts";
 import { type ActivityInputs, deriveActivityStatus } from "./activity";
 import { ASK_ACK_TEXT, awaitingQuestionToolCallId } from "./askUserQuestion";
@@ -178,4 +178,30 @@ test("an observed settlement always wins over the transcript, in both directions
 			}),
 		),
 	).toBeNull();
+});
+
+test("a truncated run is failed too — the rail must not call idle what the chat calls an error", () => {
+	expect(deriveActivityStatus(inputs({ lastSettlement: { stopReason: "length" } }))).toBe("failed");
+	expect(deriveActivityStatus(inputs({ messages: [userMessage(), assistant("length")] }))).toBe(
+		"failed",
+	);
+});
+
+test("error and length are classified identically on both the settlement and transcript paths", () => {
+	for (const stopReason of ["error", "length"] as const) {
+		expect(
+			deriveActivityStatus(inputs({ lastSettlement: { stopReason: stopReason as StopReason } })),
+		).toBe("failed");
+		expect(deriveActivityStatus(inputs({ messages: [userMessage(), assistant(stopReason)] }))).toBe(
+			"failed",
+		);
+	}
+	for (const stopReason of ["stop", "toolUse", "aborted"] as const) {
+		expect(
+			deriveActivityStatus(inputs({ lastSettlement: { stopReason: stopReason as StopReason } })),
+		).toBeNull();
+		expect(
+			deriveActivityStatus(inputs({ messages: [userMessage(), assistant(stopReason)] })),
+		).toBeNull();
+	}
 });

--- a/packages/server/src/agent/activity.ts
+++ b/packages/server/src/agent/activity.ts
@@ -9,9 +9,15 @@ export interface ActivityInputs {
 	hasPendingDialog: boolean;
 }
 
+const FAILED_STOP_REASONS: ReadonlySet<string> = new Set(["error", "length"]);
+
 interface AssistantView {
 	role?: string;
 	stopReason?: string;
+}
+
+function failedStopReason(stopReason: string | undefined): boolean {
+	return stopReason !== undefined && FAILED_STOP_REASONS.has(stopReason);
 }
 
 function trailingAssistantFailed(messages: readonly AgentMessage[]): boolean {
@@ -20,13 +26,14 @@ function trailingAssistantFailed(messages: readonly AgentMessage[]): boolean {
 		const view = views[i];
 		if (!view) continue;
 		if (view.role === "user") return false;
-		if (view.role === "assistant") return view.stopReason === "error";
+		if (view.role === "assistant") return failedStopReason(view.stopReason);
 	}
 	return false;
 }
 
 function failed(inputs: ActivityInputs): boolean {
-	if (inputs.lastSettlement !== undefined) return inputs.lastSettlement?.stopReason === "error";
+	if (inputs.lastSettlement !== undefined)
+		return failedStopReason(inputs.lastSettlement?.stopReason);
 	return trailingAssistantFailed(inputs.messages);
 }
 

--- a/packages/server/src/agent/activity.ts
+++ b/packages/server/src/agent/activity.ts
@@ -46,6 +46,7 @@ export function deriveActivityStatus(inputs: ActivityInputs): ActivityStatus | n
 }
 
 export const TRANSCRIPT_TAIL_BYTES = 64 * 1024;
+export const TRANSCRIPT_TAIL_MAX_BYTES = 8 * 1024 * 1024;
 
 export function parseTranscriptTail(text: string, partialFirstLine: boolean): AgentMessage[] {
 	const lines = text.split("\n");

--- a/packages/server/src/agent/activity.ts
+++ b/packages/server/src/agent/activity.ts
@@ -9,11 +9,31 @@ export interface ActivityInputs {
 	hasPendingDialog: boolean;
 }
 
+interface AssistantView {
+	role?: string;
+	stopReason?: string;
+}
+
+function trailingAssistantFailed(messages: readonly AgentMessage[]): boolean {
+	const views = messages as readonly AssistantView[];
+	for (let i = views.length - 1; i >= 0; i--) {
+		const view = views[i];
+		if (!view) continue;
+		if (view.role === "user") return false;
+		if (view.role === "assistant") return view.stopReason === "error";
+	}
+	return false;
+}
+
+function failed(inputs: ActivityInputs): boolean {
+	if (inputs.lastSettlement !== undefined) return inputs.lastSettlement?.stopReason === "error";
+	return trailingAssistantFailed(inputs.messages);
+}
+
 export function deriveActivityStatus(inputs: ActivityInputs): ActivityStatus | null {
 	if (inputs.hasPendingDialog) return "waiting";
 	if (inputs.isStreaming) return "running";
 	if (inputs.pendingMessageCount > 0) return "queued";
 	if (awaitingQuestionToolCallId(inputs.messages) !== null) return "waiting";
-	if (inputs.lastSettlement?.stopReason === "error") return "failed";
-	return null;
+	return failed(inputs) ? "failed" : null;
 }

--- a/packages/server/src/agent/activity.ts
+++ b/packages/server/src/agent/activity.ts
@@ -1,0 +1,19 @@
+import type { ActivityStatus, AgentMessage, AgentSettlement } from "@thinkrail/contracts";
+import { awaitingQuestionToolCallId } from "./askUserQuestion";
+
+export interface ActivityInputs {
+	isStreaming: boolean;
+	pendingMessageCount: number;
+	messages: readonly AgentMessage[];
+	lastSettlement: AgentSettlement | null | undefined;
+	hasPendingDialog: boolean;
+}
+
+export function deriveActivityStatus(inputs: ActivityInputs): ActivityStatus | null {
+	if (inputs.hasPendingDialog) return "waiting";
+	if (inputs.isStreaming) return "running";
+	if (inputs.pendingMessageCount > 0) return "queued";
+	if (awaitingQuestionToolCallId(inputs.messages) !== null) return "waiting";
+	if (inputs.lastSettlement?.stopReason === "error") return "failed";
+	return null;
+}

--- a/packages/server/src/agent/activity.ts
+++ b/packages/server/src/agent/activity.ts
@@ -44,3 +44,35 @@ export function deriveActivityStatus(inputs: ActivityInputs): ActivityStatus | n
 	if (awaitingQuestionToolCallId(inputs.messages) !== null) return "waiting";
 	return failed(inputs) ? "failed" : null;
 }
+
+export const TRANSCRIPT_TAIL_BYTES = 64 * 1024;
+
+export function parseTranscriptTail(text: string, partialFirstLine: boolean): AgentMessage[] {
+	const lines = text.split("\n");
+	if (partialFirstLine) lines.shift();
+	const messages: AgentMessage[] = [];
+	for (const line of lines) {
+		if (!line.trim()) continue;
+		let entry: unknown;
+		try {
+			entry = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (typeof entry !== "object" || entry === null) continue;
+		if (Reflect.get(entry, "type") !== "message") continue;
+		const message = Reflect.get(entry, "message");
+		if (typeof message === "object" && message !== null) messages.push(message as AgentMessage);
+	}
+	return messages;
+}
+
+export function deriveDiskActivityStatus(messages: readonly AgentMessage[]): ActivityStatus | null {
+	return deriveActivityStatus({
+		isStreaming: false,
+		pendingMessageCount: 0,
+		hasPendingDialog: false,
+		lastSettlement: undefined,
+		messages,
+	});
+}

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -1620,3 +1620,87 @@ test("an unresolvable project keeps disk sessions out of the snapshot", async ()
 	});
 	expect(await listSessionActivity([{ id: "ws-orphan", cwd }])).toEqual([]);
 });
+
+test("an oversized terminal record is still classified — the tail grows to a record boundary", async () => {
+	setActivityProjectResolver(() => "project-big");
+	const cwd = tmpCwd("trpi-activity-big-");
+	const dir = defaultSessionDirFor(process.env.PI_CODING_AGENT_DIR ?? "", cwd);
+	mkdirSync(dir, { recursive: true });
+	const huge = "x".repeat(200_000);
+
+	writeFixtureSession(dir, {
+		id: "disk-big-failed",
+		cwd,
+		messages: [
+			{ role: "user", text: "write the file", timestamp: 1 },
+			{ role: "assistant", text: huge, timestamp: 2, stopReason: "error" },
+		],
+	});
+
+	try {
+		const rows = await listSessionActivity([{ id: "ws-big", cwd }]);
+		expect(rows.filter((row) => row.workspaceId === "ws-big").map((row) => row.status)).toEqual([
+			"failed",
+		]);
+	} finally {
+		setActivityProjectResolver(() => null);
+	}
+});
+
+test("an oversized questionnaire record followed by its small ack still reads as waiting", async () => {
+	setActivityProjectResolver(() => "project-ask");
+	const cwd = tmpCwd("trpi-activity-bigask-");
+	const dir = defaultSessionDirFor(process.env.PI_CODING_AGENT_DIR ?? "", cwd);
+	mkdirSync(dir, { recursive: true });
+	const huge = "y".repeat(200_000);
+
+	writeFixtureSession(dir, {
+		id: "disk-big-ask",
+		cwd,
+		messages: [
+			{ role: "user", text: "which one?", timestamp: 1 },
+			{
+				role: "assistant",
+				timestamp: 2,
+				stopReason: "toolUse",
+				content: [
+					{
+						type: "toolCall",
+						id: "tc-big",
+						name: "ask_user_question",
+						arguments: {
+							questions: [
+								{
+									question: "Which?",
+									header: "Pick",
+									options: [
+										{ label: "A", description: "a", preview: huge },
+										{ label: "B", description: "b" },
+									],
+								},
+							],
+						},
+					},
+				],
+			},
+			{
+				role: "toolResult",
+				timestamp: 3,
+				toolCallId: "tc-big",
+				toolName: "ask_user_question",
+				content: [{ type: "text", text: "shown" }],
+				details: { kind: "ack" },
+				isError: false,
+			},
+		],
+	});
+
+	try {
+		const rows = await listSessionActivity([{ id: "ws-bigask", cwd }]);
+		expect(rows.filter((row) => row.workspaceId === "ws-bigask").map((row) => row.status)).toEqual([
+			"waiting",
+		]);
+	} finally {
+		setActivityProjectResolver(() => null);
+	}
+});

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -1,5 +1,13 @@
 import { afterAll, beforeAll, expect, jest, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -20,6 +28,7 @@ import type {
 	ImageContent,
 	SessionSummary,
 } from "@thinkrail/contracts";
+import { defaultSessionDirFor, writeFixtureSession } from "../history/testFixtures";
 import {
 	abortSession,
 	buildSessionSettings,
@@ -1509,14 +1518,15 @@ test("a rolled-back delete republishes activity — a suppressed glyph would out
 		sessionId = session.sessionId;
 		await promptSession(session.sessionId, "fail please");
 
-		const mine = () => listSessionActivity().filter((row) => row.sessionId === sessionId);
+		const mine = async () =>
+			(await listSessionActivity()).filter((row) => row.sessionId === sessionId);
 		expect(published.at(-1)).toBe("failed");
-		expect(mine().map((row) => row.status)).toEqual(["failed"]);
-		expect(mine()[0]?.projectId).toBe("project-1");
+		expect((await mine()).map((row) => row.status)).toEqual(["failed"]);
+		expect((await mine())[0]?.projectId).toBe("project-1");
 
 		deleting = deleteSession(session.sessionId, "ws-delete-activity", cwd);
 		await trashStarted;
-		expect(mine()).toEqual([]);
+		expect(await mine()).toEqual([]);
 
 		syncSessionActivity(session.sessionId);
 		expect(published.at(-1)).toBeNull();
@@ -1526,7 +1536,7 @@ test("a rolled-back delete republishes activity — a suppressed glyph would out
 
 		expect(hasSession(session.sessionId)).toBe(true);
 		expect(published.at(-1)).toBe("failed");
-		expect(mine().map((row) => row.status)).toEqual(["failed"]);
+		expect((await mine()).map((row) => row.status)).toEqual(["failed"]);
 	} finally {
 		failTrash();
 		await deleting?.catch(() => {});
@@ -1536,4 +1546,77 @@ test("a rolled-back delete republishes activity — a suppressed glyph would out
 		setActivityProjectResolver(() => null);
 		setSessionManagerFactory(() => SessionManager.inMemory());
 	}
+});
+
+test("the activity snapshot finds durable states on disk with no session ever attached", async () => {
+	setActivityProjectResolver(() => "project-disk");
+	const cwd = tmpCwd("trpi-activity-disk-");
+	const dir = defaultSessionDirFor(process.env.PI_CODING_AGENT_DIR ?? "", cwd);
+	mkdirSync(dir, { recursive: true });
+
+	const broken = writeFixtureSession(dir, {
+		id: "disk-failed",
+		cwd,
+		messages: [
+			{ role: "user", text: "ship it", timestamp: 1 },
+			{ role: "assistant", text: "tried", timestamp: 2, stopReason: "error" },
+		],
+	});
+	writeFixtureSession(dir, {
+		id: "disk-done",
+		cwd,
+		messages: [
+			{ role: "user", text: "tidy up", timestamp: 3 },
+			{ role: "assistant", text: "done", timestamp: 4, stopReason: "stop" },
+		],
+	});
+
+	try {
+		const rows = await listSessionActivity([{ id: "ws-disk", cwd }]);
+		const mine = rows.filter((row) => row.workspaceId === "ws-disk");
+		expect(mine).toEqual([
+			{
+				sessionId: "disk-failed",
+				workspaceId: "ws-disk",
+				projectId: "project-disk",
+				status: "failed",
+			},
+		]);
+		expect(hasSession("disk-failed")).toBe(false);
+
+		const repeated = (await listSessionActivity([{ id: "ws-disk", cwd }])).filter(
+			(row) => row.workspaceId === "ws-disk",
+		);
+		expect(repeated).toEqual(mine);
+
+		appendFileSync(
+			broken.path,
+			`${JSON.stringify({
+				type: "message",
+				id: "recovered",
+				message: { role: "assistant", content: [], stopReason: "stop" },
+			})}\n`,
+		);
+		const after = (await listSessionActivity([{ id: "ws-disk", cwd }])).filter(
+			(row) => row.workspaceId === "ws-disk",
+		);
+		expect(after).toEqual([]);
+	} finally {
+		setActivityProjectResolver(() => null);
+	}
+});
+
+test("an unresolvable project keeps disk sessions out of the snapshot", async () => {
+	const cwd = tmpCwd("trpi-activity-noproject-");
+	const dir = defaultSessionDirFor(process.env.PI_CODING_AGENT_DIR ?? "", cwd);
+	mkdirSync(dir, { recursive: true });
+	writeFixtureSession(dir, {
+		id: "disk-orphan",
+		cwd,
+		messages: [
+			{ role: "user", text: "hello", timestamp: 1 },
+			{ role: "assistant", text: "broke", timestamp: 2, stopReason: "error" },
+		],
+	});
+	expect(await listSessionActivity([{ id: "ws-orphan", cwd }])).toEqual([]);
 });

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@earendil-works/pi-ai/providers/faux";
 import { AgentSession, ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type {
+	ActivityStatus,
 	AgentSettlement,
 	ExtUiRequest,
 	ImageContent,
@@ -36,6 +37,7 @@ import {
 	getSessionStats,
 	hasSession,
 	listAvailableModels,
+	listSessionActivity,
 	listSessions,
 	promptSession,
 	refreshAvailableModels,
@@ -44,12 +46,15 @@ import {
 	removeQueuedSession,
 	removeSession,
 	removeWorkspaceSessions,
+	setActivityProjectResolver,
+	setSessionActivityPublisher,
 	setSessionCreatedPublisher,
 	setSessionDeletedPublisher,
 	setSessionManagerFactory,
 	setSessionPublisher,
 	setSubagentsEnabledResolver,
 	steerSession,
+	syncSessionActivity,
 	toWireModel,
 } from "./agentSessionManager";
 import { configurePiRuntime } from "./piRuntime";
@@ -1468,5 +1473,67 @@ test("an extension failing in session_start reaches the client, named, before th
 	} finally {
 		setExtUiPublisher(() => {});
 		rmSync(extensionPath, { force: true });
+	}
+});
+
+test("a rolled-back delete republishes activity — a suppressed glyph would outlive the failed deletion", async () => {
+	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
+	const published: (ActivityStatus | null)[] = [];
+	setSessionActivityPublisher((payload) => published.push(payload.status));
+	setActivityProjectResolver(() => "project-1");
+	let reportTrashStarted: () => void = () => {};
+	const trashStarted = new Promise<void>((resolve) => {
+		reportTrashStarted = resolve;
+	});
+	let failTrash: () => void = () => {};
+	const trashOutcome = new Promise<void>((_resolve, reject) => {
+		failTrash = () => reject(new Error("recycle bin unavailable"));
+	});
+	setTrashImplementationForTests(async () => {
+		reportTrashStarted();
+		await trashOutcome;
+	});
+
+	let sessionId: string | undefined;
+	let deleting: Promise<void> | undefined;
+	try {
+		fauxA.setResponses([
+			fauxAssistantMessage("broke", { stopReason: "error", errorMessage: "provider down" }),
+		]);
+		const cwd = tmpCwd("trpi-delete-activity-");
+		const session = await createSession({
+			cwd,
+			workspaceId: "ws-delete-activity",
+			model: toWireModel(fauxA.getModel()),
+		});
+		sessionId = session.sessionId;
+		await promptSession(session.sessionId, "fail please");
+
+		const mine = () => listSessionActivity().filter((row) => row.sessionId === sessionId);
+		expect(published.at(-1)).toBe("failed");
+		expect(mine().map((row) => row.status)).toEqual(["failed"]);
+		expect(mine()[0]?.projectId).toBe("project-1");
+
+		deleting = deleteSession(session.sessionId, "ws-delete-activity", cwd);
+		await trashStarted;
+		expect(mine()).toEqual([]);
+
+		syncSessionActivity(session.sessionId);
+		expect(published.at(-1)).toBeNull();
+
+		failTrash();
+		await expect(deleting).rejects.toThrow("recycle bin unavailable");
+
+		expect(hasSession(session.sessionId)).toBe(true);
+		expect(published.at(-1)).toBe("failed");
+		expect(mine().map((row) => row.status)).toEqual(["failed"]);
+	} finally {
+		failTrash();
+		await deleting?.catch(() => {});
+		if (sessionId && hasSession(sessionId)) removeSession(sessionId);
+		setTrashImplementationForTests(undefined);
+		setSessionActivityPublisher(() => {});
+		setActivityProjectResolver(() => null);
+		setSessionManagerFactory(() => SessionManager.inMemory());
 	}
 });

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -146,12 +146,16 @@ export function syncSessionActivity(sessionId: string): void {
 	if (!entry) return;
 	const status = isSessionDeleted(sessionId, entry.workspaceId) ? null : activityOf(entry);
 	if (status === entry.publishedActivity) return;
+	const projectId = activityProjectId(entry.workspaceId);
+	if (projectId === null) return;
 	entry.publishedActivity = status;
-	publishActivity({ sessionId, workspaceId: entry.workspaceId, status });
+	publishActivity({ sessionId, workspaceId: entry.workspaceId, projectId, status });
 }
 
 function retractActivity(sessionId: string, workspaceId: string): void {
-	publishActivity({ sessionId, workspaceId, status: null });
+	const projectId = activityProjectId(workspaceId);
+	if (projectId === null) return;
+	publishActivity({ sessionId, workspaceId, projectId, status: null });
 }
 
 export function listSessionActivity(): SessionActivity[] {
@@ -159,7 +163,10 @@ export function listSessionActivity(): SessionActivity[] {
 	for (const [sessionId, entry] of sessions) {
 		if (isSessionDeleted(sessionId, entry.workspaceId)) continue;
 		const status = activityOf(entry);
-		if (status) rows.push({ sessionId, workspaceId: entry.workspaceId, status });
+		if (!status) continue;
+		const projectId = activityProjectId(entry.workspaceId);
+		if (projectId === null) continue;
+		rows.push({ sessionId, workspaceId: entry.workspaceId, projectId, status });
 	}
 	return rows;
 }
@@ -180,6 +187,19 @@ export function setSkillAdmissionResolver(
 	resolver: (workspaceId: string) => SkillAdmissionContext,
 ): void {
 	skillAdmissionResolver = resolver;
+}
+
+let activityProjectResolver: (workspaceId: string) => string | null = () => null;
+export function setActivityProjectResolver(resolver: (workspaceId: string) => string | null): void {
+	activityProjectResolver = resolver;
+}
+
+function activityProjectId(workspaceId: string): string | null {
+	try {
+		return activityProjectResolver(workspaceId);
+	} catch {
+		return null;
+	}
 }
 
 let subagentsEnabledResolver: (workspaceId: string) => boolean = () => true;

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -46,6 +46,7 @@ import {
 	deriveDiskActivityStatus,
 	parseTranscriptTail,
 	TRANSCRIPT_TAIL_BYTES,
+	TRANSCRIPT_TAIL_MAX_BYTES,
 } from "./activity";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import {
@@ -171,14 +172,27 @@ interface DiskActivityMemo {
 }
 const diskActivityMemo = new Map<string, DiskActivityMemo>();
 
+const NEWLINE = 0x0a;
+
 async function readTranscriptTail(path: string): Promise<AgentMessage[]> {
 	const handle = await open(path, "r");
 	try {
 		const { size } = await handle.stat();
-		const length = Math.min(size, TRANSCRIPT_TAIL_BYTES);
-		const buffer = Buffer.allocUnsafe(length);
-		await handle.read(buffer, 0, length, size - length);
-		return parseTranscriptTail(buffer.toString("utf8"), length < size);
+		let length = Math.min(size, TRANSCRIPT_TAIL_BYTES);
+		for (;;) {
+			const start = size - length;
+			const probe = start > 0 ? 1 : 0;
+			const buffer = Buffer.allocUnsafe(length + probe);
+			await handle.read(buffer, 0, length + probe, start - probe);
+			if (probe === 0) return parseTranscriptTail(buffer.toString("utf8"), false);
+			if (buffer[0] === NEWLINE) {
+				return parseTranscriptTail(buffer.subarray(1).toString("utf8"), false);
+			}
+			if (length >= TRANSCRIPT_TAIL_MAX_BYTES) {
+				return parseTranscriptTail(buffer.toString("utf8"), true);
+			}
+			length = Math.min(size, length * 8);
+		}
 	} finally {
 		await handle.close();
 	}

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -1205,7 +1205,10 @@ async function runDeleteTransaction(
 		}
 		if (path && existsSync(path)) await trashFile(path);
 	} catch (error) {
-		if (installedTombstone) deletedSessions.delete(sessionId);
+		if (installedTombstone) {
+			deletedSessions.delete(sessionId);
+			syncSessionActivity(sessionId);
+		}
 		throw error;
 	}
 	if (liveEntry && sessions.get(sessionId) === liveEntry) await disposeSession(sessionId);

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -13,6 +13,7 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 import type {
+	ActivityStatus,
 	AgentSettlement,
 	AskUserQuestionResult,
 	ImageContent,
@@ -21,6 +22,8 @@ import type {
 	QueueLane,
 	RefreshedModels,
 	RemovedQueuedMessage,
+	SessionActivity,
+	SessionActivityPayload,
 	SessionCreatedPayload,
 	SessionDeletedPayload,
 	SessionEventPayload,
@@ -37,6 +40,7 @@ import { isTranscriptMessageRole } from "@thinkrail/contracts";
 import type { ParentContext } from "pi-delegation";
 import { RECURSION_GUARD_TOOLS } from "pi-subagents";
 import { logger } from "../log";
+import { deriveActivityStatus } from "./activity";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import {
 	disposeSessionChildren,
@@ -55,7 +59,12 @@ import { projectSessionEvent } from "./sessionEventProjection";
 import { repairDanglingToolCalls } from "./sessionRepair";
 import type { SkillAdmissionContext } from "./skillAdmission";
 import { trashFile } from "./trash";
-import { cancelExtUiForSession, createWebUiContext, notifyExtensionError } from "./webUiContext";
+import {
+	cancelExtUiForSession,
+	createWebUiContext,
+	hasPendingExtUiDialog,
+	notifyExtensionError,
+} from "./webUiContext";
 
 const log = logger("agent");
 
@@ -77,6 +86,7 @@ interface Entry {
 	piCompactionInProgress: boolean;
 	registered: boolean;
 	subagentToolsRefreshPending: boolean;
+	publishedActivity: ActivityStatus | null;
 }
 
 const sessions = new Map<string, Entry>();
@@ -114,6 +124,44 @@ export function setSessionCreatedPublisher(fn: (payload: SessionCreatedPayload) 
 let publishDeleted: (payload: SessionDeletedPayload) => void = () => {};
 export function setSessionDeletedPublisher(fn: (payload: SessionDeletedPayload) => void): void {
 	publishDeleted = fn;
+}
+
+let publishActivity: (payload: SessionActivityPayload) => void = () => {};
+export function setSessionActivityPublisher(fn: (payload: SessionActivityPayload) => void): void {
+	publishActivity = fn;
+}
+
+function activityOf(entry: Entry): ActivityStatus | null {
+	return deriveActivityStatus({
+		isStreaming: entry.session.isStreaming,
+		pendingMessageCount: entry.session.pendingMessageCount,
+		messages: entry.session.messages,
+		lastSettlement: entry.lastSettlement,
+		hasPendingDialog: hasPendingExtUiDialog(entry.session.sessionId),
+	});
+}
+
+export function syncSessionActivity(sessionId: string): void {
+	const entry = sessions.get(sessionId);
+	if (!entry) return;
+	const status = isSessionDeleted(sessionId, entry.workspaceId) ? null : activityOf(entry);
+	if (status === entry.publishedActivity) return;
+	entry.publishedActivity = status;
+	publishActivity({ sessionId, workspaceId: entry.workspaceId, status });
+}
+
+function retractActivity(sessionId: string, workspaceId: string): void {
+	publishActivity({ sessionId, workspaceId, status: null });
+}
+
+export function listSessionActivity(): SessionActivity[] {
+	const rows: SessionActivity[] = [];
+	for (const [sessionId, entry] of sessions) {
+		if (isSessionDeleted(sessionId, entry.workspaceId)) continue;
+		const status = activityOf(entry);
+		if (status) rows.push({ sessionId, workspaceId: entry.workspaceId, status });
+	}
+	return rows;
 }
 
 let sessionManagerFactory: (cwd: string) => SessionManager = (cwd) => SessionManager.create(cwd);
@@ -271,6 +319,7 @@ async function prepareSessionEntry(
 		piCompactionInProgress: false,
 		registered: false,
 		subagentToolsRefreshPending: false,
+		publishedActivity: null,
 	};
 	entry.unsubscribe = session.subscribe((event) => {
 		if (event.type === "queue_update") {
@@ -306,6 +355,7 @@ async function prepareSessionEntry(
 		}
 		if (sessions.get(sessionId) === entry) publish({ sessionId, event: projected });
 		if (event.type === "agent_settled") terminal = null;
+		if (sessions.get(sessionId) === entry) syncSessionActivity(sessionId);
 	});
 
 	const reportExtensionError = (failure: ExtensionError): void => {
@@ -357,6 +407,7 @@ async function registerSession(
 	applySubagentTools(prepared.entry);
 	log.debug(`session ${session.sessionId} attached (workspace ${workspaceId})`);
 	if (announceCreation) publishCreated(summaryOf(session.sessionId, prepared.entry));
+	syncSessionActivity(session.sessionId);
 	return prepared.result;
 }
 
@@ -675,6 +726,7 @@ export async function answerQuestion(
 	await session.sendCustomMessage(buildAnswersMessage(toolCallId, verdict.args, result), {
 		triggerTurn: true,
 	});
+	syncSessionActivity(sessionId);
 }
 
 function synchronizeQueuedLane(entry: Entry, kind: QueueLane, texts: readonly string[]): void {
@@ -817,6 +869,7 @@ export function clearQueueSession(sessionId: string, requireTextOnly = false): S
 		throw new Error("Cannot restore queued image messages as text");
 	}
 	entry.session.clearQueue();
+	syncSessionActivity(sessionId);
 	return content;
 }
 
@@ -851,6 +904,7 @@ export async function removeQueuedSession(
 			);
 		}
 	}
+	syncSessionActivity(sessionId);
 	return { removed, queue: queueStateOf(entry) };
 }
 
@@ -1000,6 +1054,7 @@ function disposeSession(sessionId: string): Promise<void> {
 	entry.unsubscribe();
 	entry.session.dispose();
 	sessions.delete(sessionId);
+	if (entry.publishedActivity !== null) retractActivity(sessionId, entry.workspaceId);
 	log.debug(`session ${sessionId} disposed`);
 	return cascade;
 }

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -1,5 +1,5 @@
 import { createReadStream, existsSync, rmSync } from "node:fs";
-import { readdir } from "node:fs/promises";
+import { open, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { clampThinkingLevel, getSupportedThinkingLevels } from "@earendil-works/pi-ai";
@@ -14,6 +14,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type {
 	ActivityStatus,
+	AgentMessage,
 	AgentSettlement,
 	AskUserQuestionResult,
 	ImageContent,
@@ -40,7 +41,12 @@ import { isTranscriptMessageRole } from "@thinkrail/contracts";
 import type { ParentContext } from "pi-delegation";
 import { RECURSION_GUARD_TOOLS } from "pi-subagents";
 import { logger } from "../log";
-import { deriveActivityStatus } from "./activity";
+import {
+	deriveActivityStatus,
+	deriveDiskActivityStatus,
+	parseTranscriptTail,
+	TRANSCRIPT_TAIL_BYTES,
+} from "./activity";
 import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
 import {
 	disposeSessionChildren,
@@ -158,7 +164,60 @@ function retractActivity(sessionId: string, workspaceId: string): void {
 	publishActivity({ sessionId, workspaceId, projectId, status: null });
 }
 
-export function listSessionActivity(): SessionActivity[] {
+interface DiskActivityMemo {
+	modifiedMs: number;
+	messageCount: number;
+	status: ActivityStatus | null;
+}
+const diskActivityMemo = new Map<string, DiskActivityMemo>();
+
+async function readTranscriptTail(path: string): Promise<AgentMessage[]> {
+	const handle = await open(path, "r");
+	try {
+		const { size } = await handle.stat();
+		const length = Math.min(size, TRANSCRIPT_TAIL_BYTES);
+		const buffer = Buffer.allocUnsafe(length);
+		await handle.read(buffer, 0, length, size - length);
+		return parseTranscriptTail(buffer.toString("utf8"), length < size);
+	} finally {
+		await handle.close();
+	}
+}
+
+async function diskActivityStatus(info: SessionInfo): Promise<ActivityStatus | null> {
+	const modifiedMs = info.modified.getTime();
+	const cached = diskActivityMemo.get(info.path);
+	if (cached && cached.modifiedMs === modifiedMs && cached.messageCount === info.messageCount) {
+		return cached.status;
+	}
+	const status = deriveDiskActivityStatus(await readTranscriptTail(info.path));
+	diskActivityMemo.set(info.path, { modifiedMs, messageCount: info.messageCount, status });
+	return status;
+}
+
+async function diskActivityRows(workspaceId: string, cwd: string): Promise<SessionActivity[]> {
+	const liveFiles = new Set<string>();
+	for (const entry of sessions.values()) {
+		if (entry.workspaceId !== workspaceId) continue;
+		const file = entry.session.sessionManager.getSessionFile();
+		if (file) liveFiles.add(resolve(file));
+	}
+	const projectId = activityProjectId(workspaceId);
+	if (projectId === null) return [];
+	const infos = await listSessionInfosStrict(cwd, liveFiles);
+	const rows: SessionActivity[] = [];
+	for (const info of infos) {
+		if (info.cwd !== cwd) continue;
+		if (sessions.has(info.id) || isSessionDeleted(info.id, workspaceId)) continue;
+		const status = await diskActivityStatus(info);
+		if (status) rows.push({ sessionId: info.id, workspaceId, projectId, status });
+	}
+	return rows;
+}
+
+export async function listSessionActivity(
+	workspaces: readonly { id: string; cwd: string }[] = [],
+): Promise<SessionActivity[]> {
 	const rows: SessionActivity[] = [];
 	for (const [sessionId, entry] of sessions) {
 		if (isSessionDeleted(sessionId, entry.workspaceId)) continue;
@@ -167,6 +226,13 @@ export function listSessionActivity(): SessionActivity[] {
 		const projectId = activityProjectId(entry.workspaceId);
 		if (projectId === null) continue;
 		rows.push({ sessionId, workspaceId: entry.workspaceId, projectId, status });
+	}
+	for (const workspace of workspaces) {
+		try {
+			rows.push(...(await diskActivityRows(workspace.id, workspace.cwd)));
+		} catch (error) {
+			log.warn(`activity snapshot skipped workspace ${workspace.id}`, error as Error);
+		}
 	}
 	return rows;
 }

--- a/packages/server/src/agent/askUserQuestion.ts
+++ b/packages/server/src/agent/askUserQuestion.ts
@@ -248,6 +248,21 @@ export function assessAnswerability(
 	return { ok: true, args };
 }
 
+export function awaitingQuestionToolCallId(messages: readonly AgentMessage[]): string | null {
+	const views = messages as readonly MessageView[];
+	for (let i = views.length - 1; i >= 0; i--) {
+		const view = views[i];
+		if (!view) continue;
+		if (view.role === "user") return null;
+		for (const block of toolCallsOf(view)) {
+			const { id } = block;
+			if (id === undefined || block.name !== ASK_USER_QUESTION_TOOL_NAME) continue;
+			if (assessAnswerability(messages, id).ok) return id;
+		}
+	}
+	return null;
+}
+
 export const ANSWERABILITY_ERRORS: Record<Extract<Answerability, { ok: false }>["reason"], string> =
 	{
 		unknown_call: "Unknown ask_user_question tool call",

--- a/packages/server/src/agent/index.ts
+++ b/packages/server/src/agent/index.ts
@@ -1,3 +1,4 @@
+export { type ActivityInputs, deriveActivityStatus } from "./activity";
 export * from "./agentSessionManager";
 export * from "./askUserQuestion";
 export { readChildTranscript } from "./delegation";

--- a/packages/server/src/agent/webUiContext.ts
+++ b/packages/server/src/agent/webUiContext.ts
@@ -15,6 +15,11 @@ export function setExtUiPublisher(fn: (request: ExtUiRequest) => void): void {
 let seq = 0;
 const nextId = (): string => `extui_${++seq}`;
 
+let onPendingChange: (sessionId: string) => void = () => {};
+export function setExtUiPendingObserver(fn: (sessionId: string) => void): void {
+	onPendingChange = fn;
+}
+
 interface Pending {
 	sessionId: string;
 	finish: (value: string | boolean | null, dismiss: boolean) => void;
@@ -29,6 +34,13 @@ export function cancelExtUiForSession(sessionId: string): void {
 	for (const entry of [...pending.values()]) {
 		if (entry.sessionId === sessionId) entry.finish(null, true);
 	}
+}
+
+export function hasPendingExtUiDialog(sessionId: string): boolean {
+	for (const entry of pending.values()) {
+		if (entry.sessionId === sessionId) return true;
+	}
+	return false;
 }
 
 export function notifyExtUi(
@@ -77,9 +89,11 @@ export function createWebUiContext(sessionId: string): ExtensionUIContext {
 				opts?.signal?.removeEventListener("abort", onAbort);
 				if (dismiss) publish({ id, sessionId, kind: "dismiss" });
 				resolve(value);
+				onPendingChange(sessionId);
 			};
 			const onAbort = (): void => finish(null, true);
 			pending.set(id, { sessionId, finish });
+			onPendingChange(sessionId);
 			if (opts?.signal) {
 				if (opts.signal.aborted) return finish(null, true);
 				opts.signal.addEventListener("abort", onAbort, { once: true });

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -399,6 +399,15 @@ channel fan-out, and the process-boot wrapper both launchers share.
   subscribes every client so permanent domain deletion converges beyond the initiating page. It remains a
   low-latency event, not a durable queue: a reconnecting client's active-workspace `session.list` is the
   authoritative read-side repair for an event missed while its socket was down.
+- **Activity fan-out:** `createServer` installs the agent module's activity publisher and broadcasts each
+  `SessionActivityPayload` on `session.activity`, which the WS `open` handler subscribes for every client
+  alongside the other session channels; `session.activityList` serves the cross-workspace snapshot, since
+  pushes are never replayed and a reconnecting client would otherwise show a stale rail. This module also
+  satisfies the agent's **`setActivityProjectResolver`** seam by mapping a workspace id to its
+  `projectId` through the workspace registry (unresolvable → `null`, and the agent then publishes
+  nothing) — the registry lives here, so attribution is composed here rather than the agent learning what
+  a project is. Derivation, precedence, and lifetime belong to [[submodule-server-agent]]; the wire shape
+  and why `projectId` rides each row are in [[module-contracts]].
 - **Interview invitation delivery:** the three user-send handlers share one post-`ackSend` path that
   filters control traffic once, tracks anonymous `message_sent`, and records the local feedback count. The
   feedback module's injected publisher maps an eligible claim to addressed `feedback.interview` delivery

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -402,7 +402,10 @@ channel fan-out, and the process-boot wrapper both launchers share.
 - **Activity fan-out:** `createServer` installs the agent module's activity publisher and broadcasts each
   `SessionActivityPayload` on `session.activity`, which the WS `open` handler subscribes for every client
   alongside the other session channels; `session.activityList` serves the cross-workspace snapshot, since
-  pushes are never replayed and a reconnecting client would otherwise show a stale rail. This module also
+  pushes are never replayed and a reconnecting client would otherwise show a stale rail. That handler is
+  where the workspace **registry** meets the agent: it passes every record's `{id, cwd}` (via
+  `listAllWorkspaceRecords`) so the agent can union on-disk sessions without ever performing a persistence
+  lookup of its own — the same shape as `session.list` receiving one workspace's `worktreePath`. This module also
   satisfies the agent's **`setActivityProjectResolver`** seam by mapping a workspace id to its
   `projectId` through the workspace registry (unresolvable → `null`, and the agent then publishes
   nothing) — the registry lives here, so attribution is composed here rather than the agent learning what

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -39,6 +39,7 @@ import {
 	isSessionStreaming,
 	listAvailableModels,
 	listProjectAliasSkillNames,
+	listSessionActivity,
 	listSessions,
 	listSkillCatalog,
 	listSkillCommands,
@@ -692,6 +693,7 @@ const handlers: Record<string, Handler> = {
 			}
 		});
 	},
+	"session.activityList": () => listSessionActivity(),
 	"session.getMessages": (params) => {
 		const p = params as { sessionId: string; workspaceId: string };
 		return getSessionMessages(p.sessionId, p.workspaceId, getWorkspace(p.workspaceId).worktreePath);

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -152,6 +152,7 @@ import {
 	ensureWorkspaceScratchDir,
 	forgetWorkspace,
 	getWorkspace,
+	listAllWorkspaceRecords,
 	listExistingWorktrees,
 	listWorkspaceRecords,
 	listWorkspaces,
@@ -693,7 +694,13 @@ const handlers: Record<string, Handler> = {
 			}
 		});
 	},
-	"session.activityList": () => listSessionActivity(),
+	"session.activityList": () =>
+		listSessionActivity(
+			listAllWorkspaceRecords().map((workspace) => ({
+				id: workspace.id,
+				cwd: workspace.worktreePath,
+			})),
+		),
 	"session.getMessages": (params) => {
 		const p = params as { sessionId: string; workspaceId: string };
 		return getSessionMessages(p.sessionId, p.workspaceId, getWorkspace(p.workspaceId).worktreePath);

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -20,6 +20,7 @@ import {
 	getSessionWorkspaceId,
 	isProjectSkillPath,
 	refreshSubagentTools,
+	setActivityProjectResolver,
 	setExtUiPendingObserver,
 	setExtUiPublisher,
 	setReviewCommentHandler,
@@ -346,6 +347,14 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 		} catch {
 			ws.close();
 			return false;
+		}
+	});
+
+	setActivityProjectResolver((workspaceId) => {
+		try {
+			return getWorkspace(workspaceId).projectId;
+		} catch {
+			return null;
 		}
 	});
 

--- a/packages/server/src/host/server.ts
+++ b/packages/server/src/host/server.ts
@@ -3,6 +3,7 @@ import { join, normalize } from "node:path";
 import type {
 	HostPlatform,
 	ServerWelcome,
+	SessionActivityPayload,
 	SessionCreatedPayload,
 	SessionDeletedPayload,
 	TerminalTabsPush,
@@ -19,14 +20,17 @@ import {
 	getSessionWorkspaceId,
 	isProjectSkillPath,
 	refreshSubagentTools,
+	setExtUiPendingObserver,
 	setExtUiPublisher,
 	setReviewCommentHandler,
+	setSessionActivityPublisher,
 	setSessionCreatedPublisher,
 	setSessionDeletedPublisher,
 	setSessionPublisher,
 	setSkillAdmissionResolver,
 	setSubagentsEnabledResolver,
 	settleSessionsForShutdown,
+	syncSessionActivity,
 } from "../agent";
 import {
 	type AnalyticsOptions,
@@ -200,6 +204,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 				ws.subscribe(WS_CHANNELS.piExtensionUi);
 				ws.subscribe(WS_CHANNELS.sessionCreated);
 				ws.subscribe(WS_CHANNELS.sessionDeleted);
+				ws.subscribe(WS_CHANNELS.sessionActivity);
 				ws.subscribe(WS_CHANNELS.providerLogin);
 				ws.subscribe(WS_CHANNELS.providerChanged);
 				ws.subscribe(WS_CHANNELS.projectUpdated);
@@ -448,6 +453,15 @@ export async function createServer(options: CreateServerOptions = {}): Promise<R
 			JSON.stringify({ channel: WS_CHANNELS.sessionDeleted, data: payload }),
 		);
 	});
+
+	setSessionActivityPublisher((payload: SessionActivityPayload) => {
+		server.publish(
+			WS_CHANNELS.sessionActivity,
+			JSON.stringify({ channel: WS_CHANNELS.sessionActivity, data: payload }),
+		);
+	});
+
+	setExtUiPendingObserver(syncSessionActivity);
 
 	setSessionPublisher((payload) => {
 		server.publish(

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -107,7 +107,9 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   fan-out for cold navigation — an automatic reload on a shared host must not diff every worktree),
   `listWorkspaceRecords`
   (raw registry records without Default ensure, folder-truth reconciliation, or per-workspace git diffStats —
-  for internal read-only paths like history scope mapping that must not block on git spawns),
+  for internal read-only paths like history scope mapping that must not block on git spawns) and its
+  project-free sibling `listAllWorkspaceRecords` (every record, for host reads that must span workspaces
+  without knowing which projects are open — the activity snapshot),
   `workspaceDiffStats`, **`setWorkspaceSubagentsOverride(id, override)`** — persist `"on"` / `"off"`,
   or delete `Workspace.subagentsOverride` for `null` (inherit), then emit the authoritative full
   `workspace.updated` snapshot. It validates the closed value but never reads the global default or
@@ -205,7 +207,8 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   module the **single source of workspace lifecycle pushes** (the auto-rename tee no longer pushes — rename
   self-publishes), so registry membership stays shared domain state across every client (architecture #9).
 - **Public surface (barrel):** `createWorkspace`, `listExistingWorktrees`, `openExistingWorktree`,
-  `listWorkspaces`, `listWorkspaceRecords`, `forgetWorkspace`, `reclaimWorktree`, `removeWorkspace`,
+  `listWorkspaces`, `listWorkspaceRecords`, `listAllWorkspaceRecords`, `forgetWorkspace`,
+  `reclaimWorktree`, `removeWorkspace`,
   `workspaceDiffStats`, `workspaceDiffKey`, `getWorkspace`, `renameWorkspace`, `refreshUserOwnedWorkspace`,
   `completeInitialTerminalReservation`, `ensureWorkspaceScratchDir`, `setWorkspacePublisher`,
   `WorkspaceLifecycleEvent`, `setWorkspaceDiffBase`, `setWorkspaceSkillOverride`,

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -513,6 +513,10 @@ export function listWorkspaceRecords(projectId: string): Workspace[] {
 	return loadWorkspaces().filter((w) => w.projectId === projectId);
 }
 
+export function listAllWorkspaceRecords(): Workspace[] {
+	return loadWorkspaces();
+}
+
 export function forgetWorkspace(id: string): Workspace | null {
 	const all = loadWorkspaces();
 	const ws = all.find((w) => w.id === id);


### PR DESCRIPTION
## Summary

With several workspaces each running their own agents, the Projects rail was the only always-visible
place that listed them — and it said nothing about what was happening inside. The only way to find out
was to open every workspace in turn.

Each workspace row now carries a glyph for what its agents are doing, rolled up across its chats, with
an explanation on hover. Collapsed project rows carry the rollup too. Idle draws **nothing**, so a quiet
rail is visually identical to before.

Five states, derived host-side: `running`, `waiting` (a question or a blocking dialog is on you),
`queued`, `failed`, and idle. A run **you** cancelled is idle, not failed — a red row for every Escape
would teach you to ignore the signal.

Two dimensions were deliberately collapsed into one. `failed` and `waiting` are *durable derived states*,
not moments: a failure stays in the settlement until the next run, and an unanswered question stays
unanswered until answered. So the states that need to persist persist by construction — no seen/unseen
layer, no acknowledgement, no clearing logic.

Notifications (toasts, native) are **out of scope** and deliberately deferred.

## Screenshots

The same workspace with a failed chat, before and after:

| Before | After |
|---|---|
| ![before](https://github.com/JetBrains/thinkrail/blob/450c9766f2a59dc5c9b87d00196bd9b885c642f7/rail-before.png?raw=true) | ![after](https://github.com/JetBrains/thinkrail/blob/450c9766f2a59dc5c9b87d00196bd9b885c642f7/rail-after.png?raw=true) |

An unanswered question, where *you* are the blocker:

![waiting](https://github.com/JetBrains/thinkrail/blob/450c9766f2a59dc5c9b87d00196bd9b885c642f7/rail-after-waiting.png?raw=true)

## Changes

**`packages/contracts`** — `ActivityStatus` + `SessionActivity`, the `session.activity` push channel, the
`session.activityList` snapshot read, and `ACTIVITY_PROTOCOL_VERSION` (protocol → 59). `idle` is **not a
union member**: it is absence everywhere, so quiet is the default a consumer gets for free rather than a
value each one must remember to special-case. Also **deletes** `TabStatus` and `Session` — unreferenced
anywhere in the repo, a vestigial first attempt at exactly this feature.

**`packages/server`** — `agent/activity.ts` derives one session's status as a pure function; the manager
owns only publish-on-change, the snapshot, and retraction on disposal. Order is dialog > running > queued
> waiting > failed, and every rung is load-bearing (see `agent/SPEC.md`): a blocking dialog outranks
streaming because pi is mid-turn while *you* are the blocker, and `queued` outranks `waiting` because a
queued message is not yet in the transcript, so answerability cannot see it. `waiting` and `failed` both
fall back to the transcript, so they survive a host restart for any attached session.

**`apps/web`** — `activityByWorkspace` (workspace → session → status), fed by the push with a snapshot
read on connect, gated on the protocol version. The rollup is derived on read by pure
`workspaceActivityRollup`/`projectActivityRollup` rather than Zustand selectors: a fresh rollup object
returned from a selector would re-render the whole rail on every store change. `ActivityGlyph` renders
Remix line icons on semantic tokens.

**Not per-chat.** The status is per session on the wire but the rail shows one glyph per row: how several
chats collapse into one row is presentation policy, and a precedence order baked into the host would be a
UI decision escaping into the engine. Notably the rollup order (`failed` first) is deliberately *not* the
host's per-session order — different questions, and both are pinned by tests so neither gets "fixed" into
the other.

**Design notes.** Icons rather than coloured dots because five states encoded purely in hue fail
colour-blind users and the shipped high-contrast themes. `running` is `feedback-info`, never the accent —
the active workspace's row already renders in the accent, so a green glyph would read as selection. No
motion: the rail is permanently in peripheral vision and concurrent runs pulsing out of phase read as
flicker (the chat plan pane keeps its pulse, since that surface is actively read).

`apps/web/src/panels/SPEC.md` recorded that workspace rows carry no badges. That decision is **amended
explicitly**, not quietly contradicted: the rail admits exactly one decoration class — live agent state,
because it answers a question the rail is the only place to ask — and the rule still excludes change
detail such as a `+N −M` badge.

## Testing

- `bun run e2e` — all 8 shards passed in 145.1s (includes 4 new specs in `e2e/workspace-activity.spec.ts`)
- `bun run test` — 14/14 workspaces, 0 fail (server 950, web 918; 39 new tests across the activity
  derivation, the store fold, the rollup, and the glyph)
- `bun run typecheck` — 14/14 green
- `bun run lint` — clean (6 pre-existing warnings, unchanged)
- `bun run check:deps` / `check:boundaries` / `check:seams` / `check:spec-surface` — all OK

The E2E runs on the **no-agent** lane with no provider spend: a seeded fixture transcript becomes real
activity the moment opening the chat attaches the session, so the full chain — host derivation, push,
store fold, rollup, render — is exercised for real. That is also why `failed` falls back to the
transcript; writing the test is what surfaced the asymmetry with `waiting`.
