### PR TITLE
feat(desktop): ship expanded macOS DMGs

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -33,8 +33,8 @@ public repositories, so `JetBrains/thinkrail-signing` (private) signs the staged
 - **Release** (`nightly.yml` / `stable.yml` → `_release.yml` → `_build.yml`): trusts a green `main`,
   produces native-smoked CLI binaries plus desktop installers, pushes the tag, and stages them as a
   **draft**. A draft and its assets are invisible to unauthenticated users, so nothing unsigned is ever
-  public. Signing and publication belong to `thinkrail-signing`; notarization and desktop updater
-  publication remain deferred gates.
+  public. Signing, macOS desktop notarization, and publication belong to `thinkrail-signing`; bare
+  macOS CLI notarization and desktop updater publication remain deferred gates.
 
 **Why Windows gates PRs and macOS does not.** A release build is all-or-nothing: `release` needs
 `build.result == 'success'`, so one red matrix leg publishes *nothing* — quietly, with no notification, and
@@ -89,7 +89,7 @@ the artifact on the real OS. Bun *can* cross-compile all five from one Linux hos
 platform's lib in one npm package), but embedding a `dlopen`'d FFI lib into a `--compile` output is a
 bug-prone, host-target-only-proven path here, and a cross-built artifact can't be smoke-tested — and you'd
 still need native runners to verify it, so cross-compile saves little. It stays a documented fallback.
-`windows-arm64` (no stable Bun target), `linux-*-musl`, and notarization are deferred.
+`windows-arm64` (no stable Bun target), `linux-*-musl`, and bare macOS CLI notarization are deferred.
 
 ## Version stamping
 
@@ -113,7 +113,9 @@ never sends anyway, since the analytics module mutes on `CI`.
 - The native build action: stamp the shared version → `build:web` → build/smoke the CLI binary →
   package/native-smoke/shared-probe the expanded desktop app → create and execute Electrobun's
   first-install artifact in an isolated install root → collect both artifacts. Desktop-backed e2e runs in
-  CI before release; each release runner still performs both target-native desktop smoke layers.
+  CI before release; each release runner still performs both target-native desktop smoke layers. The
+  macOS release build replaces Electrobun's self-extracting wrapper with the complete expanded app before
+  uploading the unsigned DMG for private signing.
 - `actions/make-checksums` — writes `SHA256SUMS` over the release artifacts. **No caller here:** a
   signature changes the bytes, so checksums must be taken after signing. `thinkrail-signing` pins it by
   commit SHA, which is what keeps the published `SHA256SUMS` format identical to pre-signing releases.
@@ -171,9 +173,10 @@ in place.
 ## Get right
 
 - **Native build == correct runtime.** Do not collapse the matrix to cross-compilation without another
