### PR TITLE
Start work dialog reworked

### DIFF
--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -676,6 +676,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							refreshing={modelsRefreshing}
 							onRefresh={onRefreshModels}
 							onSelect={onSelectModel}
+							showLabel={false}
 							className="max-w-80 gap-4 px-4 sm:max-w-144"
 						/>
 						<ThinkingSelector

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -39,6 +39,7 @@ export function ModelSelector({
 	placeholder,
 	defaultOption,
 	onSelectDefault,
+	showLabel = true,
 }: {
 	models: WireModel[];
 	current: WireModel | null;
@@ -50,6 +51,7 @@ export function ModelSelector({
 	placeholder?: string;
 	defaultOption?: string;
 	onSelectDefault?: () => void;
+	showLabel?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	const providers = [...new Set(models.map((m) => m.provider))];
@@ -75,6 +77,7 @@ export function ModelSelector({
 					className,
 				)}
 			>
+				{showLabel ? <span className="tr-text-eyebrow text-text-muted">Model</span> : null}
 				<span className="truncate text-text-muted tr-text-metadata">
 					{current?.name ?? (placeholder || "Select model")}
 				</span>

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -488,6 +488,8 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   in every connected client), and a
   **zoomed-stage preview pane** + **scope picker** — see the next bullet),
   `ModelSelector` + `ThinkingSelector` (also shared with `NewWorkspaceDialog`;
+  each trigger names what it sets with an eyebrow — **Model** / **Effort** — which `showLabel={false}`
+  drops in the composer, the one place where the row competes with the prompt for width;
   optional `container` prop portals their popovers into a host Dialog; optional
   `defaultOption`/`onSelectDefault` render an explicit use-the-default row above the provider groups
   (checked when `current` is null) for callers whose selection is an *override* — `ReviewSettings` —

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -32,13 +32,7 @@ import {
 	CommandItem,
 	CommandList,
 } from "@/components/ui/command";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib";
@@ -77,8 +71,10 @@ export function reconcileModel(
 	return catalogFresh && models.length > 0 ? "unavailable" : null;
 }
 
-const PILL =
-	"flex h-32 min-w-0 items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected";
+const PILL_SHAPE =
+	"flex h-32 min-w-0 items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors";
+
+const PILL = `${PILL_SHAPE} hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected`;
 
 export function NewWorkspaceDialog({
 	open,
@@ -102,6 +98,8 @@ export function NewWorkspaceDialog({
 	const [target, setTarget] = useState<WorkspaceTarget>("worktree");
 	const [baseRef, setBaseRef] = useState<string>("");
 	const [prompt, setPrompt] = useState("");
+	const [name, setName] = useState("");
+	const [nameTouched, setNameTouched] = useState(false);
 	const [skillCommands, setSkillCommands] = useState<SlashCommandInfo[]>([]);
 	const [templates, setTemplates] = useState<TemplateInfo[]>([]);
 	const [slotSession, setSlotSession] = useState<TemplateSlotSessionState | null>(null);
@@ -192,6 +190,7 @@ export function NewWorkspaceDialog({
 		if (!open) return;
 		setSelectedProjectId(projectId);
 		updatePromptDraft(initialPrompt ?? "", null);
+		setNameTouched(false);
 		setTarget("worktree");
 		setCreating(false);
 		hostDefaultAsked.current = false;
@@ -237,6 +236,21 @@ export function NewWorkspaceDialog({
 			cancelled = true;
 		};
 	}, [open, selectedProjectId, slashActive, supportsProjectTemplatePreview]);
+
+	useEffect(() => {
+		if (!open || nameTouched) return;
+		let cancelled = false;
+		setName("");
+		getTransport()
+			.request("workspace.suggestName", { projectId: selectedProjectId })
+			.then((suggested) => {
+				if (!cancelled) setName(suggested.name);
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, selectedProjectId, nameTouched]);
 
 	useEffect(() => {
 		if (!open) return;
@@ -349,8 +363,10 @@ export function NewWorkspaceDialog({
 		} else {
 			useAppStore.getState().beginWorktreeCreation(selectedProjectId);
 			try {
+				const chosenName = nameTouched ? name.trim() : "";
 				workspace = await getTransport().request("workspace.create", {
 					projectId: selectedProjectId,
+					...(chosenName ? { name: chosenName } : {}),
 					...(baseRef ? { baseRef } : {}),
 				});
 			} catch (err) {
@@ -439,37 +455,37 @@ export function NewWorkspaceDialog({
 					promptRef.current?.focus();
 				}}
 			>
-				<DialogHeader>
-					<DialogTitle>{isolated ? "Create workspace" : "Work in project folder"}</DialogTitle>
+				<DialogTitle>Start work</DialogTitle>
+
+				<div className="flex flex-col gap-8">
+					<fieldset
+						data-testid="ws-target"
+						className="flex w-fit items-center gap-2 rounded-[var(--radius-md)] border border-control-border-default bg-control-bg p-2"
+					>
+						<legend className="sr-only">Where the work runs</legend>
+						<TargetOption
+							icon={GitBranch}
+							label="Isolated workspace"
+							name={targetGroupName}
+							active={isolated}
+							testid="ws-target-worktree"
+							onSelect={() => setTarget("worktree")}
+						/>
+						<TargetOption
+							icon={House}
+							label="Project folder"
+							name={targetGroupName}
+							active={!isolated}
+							testid="ws-target-default"
+							onSelect={() => setTarget("default")}
+						/>
+					</fieldset>
 					<DialogDescription>
 						{isolated
-							? "A separate checkout on its own new branch. Files, chats, changes, and terminals stay scoped to it."
-							: "Runs directly in your project folder — no isolation. Changes land on the current branch."}
+							? "A separate git worktree on its own new branch."
+							: "Your project folder itself. No isolation, work lands on the current branch."}
 					</DialogDescription>
-				</DialogHeader>
-
-				<fieldset
-					data-testid="ws-target"
-					className="flex w-fit items-center gap-2 rounded-[var(--radius-md)] border border-control-border-default bg-control-bg p-2"
-				>
-					<legend className="sr-only">Where the work runs</legend>
-					<TargetOption
-						icon={GitBranch}
-						label="Isolated workspace"
-						name={targetGroupName}
-						active={isolated}
-						testid="ws-target-worktree"
-						onSelect={() => setTarget("worktree")}
-					/>
-					<TargetOption
-						icon={House}
-						label="Project folder"
-						name={targetGroupName}
-						active={!isolated}
-						testid="ws-target-default"
-						onSelect={() => setTarget("default")}
-					/>
-				</fieldset>
+				</div>
 
 				<div className="flex flex-wrap items-center gap-8">
 					<ProjectPicker
@@ -490,6 +506,32 @@ export function NewWorkspaceDialog({
 							onSelect={selectBaseRef}
 							onRefresh={refreshBranches}
 						/>
+					) : (
+						<span
+							data-testid="ws-current-branch"
+							className="flex h-32 min-w-0 max-w-[220px] items-center gap-8 text-text-muted tr-text-metadata"
+						>
+							<GitBranch className="size-14 shrink-0" />
+							<span className="truncate">On {branches?.current || "branch"}</span>
+						</span>
+					)}
+					{isolated ? (
+						<label
+							className={`${PILL_SHAPE} max-w-[160px] focus-within:border-control-border-active`}
+						>
+							<span className="shrink-0 tr-text-eyebrow text-text-muted">Name</span>
+							<input
+								type="text"
+								data-testid="ws-name"
+								value={name}
+								spellCheck={false}
+								onChange={(e) => {
+									setNameTouched(true);
+									setName(e.target.value);
+								}}
+								className="min-w-0 flex-1 bg-transparent text-text-muted tr-text-metadata outline-none"
+							/>
+						</label>
 					) : null}
 					<SkillsButton
 						onOpen={() => setManageSkills(true)}
@@ -583,7 +625,7 @@ export function NewWorkspaceDialog({
 							onNext={() => stepPromptSlot(1)}
 							className="absolute top-full left-8 z-50 mt-4"
 						/>
-					) : prompt.trim() && isolated ? (
+					) : prompt.trim() && isolated && !nameTouched ? (
 						<p
 							data-testid="workspace-naming-hint"
 							className="px-4 text-text-muted tr-text-metadata"
@@ -592,8 +634,9 @@ export function NewWorkspaceDialog({
 						</p>
 					) : (
 						<p className="mt-4 text-text-muted tr-text-metadata">
-							Type <span className="tr-code-text">/</span> for skills and prompt templates —
-							previewed from the current checkout; the created workspace's session is authoritative.
+							Type <span className="tr-code-text">/</span> for skills and prompt templates. This
+							list comes from the current checkout, so the new session may see a slightly different
+							one.
 						</p>
 					)}
 				</div>

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -246,7 +246,16 @@ treatment.
   `defaultBranch: ""`, **never the literal `HEAD`**: a sentinel that named a ref would be believed — the
   dialog would preselect it and persist it as the workspace's `baseBranch`, and that worktree would forever
   diff against its own head. Empty means "unknown", so `create` omits `baseRef` and the host resolves the
-  real branch. **`WelcomePanel`** is the first-touch surface the shell mounts (centered, left-nav beside it) whenever no
+  real branch. Worktree mode also carries a **Name** field (`ws-name`), prefilled from
+  **`workspace.suggestName`** with the host's next free `workspace-N` so the user sees the name they are
+  about to get instead of guessing it. The prefill is a **placeholder, not a choice**: while it is
+  untouched `create` omits `name` entirely — the host allocates the slot and its prompt-driven auto-rename
+  still applies (the naming hint says so, and disappears the moment the field is edited) — and once edited
+  the typed name travels with `workspace.create`, which locks it against that rename. Folder mode has no
+  base to pick, so in the picker's slot it shows the same list's
+  **`current`** as a plain "On {branch}" read-out (`ws-current-branch`) — text, not a control, so nothing
+  in that slot invites a click that folder mode cannot honour — the two modes each name the
+  branch the work will land on, one chosen, one reported. **`WelcomePanel`** is the first-touch surface the shell mounts (centered, left-nav beside it) whenever no
 workspace is active. **One hero heading** (`welcome-title`, the topbar's brand styling — accent font,
 `text-primary` — enlarged): the **shown project's name**, or `PRODUCT_NAME` when no project is shown —
 the wordmark is the empty-state identity, a project's own name is the identity once one is open (so no
@@ -309,14 +318,14 @@ skills' (attacker-controlled) names before trust. The full manager (`chat/Skills
 pre-session half of the user's skill settings; the chat header opens the same dialog in workspace mode
 (with Reload).
 
-**`NewWorkspaceDialog`** is the start-working surface: **a target control** (a two-option segment — a
-native radio group, `fieldset` + sr-only `legend` over visually-hidden radio inputs, so assistive tech
-hears one mutually-exclusive choice — both always visible: the two-mode model in one glance) chooses **where** the work runs, and the header is
-**mode-aware** so it always names the operation truthfully: **Isolated workspace** → title **“Create
-workspace”**, description **“A separate checkout on its own new branch. Files, chats, changes, and
-terminals stay scoped to it.”**; **Project folder** → title **“Work in project folder”**, description
-**“Runs directly in your project folder — no isolation. Changes land on the current branch.”** In folder
-mode the base-branch picker and the naming hint are hidden (nothing is created — submit **enters** the
+**`NewWorkspaceDialog`** is the start-working surface. Its title is the **mode-independent** **“Start
+work”** — the window is one surface, so it does not rename itself under the user. Under it, **a target
+control** (a two-option segment — a native radio group, `fieldset` + sr-only `legend` over
+visually-hidden radio inputs, so assistive tech hears one mutually-exclusive choice — both always
+visible: the two-mode model in one glance) chooses **where** the work runs, and the **one-line
+description directly below it** is the only mode-aware prose, stating just the difference: **Isolated
+workspace** → **“A separate git worktree on its own new branch.”**; **Project folder** → **“Your project
+folder itself. No isolation, work lands on the current branch.”** In folder mode the base-branch picker and the naming hint are hidden (nothing is created — submit **enters** the
 project's Default workspace via the shared **`enterDefaultWorkspace`** helper (`defaultWorkspace.ts`:
 `workspace.list` → fold into the store → activate the `kind === "default"` row, one atomic entry — the
 rail's auto-expand follows activation; error toast + `null` if an older host has none — the same helper
@@ -374,7 +383,7 @@ a project picker, the prompt hero, and the reused
   *Trust project* button — the repo's skills stay withheld until granted (`project.setTrust`, which folds the
   updated project back into the store and re-previews); personal + bundled skills show regardless. When the menu is closed, **Enter submits** (matching the submit button's
   `↵` affordance) and
-  **Shift+Enter** inserts a newline. Worktree-mode submit = `workspace.create({ projectId, baseRef })` → set active → **always open a
+  **Shift+Enter** inserts a newline. Worktree-mode submit = `workspace.create({ projectId, name?, baseRef })` → set active → **always open a
   fresh chat** (`session.create({ workspaceId, model?, thinkingLevel? })` — a held model + effort apply even
   without a prompt, and travel together: with none held both are omitted and pi resolves them) → a typed prompt is additionally sent as the first message (fire-and-forget
   `prompt`); an **empty prompt leaves the just-opened composer ready** — submitting the start-working

--- a/apps/web/src/panels/branches.ts
+++ b/apps/web/src/panels/branches.ts
@@ -2,7 +2,7 @@ import type { BranchList } from "@thinkrail/contracts";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getTransport } from "../transport";
 
-const NO_BRANCHES: BranchList = { local: [], remote: [], defaultBranch: "" };
+const NO_BRANCHES: BranchList = { local: [], remote: [], defaultBranch: "", current: "" };
 
 async function listBranchesOrEmpty(projectId: string): Promise<BranchList> {
 	try {

--- a/e2e/new-workspace.spec.ts
+++ b/e2e/new-workspace.spec.ts
@@ -67,23 +67,23 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	const dialog = page.getByTestId("new-workspace-dialog");
 	await expect(dialog).toBeVisible();
 
-	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
-	await expect(dialog).toContainText("A separate checkout on its own new branch");
+	await expect(dialog.getByRole("heading", { name: "Start work" })).toBeVisible();
+	await expect(dialog).toContainText("A separate git worktree on its own new branch");
 	await expect(dialog.getByTestId("ws-prompt-note")).toHaveCount(0);
-	await expect(dialog).toContainText("Files, chats, changes, and terminals stay scoped to it");
 	await expect(dialog.getByTestId("ws-target-worktree")).toHaveAttribute("data-active", "true");
 
 	await dialog.getByTestId("ws-target-default").click();
-	await expect(dialog.getByRole("heading", { name: "Work in project folder" })).toBeVisible();
-	await expect(dialog).toContainText("no isolation");
+	await expect(dialog).toContainText("No isolation");
 	await expect(dialog.getByTestId("ws-branch-picker")).toHaveCount(0);
+	await expect(dialog.getByTestId("ws-current-branch")).toContainText("main");
 	await expect(page.getByTestId("create-workspace")).toHaveText(/Start/);
 	await dialog.getByTestId("ws-target-worktree").click();
-	await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
+	await expect(dialog).toContainText("A separate git worktree on its own new branch");
 	await expect(dialog.getByTestId("ws-branch-picker")).toBeVisible();
 	await expect(page.getByTestId("create-workspace")).toHaveText(/Create/);
 
 	await expect(dialog.getByTestId("ws-project-picker")).toContainText("sample-project");
+	await expect(dialog.getByTestId("ws-name")).toHaveValue("workspace-1");
 
 	const branchPicker = dialog.getByTestId("ws-branch-picker");
 	await expect(branchPicker).toContainText("From");
@@ -149,6 +149,31 @@ test("the dialog lists local branches (no stray origin) and creates a worktree",
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 	await expect(page.getByTestId("chat-input")).toBeVisible();
 	await expect(page.locator('[data-testid="chat-message"][data-role="user"]')).toHaveCount(0);
+});
+
+test("an edited name names the worktree, and the placeholder leaves naming to the host", async ({
+	page,
+}) => {
+	await openFixtureProject(page);
+	await page.getByTestId("add-workspace").first().click();
+	const dialog = page.getByTestId("new-workspace-dialog");
+	await expect(dialog).toBeVisible();
+
+	const name = dialog.getByTestId("ws-name");
+	await expect(name).toHaveValue("workspace-1");
+	await dialog.getByTestId("ws-prompt").fill("rework the login screen");
+	await expect(dialog.getByTestId("workspace-naming-hint")).toBeVisible();
+
+	await name.fill("Login Rework");
+	await expect(dialog.getByTestId("workspace-naming-hint")).toHaveCount(0);
+
+	await page.getByTestId("create-workspace").click();
+	await expect(dialog).toBeHidden();
+	await expect(worktreeRows(page)).toHaveCount(1);
+	await expect(page.getByTestId("scope-context")).toContainText("Login Rework");
+
+	await page.getByTestId("add-workspace").first().click();
+	await expect(dialog.getByTestId("ws-name")).toHaveValue("workspace-1");
 });
 
 test("folder-mode Start with an empty prompt lands in a fresh chat in the Default workspace", async ({

--- a/e2e/welcome.spec.ts
+++ b/e2e/welcome.spec.ts
@@ -175,13 +175,12 @@ test("a project without specs suggests setting it up", async ({ page }) => {
 		await expect(dialog.getByTestId("ws-prompt")).toHaveValue("/skill:setting-up-a-project ");
 		await expect(dialog.getByTestId("slash-menu")).toHaveCount(0);
 		await expect(dialog.getByTestId("ws-target-worktree")).toHaveAttribute("data-active", "true");
-		await expect(dialog.getByRole("heading", { name: "Create workspace" })).toBeVisible();
+		await expect(dialog.getByRole("heading", { name: "Start work" })).toBeVisible();
 		await expect(dialog.getByTestId("ws-branch-picker")).toBeVisible();
 		await expect(dialog.getByTestId("ws-prompt-note")).toContainText("setting-up-a-project skill");
 
 		await dialog.getByTestId("ws-target-default").click();
-		await expect(dialog.getByRole("heading", { name: "Work in project folder" })).toBeVisible();
-		await expect(dialog).toContainText("no isolation");
+		await expect(dialog).toContainText("No isolation");
 		await expect(dialog.getByTestId("ws-branch-picker")).toHaveCount(0);
 
 		await dialog.getByTestId("ws-prompt").fill("");

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -388,6 +388,8 @@ of the host.
   returning `JbcentralActionResult`; none accepts an executable, artifact path, output, URL, or secret from
   the client) / **`jbcentralQuota`** (v59; optional `force` bypasses completed-cache age but still joins an
   in-flight read; disabled/unhealthy returns `hidden` without invoking quota)) /
+  **`workspace.suggestName`** (the next free `workspace-N` for a project — the placeholder the New
+  Workspace dialog shows before the user renames it; suggesting reserves nothing) /
   **`workspace.listExisting`** (the selected project's unattached Git worktrees, with detached rows
   disabled by status) / **`workspace.openExisting`** (revalidate + register one branch-backed checkout as
   `kind: "external"`, emitting the ordinary `workspace.created`, without mutating Git or disk) /

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -285,6 +285,7 @@ export interface BranchList {
 	remote: string[];
 	remoteGroups?: RemoteBranchGroup[];
 	defaultBranch: string;
+	current: string;
 }
 
 export type ProviderAuthKind = "oauth" | "api-key" | "env" | "other";

--- a/packages/contracts/src/wsProtocol.test.ts
+++ b/packages/contracts/src/wsProtocol.test.ts
@@ -46,6 +46,11 @@ test("project template previews advance the additive wire shape to v63", () => {
 });
 
 test("host update advisories advance the protocol with an immutable notice channel", () => {
-	expect(PROTOCOL_VERSION).toBe(64);
+	expect(PROTOCOL_VERSION).toBeGreaterThanOrEqual(64);
 	expect(WS_CHANNELS.hostUpdateAvailable).toBe("host.updateAvailable");
+});
+
+test("the workspace-name suggestion advances the additive wire shape to v65", () => {
+	expect(PROTOCOL_VERSION).toBe(65);
+	expect(WS_METHODS.workspaceSuggestName).toBe("workspace.suggestName");
 });

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -96,7 +96,7 @@ export type TemplateReadLocation =
 	| { projectId: string; workspaceId?: never }
 	| { workspaceId?: never; projectId?: never };
 
-export const PROTOCOL_VERSION = 64;
+export const PROTOCOL_VERSION = 65;
 export const WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION = 62;
 export const PROJECT_TEMPLATE_PREVIEW_PROTOCOL_VERSION = 63;
 export const THEME_SYSTEM_PROTOCOL_VERSION = 58;
@@ -157,6 +157,7 @@ export const WS_METHODS = {
 	projectSetGroupEnabled: "project.setGroupEnabled",
 	projectSkills: "project.skills",
 	workspaceCreate: "workspace.create",
+	workspaceSuggestName: "workspace.suggestName",
 	workspaceRename: "workspace.rename",
 	workspaceListExisting: "workspace.listExisting",
 	workspaceOpenExisting: "workspace.openExisting",
@@ -362,6 +363,7 @@ export interface WsMethodMap {
 		params: { projectId: string; name?: string; baseRef?: string };
 		result: Workspace;
 	};
+	"workspace.suggestName": { params: { projectId: string }; result: { name: string } };
 	"workspace.rename": { params: { id: string; name: string }; result: Workspace };
 	"workspace.listExisting": {
 		params: { projectId: string };

--- a/packages/server/src/git/SPEC.md
+++ b/packages/server/src/git/SPEC.md
@@ -160,9 +160,11 @@ ref off the workspace-create critical path.
   it) so the plan page can flag commits the PR doesn't have yet — the `origin/` here is the second
   deliberate survivor of the all-remotes sweep, because it asks where *this* workspace's own branch was
   pushed, not which remote a base was branched from; `listBranches(projectId)` → `{ local, remote,
-  remoteGroups?, defaultBranch }` (local `refs/heads`; canonical `remote` = every direct full ref under
-  `refs/remotes` with symbolic aliases omitted; additive `remoteGroups` = host-owned remote/branch metadata
-  for presentation; default = origin's `HEAD`→another remote's `HEAD`→`origin/main`→repo `HEAD`; any ref-list
+  remoteGroups?, defaultBranch, current }` (local `refs/heads`; canonical `remote` = every direct full ref
+  under `refs/remotes` with symbolic aliases omitted; additive `remoteGroups` = host-owned remote/branch
+  metadata for presentation; `current` = the repo's checked-out branch, so a caller that offers no base —
+  the New Workspace dialog in folder mode — can still name where the work will land; default = origin's
+  `HEAD`→another remote's `HEAD`→`origin/main`→repo `HEAD`; any ref-list
   or ownership-list failure throws, never a successful partial catalog),
   **`resolveDefaultBranch(repoPath)`** — that default-branch
   resolution factored out (named once), shared by `listBranches` and the `workspaces` module's

--- a/packages/server/src/git/git.test.ts
+++ b/packages/server/src/git/git.test.ts
@@ -206,11 +206,12 @@ test("listBranches surfaces origin branches and the origin default", async () =>
 	git(repo, "push", "origin", "main");
 	git(repo, "remote", "set-head", "origin", "main");
 
-	const { remote, defaultBranch } = await listBranches("p1");
+	const { remote, defaultBranch, current } = await listBranches("p1");
 	expect(remote).toContain("origin/main");
 	expect(remote).not.toContain("origin/HEAD");
 	expect(remote).not.toContain("origin");
 	expect(defaultBranch).toBe("origin/main");
+	expect(current).toBe("main");
 });
 
 test("the origin/main default survives a local branch with the same shorthand", async () => {

--- a/packages/server/src/git/git.ts
+++ b/packages/server/src/git/git.ts
@@ -123,6 +123,7 @@ export async function listBranches(projectId: string): Promise<BranchList> {
 		remote,
 		remoteGroups: groupRemoteRefs(remote, lines(remoteNames.out)),
 		defaultBranch: resolveDefaultBranch(repo),
+		current: currentBranch(repo),
 	};
 }
 

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -163,6 +163,7 @@ import {
 	setWorkspaceDiffBase,
 	setWorkspaceSkillOverride,
 	setWorkspaceSubagentsOverride,
+	suggestWorkspaceName,
 	workspaceDiffStats,
 } from "../workspaces";
 import { ackSend } from "./ackSend";
@@ -330,6 +331,9 @@ const handlers: Record<string, Handler> = {
 		const p = params as { projectId: string; name?: string; baseRef?: string };
 		return provisionInitialTerminal(await createWorkspace(p.projectId, p.name, p.baseRef));
 	},
+	"workspace.suggestName": (params) => ({
+		name: suggestWorkspaceName((params as { projectId: string }).projectId),
+	}),
 	"workspace.listExisting": (params) =>
 		listExistingWorktrees((params as { projectId: string }).projectId),
 	"workspace.openExisting": async (params) => {

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -14,6 +14,9 @@ A workspace is a `git worktree` on its own branch under the data dir — the anc
 chats. Its **display `name` is decoupled from its git `branch`**: `name` is a human-readable label
 (Title Case, spaces) and `branch` is a kebab slug derived from it — they were once held equal, and still
 coincide for the auto `workspace-N` placeholder, but a named workspace carries both distinctly.
+**`suggestWorkspaceName`** exposes that placeholder before creation (the same `workspace-N` scan the
+create path runs) so a client can show the name it is about to get; it reserves nothing, and the
+creating call still resolves the name itself.
 
 Two kinds are **user-owned** — ThinkRail uses their cwd but never renames or reclaims them. Every project
 carries **exactly one built-in Default workspace** (`kind: "default"`) whose `worktreePath` is the project
@@ -211,7 +214,7 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   `workspaceDiffStats`, `workspaceDiffKey`, `getWorkspace`, `renameWorkspace`, `refreshUserOwnedWorkspace`,
   `completeInitialTerminalReservation`, `ensureWorkspaceScratchDir`, `setWorkspacePublisher`,
   `WorkspaceLifecycleEvent`, `setWorkspaceDiffBase`, `setWorkspaceSkillOverride`,
-  `setWorkspaceSubagentsOverride`.
+  `setWorkspaceSubagentsOverride`, `suggestWorkspaceName`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`, `log`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -28,6 +28,7 @@ import {
 	setWorkspaceDiffBase,
 	setWorkspacePublisher,
 	setWorkspaceSubagentsOverride,
+	suggestWorkspaceName,
 	type WorkspaceLifecycleEvent,
 } from "./workspaces";
 
@@ -378,6 +379,16 @@ test("createWorkspace marks a user-named workspace renamed; an auto-named one st
 	expect(named.name).toBe("My Feature");
 	expect(named.branch).toBe("my-feature");
 	expect(named.renamed).toBe(true);
+});
+
+test("suggestWorkspaceName names the slot the next auto-named create would take", async () => {
+	expect(suggestWorkspaceName("p1")).toBe("workspace-1");
+
+	await createWorkspace("p1");
+	expect(suggestWorkspaceName("p1")).toBe("workspace-2");
+
+	await createWorkspace("p1", "My Feature");
+	expect(suggestWorkspaceName("p1")).toBe("workspace-2");
 });
 
 test("renameWorkspace moves the branch in place: record + git follow, the worktree dir does not", async () => {

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -218,6 +218,10 @@ async function diffStats(ws: Workspace): Promise<DiffStats | undefined> {
 	}
 }
 
+export function suggestWorkspaceName(projectId: string): string {
+	return nextAutoBranch(openProjectById(projectId));
+}
+
 export async function createWorkspace(
 	projectId: string,
 	name?: string,


### PR DESCRIPTION
## What changed

**The dialog no longer renames itself under the user.** Picking Isolated workspace / Project folder used to rewrite both the title and the description below it. The title is now the constant **Start work**, the target segment sits directly under it, and the only mode-aware prose is one line stating the difference:

- Isolated workspace — "A separate git worktree on its own new branch."
- Project folder — "Your project folder itself. No isolation, work lands on the current branch."

**Folder mode now says where the work lands.** Worktree mode offers a base-branch picker; folder mode had an empty slot and never named the branch. `git.listBranches` now also reports the repo's checked-out branch (`current`), and folder mode renders it as a plain `On <branch>` read-out — text, not a control, since there is nothing to pick.

**Both bottom-row triggers name what they set** (`MODEL` / `EFFORT`). The chat composer opts out of the labels, where that row competes with the prompt for width.

**Worktree mode gained a Name field** (closes #420), prefilled from a new `workspace.suggestName` request
with the host's next free `workspace-N`. Untouched it stays a placeholder — `create` omits it, the host
allocates the slot, and its prompt-driven auto-rename still applies. Edited, the typed name is sent and locks that rename out, so the branch matches the name from the start.

The skill caption was reworded in plainer language.

## Verification

`lint`, `typecheck`, `test`, `check:deps`, `check:boundaries`, `check:spec-surface`, and the full `bun run e2e` (6 shards, all passed).

## Screenshots

| | Before | After |
| --- | --- | --- |
| **Isolated workspace** | <img width="420" alt="before-worktree" src="https://github.com/user-attachments/assets/9bdad21c-d98f-4e5e-bdb1-df709b9fec08" /> | <img width="420" alt="after-worktree" src="https://github.com/user-attachments/assets/9c43504a-f2ab-4f68-aca9-53efe1529092" /> |
| **Project folder** | <img width="420" alt="before-folder" src="https://github.com/user-attachments/assets/291374d3-8fc7-4c6b-98c0-e56f7c33043a" /> | <img width="420" alt="after-folder" src="https://github.com/user-attachments/assets/a19c57a1-d9f1-4076-85b3-a2a2362d475f" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

