### PR TITLE
docs: require the PR and issue templates for programmatic PRs and issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,12 @@ Before committing, opening/updating a PR, or declaring work done, re-read the fu
   change is warranted, finish with the concrete change + "apply?" (or just apply it if it's within the
   approved scope) — never with prose that makes the user say "do the cleanup then please".
 - **UI-visible changes:** offer before/after screenshots alongside the PR without being asked.
+- **PRs and issues follow their templates.** `gh pr create` / `gh issue create` do not apply
+  `.github/PULL_REQUEST_TEMPLATE.md` or `.github/ISSUE_TEMPLATE/*.md`, so anything opened
+  programmatically must reproduce the template by hand: same sections in the same order, every
+  checklist item kept and ticked only when actually done. For a PR, drop the `Related issues` line
+  only when it closes nothing. For an issue, pick the template that fits (bug report / feature
+  request) and pass its frontmatter `labels` via `--label`.
 
 ## Stack
 


### PR DESCRIPTION
## Summary

`gh pr create` / `gh issue create` do not pick up `.github/PULL_REQUEST_TEMPLATE.md` or `.github/ISSUE_TEMPLATE/*.md`, so agent-opened PRs and issues silently skipped them — no checklist, no Related issues section, no labels. AGENTS.md now says so under *Handoff hygiene*: reproduce the template by hand, same sections in the same order, checklist items ticked only when actually done, and pass an issue template's frontmatter `labels` via `--label`.

## Related issues

None.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior) — n/a, docs-only
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change — this change *is* the spec update
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)