-  way to execute each target's PTY, trash helper, Electrobun wrapper/system renderer, and normal quit path.
-  Linux release additionally requires clean Ubuntu 24.04 x64/ARM64 smoke with glibc 2.38 and the declared
-  GTK/WebKitGTK/AppIndicator/RSVG packages.
+  way to execute each target's PTY, trash helper, Electrobun system renderer, and normal quit path. Linux
+  release additionally requires clean Ubuntu 24.04 x64/ARM64 smoke with glibc 2.38 and the declared
+  GTK/WebKitGTK/AppIndicator/RSVG packages. The macOS release DMG contains the complete expanded app; a
+  first-launch extractor cannot be signed as the final installed bundle.
 - **`server.welcome` stays additive.** `appVersion` is optional; adding wire fields that clients can
   ignore doesn't bump `PROTOCOL_VERSION`. A field clients must understand does.
 - **Windows has no real SIGTERM** — `smoke:binary` relaxes its clean-exit assertion there (Bun

--- a/apps/desktop/SPEC.md
+++ b/apps/desktop/SPEC.md
@@ -24,7 +24,8 @@ engine architecture.
   a bounded generic client-preference adapter under stable backend-profile/window identity; desktop package
   smoke; and the desktop artifact adapter used by shared host probes.
 - **Public surface:** the packaged desktop application and its installers — the Windows setup stub
-  signed, the macOS `.dmg` and the Linux tarballs not (see *Signing*, below); the build/test-only
+  signed, the macOS `.dmg` Developer ID signed and notarized, and the Linux tarballs unsigned (see
+  *Signing*, below); the build/test-only
   `@thinkrail/desktop/artifact` launcher and installer locators consumed by smoke and E2E harnesses.
 - **Allowed deps:** `server` for the embedded host, build-support manifest, and artifact probes; `shared`
   for release identity and the retrying teardown both smokes clean up with; `contracts` for
@@ -76,7 +77,8 @@ a hidden host.
 
 Packaged resources remain physical and unpacked: web assets and skills are read through filesystem paths,
 the PTY uses FFI, trash helpers are executable sidecars, and the preload is read as source text. ASAR is
-not part of this design.
+not part of this design. The macOS DMG carries this complete app directly; first launch does not extract an
+archive or replace the application bundle.
 
 ## Native application menu
 
@@ -125,8 +127,11 @@ The package pins Electrobun `1.18.1` and packaged Bun `1.3.14`. Its explicit bui
 completed `apps/web/dist`, consumes the server-owned runtime manifest, stages target PTY/trash/skill/web
 resources under an ignored package-local directory, emits the transient static factory entry, bundles the
 self-contained server runtime to a packaged `.ts` filename, runs Electrobun, and removes generated source
-even on failure. Ordinary root development and web-build commands do not download or build Electrobun.
-The wrapper also injects the shared baked version while Electrobun evaluates its isolated config process.
+even on failure. For macOS canary/stable builds, it then extracts Electrobun's complete inner app archive
+and replaces the self-extracting wrapper DMG with that expanded app plus the `/Applications` link. The
+archive remains an internal/update build output, not a release asset or first-launch mechanism. Ordinary
+root development and web-build commands do not download or build Electrobun. The wrapper also injects the
+shared baked version while Electrobun evaluates its isolated config process.
 
 Electrobun `1.18.1` publishes implementation `.ts` files that do not typecheck under the repository's
 strict TypeScript 6 settings. Desktop typecheck therefore maps only the consumed Electrobun API surface
@@ -139,14 +144,12 @@ Linux ARM64. Nightly maps to Electrobun canary and stable maps to stable. Update
 
 ### Signing
 
-Signing happens outside this repository (`JetBrains/thinkrail-signing`), and reaches only the Windows
-installer's `ThinkRail-Setup.exe` stub. The payload beside it is keyed by the `hash` field in
-`ThinkRail-Setup.metadata.json`, so rewriting it would desync the installer. The macOS `.dmg` is not
-signed at all: `ThinkRail.app` seals no resources and its real payload — Bun runtime, `bun-pty` — is a
-`.tar.zst` under `Contents/Resources/` that self-extracts on first launch. Notarization requires every
-executable to be present and signed at submission, so signing the `.dmg` would be cosmetic while
-Gatekeeper still blocked the download. Making macOS desktop signable is a packaging change here, not a
-pipeline change.
+Signing happens outside this repository (`JetBrains/thinkrail-signing`). The existing Windows CLI,
+Windows installer-stub, macOS CLI, Linux passthrough, checksum, schedule, dry-run, and publication paths are
+unchanged. For the macOS desktop only, the private workflow removes the expanded DMG from passthrough,
+signs every nested Mach-O and the app through JetBrains CodeSign, embeds that signed app back into the same
+image, then signs, notarizes, and staples the DMG. The app is not distributed or stapled separately. The
+private hop does not rebuild product code, and no signing implementation or credential lives here.
 
 Smoke teardown of a temp tree that a launcher ran from must go through `@thinkrail/shared/removeTree`.
 Windows releases handles asynchronously after a child exits, so a bare recursive remove throws `EBUSY`
@@ -164,9 +167,9 @@ CI-only and are never shipped as user configuration.
   real webview to reach DOM-ready, confirms native application-menu registration on supported targets,
   runs the shared artifact probes with repository reads denied, quits through normal lifecycle, and
   observes clean process exit.
-- First-install smoke executes the produced DMG app, Windows setup ZIP, or Linux setup tarball against
-  isolated installation roots, boots the installed host, checks health, and requires graceful exit. The
-  release matrix must pass both smoke layers before uploading the installer.
+- First-install smoke executes the produced expanded DMG app, Windows setup ZIP, or Linux setup tarball
+  against isolated installation roots, boots the installed host, checks health, and requires graceful exit.
+  The release matrix must pass both smoke layers before uploading the installer.
 - Electrobun names installer artifacts per channel, and the channel lands in a different position on each
   platform: the Linux setup tarball carries it in the app-file stem (`ThinkRail-canary-Setup.tar.gz`)
   while the Windows setup executable inside the ZIP carries it after `-Setup`
@@ -187,5 +190,5 @@ CI-only and are never shipped as user configuration.
 
 ## Deferred
 
-Shared/remote backend profiles, profile selection, multi-window/deep-link routing, CEF, a signed and
-notarized macOS `.dmg` (see above), and Electrobun updater UX.
+Shared/remote backend profiles, profile selection, multi-window/deep-link routing, CEF, bare macOS CLI
+notarization, standalone app distribution/ticketing, and Electrobun updater UX.

--- a/apps/desktop/build.ts
+++ b/apps/desktop/build.ts
@@ -14,6 +14,7 @@ import { basename, join, relative, resolve, sep } from "node:path";
 import type { BundledExtensions } from "@thinkrail/server";
 import { resolveBuildRuntimeSources } from "@thinkrail/server/build-support";
 import { version } from "@thinkrail/shared/version";
+import { isMacosPackageChannel, postPackageExpandedMacosDmg } from "./src/macosPackage";
 import { ptyLibraryName, runtimeTarget } from "./src/runtimeTarget";
 
 const desktopDir = import.meta.dir;
@@ -150,6 +151,9 @@ function electrobun(...args: string[]): void {
 try {
 	await stage();
 	electrobun("build", `--env=${environment}`);
+	if (process.platform === "darwin" && isMacosPackageChannel(environment)) {
+		postPackageExpandedMacosDmg(desktopDir, environment);
+	}
 	if (shouldRun) electrobun("run");
 } finally {
 	rmSync(stageDir, { recursive: true, force: true });

--- a/apps/desktop/src/macosPackage.test.ts
+++ b/apps/desktop/src/macosPackage.test.ts
@@ -1,0 +1,340 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	chmodSync,
+	copyFileSync,
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	extractTarSafely,
+	type MacosPackageChannel,
+	macosArtifactNames,
+	postPackageExpandedMacosDmg,
+	snapshotMacosAppBundle,
+	validateExpandedMacosApp,
+	validateExpandedMacosPackage,
+} from "./macosPackage";
+
+const roots: string[] = [];
+const executableRoutes = [
+	"Contents/MacOS/bspatch",
+	"Contents/MacOS/bun",
+	"Contents/MacOS/launcher",
+	"Contents/MacOS/libasar.dylib",
+	"Contents/MacOS/libNativeWrapper.dylib",
+	"Contents/MacOS/zig-zstd",
+	"Contents/Resources/app/runtime/macos-trash",
+] as const;
+const fileRoutes = [
+	"Contents/Info.plist",
+	...executableRoutes,
+	"Contents/Resources/AppIcon.icns",
+	"Contents/Resources/build.json",
+	"Contents/Resources/main.js",
+	"Contents/Resources/version.json",
+	"Contents/Resources/app/bun/index.js",
+	"Contents/Resources/app/runtime/librust_pty_arm64.dylib",
+	"Contents/Resources/app/runtime/preload.js",
+	"Contents/Resources/app/runtime/server-runtime.ts",
+	"Contents/Resources/app/runtime/windows-trash.exe",
+	"Contents/Resources/app/runtime/skills/example/SKILL.md",
+	"Contents/Resources/app/views/web/index.html",
+	"Contents/Resources/app/views/web/assets/app.js",
+] as const;
+
+function temporaryRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "thinkrail-macos-package-test-"));
+	roots.push(root);
+	return root;
+}
+
+function writeRoute(root: string, route: string, value = route): string {
+	const path = join(root, ...route.split("/"));
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, value);
+	return path;
+}
+
+function createApp(root: string, channel: MacosPackageChannel): string {
+	const app = join(root, macosArtifactNames(channel).appBundle);
+	mkdirSync(join(app, "Contents", "Frameworks"), { recursive: true });
+	for (const route of fileRoutes) writeRoute(app, route);
+	for (const route of executableRoutes) chmodSync(join(app, ...route.split("/")), 0o755);
+	return app;
+}
+
+function createPackage(channel: MacosPackageChannel): { app: string; root: string } {
+	const root = temporaryRoot();
+	const app = createApp(root, channel);
+	symlinkSync("/Applications", join(root, "Applications"));
+	return { app, root };
+}
+
+interface TarEntry {
+	readonly path: string;
+	readonly type?: "0" | "2" | "5";
+	readonly target?: string;
+}
+
+function writeTar(path: string, entries: readonly TarEntry[]): void {
+	const blocks: Buffer[] = [];
+	for (const entry of entries) {
+		const header = Buffer.alloc(512);
+		header.write(entry.path, 0, 100, "utf8");
+		header.write("0000755\0", 100, 8, "ascii");
+		header.write("0000000\0", 108, 8, "ascii");
+		header.write("0000000\0", 116, 8, "ascii");
+		header.write("00000000000\0", 124, 12, "ascii");
+		header.write("00000000000\0", 136, 12, "ascii");
+		header.fill(32, 148, 156);
+		header.write(entry.type ?? "0", 156, 1, "ascii");
+		if (entry.target) header.write(entry.target, 157, 100, "utf8");
+		header.write("ustar\0", 257, 6, "ascii");
+		header.write("00", 263, 2, "ascii");
+		let checksum = 0;
+		for (const byte of header) checksum += byte;
+		header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+		blocks.push(header);
+	}
+	blocks.push(Buffer.alloc(1024));
+	writeFileSync(path, Buffer.concat(blocks));
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test("pins Electrobun's macOS ARM64 artifact names per channel", () => {
+	expect(macosArtifactNames("stable")).toEqual({
+		appBundle: "ThinkRail.app",
+		appArchive: "stable-macos-arm64-ThinkRail.app.tar.zst",
+		dmg: "stable-macos-arm64-ThinkRail.dmg",
+		volume: "ThinkRail",
+	});
+	expect(macosArtifactNames("canary")).toEqual({
+		appBundle: "ThinkRail-canary.app",
+		appArchive: "canary-macos-arm64-ThinkRail-canary.app.tar.zst",
+		dmg: "canary-macos-arm64-ThinkRail-canary.dmg",
+		volume: "ThinkRail-canary",
+	});
+});
+
+describe("expanded package validation", () => {
+	for (const channel of ["canary", "stable"] as const) {
+		test(`accepts the complete ${channel} ARM64 layout`, () => {
+			const fixture = createPackage(channel);
+			expect(validateExpandedMacosPackage(fixture.root, channel)).toBe(fixture.app);
+		});
+	}
+
+	test("rejects legacy Electrobun extractor metadata and payload archives", () => {
+		const fixture = createPackage("canary");
+		const resources = join(fixture.app, "Contents", "Resources");
+		writeFileSync(join(resources, "metadata.json"), "{}");
+		expect(() => validateExpandedMacosApp(fixture.app, "canary")).toThrow(
+			"legacy Electrobun extractor metadata",
+		);
+		rmSync(join(resources, "metadata.json"));
+		writeFileSync(join(resources, "payload.tar.zst"), "payload");
+		expect(() => validateExpandedMacosApp(fixture.app, "canary")).toThrow(
+			"legacy Electrobun payload archive",
+		);
+	});
+
+	test("rejects missing ARM64 runtime resources and package-root extras", () => {
+		const fixture = createPackage("stable");
+		rmSync(join(fixture.app, "Contents", "Resources", "app", "runtime", "librust_pty_arm64.dylib"));
+		expect(() => validateExpandedMacosPackage(fixture.root, "stable")).toThrow(
+			"Contents/Resources/app/runtime/librust_pty_arm64.dylib",
+		);
+		writeFileSync(join(fixture.root, ".DS_Store"), "extra");
+		expect(() => validateExpandedMacosPackage(fixture.root, "stable")).toThrow(
+			"must contain exactly Applications, ThinkRail.app",
+		);
+	});
+});
+
+describe("safe tar extraction", () => {
+	test.each([
+		"../escape",
+		"/absolute",
+		"ThinkRail.app/../../escape",
+	])("rejects the traversal path %s before extraction", (path) => {
+		const root = temporaryRoot();
+		const tar = join(root, "unsafe.tar");
+		const destination = join(root, "destination");
+		mkdirSync(destination);
+		writeTar(tar, [{ path }]);
+		let ran = false;
+		expect(() =>
+			extractTarSafely(tar, destination, undefined, "tar", () => {
+				ran = true;
+			}),
+		).toThrow("unsafe path");
+		expect(ran).toBe(false);
+	});
+
+	test("rejects links and additional archive roots before extraction", () => {
+		const root = temporaryRoot();
+		const destination = join(root, "destination");
+		mkdirSync(destination);
+		const linked = join(root, "linked.tar");
+		writeTar(linked, [
+			{ path: "ThinkRail.app/", type: "5" },
+			{ path: "ThinkRail.app/Contents/link", type: "2", target: "../../../escape" },
+		]);
+		expect(() => extractTarSafely(linked, destination, "ThinkRail.app", "tar", () => {})).toThrow(
+			"unsupported link",
+		);
+		const extra = join(root, "extra.tar");
+		writeTar(extra, [
+			{ path: "ThinkRail.app/", type: "5" },
+			{ path: "unexpected/", type: "5" },
+		]);
+		expect(() => extractTarSafely(extra, destination, "ThinkRail.app", "tar", () => {})).toThrow(
+			"must contain exactly the ThinkRail.app root",
+		);
+	});
+});
+
+test("app bundle snapshots pin bytes, entry types, modes, and symlink targets", () => {
+	const first = temporaryRoot();
+	const second = temporaryRoot();
+	for (const root of [first, second]) {
+		const app = join(root, "ThinkRail.app");
+		mkdirSync(join(app, "b"), { recursive: true });
+		writeFileSync(join(app, "b", "value"), "same");
+		writeFileSync(join(app, "a"), "first");
+		symlinkSync("b/value", join(app, "link"));
+	}
+	const firstSnapshot = snapshotMacosAppBundle(join(first, "ThinkRail.app"));
+	const secondApp = join(second, "ThinkRail.app");
+	expect(snapshotMacosAppBundle(secondApp)).toEqual(firstSnapshot);
+	expect(firstSnapshot.map((entry) => entry.path)).toEqual([".", "a", "b", "b/value", "link"]);
+
+	writeFileSync(join(secondApp, "b", "value"), "changed");
+	expect(snapshotMacosAppBundle(secondApp)).not.toEqual(firstSnapshot);
+	writeFileSync(join(secondApp, "b", "value"), "same");
+
+	const originalMode = firstSnapshot.find((entry) => entry.path === "a")?.mode;
+	if (originalMode === undefined) throw new Error("snapshot omitted fixture file mode");
+	chmodSync(join(secondApp, "a"), originalMode ^ 0o100);
+	expect(snapshotMacosAppBundle(secondApp)).not.toEqual(firstSnapshot);
+	chmodSync(join(secondApp, "a"), originalMode);
+
+	rmSync(join(secondApp, "link"));
+	symlinkSync("a", join(secondApp, "link"));
+	expect(snapshotMacosAppBundle(secondApp)).not.toEqual(firstSnapshot);
+	rmSync(join(secondApp, "link"));
+	symlinkSync("b/value", join(secondApp, "link"));
+
+	rmSync(join(secondApp, "b", "value"));
+	mkdirSync(join(secondApp, "b", "value"));
+	expect(snapshotMacosAppBundle(secondApp)).not.toEqual(firstSnapshot);
+});
+
+describe("expanded DMG post-packaging", () => {
+	function setup(channel: MacosPackageChannel) {
+		const desktop = temporaryRoot();
+		const artifacts = join(desktop, "artifacts");
+		mkdirSync(artifacts);
+		const names = macosArtifactNames(channel);
+		const archive = join(artifacts, names.appArchive);
+		writeTar(archive, [{ path: `${names.appBundle}/`, type: "5" }]);
+		const dmg = join(artifacts, names.dmg);
+		writeFileSync(dmg, "wrapper");
+		const zstd = join(desktop, "zig-zstd");
+		writeFileSync(zstd, "tool");
+		const source = temporaryRoot();
+		createApp(source, channel);
+		return { archive, artifacts, channel, desktop, dmg, names, source, zstd };
+	}
+
+	function runnerFor(
+		fixture: ReturnType<typeof setup>,
+		hdiutil: (command: readonly string[]) => void,
+	) {
+		return (command: readonly string[]): void => {
+			if (command[0] === fixture.zstd) {
+				copyFileSync(fixture.archive, command[command.indexOf("-o") + 1] ?? "");
+				return;
+			}
+			if (command[0] === "tar") {
+				const destination = command[command.indexOf("-C") + 1];
+				if (!destination) throw new Error("missing tar destination");
+				cpSync(
+					join(fixture.source, fixture.names.appBundle),
+					join(destination, fixture.names.appBundle),
+					{
+						recursive: true,
+					},
+				);
+				return;
+			}
+			hdiutil(command);
+		};
+	}
+
+	test("replaces the existing artifact only after hdiutil creates the expanded image", () => {
+		const fixture = setup("canary");
+		const commands: (readonly string[])[] = [];
+		const result = postPackageExpandedMacosDmg(fixture.desktop, fixture.channel, {
+			zstdPath: fixture.zstd,
+			tarPath: "tar",
+			hdiutilPath: "hdiutil",
+			runCommand: runnerFor(fixture, (command) => {
+				commands.push(command);
+				const source = command[command.indexOf("-srcfolder") + 1];
+				const output = command.at(-1);
+				if (!source || !output) throw new Error("invalid hdiutil command");
+				validateExpandedMacosPackage(source, "canary");
+				writeFileSync(output, "expanded");
+			}),
+		});
+		expect(result).toBe(fixture.dmg);
+		expect(readFileSync(fixture.dmg, "utf8")).toBe("expanded");
+		expect(commands).toEqual([
+			[
+				"hdiutil",
+				"create",
+				"-volname",
+				"ThinkRail-canary",
+				"-srcfolder",
+				expect.any(String),
+				"-ov",
+				"-format",
+				"ULFO",
+				expect.any(String),
+			],
+		]);
+		expect(
+			readdirSync(fixture.artifacts).some((entry) => entry.startsWith(".macos-package-")),
+		).toBe(false);
+	});
+
+	test("leaves the wrapper artifact untouched when image creation fails", () => {
+		const fixture = setup("stable");
+		expect(() =>
+			postPackageExpandedMacosDmg(fixture.desktop, fixture.channel, {
+				zstdPath: fixture.zstd,
+				tarPath: "tar",
+				hdiutilPath: "hdiutil",
+				runCommand: runnerFor(fixture, () => {
+					throw new Error("hdiutil failed");
+				}),
+			}),
+		).toThrow("hdiutil failed");
+		expect(readFileSync(fixture.dmg, "utf8")).toBe("wrapper");
+		expect(
+			readdirSync(fixture.artifacts).some((entry) => entry.startsWith(".macos-package-")),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/macosPackage.ts
+++ b/apps/desktop/src/macosPackage.ts
@@ -1,0 +1,506 @@
+import { createHash } from "node:crypto";
+import {
+	closeSync,
+	cpSync,
+	existsSync,
+	fstatSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	openSync,
+	readdirSync,
+	readlinkSync,
+	readSync,
+	renameSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+} from "node:fs";
+import { basename, dirname, join, posix, resolve, sep } from "node:path";
+
+export type MacosPackageChannel = "canary" | "stable";
+
+export interface MacosArtifactNames {
+	readonly appBundle: string;
+	readonly appArchive: string;
+	readonly dmg: string;
+	readonly volume: string;
+}
+
+export interface MacosAppSnapshotEntry {
+	readonly path: string;
+	readonly type: "directory" | "file" | "symlink";
+	readonly mode: number;
+	readonly size?: number;
+	readonly sha256?: string;
+	readonly target?: string;
+}
+
+export type MacosAppBundleSnapshot = readonly MacosAppSnapshotEntry[];
+
+export type MacosPackageCommandRunner = (command: readonly string[]) => void;
+
+export interface MacosPostPackageOptions {
+	readonly zstdPath?: string;
+	readonly tarPath?: string;
+	readonly hdiutilPath?: string;
+	readonly runCommand?: MacosPackageCommandRunner;
+}
+
+const appName = "ThinkRail";
+const macosPlatform = "macos-arm64";
+const requiredDirectories = [
+	"Contents",
+	"Contents/Frameworks",
+	"Contents/MacOS",
+	"Contents/Resources",
+	"Contents/Resources/app",
+	"Contents/Resources/app/bun",
+	"Contents/Resources/app/runtime",
+	"Contents/Resources/app/runtime/skills",
+	"Contents/Resources/app/views",
+	"Contents/Resources/app/views/web",
+	"Contents/Resources/app/views/web/assets",
+] as const;
+const requiredFiles = [
+	"Contents/Info.plist",
+	"Contents/MacOS/bspatch",
+	"Contents/MacOS/bun",
+	"Contents/MacOS/launcher",
+	"Contents/MacOS/libasar.dylib",
+	"Contents/MacOS/libNativeWrapper.dylib",
+	"Contents/MacOS/zig-zstd",
+	"Contents/Resources/AppIcon.icns",
+	"Contents/Resources/build.json",
+	"Contents/Resources/main.js",
+	"Contents/Resources/version.json",
+	"Contents/Resources/app/bun/index.js",
+	"Contents/Resources/app/runtime/librust_pty_arm64.dylib",
+	"Contents/Resources/app/runtime/macos-trash",
+	"Contents/Resources/app/runtime/preload.js",
+	"Contents/Resources/app/runtime/server-runtime.ts",
+	"Contents/Resources/app/runtime/windows-trash.exe",
+	"Contents/Resources/app/views/web/index.html",
+] as const;
+const requiredExecutables = [
+	"Contents/MacOS/bspatch",
+	"Contents/MacOS/bun",
+	"Contents/MacOS/launcher",
+	"Contents/MacOS/libasar.dylib",
+	"Contents/MacOS/libNativeWrapper.dylib",
+	"Contents/MacOS/zig-zstd",
+	"Contents/Resources/app/runtime/macos-trash",
+] as const;
+const tarBlockSize = 512;
+const tarMetadataLimit = 1024 * 1024;
+
+export function isMacosPackageChannel(value: string): value is MacosPackageChannel {
+	return value === "canary" || value === "stable";
+}
+
+export function macosArtifactNames(channel: MacosPackageChannel): MacosArtifactNames {
+	const stem = channel === "stable" ? appName : `${appName}-${channel}`;
+	const prefix = `${channel}-${macosPlatform}`;
+	return {
+		appBundle: `${stem}.app`,
+		appArchive: `${prefix}-${stem}.app.tar.zst`,
+		dmg: `${prefix}-${stem}.dmg`,
+		volume: stem,
+	};
+}
+
+function requireDirectory(path: string, label: string): void {
+	if (!existsSync(path) || !lstatSync(path).isDirectory()) {
+		throw new Error(`${label} is not a directory: ${path}`);
+	}
+}
+
+function requireRegularFile(path: string, label: string): void {
+	if (!existsSync(path)) throw new Error(`${label} is missing: ${path}`);
+	const entry = lstatSync(path);
+	if (!entry.isFile()) throw new Error(`${label} is not a regular file: ${path}`);
+	if (entry.size === 0) throw new Error(`${label} is empty: ${path}`);
+}
+
+function sortedEntries(path: string): string[] {
+	return readdirSync(path).sort();
+}
+
+function hasFiles(path: string): boolean {
+	for (const name of readdirSync(path)) {
+		const entry = lstatSync(join(path, name));
+		if (entry.isFile()) return true;
+		if (entry.isDirectory() && hasFiles(join(path, name))) return true;
+	}
+	return false;
+}
+
+function relativeDisplay(root: string, path: string): string {
+	return path
+		.slice(root.length + 1)
+		.split(sep)
+		.join("/");
+}
+
+export function validateExpandedMacosApp(appPath: string, channel: MacosPackageChannel): void {
+	const expected = macosArtifactNames(channel).appBundle;
+	if (basename(appPath) !== expected) {
+		throw new Error(`macOS app must be named ${expected}: ${appPath}`);
+	}
+	requireDirectory(appPath, "macOS app bundle");
+	const resources = join(appPath, "Contents", "Resources");
+	const metadata = join(resources, "metadata.json");
+	if (existsSync(metadata)) {
+		throw new Error(`macOS app contains legacy Electrobun extractor metadata: ${metadata}`);
+	}
+	if (existsSync(resources)) {
+		const pending = [resources];
+		while (pending.length > 0) {
+			const directory = pending.pop();
+			if (!directory) break;
+			for (const name of readdirSync(directory)) {
+				const path = join(directory, name);
+				const entry = lstatSync(path);
+				if (entry.isDirectory()) pending.push(path);
+				if (entry.isFile() && name.endsWith(".tar.zst")) {
+					throw new Error(
+						`macOS app contains a legacy Electrobun payload archive: ${relativeDisplay(appPath, path)}`,
+					);
+				}
+			}
+		}
+	}
+	for (const route of requiredDirectories) {
+		requireDirectory(join(appPath, ...route.split("/")), `required macOS app directory ${route}`);
+	}
+	for (const route of requiredFiles) {
+		requireRegularFile(join(appPath, ...route.split("/")), `required macOS app file ${route}`);
+	}
+	for (const route of requiredExecutables) {
+		const path = join(appPath, ...route.split("/"));
+		if ((statSync(path).mode & 0o111) === 0) {
+			throw new Error(`required macOS app executable is not executable: ${route}`);
+		}
+	}
+	for (const route of [
+		"Contents/Resources/app/runtime/skills",
+		"Contents/Resources/app/views/web/assets",
+	] as const) {
+		const path = join(appPath, ...route.split("/"));
+		if (!hasFiles(path)) throw new Error(`required macOS app directory is empty: ${route}`);
+	}
+}
+
+export function validateExpandedMacosPackage(
+	packageRoot: string,
+	channel: MacosPackageChannel,
+): string {
+	requireDirectory(packageRoot, "macOS package root");
+	const names = macosArtifactNames(channel);
+	const expected = ["Applications", names.appBundle].sort();
+	const actual = sortedEntries(packageRoot);
+	if (
+		actual.length !== expected.length ||
+		actual.some((entry, index) => entry !== expected[index])
+	) {
+		throw new Error(
+			`macOS package root must contain exactly ${expected.join(", ")}; found ${actual.join(", ") || "nothing"}`,
+		);
+	}
+	const applications = join(packageRoot, "Applications");
+	if (!lstatSync(applications).isSymbolicLink() || readlinkSync(applications) !== "/Applications") {
+		throw new Error("macOS package Applications entry must link to /Applications");
+	}
+	const appPath = join(packageRoot, names.appBundle);
+	validateExpandedMacosApp(appPath, channel);
+	return appPath;
+}
+
+function hashFile(path: string): string {
+	const hash = createHash("sha256");
+	const descriptor = openSync(path, "r");
+	const buffer = Buffer.allocUnsafe(1024 * 1024);
+	try {
+		while (true) {
+			const length = readSync(descriptor, buffer, 0, buffer.length, null);
+			if (length === 0) break;
+			hash.update(buffer.subarray(0, length));
+		}
+	} finally {
+		closeSync(descriptor);
+	}
+	return hash.digest("hex");
+}
+
+export function snapshotMacosAppBundle(appPath: string): MacosAppBundleSnapshot {
+	requireDirectory(appPath, "macOS app bundle");
+	const snapshot: MacosAppSnapshotEntry[] = [];
+	const visit = (path: string, route: string): void => {
+		const entry = lstatSync(path);
+		const mode = entry.mode & 0o777;
+		if (entry.isDirectory()) {
+			snapshot.push({ path: route, type: "directory", mode });
+			for (const name of sortedEntries(path)) {
+				visit(join(path, name), route === "." ? name : `${route}/${name}`);
+			}
+			return;
+		}
+		if (entry.isFile()) {
+			snapshot.push({
+				path: route,
+				type: "file",
+				mode,
+				size: entry.size,
+				sha256: hashFile(path),
+			});
+			return;
+		}
+		if (entry.isSymbolicLink()) {
+			snapshot.push({ path: route, type: "symlink", mode, target: readlinkSync(path) });
+			return;
+		}
+		throw new Error(`unsupported macOS app bundle entry: ${route}`);
+	};
+	visit(appPath, ".");
+	return snapshot;
+}
+
+function parseTarNumber(field: Buffer, label: string): number {
+	if ((field[0] ?? 0) & 0x80) throw new Error(`tar archive uses unsupported ${label} encoding`);
+	const text = field.toString("ascii").replaceAll("\0", "").trim();
+	if (!/^[0-7]+$/.test(text)) throw new Error(`tar archive has invalid ${label}`);
+	const value = Number.parseInt(text, 8);
+	if (!Number.isSafeInteger(value) || value < 0)
+		throw new Error(`tar archive has invalid ${label}`);
+	return value;
+}
+
+function tarText(field: Buffer): string {
+	const end = field.indexOf(0);
+	return field.subarray(0, end === -1 ? field.length : end).toString("utf8");
+}
+
+function validateTarChecksum(header: Buffer): void {
+	const expected = parseTarNumber(header.subarray(148, 156), "checksum");
+	let actual = 0;
+	for (let index = 0; index < header.length; index += 1) {
+		actual += index >= 148 && index < 156 ? 32 : (header[index] ?? 0);
+	}
+	if (actual !== expected) throw new Error("tar archive has an invalid header checksum");
+}
+
+function readExactly(descriptor: number, length: number, position: number): Buffer {
+	const value = Buffer.alloc(length);
+	let offset = 0;
+	while (offset < length) {
+		const count = readSync(descriptor, value, offset, length - offset, position + offset);
+		if (count === 0) throw new Error("tar archive is truncated");
+		offset += count;
+	}
+	return value;
+}
+
+function parsePax(payload: Buffer): Readonly<Record<string, string>> {
+	const values: Record<string, string> = {};
+	let offset = 0;
+	while (offset < payload.length) {
+		const separator = payload.indexOf(32, offset);
+		if (separator === -1) throw new Error("tar archive has invalid pax metadata");
+		const length = Number.parseInt(payload.subarray(offset, separator).toString("ascii"), 10);
+		if (
+			!Number.isSafeInteger(length) ||
+			length <= separator - offset ||
+			offset + length > payload.length
+		) {
+			throw new Error("tar archive has invalid pax metadata");
+		}
+		const record = payload.subarray(separator + 1, offset + length);
+		if (record[record.length - 1] !== 10) throw new Error("tar archive has invalid pax metadata");
+		const content = record.subarray(0, -1).toString("utf8");
+		const equals = content.indexOf("=");
+		if (equals <= 0) throw new Error("tar archive has invalid pax metadata");
+		values[content.slice(0, equals)] = content.slice(equals + 1);
+		offset += length;
+	}
+	return values;
+}
+
+function normalizeTarEntry(rawPath: string): string {
+	if (!rawPath || rawPath.includes("\0") || posix.isAbsolute(rawPath)) {
+		throw new Error(`tar archive contains an unsafe path: ${JSON.stringify(rawPath)}`);
+	}
+	const components = rawPath.split("/");
+	if (components.includes("..")) {
+		throw new Error(`tar archive contains an unsafe path: ${JSON.stringify(rawPath)}`);
+	}
+	const normalized = posix.normalize(rawPath);
+	if (normalized === "." || normalized.startsWith("../")) {
+		throw new Error(`tar archive contains an unsafe path: ${JSON.stringify(rawPath)}`);
+	}
+	return normalized.replace(/\/$/, "");
+}
+
+function inspectTarArchive(tarPath: string, expectedRoot?: string): void {
+	requireRegularFile(tarPath, "tar archive");
+	const descriptor = openSync(tarPath, "r");
+	const archiveSize = fstatSync(descriptor).size;
+	const paths = new Set<string>();
+	const roots = new Set<string>();
+	let position = 0;
+	let nextPax: Readonly<Record<string, string>> = {};
+	let globalPax: Readonly<Record<string, string>> = {};
+	let longPath: string | undefined;
+	let longLink: string | undefined;
+	try {
+		while (position < archiveSize) {
+			if (position + tarBlockSize > archiveSize) throw new Error("tar archive is truncated");
+			const header = readExactly(descriptor, tarBlockSize, position);
+			position += tarBlockSize;
+			if (header.every((byte) => byte === 0)) break;
+			validateTarChecksum(header);
+			const size = parseTarNumber(header.subarray(124, 136), "entry size");
+			const paddedSize = Math.ceil(size / tarBlockSize) * tarBlockSize;
+			if (position + paddedSize > archiveSize) throw new Error("tar archive is truncated");
+			const type = String.fromCharCode(header[156] ?? 0);
+			const prefix = tarText(header.subarray(345, 500));
+			const headerPath = [prefix, tarText(header.subarray(0, 100))].filter(Boolean).join("/");
+			if (type === "x" || type === "g" || type === "L" || type === "K") {
+				if (size > tarMetadataLimit) throw new Error("tar archive metadata is too large");
+				const payload = readExactly(descriptor, size, position);
+				if (type === "x") nextPax = parsePax(payload);
+				if (type === "g") globalPax = { ...globalPax, ...parsePax(payload) };
+				if (type === "L") longPath = tarText(payload);
+				if (type === "K") longLink = tarText(payload);
+				position += paddedSize;
+				continue;
+			}
+			if (type === "1" || type === "2") {
+				const target =
+					nextPax.linkpath ?? globalPax.linkpath ?? longLink ?? tarText(header.subarray(157, 257));
+				throw new Error(
+					`tar archive contains an unsupported link: ${JSON.stringify(headerPath)} -> ${JSON.stringify(target)}`,
+				);
+			}
+			if (type !== "\0" && type !== "0" && type !== "5" && type !== "7") {
+				throw new Error(`tar archive contains an unsupported entry type: ${JSON.stringify(type)}`);
+			}
+			const path = normalizeTarEntry(nextPax.path ?? globalPax.path ?? longPath ?? headerPath);
+			if (paths.has(path)) throw new Error(`tar archive contains a duplicate path: ${path}`);
+			paths.add(path);
+			roots.add(path.split("/")[0] ?? path);
+			nextPax = {};
+			longPath = undefined;
+			longLink = undefined;
+			position += paddedSize;
+		}
+	} finally {
+		closeSync(descriptor);
+	}
+	if (paths.size === 0) throw new Error("tar archive contains no entries");
+	if (expectedRoot) {
+		const normalizedRoot = normalizeTarEntry(expectedRoot);
+		const foundRoots = [...roots].sort();
+		if (foundRoots.length !== 1 || foundRoots[0] !== normalizedRoot) {
+			throw new Error(
+				`tar archive must contain exactly the ${normalizedRoot} root; found ${foundRoots.join(", ")}`,
+			);
+		}
+	}
+}
+
+function defaultRunCommand(command: readonly string[]): void {
+	const result = Bun.spawnSync([...command], {
+		stdin: "ignore",
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+	if (!result.success) throw new Error(`${command[0] ?? "command"} exited ${result.exitCode}`);
+}
+
+export function extractTarSafely(
+	tarPath: string,
+	destination: string,
+	expectedRoot?: string,
+	tarExecutable = "/usr/bin/tar",
+	runCommand: MacosPackageCommandRunner = defaultRunCommand,
+): void {
+	requireDirectory(destination, "tar extraction destination");
+	const entries = sortedEntries(destination);
+	if (entries.length > 0) {
+		throw new Error(`tar extraction destination is not empty: ${destination}`);
+	}
+	inspectTarArchive(tarPath, expectedRoot);
+	runCommand([tarExecutable, "-xf", resolve(tarPath), "-C", resolve(destination)]);
+}
+
+function resolveElectrobunZstd(desktopDir: string): string {
+	let directory = resolve(desktopDir);
+	while (true) {
+		const candidate = join(directory, "node_modules", "electrobun", "dist-macos-arm64", "zig-zstd");
+		if (existsSync(candidate) && lstatSync(candidate).isFile()) return candidate;
+		const parent = dirname(directory);
+		if (parent === directory) break;
+		directory = parent;
+	}
+	throw new Error("Electrobun's bundled macOS ARM64 zig-zstd was not found");
+}
+
+export function postPackageExpandedMacosDmg(
+	desktopDir: string,
+	channel: MacosPackageChannel,
+	options: MacosPostPackageOptions = {},
+): string {
+	const root = resolve(desktopDir);
+	const artifacts = join(root, "artifacts");
+	requireDirectory(artifacts, "Electrobun artifact directory");
+	const names = macosArtifactNames(channel);
+	const archivePath = join(artifacts, names.appArchive);
+	const dmgPath = join(artifacts, names.dmg);
+	requireRegularFile(archivePath, "Electrobun app archive");
+	requireRegularFile(dmgPath, "Electrobun wrapper DMG");
+	const zstdPath = options.zstdPath ?? resolveElectrobunZstd(root);
+	const tarExecutable = options.tarPath ?? "/usr/bin/tar";
+	const hdiutilPath = options.hdiutilPath ?? "/usr/bin/hdiutil";
+	const runCommand = options.runCommand ?? defaultRunCommand;
+	requireRegularFile(zstdPath, "Electrobun zig-zstd");
+	const temporary = mkdtempSync(join(artifacts, ".macos-package-"));
+	const tarPath = join(temporary, `${names.appBundle}.tar`);
+	const extraction = join(temporary, "extracted");
+	const staging = join(temporary, "dmg-root");
+	const temporaryDmg = join(temporary, names.dmg);
+	mkdirSync(extraction);
+	mkdirSync(staging);
+	try {
+		runCommand([zstdPath, "decompress", "-i", archivePath, "-o", tarPath]);
+		requireRegularFile(tarPath, "decompressed Electrobun tar archive");
+		extractTarSafely(tarPath, extraction, names.appBundle, tarExecutable, runCommand);
+		const extractedEntries = sortedEntries(extraction);
+		if (extractedEntries.length !== 1 || extractedEntries[0] !== names.appBundle) {
+			throw new Error(
+				`Electrobun app archive must extract exactly ${names.appBundle}; found ${extractedEntries.join(", ") || "nothing"}`,
+			);
+		}
+		const extractedApp = join(extraction, names.appBundle);
+		validateExpandedMacosApp(extractedApp, channel);
+		cpSync(extractedApp, join(staging, names.appBundle), { recursive: true });
+		symlinkSync("/Applications", join(staging, "Applications"));
+		validateExpandedMacosPackage(staging, channel);
+		runCommand([
+			hdiutilPath,
+			"create",
+			"-volname",
+			names.volume,
+			"-srcfolder",
+			staging,
+			"-ov",
+			"-format",
+			"ULFO",
+			temporaryDmg,
+		]);
+		requireRegularFile(temporaryDmg, "expanded macOS DMG");
+		renameSync(temporaryDmg, dmgPath);
+		return dmgPath;
+	} finally {
+		rmSync(temporary, { recursive: true, force: true });
+	}
+}

--- a/architecture.md
+++ b/architecture.md
@@ -210,9 +210,11 @@ packages/pi-thinkrail-workflow pi extension: the workflow skill system + its alw
     the supported Linux floor. Releases are **staged as drafts here and signed elsewhere**: the
     JetBrains signing runners are unavailable to public repositories, so `JetBrains/thinkrail-signing`
     (private) signs the staged assets and publishes the draft. Windows artifacts carry an EV
-    Authenticode signature; the macOS CLI binary carries a Developer ID signature that Gatekeeper
-    still rejects without notarization, and the macOS `.dmg` stays unsigned because Electrobun's
-    payload self-extracts after download.
+    Authenticode signature, and the existing Linux, Windows, macOS CLI, scheduling, dry-run, checksum, and
+    publication paths remain unchanged. The macOS CLI binary still lacks notarization; the desktop DMG
+    instead contains the complete expanded app and is signed, notarized, and stapled through the JetBrains
+    CodeSign service. Only the macOS desktop artifact leaves the existing passthrough path, and the private
+    signer transforms it without rebuilding product code.
 
     Signing can only fail *closed*, so a draft that is never published means releases stop appearing
     rather than appearing unsigned — the failure mode that silently ended the pre-pivot pipeline, and the


### PR DESCRIPTION
## Summary

- replace Electrobun 1.18.1's self-extracting macOS wrapper DMG with the complete expanded `ThinkRail.app` for canary and stable release builds
- retain Electrobun's existing app payload and installer layout while removing first-launch extraction/self-replacement from the distributed DMG
- validate the exact bundle/runtime shape, preserve modes and symlinks, and replace the DMG atomically only after the expanded image is complete

## Repository boundary

- this public repository owns only the unsigned expanded-DMG packaging and focused package tests
- all macOS signing, app sealing, DMG notarization/stapling, credentials, and final Gatekeeper verification live in the paired private repository
- the private signer transforms the staged public artifact; it does not rebuild ThinkRail or recreate the installer independently
- no public release workflow, signing action, credential, provenance policy, or permanent macOS PR job changes in this PR

## Preserved behavior

- Linux, Windows, and macOS CLI build/release behavior is unchanged
- Windows and Linux desktop packaging is unchanged
- the existing release schedules, draft staging, checksums, retention, and publication flow are unchanged
- only macOS canary/stable desktop packaging receives the post-package expansion step

## Paired change

- private signer: https://github.com/JetBrains/thinkrail-signing/pull/1
- merge the private signer first so the signing path is ready before this packaging reaches a staged release

## Verification

- `bun run check:deps && bun run check:boundaries && bun run check:seams && bun run lint && bun run typecheck && bun run test`
- `bun run e2e` — 352 passed across 8 shards
- `bun run check:spec-surface` — 14/14 enrolled specs matched
- focused macOS package tests — 12 passed
- real canary and stable expanded-DMG builds and installer smoke tests
- private prepare handoff validated both images at 312 manifest entries and exactly eight ARM64 Mach-O paths
- cumulative diff review confirmed the change is limited to six packaging/spec files
