### PR TITLE
fix(web): make chat scrolling deterministic

### DIFF
--- a/apps/web/src/chat/ActivityGroup.tsx
+++ b/apps/web/src/chat/ActivityGroup.tsx
@@ -170,10 +170,11 @@ function GroupDisclosure({
 	summary: string;
 	children: React.ReactNode;
 }) {
-	const [expanded, toggle] = useFold(id);
+	const [expanded, toggle, toggleRef] = useFold(id);
 	return (
 		<div
 			data-testid={testId}
+			data-chat-fold-root
 			data-activity-node-id={id}
 			data-activity-parent-id={parentId}
 			data-activity-node-kind={kind}
@@ -185,6 +186,7 @@ function GroupDisclosure({
 			className="text-text-muted tr-text-metadata"
 		>
 			<button
+				ref={toggleRef}
 				type="button"
 				data-testid={`${testId}-toggle`}
 				data-activity-node-toggle
@@ -305,13 +307,14 @@ function RoutineToolRow({
 	workspaceRoot?: string | undefined;
 	onOpenFile?: ((path: string) => void) | undefined;
 }) {
-	const [expanded, toggle] = useFold(step.id);
+	const [expanded, toggle, toggleRef] = useFold(step.id);
 	const status: ToolStatus = step.tool?.status ?? (step.dead ? "error" : "running");
 	const renderProps = toolRenderProps(step, workspaceRoot, onOpenFile);
 	const summary = getToolSummary(step.toolName, renderProps);
 	return (
 		<div
 			data-testid="activity-step"
+			data-chat-fold-root
 			data-activity-node-id={step.id}
 			data-activity-parent-id={parentId}
 			data-activity-node-kind="tool"
@@ -326,6 +329,7 @@ function RoutineToolRow({
 			<StepHeader
 				expanded={expanded}
 				onToggle={toggle}
+				toggleRef={toggleRef}
 				icon={
 					status === "running" ? (
 						<Loader2 className="size-12 shrink-0 animate-spin motion-reduce:animate-none" />
@@ -350,18 +354,21 @@ function RoutineToolRow({
 function StepHeader({
 	expanded,
 	onToggle,
+	toggleRef,
 	icon,
 	name,
 	summary,
 }: {
 	expanded: boolean;
 	onToggle: () => void;
+	toggleRef: (element: HTMLButtonElement | null) => void;
 	icon: React.ReactNode;
 	name: string;
 	summary: string;
 }) {
 	return (
 		<button
+			ref={toggleRef}
 			type="button"
 			data-testid="activity-step-toggle"
 			data-activity-node-toggle

--- a/apps/web/src/chat/ChatActions.tsx
+++ b/apps/web/src/chat/ChatActions.tsx
@@ -2,15 +2,20 @@ import type { AskUserQuestionResult } from "@thinkrail/contracts";
 import { createContext, useContext } from "react";
 import type { RevealBlock } from "./scrollGeometry";
 
+export interface ChatRevealOptions {
+	block: RevealBlock;
+	provenance: "automatic-attention" | "user-navigation";
+	runway: "preserve" | "release";
+	stability: "none" | "bounded";
+	topInset?: number;
+}
+
 export interface ChatActions {
 	answerQuestion: (toolCallId: string, result: AskUserQuestionResult) => Promise<void>;
+	cancelAutomaticReveal: () => void;
 	focusComposer: () => void;
 	openSubagentTranscript: (childSessionId: string) => void;
-	revealChatElement: (
-		element: HTMLElement,
-		block?: RevealBlock,
-		runway?: "preserve" | "release",
-	) => void;
+	revealChatElement: (element: HTMLElement, options: ChatRevealOptions) => void;
 }
 
 export const ChatActionsContext = createContext<ChatActions | null>(null);

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -77,6 +77,7 @@ const TRY_AGAIN_PROMPT = "Try again.";
 const CHAT_VIEWPORT_INCREASE = 800;
 const CHAT_MIN_OVERSCAN_ITEMS = 2;
 const CHAT_LATEST_EDGE_MARGIN = 8;
+const chatLocationRevealClaims = new WeakMap<object, object>();
 
 function turnAnchorText(turn: ChatTurn): string {
 	if (turn.kind === "user") {
@@ -346,6 +347,7 @@ export default function ChatView({
 		chatMessageOrder,
 		latestUserRow,
 		latestRow,
+		firstItemIndex,
 		rowHeightEstimates,
 		streamingResponseMovement,
 	);
@@ -397,6 +399,14 @@ export default function ChatView({
 	} = useHistorySearch(sessionId, workspaceId, projectId);
 
 	const chatLocationRequest = useAppStore((s) => s.chatLocationRequest);
+	const activeChatLocationReveal = useRef<typeof chatLocationRequest>(null);
+	const locationRowsRef = useRef(rows);
+	locationRowsRef.current = rows;
+	const locationTurnsRef = useRef(turns);
+	locationTurnsRef.current = turns;
+	const locationTurnMapRef = useRef(runtime.turnIdByMessageIndex);
+	locationTurnMapRef.current = runtime.turnIdByMessageIndex;
+	const locationRowsReady = rows.length > 0;
 	const [flashRowId, setFlashRowId] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -676,42 +686,63 @@ export default function ChatView({
 			!chatLocationRequest ||
 			chatLocationRequest.workspaceId !== workspaceId ||
 			chatLocationRequest.sessionId !== sessionId ||
-			rows.length === 0
+			!locationRowsReady
 		) {
 			return;
 		}
 		if (useAppStore.getState().chatLocationRequest !== chatLocationRequest) return;
+		if (activeChatLocationReveal.current === chatLocationRequest) return;
 		const { messageIndex, anchorText } = chatLocationRequest;
+		const currentRows = locationRowsRef.current;
+		const currentTurns = locationTurnsRef.current;
 		const prefix = anchorText.slice(0, 40);
-		const mappedId = runtime.turnIdByMessageIndex?.[messageIndex];
-		const mapped = mappedId ? turns.find((t) => t.id === mappedId) : undefined;
+		const mappedId = locationTurnMapRef.current?.[messageIndex];
+		const mapped = mappedId ? currentTurns.find((t) => t.id === mappedId) : undefined;
 		const target =
 			mapped && turnAnchorText(mapped).includes(prefix)
 				? mapped
-				: turns.findLast((t) => turnAnchorText(t).includes(prefix));
-		const index = target ? rowIndexForTurn(rows, target.id) : -1;
+				: currentTurns.findLast((t) => turnAnchorText(t).includes(prefix));
+		const index = target ? rowIndexForTurn(currentRows, target.id) : -1;
 		if (index === -1) {
 			toast.error("couldn't locate the message — the session may have changed");
 			useAppStore.getState().clearChatLocation();
 			return;
 		}
-		const rowId = rows[index]?.id;
+		const rowId = currentRows[index]?.id;
 		if (!rowId) {
 			useAppStore.getState().clearChatLocation();
 			return;
 		}
-		revealRow(rowId, index, "center");
-		setFlashRowId(rowId);
-		useAppStore.getState().clearChatLocation();
-	}, [
-		chatLocationRequest,
-		revealRow,
-		rows,
-		runtime.turnIdByMessageIndex,
-		sessionId,
-		turns,
-		workspaceId,
-	]);
+		const revealClaim = {};
+		chatLocationRevealClaims.set(chatLocationRequest, revealClaim);
+		activeChatLocationReveal.current = chatLocationRequest;
+		const cancelReveal = revealRow(
+			rowId,
+			() => locationRowsRef.current.findIndex((row) => row.id === rowId),
+			"center",
+			(result) => {
+				if (activeChatLocationReveal.current !== chatLocationRequest) return;
+				activeChatLocationReveal.current = null;
+				if (useAppStore.getState().chatLocationRequest !== chatLocationRequest) return;
+				if (result === "found") setFlashRowId(rowId);
+				else if (result === "missing")
+					toast.error("couldn't locate the message — the session may have changed");
+				useAppStore.getState().clearChatLocation();
+			},
+		);
+		return () => {
+			if (activeChatLocationReveal.current === chatLocationRequest) {
+				activeChatLocationReveal.current = null;
+			}
+			cancelReveal();
+			queueMicrotask(() => {
+				if (chatLocationRevealClaims.get(chatLocationRequest) !== revealClaim) return;
+				chatLocationRevealClaims.delete(chatLocationRequest);
+				const state = useAppStore.getState();
+				if (state.chatLocationRequest === chatLocationRequest) state.clearChatLocation();
+			});
+		};
+	}, [chatLocationRequest, locationRowsReady, revealRow, sessionId, workspaceId]);
 
 	const historyOpenRequest = useAppStore((s) => s.historyOpenRequest);
 	const historyOverlayOpen = historyState.open;

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -39,6 +39,7 @@ import {
 } from "./Composer";
 import type { ChatMessageOrder } from "./chatPreferences";
 import { ExtUiDialog } from "./ExtUiDialog";
+import { FoldGeometryProvider } from "./foldState";
 import { HistoryOverlay } from "./HistoryOverlay";
 import { deriveMessageActions } from "./messageActions";
 import {
@@ -327,12 +328,14 @@ export default function ChatView({
 		scrollerElement,
 		showScrollButton,
 		scrollButtonLabel,
+		scrollMoving,
 		scrollToLatest,
 		armImmediateTurn,
 		cancelImmediateTurn,
 		cancelAutomaticReveal,
 		revealElement,
 		revealRow,
+		prepareFoldChange,
 		runwayActive,
 		followState,
 		containerProps,
@@ -832,6 +835,7 @@ export default function ChatView({
 						data-follow-state={followState}
 						data-latest-edge={chatMessageOrder === "newest-first" ? "top" : "bottom"}
 						data-streaming={isStreaming}
+						data-scroll-moving={scrollMoving}
 						className="relative flex min-h-0 flex-1 flex-col [container-type:size]"
 						{...containerProps}
 					>
@@ -886,17 +890,19 @@ export default function ChatView({
 											"rounded-[var(--radius-sm)] px-12 py-4 transition-colors data-[flash]:bg-primary-subtle",
 										)}
 									>
-										<ChatTurnView
-											row={row}
-											workspaceRoot={workspaceRoot}
-											onOpenFile={onOpenFile}
-											agentResponded={messageActions.agentRespondedByUserId.get(row.id) ?? false}
-											isFinalAnswer={messageActions.finalAnswerRowIds.has(row.id)}
-											onOpenSpec={onOpenSpec}
-											onOpenChange={onOpenChange}
-											onReveal={onReveal}
-											onTryAgain={() => performSend(TRY_AGAIN_PROMPT, [], "send")}
-										/>
+										<FoldGeometryProvider onBeforeChange={prepareFoldChange}>
+											<ChatTurnView
+												row={row}
+												workspaceRoot={workspaceRoot}
+												onOpenFile={onOpenFile}
+												agentResponded={messageActions.agentRespondedByUserId.get(row.id) ?? false}
+												isFinalAnswer={messageActions.finalAnswerRowIds.has(row.id)}
+												onOpenSpec={onOpenSpec}
+												onOpenChange={onOpenChange}
+												onReveal={onReveal}
+												onTryAgain={() => performSend(TRY_AGAIN_PROMPT, [], "send")}
+											/>
+										</FoldGeometryProvider>
 										{chatMessageOrder === "newest-first" &&
 										runwayActive &&
 										index === firstItemIndex ? (

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -25,7 +25,7 @@ import {
 	useAppStore,
 } from "@/store";
 import { errorText, getTransport } from "@/transport";
-import { ActivityBreadcrumbTrail } from "./activityBreadcrumbs";
+import { ACTIVITY_BREADCRUMB_HEIGHT, ActivityBreadcrumbTrail } from "./activityBreadcrumbs";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { type ChatActions, ChatActionsContext } from "./ChatActions";
 import { ChatHeader } from "./ChatHeader";
@@ -51,7 +51,12 @@ import { QueueStrip } from "./QueueStrip";
 import { estimateChatRowHeights, type RowHeightEstimateCache } from "./rowHeightEstimates";
 import { type ChatRow, deriveRows, projectRows, rowIndexForTurn } from "./rows";
 import { SkillsDialog } from "./SkillsDialog";
-import { StreamIndicator, type StreamStatus, streamStatus } from "./StreamIndicator";
+import {
+	CHAT_STATUS_SLOT_HEIGHT,
+	type StreamStatus,
+	StreamStatusSlot,
+	streamStatus,
+} from "./StreamIndicator";
 import { SubagentTranscriptDialog } from "./SubagentTranscriptDialog";
 import { parseTemplateSlots } from "./slotSession";
 import { TemplateEditorDialog } from "./TemplateEditorDialog";
@@ -131,10 +136,8 @@ function StreamHeader({ context }: { context: ChatListContext }) {
 	return (
 		<div ref={context.headerRef}>
 			{inset}
-			{context.messageOrder === "newest-first" && context.status ? (
-				<div className={cn(context.measureClassName, "px-12 pb-8")}>
-					<StreamIndicator status={context.status} />
-				</div>
+			{context.messageOrder === "newest-first" ? (
+				<StreamStatusSlot status={context.status} measureClassName={context.measureClassName} />
 			) : null}
 		</div>
 	);
@@ -146,14 +149,9 @@ function StreamFooter({ context }: { context: ChatListContext }) {
 			<div ref={context.runwayRef} data-testid="chat-stream-runway" className="h-0" aria-hidden />
 		) : null;
 	}
-	if (!context.status && !context.runwayActive) return null;
 	return (
 		<>
-			{context.status ? (
-				<div className={cn(context.measureClassName, "px-12 pb-8")}>
-					<StreamIndicator status={context.status} />
-				</div>
-			) : null}
+			<StreamStatusSlot status={context.status} measureClassName={context.measureClassName} />
 			{context.runwayActive ? (
 				<>
 					<div ref={context.streamEdgeRef} data-testid="chat-stream-edge" className="h-0" />
@@ -223,6 +221,7 @@ export default function ChatView({
 		turns,
 		toolResults,
 		isStreaming,
+		settlementTick,
 		currentAssistantId,
 		stats,
 		commands,
@@ -278,10 +277,10 @@ export default function ChatView({
 		[chronologicalRows, isStreaming],
 	);
 
-	const currentStreamStatus = useMemo<StreamStatus | null>(() => {
-		const last = turns[turns.length - 1];
-		return isStreaming && last?.kind !== "retry" ? streamStatus(turns, currentAssistantId) : null;
-	}, [turns, isStreaming, currentAssistantId]);
+	const currentStreamStatus = useMemo<StreamStatus | null>(
+		() => (isStreaming ? streamStatus(turns, currentAssistantId) : null),
+		[turns, isStreaming, currentAssistantId],
+	);
 
 	const recentPrompts = useMemo(() => {
 		const texts = turns
@@ -319,8 +318,6 @@ export default function ChatView({
 			: null;
 	const {
 		followOutput,
-		handleAtBottom,
-		handleAtTop,
 		handleContentHeight,
 		handleScrollerRef,
 		headerRef,
@@ -332,17 +329,21 @@ export default function ChatView({
 		scrollButtonLabel,
 		scrollToLatest,
 		armImmediateTurn,
-		releaseFollow,
+		cancelImmediateTurn,
+		cancelAutomaticReveal,
 		revealElement,
+		revealRow,
 		runwayActive,
 		followState,
 		containerProps,
 	} = useChatScroll(
 		virtuosoRef,
 		isStreaming,
+		settlementTick,
 		chatMessageOrder,
 		latestUserRow,
 		latestRow,
+		rowHeightEstimates,
 		streamingResponseMovement,
 	);
 	const measureClassName = transcriptMeasureClassName(chatLineWidthBounded);
@@ -531,7 +532,6 @@ export default function ChatView({
 		behavior: Exclude<SubmitBehavior, "interrupt">,
 	) => {
 		const queued = behavior !== "send";
-		if (queued) releaseFollow();
 		if (!queued && (text || attachments.length > 0)) {
 			armImmediateTurn();
 			useAppStore.getState().appendUserMessage(sessionId, text, attachments);
@@ -549,6 +549,10 @@ export default function ChatView({
 			.catch((err) => {
 				useAppStore.getState().appendErrorTurn(sessionId, errorText(err));
 				if (queued) restoreTextToDraft(text);
+				else {
+					const streaming = useAppStore.getState().sessions[sessionId]?.isStreaming ?? false;
+					cancelImmediateTurn(streaming);
+				}
 			});
 	};
 
@@ -688,13 +692,17 @@ export default function ChatView({
 			useAppStore.getState().clearChatLocation();
 			return;
 		}
-		releaseFollow();
-		virtuosoRef.current?.scrollToIndex({ index, align: "center" });
-		setFlashRowId(rows[index]?.id ?? null);
+		const rowId = rows[index]?.id;
+		if (!rowId) {
+			useAppStore.getState().clearChatLocation();
+			return;
+		}
+		revealRow(rowId, index, "center");
+		setFlashRowId(rowId);
 		useAppStore.getState().clearChatLocation();
 	}, [
 		chatLocationRequest,
-		releaseFollow,
+		revealRow,
 		rows,
 		runtime.turnIdByMessageIndex,
 		sessionId,
@@ -759,11 +767,12 @@ export default function ChatView({
 				getTransport()
 					.request("session.answerQuestion", { sessionId, toolCallId, result })
 					.then(() => undefined),
+			cancelAutomaticReveal,
 			focusComposer: () => composerRef.current?.refocus(),
 			openSubagentTranscript: setTranscriptChildId,
 			revealChatElement: revealElement,
 		}),
-		[revealElement, sessionId],
+		[cancelAutomaticReveal, revealElement, sessionId],
 	);
 
 	const onExtUiReply = (value: string | boolean | null) => {
@@ -785,18 +794,6 @@ export default function ChatView({
 					data-testid="chat-view"
 					data-line-width-bounded={chatLineWidthBounded}
 					data-message-order={chatMessageOrder}
-					onPointerDownCapture={() => {
-						if (isStreaming) releaseFollow();
-					}}
-					onKeyDownCapture={(event) => {
-						if (
-							isStreaming &&
-							event.target instanceof Element &&
-							!event.target.closest('[data-testid="chat-scroll"]')
-						) {
-							releaseFollow();
-						}
-					}}
 					className="flex h-full min-h-0 min-w-0 flex-col bg-container-workspace-bg [container-type:size]"
 				>
 					<Popover open={planOpen} onOpenChange={setPlanOpen}>
@@ -864,7 +861,7 @@ export default function ChatView({
 								)}
 								initialTopMostItemIndex={
 									chatMessageOrder === "newest-first"
-										? { index: 0, align: "start" }
+										? { index: 0, align: "start", offset: -CHAT_STATUS_SLOT_HEIGHT }
 										: {
 												index: Math.max(rows.length - 1, 0),
 												align: "end",
@@ -872,19 +869,17 @@ export default function ChatView({
 											}
 								}
 								followOutput={followOutput}
-								atBottomStateChange={handleAtBottom}
-								atTopStateChange={handleAtTop}
 								rangeChanged={({ startIndex }) => {
 									const localIndex = startIndex - firstItemIndex;
 									visibleAnchorRowId.current = rows[localIndex]?.id ?? null;
 								}}
 								totalListHeightChanged={handleContentHeight}
-								atBottomThreshold={50}
-								atTopThreshold={50}
 								computeItemKey={(_, row) => row.id}
 								itemContent={(index, row) => (
 									<div
 										data-testid="chat-row"
+										data-chat-row-id={row.id}
+										data-chat-row-index={index - firstItemIndex}
 										data-flash={row.id === flashRowId || undefined}
 										className={cn(
 											measureClassName,
@@ -918,6 +913,15 @@ export default function ChatView({
 							<ActivityBreadcrumbTrail
 								scroller={scrollerElement}
 								measureClassName={measureClassName}
+								onReveal={(node) =>
+									revealElement(node, {
+										block: "start",
+										provenance: "user-navigation",
+										runway: "preserve",
+										stability: "none",
+										topInset: ACTIVITY_BREADCRUMB_HEIGHT,
+									})
+								}
 							/>
 						</div>
 						{showScrollButton ? (

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -208,7 +208,14 @@ and **`useSelection`** for a single-choice group — the divider's chips, which 
 `${rowId}:artifacts` rather than a boolean per side, so "only one list open" cannot be violated;
 the `AskUserQuestionCard` pattern, see tools/SPEC.md; deliberately
 never evicted — growth is bounded by manual toggles). A manual toggle always wins — over auto-expand
-defaults *and* over a virtualization remount.
+defaults *and* over a virtualization remount. `FoldGeometryProvider` is the transcript's explicit pre/post
+change seam: every fold header registers a stable row-derived id through `useFold`, including `Collapsible`
+and fallback-driven auto expansion/collapse. It routes detached anchor stabilization through
+`ReadingBandController`'s single motion channel and refreshes from the changing row's measured geometry.
+A wholly offscreen disclosure preserves the visible transcript by its own row-height delta. If a sticky
+breadcrumb collapses the disclosure body that contains the reader's viewport, that content no longer has a
+surviving anchor, so the collapsed original header takes its place at the viewport boundary. Reader input or
+a newer reveal supersedes only the stabilization's scroll leg and cannot strand an in-flight runway release.
 
 **Message-order projection.** `deriveRows` remains canonical and chronological. The pure
 `projectRows(rows, chatMessageOrder)` partitions that sequence at user rows (a pre-user notice span is its

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -378,8 +378,11 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   message/history, breadcrumb, or tool-page navigation also detach. A return gesture rearms once only when
   it reaches the physical latest edge within the shared 1px geometry tolerance; directions invert with
   order, and touch/trackpad intent survives through momentum. No 50px near-edge threshold and no geometry
-  change alone may rearm. An own Send deliberately reattaches and places its user row at 10% of transcript
-  height clamped to 48–80px; a queued/background continuation preserves a detached reader when it starts.
+  change alone may rearm. Expanding or collapsing an Activity, Thinking, tool, or message disclosure is a
+  geometry change rather than navigation: it preserves alignment, retargets the current latest/response
+  destination while following, and leaves a detached reader's visible anchor fixed. An own Send deliberately
+  reattaches and places its user row at 10% of transcript height clamped to 48–80px; a queued/background
+  continuation preserves a detached reader when it starts.
 - **Streaming response movement exists only during work** — while following, the active response grows to
   Trigger (default 100%), then the sole motion owner places it at Settle (default 75%); each later crossing
   repeats the same sparse advance. Immediately before a move the controller adds only the scroll-range
@@ -404,8 +407,10 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   room and perform its established bounded start reveal/focus, but that automatic path leaves following or
   detached exactly as it found it and cannot expose the button. A reader who was already detached keeps the
   affordance because of that prior action; a subsequent user-driven tool-page navigation may detach. All
-  attention, history, breadcrumb, and row reveals route through the same controller; size-aware `nearest`
-  keeps a tall target's useful leading edge visible.
+  attention, history, breadcrumb, and row reveals route through the same controller. A history row outside
+  the virtual DOM gets one non-animated Virtuoso materialization; once mounted, its centered correction uses
+  the controller, so no independent smooth retry can compete with settlement. Size-aware `nearest` keeps a
+  tall target's useful leading edge visible.
 - **One cancellable, retargetable motion owner** — renderers and projections never scroll themselves.
   New-turn placement, Trigger→Settle advances, contextual-button returns, settlement, and explicit reveals
   share one non-overlapping channel whose destination can retarget as Virtuoso measurements, status geometry,

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -349,59 +349,71 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   turnId)`** (`rows.ts`), called with the projected rows — a turn's own row for
   `user`/`system`/`error`/`retry`, or its first `:text:` row for `assistant` (whose turns dissolve
   into `markdown`/`tool`/`activity` rows, never a row of their own)
-  — then `virtuosoRef.scrollToIndex({ align: "center" })` plus a transient `flashRowId` (rendered as
-  `data-flash` + a `bg-primary-subtle` transition on the row wrapper, cleared after 1600ms) draw the
-  eye to it. Either resolving a row or giving up (toasted as "couldn't locate the message") clears that
+  — then a controller-owned centered row reveal plus a transient `flashRowId` (rendered as `data-flash` +
+  a `bg-primary-subtle` transition on the row wrapper, cleared after 1600ms) draw the eye to it. Either
+  resolving a row or giving up (toasted as "couldn't locate the message") clears that
   exact still-current request; an older effect may not clear a newer jump. `ChatView` is its only terminal
   consumer, so an unresolved current request must never linger.
-- **Open at the latest message** — `ChatMessageOrder` chooses the mounted edge: oldest-first starts at
-  `{ index: last row, align: "end" }`; newest-first starts at `{ index: 0, align: "start" }`. Thus every
-  freshly shown transcript (new tab, history reopen, local-placement restore, reload) shows the latest work
-  without an intermediate wrong-edge paint. Switching the preference remounts the projection and lands at
-  its new latest edge; preserving a pixel position across total reversal has no stable meaning.
-  Jump-to-message runs post-mount and overrides either rule with its centered `scrollToIndex`.
-  Initial virtual geometry is **row-aware**: every projected row receives a conservative height estimate,
-  with Markdown estimated from prose wrapping, block breaks, and physical fenced-code lines. A canonical
-  assistant text block remains one Markdown row — estimation never splits syntax or changes projection.
-  Bounded pixel and item overscan gives nearby outlier rows time to replace estimates with authoritative
-  measurements before coarse wheel input can exhaust a false range. Native wheel physics remain untouched.
-  `chat-history.spec.ts` pins the default latest edge and tall-history geometry; `chat-order.spec.ts` pins
-  both projections.
-- **One direction-aware streaming controller** — `useChatScroll` remains the sole imperative,
-  cancellable owner for every kind of live row growth; renderers and the message-order projection never
-  scroll themselves. Both orders consume the client-local **Streaming response movement** window. While
-  following, the active response edge grows to Trigger (default 100%), then one non-overlapping 220ms
-  ease-out places it at Settle (default 75%); every crossing repeats that same move. The controller does
-  **not** preallocate a percentage runway: immediately before a move it adds only the scroll-range deficit
-  needed to reach Settle, then removes that room one-for-one as response growth fills the distance back to
-  Trigger. Reduced motion makes movement and removal immediate.
-- **Runway lifetime follows actual work** — remaining artificial room collapses smoothly at
-  `agent_settled`, never `agent_end`. An awaiting `ask_user_question` clears it before the card's existing
-  start-aligned attention reveal. Reader takeover during a stream cancels movement, clears the room, and
-  detaches; later agent output cannot move that reader. Takeover retains the established intent boundary:
-  pointer/touch interaction, any wheel/scrollbar/navigation-key movement, selection, interactive
-  focus, message/history reveal, and a live user submit. **Follow response** derives enough room to place
-  the active edge at Settle, makes that one move, and rearms the Trigger→Settle cycle. Geometry alone never
-  rearms a detached reader. After settlement, **Latest** retains its physical-latest-edge meaning and bounded
-  pin window while virtual measurements land.
-- **Order-aware geometry, one visible window** — an immediate local send still aligns its user row at 10%
-  of transcript height clamped to 48–80px; the transient list header still makes that inset possible for a
-  first row. Oldest first can need at most the lower `100% - Settle` band as temporary tail room (25% by
-  default), rather than the retired 102% initial / 42% floor. Newest first applies the same edge percentages;
-  older projected content supplies real scroll range where available, and any remaining synthetic space
-  stays after the oldest group, never between reversed request/answer rows. Its live phase indicator still
-  leads the newest projected row, runway consumption still measures the latest group's stable trailing edge,
-  and `firstItemIndex` still gives projected prefix insertion/removal stable logical indices.
-- **Intent and changing geometry** — latest-edge directions still invert with order. Touch return intent
-  survives pointer release/cancellation through momentum and rearms only when explicit motion reaches that
-  edge. Newest-first header height deltas apply directly to `scrollTop` only while detached, preserving the
-  historical anchor and pixel offset; no insertion moves a detached reader. While live and following, a
-  viewport resize immediately reevaluates the percentages: crossing the resized Trigger makes one move to
-  Settle, otherwise the current position stays and derived room reconciles to the new height. Opening an
-  already-streaming chat and switching order restore the active edge at Settle with derived room, not a
-  fixed floor. Renderers needing attention still route through `ChatActions` to the controller's clamped
-  `start`/`nearest` reveal; size-aware `nearest` keeps a tall target's useful leading edge visible and never
-  changes follow state by itself.
+- **Open at the current alignment target** — `ChatMessageOrder` chooses the physical latest edge: bottom
+  for oldest-first, top for newest-first. A freshly shown idle transcript mounts there; an already-working
+  transcript reconstructs directly at Settle with only the room its active response needs. Switching order
+  remounts at that order's current target because preserving a pixel position across total reversal has no
+  stable meaning. A pending jump-to-message then overrides the mount with its centered controller reveal.
+  There is no intermediate wrong-edge paint or cross-order animation. Initial virtual geometry is
+  **row-aware**: each projected row receives a conservative estimate derived from prose wrapping, block
+  breaks, and physical fenced-code lines without splitting one canonical Markdown block. Bounded pixel and
+  item overscan lets nearby outliers replace estimates before coarse input exhausts a false range. Native
+  wheel physics remain untouched. `chat-history.spec.ts` pins the default latest edge and tall-history
+  geometry; `chat-order.spec.ts` pins both projections.
+- **Alignment is explicit, not inferred from proximity** — `useChatScroll` owns two orthogonal facts:
+  actual work (`agent_start` through `agent_settled`) and alignment (`following` or manually `detached`).
+  Following while working means the configured response window; following while idle means the physical
+  latest edge. Detached while working shows the order-aware **Follow response** button; detached while idle
+  shows **Latest**. Automatic focus, row measurement, content growth, programmatic reveal, and Virtuoso's
+  convenience edge thresholds can never create or clear detachment, so the button always means that a
+  person took over.
+- **Reader intent and exact-edge rearm** — wheel, trackpad, touch, scrollbar, and navigation-key input
+  detaches only when it can cause or has caused real viewport movement; pushing outward against the current
+  physical edge is a no-op. Movement into history detaches once. Explicit text selection and user-invoked
+  message/history, breadcrumb, or tool-page navigation also detach. A return gesture rearms once only when
+  it reaches the physical latest edge within the shared 1px geometry tolerance; directions invert with
+  order, and touch/trackpad intent survives through momentum. No 50px near-edge threshold and no geometry
+  change alone may rearm. An own Send deliberately reattaches and places its user row at 10% of transcript
+  height clamped to 48–80px; a queued/background continuation preserves a detached reader when it starts.
+- **Streaming response movement exists only during work** — while following, the active response grows to
+  Trigger (default 100%), then the sole motion owner places it at Settle (default 75%); each later crossing
+  repeats the same sparse advance. Immediately before a move the controller adds only the scroll-range
+  deficit needed to reach Settle, then removes that room one-for-one as real response growth fills it.
+  Oldest-first therefore needs at most the lower `100% - Settle` band; newest-first uses older projected
+  content where available, keeps any synthetic remainder after the oldest group, and measures consumption
+  from the latest group's stable trailing edge. Synthetic room never splits a reversed request/answer group.
+  **Follow response** reconstructs the needed room, moves to Settle, and rearms the cycle.
+- **Settlement always returns to physical latest** — every `agent_settled`, never `agent_end`, ends response
+  movement, removes remaining synthetic room, reattaches even a manually detached reader, and makes one
+  smooth move to the order's physical latest edge. The store exposes a monotonic per-session settlement
+  tick alongside `isStreaming`, so a start and settlement coalesced into one React render cannot strand an
+  optimistic turn inset or runway. Delayed virtual measurements retarget that same bounded return rather
+  than creating a hard-pin loop. A rejected immediate prompt likewise cancels its locally armed turn state.
+- **Stable work-status geometry** — one fixed-size slot always occupies the logical latest transcript edge:
+  after rows in oldest-first and before rows in newest-first. While work is active it always contains one
+  polite live phase — **Working…**, **Thinking…**, **Running `<tool>`…**, **Writing…**, or
+  **Compacting context…**; retry/provider gaps fall back to Working rather than unmounting it. Idle keeps an
+  inaccessible, visually empty slot with identical geometry. Starting, changing, or ending a phase therefore
+  moves neither transcript alignment nor composer.
+- **Tool attention preserves alignment provenance** — an awaiting `ask_user_question` may clear temporary
+  room and perform its established bounded start reveal/focus, but that automatic path leaves following or
+  detached exactly as it found it and cannot expose the button. A reader who was already detached keeps the
+  affordance because of that prior action; a subsequent user-driven tool-page navigation may detach. All
+  attention, history, breadcrumb, and row reveals route through the same controller; size-aware `nearest`
+  keeps a tall target's useful leading edge visible.
+- **One cancellable, retargetable motion owner** — renderers and projections never scroll themselves.
+  New-turn placement, Trigger→Settle advances, contextual-button returns, settlement, and explicit reveals
+  share one non-overlapping channel whose destination can retarget as Virtuoso measurements, status geometry,
+  or runway changes land. Corrections continue the current motion instead of launching overlapping eases or
+  alternating hard writes. The first real reader movement cancels it synchronously and native physics win.
+  Newest-first header deltas preserve a detached historical anchor; viewport resize reevaluates the live
+  percentages without moving a below-Trigger response. Initial/order placement is direct, and reduced motion
+  makes every programmatic destination immediate while preserving identical state and final geometry.
 - **Composer & chrome** — `Composer` (prompt field + send/steer/followUp/abort, `@`-mentions, `/`
   commands + template **slot sessions** (Tab-through placeholders — see the Template slots bullet
   below), image paste/drop — routed through **`imageAttachment.ts`**: `fileToAttachedImage` decodes in

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -356,11 +356,21 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   turnId)`** (`rows.ts`), called with the projected rows — a turn's own row for
   `user`/`system`/`error`/`retry`, or its first `:text:` row for `assistant` (whose turns dissolve
   into `markdown`/`tool`/`activity` rows, never a row of their own)
-  — then a controller-owned centered row reveal plus a transient `flashRowId` (rendered as `data-flash` +
-  a `bg-primary-subtle` transition on the row wrapper, cleared after 1600ms) draw the eye to it. Either
-  resolving a row or giving up (toasted as "couldn't locate the message") clears that
-  exact still-current request; an older effect may not clear a newer jump. `ChatView` is its only terminal
-  consumer, so an unresolved current request must never linger.
+  — then a cancellable, non-animated materialization derives the target from Virtuoso's measured size
+  snapshot (with conservative estimates only for never-measured rows) before the controller-owned centered
+  pixel correction. Materialization remains pending until the exact row stays mounted and measured at that
+  alignment across stable frames; a transient mount during Virtuoso's estimate correction is not success.
+  It never starts Virtuoso's internally retrying `scrollToIndex`, so reader takeover can cancel every
+  outstanding write. Its lifecycle is keyed to request identity rather than streaming row-array churn, and
+  its live row-index resolver follows projections that change while the request is pending. A transient
+  `flashRowId` (rendered as `data-flash` + a `bg-primary-subtle` transition on the row wrapper, cleared after
+  1600ms) draws the eye only after the row mounts. Resolving a row, explicit reader cancellation, or
+  exhausting the bounded materialization wait (toasted as "couldn't locate the message") clears that exact
+  still-current request; an older effect may not clear a newer jump. Cancellation is the user-wins failure
+  path and is intentionally silent rather than restarted against the reader. Effect teardown defers its
+  identity-checked clear for one microtask: an immediate StrictMode or replacement mount claims the same
+  request first, while a real unmount terminates it. `ChatView` is its only terminal consumer, so an
+  unresolved current request must never linger.
 - **Open at the current alignment target** — `ChatMessageOrder` chooses the physical latest edge: bottom
   for oldest-first, top for newest-first. A freshly shown idle transcript mounts there; an already-working
   transcript reconstructs directly at Settle with only the room its active response needs. Switching order
@@ -381,9 +391,15 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   person took over.
 - **Reader intent and exact-edge rearm** — wheel, trackpad, touch, scrollbar, and navigation-key input
   detaches only when it can cause or has caused real viewport movement; pushing outward against the current
-  physical edge is a no-op. Movement into history detaches once. Explicit text selection and user-invoked
-  message/history, breadcrumb, or tool-page navigation also detach. A return gesture rearms once only when
-  it reaches the physical latest edge within the shared 1px geometry tolerance; directions invert with
+  physical edge is a no-op. Potential native input pauses competing controller motion without changing
+  alignment; if no movement follows, alignment resumes on the next frame. Movement into history detaches
+  once; native movement that interrupts an active alignment also detaches even when directed toward latest,
+  unless that movement itself reaches the exact edge. Explicit text selection and user-invoked
+  message/history, breadcrumb, or tool-page navigation also
+  detach. Pointer provenance survives release long enough for native scrollbar-track animation, keyboard
+  provenance covers focus-induced scrolling from interactive transcript controls, and both expire on
+  scroll-end or a bounded timeout so later geometry cannot inherit them. A return gesture rearms once only
+  when it reaches the physical latest edge within the shared 1px geometry tolerance; directions invert with
   order, and touch/trackpad intent survives through momentum. No 50px near-edge threshold and no geometry
   change alone may rearm. Expanding or collapsing an Activity, Thinking, tool, or message disclosure is a
   geometry change rather than navigation: it preserves alignment, retargets the current latest/response
@@ -403,20 +419,24 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   smooth move to the order's physical latest edge. The store exposes a monotonic per-session settlement
   tick alongside `isStreaming`, so a start and settlement coalesced into one React render cannot strand an
   optimistic turn inset or runway. Delayed virtual measurements retarget that same bounded return rather
-  than creating a hard-pin loop. A rejected immediate prompt likewise cancels its locally armed turn state.
+  than creating a hard-pin loop. If reader input intersects settlement, either idle reattach path carries
+  the partial room-to-zero leg forward instead of leaking hidden runway. A rejected immediate prompt likewise
+  cancels its locally armed turn state.
 - **Stable work-status geometry** — one fixed-size slot always occupies the logical latest transcript edge:
   after rows in oldest-first and before rows in newest-first. While work is active it always contains one
   polite live phase — **Working…**, **Thinking…**, **Running `<tool>`…**, **Writing…**, or
   **Compacting context…**; retry/provider gaps fall back to Working rather than unmounting it. Idle keeps an
-  inaccessible, visually empty slot with identical geometry. Starting, changing, or ending a phase therefore
-  moves neither transcript alignment nor composer.
+  inaccessible, visually empty slot with identical geometry. The visible phase is single-line and clipped
+  within the slot on narrow panes while its complete live-region text remains accessible. Starting, changing,
+  or ending a phase therefore moves neither transcript alignment nor composer.
 - **Tool attention preserves alignment provenance** — an awaiting `ask_user_question` may clear temporary
   room and perform its established bounded start reveal/focus, but that automatic path leaves following or
   detached exactly as it found it and cannot expose the button. A reader who was already detached keeps the
   affordance because of that prior action; a subsequent user-driven tool-page navigation may detach. All
   attention, history, breadcrumb, and row reveals route through the same controller. A history row outside
-  the virtual DOM gets one non-animated Virtuoso materialization; once mounted, its centered correction uses
-  the controller, so no independent smooth retry can compete with settlement. Size-aware `nearest` keeps a
+  the virtual DOM gets a bounded, hook-owned materialization from Virtuoso's measured size snapshot; once
+  mounted, its centered correction uses the controller, so no independent retry can outlive reader
+  cancellation or compete with settlement. Size-aware `nearest` keeps a
   tall target's useful leading edge visible.
 - **One cancellable, retargetable motion owner** — renderers and projections never scroll themselves.
   New-turn placement, Trigger→Settle advances, contextual-button returns, settlement, and explicit reveals

--- a/apps/web/src/chat/StreamIndicator.test.ts
+++ b/apps/web/src/chat/StreamIndicator.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
-import { phaseLabel, streamStatus } from "./StreamIndicator";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { phaseLabel, StreamStatusSlot, streamStatus } from "./StreamIndicator";
 import type { ChatTurn } from "./types";
 
 type Block =
@@ -84,6 +86,20 @@ test("a trailing running compaction outranks assistant fallbacks — the footer 
 		{ kind: "compaction", id: "c1", status: "done" },
 	];
 	expect(streamStatus(settled, null)).toEqual({ phase: "working" });
+});
+
+test("the status slot keeps one fixed shell while idle content stays inaccessible", () => {
+	const idle = renderToStaticMarkup(createElement(StreamStatusSlot, { status: null }));
+	const active = renderToStaticMarkup(
+		createElement(StreamStatusSlot, { status: { phase: "working" } }),
+	);
+
+	expect(idle).toContain('data-testid="chat-status-slot"');
+	expect(idle).toContain('data-active="false"');
+	expect(idle).toContain('aria-hidden="true"');
+	expect(idle).not.toContain('data-testid="stream-indicator"');
+	expect(active).toContain('data-active="true"');
+	expect(active).toContain('data-testid="stream-indicator"');
 });
 
 test("phaseLabel names every phase (and falls back to a generic tool label)", () => {

--- a/apps/web/src/chat/StreamIndicator.tsx
+++ b/apps/web/src/chat/StreamIndicator.tsx
@@ -44,7 +44,7 @@ export function phaseLabel({ phase, toolName }: StreamStatus): string {
 
 function TypingDots() {
 	return (
-		<span className="flex items-center gap-2" aria-hidden="true">
+		<span className="flex shrink-0 items-center gap-2" aria-hidden="true">
 			<span className="size-6 animate-pulse rounded-full bg-current" />
 			<span className="size-6 animate-pulse rounded-full bg-current [animation-delay:200ms]" />
 			<span className="size-6 animate-pulse rounded-full bg-current [animation-delay:400ms]" />
@@ -59,10 +59,10 @@ export function StreamIndicator({ status }: { status: StreamStatus }) {
 			data-phase={status.phase}
 			role="status"
 			aria-live="polite"
-			className="flex items-center gap-8 py-4 text-text-muted tr-text-metadata"
+			className="flex min-w-0 items-center gap-8 overflow-hidden py-4 text-text-muted tr-text-metadata"
 		>
 			<TypingDots />
-			<span>{phaseLabel(status)}</span>
+			<span className="min-w-0 truncate">{phaseLabel(status)}</span>
 		</div>
 	);
 }
@@ -79,7 +79,7 @@ export function StreamStatusSlot({
 			data-testid="chat-status-slot"
 			data-active={status !== null}
 			aria-hidden={status === null ? true : undefined}
-			className={`${measureClassName} h-40 px-12`}
+			className={`${measureClassName} h-40 overflow-hidden px-12`}
 		>
 			{status ? <StreamIndicator status={status} /> : null}
 		</div>

--- a/apps/web/src/chat/StreamIndicator.tsx
+++ b/apps/web/src/chat/StreamIndicator.tsx
@@ -1,5 +1,7 @@
 import type { ChatTurn } from "./types";
 
+export const CHAT_STATUS_SLOT_HEIGHT = 40;
+
 export type StreamPhase = "working" | "thinking" | "running-tool" | "writing" | "compacting";
 
 export interface StreamStatus {
@@ -61,6 +63,25 @@ export function StreamIndicator({ status }: { status: StreamStatus }) {
 		>
 			<TypingDots />
 			<span>{phaseLabel(status)}</span>
+		</div>
+	);
+}
+
+export function StreamStatusSlot({
+	status,
+	measureClassName = "mx-auto max-w-3xl",
+}: {
+	status: StreamStatus | null;
+	measureClassName?: string;
+}) {
+	return (
+		<div
+			data-testid="chat-status-slot"
+			data-active={status !== null}
+			aria-hidden={status === null ? true : undefined}
+			className={`${measureClassName} h-40 px-12`}
+		>
+			{status ? <StreamIndicator status={status} /> : null}
 		</div>
 	);
 }

--- a/apps/web/src/chat/ToolCard.tsx
+++ b/apps/web/src/chat/ToolCard.tsx
@@ -44,17 +44,19 @@ export function ToolCard({
 	const summary = getToolSummary(toolName, renderProps);
 
 	const autoExpand = isError || (resolveProminence(toolName).defaultExpanded && status === "done");
-	const [expanded, toggle] = useFold(toolCallId, autoExpand);
+	const [expanded, toggle, toggleRef] = useFold(toolCallId, autoExpand);
 
 	return (
 		<div
 			data-testid="tool-card"
+			data-chat-fold-root
 			data-tool={toolName}
 			data-status={status}
 			data-expanded={expanded}
 			className="rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg"
 		>
 			<button
+				ref={toggleRef}
 				type="button"
 				data-testid="tool-card-toggle"
 				aria-expanded={expanded}

--- a/apps/web/src/chat/activityBreadcrumbs.test.ts
+++ b/apps/web/src/chat/activityBreadcrumbs.test.ts
@@ -5,7 +5,6 @@ import {
 	ActivityBreadcrumbBar,
 	type ActivityBreadcrumbDescriptor,
 	ActivityBreadcrumbTrail,
-	activityBreadcrumbJumpTop,
 	compressBreadcrumbPath,
 	deriveActiveBreadcrumbPath,
 	isCompactBreadcrumbWidth,
@@ -96,20 +95,27 @@ describe("activity breadcrumb path", () => {
 		expect(isCompact(390)).toBe(true);
 	});
 
-	test("aligns jump targets immediately below the sticky row", () => {
-		const jumpTop = activityBreadcrumbJumpTop;
-		expect(jumpTop(600, 100, 420)).toBe(886);
-		expect(jumpTop(10, 100, 80)).toBe(0);
-	});
-
 	test("mounts no sticky overlay until a transcript scroller is available", () => {
-		const Trail: ComponentType<{ scroller: HTMLElement | null }> = ActivityBreadcrumbTrail;
-		expect(renderToStaticMarkup(createElement(Trail, { scroller: null }))).toBe("");
+		const Trail: ComponentType<{
+			scroller: HTMLElement | null;
+			measureClassName: string;
+			onReveal: (node: HTMLElement) => void;
+		}> = ActivityBreadcrumbTrail;
+		expect(
+			renderToStaticMarkup(
+				createElement(Trail, {
+					scroller: null,
+					measureClassName: "mx-auto",
+					onReveal: () => undefined,
+				}),
+			),
+		).toBe("");
 	});
 
 	test("renders one labelled root-to-leaf navigation row with separate fold controls", () => {
 		type BarProps = {
 			segments: ActivityBreadcrumbDescriptor[];
+			measureClassName: string;
 			onJump: (id: string) => void;
 			onToggle: (id: string) => void;
 		};
@@ -121,6 +127,7 @@ describe("activity breadcrumb path", () => {
 					{ ...node("Thinking", "thinking", 0, 1, "7 steps"), meta: "1 step · bash" },
 					{ ...node("bash", "tool", 0, 1, "Thinking"), meta: "bun test watch.test.ts" },
 				],
+				measureClassName: "mx-auto",
 				onJump: () => {},
 				onToggle: () => {},
 			}),

--- a/apps/web/src/chat/activityBreadcrumbs.tsx
+++ b/apps/web/src/chat/activityBreadcrumbs.tsx
@@ -36,14 +36,6 @@ export function isCompactBreadcrumbWidth(width: number): boolean {
 	return width < ACTIVITY_BREADCRUMB_COMPACT_WIDTH;
 }
 
-export function activityBreadcrumbJumpTop(
-	scrollTop: number,
-	scrollerTop: number,
-	nodeTop: number,
-): number {
-	return Math.max(0, scrollTop + nodeTop - scrollerTop - ACTIVITY_BREADCRUMB_HEIGHT);
-}
-
 export function deriveActiveBreadcrumbPath(
 	nodes: ActivityBreadcrumbGeometry[],
 	boundary: number,
@@ -205,9 +197,11 @@ function originalActivityToggle(node: HTMLElement): HTMLButtonElement | undefine
 export function ActivityBreadcrumbTrail({
 	scroller,
 	measureClassName,
+	onReveal,
 }: {
 	scroller: HTMLElement | null;
 	measureClassName: string;
+	onReveal: (node: HTMLElement) => void;
 }) {
 	const [path, setPath] = useState<ActivityBreadcrumbDescriptor[]>([]);
 	const [compact, setCompact] = useState(false);
@@ -252,19 +246,10 @@ export function ActivityBreadcrumbTrail({
 			const node = originalActivityNode(scroller, id);
 			const toggle = node ? originalActivityToggle(node) : undefined;
 			if (!node || !toggle) return;
-			const view = scroller.ownerDocument.defaultView;
-			const top = activityBreadcrumbJumpTop(
-				scroller.scrollTop,
-				scroller.getBoundingClientRect().top,
-				node.getBoundingClientRect().top,
-			);
-			scroller.scrollTo({
-				top,
-				behavior: view?.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
-			});
+			onReveal(node);
 			toggle.focus({ preventScroll: true });
 		},
-		[scroller],
+		[onReveal, scroller],
 	);
 
 	const toggle = useCallback(

--- a/apps/web/src/chat/foldState.ts
+++ b/apps/web/src/chat/foldState.ts
@@ -1,23 +1,109 @@
-import { useState } from "react";
+import {
+	createContext,
+	createElement,
+	type MouseEvent as ReactMouseEvent,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 
 const foldState = new Map<string, boolean>();
+const noop = () => undefined;
 
-export function useFold(id: string, fallback = false): [boolean, () => void] {
+export type FoldAnchorResolver = () => HTMLElement | null;
+type FoldChangeCompletion = () => void;
+type PrepareFoldChange = (resolveAnchor: FoldAnchorResolver) => FoldChangeCompletion;
+type FoldAnchorRef = (element: HTMLElement | null) => void;
+type FoldToggle = (event?: ReactMouseEvent<HTMLElement>) => void;
+
+const FoldGeometryContext = createContext<PrepareFoldChange>(() => noop);
+
+export function FoldGeometryProvider({
+	onBeforeChange,
+	children,
+}: {
+	onBeforeChange: PrepareFoldChange;
+	children: ReactNode;
+}) {
+	return createElement(FoldGeometryContext.Provider, { value: onBeforeChange }, children);
+}
+
+export function useFoldGeometry(): PrepareFoldChange {
+	return useContext(FoldGeometryContext);
+}
+
+export function useFoldAnchor(id: string): [FoldAnchorResolver, FoldAnchorRef] {
+	const anchor = useRef<HTMLElement | null>(null);
+	const chatRoot = useRef<HTMLElement | null>(null);
+	const resolveAnchor = useCallback(() => {
+		if (anchor.current?.isConnected) return anchor.current;
+		return (
+			Array.from(
+				chatRoot.current?.querySelectorAll<HTMLElement>("[data-chat-fold-anchor]") ?? [],
+			).find((element) => element.dataset.chatFoldAnchor === id) ?? null
+		);
+	}, [id]);
+	const anchorRef = useCallback<FoldAnchorRef>(
+		(element) => {
+			anchor.current = element;
+			if (!element) return;
+			element.dataset.chatFoldAnchor = id;
+			chatRoot.current = element.closest<HTMLElement>("[data-testid=chat-scroll]");
+		},
+		[id],
+	);
+	return [resolveAnchor, anchorRef];
+}
+
+export function useFold(id: string, fallback = false): [boolean, FoldToggle, FoldAnchorRef] {
+	const prepareChange = useFoldGeometry();
+	const completeChange = useRef<FoldChangeCompletion>(noop);
+	const [resolveAnchor, anchorRef] = useFoldAnchor(id);
 	const [override, setOverride] = useState<boolean | undefined>(() => foldState.get(id));
-	const expanded = override ?? fallback;
-	const toggle = () => {
+	const [fallbackExpanded, setFallbackExpanded] = useState(fallback);
+	const expanded = override ?? fallbackExpanded;
+	useLayoutEffect(() => {
+		if (fallback === fallbackExpanded) return;
+		if (override === undefined && resolveAnchor()) {
+			completeChange.current = prepareChange(resolveAnchor);
+		}
+		setFallbackExpanded(fallback);
+	}, [fallback, fallbackExpanded, override, prepareChange, resolveAnchor]);
+	useLayoutEffect(() => {
+		const complete = completeChange.current;
+		completeChange.current = noop;
+		complete();
+	}, [expanded]);
+	const toggle: FoldToggle = (event) => {
+		if (event) completeChange.current = prepareChange(resolveAnchor);
 		const next = !expanded;
 		foldState.set(id, next);
 		setOverride(next);
 	};
-	return [expanded, toggle];
+	return [expanded, toggle, anchorRef];
 }
 
 const selectionState = new Map<string, string | null>();
 
-export function useSelection(id: string): [string | null, (key: string) => void] {
+export function useSelection(
+	id: string,
+): [string | null, (key: string, event?: ReactMouseEvent<HTMLElement>) => void] {
+	const prepareChange = useFoldGeometry();
+	const completeChange = useRef<FoldChangeCompletion>(noop);
 	const [selected, setSelected] = useState<string | null>(() => selectionState.get(id) ?? null);
-	const select = (key: string) => {
+	useLayoutEffect(() => {
+		const complete = completeChange.current;
+		completeChange.current = noop;
+		complete();
+	}, [selected]);
+	const select = (key: string, event?: ReactMouseEvent<HTMLElement>) => {
+		if (event) {
+			const anchor = event.currentTarget;
+			completeChange.current = prepareChange(() => anchor);
+		}
 		const next = selected === key ? null : key;
 		selectionState.set(id, next);
 		setSelected(next);

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -367,6 +367,24 @@ describe("reading-band reader intent", () => {
 		expect(harness.writes).toEqual([0]);
 	});
 
+	it("settlement reattaches a detached reader at the physical latest edge in both orders", () => {
+		for (const latestEdge of ["bottom", "top"] as const) {
+			const harness = createHarness({ latestEdge });
+			harness.setGeometry({ scrollTop: 300, maxScrollTop: 900, edgeBottom: 500 });
+			harness.controller.readerLeft();
+			harness.controller.setStreaming(false);
+			harness.advance(220);
+
+			expect(harness.controller.getSnapshot()).toEqual({
+				following: true,
+				moving: false,
+				runway: false,
+				buttonLabel: null,
+			});
+			expect(harness.writes.at(-1)).toBe(latestEdge === "bottom" ? 900 : 0);
+		}
+	});
+
 	it("keeps a settled Latest return pinned through delayed measurement", () => {
 		const harness = createHarness({ streaming: false });
 		harness.controller.readerLeft();

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -362,6 +362,54 @@ describe("reading-band reader intent", () => {
 		expect(detached.controller.getSnapshot().following).toBe(false);
 	});
 
+	it("pauses for potential native input without detaching and can resume alignment", () => {
+		const harness = createHarness({ streaming: false });
+		harness.controller.returnToEdge();
+		expect(harness.controller.getSnapshot()).toMatchObject({ following: true, moving: true });
+
+		const resume = harness.controller.interruptForNativeInput();
+		expect(harness.cancelledFrames()).toBe(1);
+		expect(harness.controller.getSnapshot()).toMatchObject({ following: true, moving: false });
+
+		resume();
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(1_000);
+		expect(harness.controller.getSnapshot()).toMatchObject({ following: true, buttonLabel: null });
+
+		const detached = createHarness();
+		detached.controller.readerLeft();
+		detached.controller.revealTo(() => 700, true);
+		const resumeDetached = detached.controller.interruptForNativeInput();
+		expect(detached.controller.getSnapshot()).toMatchObject({ following: false, moving: false });
+		resumeDetached();
+		expect(detached.controller.getSnapshot()).toMatchObject({ following: false, moving: true });
+	});
+
+	it("keeps active streaming runway intact across a no-move native pause", () => {
+		const harness = createHarness();
+		harness.setGeometry({
+			scrollTop: 100,
+			maxScrollTop: 100,
+			edgeBottom: 601,
+			runwayBottom: 601,
+		});
+		harness.controller.contentChanged();
+		expect(harness.runwayHeights).toEqual([151]);
+
+		const resume = harness.controller.interruptForNativeInput();
+		expect(harness.runwayHeights).toEqual([151]);
+		expect(harness.controller.getSnapshot()).toMatchObject({
+			following: true,
+			moving: false,
+			runway: true,
+		});
+
+		resume();
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(251);
+		expect(harness.controller.getSnapshot()).toMatchObject({ following: true, runway: true });
+	});
+
 	it("moves an automatic reveal through the shared motion without detaching", () => {
 		const harness = createHarness();
 		harness.controller.revealTo(() => 700, false);
@@ -408,17 +456,6 @@ describe("reading-band reader intent", () => {
 		expect(harness.pendingFrames()).toBe(1);
 		harness.controller.cancelReveal();
 		expect(harness.pendingFrames()).toBe(0);
-		expect(harness.controller.getSnapshot().following).toBe(true);
-	});
-
-	it("latest-directed native movement yields alignment motion without detaching", () => {
-		const harness = createHarness({ latestEdge: "bottom" });
-		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
-		harness.controller.settle();
-		const writesBeforeReader = harness.writes.length;
-		harness.controller.readerMovedWhileFollowing();
-		harness.advance(220);
-		expect(harness.writes).toHaveLength(writesBeforeReader);
 		expect(harness.controller.getSnapshot().following).toBe(true);
 	});
 
@@ -565,6 +602,34 @@ describe("reading-band reader intent", () => {
 		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
 		harness.controller.setStreaming(false);
 		expect(harness.pendingFrames()).toBe(1);
+	});
+
+	it("finishes partial settlement runway cleanup on either idle reattach path", () => {
+		for (const reattach of ["return", "edge"] as const) {
+			const harness = createHarness();
+			harness.setGeometry({
+				scrollTop: 100,
+				maxScrollTop: 100,
+				edgeBottom: 601,
+				runwayBottom: 601,
+			});
+			harness.controller.contentChanged();
+			harness.advance(220);
+			harness.controller.setStreaming(false);
+			harness.advance(110);
+			expect(harness.runwayHeights.at(-1)).toBeGreaterThan(0);
+
+			harness.controller.readerLeft();
+			if (reattach === "return") harness.controller.returnToEdge();
+			else harness.controller.readerReachedEdge();
+			harness.advance(220);
+
+			expect(harness.runwayHeights.at(-1)).toBe(0);
+			expect(harness.controller.getSnapshot()).toMatchObject({
+				following: true,
+				runway: false,
+			});
+		}
 	});
 
 	it("follows idle disclosure geometry after settlement suppression ends", () => {

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -371,6 +371,37 @@ describe("reading-band reader intent", () => {
 		expect(harness.controller.getSnapshot().following).toBe(true);
 	});
 
+	it("owns detached fold-anchor stabilization and yields it to reader input", () => {
+		const harness = createHarness();
+		harness.controller.readerLeft();
+		let target = 100;
+		harness.controller.stabilizeAnchor(() => target);
+		expect(harness.pendingFrames()).toBe(1);
+		target = 260;
+		harness.controller.refreshAnchor();
+		expect(harness.writes.at(-1)).toBe(260);
+		harness.advance(16);
+		expect(harness.writes.at(-1)).toBe(260);
+		expect(harness.controller.getSnapshot()).toMatchObject({ following: false, moving: true });
+
+		const writesBeforeInput = harness.writes.length;
+		harness.controller.cancelReveal();
+		harness.advance(16);
+		expect(harness.writes).toHaveLength(writesBeforeInput);
+		expect(harness.pendingFrames()).toBe(0);
+		expect(harness.controller.getSnapshot()).toMatchObject({ following: false, moving: false });
+	});
+
+	it("lets a reveal supersede fold-anchor stabilization through the shared owner", () => {
+		const harness = createHarness();
+		harness.controller.readerLeft();
+		harness.controller.stabilizeAnchor(() => 300);
+		harness.controller.revealTo(() => 700, false);
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(700);
+		expect(harness.pendingFrames()).toBe(0);
+	});
+
 	it("cancels only the active automatic reveal when the user takes over", () => {
 		const harness = createHarness();
 		harness.controller.revealTo(() => 700, true);
@@ -732,6 +763,31 @@ describe("reading-band derived room", () => {
 		harness.advance(220);
 		expect(harness.runwayHeights.at(-1)).toBe(0);
 		expect(harness.controller.getSnapshot().runway).toBe(false);
+	});
+
+	it("keeps runway cleanup when fold anchoring is started and interrupted", () => {
+		const harness = createHarness();
+		harness.setGeometry({
+			scrollTop: 100,
+			maxScrollTop: 100,
+			edgeBottom: 601,
+			runwayBottom: 601,
+		});
+		harness.controller.contentChanged();
+		harness.advance(220);
+		harness.controller.readerLeft();
+		harness.advance(100);
+		expect(harness.runwayHeights.at(-1)).toBeGreaterThan(0);
+
+		harness.controller.stabilizeAnchor(() => 120);
+		harness.controller.cancelReveal();
+		expect(harness.pendingFrames()).toBe(1);
+		harness.advance(220);
+		expect(harness.runwayHeights.at(-1)).toBe(0);
+		expect(harness.controller.getSnapshot()).toMatchObject({
+			following: false,
+			runway: false,
+		});
 	});
 
 	it("reader takeover removes room, detaches, and ignores later growth", () => {

--- a/apps/web/src/chat/readingBand.test.ts
+++ b/apps/web/src/chat/readingBand.test.ts
@@ -191,6 +191,29 @@ describe("reading-band turn anchoring", () => {
 		expect(harness.runwayHeights).toEqual([]);
 	});
 
+	it("keeps idle latest-edge reconciliation behind an armed immediate-turn anchor", () => {
+		const harness = createHarness({ streaming: false, reducedMotion: true });
+		harness.controller.armImmediateTurn();
+		harness.controller.userTurnArrived(3, "immediate");
+		harness.advance(0);
+		expect(harness.anchors).toEqual([{ index: 3, inset: 60 }]);
+		harness.setGeometry({ scrollTop: 100, maxScrollTop: 500 });
+		harness.controller.contentChanged();
+		expect(harness.writes).toEqual([]);
+	});
+
+	it("cancels only the local immediate arm when another client already started work", () => {
+		const harness = createHarness({ streaming: false });
+		harness.controller.armImmediateTurn();
+		harness.controller.setStreaming(true);
+		harness.controller.cancelImmediateTurn(true);
+		expect(harness.controller.getSnapshot()).toMatchObject({
+			following: true,
+			runway: true,
+			buttonLabel: null,
+		});
+	});
+
 	it("anchors a queued turn only while the reader is still following", () => {
 		const harness = createHarness();
 		harness.controller.userTurnArrived(4, "queued");
@@ -339,6 +362,46 @@ describe("reading-band reader intent", () => {
 		expect(detached.controller.getSnapshot().following).toBe(false);
 	});
 
+	it("moves an automatic reveal through the shared motion without detaching", () => {
+		const harness = createHarness();
+		harness.controller.revealTo(() => 700, false);
+		expect(harness.pendingFrames()).toBe(1);
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(700);
+		expect(harness.controller.getSnapshot().following).toBe(true);
+	});
+
+	it("cancels only the active automatic reveal when the user takes over", () => {
+		const harness = createHarness();
+		harness.controller.revealTo(() => 700, true);
+		expect(harness.pendingFrames()).toBe(1);
+		harness.controller.cancelReveal();
+		expect(harness.pendingFrames()).toBe(0);
+		expect(harness.controller.getSnapshot().following).toBe(true);
+	});
+
+	it("latest-directed native movement yields alignment motion without detaching", () => {
+		const harness = createHarness({ latestEdge: "bottom" });
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
+		harness.controller.settle();
+		const writesBeforeReader = harness.writes.length;
+		harness.controller.readerMovedWhileFollowing();
+		harness.advance(220);
+		expect(harness.writes).toHaveLength(writesBeforeReader);
+		expect(harness.controller.getSnapshot().following).toBe(true);
+	});
+
+	it("does not cancel a settlement return when a non-scrolling pointer only cancels reveals", () => {
+		const harness = createHarness({ latestEdge: "bottom" });
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
+		harness.controller.readerLeft();
+		harness.controller.settle();
+		harness.controller.cancelReveal();
+		expect(harness.pendingFrames()).toBe(1);
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(900);
+	});
+
 	it("does not re-arm from geometry alone, but edge return and Follow response do", () => {
 		const harness = createHarness({ reducedMotion: true });
 		harness.controller.readerLeft();
@@ -364,7 +427,9 @@ describe("reading-band reader intent", () => {
 		harness.controller.readerLeft();
 		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
 		harness.controller.returnToEdge();
-		expect(harness.writes).toEqual([0]);
+		expect(harness.writes).toEqual([]);
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(0);
 	});
 
 	it("settlement reattaches a detached reader at the physical latest edge in both orders", () => {
@@ -377,25 +442,137 @@ describe("reading-band reader intent", () => {
 
 			expect(harness.controller.getSnapshot()).toEqual({
 				following: true,
-				moving: false,
+				moving: true,
 				runway: false,
 				buttonLabel: null,
 			});
 			expect(harness.writes.at(-1)).toBe(latestEdge === "bottom" ? 900 : 0);
+			for (let frame = 0; frame < 30; frame += 1) harness.advance(16);
+			expect(harness.controller.getSnapshot().moving).toBe(false);
 		}
 	});
 
-	it("keeps a settled Latest return pinned through delayed measurement", () => {
+	it("keeps the settlement return when another run is already active", () => {
+		const harness = createHarness({ latestEdge: "bottom" });
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900, edgeBottom: 500 });
+		harness.controller.readerLeft();
+		harness.controller.settle();
+		harness.controller.setStreaming(true);
+		expect(harness.pendingFrames()).toBe(1);
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(900);
+		expect(harness.controller.getSnapshot()).toMatchObject({
+			following: true,
+			runway: true,
+			buttonLabel: null,
+		});
+	});
+
+	it("defers a queued user-row anchor until settlement cleanup completes", () => {
+		const harness = createHarness();
+		harness.setGeometry({
+			scrollTop: 100,
+			maxScrollTop: 100,
+			edgeBottom: 601,
+			runwayBottom: 601,
+		});
+		harness.controller.contentChanged();
+		harness.advance(220);
+		harness.controller.settle();
+		harness.controller.setStreaming(true);
+		harness.controller.userTurnArrived(5, "queued");
+		expect(harness.anchors).toEqual([]);
+		harness.advance(220);
+		expect(harness.runwayHeights.at(-1)).toBe(0);
+		for (let frame = 0; frame < 30; frame += 1) harness.advance(16);
+		harness.advance(0);
+		expect(harness.anchors).toEqual([{ index: 5, inset: 60 }]);
+	});
+
+	it("does not let a newest row replace settlement cleanup", () => {
+		const harness = createHarness({ latestEdge: "top" });
+		harness.setGeometry({
+			scrollTop: 100,
+			maxScrollTop: 100,
+			edgeBottom: 601,
+			runwayBottom: 601,
+		});
+		harness.controller.contentChanged();
+		harness.advance(220);
+		harness.controller.settle();
+		harness.controller.setStreaming(true);
+		harness.controller.latestRowArrived(0);
+		harness.advance(220);
+		expect(harness.runwayHeights.at(-1)).toBe(0);
+	});
+
+	it("retargets one settlement return when the physical latest edge changes", () => {
+		const harness = createHarness({ latestEdge: "bottom" });
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900, edgeBottom: 500 });
+		harness.controller.readerLeft();
+		harness.controller.setStreaming(false);
+		expect(harness.pendingFrames()).toBe(1);
+		harness.advance(100);
+		harness.setGeometry({ maxScrollTop: 1_400 });
+		harness.controller.contentChanged();
+		expect(harness.pendingFrames()).toBe(1);
+		harness.advance(120);
+		expect(harness.writes.at(-1)).toBe(1_400);
+	});
+
+	it("settles runway and scroll through one motion channel", () => {
+		const harness = createHarness();
+		harness.setGeometry({
+			scrollTop: 100,
+			maxScrollTop: 100,
+			edgeBottom: 601,
+			runwayBottom: 601,
+		});
+		harness.controller.contentChanged();
+		harness.advance(220);
+		harness.controller.readerLeft();
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
+		harness.controller.setStreaming(false);
+		expect(harness.pendingFrames()).toBe(1);
+	});
+
+	it("follows idle disclosure geometry after settlement suppression ends", () => {
+		const harness = createHarness({ streaming: true, reducedMotion: true });
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
+		harness.controller.settle();
+		expect(harness.writes.at(-1)).toBe(900);
+		harness.setGeometry({ scrollTop: 900, maxScrollTop: 1_200 });
+		harness.controller.contentChanged();
+		expect(harness.writes.at(-1)).toBe(1_200);
+	});
+
+	it("retains immediate settlement corrections under reduced motion", () => {
+		const harness = createHarness({ streaming: true, reducedMotion: true });
+		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
+		harness.controller.settle();
+		expect(harness.writes.at(-1)).toBe(900);
+		expect(harness.pendingFrames()).toBe(1);
+		harness.setGeometry({ maxScrollTop: 1_400 });
+		harness.advance(16);
+		expect(harness.writes.at(-1)).toBe(1_400);
+		for (let frame = 0; frame < 29; frame += 1) harness.advance(16);
+		expect(harness.pendingFrames()).toBe(0);
+	});
+
+	it("retargets a settled Latest return through delayed measurement", () => {
 		const harness = createHarness({ streaming: false });
 		harness.controller.readerLeft();
 		harness.setGeometry({ scrollTop: 300, maxScrollTop: 900 });
 		harness.controller.returnToEdge();
-		expect(harness.writes).toEqual([900]);
+		expect(harness.writes).toEqual([]);
+		harness.advance(220);
+		expect(harness.writes.at(-1)).toBe(900);
 		for (let frame = 0; frame < 10; frame += 1) harness.advance(16);
 		harness.setGeometry({ maxScrollTop: 1_400 });
 		harness.advance(16);
+		harness.advance(220);
 		expect(harness.writes.at(-1)).toBe(1_400);
-		for (let frame = 0; frame < 19; frame += 1) harness.advance(16);
+		for (let frame = 0; frame < 20; frame += 1) harness.advance(16);
 		expect(harness.pendingFrames()).toBe(0);
 	});
 
@@ -533,6 +710,25 @@ describe("reading-band derived room", () => {
 		harness.advance(220);
 		harness.controller.setStreaming(false);
 		expect(harness.controller.getSnapshot().runway).toBe(true);
+		harness.advance(220);
+		expect(harness.runwayHeights.at(-1)).toBe(0);
+		expect(harness.controller.getSnapshot().runway).toBe(false);
+	});
+
+	it("repeated reader input cannot cancel an in-flight runway collapse", () => {
+		const harness = createHarness();
+		harness.setGeometry({
+			scrollTop: 100,
+			maxScrollTop: 100,
+			edgeBottom: 601,
+			runwayBottom: 601,
+		});
+		harness.controller.contentChanged();
+		harness.advance(220);
+		harness.controller.readerLeft();
+		expect(harness.pendingFrames()).toBe(1);
+		harness.controller.readerLeft();
+		expect(harness.pendingFrames()).toBe(1);
 		harness.advance(220);
 		expect(harness.runwayHeights.at(-1)).toBe(0);
 		expect(harness.controller.getSnapshot().runway).toBe(false);

--- a/apps/web/src/chat/readingBand.ts
+++ b/apps/web/src/chat/readingBand.ts
@@ -2,7 +2,7 @@ const TURN_INSET_RATIO = 0.1;
 const TURN_INSET_MIN = 48;
 const TURN_INSET_MAX = 80;
 const ADVANCE_DURATION_MS = 220;
-const EDGE_PIN_MAX_FRAMES = 30;
+const EDGE_STABILITY_FRAMES = 30;
 const GEOMETRY_EPSILON = 0.5;
 
 export type ReadingBandLatestEdge = "top" | "bottom";
@@ -47,14 +47,19 @@ export interface ReadingBandEnvironment {
 export interface ReadingBandController {
 	getSnapshot: () => ReadingBandSnapshot;
 	armImmediateTurn: () => void;
+	cancelImmediateTurn: (streaming: boolean) => void;
 	userTurnArrived: (index: number, source: "immediate" | "queued") => void;
 	latestRowArrived: (index: number) => void;
 	contentChanged: () => void;
 	cancelMovement: () => void;
+	cancelReveal: () => void;
+	revealTo: (target: () => number | null, stabilize: boolean) => void;
 	readerLeft: () => void;
+	readerMovedWhileFollowing: () => void;
 	readerReachedEdge: () => void;
 	returnToEdge: () => void;
 	releaseRunway: (smooth?: boolean) => void;
+	settle: () => void;
 	setStreaming: (streaming: boolean) => void;
 	setMovement: (movement: ReadingBandMovement) => void;
 	reconstructActiveStream: () => void;
@@ -67,6 +72,24 @@ interface ReadingBandState {
 	moving: boolean;
 	runway: boolean;
 	streaming: boolean;
+}
+
+type ScrollTarget = () => number | null;
+
+interface ActiveMotion {
+	kind: "alignment" | "reveal" | "runway" | "settlement";
+	scrollTarget: ScrollTarget | null;
+	runwayTarget: number | null;
+	retainActiveRunway: boolean;
+	requireFollowing: boolean;
+	requireStreaming: boolean;
+	reevaluate: boolean;
+	startedAt: number;
+	startScrollTop: number;
+	startRunwayHeight: number;
+	stabilityFrames: number;
+	stabilizing: boolean;
+	instant: boolean;
 }
 
 function snapshotOf(state: ReadingBandState): ReadingBandSnapshot {
@@ -137,15 +160,17 @@ export function createReadingBandController(
 		streaming,
 	};
 	let frame: number | null = null;
-	let runwayFrame: number | null = null;
+	let motion: ActiveMotion | null = null;
 	let anchorFrame: number | null = null;
-	let edgePinFrame: number | null = null;
 	let activeStreamMount = streaming;
 	let reconstructed = false;
 	let runwayHeight = 0;
 	let runwayStartEdge: number | null = null;
 	let runwayStartHeight = 0;
+	let immediateTurnPending = false;
 	let pendingSettleReturn = false;
+	let deferredUserTurn: { index: number; source: "immediate" | "queued" } | null = null;
+	let deferredLatestRow: number | null = null;
 	let runwaySuppressed = false;
 
 	const publish = (patch: Partial<ReadingBandState>) => {
@@ -162,27 +187,6 @@ export function createReadingBandController(
 		environment.onStateChange(snapshotOf(state));
 	};
 
-	const cancelMotion = () => {
-		if (frame !== null) environment.cancelFrame(frame);
-		frame = null;
-		if (state.moving) publish({ moving: false });
-	};
-
-	const cancelRunwayMotion = () => {
-		if (runwayFrame !== null) environment.cancelFrame(runwayFrame);
-		runwayFrame = null;
-	};
-
-	const cancelAnchor = () => {
-		if (anchorFrame !== null) environment.cancelFrame(anchorFrame);
-		anchorFrame = null;
-	};
-
-	const cancelEdgePin = () => {
-		if (edgePinFrame !== null) environment.cancelFrame(edgePinFrame);
-		edgePinFrame = null;
-	};
-
 	const resetRunwayTracking = () => {
 		runwayStartEdge = null;
 		runwayStartHeight = 0;
@@ -196,37 +200,236 @@ export function createReadingBandController(
 		if (pixels === 0) resetRunwayTracking();
 	};
 
-	const finishRunwayRelease = () => {
-		writeRunwayHeight(0);
-		resetRunwayTracking();
-		publish({ runway: false });
+	const cancelAnchor = () => {
+		if (anchorFrame !== null) environment.cancelFrame(anchorFrame);
+		anchorFrame = null;
+	};
+
+	const completeMotion = (reevaluate: boolean) => {
+		const completed = motion;
+		motion = null;
+		frame = null;
+		if (completed?.runwayTarget === 0) {
+			writeRunwayHeight(0);
+			publish({
+				runway: completed.retainActiveRunway && state.streaming && state.following,
+			});
+		}
+		if (state.moving) publish({ moving: false });
+		const appliedDeferredRow = completed?.kind === "settlement" && flushDeferredRows();
+		if (reevaluate && !appliedDeferredRow) contentChanged();
+	};
+
+	const cancelMotion = () => {
+		if (frame !== null) environment.cancelFrame(frame);
+		frame = null;
+		motion = null;
+		if (state.moving) publish({ moving: false });
+	};
+
+	const boundedScrollTarget = (target: ScrollTarget | null): number | null => {
+		if (!target) return null;
+		const bounds = environment.readScrollBounds();
+		const value = target();
+		if (!bounds || value === null) return null;
+		return Math.min(bounds.maxScrollTop, Math.max(0, value));
+	};
+
+	const motionSettled = (active: ActiveMotion): boolean => {
+		const bounds = environment.readScrollBounds();
+		const target = boundedScrollTarget(active.scrollTarget);
+		const scrollSettled =
+			target === null || !bounds || Math.abs(target - bounds.scrollTop) <= GEOMETRY_EPSILON;
+		const runwaySettled =
+			active.runwayTarget === null ||
+			Math.abs(active.runwayTarget - runwayHeight) <= GEOMETRY_EPSILON;
+		return scrollSettled && runwaySettled;
+	};
+
+	const applyInstantMotion = (active: ActiveMotion) => {
+		const target = boundedScrollTarget(active.scrollTarget);
+		if (target !== null) environment.writeScrollTop(target);
+		if (active.runwayTarget !== null) writeRunwayHeight(active.runwayTarget);
+		if (active.runwayTarget === 0) {
+			publish({
+				runway: active.retainActiveRunway && state.streaming && state.following,
+			});
+		}
+	};
+
+	const advanceMotion = (time: number) => {
+		frame = null;
+		const active = motion;
+		if (!active) return;
+		if (
+			(active.requireFollowing && !state.following) ||
+			(active.requireStreaming && !state.streaming)
+		) {
+			completeMotion(false);
+			return;
+		}
+		if (active.stabilizing) {
+			if (!motionSettled(active)) {
+				if (active.instant) {
+					applyInstantMotion(active);
+				} else {
+					const bounds = environment.readScrollBounds();
+					active.startScrollTop = bounds?.scrollTop ?? active.startScrollTop;
+					active.startRunwayHeight = runwayHeight;
+					active.startedAt = time;
+					active.stabilizing = false;
+					frame = environment.requestFrame(advanceMotion);
+					return;
+				}
+			}
+			active.stabilityFrames -= 1;
+			if (active.stabilityFrames <= 0) {
+				completeMotion(active.reevaluate);
+				return;
+			}
+			frame = environment.requestFrame(advanceMotion);
+			return;
+		}
+		const progress = Math.min(1, Math.max(0, (time - active.startedAt) / ADVANCE_DURATION_MS));
+		const eased = easeOutCubic(progress);
+		const target = boundedScrollTarget(active.scrollTarget);
+		if (target !== null) {
+			environment.writeScrollTop(active.startScrollTop + (target - active.startScrollTop) * eased);
+		}
+		if (active.runwayTarget !== null) {
+			writeRunwayHeight(
+				active.startRunwayHeight + (active.runwayTarget - active.startRunwayHeight) * eased,
+			);
+			if (active.runwayTarget === 0 && runwayHeight <= GEOMETRY_EPSILON) {
+				active.runwayTarget = null;
+				publish({
+					runway: active.retainActiveRunway && state.streaming && state.following,
+				});
+			}
+		}
+		if (progress < 1) {
+			frame = environment.requestFrame(advanceMotion);
+			return;
+		}
+		if (!motionSettled(active)) {
+			const bounds = environment.readScrollBounds();
+			active.startScrollTop = bounds?.scrollTop ?? active.startScrollTop;
+			active.startRunwayHeight = runwayHeight;
+			active.startedAt = time;
+			frame = environment.requestFrame(advanceMotion);
+			return;
+		}
+		if (active.stabilityFrames > 0) {
+			active.stabilizing = true;
+			frame = environment.requestFrame(advanceMotion);
+			return;
+		}
+		completeMotion(active.reevaluate);
+	};
+
+	const startMotion = ({
+		kind = "alignment",
+		scrollTarget = null,
+		runwayTarget = null,
+		retainActiveRunway = false,
+		requireFollowing = true,
+		requireStreaming = false,
+		reevaluate = false,
+		stabilityFrames = 0,
+	}: {
+		kind?: ActiveMotion["kind"];
+		scrollTarget?: ScrollTarget | null;
+		runwayTarget?: number | null;
+		retainActiveRunway?: boolean;
+		requireFollowing?: boolean;
+		requireStreaming?: boolean;
+		reevaluate?: boolean;
+		stabilityFrames?: number;
+	}) => {
+		const bounds = environment.readScrollBounds();
+		const initialScrollTarget = boundedScrollTarget(scrollTarget);
+		const scrollAlreadySettled =
+			initialScrollTarget === null ||
+			!bounds ||
+			Math.abs(initialScrollTarget - bounds.scrollTop) <= GEOMETRY_EPSILON;
+		const runwayAlreadySettled =
+			runwayTarget === null || Math.abs(runwayTarget - runwayHeight) <= GEOMETRY_EPSILON;
+		if (scrollAlreadySettled && runwayAlreadySettled && stabilityFrames === 0) {
+			if (runwayTarget === 0) {
+				publish({ runway: retainActiveRunway && state.streaming && state.following });
+			}
+			if (reevaluate) contentChanged();
+			return;
+		}
+		if (environment.prefersReducedMotion()) {
+			cancelMotion();
+			const target = boundedScrollTarget(scrollTarget);
+			if (target !== null) environment.writeScrollTop(target);
+			if (runwayTarget !== null) writeRunwayHeight(runwayTarget);
+			if (runwayTarget === 0) {
+				publish({ runway: retainActiveRunway && state.streaming && state.following });
+			}
+			if (stabilityFrames > 0) {
+				const currentBounds = environment.readScrollBounds();
+				motion = {
+					kind,
+					scrollTarget,
+					runwayTarget,
+					retainActiveRunway,
+					requireFollowing,
+					requireStreaming,
+					reevaluate,
+					startedAt: environment.now(),
+					startScrollTop: currentBounds?.scrollTop ?? 0,
+					startRunwayHeight: runwayHeight,
+					stabilityFrames,
+					stabilizing: true,
+					instant: true,
+				};
+				publish({ moving: true });
+				frame = environment.requestFrame(advanceMotion);
+			} else if (reevaluate) {
+				contentChanged();
+			}
+			return;
+		}
+		motion = {
+			kind,
+			scrollTarget,
+			runwayTarget,
+			retainActiveRunway,
+			requireFollowing,
+			requireStreaming,
+			reevaluate,
+			startedAt: environment.now(),
+			startScrollTop: bounds?.scrollTop ?? 0,
+			startRunwayHeight: runwayHeight,
+			stabilityFrames,
+			stabilizing: false,
+			instant: false,
+		};
+		publish({ moving: true });
+		frame ??= environment.requestFrame(advanceMotion);
 	};
 
 	const releaseRunway = (smooth = true) => {
 		pendingSettleReturn = false;
 		runwaySuppressed = true;
-		cancelRunwayMotion();
 		if (!smooth || runwayHeight <= GEOMETRY_EPSILON || environment.prefersReducedMotion()) {
-			finishRunwayRelease();
+			cancelMotion();
+			writeRunwayHeight(0);
+			publish({ runway: false });
 			return;
 		}
-		const startHeight = runwayHeight;
-		const startedAt = environment.now();
-		const collapse = (time: number) => {
-			const progress = Math.min(1, Math.max(0, (time - startedAt) / ADVANCE_DURATION_MS));
-			writeRunwayHeight(startHeight * (1 - easeOutCubic(progress)));
-			if (progress < 1) {
-				runwayFrame = environment.requestFrame(collapse);
-				return;
-			}
-			runwayFrame = null;
-			finishRunwayRelease();
-		};
-		runwayFrame = environment.requestFrame(collapse);
+		startMotion({
+			kind: "runway",
+			runwayTarget: 0,
+			requireFollowing: false,
+		});
 	};
 
 	const reconcileRunwayGrowth = (geometry: ReadingBandGeometry) => {
-		if (runwayStartHeight <= 0 || runwayFrame !== null) return;
+		if (runwayStartHeight <= 0 || (motion && motion.runwayTarget !== null)) return;
 		const bottom = runwayBottom(geometry);
 		if (bottom === null) return;
 		if (runwayStartEdge === null) {
@@ -240,59 +443,12 @@ export function createReadingBandController(
 	const latestScrollTop = (bounds: ReadingBandScrollBounds) =>
 		latestEdge === "top" ? 0 : bounds.maxScrollTop;
 
-	const pinLatestEdge = () => {
-		cancelEdgePin();
-		let remainingFrames = EDGE_PIN_MAX_FRAMES;
-		const pin = () => {
-			edgePinFrame = null;
-			const bounds = environment.readScrollBounds();
-			if (!bounds) return;
-			environment.writeScrollTop(latestScrollTop(bounds));
-			remainingFrames -= 1;
-			if (remainingFrames <= 0) return;
-			edgePinFrame = environment.requestFrame(pin);
-		};
-		pin();
-	};
-
-	const moveTo = (target: number, requireStreaming: boolean, reevaluate: boolean) => {
-		cancelEdgePin();
+	const latestTarget: ScrollTarget = () => {
 		const bounds = environment.readScrollBounds();
-		if (!bounds) return;
-		const boundedTarget = Math.min(bounds.maxScrollTop, Math.max(0, target));
-		if (Math.abs(boundedTarget - bounds.scrollTop) <= GEOMETRY_EPSILON) return;
-		cancelMotion();
-		if (environment.prefersReducedMotion()) {
-			environment.writeScrollTop(boundedTarget);
-			if (reevaluate) contentChanged();
-			return;
-		}
-
-		const start = bounds.scrollTop;
-		const distance = boundedTarget - start;
-		const startedAt = environment.now();
-		publish({ moving: true });
-		const advance = (time: number) => {
-			if (!state.following || (requireStreaming && !state.streaming)) {
-				frame = null;
-				publish({ moving: false });
-				return;
-			}
-			const progress = Math.min(1, Math.max(0, (time - startedAt) / ADVANCE_DURATION_MS));
-			environment.writeScrollTop(start + distance * easeOutCubic(progress));
-			if (progress < 1) {
-				frame = environment.requestFrame(advance);
-				return;
-			}
-			frame = null;
-			publish({ moving: false });
-			if (reevaluate) contentChanged();
-		};
-		frame = environment.requestFrame(advance);
+		return bounds ? latestScrollTop(bounds) : null;
 	};
 
 	const addRunwayForTarget = (geometry: ReadingBandGeometry, target: number) => {
-		cancelRunwayMotion();
 		const naturalMaxScrollTop = Math.max(0, geometry.maxScrollTop - runwayHeight);
 		const required = Math.max(0, target - naturalMaxScrollTop);
 		const bottom = runwayBottom(geometry);
@@ -310,30 +466,56 @@ export function createReadingBandController(
 		);
 	};
 
+	const liveSettleTarget: ScrollTarget = () => {
+		const geometry = environment.readGeometry();
+		return geometry ? settleTarget(geometry) : null;
+	};
+
 	const moveEdgeToSettle = (geometry: ReadingBandGeometry, animate: boolean) => {
 		const target = settleTarget(geometry);
 		if (target === null) return false;
 		addRunwayForTarget(geometry, target);
-		const refreshed = environment.readGeometry() ?? geometry;
-		const refreshedTarget = settleTarget(refreshed) ?? target;
-		if (animate) moveTo(refreshedTarget, true, true);
-		else environment.writeScrollTop(refreshedTarget);
+		if (animate) {
+			startMotion({ scrollTarget: liveSettleTarget, requireStreaming: true, reevaluate: true });
+		} else {
+			const refreshedTarget = boundedScrollTarget(liveSettleTarget);
+			if (refreshedTarget !== null) environment.writeScrollTop(refreshedTarget);
+		}
 		return true;
+	};
+
+	const settle = () => {
+		cancelAnchor();
+		immediateTurnPending = false;
+		pendingSettleReturn = false;
+		deferredUserTurn = null;
+		deferredLatestRow = null;
+		runwaySuppressed = true;
+		publish({ following: true, streaming: false });
+		startMotion({
+			kind: "settlement",
+			scrollTarget: latestTarget,
+			runwayTarget: 0,
+			retainActiveRunway: true,
+			reevaluate: true,
+			stabilityFrames: EDGE_STABILITY_FRAMES,
+		});
 	};
 
 	function contentChanged() {
 		let geometry = environment.readGeometry();
 		if (!geometry || geometry.viewportHeight <= 0) return;
 		reconcileRunwayGrowth(geometry);
-		if (
-			!state.streaming ||
-			!state.following ||
-			state.moving ||
-			runwayFrame !== null ||
-			runwaySuppressed
-		) {
+		if (immediateTurnPending || !state.following) return;
+		if (state.moving) {
+			if (motion?.instant) applyInstantMotion(motion);
 			return;
 		}
+		if (!state.streaming) {
+			startMotion({ scrollTarget: latestTarget });
+			return;
+		}
+		if (runwaySuppressed) return;
 		geometry = environment.readGeometry() ?? geometry;
 		if (pendingSettleReturn) {
 			pendingSettleReturn = !moveEdgeToSettle(geometry, true);
@@ -346,78 +528,172 @@ export function createReadingBandController(
 		moveEdgeToSettle(geometry, true);
 	}
 
+	function applyUserTurn(index: number, source: "immediate" | "queued") {
+		if (source === "queued" && !state.following) return;
+		cancelMotion();
+		if (source === "immediate") publish({ following: true, runway: true });
+		const viewportHeight = environment.readViewportHeight();
+		if (viewportHeight <= 0) return;
+		const inset = turnInset(viewportHeight);
+		cancelAnchor();
+		anchorFrame = environment.requestFrame(() => {
+			anchorFrame = null;
+			if (state.following) environment.anchorTurn(index, inset);
+		});
+	}
+
+	function applyLatestRow(index: number) {
+		if (latestEdge !== "top" || index !== 0 || !state.following) return;
+		startMotion({ scrollTarget: latestTarget });
+	}
+
+	function flushDeferredRows(): boolean {
+		const userTurn = deferredUserTurn;
+		const latestRow = deferredLatestRow;
+		deferredUserTurn = null;
+		deferredLatestRow = null;
+		if (userTurn) {
+			applyUserTurn(userTurn.index, userTurn.source);
+			return true;
+		}
+		if (latestRow !== null) {
+			applyLatestRow(latestRow);
+			return true;
+		}
+		return false;
+	}
+
+	const yieldMotionToReader = () => {
+		cancelAnchor();
+		immediateTurnPending = false;
+		deferredUserTurn = null;
+		deferredLatestRow = null;
+		if (motion?.instant) {
+			cancelMotion();
+		} else if (motion?.runwayTarget === 0) {
+			if (motion.scrollTarget !== null || motion.requireFollowing || motion.stabilizing) {
+				const bounds = environment.readScrollBounds();
+				motion.kind = "runway";
+				motion.scrollTarget = null;
+				motion.retainActiveRunway = false;
+				motion.requireFollowing = false;
+				motion.requireStreaming = false;
+				motion.reevaluate = false;
+				motion.startScrollTop = bounds?.scrollTop ?? motion.startScrollTop;
+				motion.startRunwayHeight = runwayHeight;
+				motion.startedAt = environment.now();
+				motion.stabilityFrames = 0;
+				motion.stabilizing = false;
+			}
+		} else {
+			cancelMotion();
+		}
+		if (runwayHeight > GEOMETRY_EPSILON) {
+			if (motion?.runwayTarget !== 0) releaseRunway(true);
+		} else {
+			publish({ runway: false });
+		}
+	};
+
 	return {
 		getSnapshot: () => snapshotOf(state),
 		armImmediateTurn: () => {
 			cancelMotion();
-			cancelRunwayMotion();
 			cancelAnchor();
-			cancelEdgePin();
+			immediateTurnPending = true;
 			pendingSettleReturn = false;
+			deferredUserTurn = null;
+			deferredLatestRow = null;
 			runwaySuppressed = false;
 			writeRunwayHeight(0);
 			publish({ following: true, runway: true });
 		},
-		userTurnArrived: (index, source) => {
-			if (source === "queued" && !state.following) return;
-			cancelMotion();
-			cancelEdgePin();
-			if (source === "immediate") publish({ following: true, runway: true });
-			const viewportHeight = environment.readViewportHeight();
-			if (viewportHeight <= 0) return;
-			const inset = turnInset(viewportHeight);
+		cancelImmediateTurn: (streaming) => {
+			immediateTurnPending = false;
 			cancelAnchor();
-			anchorFrame = environment.requestFrame(() => {
-				anchorFrame = null;
-				if (state.following) environment.anchorTurn(index, inset);
-			});
+			if (!streaming) {
+				settle();
+				return;
+			}
+			runwaySuppressed = false;
+			publish({ streaming: true, runway: state.following });
+			contentChanged();
+		},
+		userTurnArrived: (index, source) => {
+			if (motion?.kind === "settlement") {
+				deferredUserTurn = { index, source };
+				return;
+			}
+			applyUserTurn(index, source);
 		},
 		latestRowArrived: (index) => {
-			if (latestEdge !== "top" || index !== 0 || !state.following) return;
-			const bounds = environment.readScrollBounds();
-			if (bounds) moveTo(latestScrollTop(bounds), false, false);
+			if (motion?.kind === "settlement") {
+				deferredLatestRow = index;
+				return;
+			}
+			applyLatestRow(index);
 		},
 		contentChanged,
 		cancelMovement: () => {
 			cancelMotion();
 			cancelAnchor();
-			cancelEdgePin();
+		},
+		cancelReveal: () => {
+			if (motion?.kind === "reveal") cancelMotion();
+		},
+		revealTo: (target, stabilize) => {
+			cancelAnchor();
+			startMotion({
+				kind: "reveal",
+				scrollTarget: target,
+				runwayTarget: runwayHeight > GEOMETRY_EPSILON ? 0 : null,
+				requireFollowing: false,
+				stabilityFrames: stabilize ? EDGE_STABILITY_FRAMES : 0,
+			});
 		},
 		readerLeft: () => {
-			if (!state.following) return;
-			cancelMotion();
-			cancelAnchor();
-			cancelEdgePin();
+			yieldMotionToReader();
 			publish({ following: false });
-			releaseRunway(true);
 		},
+		readerMovedWhileFollowing: yieldMotionToReader,
 		readerReachedEdge: () => {
-			cancelRunwayMotion();
+			cancelMotion();
 			runwaySuppressed = false;
 			publish({ following: true, runway: state.streaming });
+			if (!state.streaming) {
+				startMotion({
+					scrollTarget: latestTarget,
+					stabilityFrames: EDGE_STABILITY_FRAMES,
+				});
+				return;
+			}
+			const geometry = environment.readGeometry();
+			if (!geometry || !moveEdgeToSettle(geometry, true)) pendingSettleReturn = true;
 		},
 		returnToEdge: () => {
 			cancelMotion();
 			cancelAnchor();
-			cancelRunwayMotion();
+			immediateTurnPending = false;
 			runwaySuppressed = false;
 			publish({ following: true, runway: state.streaming });
 			if (!state.streaming) {
-				pinLatestEdge();
+				startMotion({
+					scrollTarget: latestTarget,
+					stabilityFrames: EDGE_STABILITY_FRAMES,
+				});
 				return;
 			}
 			const geometry = environment.readGeometry();
 			if (!geometry || !moveEdgeToSettle(geometry, true)) pendingSettleReturn = true;
 		},
 		releaseRunway,
+		settle,
 		setStreaming: (nextStreaming) => {
 			if (!nextStreaming) {
-				cancelMotion();
-				publish({ streaming: false });
-				releaseRunway(true);
+				settle();
 				return;
 			}
-			cancelRunwayMotion();
+			immediateTurnPending = false;
 			runwaySuppressed = false;
 			publish({ streaming: true, runway: state.following });
 		},
@@ -430,7 +706,7 @@ export function createReadingBandController(
 			const geometry = environment.readGeometry();
 			if (!geometry) return;
 			reconstructed = true;
-			cancelRunwayMotion();
+			cancelMotion();
 			runwaySuppressed = false;
 			publish({ runway: true });
 			if (!moveEdgeToSettle(geometry, false)) pendingSettleReturn = true;
@@ -438,10 +714,11 @@ export function createReadingBandController(
 		setLatestEdge: (edge) => {
 			if (edge === latestEdge) return;
 			cancelMotion();
-			cancelRunwayMotion();
 			cancelAnchor();
-			cancelEdgePin();
 			latestEdge = edge;
+			immediateTurnPending = false;
+			deferredUserTurn = null;
+			deferredLatestRow = null;
 			activeStreamMount = state.streaming;
 			reconstructed = false;
 			pendingSettleReturn = false;
@@ -451,10 +728,11 @@ export function createReadingBandController(
 		},
 		dispose: () => {
 			cancelMotion();
-			cancelRunwayMotion();
 			cancelAnchor();
-			cancelEdgePin();
+			immediateTurnPending = false;
 			pendingSettleReturn = false;
+			deferredUserTurn = null;
+			deferredLatestRow = null;
 		},
 	};
 }

--- a/apps/web/src/chat/readingBand.ts
+++ b/apps/web/src/chat/readingBand.ts
@@ -54,6 +54,8 @@ export interface ReadingBandController {
 	cancelMovement: () => void;
 	cancelReveal: () => void;
 	revealTo: (target: () => number | null, stabilize: boolean) => void;
+	stabilizeAnchor: (target: () => number | null) => void;
+	refreshAnchor: () => void;
 	readerLeft: () => void;
 	readerMovedWhileFollowing: () => void;
 	readerReachedEdge: () => void;
@@ -77,7 +79,7 @@ interface ReadingBandState {
 type ScrollTarget = () => number | null;
 
 interface ActiveMotion {
-	kind: "alignment" | "reveal" | "runway" | "settlement";
+	kind: "alignment" | "anchor" | "reveal" | "runway" | "settlement";
 	scrollTarget: ScrollTarget | null;
 	runwayTarget: number | null;
 	retainActiveRunway: boolean;
@@ -90,6 +92,7 @@ interface ActiveMotion {
 	stabilityFrames: number;
 	stabilizing: boolean;
 	instant: boolean;
+	instantScroll: boolean;
 }
 
 function snapshotOf(state: ReadingBandState): ReadingBandSnapshot {
@@ -273,6 +276,10 @@ export function createReadingBandController(
 				if (active.instant) {
 					applyInstantMotion(active);
 				} else {
+					if (active.instantScroll) {
+						const target = boundedScrollTarget(active.scrollTarget);
+						if (target !== null) environment.writeScrollTop(target);
+					}
 					const bounds = environment.readScrollBounds();
 					active.startScrollTop = bounds?.scrollTop ?? active.startScrollTop;
 					active.startRunwayHeight = runwayHeight;
@@ -294,7 +301,11 @@ export function createReadingBandController(
 		const eased = easeOutCubic(progress);
 		const target = boundedScrollTarget(active.scrollTarget);
 		if (target !== null) {
-			environment.writeScrollTop(active.startScrollTop + (target - active.startScrollTop) * eased);
+			environment.writeScrollTop(
+				active.instantScroll
+					? target
+					: active.startScrollTop + (target - active.startScrollTop) * eased,
+			);
 		}
 		if (active.runwayTarget !== null) {
 			writeRunwayHeight(
@@ -336,6 +347,8 @@ export function createReadingBandController(
 		requireStreaming = false,
 		reevaluate = false,
 		stabilityFrames = 0,
+		instant = false,
+		instantScroll = false,
 	}: {
 		kind?: ActiveMotion["kind"];
 		scrollTarget?: ScrollTarget | null;
@@ -345,6 +358,8 @@ export function createReadingBandController(
 		requireStreaming?: boolean;
 		reevaluate?: boolean;
 		stabilityFrames?: number;
+		instant?: boolean;
+		instantScroll?: boolean;
 	}) => {
 		const bounds = environment.readScrollBounds();
 		const initialScrollTarget = boundedScrollTarget(scrollTarget);
@@ -361,7 +376,7 @@ export function createReadingBandController(
 			if (reevaluate) contentChanged();
 			return;
 		}
-		if (environment.prefersReducedMotion()) {
+		if (instant || environment.prefersReducedMotion()) {
 			cancelMotion();
 			const target = boundedScrollTarget(scrollTarget);
 			if (target !== null) environment.writeScrollTop(target);
@@ -385,6 +400,7 @@ export function createReadingBandController(
 					stabilityFrames,
 					stabilizing: true,
 					instant: true,
+					instantScroll,
 				};
 				publish({ moving: true });
 				frame = environment.requestFrame(advanceMotion);
@@ -407,6 +423,7 @@ export function createReadingBandController(
 			stabilityFrames,
 			stabilizing: false,
 			instant: false,
+			instantScroll,
 		};
 		publish({ moving: true });
 		frame ??= environment.requestFrame(advanceMotion);
@@ -484,6 +501,12 @@ export function createReadingBandController(
 		return true;
 	};
 
+	const refreshAnchor = () => {
+		if (motion?.kind !== "anchor") return;
+		const target = boundedScrollTarget(motion.scrollTarget);
+		if (target !== null) environment.writeScrollTop(target);
+	};
+
 	const settle = () => {
 		cancelAnchor();
 		immediateTurnPending = false;
@@ -503,6 +526,7 @@ export function createReadingBandController(
 	};
 
 	function contentChanged() {
+		refreshAnchor();
 		let geometry = environment.readGeometry();
 		if (!geometry || geometry.viewportHeight <= 0) return;
 		reconcileRunwayGrowth(geometry);
@@ -563,31 +587,32 @@ export function createReadingBandController(
 		return false;
 	}
 
+	const retainRunwayRelease = () => {
+		if (motion?.runwayTarget !== 0) return false;
+		if (motion.scrollTarget !== null || motion.requireFollowing || motion.stabilizing) {
+			const bounds = environment.readScrollBounds();
+			motion.kind = "runway";
+			motion.scrollTarget = null;
+			motion.retainActiveRunway = false;
+			motion.requireFollowing = false;
+			motion.requireStreaming = false;
+			motion.reevaluate = false;
+			motion.startScrollTop = bounds?.scrollTop ?? motion.startScrollTop;
+			motion.startRunwayHeight = runwayHeight;
+			motion.startedAt = environment.now();
+			motion.stabilityFrames = 0;
+			motion.stabilizing = false;
+			motion.instantScroll = false;
+		}
+		return true;
+	};
+
 	const yieldMotionToReader = () => {
 		cancelAnchor();
 		immediateTurnPending = false;
 		deferredUserTurn = null;
 		deferredLatestRow = null;
-		if (motion?.instant) {
-			cancelMotion();
-		} else if (motion?.runwayTarget === 0) {
-			if (motion.scrollTarget !== null || motion.requireFollowing || motion.stabilizing) {
-				const bounds = environment.readScrollBounds();
-				motion.kind = "runway";
-				motion.scrollTarget = null;
-				motion.retainActiveRunway = false;
-				motion.requireFollowing = false;
-				motion.requireStreaming = false;
-				motion.reevaluate = false;
-				motion.startScrollTop = bounds?.scrollTop ?? motion.startScrollTop;
-				motion.startRunwayHeight = runwayHeight;
-				motion.startedAt = environment.now();
-				motion.stabilityFrames = 0;
-				motion.stabilizing = false;
-			}
-		} else {
-			cancelMotion();
-		}
+		if (!retainRunwayRelease()) cancelMotion();
 		if (runwayHeight > GEOMETRY_EPSILON) {
 			if (motion?.runwayTarget !== 0) releaseRunway(true);
 		} else {
@@ -639,7 +664,8 @@ export function createReadingBandController(
 			cancelAnchor();
 		},
 		cancelReveal: () => {
-			if (motion?.kind === "reveal") cancelMotion();
+			if (motion?.kind !== "anchor" && motion?.kind !== "reveal") return;
+			if (!retainRunwayRelease()) cancelMotion();
 		},
 		revealTo: (target, stabilize) => {
 			cancelAnchor();
@@ -651,6 +677,19 @@ export function createReadingBandController(
 				stabilityFrames: stabilize ? EDGE_STABILITY_FRAMES : 0,
 			});
 		},
+		stabilizeAnchor: (target) => {
+			cancelAnchor();
+			const runwayTarget = motion?.runwayTarget === 0 ? 0 : null;
+			startMotion({
+				kind: "anchor",
+				scrollTarget: target,
+				runwayTarget,
+				requireFollowing: false,
+				stabilityFrames: EDGE_STABILITY_FRAMES,
+				instantScroll: true,
+			});
+		},
+		refreshAnchor,
 		readerLeft: () => {
 			yieldMotionToReader();
 			publish({ following: false });

--- a/apps/web/src/chat/readingBand.ts
+++ b/apps/web/src/chat/readingBand.ts
@@ -52,12 +52,12 @@ export interface ReadingBandController {
 	latestRowArrived: (index: number) => void;
 	contentChanged: () => void;
 	cancelMovement: () => void;
+	interruptForNativeInput: () => () => void;
 	cancelReveal: () => void;
 	revealTo: (target: () => number | null, stabilize: boolean) => void;
 	stabilizeAnchor: (target: () => number | null) => void;
 	refreshAnchor: () => void;
 	readerLeft: () => void;
-	readerMovedWhileFollowing: () => void;
 	readerReachedEdge: () => void;
 	returnToEdge: () => void;
 	releaseRunway: (smooth?: boolean) => void;
@@ -164,6 +164,7 @@ export function createReadingBandController(
 	};
 	let frame: number | null = null;
 	let motion: ActiveMotion | null = null;
+	let motionEpoch = 0;
 	let anchorFrame: number | null = null;
 	let activeStreamMount = streaming;
 	let reconstructed = false;
@@ -224,6 +225,7 @@ export function createReadingBandController(
 	};
 
 	const cancelMotion = () => {
+		motionEpoch += 1;
 		if (frame !== null) environment.cancelFrame(frame);
 		frame = null;
 		motion = null;
@@ -361,6 +363,7 @@ export function createReadingBandController(
 		instant?: boolean;
 		instantScroll?: boolean;
 	}) => {
+		motionEpoch += 1;
 		const bounds = environment.readScrollBounds();
 		const initialScrollTarget = boundedScrollTarget(scrollTarget);
 		const scrollAlreadySettled =
@@ -607,6 +610,38 @@ export function createReadingBandController(
 		return true;
 	};
 
+	const interruptForNativeInput = () => {
+		const paused = motion;
+		if (!paused) return () => undefined;
+		if (frame !== null) environment.cancelFrame(frame);
+		frame = null;
+		motion = null;
+		const epoch = motionEpoch + 1;
+		motionEpoch = epoch;
+		const wasFollowing = state.following;
+		const wasStreaming = state.streaming;
+		if (state.moving) publish({ moving: false });
+		return () => {
+			if (
+				motionEpoch !== epoch ||
+				motion !== null ||
+				state.following !== wasFollowing ||
+				state.streaming !== wasStreaming
+			)
+				return;
+			motionEpoch += 1;
+			const bounds = environment.readScrollBounds();
+			motion = {
+				...paused,
+				startedAt: environment.now(),
+				startScrollTop: bounds?.scrollTop ?? paused.startScrollTop,
+				startRunwayHeight: runwayHeight,
+			};
+			publish({ moving: true });
+			frame = environment.requestFrame(advanceMotion);
+		};
+	};
+
 	const yieldMotionToReader = () => {
 		cancelAnchor();
 		immediateTurnPending = false;
@@ -663,6 +698,7 @@ export function createReadingBandController(
 			cancelMotion();
 			cancelAnchor();
 		},
+		interruptForNativeInput,
 		cancelReveal: () => {
 			if (motion?.kind !== "anchor" && motion?.kind !== "reveal") return;
 			if (!retainRunwayRelease()) cancelMotion();
@@ -694,7 +730,6 @@ export function createReadingBandController(
 			yieldMotionToReader();
 			publish({ following: false });
 		},
-		readerMovedWhileFollowing: yieldMotionToReader,
 		readerReachedEdge: () => {
 			cancelMotion();
 			runwaySuppressed = false;
@@ -702,6 +737,7 @@ export function createReadingBandController(
 			if (!state.streaming) {
 				startMotion({
 					scrollTarget: latestTarget,
+					runwayTarget: 0,
 					stabilityFrames: EDGE_STABILITY_FRAMES,
 				});
 				return;
@@ -718,6 +754,7 @@ export function createReadingBandController(
 			if (!state.streaming) {
 				startMotion({
 					scrollTarget: latestTarget,
+					runwayTarget: 0,
 					stabilityFrames: EDGE_STABILITY_FRAMES,
 				});
 				return;

--- a/apps/web/src/chat/scrollGeometry.test.ts
+++ b/apps/web/src/chat/scrollGeometry.test.ts
@@ -13,7 +13,7 @@ function reveal(targetTop: number, targetBottom: number, block: "start" | "neare
 }
 
 describe("virtual row materialization", () => {
-	test("derives an offscreen row from one mounted row and shared height estimates", () => {
+	test("derives an offscreen row from one mounted row and measured-height fallbacks", () => {
 		const heights = [40, 80, 60, 100];
 		expect(estimatedRowTop(heights, 1, 200, 3)).toBe(340);
 		expect(estimatedRowTop(heights, 2, 280, 0)).toBe(160);

--- a/apps/web/src/chat/scrollGeometry.test.ts
+++ b/apps/web/src/chat/scrollGeometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { revealScrollTop } from "./scrollGeometry";
+import { alignedRowScrollTop, estimatedRowTop, revealScrollTop } from "./scrollGeometry";
 
 const viewport = {
 	scrollTop: 400,
@@ -11,6 +11,17 @@ const viewport = {
 function reveal(targetTop: number, targetBottom: number, block: "start" | "nearest") {
 	return revealScrollTop({ ...viewport, targetTop, targetBottom }, block);
 }
+
+describe("virtual row materialization", () => {
+	test("derives an offscreen row from one mounted row and shared height estimates", () => {
+		const heights = [40, 80, 60, 100];
+		expect(estimatedRowTop(heights, 1, 200, 3)).toBe(340);
+		expect(estimatedRowTop(heights, 2, 280, 0)).toBe(160);
+		expect(alignedRowScrollTop(340, 100, 300, "start")).toBe(340);
+		expect(alignedRowScrollTop(340, 100, 300, "center")).toBe(240);
+		expect(alignedRowScrollTop(340, 100, 300, "end")).toBe(140);
+	});
+});
 
 describe("revealScrollTop", () => {
 	test("leaves an already visible target unchanged for nearest reveal", () => {
@@ -27,6 +38,12 @@ describe("revealScrollTop", () => {
 		expect(reveal(20, 80, "start")).toBe(320);
 		expect(reveal(550, 650, "start")).toBe(850);
 		expect(reveal(180, 900, "start")).toBe(480);
+	});
+
+	test("aligns a target below a reserved sticky-row inset", () => {
+		expect(
+			revealScrollTop({ ...viewport, targetTop: 420, targetBottom: 460, topInset: 34 }, "start"),
+		).toBe(686);
 	});
 
 	test("uses the useful edge when an oversized target is outside the viewport", () => {

--- a/apps/web/src/chat/scrollGeometry.ts
+++ b/apps/web/src/chat/scrollGeometry.ts
@@ -5,6 +5,7 @@ export interface RevealScrollGeometry {
 	maxScrollTop: number;
 	viewportTop: number;
 	viewportBottom: number;
+	topInset?: number;
 	targetTop: number;
 	targetBottom: number;
 }
@@ -13,22 +14,60 @@ function clampScrollTop(scrollTop: number, maxScrollTop: number): number {
 	return Math.min(Math.max(0, maxScrollTop), Math.max(0, scrollTop));
 }
 
+export function estimatedRowTop(
+	heights: readonly number[],
+	anchorIndex: number,
+	anchorTop: number,
+	targetIndex: number,
+): number {
+	let top = anchorTop;
+	if (targetIndex > anchorIndex) {
+		for (let index = anchorIndex; index < targetIndex; index += 1) {
+			top += heights[index] ?? 0;
+		}
+	} else {
+		for (let index = targetIndex; index < anchorIndex; index += 1) {
+			top -= heights[index] ?? 0;
+		}
+	}
+	return top;
+}
+
+export function alignedRowScrollTop(
+	rowTop: number,
+	rowHeight: number,
+	viewportHeight: number,
+	align: "start" | "center" | "end",
+): number {
+	if (align === "start") return rowTop;
+	if (align === "end") return rowTop + rowHeight - viewportHeight;
+	return rowTop + rowHeight / 2 - viewportHeight / 2;
+}
+
 export function revealScrollTop(geometry: RevealScrollGeometry, block: RevealBlock): number {
-	const { scrollTop, maxScrollTop, viewportTop, viewportBottom, targetTop, targetBottom } =
-		geometry;
+	const {
+		scrollTop,
+		maxScrollTop,
+		viewportTop,
+		viewportBottom,
+		topInset = 0,
+		targetTop,
+		targetBottom,
+	} = geometry;
+	const contentTop = viewportTop + topInset;
 	let destination = scrollTop;
 
 	if (block === "start") {
-		destination += targetTop - viewportTop;
+		destination += targetTop - contentTop;
 	} else {
-		const viewportHeight = viewportBottom - viewportTop;
+		const viewportHeight = viewportBottom - contentTop;
 		const targetHeight = targetBottom - targetTop;
-		if (targetTop < viewportTop && targetBottom < viewportBottom) {
+		if (targetTop < contentTop && targetBottom < viewportBottom) {
 			destination +=
-				targetHeight > viewportHeight ? targetBottom - viewportBottom : targetTop - viewportTop;
-		} else if (targetBottom > viewportBottom && targetTop > viewportTop) {
+				targetHeight > viewportHeight ? targetBottom - viewportBottom : targetTop - contentTop;
+		} else if (targetBottom > viewportBottom && targetTop > contentTop) {
 			destination +=
-				targetHeight > viewportHeight ? targetTop - viewportTop : targetBottom - viewportBottom;
+				targetHeight > viewportHeight ? targetTop - contentTop : targetBottom - viewportBottom;
 		}
 	}
 

--- a/apps/web/src/chat/tools/AskUserQuestionCard.tsx
+++ b/apps/web/src/chat/tools/AskUserQuestionCard.tsx
@@ -395,7 +395,12 @@ export function AskUserQuestionCard({
 		const frame = requestAnimationFrame(() => {
 			const card = cardRef.current;
 			if (!card) return;
-			actions?.revealChatElement(currentQuestionPageStart(card), "start", "release");
+			actions?.revealChatElement(currentQuestionPageStart(card), {
+				block: "start",
+				provenance: "user-navigation",
+				runway: "release",
+				stability: "bounded",
+			});
 			focusCurrentQuestionPage(card);
 		});
 		return () => cancelAnimationFrame(frame);
@@ -408,6 +413,7 @@ export function AskUserQuestionCard({
 		let userTookOver = false;
 		const yieldToUser = () => {
 			userTookOver = true;
+			actions?.cancelAutomaticReveal();
 		};
 		window.addEventListener("pointerdown", yieldToUser, { capture: true, once: true });
 		window.addEventListener("keydown", yieldToUser, { capture: true, once: true });
@@ -415,7 +421,14 @@ export function AskUserQuestionCard({
 		const settleAttention = () => {
 			const card = cardRef.current;
 			if (!card || userTookOver) return;
-			actions?.revealChatElement(currentQuestionPageStart(card), "start", "release");
+			if (attempts === 0) {
+				actions?.revealChatElement(currentQuestionPageStart(card), {
+					block: "start",
+					provenance: "automatic-attention",
+					runway: "release",
+					stability: "bounded",
+				});
+			}
 			if (!card.contains(document.activeElement)) {
 				const kind = focusTargetKind(document.activeElement, card);
 				if (shouldClaimQuestionFocus(kind, hasCoarsePointer())) focusQuestionAttention(card);

--- a/apps/web/src/chat/tools/Collapsible.tsx
+++ b/apps/web/src/chat/tools/Collapsible.tsx
@@ -1,22 +1,30 @@
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { useFold } from "../foldState";
 
 const THRESHOLD = 24;
 
 export function Collapsible({
+	id,
 	lines,
 	children,
 	fadeClass = "bg-[linear-gradient(to_top,var(--container-header-bg),transparent)]",
 }: {
+	id: string;
 	lines: number;
 	children: ReactNode;
 	fadeClass?: string;
 }) {
-	const [expanded, setExpanded] = useState(false);
+	const [expanded, toggle, toggleRef] = useFold(id);
 
 	if (lines <= THRESHOLD) return <>{children}</>;
 
 	return (
-		<div data-testid="collapsible" data-expanded={expanded} className="flex flex-col gap-4">
+		<div
+			data-testid="collapsible"
+			data-chat-fold-root
+			data-expanded={expanded}
+			className="flex flex-col gap-4"
+		>
 			<div className={expanded ? undefined : "relative max-h-384 overflow-hidden"}>
 				{children}
 				{expanded ? null : (
@@ -24,9 +32,11 @@ export function Collapsible({
 				)}
 			</div>
 			<button
+				ref={toggleRef}
 				type="button"
 				data-testid="collapsible-toggle"
-				onClick={() => setExpanded((e) => !e)}
+				aria-expanded={expanded}
+				onClick={toggle}
 				className="self-start text-primary tr-text-metadata hover:underline"
 			>
 				{expanded ? "Show less" : `Show all ${lines} lines`}

--- a/apps/web/src/chat/tools/EditCard.tsx
+++ b/apps/web/src/chat/tools/EditCard.tsx
@@ -4,7 +4,14 @@ import { Collapsible } from "./Collapsible";
 import { ToolFileLink } from "./ToolFileLink";
 import { resultText, strArg } from "./toolHelpers";
 
-export function EditCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
+export function EditCard({
+	toolCallId,
+	args,
+	result,
+	status,
+	workspaceRoot,
+	onOpenFile,
+}: ToolRenderProps) {
 	const path = strArg(args, "path");
 	const oldText = strArg(args, "oldText") || strArg(args, "old_string") || strArg(args, "old");
 	const newText = strArg(args, "newText") || strArg(args, "new_string") || strArg(args, "new");
@@ -36,6 +43,7 @@ export function EditCard({ args, result, status, workspaceRoot, onOpenFile }: To
 				disabled={status !== "done"}
 			/>
 			<Collapsible
+				id={`${toolCallId}:content`}
 				lines={oldLines.length + newLines.length}
 				fadeClass="bg-[linear-gradient(to_top,var(--container-elevated-bg),transparent)]"
 			>

--- a/apps/web/src/chat/tools/ReadCard.tsx
+++ b/apps/web/src/chat/tools/ReadCard.tsx
@@ -5,7 +5,14 @@ import { Collapsible, countLines } from "./Collapsible";
 import { ToolFileLink } from "./ToolFileLink";
 import { languageFromPath, numArg, resultText, strArg } from "./toolHelpers";
 
-export function ReadCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
+export function ReadCard({
+	toolCallId,
+	args,
+	result,
+	status,
+	workspaceRoot,
+	onOpenFile,
+}: ToolRenderProps) {
 	const path = strArg(args, "path");
 	const offset = numArg(args, "offset");
 	const limit = numArg(args, "limit");
@@ -37,7 +44,7 @@ export function ReadCard({ args, result, status, workspaceRoot, onOpenFile }: To
 			) : status === "error" ? (
 				<pre className="overflow-auto px-8 py-4 text-feedback-error tr-code-text">{output}</pre>
 			) : output ? (
-				<Collapsible lines={countLines(output)}>
+				<Collapsible id={`${toolCallId}:content`} lines={countLines(output)}>
 					<CodeBlock code={output} lang={lang} />
 				</Collapsible>
 			) : (

--- a/apps/web/src/chat/tools/SPEC.md
+++ b/apps/web/src/chat/tools/SPEC.md
@@ -205,7 +205,8 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 - **`subagent/`** — delegation renderers for `pi-subagents`: `AgentCard` (the `Agent` tool — **primary**;
   also registered for `get_subagent_result`, routine), the `SubagentCompletionCard` turn card, and the
   pure `runDetails` readers/formatters; own child spec ([subagent/SPEC.md](subagent/SPEC.md)).
-- **Shared pieces** — `CodeBlock` (shiki), `Collapsible` ("Show all N lines" fold for long output),
+- **Shared pieces** — `CodeBlock` (shiki), `Collapsible` ("Show all N lines" fold for long output;
+  callers supply a stable tool-call-derived id so state and geometry anchoring survive virtualization),
   `ToolFileLink` + exact-reference linked text backed by the parent chat module's shared
   `workspaceFileTarget`, pure `toolHelpers` (arg readers, `resultText`, `languageFromPath`) + `lib`'s
   `projectRelativePath`. `resultText` delegates canonical result parsing to
@@ -217,7 +218,7 @@ registration runs once when the chat module mounts. Unregistered tools fall back
 - **Public surface:** the side-effect `register` import + the shared `CodeBlock`/`Collapsible`/
   `toolHelpers` for sibling renderers + `visualize/MermaidView` for the parent `Markdown` primitive. No barrel (chat pulls shiki — per-file imports, as in the parent).
 - **Allowed deps:** parent chat primitives (`toolRegistry`, `Markdown`, `ChatActions`, `askState`,
-  `fileTargets`);
+  `fileTargets`, `foldState`);
   `contracts` (type-only + the `ASK_USER_ANSWERS_CUSTOM_TYPE` constant); `components/ui`; `lib`;
   `@remixicon/react`; `mermaid` (**lazy, `visualize/` only**).
 - **Forbidden:** value-importing any `pi` package; `store`/`transport` (renderers stay presentational —

--- a/apps/web/src/chat/tools/SpecToolCard.tsx
+++ b/apps/web/src/chat/tools/SpecToolCard.tsx
@@ -168,6 +168,7 @@ export function specToolSummary({ toolName, args }: ToolRenderProps): string {
 }
 
 export function SpecToolCard({
+	toolCallId,
 	toolName,
 	args,
 	result,
@@ -199,7 +200,9 @@ export function SpecToolCard({
 	);
 	return (
 		<div data-testid={`tool-${toolName}`}>
-			<Collapsible lines={countLines(output)}>{content}</Collapsible>
+			<Collapsible id={`${toolCallId}:content`} lines={countLines(output)}>
+				{content}
+			</Collapsible>
 		</div>
 	);
 }

--- a/apps/web/src/chat/tools/WriteCard.tsx
+++ b/apps/web/src/chat/tools/WriteCard.tsx
@@ -5,7 +5,14 @@ import { Collapsible, countLines } from "./Collapsible";
 import { ToolFileLink } from "./ToolFileLink";
 import { languageFromPath, resultText, strArg } from "./toolHelpers";
 
-export function WriteCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
+export function WriteCard({
+	toolCallId,
+	args,
+	result,
+	status,
+	workspaceRoot,
+	onOpenFile,
+}: ToolRenderProps) {
 	const path = strArg(args, "path");
 	const content = strArg(args, "content");
 	const lang = languageFromPath(path);
@@ -27,7 +34,7 @@ export function WriteCard({ args, result, status, workspaceRoot, onOpenFile }: T
 			{status === "error" ? (
 				<pre className="overflow-auto px-8 py-4 text-feedback-error tr-code-text">{message}</pre>
 			) : content ? (
-				<Collapsible lines={countLines(content)}>
+				<Collapsible id={`${toolCallId}:content`} lines={countLines(content)}>
 					<CodeBlock code={content} lang={lang} />
 				</Collapsible>
 			) : (

--- a/apps/web/src/chat/tools/subagent/AgentCard.tsx
+++ b/apps/web/src/chat/tools/subagent/AgentCard.tsx
@@ -22,10 +22,10 @@ export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps)
 	const backgroundAck = args.run_in_background === true && details !== undefined && !terminal;
 	const meta = details ? [details.model, ...runCounters(details, "split")].filter(Boolean) : [];
 	const output = resultText(result);
-	const [reportOpen, toggleReport] = useFold(`${toolCallId}:report`, false);
+	const [reportOpen, toggleReport, reportToggleRef] = useFold(`${toolCallId}:report`, false);
 
 	return (
-		<div data-testid="tool-agent" className="flex flex-col gap-4">
+		<div data-testid="tool-agent" data-chat-fold-root className="flex flex-col gap-4">
 			<div className="flex items-center gap-4 tr-text-metadata">
 				<Bot className="size-12 shrink-0 text-text-muted" />
 				<span className="shrink-0 text-primary">{role || "subagent"}</span>
@@ -36,7 +36,7 @@ export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps)
 				) : null}
 			</div>
 			{task ? (
-				<Collapsible lines={countLines(task)}>
+				<Collapsible id={`${toolCallId}:task`} lines={countLines(task)}>
 					<div className="whitespace-pre-wrap break-words text-text-muted tr-text-metadata">
 						{task}
 					</div>
@@ -74,6 +74,7 @@ export function AgentCard({ toolCallId, args, result, status }: ToolRenderProps)
 			) : status === "done" && output ? (
 				<div className="flex flex-col gap-4">
 					<button
+						ref={reportToggleRef}
 						type="button"
 						data-testid="agent-report-toggle"
 						aria-expanded={reportOpen}

--- a/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
+++ b/apps/web/src/chat/tools/subagent/SubagentCompletionCard.tsx
@@ -32,13 +32,14 @@ export function SubagentCompletionCard({
 	text: string;
 }) {
 	const actions = useChatActions();
-	const [reportOpen, toggleReport] = useFold(`${id}:report`, false);
+	const [reportOpen, toggleReport, reportToggleRef] = useFold(`${id}:report`, false);
 	const role = details.roleName ?? "subagent";
 	const counters = runCounters(details).join(" · ");
 
 	return (
 		<div
 			data-testid="subagent-completion"
+			data-chat-fold-root
 			data-status={details.status}
 			className="flex flex-col gap-4 rounded-[var(--radius-sm)] border border-border-default bg-container-elevated-bg px-8 py-4 tr-text-metadata"
 		>
@@ -77,6 +78,7 @@ export function SubagentCompletionCard({
 			{text ? (
 				<div className="flex flex-col gap-4">
 					<button
+						ref={reportToggleRef}
 						type="button"
 						data-testid="subagent-completion-report-toggle"
 						aria-expanded={reportOpen}

--- a/apps/web/src/chat/tools/web/WebFetchCard.tsx
+++ b/apps/web/src/chat/tools/web/WebFetchCard.tsx
@@ -24,7 +24,14 @@ export function webFetchSummary({ args }: ToolRenderProps): string {
 	return firstUrl(args);
 }
 
-export function WebFetchCard({ args, result, status, workspaceRoot, onOpenFile }: ToolRenderProps) {
+export function WebFetchCard({
+	toolCallId,
+	args,
+	result,
+	status,
+	workspaceRoot,
+	onOpenFile,
+}: ToolRenderProps) {
 	const url = firstUrl(args);
 	const external = httpUrl(url);
 	const label = external ? external.hostname.replace(/^www\./, "") : "fetch";
@@ -57,6 +64,7 @@ export function WebFetchCard({ args, result, status, workspaceRoot, onOpenFile }
 				)}
 			</div>
 			<WebResultBody
+				id={`${toolCallId}:content`}
 				output={output}
 				status={status}
 				runningLabel="Fetching…"

--- a/apps/web/src/chat/tools/web/WebResultBody.tsx
+++ b/apps/web/src/chat/tools/web/WebResultBody.tsx
@@ -3,11 +3,13 @@ import type { ToolStatus } from "../../types";
 import { Collapsible, countLines } from "../Collapsible";
 
 export function WebResultBody({
+	id,
 	output,
 	status,
 	runningLabel,
 	emptyLabel,
 }: {
+	id: string;
 	output: string;
 	status: ToolStatus;
 	runningLabel: string;
@@ -23,7 +25,7 @@ export function WebResultBody({
 		return <span className="text-text-muted tr-text-metadata italic">{emptyLabel}</span>;
 	}
 	return (
-		<Collapsible lines={countLines(output)}>
+		<Collapsible id={id} lines={countLines(output)}>
 			<Markdown text={output} />
 		</Collapsible>
 	);

--- a/apps/web/src/chat/tools/web/WebSearchCard.tsx
+++ b/apps/web/src/chat/tools/web/WebSearchCard.tsx
@@ -22,7 +22,7 @@ function providerOf(result: unknown): string {
 	return typeof p === "string" ? p : "";
 }
 
-export function WebSearchCard({ args, result, status }: ToolRenderProps) {
+export function WebSearchCard({ toolCallId, args, result, status }: ToolRenderProps) {
 	const query = firstQuery(args);
 	const provider = providerOf(result);
 	const output = resultText(result);
@@ -37,6 +37,7 @@ export function WebSearchCard({ args, result, status }: ToolRenderProps) {
 				{provider ? <span className="shrink-0 text-text-muted">via {provider}</span> : null}
 			</div>
 			<WebResultBody
+				id={`${toolCallId}:content`}
 				output={output}
 				status={status}
 				runningLabel="Searching…"

--- a/apps/web/src/chat/tools/web/WebStoredContentCard.tsx
+++ b/apps/web/src/chat/tools/web/WebStoredContentCard.tsx
@@ -27,7 +27,7 @@ export function storedContentSummary({ args, result }: ToolRenderProps): string 
 	return storedContentTarget(args, result) || strArg(args, "responseId");
 }
 
-export function WebStoredContentCard({ args, result, status }: ToolRenderProps) {
+export function WebStoredContentCard({ toolCallId, args, result, status }: ToolRenderProps) {
 	const responseId = strArg(args, "responseId");
 	const target = storedContentTarget(args, result);
 	const output = resultText(result);
@@ -45,6 +45,7 @@ export function WebStoredContentCard({ args, result, status }: ToolRenderProps) 
 				) : null}
 			</div>
 			<WebResultBody
+				id={`${toolCallId}:content`}
 				output={output}
 				status={status}
 				runningLabel="Loading stored content…"

--- a/apps/web/src/chat/turns.tsx
+++ b/apps/web/src/chat/turns.tsx
@@ -11,7 +11,7 @@ import {
 	RiToolsLine as Wrench,
 } from "@remixicon/react";
 import type { ImageContent, UserMessage } from "@thinkrail/contracts";
-import { type ReactNode, useEffect, useState } from "react";
+import { type MouseEvent as ReactMouseEvent, type ReactNode, useEffect, useState } from "react";
 import { CustomIcon } from "@/components/CustomIcon";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -301,11 +301,11 @@ function PlainUserTurn({
 	agentResponded: boolean;
 }) {
 	const large = text.length > LARGE_USER_MESSAGE;
-	const [expanded, toggle] = useFold(`${id}:user-collapse`, !agentResponded);
+	const [expanded, toggle, toggleRef] = useFold(`${id}:user-collapse`, !agentResponded);
 	const collapsed = large && !expanded;
 	return (
 		<MessageWithCopy messageRole="user" side="right" getText={() => text}>
-			<div className="flex w-fit max-w-[85%] flex-col items-end">
+			<div data-chat-fold-root className="flex w-fit max-w-[85%] flex-col items-end">
 				<div className={cn(USER_BUBBLE_BASE, "pr-24")}>
 					{attachments.length > 0 ? (
 						<div className="flex flex-wrap gap-4 pb-4" data-testid="chat-message-images">
@@ -323,6 +323,7 @@ function PlainUserTurn({
 					</div>
 					{large ? (
 						<button
+							ref={toggleRef}
 							type="button"
 							data-testid="user-message-toggle"
 							aria-expanded={expanded}
@@ -350,14 +351,16 @@ function SkillInvocationCard({
 	foldId: string;
 	invocation: SkillInvocation;
 }) {
-	const [expanded, toggle] = useFold(foldId);
+	const [expanded, toggle, toggleRef] = useFold(foldId);
 	return (
 		<div
 			data-testid="skill-invocation-card"
+			data-chat-fold-root
 			data-expanded={expanded}
 			className="max-w-[85%] overflow-hidden rounded-[var(--radius-lg)] border border-bubble-user-border bg-clip-padding bg-bubble-user-bg"
 		>
 			<button
+				ref={toggleRef}
 				type="button"
 				data-testid="skill-invocation-toggle"
 				aria-expanded={expanded}
@@ -405,10 +408,11 @@ function keyPackageItems(items: ReviewPackageItem[]): { key: string; item: Revie
 }
 
 function PackageCommentRow({ foldId, item }: { foldId: string; item: ReviewPackageItem }) {
-	const [expanded, toggle] = useFold(foldId);
+	const [expanded, toggle, toggleRef] = useFold(foldId);
 	return (
-		<li data-testid="review-package-item" data-expanded={expanded}>
+		<li data-testid="review-package-item" data-chat-fold-root data-expanded={expanded}>
 			<button
+				ref={toggleRef}
 				type="button"
 				data-testid="review-package-item-toggle"
 				aria-expanded={expanded}
@@ -507,15 +511,16 @@ function CompactionTurn({
 	tokensAfter?: number | undefined;
 	resuming?: boolean | undefined;
 }) {
-	const [open, toggle] = useFold(id);
+	const [open, toggle, toggleRef] = useFold(id);
 	const label = resuming ? "Context compacted — resuming…" : "Context compacted";
 	const tokens =
 		tokensAfter === undefined
 			? `${formatTokens(tokensBefore)} tokens`
 			: `${formatTokens(tokensBefore)} → ${formatTokens(tokensAfter)} tokens`;
 	return (
-		<div data-testid="chat-compaction" className="flex flex-col gap-8">
+		<div data-testid="chat-compaction" data-chat-fold-root className="flex flex-col gap-8">
 			<button
+				ref={toggleRef}
 				type="button"
 				aria-expanded={open}
 				onClick={toggle}
@@ -671,7 +676,7 @@ function ArtifactChip({
 }: {
 	group: ArtifactGroup;
 	listId: string;
-	onSelect: () => void;
+	onSelect: (event: ReactMouseEvent<HTMLButtonElement>) => void;
 }) {
 	const { id, icon: Icon, paths, label, expanded, onOpen, reveal } = group;
 	const many = paths.length > 1;
@@ -683,13 +688,13 @@ function ArtifactChip({
 			data-expanded={many && expanded ? true : undefined}
 			aria-expanded={many ? expanded : undefined}
 			aria-controls={many && expanded ? listId : undefined}
-			onClick={() => {
+			onClick={(event) => {
 				if (!many) {
 					if (first) onOpen(first);
 					return;
 				}
 				if (!expanded) reveal();
-				onSelect();
+				onSelect(event);
 			}}
 			className={cn(
 				"flex items-center gap-4 rounded-[var(--radius-sm)] px-4 text-primary hover:bg-control-bg-hovered",
@@ -787,6 +792,7 @@ export function TurnDivider({
 	return (
 		<div
 			data-testid="turn-divider"
+			data-chat-fold-root
 			className="my-8 flex flex-col gap-4 text-text-muted tr-text-metadata"
 		>
 			<div className="flex items-center gap-8">
@@ -802,7 +808,7 @@ export function TurnDivider({
 						key={group.id}
 						group={group}
 						listId={`${id}-${group.id}-list`}
-						onSelect={() => select(group.id)}
+						onSelect={(event) => select(group.id, event)}
 					/>
 				))}
 				{elapsedMs != null && elapsedMs >= 1000 ? (

--- a/apps/web/src/chat/useChatScroll.ts
+++ b/apps/web/src/chat/useChatScroll.ts
@@ -35,6 +35,8 @@ interface RowLocation {
 	index: number;
 }
 
+type RowRevealResult = "cancelled" | "found" | "missing";
+
 export interface ChatScroll {
 	followOutput: false;
 	handleContentHeight: () => void;
@@ -52,23 +54,30 @@ export interface ChatScroll {
 	cancelImmediateTurn: (streaming: boolean) => void;
 	cancelAutomaticReveal: () => void;
 	revealElement: (target: HTMLElement, options: ChatRevealOptions) => void;
-	revealRow: (rowId: string, index: number, align: "start" | "center" | "end") => void;
+	revealRow: (
+		rowId: string,
+		resolveIndex: () => number,
+		align: "start" | "center" | "end",
+		onComplete: (result: RowRevealResult) => void,
+	) => () => void;
 	prepareFoldChange: (resolveTarget: FoldAnchorResolver) => () => void;
 	runwayActive: boolean;
 	followState: "following" | "detached";
 	containerProps: ScrollContainerProps;
 }
 
-const TRANSIENT_MOTION_CANCEL_KEYS = new Set([
+const NATIVE_SCROLL_INTENT_MS = 500;
+const ROW_MATERIALIZATION_FRAMES = 90;
+const ROW_ALIGNMENT_STABILITY_FRAMES = 4;
+
+const KEYBOARD_SCROLL_KEYS = new Set([
 	" ",
 	"ArrowDown",
 	"ArrowUp",
 	"End",
-	"Enter",
 	"Home",
 	"PageDown",
 	"PageUp",
-	"Tab",
 ]);
 
 function nearestHtmlElement(element: Element | null): HTMLElement | null {
@@ -163,10 +172,15 @@ export function useChatScroll(
 	messageOrder: ChatMessageOrder,
 	latestUserRow: RowLocation | null,
 	latestRow: RowLocation | null,
+	firstItemIndex: number,
 	rowHeightEstimates: readonly number[],
 	movement: StreamingResponseMovement,
 ): ChatScroll {
 	const edge = latestEdge(messageOrder);
+	const firstItemIndexRef = useRef(firstItemIndex);
+	firstItemIndexRef.current = firstItemIndex;
+	const rowHeightEstimatesRef = useRef(rowHeightEstimates);
+	rowHeightEstimatesRef.current = rowHeightEstimates;
 	const scrollerRef = useRef<HTMLElement | null>(null);
 	const headerElementRef = useRef<HTMLDivElement | null>(null);
 	const edgeRef = useRef<HTMLDivElement | null>(null);
@@ -179,14 +193,20 @@ export function useChatScroll(
 	latestEdgeRef.current = edge;
 	const interactionStartScrollTop = useRef(0);
 	const returnIntentUntil = useRef(0);
+	const pointerIntentUntil = useRef(0);
+	const keyboardIntentUntil = useRef(0);
+	const wheelIntentUntil = useRef(0);
 	const activePointerId = useRef<number | null>(null);
 	const activePointerType = useRef<string | null>(null);
+	const pointerMayContinueScroll = useRef(false);
 	const touchPointerActive = useRef(false);
 	const touchMomentum = useRef(false);
 	const touchMovingTowardLatest = useRef<boolean | null>(null);
 	const previousTouchScrollTop = useRef(0);
 	const programmaticScrollTop = useRef<number | null>(null);
 	const touchSettleTimer = useRef<number | null>(null);
+	const nativeInterruptionGeneration = useRef(0);
+	const nativeResume = useRef<(() => void) | null>(null);
 	const pendingImmediateTurn = useRef(false);
 	const observedLifecycle = useRef({ isStreaming, settlementTick });
 	const previousUserRowId = useRef(latestUserRow?.id ?? null);
@@ -194,6 +214,7 @@ export function useChatScroll(
 	const latestRowFrame = useRef<number | null>(null);
 	const rowRevealFrame = useRef<number | null>(null);
 	const rowRevealGeneration = useRef(0);
+	const rowRevealCompletion = useRef<((result: RowRevealResult) => void) | null>(null);
 	const foldResizeObserver = useRef<ResizeObserver | null>(null);
 	const foldSurvivorElement = useRef<HTMLElement | null>(null);
 	const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
@@ -286,21 +307,43 @@ export function useChatScroll(
 		),
 	);
 
+	const resumeNativeMotion = useCallback(() => {
+		const resume = nativeResume.current;
+		nativeResume.current = null;
+		resume?.();
+	}, []);
+
+	const pauseForNativeInput = useCallback(() => {
+		resumeNativeMotion();
+		const resume = controller.interruptForNativeInput();
+		nativeResume.current = resume;
+		return resume;
+	}, [controller, resumeNativeMotion]);
+
 	const clearReturnIntent = useCallback(() => {
+		resumeNativeMotion();
+		nativeInterruptionGeneration.current += 1;
 		returnIntentUntil.current = 0;
+		pointerIntentUntil.current = 0;
+		keyboardIntentUntil.current = 0;
+		wheelIntentUntil.current = 0;
 		activePointerId.current = null;
 		activePointerType.current = null;
+		pointerMayContinueScroll.current = false;
 		touchPointerActive.current = false;
 		touchMomentum.current = false;
 		touchMovingTowardLatest.current = null;
 		if (touchSettleTimer.current !== null) window.clearTimeout(touchSettleTimer.current);
 		touchSettleTimer.current = null;
-	}, []);
+	}, [resumeNativeMotion]);
 
-	const cancelRowReveal = useCallback(() => {
+	const cancelRowReveal = useCallback((notify = true) => {
 		rowRevealGeneration.current += 1;
 		if (rowRevealFrame.current !== null) cancelAnimationFrame(rowRevealFrame.current);
 		rowRevealFrame.current = null;
+		const completion = rowRevealCompletion.current;
+		rowRevealCompletion.current = null;
+		if (notify) completion?.("cancelled");
 	}, []);
 
 	const clearFoldResizeObserver = useCallback(() => {
@@ -314,7 +357,7 @@ export function useChatScroll(
 		const scroller = scrollerRef.current;
 		const returning = touchMomentum.current
 			? touchMovingTowardLatest.current === true
-			: returnIntentUntil.current > 0;
+			: returnIntentUntil.current > performance.now();
 		if (returning && scroller && reachedLatestEdge(scroller, edge)) {
 			controller.readerReachedEdge();
 		}
@@ -336,6 +379,25 @@ export function useChatScroll(
 		controller.readerLeft();
 	}, [cancelRowReveal, clearReturnIntent, controller]);
 
+	const interruptForNativeInput = useCallback(
+		(scroller: HTMLElement) => {
+			const generation = nativeInterruptionGeneration.current + 1;
+			nativeInterruptionGeneration.current = generation;
+			const scrollTopBeforeInput = boundedScrollTop(scroller);
+			const resume = pauseForNativeInput();
+			requestAnimationFrame(() => {
+				if (
+					nativeInterruptionGeneration.current !== generation ||
+					Math.abs(boundedScrollTop(scroller) - scrollTopBeforeInput) > 1
+				)
+					return;
+				nativeResume.current = null;
+				resume();
+			});
+		},
+		[pauseForNativeInput],
+	);
+
 	const prepareFoldChange = useCallback(
 		(resolveTarget: FoldAnchorResolver) => {
 			let afterChange = false;
@@ -347,6 +409,10 @@ export function useChatScroll(
 			const target = resolveTarget();
 			if (!scroller || !target || !scroller.contains(target)) return complete;
 			controller.cancelReveal();
+			pointerIntentUntil.current = 0;
+			keyboardIntentUntil.current = 0;
+			wheelIntentUntil.current = 0;
+			returnIntentUntil.current = 0;
 			clearFoldResizeObserver();
 			if (controller.getSnapshot().following) return complete;
 			const changedRow = target.closest<HTMLElement>("[data-chat-row-id]");
@@ -571,19 +637,32 @@ export function useChatScroll(
 			}
 			programmaticScrollTop.current = null;
 			if (delta === 0) return;
-			const pointerMoving = activePointerId.current !== null;
-			const wheelReturning = returnIntentUntil.current > 0;
-			if (!touchMomentum.current && !pointerMoving && !wheelReturning) return;
+			const now = performance.now();
+			if (returnIntentUntil.current <= now) returnIntentUntil.current = 0;
+			if (pointerIntentUntil.current <= now) pointerIntentUntil.current = 0;
+			if (keyboardIntentUntil.current <= now) keyboardIntentUntil.current = 0;
+			if (wheelIntentUntil.current <= now) wheelIntentUntil.current = 0;
+			const pointerMoving =
+				(activePointerId.current !== null && pointerMayContinueScroll.current) ||
+				pointerIntentUntil.current > now;
+			const keyboardMoving = keyboardIntentUntil.current > now;
+			const wheelMoving = wheelIntentUntil.current > now;
+			const wheelReturning = returnIntentUntil.current > now;
+			if (
+				!touchMomentum.current &&
+				!pointerMoving &&
+				!keyboardMoving &&
+				!wheelMoving &&
+				!wheelReturning
+			)
+				return;
 			const movedTowardLatest = edge === "bottom" ? delta > 0 : delta < 0;
 			touchMovingTowardLatest.current = movedTowardLatest;
-			if (!isStreaming && movedTowardLatest && controller.getSnapshot().following) {
-				controller.readerMovedWhileFollowing();
-				return;
-			}
-			if (controller.getSnapshot().following) controller.readerLeft();
+			nativeResume.current = null;
+			cancelRowReveal();
+			controller.readerLeft();
 			if (!movedTowardLatest) {
 				returnIntentUntil.current = 0;
-				controller.readerLeft();
 				return;
 			}
 			if (reachedLatestEdge(scrollerElement, edge)) {
@@ -595,14 +674,22 @@ export function useChatScroll(
 			if (touchMomentum.current && !touchPointerActive.current) scheduleTouchSettle(1_000);
 		};
 		const onScrollEnd = () => {
+			if (activePointerId.current !== null) return;
 			if (touchMomentum.current) {
-				settleTouch();
+				if (touchMovingTowardLatest.current === true || reachedLatestEdge(scrollerElement, edge)) {
+					settleTouch();
+				} else {
+					scheduleTouchSettle(1_000);
+				}
 				return;
 			}
-			if (returnIntentUntil.current > 0 && reachedLatestEdge(scrollerElement, edge)) {
+			if (
+				returnIntentUntil.current > performance.now() &&
+				reachedLatestEdge(scrollerElement, edge)
+			) {
 				controller.readerReachedEdge();
-				clearReturnIntent();
 			}
+			clearReturnIntent();
 		};
 		scrollerElement.addEventListener("scroll", onScroll, { passive: true });
 		scrollerElement.addEventListener("scrollend", onScrollEnd);
@@ -610,7 +697,15 @@ export function useChatScroll(
 			scrollerElement.removeEventListener("scroll", onScroll);
 			scrollerElement.removeEventListener("scrollend", onScrollEnd);
 		};
-	}, [controller, edge, isStreaming, scheduleTouchSettle, scrollerElement, settleTouch]);
+	}, [
+		cancelRowReveal,
+		clearReturnIntent,
+		controller,
+		edge,
+		scheduleTouchSettle,
+		scrollerElement,
+		settleTouch,
+	]);
 
 	useEffect(() => {
 		const onSelectionChange = () => {
@@ -637,7 +732,7 @@ export function useChatScroll(
 			if (latestRowFrame.current !== null) cancelAnimationFrame(latestRowFrame.current);
 			latestRowFrame.current = null;
 			clearFoldResizeObserver();
-			cancelRowReveal();
+			cancelRowReveal(false);
 			controller.dispose();
 		},
 		[cancelRowReveal, clearFoldResizeObserver, clearReturnIntent, controller],
@@ -725,54 +820,118 @@ export function useChatScroll(
 	);
 
 	const revealRow = useCallback(
-		(rowId: string, index: number, align: "start" | "center" | "end") => {
+		(
+			rowId: string,
+			resolveIndex: () => number,
+			align: "start" | "center" | "end",
+			onComplete: (result: RowRevealResult) => void,
+		) => {
+			cancelRowReveal();
 			readerLeft();
+			rowRevealCompletion.current = onComplete;
 			controller.releaseRunway(false);
 			const scroller = scrollerRef.current;
-			if (!scroller) return;
+			if (!scroller) {
+				rowRevealCompletion.current = null;
+				onComplete("missing");
+				return () => undefined;
+			}
 			const generation = rowRevealGeneration.current;
-			const revealMountedRow = () => {
-				if (generation !== rowRevealGeneration.current) return true;
-				const row = mountedChatRow(scroller, rowId);
-				if (!row) return false;
+			let attempts = 0;
+			let alignedFrames = 0;
+			let revealStarted = false;
+			const finish = (result: RowRevealResult) => {
+				if (generation !== rowRevealGeneration.current) return;
+				rowRevealGeneration.current += 1;
+				if (rowRevealFrame.current !== null) cancelAnimationFrame(rowRevealFrame.current);
 				rowRevealFrame.current = null;
+				if (result !== "found") controller.cancelReveal();
+				const completion = rowRevealCompletion.current;
+				rowRevealCompletion.current = null;
+				completion?.(result);
+			};
+			const startMeasuredReveal = () => {
+				revealStarted = true;
+				alignedFrames = 0;
 				controller.revealTo(() => {
 					const current = mountedChatRow(scroller, rowId);
 					return current ? rowAlignmentTarget(scroller, current, align) : null;
 				}, true);
-				return true;
 			};
-			if (revealMountedRow()) return;
-			const viewport = scroller.getBoundingClientRect();
-			const anchor = Array.from(
-				scroller.querySelectorAll<HTMLElement>("[data-chat-row-index]"),
-			).find((row) => Number.isInteger(Number(row.dataset.chatRowIndex)));
-			const anchorIndex = anchor ? Number(anchor.dataset.chatRowIndex) : 0;
-			const anchorTop = anchor
-				? scroller.scrollTop + anchor.getBoundingClientRect().top - viewport.top
-				: (headerElementRef.current?.getBoundingClientRect().height ?? 0);
-			const rowTop = estimatedRowTop(rowHeightEstimates, anchorIndex, anchorTop, index);
-			const target = alignedRowScrollTop(
-				rowTop,
-				rowHeightEstimates[index] ?? 40,
-				scroller.clientHeight,
-				align,
-			);
-			scroller.scrollTop = Math.min(scrollBounds(scroller).maxScrollTop, Math.max(0, target));
-			recordProgrammaticScrollPosition();
-			let attempts = 0;
-			const waitForRow = () => {
-				if (revealMountedRow()) return;
+			const materialize = () => {
+				virtuosoRef.current?.getState(({ ranges }) => {
+					if (generation !== rowRevealGeneration.current) return;
+					const index = resolveIndex();
+					if (index < 0) return;
+					const viewport = scroller.getBoundingClientRect();
+					const anchor = Array.from(
+						scroller.querySelectorAll<HTMLElement>("[data-chat-row-index]"),
+					).find((row) => Number.isInteger(Number(row.dataset.chatRowIndex)));
+					if (!anchor) return;
+					const heights = [...rowHeightEstimatesRef.current];
+					const currentFirstItemIndex = firstItemIndexRef.current;
+					const rangeOffset =
+						currentFirstItemIndex > 0 &&
+						ranges.some((range) => range.startIndex >= currentFirstItemIndex)
+							? currentFirstItemIndex
+							: 0;
+					for (const range of ranges) {
+						const start = Math.max(0, range.startIndex - rangeOffset);
+						const end = Math.min(heights.length - 1, range.endIndex - rangeOffset);
+						for (let measuredIndex = start; measuredIndex <= end; measuredIndex += 1) {
+							heights[measuredIndex] = range.size;
+						}
+					}
+					const anchorIndex = Number(anchor.dataset.chatRowIndex);
+					const anchorTop = scroller.scrollTop + anchor.getBoundingClientRect().top - viewport.top;
+					const rowTop = estimatedRowTop(heights, anchorIndex, anchorTop, index);
+					const target = alignedRowScrollTop(
+						rowTop,
+						heights[index] ?? 40,
+						scroller.clientHeight,
+						align,
+					);
+					scroller.scrollTop = Math.min(scrollBounds(scroller).maxScrollTop, Math.max(0, target));
+					recordProgrammaticScrollPosition();
+				});
+			};
+			const waitForAlignedRow = () => {
+				if (generation !== rowRevealGeneration.current) return;
 				attempts += 1;
-				if (attempts >= 30) {
-					cancelRowReveal();
+				const row = mountedChatRow(scroller, rowId);
+				if (!row) {
+					revealStarted = false;
+					alignedFrames = 0;
+					if (attempts === 1 || attempts % 5 === 0) materialize();
+				} else if (!revealStarted) {
+					startMeasuredReveal();
+				} else if (!controller.getSnapshot().moving) {
+					const bounds = scrollBounds(scroller);
+					const target = Math.min(
+						bounds.maxScrollTop,
+						Math.max(0, rowAlignmentTarget(scroller, row, align)),
+					);
+					if (Math.abs(target - bounds.scrollTop) > 1) startMeasuredReveal();
+					else alignedFrames += 1;
+					if (alignedFrames >= ROW_ALIGNMENT_STABILITY_FRAMES) {
+						finish("found");
+						return;
+					}
+				}
+				if (attempts >= ROW_MATERIALIZATION_FRAMES) {
+					finish("missing");
 					return;
 				}
-				rowRevealFrame.current = requestAnimationFrame(waitForRow);
+				rowRevealFrame.current = requestAnimationFrame(waitForAlignedRow);
 			};
-			rowRevealFrame.current = requestAnimationFrame(waitForRow);
+			waitForAlignedRow();
+			return () => {
+				if (generation !== rowRevealGeneration.current) return;
+				cancelRowReveal(false);
+				controller.cancelReveal();
+			};
 		},
-		[cancelRowReveal, controller, readerLeft, recordProgrammaticScrollPosition, rowHeightEstimates],
+		[cancelRowReveal, controller, readerLeft, recordProgrammaticScrollPosition, virtuosoRef],
 	);
 
 	const scrollToLatest = useCallback(() => {
@@ -786,19 +945,21 @@ export function useChatScroll(
 		(event) => {
 			clearReturnIntent();
 			programmaticScrollTop.current = null;
-			cancelRowReveal();
-			controller.cancelReveal();
 			const scroller = scrollerRef.current;
 			const scrollTop = scroller ? boundedScrollTop(scroller) : 0;
 			interactionStartScrollTop.current = scrollTop;
 			previousTouchScrollTop.current = scrollTop;
 			activePointerId.current = event.pointerId;
 			activePointerType.current = event.pointerType;
+			pointerMayContinueScroll.current = event.pointerType !== "touch" && event.target === scroller;
+			if (scroller && (event.pointerType === "touch" || event.target === scroller)) {
+				pauseForNativeInput();
+			}
 			touchPointerActive.current = event.pointerType === "touch";
 			touchMomentum.current = event.pointerType === "touch";
 			touchMovingTowardLatest.current = null;
 		},
-		[cancelRowReveal, clearReturnIntent, controller],
+		[clearReturnIntent, pauseForNativeInput],
 	);
 
 	const finishPointerInteraction = useCallback(
@@ -806,8 +967,11 @@ export function useChatScroll(
 			if (activePointerId.current !== pointerId || activePointerType.current !== pointerType) {
 				return;
 			}
+			const mayContinueScrolling = pointerMayContinueScroll.current;
 			activePointerId.current = null;
 			activePointerType.current = null;
+			pointerMayContinueScroll.current = false;
+			resumeNativeMotion();
 			const scroller = scrollerRef.current;
 			const delta = (scroller ? boundedScrollTop(scroller) : 0) - interactionStartScrollTop.current;
 			const totalMovedTowardLatest = edge === "bottom" ? delta > 1 : delta < -1;
@@ -830,18 +994,24 @@ export function useChatScroll(
 				scheduleTouchSettle(terminal === "cancel" ? 1_000 : 500);
 				return;
 			}
-			const movedTowardLatest = touchMovingTowardLatest.current ?? totalMovedTowardLatest;
-			if (movedTowardLatest) {
-				returnIntentUntil.current = performance.now() + 500;
-				if (scroller && reachedLatestEdge(scroller, edge)) {
-					controller.readerReachedEdge();
-					clearReturnIntent();
-				}
+			const pointerMoved =
+				touchMovingTowardLatest.current !== null || (mayContinueScrolling && Math.abs(delta) > 1);
+			if (!pointerMoved && !mayContinueScrolling) {
+				clearReturnIntent();
 				return;
 			}
-			clearReturnIntent();
+			const movedTowardLatest = touchMovingTowardLatest.current ?? totalMovedTowardLatest;
+			const intentUntil = performance.now() + NATIVE_SCROLL_INTENT_MS;
+			pointerIntentUntil.current = intentUntil;
+			returnIntentUntil.current = movedTowardLatest ? intentUntil : 0;
+			if (movedTowardLatest && scroller && reachedLatestEdge(scroller, edge)) {
+				controller.readerReachedEdge();
+				clearReturnIntent();
+				return;
+			}
+			scheduleTouchSettle(NATIVE_SCROLL_INTENT_MS);
 		},
-		[clearReturnIntent, controller, edge, scheduleTouchSettle],
+		[clearReturnIntent, controller, edge, resumeNativeMotion, scheduleTouchSettle],
 	);
 
 	const onPointerUp = useCallback<PointerEventHandler>(
@@ -857,33 +1027,36 @@ export function useChatScroll(
 	useEffect(() => {
 		if (!scrollerElement) return;
 		const onWheel = (event: WheelEvent) => {
-			if (event.deltaY === 0) return;
-			controller.cancelReveal();
-			if (!canScrollBy(scrollerElement, event.deltaY)) return;
+			if (event.deltaY === 0 || !canScrollBy(scrollerElement, event.deltaY)) return;
+			pointerIntentUntil.current = 0;
+			keyboardIntentUntil.current = 0;
 			programmaticScrollTop.current = null;
-			cancelRowReveal();
 			const movesTowardLatest = edge === "bottom" ? event.deltaY > 0 : event.deltaY < 0;
-			if (!isStreaming && movesTowardLatest && controller.getSnapshot().following) {
-				controller.readerMovedWhileFollowing();
-				return;
-			}
-			controller.readerLeft();
-			if (!movesTowardLatest) {
-				returnIntentUntil.current = 0;
-				return;
-			}
-			returnIntentUntil.current = performance.now() + 1_000;
+			const intentUntil = performance.now() + 1_000;
+			wheelIntentUntil.current = intentUntil;
+			returnIntentUntil.current = movesTowardLatest ? intentUntil : 0;
+			interruptForNativeInput(scrollerElement);
 			scheduleTouchSettle(1_000);
 		};
 		scrollerElement.addEventListener("wheel", onWheel, { capture: true, passive: false });
 		return () => scrollerElement.removeEventListener("wheel", onWheel, { capture: true });
-	}, [cancelRowReveal, controller, edge, isStreaming, scheduleTouchSettle, scrollerElement]);
+	}, [edge, interruptForNativeInput, scheduleTouchSettle, scrollerElement]);
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent) => {
 			if (event.defaultPrevented) return;
-			if (TRANSIENT_MOTION_CANCEL_KEYS.has(event.key)) controller.cancelReveal();
-			if (event.target !== scrollerRef.current && isInteractiveTarget(event.target)) return;
+			const interactive = event.target !== scrollerRef.current && isInteractiveTarget(event.target);
+			if (event.key === "Tab") {
+				pointerIntentUntil.current = 0;
+				wheelIntentUntil.current = 0;
+				returnIntentUntil.current = 0;
+				keyboardIntentUntil.current = performance.now() + NATIVE_SCROLL_INTENT_MS;
+				const scroller = scrollerRef.current;
+				if (scroller) interruptForNativeInput(scroller);
+				scheduleTouchSettle(NATIVE_SCROLL_INTENT_MS);
+				return;
+			}
+			if (interactive || !KEYBOARD_SCROLL_KEYS.has(event.key)) return;
 			const movesTowardTop =
 				event.key === "ArrowUp" ||
 				event.key === "PageUp" ||
@@ -908,21 +1081,15 @@ export function useChatScroll(
 			const scroller = scrollerRef.current;
 			const deltaY = movesTowardTop ? -1 : 1;
 			if (!scroller || !canScrollBy(scroller, deltaY)) return;
+			pointerIntentUntil.current = 0;
+			wheelIntentUntil.current = 0;
 			programmaticScrollTop.current = null;
-			cancelRowReveal();
-			if (!isStreaming && movesTowardLatest && controller.getSnapshot().following) {
-				controller.readerMovedWhileFollowing();
-				return;
-			}
-			controller.readerLeft();
-			if (movesTowardHistory) {
-				returnIntentUntil.current = 0;
-				return;
-			}
-			returnIntentUntil.current = performance.now() + 1_000;
-			scheduleTouchSettle(1_000);
+			keyboardIntentUntil.current = performance.now() + NATIVE_SCROLL_INTENT_MS;
+			returnIntentUntil.current = movesTowardHistory ? 0 : keyboardIntentUntil.current;
+			interruptForNativeInput(scroller);
+			scheduleTouchSettle(NATIVE_SCROLL_INTENT_MS);
 		},
-		[cancelRowReveal, controller, edge, isStreaming, scheduleTouchSettle, scrollToLatest],
+		[edge, interruptForNativeInput, scheduleTouchSettle, scrollToLatest],
 	);
 
 	useEffect(() => {

--- a/apps/web/src/chat/useChatScroll.ts
+++ b/apps/web/src/chat/useChatScroll.ts
@@ -11,6 +11,7 @@ import {
 import type { VirtuosoHandle } from "react-virtuoso";
 import type { ChatRevealOptions } from "./ChatActions";
 import type { ChatMessageOrder, StreamingResponseMovement } from "./chatPreferences";
+import type { FoldAnchorResolver } from "./foldState";
 import {
 	createReadingBandController,
 	headerHeightScrollTarget,
@@ -45,15 +46,58 @@ export interface ChatScroll {
 	scrollerElement: HTMLElement | null;
 	showScrollButton: boolean;
 	scrollButtonLabel: "Follow response" | "Latest" | null;
+	scrollMoving: boolean;
 	scrollToLatest: () => void;
 	armImmediateTurn: () => void;
 	cancelImmediateTurn: (streaming: boolean) => void;
 	cancelAutomaticReveal: () => void;
 	revealElement: (target: HTMLElement, options: ChatRevealOptions) => void;
 	revealRow: (rowId: string, index: number, align: "start" | "center" | "end") => void;
+	prepareFoldChange: (resolveTarget: FoldAnchorResolver) => () => void;
 	runwayActive: boolean;
 	followState: "following" | "detached";
 	containerProps: ScrollContainerProps;
+}
+
+const TRANSIENT_MOTION_CANCEL_KEYS = new Set([
+	" ",
+	"ArrowDown",
+	"ArrowUp",
+	"End",
+	"Enter",
+	"Home",
+	"PageDown",
+	"PageUp",
+	"Tab",
+]);
+
+function nearestHtmlElement(element: Element | null): HTMLElement | null {
+	let current = element;
+	while (current && !(current instanceof HTMLElement)) current = current.parentElement;
+	return current;
+}
+
+function survivesInternalClipping(
+	element: HTMLElement,
+	scroller: HTMLElement,
+	anchorOffset: number,
+): boolean {
+	if (!element.isConnected) return false;
+	const elementRect = element.getBoundingClientRect();
+	if (elementRect.height <= 0 || anchorOffset < 0 || anchorOffset > elementRect.height)
+		return false;
+	const anchor = elementRect.top + anchorOffset;
+	let ancestor = element.parentElement;
+	while (ancestor && ancestor !== scroller) {
+		const { overflowY, visibility } = getComputedStyle(ancestor);
+		if (visibility === "hidden") return false;
+		if (["auto", "clip", "hidden", "scroll"].includes(overflowY)) {
+			const rect = ancestor.getBoundingClientRect();
+			if (anchor <= rect.top || anchor >= rect.bottom) return false;
+		}
+		ancestor = ancestor.parentElement;
+	}
+	return ancestor === scroller;
 }
 
 function isInteractiveTarget(target: EventTarget | null): boolean {
@@ -150,6 +194,8 @@ export function useChatScroll(
 	const latestRowFrame = useRef<number | null>(null);
 	const rowRevealFrame = useRef<number | null>(null);
 	const rowRevealGeneration = useRef(0);
+	const foldResizeObserver = useRef<ResizeObserver | null>(null);
+	const foldSurvivorElement = useRef<HTMLElement | null>(null);
 	const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
 	const [headerElement, setHeaderElement] = useState<HTMLDivElement | null>(null);
 	const [streamEdgeElement, setStreamEdgeElement] = useState<HTMLDivElement | null>(null);
@@ -257,6 +303,12 @@ export function useChatScroll(
 		rowRevealFrame.current = null;
 	}, []);
 
+	const clearFoldResizeObserver = useCallback(() => {
+		foldResizeObserver.current?.disconnect();
+		foldResizeObserver.current = null;
+		foldSurvivorElement.current = null;
+	}, []);
+
 	const settleTouch = useCallback(() => {
 		if (touchPointerActive.current) return;
 		const scroller = scrollerRef.current;
@@ -283,6 +335,119 @@ export function useChatScroll(
 		cancelRowReveal();
 		controller.readerLeft();
 	}, [cancelRowReveal, clearReturnIntent, controller]);
+
+	const prepareFoldChange = useCallback(
+		(resolveTarget: FoldAnchorResolver) => {
+			let afterChange = false;
+			const complete = () => {
+				afterChange = true;
+				controller.refreshAnchor();
+			};
+			const scroller = scrollerRef.current;
+			const target = resolveTarget();
+			if (!scroller || !target || !scroller.contains(target)) return complete;
+			controller.cancelReveal();
+			clearFoldResizeObserver();
+			if (controller.getSnapshot().following) return complete;
+			const changedRow = target.closest<HTMLElement>("[data-chat-row-id]");
+			const changedRowId = changedRow?.dataset.chatRowId;
+			const changedRowHeight = changedRow?.getBoundingClientRect().height ?? 0;
+			const resolveChangedRow = () =>
+				changedRowId
+					? (Array.from(scroller.querySelectorAll<HTMLElement>("[data-chat-row-id]")).find(
+							(row) => row.dataset.chatRowId === changedRowId,
+						) ?? null)
+					: null;
+			if (changedRow) {
+				foldResizeObserver.current = new ResizeObserver(() => controller.refreshAnchor());
+				foldResizeObserver.current.observe(changedRow);
+			}
+			const viewport = scroller.getBoundingClientRect();
+			const trail = scroller
+				.closest<HTMLElement>("[data-testid=chat-scroll]")
+				?.querySelector<HTMLElement>("[data-testid=activity-breadcrumb-trail]");
+			const unobscuredTop = Math.max(viewport.top, trail?.getBoundingClientRect().bottom ?? 0);
+			const targetRect = target.getBoundingClientRect();
+			const disclosure = target.closest<HTMLElement>("[data-chat-fold-root]") ?? changedRow;
+			const disclosureRect = disclosure?.getBoundingClientRect() ?? targetRect;
+			const targetVisible = targetRect.top >= unobscuredTop && targetRect.bottom <= viewport.bottom;
+			const disclosureAboveViewport = disclosureRect.bottom <= unobscuredTop;
+			const disclosureBelowViewport = disclosureRect.top >= viewport.bottom;
+			const initialScrollTop = boundedScrollTop(scroller);
+			const initialScrollHeight = scroller.scrollHeight;
+			if (targetVisible) {
+				const top = targetRect.top;
+				controller.stabilizeAnchor(() => {
+					if (controller.getSnapshot().following) return null;
+					const currentTarget = resolveTarget();
+					const bounds = scrollBounds(scroller);
+					return currentTarget
+						? bounds.scrollTop + currentTarget.getBoundingClientRect().top - top
+						: null;
+				});
+				return complete;
+			}
+			const centerX = viewport.left + viewport.width / 2;
+			const centerY = viewport.top + viewport.height / 2;
+			const survivorCandidate = target.ownerDocument.elementFromPoint(centerX, centerY);
+			const survivor = scroller.contains(survivorCandidate)
+				? nearestHtmlElement(survivorCandidate)
+				: null;
+			foldSurvivorElement.current = survivor;
+			const survivorTop = survivor?.getBoundingClientRect().top ?? 0;
+			const survivorOffset = centerY - survivorTop;
+			const survivorInsideDisclosure = Boolean(survivor && disclosure?.contains(survivor));
+			const visibleRow = survivor?.closest<HTMLElement>("[data-chat-row-id]");
+			const visibleRowId = visibleRow?.dataset.chatRowId;
+			const visibleRowTop = visibleRow?.getBoundingClientRect().top ?? 0;
+			const resolveVisibleRow = () =>
+				visibleRowId
+					? (Array.from(scroller.querySelectorAll<HTMLElement>("[data-chat-row-id]")).find(
+							(row) => row.dataset.chatRowId === visibleRowId,
+						) ?? null)
+					: null;
+			const alignToTop = targetRect.top < unobscuredTop;
+			controller.stabilizeAnchor(() => {
+				if (controller.getSnapshot().following) return null;
+				const bounds = scrollBounds(scroller);
+				const currentSurvivor = foldSurvivorElement.current;
+				if (
+					currentSurvivor &&
+					survivesInternalClipping(currentSurvivor, scroller, survivorOffset)
+				) {
+					return bounds.scrollTop + currentSurvivor.getBoundingClientRect().top - survivorTop;
+				}
+				if (!survivorInsideDisclosure) {
+					const currentVisibleRow = resolveVisibleRow();
+					if (currentVisibleRow) {
+						return bounds.scrollTop + currentVisibleRow.getBoundingClientRect().top - visibleRowTop;
+					}
+				}
+				if (disclosureAboveViewport) {
+					const currentRow = resolveChangedRow();
+					const heightDelta = currentRow
+						? currentRow.getBoundingClientRect().height - changedRowHeight
+						: scroller.scrollHeight - initialScrollHeight;
+					return initialScrollTop + heightDelta;
+				}
+				if (disclosureBelowViewport) return initialScrollTop;
+				if (!afterChange) return initialScrollTop;
+				const currentTarget = resolveTarget();
+				if (!currentTarget) return null;
+				const currentRect = currentTarget.getBoundingClientRect();
+				const currentViewport = scroller.getBoundingClientRect();
+				const currentTrail = scroller
+					.closest<HTMLElement>("[data-testid=chat-scroll]")
+					?.querySelector<HTMLElement>("[data-testid=activity-breadcrumb-trail]");
+				const destination = alignToTop
+					? Math.max(currentViewport.top, currentTrail?.getBoundingClientRect().bottom ?? 0)
+					: currentViewport.bottom - currentRect.height;
+				return bounds.scrollTop + currentRect.top - destination;
+			});
+			return complete;
+		},
+		[clearFoldResizeObserver, controller],
+	);
 
 	useLayoutEffect(() => {
 		clearReturnIntent();
@@ -311,6 +476,10 @@ export function useChatScroll(
 	useLayoutEffect(() => {
 		controller.setMovement(movement);
 	}, [controller, movement]);
+
+	useEffect(() => {
+		if (!snapshot.moving) clearFoldResizeObserver();
+	}, [clearFoldResizeObserver, snapshot.moving]);
 
 	useLayoutEffect(() => {
 		const row = latestUserRow;
@@ -467,10 +636,11 @@ export function useChatScroll(
 			clearReturnIntent();
 			if (latestRowFrame.current !== null) cancelAnimationFrame(latestRowFrame.current);
 			latestRowFrame.current = null;
+			clearFoldResizeObserver();
 			cancelRowReveal();
 			controller.dispose();
 		},
-		[cancelRowReveal, clearReturnIntent, controller],
+		[cancelRowReveal, clearFoldResizeObserver, clearReturnIntent, controller],
 	);
 
 	const handleScrollerRef = useCallback((element: HTMLElement | Window | null) => {
@@ -687,7 +857,9 @@ export function useChatScroll(
 	useEffect(() => {
 		if (!scrollerElement) return;
 		const onWheel = (event: WheelEvent) => {
-			if (event.deltaY === 0 || !canScrollBy(scrollerElement, event.deltaY)) return;
+			if (event.deltaY === 0) return;
+			controller.cancelReveal();
+			if (!canScrollBy(scrollerElement, event.deltaY)) return;
 			programmaticScrollTop.current = null;
 			cancelRowReveal();
 			const movesTowardLatest = edge === "bottom" ? event.deltaY > 0 : event.deltaY < 0;
@@ -709,12 +881,9 @@ export function useChatScroll(
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent) => {
-			if (
-				event.defaultPrevented ||
-				(event.target !== scrollerRef.current && isInteractiveTarget(event.target))
-			) {
-				return;
-			}
+			if (event.defaultPrevented) return;
+			if (TRANSIENT_MOTION_CANCEL_KEYS.has(event.key)) controller.cancelReveal();
+			if (event.target !== scrollerRef.current && isInteractiveTarget(event.target)) return;
 			const movesTowardTop =
 				event.key === "ArrowUp" ||
 				event.key === "PageUp" ||
@@ -773,12 +942,14 @@ export function useChatScroll(
 		scrollerElement,
 		showScrollButton: snapshot.buttonLabel !== null,
 		scrollButtonLabel: snapshot.buttonLabel,
+		scrollMoving: snapshot.moving,
 		scrollToLatest,
 		armImmediateTurn,
 		cancelImmediateTurn,
 		cancelAutomaticReveal,
 		revealElement,
 		revealRow,
+		prepareFoldChange,
 		runwayActive: snapshot.runway,
 		followState: snapshot.following ? "following" : "detached",
 		containerProps: {

--- a/apps/web/src/chat/useChatScroll.ts
+++ b/apps/web/src/chat/useChatScroll.ts
@@ -1,6 +1,4 @@
 import {
-	type FocusEventHandler,
-	type KeyboardEventHandler,
 	type PointerEventHandler,
 	type RefCallback,
 	type RefObject,
@@ -9,9 +7,9 @@ import {
 	useLayoutEffect,
 	useRef,
 	useState,
-	type WheelEventHandler,
 } from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
+import type { ChatRevealOptions } from "./ChatActions";
 import type { ChatMessageOrder, StreamingResponseMovement } from "./chatPreferences";
 import {
 	createReadingBandController,
@@ -23,15 +21,12 @@ import {
 	type ReadingBandScrollBounds,
 	type ReadingBandSnapshot,
 } from "./readingBand";
-import { type RevealBlock, revealScrollTop } from "./scrollGeometry";
+import { alignedRowScrollTop, estimatedRowTop, revealScrollTop } from "./scrollGeometry";
 
 interface ScrollContainerProps {
-	onFocusCapture: FocusEventHandler;
-	onKeyDown: KeyboardEventHandler;
 	onPointerCancel: PointerEventHandler;
 	onPointerDown: PointerEventHandler;
 	onPointerUp: PointerEventHandler;
-	onWheel: WheelEventHandler;
 }
 
 interface RowLocation {
@@ -41,8 +36,6 @@ interface RowLocation {
 
 export interface ChatScroll {
 	followOutput: false;
-	handleAtBottom: (atBottom: boolean) => void;
-	handleAtTop: (atTop: boolean) => void;
 	handleContentHeight: () => void;
 	handleScrollerRef: (element: HTMLElement | Window | null) => void;
 	headerRef: RefCallback<HTMLDivElement>;
@@ -54,12 +47,10 @@ export interface ChatScroll {
 	scrollButtonLabel: "Follow response" | "Latest" | null;
 	scrollToLatest: () => void;
 	armImmediateTurn: () => void;
-	releaseFollow: () => void;
-	revealElement: (
-		target: HTMLElement,
-		block?: RevealBlock,
-		runway?: "preserve" | "release",
-	) => void;
+	cancelImmediateTurn: (streaming: boolean) => void;
+	cancelAutomaticReveal: () => void;
+	revealElement: (target: HTMLElement, options: ChatRevealOptions) => void;
+	revealRow: (rowId: string, index: number, align: "start" | "center" | "end") => void;
 	runwayActive: boolean;
 	followState: "following" | "detached";
 	containerProps: ScrollContainerProps;
@@ -94,12 +85,41 @@ function reachedLatestEdge(scroller: HTMLElement, edge: ReadingBandLatestEdge): 
 	return edge === "top" ? bounds.scrollTop <= 1 : bounds.maxScrollTop - bounds.scrollTop <= 1;
 }
 
+function canScrollBy(scroller: HTMLElement, deltaY: number): boolean {
+	const bounds = scrollBounds(scroller);
+	if (deltaY < 0) return bounds.scrollTop > 1;
+	if (deltaY > 0) return bounds.maxScrollTop - bounds.scrollTop > 1;
+	return false;
+}
+
+function mountedChatRow(scroller: HTMLElement, rowId: string): HTMLElement | null {
+	return (
+		Array.from(scroller.querySelectorAll<HTMLElement>("[data-chat-row-id]")).find(
+			(row) => row.dataset.chatRowId === rowId,
+		) ?? null
+	);
+}
+
+function rowAlignmentTarget(
+	scroller: HTMLElement,
+	row: HTMLElement,
+	align: "start" | "center" | "end",
+): number {
+	const viewport = scroller.getBoundingClientRect();
+	const target = row.getBoundingClientRect();
+	if (align === "start") return scroller.scrollTop + target.top - viewport.top;
+	if (align === "end") return scroller.scrollTop + target.bottom - viewport.bottom;
+	return scroller.scrollTop + (target.top + target.bottom - viewport.top - viewport.bottom) / 2;
+}
+
 export function useChatScroll(
 	virtuosoRef: RefObject<VirtuosoHandle | null>,
 	isStreaming: boolean,
+	settlementTick: number,
 	messageOrder: ChatMessageOrder,
 	latestUserRow: RowLocation | null,
 	latestRow: RowLocation | null,
+	rowHeightEstimates: readonly number[],
 	movement: StreamingResponseMovement,
 ): ChatScroll {
 	const edge = latestEdge(messageOrder);
@@ -113,7 +133,6 @@ export function useChatScroll(
 	const headerAnchorScrollTop = useRef(0);
 	const latestEdgeRef = useRef(edge);
 	latestEdgeRef.current = edge;
-	const atLatest = useRef(true);
 	const interactionStartScrollTop = useRef(0);
 	const returnIntentUntil = useRef(0);
 	const activePointerId = useRef<number | null>(null);
@@ -122,15 +141,27 @@ export function useChatScroll(
 	const touchMomentum = useRef(false);
 	const touchMovingTowardLatest = useRef<boolean | null>(null);
 	const previousTouchScrollTop = useRef(0);
+	const programmaticScrollTop = useRef<number | null>(null);
 	const touchSettleTimer = useRef<number | null>(null);
 	const pendingImmediateTurn = useRef(false);
+	const observedLifecycle = useRef({ isStreaming, settlementTick });
 	const previousUserRowId = useRef(latestUserRow?.id ?? null);
 	const previousLatestRowId = useRef(latestRow?.id ?? null);
 	const latestRowFrame = useRef<number | null>(null);
+	const rowRevealFrame = useRef<number | null>(null);
+	const rowRevealGeneration = useRef(0);
 	const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
 	const [headerElement, setHeaderElement] = useState<HTMLDivElement | null>(null);
 	const [streamEdgeElement, setStreamEdgeElement] = useState<HTMLDivElement | null>(null);
 	const [runwayEdgeElement, setRunwayEdgeElement] = useState<HTMLDivElement | null>(null);
+	const recordProgrammaticScrollPosition = useCallback(() => {
+		const scroller = scrollerRef.current;
+		if (!scroller) return;
+		const actual = boundedScrollTop(scroller);
+		programmaticScrollTop.current = actual;
+		previousTouchScrollTop.current = actual;
+		headerAnchorScrollTop.current = actual;
+	}, []);
 	const [snapshot, setSnapshot] = useState<ReadingBandSnapshot>(() =>
 		initialReadingBandSnapshot(isStreaming),
 	);
@@ -177,6 +208,7 @@ export function useChatScroll(
 					const scroller = scrollerRef.current;
 					if (!scroller) return;
 					scroller.scrollTop = top;
+					recordProgrammaticScrollPosition();
 					const headerHeight = headerElementRef.current?.getBoundingClientRect().height ?? 0;
 					if (Math.abs(headerHeight - measuredHeaderHeight.current) <= 0.5) {
 						headerAnchorScrollTop.current = boundedScrollTop(scroller);
@@ -185,7 +217,10 @@ export function useChatScroll(
 				writeRunwayHeight: (height) => {
 					runwayHeightRef.current = height;
 					const runway = runwayElementRef.current;
-					if (runway) runway.style.height = `${height}px`;
+					if (runway) {
+						runway.style.height = `${height}px`;
+						recordProgrammaticScrollPosition();
+					}
 				},
 				anchorTurn: (index, inset) => {
 					virtuosoRef.current?.scrollToIndex({
@@ -216,15 +251,19 @@ export function useChatScroll(
 		touchSettleTimer.current = null;
 	}, []);
 
+	const cancelRowReveal = useCallback(() => {
+		rowRevealGeneration.current += 1;
+		if (rowRevealFrame.current !== null) cancelAnimationFrame(rowRevealFrame.current);
+		rowRevealFrame.current = null;
+	}, []);
+
 	const settleTouch = useCallback(() => {
 		if (touchPointerActive.current) return;
 		const scroller = scrollerRef.current;
-		if (
-			touchMomentum.current &&
-			touchMovingTowardLatest.current === true &&
-			scroller &&
-			reachedLatestEdge(scroller, edge)
-		) {
+		const returning = touchMomentum.current
+			? touchMovingTowardLatest.current === true
+			: returnIntentUntil.current > 0;
+		if (returning && scroller && reachedLatestEdge(scroller, edge)) {
 			controller.readerReachedEdge();
 		}
 		clearReturnIntent();
@@ -240,11 +279,12 @@ export function useChatScroll(
 
 	const readerLeft = useCallback(() => {
 		clearReturnIntent();
+		programmaticScrollTop.current = null;
+		cancelRowReveal();
 		controller.readerLeft();
-	}, [clearReturnIntent, controller]);
+	}, [cancelRowReveal, clearReturnIntent, controller]);
 
 	useLayoutEffect(() => {
-		atLatest.current = true;
 		clearReturnIntent();
 		if (latestRowFrame.current !== null) cancelAnimationFrame(latestRowFrame.current);
 		latestRowFrame.current = null;
@@ -256,8 +296,17 @@ export function useChatScroll(
 	}, [clearReturnIntent, controller, edge]);
 
 	useLayoutEffect(() => {
-		controller.setStreaming(isStreaming);
-	}, [controller, isStreaming]);
+		const previous = observedLifecycle.current;
+		observedLifecycle.current = { isStreaming, settlementTick };
+		if (settlementTick !== previous.settlementTick) {
+			pendingImmediateTurn.current = false;
+			cancelRowReveal();
+			controller.settle();
+			if (isStreaming) controller.setStreaming(true);
+			return;
+		}
+		if (isStreaming !== previous.isStreaming) controller.setStreaming(isStreaming);
+	}, [cancelRowReveal, controller, isStreaming, settlementTick]);
 
 	useLayoutEffect(() => {
 		controller.setMovement(movement);
@@ -279,13 +328,15 @@ export function useChatScroll(
 		previousLatestRowId.current = rowId;
 		if (latestRowFrame.current !== null) cancelAnimationFrame(latestRowFrame.current);
 		latestRowFrame.current = null;
-		if (!latestRow || edge !== "top" || rowId === latestUserRow?.id) return;
+		if (!isStreaming || !latestRow || edge !== "top" || rowId === latestUserRow?.id) {
+			return;
+		}
 		latestRowFrame.current = requestAnimationFrame(() => {
 			latestRowFrame.current = null;
 			if (previousLatestRowId.current !== rowId) return;
 			controller.latestRowArrived(latestRow.index);
 		});
-	}, [controller, edge, latestRow, latestUserRow?.id]);
+	}, [controller, edge, isStreaming, latestRow, latestUserRow?.id]);
 
 	useLayoutEffect(() => {
 		if (!scrollerElement || (!streamEdgeElement && !runwayEdgeElement)) return;
@@ -313,16 +364,15 @@ export function useChatScroll(
 				);
 				scroller.scrollTop = target;
 				const actual = boundedScrollTop(scroller);
+				recordProgrammaticScrollPosition();
 				interactionStartScrollTop.current += actual - previousScrollTop;
-				previousTouchScrollTop.current = actual;
-				headerAnchorScrollTop.current = actual;
 			}
 			measuredHeaderHeight.current = nextHeight;
 			controller.contentChanged();
 		});
 		observer.observe(headerElement);
 		return () => observer.disconnect();
-	}, [controller, edge, headerElement]);
+	}, [controller, edge, headerElement, recordProgrammaticScrollPosition]);
 
 	useEffect(() => {
 		if (!scrollerElement) return;
@@ -342,21 +392,56 @@ export function useChatScroll(
 			}
 			const delta = nextScrollTop - previousTouchScrollTop.current;
 			previousTouchScrollTop.current = nextScrollTop;
-			if (!touchMomentum.current || delta === 0) return;
+			const expectedProgrammaticScrollTop = programmaticScrollTop.current;
+			if (
+				expectedProgrammaticScrollTop !== null &&
+				Math.abs(nextScrollTop - expectedProgrammaticScrollTop) <= 1
+			) {
+				programmaticScrollTop.current = null;
+				return;
+			}
+			programmaticScrollTop.current = null;
+			if (delta === 0) return;
+			const pointerMoving = activePointerId.current !== null;
+			const wheelReturning = returnIntentUntil.current > 0;
+			if (!touchMomentum.current && !pointerMoving && !wheelReturning) return;
 			const movedTowardLatest = edge === "bottom" ? delta > 0 : delta < 0;
 			touchMovingTowardLatest.current = movedTowardLatest;
-			returnIntentUntil.current = 0;
-			if (!movedTowardLatest) controller.readerLeft();
-			if (!touchPointerActive.current) scheduleTouchSettle(1_000);
+			if (!isStreaming && movedTowardLatest && controller.getSnapshot().following) {
+				controller.readerMovedWhileFollowing();
+				return;
+			}
+			if (controller.getSnapshot().following) controller.readerLeft();
+			if (!movedTowardLatest) {
+				returnIntentUntil.current = 0;
+				controller.readerLeft();
+				return;
+			}
+			if (reachedLatestEdge(scrollerElement, edge)) {
+				controller.readerReachedEdge();
+				returnIntentUntil.current = 0;
+				if (activePointerId.current === null && !touchMomentum.current) clearReturnIntent();
+				return;
+			}
+			if (touchMomentum.current && !touchPointerActive.current) scheduleTouchSettle(1_000);
 		};
-		const onScrollEnd = () => settleTouch();
+		const onScrollEnd = () => {
+			if (touchMomentum.current) {
+				settleTouch();
+				return;
+			}
+			if (returnIntentUntil.current > 0 && reachedLatestEdge(scrollerElement, edge)) {
+				controller.readerReachedEdge();
+				clearReturnIntent();
+			}
+		};
 		scrollerElement.addEventListener("scroll", onScroll, { passive: true });
 		scrollerElement.addEventListener("scrollend", onScrollEnd);
 		return () => {
 			scrollerElement.removeEventListener("scroll", onScroll);
 			scrollerElement.removeEventListener("scrollend", onScrollEnd);
 		};
-	}, [controller, edge, scheduleTouchSettle, scrollerElement, settleTouch]);
+	}, [controller, edge, isStreaming, scheduleTouchSettle, scrollerElement, settleTouch]);
 
 	useEffect(() => {
 		const onSelectionChange = () => {
@@ -382,9 +467,10 @@ export function useChatScroll(
 			clearReturnIntent();
 			if (latestRowFrame.current !== null) cancelAnimationFrame(latestRowFrame.current);
 			latestRowFrame.current = null;
+			cancelRowReveal();
 			controller.dispose();
 		},
-		[clearReturnIntent, controller],
+		[cancelRowReveal, clearReturnIntent, controller],
 	);
 
 	const handleScrollerRef = useCallback((element: HTMLElement | Window | null) => {
@@ -417,75 +503,121 @@ export function useChatScroll(
 			runwayElementRef.current = element;
 			if (!element) return;
 			element.style.height = `${runwayHeightRef.current}px`;
+			recordProgrammaticScrollPosition();
 			controller.contentChanged();
 		},
-		[controller],
+		[controller, recordProgrammaticScrollPosition],
 	);
 
 	const armImmediateTurn = useCallback(() => {
 		clearReturnIntent();
+		cancelRowReveal();
 		pendingImmediateTurn.current = true;
 		controller.armImmediateTurn();
-	}, [clearReturnIntent, controller]);
+	}, [cancelRowReveal, clearReturnIntent, controller]);
+
+	const cancelImmediateTurn = useCallback(
+		(streaming: boolean) => {
+			pendingImmediateTurn.current = false;
+			controller.cancelImmediateTurn(streaming);
+		},
+		[controller],
+	);
+
+	const cancelAutomaticReveal = useCallback(() => controller.cancelReveal(), [controller]);
 
 	const revealElement = useCallback(
-		(target: HTMLElement, block: RevealBlock = "nearest", runway = "preserve") => {
+		(target: HTMLElement, options: ChatRevealOptions) => {
 			const scroller = scrollerRef.current;
 			if (!scroller?.contains(target)) return;
-			clearReturnIntent();
-			controller.cancelMovement();
-			if (runway === "release") controller.releaseRunway(false);
-			const viewportRect = scroller.getBoundingClientRect();
-			const targetRect = target.getBoundingClientRect();
-			scroller.scrollTop = revealScrollTop(
-				{
-					...scrollBounds(scroller),
-					viewportTop: viewportRect.top,
-					viewportBottom: viewportRect.bottom,
-					targetTop: targetRect.top,
-					targetBottom: targetRect.bottom,
-				},
-				block,
-			);
+			cancelRowReveal();
+			if (options.provenance === "user-navigation") readerLeft();
+			else clearReturnIntent();
+			if (options.runway === "release") controller.releaseRunway(false);
+			controller.revealTo(() => {
+				if (!scroller.contains(target)) return null;
+				const viewportRect = scroller.getBoundingClientRect();
+				const targetRect = target.getBoundingClientRect();
+				return revealScrollTop(
+					{
+						...scrollBounds(scroller),
+						viewportTop: viewportRect.top,
+						viewportBottom: viewportRect.bottom,
+						topInset: options.topInset ?? 0,
+						targetTop: targetRect.top,
+						targetBottom: targetRect.bottom,
+					},
+					options.block,
+				);
+			}, options.stability === "bounded");
 		},
-		[clearReturnIntent, controller],
+		[cancelRowReveal, clearReturnIntent, controller, readerLeft],
 	);
 
-	const releaseFollow = readerLeft;
+	const revealRow = useCallback(
+		(rowId: string, index: number, align: "start" | "center" | "end") => {
+			readerLeft();
+			controller.releaseRunway(false);
+			const scroller = scrollerRef.current;
+			if (!scroller) return;
+			const generation = rowRevealGeneration.current;
+			const revealMountedRow = () => {
+				if (generation !== rowRevealGeneration.current) return true;
+				const row = mountedChatRow(scroller, rowId);
+				if (!row) return false;
+				rowRevealFrame.current = null;
+				controller.revealTo(() => {
+					const current = mountedChatRow(scroller, rowId);
+					return current ? rowAlignmentTarget(scroller, current, align) : null;
+				}, true);
+				return true;
+			};
+			if (revealMountedRow()) return;
+			const viewport = scroller.getBoundingClientRect();
+			const anchor = Array.from(
+				scroller.querySelectorAll<HTMLElement>("[data-chat-row-index]"),
+			).find((row) => Number.isInteger(Number(row.dataset.chatRowIndex)));
+			const anchorIndex = anchor ? Number(anchor.dataset.chatRowIndex) : 0;
+			const anchorTop = anchor
+				? scroller.scrollTop + anchor.getBoundingClientRect().top - viewport.top
+				: (headerElementRef.current?.getBoundingClientRect().height ?? 0);
+			const rowTop = estimatedRowTop(rowHeightEstimates, anchorIndex, anchorTop, index);
+			const target = alignedRowScrollTop(
+				rowTop,
+				rowHeightEstimates[index] ?? 40,
+				scroller.clientHeight,
+				align,
+			);
+			scroller.scrollTop = Math.min(scrollBounds(scroller).maxScrollTop, Math.max(0, target));
+			recordProgrammaticScrollPosition();
+			let attempts = 0;
+			const waitForRow = () => {
+				if (revealMountedRow()) return;
+				attempts += 1;
+				if (attempts >= 30) {
+					cancelRowReveal();
+					return;
+				}
+				rowRevealFrame.current = requestAnimationFrame(waitForRow);
+			};
+			rowRevealFrame.current = requestAnimationFrame(waitForRow);
+		},
+		[cancelRowReveal, controller, readerLeft, recordProgrammaticScrollPosition, rowHeightEstimates],
+	);
+
 	const scrollToLatest = useCallback(() => {
 		clearReturnIntent();
+		cancelRowReveal();
 		controller.returnToEdge();
-	}, [clearReturnIntent, controller]);
+	}, [cancelRowReveal, clearReturnIntent, controller]);
 	const handleContentHeight = useCallback(() => controller.contentChanged(), [controller]);
-
-	const handleLatestState = useCallback(
-		(next: boolean) => {
-			atLatest.current = next;
-			if (next && !touchMomentum.current && performance.now() <= returnIntentUntil.current) {
-				controller.readerReachedEdge();
-				clearReturnIntent();
-			}
-		},
-		[clearReturnIntent, controller],
-	);
-
-	const handleAtBottom = useCallback(
-		(next: boolean) => {
-			if (edge === "bottom") handleLatestState(next);
-		},
-		[edge, handleLatestState],
-	);
-
-	const handleAtTop = useCallback(
-		(next: boolean) => {
-			if (edge === "top") handleLatestState(next);
-		},
-		[edge, handleLatestState],
-	);
 
 	const onPointerDown = useCallback<PointerEventHandler>(
 		(event) => {
 			clearReturnIntent();
+			programmaticScrollTop.current = null;
+			cancelRowReveal();
+			controller.cancelReveal();
 			const scroller = scrollerRef.current;
 			const scrollTop = scroller ? boundedScrollTop(scroller) : 0;
 			interactionStartScrollTop.current = scrollTop;
@@ -495,9 +627,8 @@ export function useChatScroll(
 			touchPointerActive.current = event.pointerType === "touch";
 			touchMomentum.current = event.pointerType === "touch";
 			touchMovingTowardLatest.current = null;
-			controller.readerLeft();
 		},
-		[clearReturnIntent, controller],
+		[cancelRowReveal, clearReturnIntent, controller],
 	);
 
 	const finishPointerInteraction = useCallback(
@@ -529,7 +660,8 @@ export function useChatScroll(
 				scheduleTouchSettle(terminal === "cancel" ? 1_000 : 500);
 				return;
 			}
-			if (totalMovedTowardLatest) {
+			const movedTowardLatest = touchMovingTowardLatest.current ?? totalMovedTowardLatest;
+			if (movedTowardLatest) {
 				returnIntentUntil.current = performance.now() + 500;
 				if (scroller && reachedLatestEdge(scroller, edge)) {
 					controller.readerReachedEdge();
@@ -552,26 +684,31 @@ export function useChatScroll(
 		[finishPointerInteraction],
 	);
 
-	const onWheel = useCallback<WheelEventHandler>(
-		(event) => {
-			if (event.deltaY === 0) return;
-			if (controller.getSnapshot().following) {
-				readerLeft();
-				return;
-			}
+	useEffect(() => {
+		if (!scrollerElement) return;
+		const onWheel = (event: WheelEvent) => {
+			if (event.deltaY === 0 || !canScrollBy(scrollerElement, event.deltaY)) return;
+			programmaticScrollTop.current = null;
+			cancelRowReveal();
 			const movesTowardLatest = edge === "bottom" ? event.deltaY > 0 : event.deltaY < 0;
-			if (!movesTowardLatest) {
-				readerLeft();
+			if (!isStreaming && movesTowardLatest && controller.getSnapshot().following) {
+				controller.readerMovedWhileFollowing();
 				return;
 			}
-			returnIntentUntil.current = performance.now() + 500;
-			if (atLatest.current) controller.readerReachedEdge();
-		},
-		[controller, edge, readerLeft],
-	);
+			controller.readerLeft();
+			if (!movesTowardLatest) {
+				returnIntentUntil.current = 0;
+				return;
+			}
+			returnIntentUntil.current = performance.now() + 1_000;
+			scheduleTouchSettle(1_000);
+		};
+		scrollerElement.addEventListener("wheel", onWheel, { capture: true, passive: false });
+		return () => scrollerElement.removeEventListener("wheel", onWheel, { capture: true });
+	}, [cancelRowReveal, controller, edge, isStreaming, scheduleTouchSettle, scrollerElement]);
 
-	const onKeyDown = useCallback<KeyboardEventHandler>(
-		(event) => {
+	const onKeyDown = useCallback(
+		(event: KeyboardEvent) => {
 			if (
 				event.defaultPrevented ||
 				(event.target !== scrollerRef.current && isInteractiveTarget(event.target))
@@ -590,37 +727,43 @@ export function useChatScroll(
 				(event.key === " " && !event.shiftKey);
 			const movesTowardLatest = edge === "top" ? movesTowardTop : movesTowardBottom;
 			const movesTowardHistory = edge === "top" ? movesTowardBottom : movesTowardTop;
-			if (controller.getSnapshot().following && (movesTowardLatest || movesTowardHistory)) {
-				readerLeft();
-				return;
-			}
-			if (movesTowardHistory) {
-				readerLeft();
-				return;
-			}
-			if (!movesTowardLatest) return;
-			if ((edge === "top" && event.key === "Home") || (edge === "bottom" && event.key === "End")) {
+			if (!movesTowardLatest && !movesTowardHistory) return;
+			if (
+				movesTowardLatest &&
+				((edge === "top" && event.key === "Home") || (edge === "bottom" && event.key === "End"))
+			) {
 				event.preventDefault();
 				scrollToLatest();
 				return;
 			}
-			returnIntentUntil.current = performance.now() + 500;
-			if (atLatest.current) controller.readerReachedEdge();
+			const scroller = scrollerRef.current;
+			const deltaY = movesTowardTop ? -1 : 1;
+			if (!scroller || !canScrollBy(scroller, deltaY)) return;
+			programmaticScrollTop.current = null;
+			cancelRowReveal();
+			if (!isStreaming && movesTowardLatest && controller.getSnapshot().following) {
+				controller.readerMovedWhileFollowing();
+				return;
+			}
+			controller.readerLeft();
+			if (movesTowardHistory) {
+				returnIntentUntil.current = 0;
+				return;
+			}
+			returnIntentUntil.current = performance.now() + 1_000;
+			scheduleTouchSettle(1_000);
 		},
-		[controller, edge, readerLeft, scrollToLatest],
+		[cancelRowReveal, controller, edge, isStreaming, scheduleTouchSettle, scrollToLatest],
 	);
 
-	const onFocusCapture = useCallback<FocusEventHandler>(
-		(event) => {
-			if (isInteractiveTarget(event.target)) readerLeft();
-		},
-		[readerLeft],
-	);
+	useEffect(() => {
+		if (!scrollerElement) return;
+		scrollerElement.addEventListener("keydown", onKeyDown);
+		return () => scrollerElement.removeEventListener("keydown", onKeyDown);
+	}, [onKeyDown, scrollerElement]);
 
 	return {
 		followOutput: false,
-		handleAtBottom,
-		handleAtTop,
 		handleContentHeight,
 		handleScrollerRef,
 		headerRef,
@@ -632,17 +775,16 @@ export function useChatScroll(
 		scrollButtonLabel: snapshot.buttonLabel,
 		scrollToLatest,
 		armImmediateTurn,
-		releaseFollow,
+		cancelImmediateTurn,
+		cancelAutomaticReveal,
 		revealElement,
+		revealRow,
 		runwayActive: snapshot.runway,
 		followState: snapshot.following ? "following" : "detached",
 		containerProps: {
-			onFocusCapture,
-			onKeyDown,
 			onPointerCancel,
 			onPointerDown,
 			onPointerUp,
-			onWheel,
 		},
 	};
 }

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -147,7 +147,9 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   detached subagent's terminal report is transcript-positioned, rendered by `chat`'s completion card —
   both narrowed by the shared contracts guards) /
   `currentAssistantId` / `attemptAssistantId` (scopes overflow removal to the attempt actually observed) /
-  `isStreaming` / `model` / `thinkingLevel` / **`eventRevision`** (browser-local, incremented for every
+  `isStreaming` / **`settlementTick`** (browser-local, monotonically incremented for every
+  `agent_settled`, so batched start+settle still exposes the completion edge to chat layout) / `model` /
+  `thinkingLevel` / **`eventRevision`** (browser-local, incremented for every
   received Pi event; the compare-and-install fence for an authoritative transcript read) /
   **`syncedConnectionGeneration`** (which connected host generation the runtime's transcript was last read
   from) / `stats` / `commands` / `draft` and its **extension-UI state** (`pendingExtUi` (typed by
@@ -167,7 +169,9 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   follow-on user turn, while `agent_start` consumes it for work begun by another client or a custom message.
   Thus the renderer can offer one ordinary `Try again.` send without parsing errors or leaving an actionable
   historical failure. `agent_end` is attempt-level and never clears `isStreaming`; settlement alone finishes
-  retries, compaction, and queued continuations. The
+  retries, compaction, and queued continuations. The same `agent_settled` fold increments `settlementTick`
+  independently of the final `isStreaming` value, preserving the transition when the Pi-event batcher gives
+  React only the batch's false→false endpoint. The
   **compaction lifecycle is a first-class turn**: `compaction_start` appends a `compaction` turn
   (`running`), `compaction_end` settles the trailing running one in place (success → `done` +
   tokens-before/after from the typed `CompactionEndResult`, guarded — wire data is untrusted; `aborted`

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -160,7 +160,8 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   **`appendErrorTurn(sessionId, text)`** appends an `error` turn for a **rejected** turn-driving wire call
   (`session.prompt`/`steer`/`followUp`/`create`) — e.g. `prompt()` throwing "no API key" / a bad model —
   so a failed send lands in the chat instead of being swallowed; it carries no recovery action because Pi
-  never accepted the missing turn. A *streaming* fault instead ends the run through
+  never accepted the missing turn. It does not clear `isStreaming` or the active assistant id: a rejected
+  steer/follow-up cannot settle work the host is still running. A *streaming* fault instead ends the run through
   **`reduceSessionEvent`** at `agent_settled`, using the host-projected final terminal metadata:
   `stopReason: "error"` carries Pi's `errorMessage`, and `stopReason: "length"` becomes an actionable
   truncation error — neither may become "✓ Done". That settlement-created error turn alone carries the

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -260,6 +260,31 @@ test("an ordered Pi-event batch commits once while preserving every session revi
 	expect(rt("b").isStreaming).toBe(true);
 });
 
+test("a settlement tick survives a batched false-to-false streaming endpoint", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+	expect(rt("a").settlementTick).toBe(0);
+	let commits = 0;
+	const unsubscribe = useAppStore.subscribe(() => {
+		commits += 1;
+	});
+
+	store.handlePiEvents([
+		{ sessionId: "a", event: agentStart },
+		{ sessionId: "a", event: agentEnd },
+		{ sessionId: "a", event: agentSettled() },
+	]);
+	unsubscribe();
+
+	expect(commits).toBe(1);
+	expect(rt("a").isStreaming).toBe(false);
+	expect(rt("a").settlementTick).toBe(1);
+	store.handlePiEvent(agentEnd, "a");
+	expect(rt("a").settlementTick).toBe(1);
+	store.handlePiEvent(agentSettled(), "a");
+	expect(rt("a").settlementTick).toBe(2);
+});
+
 test("a host-fired USER message folds into the transcript; the composer's optimistic twin doesn't duplicate", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -1000,6 +1000,21 @@ test("appendErrorTurn surfaces a failed send (a rejected prompt) as a visible er
 	expect(rt("a").isStreaming).toBe(false);
 });
 
+test("a rejected queued send cannot settle work the host is still running", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "a", null, "medium");
+	store.handlePiEvent(agentStart, "a");
+	store.handlePiEvent(assistantStart, "a");
+	store.handlePiEvent(assistantText("still working"), "a");
+	const currentAssistantId = rt("a").currentAssistantId;
+
+	store.appendErrorTurn("a", "follow-up rejected");
+
+	expect(rt("a").isStreaming).toBe(true);
+	expect(rt("a").currentAssistantId).toBe(currentAssistantId);
+	expect(rt("a").turns.at(-1)).toMatchObject({ kind: "error", text: "follow-up rejected" });
+});
+
 test("a message_update with no prior message_start still builds the turn (mid-stream hydration)", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -325,6 +325,7 @@ export interface SessionRuntime {
 	currentAssistantId: string | null;
 	attemptAssistantId: string | null;
 	isStreaming: boolean;
+	settlementTick: number;
 	queue: SessionQueueState;
 	model: WireModel | null;
 	thinkingLevel: ThinkingLevel;
@@ -353,6 +354,7 @@ function newRuntime(
 		currentAssistantId: null,
 		attemptAssistantId: null,
 		isStreaming: false,
+		settlementTick: 0,
 		queue: EMPTY_QUEUE,
 		model,
 		thinkingLevel,
@@ -635,6 +637,7 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 					closer,
 				],
 				isStreaming: false,
+				settlementTick: rt.settlementTick + 1,
 				currentAssistantId: null,
 				attemptAssistantId: null,
 			};
@@ -2929,10 +2932,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 		set((s) =>
 			withRuntime(s, sessionId, (rt) => ({
 				...rt,
-				isStreaming: false,
-				currentAssistantId: null,
-				attemptAssistantId: null,
-				turns: [...clearTurnStreaming(rt.turns), { kind: "error", id: crypto.randomUUID(), text }],
+				turns: [...rt.turns, { kind: "error", id: crypto.randomUUID(), text }],
 			})),
 		),
 	appendCompactionFailureUnlessObserved: (sessionId, observedTurnIds, detail) =>

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -1,7 +1,11 @@
 import { appendFileSync, realpathSync, utimesSync } from "node:fs";
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
-import { readChatScrollGeometry } from "./fixtures/chatScroll";
+import {
+	moveMouseToChatViewport,
+	readChatScrollGeometry,
+	readChatViewportIntersection,
+} from "./fixtures/chatScroll";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
 import { seedWorkspaceSession } from "./fixtures/sessions";
 
@@ -28,6 +32,105 @@ function appendMessage(path: string, id: string, parentId: string, message: obje
 		})}\n`,
 	);
 	return id;
+}
+
+async function selectMessageOrder(
+	page: Page,
+	order: "oldest-first" | "newest-first",
+): Promise<void> {
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	const option = page.getByTestId(`chat-order-${order}`);
+	await option.click();
+	await expect(option).toHaveAttribute("data-active", "true");
+	await page.keyboard.press("Escape");
+}
+
+function seedNestedActivityChat(name: string) {
+	const chat = seedWorkspaceSession(repoCwd(), {
+		name,
+		messages: [
+			{ role: "user", text: "Record the earlier watcher investigation.", timestamp: BASE_TS },
+			{
+				role: "assistant",
+				text: Array.from(
+					{ length: 60 },
+					(_, index) => `Historical watcher checkpoint ${index + 1} remained stable.`,
+				).join("\n\n"),
+				timestamp: BASE_TS + 1_000,
+			},
+			{
+				role: "user",
+				text: Array.from(
+					{ length: 24 },
+					(_, index) => `Inspect sustained watcher churn scenario ${index + 1}.`,
+				).join(" "),
+				timestamp: BASE_TS + 2_000,
+			},
+		],
+	});
+	const assistantId = `${chat.id}-a1`;
+	appendMessage(chat.path, assistantId, `${chat.id}-m2`, {
+		role: "assistant",
+		content: [
+			{ type: "toolCall", id: "read-prefix", name: "read", arguments: { path: "watch.ts" } },
+			{ type: "thinking", thinking: "I should inspect the coalescer test next." },
+			{ type: "toolCall", id: "read-nested", name: "read", arguments: { path: "watch.test.ts" } },
+			{ type: "thinking", thinking: "The failing case needs a bounded max-wait assertion." },
+			{
+				type: "toolCall",
+				id: "bash-long",
+				name: "bash",
+				arguments: { command: "bun test watch.test.ts" },
+			},
+		],
+		usage,
+		stopReason: "toolUse",
+		timestamp: BASE_TS + 1_000,
+	});
+	let parentId = assistantId;
+	for (const [toolCallId, toolName, output] of [
+		["read-prefix", "read", "watcher source"],
+		[
+			"read-nested",
+			"read",
+			Array.from({ length: 60 }, (_, index) => `coalescer regression line ${index + 1}`).join("\n"),
+		],
+		[
+			"bash-long",
+			"bash",
+			Array.from({ length: 120 }, (_, index) => `passing watcher assertion ${index + 1}`).join(
+				"\n",
+			),
+		],
+	] as const) {
+		parentId = appendMessage(chat.path, `${chat.id}-${toolCallId}`, parentId, {
+			role: "toolResult",
+			toolCallId,
+			toolName,
+			content: [{ type: "text", text: output }],
+			isError: false,
+			timestamp: BASE_TS + 2_000,
+		});
+	}
+	appendMessage(chat.path, `${chat.id}-a2`, parentId, {
+		role: "assistant",
+		content: [
+			{
+				type: "text",
+				text: Array.from(
+					{ length: 15 },
+					(_, index) =>
+						`The watcher checkpoint ${index + 1} now flushes within the bounded window.`,
+				).join("\n\n"),
+			},
+		],
+		usage,
+		stopReason: "stop",
+		timestamp: BASE_TS + 3_000,
+	});
+	utimesSync(chat.path, new Date(BASE_TS), new Date(BASE_TS));
+	return chat;
 }
 
 test("a model-authored Thinking heading stays bounded and appears only while folded", async ({
@@ -132,64 +235,295 @@ test("a model-authored Thinking heading stays bounded and appears only while fol
 	);
 });
 
+for (const order of ["oldest-first", "newest-first"] as const) {
+	test(`${order} disclosure expansion preserves following and detached reading anchors`, async ({
+		page,
+	}) => {
+		test.setTimeout(60_000);
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await openFixtureProject(page);
+		seedNestedActivityChat(`${order} disclosure geometry`);
+		await selectMessageOrder(page, order);
+		await enterDefaultWorkspace(page);
+		const chatScroll = page.getByTestId("chat-scroll");
+		const button = page.getByTestId(
+			order === "newest-first" ? "scroll-to-top" : "scroll-to-bottom",
+		);
+		const latestDistance = async () => {
+			const geometry = await readChatScrollGeometry(chatScroll);
+			return order === "newest-first" ? geometry.distanceFromStart : geometry.distanceFromEnd;
+		};
+		const expectFollowingLatest = async () => {
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await expect(button).toHaveCount(0);
+			await expect.poll(latestDistance).toBeLessThanOrEqual(1);
+			await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+			const maximumDistance = await chatScroll.evaluate(async (root, messageOrder) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				let maximum = 0;
+				for (let frame = 0; frame < 32; frame += 1) {
+					await new Promise(requestAnimationFrame);
+					const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+					const distance =
+						messageOrder === "newest-first"
+							? scroller.scrollTop
+							: maxScrollTop - scroller.scrollTop;
+					maximum = Math.max(maximum, Math.abs(distance));
+				}
+				return maximum;
+			}, order);
+			expect(maximumDistance).toBeLessThanOrEqual(1);
+		};
+		await expectFollowingLatest();
+
+		const messageToggle = page.getByTestId("user-message-toggle");
+		await expect(messageToggle).toHaveAttribute("aria-expanded", "false");
+		await messageToggle.click();
+		await expect(messageToggle).toHaveAttribute("aria-expanded", "true");
+		await expectFollowingLatest();
+		const activity = page.getByTestId("activity-group").first();
+		const activityToggle = activity.getByTestId("activity-group-toggle");
+		await expect(activityToggle).toHaveAttribute("aria-expanded", "false");
+		await activityToggle.focus();
+		await page.keyboard.press("Enter");
+		await expect(activityToggle).toHaveAttribute("aria-expanded", "true");
+		await expectFollowingLatest();
+		const thinking = activity.getByTestId("thinking-group").first();
+		const thinkingToggle = thinking.getByTestId("thinking-group-toggle");
+		await expect(thinkingToggle).toHaveAttribute("aria-expanded", "false");
+		await thinkingToggle.click();
+		await expect(thinkingToggle).toHaveAttribute("aria-expanded", "true");
+		await expectFollowingLatest();
+		const toolToggle = thinking
+			.locator('[data-testid="activity-step"][data-tool="read"]')
+			.getByTestId("activity-step-toggle");
+		await expect(toolToggle).toHaveAttribute("aria-expanded", "false");
+		await toolToggle.click();
+		await expect(toolToggle).toHaveAttribute("aria-expanded", "true");
+		await expectFollowingLatest();
+		const longOutputToggle = thinking.getByTestId("collapsible-toggle");
+		await expect(longOutputToggle).toHaveAttribute("aria-expanded", "false");
+		await longOutputToggle.click();
+		await expect(longOutputToggle).toHaveAttribute("aria-expanded", "true");
+		await expectFollowingLatest();
+
+		await moveMouseToChatViewport(page, chatScroll);
+		const historyDelta = order === "newest-first" ? 160 : -160;
+		await page.mouse.wheel(0, historyDelta);
+		await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+		await expect(button).toContainText("Latest");
+
+		const placeToggleInViewport = async (toggle: Locator) => {
+			await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+			for (let attempt = 0; attempt < 80; attempt += 1) {
+				if ((await toggle.count()) > 0) {
+					const intersection = await readChatViewportIntersection(toggle);
+					if (intersection.intersectionHeight >= intersection.elementHeight - 1) return;
+					await toggle.evaluate((element) => {
+						const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+						if (!scroller) throw new Error("missing Virtuoso scroller");
+						const target = element.getBoundingClientRect();
+						const viewport = scroller.getBoundingClientRect();
+						scroller.scrollTop +=
+							target.top + target.height / 2 - (viewport.top + viewport.height / 2);
+					});
+				} else {
+					await page.mouse.wheel(0, historyDelta);
+				}
+				await page.evaluate(() => new Promise(requestAnimationFrame));
+			}
+			throw new Error("fold toggle did not enter the chat viewport");
+		};
+		const maximumAnchorDeviation = (toggle: Locator, top: number) =>
+			toggle.evaluate(async (element, expectedTop) => {
+				let maximum = 0;
+				for (let frame = 0; frame < 48; frame += 1) {
+					await new Promise(requestAnimationFrame);
+					maximum = Math.max(maximum, Math.abs(element.getBoundingClientRect().top - expectedTop));
+				}
+				return maximum;
+			}, top);
+		const expectDetachedToggleAnchor = async (
+			toggle: Locator,
+			activation: "keyboard" | "pointer" = "pointer",
+		) => {
+			await placeToggleInViewport(toggle);
+			if (activation === "keyboard") await toggle.focus();
+			const before = await toggle.boundingBox();
+			expect(before).not.toBeNull();
+			await expect(toggle).toHaveAttribute("aria-expanded", "true");
+			if (activation === "keyboard") await page.keyboard.press("Enter");
+			else await toggle.click();
+			await expect(toggle).toHaveAttribute("aria-expanded", "false");
+			expect(await maximumAnchorDeviation(toggle, before?.y ?? 0)).toBeLessThanOrEqual(2);
+			await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await expect(button).toContainText("Latest");
+			if (activation === "keyboard") await page.keyboard.press("Enter");
+			else await toggle.click();
+			await expect(toggle).toHaveAttribute("aria-expanded", "true");
+			expect(await maximumAnchorDeviation(toggle, before?.y ?? 0)).toBeLessThanOrEqual(2);
+			await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+		};
+
+		await expectDetachedToggleAnchor(longOutputToggle);
+		await expectDetachedToggleAnchor(toolToggle);
+		await expectDetachedToggleAnchor(thinkingToggle, "keyboard");
+		await expectDetachedToggleAnchor(activityToggle);
+		await expectDetachedToggleAnchor(messageToggle);
+
+		const retainedPreviewAnchor = page.getByText("coalescer regression line 5", { exact: true });
+		await retainedPreviewAnchor.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			const target = element.getBoundingClientRect();
+			const viewport = scroller.getBoundingClientRect();
+			scroller.scrollTop += target.top + target.height / 2 - (viewport.top + viewport.height / 2);
+		});
+		await page.evaluate(() => new Promise(requestAnimationFrame));
+		expect((await readChatViewportIntersection(longOutputToggle)).intersects).toBe(false);
+		const retainedPreviewTop = (await retainedPreviewAnchor.boundingBox())?.y;
+		expect(retainedPreviewTop).toBeDefined();
+		await longOutputToggle.evaluate((element) => element.click());
+		await expect(longOutputToggle).toHaveAttribute("aria-expanded", "false");
+		expect(
+			await maximumAnchorDeviation(retainedPreviewAnchor, retainedPreviewTop ?? 0),
+		).toBeLessThanOrEqual(2);
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		await longOutputToggle.evaluate((element) => element.click());
+		await expect(longOutputToggle).toHaveAttribute("aria-expanded", "true");
+		expect(
+			await maximumAnchorDeviation(retainedPreviewAnchor, retainedPreviewTop ?? 0),
+		).toBeLessThanOrEqual(2);
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+
+		const clippedPreviewAnchor = page.getByText("coalescer regression line 30", { exact: true });
+		await clippedPreviewAnchor.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			const target = element.getBoundingClientRect();
+			const viewport = scroller.getBoundingClientRect();
+			scroller.scrollTop += target.top + target.height / 2 - (viewport.top + viewport.height / 2);
+		});
+		await page.evaluate(() => new Promise(requestAnimationFrame));
+		expect((await readChatViewportIntersection(longOutputToggle)).intersects).toBe(false);
+		await longOutputToggle.evaluate((element) => element.click());
+		await expect(longOutputToggle).toHaveAttribute("aria-expanded", "false");
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		const collapsedOutputBoundary = await longOutputToggle.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			return scroller.getBoundingClientRect().bottom - element.getBoundingClientRect().bottom;
+		});
+		expect(Math.abs(collapsedOutputBoundary)).toBeLessThanOrEqual(2);
+		await longOutputToggle.click();
+		await expect(longOutputToggle).toHaveAttribute("aria-expanded", "true");
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+
+		const offscreenAnchor = page.getByText(
+			order === "newest-first"
+				? "Historical watcher checkpoint 8 remained stable."
+				: "The watcher checkpoint 8 now flushes within the bounded window.",
+			{ exact: true },
+		);
+		for (let attempt = 0; attempt < 80 && (await offscreenAnchor.count()) === 0; attempt += 1) {
+			await page.mouse.wheel(0, 160);
+			await page.evaluate(() => new Promise(requestAnimationFrame));
+		}
+		await expect(offscreenAnchor).toHaveCount(1);
+		await offscreenAnchor.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			const target = element.getBoundingClientRect();
+			const viewport = scroller.getBoundingClientRect();
+			scroller.scrollTop += target.top + target.height / 2 - (viewport.top + viewport.height / 2);
+		});
+		await page.evaluate(() => new Promise(requestAnimationFrame));
+		await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+		await expect(activityToggle).toHaveCount(1);
+		expect((await readChatViewportIntersection(activityToggle)).intersects).toBe(false);
+		const anchorTop = (await offscreenAnchor.boundingBox())?.y;
+		expect(anchorTop).toBeDefined();
+		await activityToggle.evaluate((element) => element.click());
+		await expect(activityToggle).toHaveAttribute("aria-expanded", "false");
+		expect(await maximumAnchorDeviation(offscreenAnchor, anchorTop ?? 0)).toBeLessThanOrEqual(2);
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		expect((await readChatViewportIntersection(activityToggle)).intersects).toBe(false);
+		await activityToggle.evaluate((element) => element.click());
+		await expect(activityToggle).toHaveAttribute("aria-expanded", "true");
+		expect(await maximumAnchorDeviation(offscreenAnchor, anchorTop ?? 0)).toBeLessThanOrEqual(2);
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+
+		await thinkingToggle.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			const target = element.getBoundingClientRect();
+			const viewport = scroller.getBoundingClientRect();
+			scroller.scrollTop += target.top - viewport.top - 20;
+		});
+		await page.evaluate(() => new Promise(requestAnimationFrame));
+		const trail = page.getByTestId("activity-breadcrumb-trail");
+		await expect(trail).toBeVisible();
+		const parentBreadcrumbHeight = (await trail.boundingBox())?.height ?? 0;
+		const partiallyCoveredOffset = await thinkingToggle.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			return element.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+		});
+		expect(partiallyCoveredOffset).toBeGreaterThan(0);
+		expect(partiallyCoveredOffset).toBeLessThan(parentBreadcrumbHeight);
+		await trail
+			.locator('[data-testid="activity-breadcrumb-segment"][data-kind="thinking"]')
+			.locator("button")
+			.first()
+			.click();
+		await expect(thinkingToggle).toHaveAttribute("aria-expanded", "false");
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		const nestedHeaderOffset = await thinkingToggle.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			return element.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+		});
+		expect(Math.abs(nestedHeaderOffset - parentBreadcrumbHeight)).toBeLessThanOrEqual(2);
+		await thinkingToggle.evaluate((element) => element.click());
+		await expect(thinkingToggle).toHaveAttribute("aria-expanded", "true");
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		const activityContent = page.getByText("coalescer regression line 30", { exact: true });
+		await activityContent.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			const target = element.getBoundingClientRect();
+			const viewport = scroller.getBoundingClientRect();
+			scroller.scrollTop += target.top + target.height / 2 - (viewport.top + viewport.height / 2);
+		});
+		await page.evaluate(() => new Promise(requestAnimationFrame));
+		await expect(trail).toBeVisible();
+		await trail
+			.locator('[data-testid="activity-breadcrumb-segment"][data-kind="activity"]')
+			.locator("button")
+			.first()
+			.click();
+		await expect(activityToggle).toHaveAttribute("aria-expanded", "false");
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		const collapsedHeaderOffset = await activityToggle.evaluate((element) => {
+			const scroller = element.closest<HTMLElement>("[data-virtuoso-scroller]");
+			if (!scroller) throw new Error("missing Virtuoso scroller");
+			return element.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+		});
+		expect(Math.abs(collapsedHeaderOffset)).toBeLessThanOrEqual(2);
+		await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+		await expect(button).toContainText("Latest");
+	});
+}
+
 test("sticky activity breadcrumbs expose the off-screen Activity → Thinking → tool path", async ({
 	page,
 }) => {
 	await openFixtureProject(page);
-	const chat = seedWorkspaceSession(repoCwd(), {
-		name: "sticky activity",
-		messages: [
-			{ role: "user", text: "Inspect the watcher under sustained churn.", timestamp: BASE_TS },
-		],
-	});
-	const assistantId = `${chat.id}-a1`;
-	appendMessage(chat.path, assistantId, `${chat.id}-m0`, {
-		role: "assistant",
-		content: [
-			{ type: "toolCall", id: "read-prefix", name: "read", arguments: { path: "watch.ts" } },
-			{ type: "thinking", thinking: "I should inspect the coalescer test next." },
-			{ type: "toolCall", id: "read-nested", name: "read", arguments: { path: "watch.test.ts" } },
-			{ type: "thinking", thinking: "The failing case needs a bounded max-wait assertion." },
-			{
-				type: "toolCall",
-				id: "bash-long",
-				name: "bash",
-				arguments: { command: "bun test watch.test.ts" },
-			},
-		],
-		usage,
-		stopReason: "toolUse",
-		timestamp: BASE_TS + 1_000,
-	});
-	let parentId = assistantId;
-	for (const [toolCallId, toolName, output] of [
-		["read-prefix", "read", "watcher source"],
-		["read-nested", "read", "coalescer regression"],
-		[
-			"bash-long",
-			"bash",
-			Array.from({ length: 120 }, (_, index) => `passing watcher assertion ${index + 1}`).join(
-				"\n",
-			),
-		],
-	] as const) {
-		parentId = appendMessage(chat.path, `${chat.id}-${toolCallId}`, parentId, {
-			role: "toolResult",
-			toolCallId,
-			toolName,
-			content: [{ type: "text", text: output }],
-			isError: false,
-			timestamp: BASE_TS + 2_000,
-		});
-	}
-	appendMessage(chat.path, `${chat.id}-a2`, parentId, {
-		role: "assistant",
-		content: [{ type: "text", text: "The watcher now flushes within the bounded window." }],
-		usage,
-		stopReason: "stop",
-		timestamp: BASE_TS + 3_000,
-	});
-	utimesSync(chat.path, new Date(BASE_TS), new Date(BASE_TS));
+	seedNestedActivityChat("sticky activity");
 
 	await expect(defaultWorkspaceRow(page)).toBeVisible();
 	await enterDefaultWorkspace(page);

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -4,6 +4,7 @@ import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "
 import {
 	moveMouseToChatViewport,
 	readChatScrollGeometry,
+	readChatViewportCenterOffsets,
 	readChatViewportIntersection,
 } from "./fixtures/chatScroll";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
@@ -282,6 +283,12 @@ for (const order of ["oldest-first", "newest-first"] as const) {
 		await messageToggle.click();
 		await expect(messageToggle).toHaveAttribute("aria-expanded", "true");
 		await expectFollowingLatest();
+		await messageToggle.click();
+		await expect(messageToggle).toHaveAttribute("aria-expanded", "false");
+		await expectFollowingLatest();
+		await messageToggle.click();
+		await expect(messageToggle).toHaveAttribute("aria-expanded", "true");
+		await expectFollowingLatest();
 		const activity = page.getByTestId("activity-group").first();
 		const activityToggle = activity.getByTestId("activity-group-toggle");
 		await expect(activityToggle).toHaveAttribute("aria-expanded", "false");
@@ -516,6 +523,40 @@ for (const order of ["oldest-first", "newest-first"] as const) {
 		expect(Math.abs(collapsedHeaderOffset)).toBeLessThanOrEqual(2);
 		await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
 		await expect(button).toContainText("Latest");
+
+		await activityToggle.click();
+		await expect(activityToggle).toHaveAttribute("aria-expanded", "true");
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		await button.click();
+		await expectFollowingLatest();
+		await page.getByTestId("chat-input").press("Control+r");
+		const history = page.getByTestId("history-overlay");
+		await expect(history).toBeVisible();
+		const historyQuery = page.getByTestId("history-query");
+		await historyQuery.fill("Historical watcher checkpoint 30 remained stable");
+		await expect(page.getByTestId("history-expand-hint")).toBeVisible();
+		await historyQuery.press("Tab");
+		const historyHit = page.locator('[data-testid="history-item"][data-kind="message"]');
+		await expect(historyHit).toHaveCount(1);
+		await expect(historyHit).toBeVisible();
+		await historyQuery.press("Enter");
+		await expect(history).toBeHidden();
+		const flashedHistoryRow = page.locator("[data-flash]");
+		await expect(flashedHistoryRow).toBeVisible();
+		await expect(flashedHistoryRow).toContainText(
+			"Historical watcher checkpoint 30 remained stable",
+		);
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		const exactHistoryAnchor = page.getByText("Historical watcher checkpoint 30 remained stable.", {
+			exact: true,
+		});
+		await expect(exactHistoryAnchor).toBeAttached();
+		expect((await readChatViewportIntersection(exactHistoryAnchor)).intersects).toBe(true);
+		const historyCenterOffsets = await readChatViewportCenterOffsets(exactHistoryAnchor);
+		expect(historyCenterOffsets.every((offset) => Math.abs(offset) <= 80)).toBe(true);
+		expect(
+			Math.max(...historyCenterOffsets) - Math.min(...historyCenterOffsets),
+		).toBeLessThanOrEqual(1);
 	});
 }
 

--- a/e2e/activity-breadcrumbs.spec.ts
+++ b/e2e/activity-breadcrumbs.spec.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, realpathSync, utimesSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 import { defaultWorkspaceRow, enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import { readChatScrollGeometry } from "./fixtures/chatScroll";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
 import { seedWorkspaceSession } from "./fixtures/sessions";
 
@@ -194,12 +195,25 @@ test("sticky activity breadcrumbs expose the off-screen Activity â†’ Thinking â†
 	await enterDefaultWorkspace(page);
 	await expect(page.locator('[data-testid="editor-tab"][data-kind="chat"]')).toHaveCount(1);
 
+	const chatScroll = page.getByTestId("chat-scroll");
+	const assertFollowingLatest = async () => {
+		await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+		await expect(page.getByTestId("scroll-to-bottom")).toHaveCount(0);
+		await expect
+			.poll(async () => (await readChatScrollGeometry(chatScroll)).distanceFromEnd)
+			.toBeLessThanOrEqual(1);
+	};
+	await assertFollowingLatest();
+
 	const activity = page.getByTestId("activity-group").first();
 	await activity.getByTestId("activity-group-toggle").click();
+	await assertFollowingLatest();
 	const thinking = activity.getByTestId("thinking-group").last();
 	await thinking.getByTestId("thinking-group-toggle").click();
+	await assertFollowingLatest();
 	const tool = thinking.locator('[data-testid="activity-step"][data-tool="bash"]');
 	await tool.getByTestId("activity-step-toggle").click();
+	await assertFollowingLatest();
 
 	const trail = page.getByTestId("activity-breadcrumb-trail");
 	await expect

--- a/e2e/ask-user-question.spec.ts
+++ b/e2e/ask-user-question.spec.ts
@@ -145,6 +145,9 @@ test("a persisted tall questionnaire reveals page changes and a restored page wi
 		);
 
 		const firstOption = card.getByTestId("ask-option").first();
+		await expect(firstOption).toBeFocused();
+		await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+		await expect(page.getByTestId("scroll-to-bottom")).toHaveCount(0);
 		await firstOption.click();
 		await expect(firstOption).toHaveAttribute("data-selected", "true");
 		const next = card.getByTestId("ask-continue");

--- a/e2e/chat-scroll.live.spec.ts
+++ b/e2e/chat-scroll.live.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { hideAuxiliaryWorkbench, openWorkspaceChat, waitForAgentSettled } from "./fixtures/app";
+import { readChatScrollGeometry } from "./fixtures/chatScroll";
 
 async function openChatAndSend(
 	page: import("@playwright/test").Page,
@@ -17,6 +18,11 @@ test("the reading band removes its temporary runway when the agent settles", {
 	await openWorkspaceChat(page);
 	await page.setViewportSize({ width: 1100, height: 800 });
 	await hideAuxiliaryWorkbench(page);
+	const statusSlot = page.getByTestId("chat-status-slot");
+	const composer = page.getByTestId("chat-composer");
+	await expect(statusSlot).toHaveAttribute("data-active", "false");
+	const idleStatusHeight = (await statusSlot.boundingBox())?.height;
+	const idleComposerTop = (await composer.boundingBox())?.y;
 	await page
 		.getByTestId("chat-input")
 		.fill(
@@ -30,8 +36,18 @@ test("the reading band removes its temporary runway when the agent settles", {
 	await expect(page.getByTestId("chat-stream-runway")).toBeVisible();
 	await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
 	await expect(chatScroll).toHaveAttribute("data-streaming", "true");
+	await expect(statusSlot).toHaveAttribute("data-active", "true");
+	expect((await statusSlot.boundingBox())?.height).toBe(idleStatusHeight);
+	expect((await composer.boundingBox())?.y).toBe(idleComposerTop);
 	await expect(chatScroll).toHaveAttribute("data-streaming", "false", { timeout: 90_000 });
 
+	await expect(statusSlot).toHaveAttribute("data-active", "false");
+	expect((await statusSlot.boundingBox())?.height).toBe(idleStatusHeight);
+	expect((await composer.boundingBox())?.y).toBe(idleComposerTop);
+	await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+	await expect
+		.poll(async () => (await readChatScrollGeometry(chatScroll)).distanceFromEnd)
+		.toBeLessThanOrEqual(1);
 	await expect(page.getByTestId("chat-stream-runway")).toHaveCount(0);
 	await expect(page.getByTestId("scroll-to-bottom")).toHaveCount(0);
 

--- a/e2e/chat-scroll.spec.ts
+++ b/e2e/chat-scroll.spec.ts
@@ -1,0 +1,152 @@
+import { realpathSync, rmSync, utimesSync } from "node:fs";
+import { expect, type Page, test } from "@playwright/test";
+import { enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
+import { moveMouseToChatViewport, readChatScrollGeometry } from "./fixtures/chatScroll";
+import { E2E_FIXTURE_REPO } from "./fixtures/paths";
+import { seedWorkspaceSession } from "./fixtures/sessions";
+
+const BASE_TS = 1_700_850_000_000;
+
+type MessageOrder = "oldest-first" | "newest-first";
+
+const orderCases: Array<{
+	order: MessageOrder;
+	buttonTestId: "scroll-to-bottom" | "scroll-to-top";
+	outwardWheel: number;
+	historyWheel: number;
+	latestWheel: number;
+}> = [
+	{
+		order: "oldest-first",
+		buttonTestId: "scroll-to-bottom",
+		outwardWheel: 120,
+		historyWheel: -900,
+		latestWheel: 900,
+	},
+	{
+		order: "newest-first",
+		buttonTestId: "scroll-to-top",
+		outwardWheel: -120,
+		historyWheel: 900,
+		latestWheel: -900,
+	},
+];
+
+async function selectMessageOrder(page: Page, order: MessageOrder): Promise<void> {
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	const option = page.getByTestId(`chat-order-${order}`);
+	await option.click();
+	await expect(option).toHaveAttribute("data-active", "true");
+	await page.keyboard.press("Escape");
+}
+
+function seedTallChat(name: string) {
+	const session = seedWorkspaceSession(realpathSync(E2E_FIXTURE_REPO), {
+		name,
+		messages: Array.from({ length: 40 }, (_, index) => [
+			{
+				role: "user" as const,
+				text: `request ${index + 1}: inspect the deterministic scrolling fixture`,
+				timestamp: BASE_TS + index * 2_000,
+			},
+			{
+				role: "assistant" as const,
+				text: `answer ${index + 1}: the deterministic scrolling fixture is complete`,
+				timestamp: BASE_TS + index * 2_000 + 1_000,
+			},
+		]).flat(),
+	});
+	utimesSync(session.path, new Date(BASE_TS + 100_000), new Date(BASE_TS + 100_000));
+	return session;
+}
+
+async function openTallChat(page: Page, order: MessageOrder) {
+	await openFixtureProject(page);
+	const session = seedTallChat(`${order} deterministic scrolling`);
+	await selectMessageOrder(page, order);
+	await enterDefaultWorkspace(page);
+	const chatScroll = page.getByTestId("chat-scroll");
+	await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+	await expect
+		.poll(async () => {
+			const geometry = await readChatScrollGeometry(chatScroll);
+			return order === "newest-first" ? geometry.distanceFromStart : geometry.distanceFromEnd;
+		})
+		.toBeLessThanOrEqual(1);
+	return { session, chatScroll };
+}
+
+for (const testCase of orderCases) {
+	test(`${testCase.order} ignores repeated outward wheel input at the physical latest edge`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		try {
+			await moveMouseToChatViewport(page, chatScroll);
+			for (let tick = 0; tick < 4; tick += 1) {
+				await page.mouse.wheel(0, testCase.outwardWheel);
+				await page.evaluate(() => new Promise(requestAnimationFrame));
+				await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+				await expect(page.getByTestId(testCase.buttonTestId)).toHaveCount(0);
+			}
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} rearms only when a latest-directed wheel reaches the physical edge`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		try {
+			await moveMouseToChatViewport(page, chatScroll);
+			await page.mouse.wheel(0, testCase.historyWheel);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+
+			await chatScroll.evaluate((root, order) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+				scroller.scrollTop = order === "newest-first" ? 25 : maxScrollTop - 25;
+				scroller.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+
+			await moveMouseToChatViewport(page, chatScroll);
+			await page.mouse.wheel(0, testCase.latestWheel > 0 ? 4 : -4);
+			const near = await readChatScrollGeometry(chatScroll);
+			const nearDistance =
+				testCase.order === "newest-first" ? near.distanceFromStart : near.distanceFromEnd;
+			expect(nearDistance).toBeGreaterThan(1);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+
+			await page.mouse.wheel(0, testCase.latestWheel);
+			await expect
+				.poll(async () => {
+					const geometry = await readChatScrollGeometry(chatScroll);
+					return testCase.order === "newest-first"
+						? geometry.distanceFromStart
+						: geometry.distanceFromEnd;
+				})
+				.toBeLessThanOrEqual(1);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await expect(page.getByTestId(testCase.buttonTestId)).toHaveCount(0);
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} keeps an idle status slot at the logical latest edge`, async ({ page }) => {
+		const { session } = await openTallChat(page, testCase.order);
+		try {
+			const slot = page.getByTestId("chat-status-slot");
+			await expect(slot).toHaveCount(1);
+			await expect(slot).toHaveAttribute("data-active", "false");
+			expect((await slot.boundingBox())?.height).toBeGreaterThan(0);
+			await expect(page.getByTestId("stream-indicator")).toHaveCount(0);
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+}

--- a/e2e/chat-scroll.spec.ts
+++ b/e2e/chat-scroll.spec.ts
@@ -103,6 +103,7 @@ for (const testCase of orderCases) {
 			await moveMouseToChatViewport(page, chatScroll);
 			await page.mouse.wheel(0, testCase.historyWheel);
 			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await page.waitForTimeout(150);
 
 			await chatScroll.evaluate((root, order) => {
 				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
@@ -112,9 +113,16 @@ for (const testCase of orderCases) {
 				scroller.dispatchEvent(new Event("scroll"));
 			}, testCase.order);
 			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			const positionedNearLatest = await readChatScrollGeometry(chatScroll);
+			const positionedDistance =
+				testCase.order === "newest-first"
+					? positionedNearLatest.distanceFromStart
+					: positionedNearLatest.distanceFromEnd;
+			expect(positionedDistance).toBeGreaterThan(1);
+			expect(positionedDistance).toBeLessThan(50);
 
 			await moveMouseToChatViewport(page, chatScroll);
-			await page.mouse.wheel(0, testCase.latestWheel > 0 ? 4 : -4);
+			await page.mouse.wheel(0, testCase.latestWheel > 0 ? 1 : -1);
 			const near = await readChatScrollGeometry(chatScroll);
 			const nearDistance =
 				testCase.order === "newest-first" ? near.distanceFromStart : near.distanceFromEnd;
@@ -137,7 +145,9 @@ for (const testCase of orderCases) {
 		}
 	});
 
-	test(`${testCase.order} keeps an idle status slot at the logical latest edge`, async ({ page }) => {
+	test(`${testCase.order} keeps an idle status slot at the logical latest edge`, async ({
+		page,
+	}) => {
 		const { session } = await openTallChat(page, testCase.order);
 		try {
 			const slot = page.getByTestId("chat-status-slot");

--- a/e2e/chat-scroll.spec.ts
+++ b/e2e/chat-scroll.spec.ts
@@ -1,11 +1,12 @@
 import { realpathSync, rmSync, utimesSync } from "node:fs";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { enterDefaultWorkspace, openFixtureProject } from "./fixtures/app";
 import { moveMouseToChatViewport, readChatScrollGeometry } from "./fixtures/chatScroll";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
 import { seedWorkspaceSession } from "./fixtures/sessions";
 
 const BASE_TS = 1_700_850_000_000;
+const NATIVE_SCROLL_INTENT_EXPIRY_MS = 650;
 
 type MessageOrder = "oldest-first" | "newest-first";
 
@@ -61,6 +62,54 @@ function seedTallChat(name: string) {
 	return session;
 }
 
+async function waitForScrollStability(chatScroll: Locator): Promise<void> {
+	await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+	await chatScroll.evaluate(async (root) => {
+		const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+		if (!scroller) throw new Error("missing Virtuoso scroller");
+		let previousTop = scroller.scrollTop;
+		let previousHeight = scroller.scrollHeight;
+		let stableFrames = 0;
+		for (let frame = 0; frame < 120; frame += 1) {
+			await new Promise(requestAnimationFrame);
+			const currentTop = scroller.scrollTop;
+			const currentHeight = scroller.scrollHeight;
+			stableFrames =
+				Math.abs(currentTop - previousTop) <= 0.5 && Math.abs(currentHeight - previousHeight) <= 0.5
+					? stableFrames + 1
+					: 0;
+			if (stableFrames >= 4) return;
+			previousTop = currentTop;
+			previousHeight = currentHeight;
+		}
+		throw new Error("chat scroll did not stabilize");
+	});
+	await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+}
+
+function latestDistance(
+	order: MessageOrder,
+	geometry: Awaited<ReturnType<typeof readChatScrollGeometry>>,
+) {
+	return order === "newest-first" ? geometry.distanceFromStart : geometry.distanceFromEnd;
+}
+
+async function moveIntoStableHistory(
+	page: Page,
+	chatScroll: Locator,
+	order: MessageOrder,
+	historyWheel: number,
+) {
+	await moveMouseToChatViewport(page, chatScroll);
+	for (let attempt = 0; attempt < 8; attempt += 1) {
+		await page.mouse.wheel(0, historyWheel);
+		await waitForScrollStability(chatScroll);
+		const geometry = await readChatScrollGeometry(chatScroll);
+		if (latestDistance(order, geometry) > 100) return geometry;
+	}
+	throw new Error("chat did not remain positioned in history");
+}
+
 async function openTallChat(page: Page, order: MessageOrder) {
 	await openFixtureProject(page);
 	const session = seedTallChat(`${order} deterministic scrolling`);
@@ -68,6 +117,7 @@ async function openTallChat(page: Page, order: MessageOrder) {
 	await enterDefaultWorkspace(page);
 	const chatScroll = page.getByTestId("chat-scroll");
 	await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+	await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
 	await expect
 		.poll(async () => {
 			const geometry = await readChatScrollGeometry(chatScroll);
@@ -95,6 +145,95 @@ for (const testCase of orderCases) {
 		}
 	});
 
+	test(`${testCase.order} does not strand following after a no-op native gesture`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		try {
+			await chatScroll.evaluate(
+				(root, { order, historyWheel }) => {
+					const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+					if (!scroller) throw new Error("missing Virtuoso scroller");
+					scroller.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: historyWheel }));
+					const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+					scroller.scrollTop =
+						order === "newest-first"
+							? Math.max(0, maxScrollTop - 300)
+							: Math.min(300, maxScrollTop);
+					scroller.dispatchEvent(new Event("scroll"));
+				},
+				{ order: testCase.order, historyWheel: testCase.historyWheel },
+			);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await chatScroll.evaluate(
+				(root, { buttonTestId, historyWheel }) => {
+					const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+					const latest = root.querySelector<HTMLButtonElement>(`[data-testid="${buttonTestId}"]`);
+					if (!scroller || !latest) throw new Error("missing chat scroll controls");
+					latest.click();
+					scroller.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: historyWheel }));
+				},
+				{ buttonTestId: testCase.buttonTestId, historyWheel: testCase.historyWheel },
+			);
+			await waitForScrollStability(chatScroll);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			expect(
+				latestDistance(testCase.order, await readChatScrollGeometry(chatScroll)),
+			).toBeLessThanOrEqual(1);
+			await expect(page.getByTestId(testCase.buttonTestId)).toHaveCount(0);
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} pauses an active return while a scrollbar pointer is held`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		try {
+			await moveIntoStableHistory(page, chatScroll, testCase.order, testCase.historyWheel);
+			await chatScroll.evaluate(
+				(root, { buttonTestId }) => {
+					const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+					const latest = root.querySelector<HTMLButtonElement>(`[data-testid="${buttonTestId}"]`);
+					if (!scroller || !latest) throw new Error("missing chat scroll controls");
+					latest.click();
+					scroller.dispatchEvent(
+						new PointerEvent("pointerdown", {
+							bubbles: true,
+							isPrimary: true,
+							pointerId: 64,
+							pointerType: "mouse",
+						}),
+					);
+				},
+				{ buttonTestId: testCase.buttonTestId },
+			);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+			const heldDrift = await chatScroll.evaluate(async (root) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				const start = scroller.scrollTop;
+				for (let frame = 0; frame < 4; frame += 1) await new Promise(requestAnimationFrame);
+				return Math.abs(scroller.scrollTop - start);
+			});
+			expect(heldDrift).toBeLessThanOrEqual(1);
+			await chatScroll.locator("[data-virtuoso-scroller]").dispatchEvent("pointerup", {
+				isPrimary: true,
+				pointerId: 64,
+				pointerType: "mouse",
+			});
+			await waitForScrollStability(chatScroll);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			expect(
+				latestDistance(testCase.order, await readChatScrollGeometry(chatScroll)),
+			).toBeLessThanOrEqual(1);
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
 	test(`${testCase.order} rearms only when a latest-directed wheel reaches the physical edge`, async ({
 		page,
 	}) => {
@@ -102,8 +241,8 @@ for (const testCase of orderCases) {
 		try {
 			await moveMouseToChatViewport(page, chatScroll);
 			await page.mouse.wheel(0, testCase.historyWheel);
+			await waitForScrollStability(chatScroll);
 			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
-			await page.waitForTimeout(150);
 
 			await chatScroll.evaluate((root, order) => {
 				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
@@ -123,9 +262,13 @@ for (const testCase of orderCases) {
 
 			await moveMouseToChatViewport(page, chatScroll);
 			await page.mouse.wheel(0, testCase.latestWheel > 0 ? 1 : -1);
+			await expect
+				.poll(async () => latestDistance(testCase.order, await readChatScrollGeometry(chatScroll)))
+				.toBeLessThan(positionedDistance);
+			await waitForScrollStability(chatScroll);
 			const near = await readChatScrollGeometry(chatScroll);
-			const nearDistance =
-				testCase.order === "newest-first" ? near.distanceFromStart : near.distanceFromEnd;
+			const nearDistance = latestDistance(testCase.order, near);
+			expect(nearDistance).toBeLessThan(positionedDistance);
 			expect(nearDistance).toBeGreaterThan(1);
 			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
 
@@ -138,8 +281,263 @@ for (const testCase of orderCases) {
 						: geometry.distanceFromEnd;
 				})
 				.toBeLessThanOrEqual(1);
+			await waitForScrollStability(chatScroll);
 			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
 			await expect(page.getByTestId(testCase.buttonTestId)).toHaveCount(0);
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} detaches when native latest input interrupts an idle return`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		try {
+			const interruptionStart = await moveIntoStableHistory(
+				page,
+				chatScroll,
+				testCase.order,
+				testCase.historyWheel,
+			);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await page.getByTestId(testCase.buttonTestId).evaluate((button) => button.click());
+			await chatScroll.evaluate(
+				(root, { scrollTop, deltaY }) => {
+					const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+					if (!scroller) throw new Error("missing Virtuoso scroller");
+					scroller.scrollTop = scrollTop;
+					scroller.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY }));
+					scroller.scrollTop = scrollTop + deltaY;
+					scroller.dispatchEvent(new Event("scroll"));
+				},
+				{
+					scrollTop: interruptionStart.scrollTop,
+					deltaY: testCase.latestWheel > 0 ? 20 : -20,
+				},
+			);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await waitForScrollStability(chatScroll);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			expect(
+				latestDistance(testCase.order, await readChatScrollGeometry(chatScroll)),
+			).toBeGreaterThan(1);
+			await expect(page.getByTestId(testCase.buttonTestId)).toContainText("Latest");
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} retains pointer intent through post-release scrollbar scrolling`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		const scroller = chatScroll.locator("[data-virtuoso-scroller]");
+		const releasedPointerScroll = async (target: "history" | "latest" | "near-latest") => {
+			await scroller.dispatchEvent("pointerdown", {
+				pointerId: 41,
+				pointerType: "mouse",
+				isPrimary: true,
+			});
+			await scroller.dispatchEvent("pointerup", {
+				pointerId: 41,
+				pointerType: "mouse",
+				isPrimary: true,
+			});
+			await chatScroll.evaluate(
+				async (root, { order, target }) => {
+					await new Promise(requestAnimationFrame);
+					const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+					if (!scroller) throw new Error("missing Virtuoso scroller");
+					const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+					scroller.scrollTop =
+						target === "history"
+							? order === "newest-first"
+								? Math.min(300, maxScrollTop)
+								: Math.max(0, maxScrollTop - 300)
+							: target === "near-latest"
+								? order === "newest-first"
+									? 25
+									: Math.max(0, maxScrollTop - 25)
+								: order === "newest-first"
+									? 0
+									: maxScrollTop;
+					scroller.dispatchEvent(new Event("scroll"));
+				},
+				{ order: testCase.order, target },
+			);
+		};
+		try {
+			await releasedPointerScroll("history");
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await chatScroll.evaluate((root) => {
+				root
+					.querySelector<HTMLElement>("[data-virtuoso-scroller]")
+					?.dispatchEvent(new Event("scrollend"));
+			});
+			const latest = page.getByTestId(testCase.buttonTestId);
+			await latest.click();
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+			await moveMouseToChatViewport(page, chatScroll);
+			await page.mouse.wheel(0, testCase.historyWheel);
+			await expect
+				.poll(async () => latestDistance(testCase.order, await readChatScrollGeometry(chatScroll)))
+				.toBeGreaterThan(100);
+			await waitForScrollStability(chatScroll);
+
+			await releasedPointerScroll("latest");
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+
+			await releasedPointerScroll("history");
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await releasedPointerScroll("near-latest");
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await page.waitForTimeout(NATIVE_SCROLL_INTENT_EXPIRY_MS);
+			await chatScroll.evaluate((root, order) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				scroller.scrollTop =
+					order === "newest-first" ? 0 : Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+				scroller.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} recognizes keyboard and focus-induced transcript scrolling`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		const scroller = chatScroll.locator("[data-virtuoso-scroller]");
+		try {
+			await scroller.dispatchEvent("keydown", {
+				key: testCase.order === "newest-first" ? "PageDown" : "PageUp",
+			});
+			await chatScroll.evaluate((root, order) => {
+				const element = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!element) throw new Error("missing Virtuoso scroller");
+				const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+				element.scrollTop =
+					order === "newest-first" ? Math.min(300, maxScrollTop) : Math.max(0, maxScrollTop - 300);
+				element.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+
+			await scroller.dispatchEvent("keydown", {
+				key: testCase.order === "newest-first" ? "Home" : "End",
+			});
+			await expect
+				.poll(async () => latestDistance(testCase.order, await readChatScrollGeometry(chatScroll)))
+				.toBeLessThanOrEqual(1);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+
+			const interactive = chatScroll.getByTestId("chat-copy").last();
+			await expect(interactive).toBeAttached();
+			await interactive.dispatchEvent("keydown", { key: "Tab" });
+			await chatScroll.evaluate((root, order) => {
+				const element = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!element) throw new Error("missing Virtuoso scroller");
+				const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+				element.scrollTop =
+					order === "newest-first" ? Math.min(200, maxScrollTop) : Math.max(0, maxScrollTop - 200);
+				element.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} keeps control activation neutral during automatic geometry`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		const copy = chatScroll.getByTestId("chat-copy").last();
+		const applyGeometryShift = () =>
+			chatScroll.evaluate((root, order) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+				scroller.scrollTop =
+					order === "newest-first" ? Math.min(200, maxScrollTop) : Math.max(0, maxScrollTop - 200);
+				scroller.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+		try {
+			await expect(copy).toBeAttached();
+			await copy.dispatchEvent("pointerdown", {
+				pointerId: 52,
+				pointerType: "mouse",
+				isPrimary: true,
+			});
+			await applyGeometryShift();
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await copy.dispatchEvent("pointerup", {
+				pointerId: 52,
+				pointerType: "mouse",
+				isPrimary: true,
+			});
+			await chatScroll.evaluate((root, order) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				scroller.scrollTop =
+					order === "newest-first" ? 0 : Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+				scroller.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await applyGeometryShift();
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await chatScroll.evaluate((root, order) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				scroller.scrollTop =
+					order === "newest-first" ? 0 : Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+				scroller.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await expect(copy).toBeAttached();
+			await copy.dispatchEvent("keydown", { key: "Enter" });
+			await applyGeometryShift();
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
+			await expect(page.getByTestId(testCase.buttonTestId)).toHaveCount(0);
+		} finally {
+			rmSync(session.path, { force: true });
+		}
+	});
+
+	test(`${testCase.order} keeps touch intent through canceled-pointer momentum`, async ({
+		page,
+	}) => {
+		const { session, chatScroll } = await openTallChat(page, testCase.order);
+		try {
+			await chatScroll.dispatchEvent("pointerdown", {
+				pointerId: 73,
+				pointerType: "touch",
+				isPrimary: true,
+			});
+			await chatScroll.evaluate((root, order) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+				scroller.scrollTop =
+					order === "newest-first" ? Math.min(300, maxScrollTop) : Math.max(0, maxScrollTop - 300);
+				scroller.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "detached");
+			await chatScroll.dispatchEvent("pointercancel", {
+				pointerId: 73,
+				pointerType: "touch",
+				isPrimary: true,
+			});
+			await chatScroll.evaluate((root, order) => {
+				const scroller = root.querySelector<HTMLElement>("[data-virtuoso-scroller]");
+				if (!scroller) throw new Error("missing Virtuoso scroller");
+				scroller.scrollTop =
+					order === "newest-first" ? 0 : Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+				scroller.dispatchEvent(new Event("scroll"));
+			}, testCase.order);
+			await expect(chatScroll).toHaveAttribute("data-follow-state", "following");
 		} finally {
 			rmSync(session.path, { force: true });
 		}
@@ -153,7 +551,23 @@ for (const testCase of orderCases) {
 			const slot = page.getByTestId("chat-status-slot");
 			await expect(slot).toHaveCount(1);
 			await expect(slot).toHaveAttribute("data-active", "false");
-			expect((await slot.boundingBox())?.height).toBeGreaterThan(0);
+			const slotBox = await slot.boundingBox();
+			expect(slotBox?.height).toBeGreaterThan(0);
+			const latestRow = page
+				.locator("[data-chat-row-index]")
+				.filter({ hasText: "answer 40: the deterministic scrolling fixture is complete" });
+			await expect(latestRow).toBeAttached();
+			const latestRowBox = await latestRow.boundingBox();
+			expect(latestRowBox).not.toBeNull();
+			if (testCase.order === "newest-first") {
+				expect((slotBox?.y ?? 0) + (slotBox?.height ?? 0)).toBeLessThanOrEqual(
+					(latestRowBox?.y ?? 0) + 1,
+				);
+			} else {
+				expect(slotBox?.y ?? 0).toBeGreaterThanOrEqual(
+					(latestRowBox?.y ?? 0) + (latestRowBox?.height ?? 0) - 1,
+				);
+			}
 			await expect(page.getByTestId("stream-indicator")).toHaveCount(0);
 		} finally {
 			rmSync(session.path, { force: true });

--- a/e2e/fixtures/chatScroll.ts
+++ b/e2e/fixtures/chatScroll.ts
@@ -62,6 +62,26 @@ export async function readChatViewportIntersection(
 	});
 }
 
+export async function readChatViewportCenterOffsets(
+	element: Locator,
+	frames = 4,
+): Promise<number[]> {
+	return element.evaluate(async (node, sampleCount) => {
+		const scroller = node.closest<HTMLElement>("[data-virtuoso-scroller]");
+		if (!scroller) throw new Error("element is not inside a Virtuoso scroller");
+		const offsets: number[] = [];
+		for (let sample = 0; sample < sampleCount; sample += 1) {
+			await new Promise(requestAnimationFrame);
+			const elementRect = node.getBoundingClientRect();
+			const viewportRect = scroller.getBoundingClientRect();
+			offsets.push(
+				(elementRect.top + elementRect.bottom - viewportRect.top - viewportRect.bottom) / 2,
+			);
+		}
+		return offsets;
+	}, frames);
+}
+
 export interface NestedVerticalScrollSurface {
 	tag: string;
 	testId: string | null;

--- a/e2e/history-jump.spec.ts
+++ b/e2e/history-jump.spec.ts
@@ -1,11 +1,23 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import {
 	activeWorktreeRow,
 	createWorkspaceViaDialog,
 	openFixtureProject,
 	worktreeRows,
 } from "./fixtures/app";
+import { readChatViewportCenterOffsets } from "./fixtures/chatScroll";
 import { seedExternalCwdSessions, seedWorkspaceSession } from "./fixtures/sessions";
+
+type MessageOrder = "oldest-first" | "newest-first";
+
+async function selectMessageOrder(page: Page, order: MessageOrder) {
+	await page.getByTestId("open-settings").click();
+	await page.getByTestId("settings-nav-chat").click();
+	const option = page.getByTestId(`chat-order-${order}`);
+	await option.click();
+	await expect(option).toHaveAttribute("data-active", "true");
+	await page.keyboard.press("Escape");
+}
 
 test("selecting a same-workspace message hit opens the chat and flashes the matched row", async ({
 	page,
@@ -53,6 +65,60 @@ test("selecting a same-workspace message hit opens the chat and flashes the matc
 	await expect(flashRow).toContainText("jittered ceiling");
 	await expect(page.locator("[data-flash]")).toHaveCount(0, { timeout: 5_000 });
 });
+
+for (const order of ["oldest-first", "newest-first"] as const) {
+	test(`${order} offscreen jump in a newly mounted tall chat survives StrictMode materialization`, async ({
+		page,
+	}) => {
+		await openFixtureProject(page);
+		const workspace = await createWorkspaceViaDialog(page);
+		await selectMessageOrder(page, order);
+		seedWorkspaceSession(workspace.worktreePath, {
+			name: `${order} tall strict-mode jump`,
+			messages: Array.from({ length: 50 }, (_, index) => [
+				{
+					role: "user" as const,
+					text: `strict mode request ${index + 1}`,
+					timestamp: 1_700_150_000_000 + index * 2_000,
+				},
+				{
+					role: "assistant" as const,
+					text:
+						index === 10
+							? "quartz-offscreen-needle marks the exact history target"
+							: `strict mode answer ${index + 1}`,
+					timestamp: 1_700_150_001_000 + index * 2_000,
+				},
+			]).flat(),
+		});
+		await page.waitForTimeout(2_100);
+		await page.reload();
+		await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+		await page.getByTestId("chat-input").press("Control+r");
+		const overlay = page.getByTestId("history-overlay");
+		const query = page.getByTestId("history-query");
+		await query.fill("quartz-offscreen-needle");
+		await expect(page.getByTestId("history-expand-hint")).toBeVisible();
+		await query.press("Tab");
+		const hit = page
+			.locator('[data-testid="history-item"][data-kind="message"]')
+			.filter({ hasText: "quartz-offscreen-needle" });
+		await expect(hit).toBeVisible();
+		await query.press("Enter");
+
+		await expect(overlay).toBeHidden();
+		const chatScroll = page.getByTestId("chat-scroll");
+		const target = page.getByText("quartz-offscreen-needle marks the exact history target", {
+			exact: true,
+		});
+		await expect(page.locator("[data-flash]")).toContainText("quartz-offscreen-needle");
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
+		await expect(target).toBeAttached();
+		const centerOffsets = await readChatViewportCenterOffsets(target);
+		expect(Math.max(...centerOffsets.map((offset) => Math.abs(offset)))).toBeLessThanOrEqual(5);
+		expect(Math.max(...centerOffsets) - Math.min(...centerOffsets)).toBeLessThanOrEqual(1);
+	});
+}
 
 test("selecting a cross-workspace message hit switches the active workspace and flashes the row", async ({
 	page,


### PR DESCRIPTION
## Summary

Make chat scrolling deterministic and symmetric in oldest-first and newest-first layouts. Reader intent, active work, and physical alignment are now explicit state instead of being inferred from proximity, so native input wins immediately without oscillating follow state and every settlement returns to the true latest edge.

## Changes

### Chat scrolling and lifecycle

- Route streaming advances, settlement, Latest/Follow response, attention reveals, fold stabilization, and history jumps through one cancellable motion controller.
- Track wheel, touch momentum, scrollbar, keyboard, and focus-induced scrolling by provenance; detach only after real movement and rearm only at the exact physical latest edge.
- Preserve queued/background detachment, reattach on an own Send, and expose every `agent_settled` through a monotonic runtime tick.
- Reserve a fixed status slot for Working, Thinking, tool, writing, and compaction phases without shifting the transcript or composer, aligned to the synchronized configurable transcript measure in both bounded and unbounded modes.

### Disclosure and history geometry

- Give disclosure surfaces stable fold anchors that preserve surviving visible content across expansion, collapse, virtualization, and sticky activity breadcrumbs.
- Materialize off-DOM history targets with cancellable estimated positioning followed by measured, stable controller alignment; StrictMode, row churn, reader cancellation, and real unmounts have explicit terminal paths.

### Coverage and specifications

- Update the chat, tool, and store specifications with the state model, geometry rules, and lifecycle contracts.
- Add both-order unit and browser coverage for settlement, exact-edge rearm, no-op input, interrupted motion, post-release scrollbar scrolling, touch cancellation/momentum, interactive Tab scrolling, status placement, fold geometry, and virtualized history targets.

## Testing

Post-rebase checks run during PR preparation:

- `bun run check:deps` — passed
- `bun run check:boundaries` — passed
- `bun run check:seams` — passed
- `bun run lint` — passed (six pre-existing unused-suppression warnings)
- `bun run typecheck` — passed (14/14 workspaces)
- `bun run check:spec-surface` — passed (14/14 enrolled specs)
- `bun run test` — passed on full rerun (14/14 tasks; 987 server tests). The first run hit an intermittent main-owned Central runtime timing test; that test passed in isolation and the complete rerun passed.

Earlier on the same change set, before refreshing onto the latest `origin/main`:

- `bun run e2e` — 372 passed across 8 shards
- Touch momentum regression — 20/20 repeated passes
- Newest-first interrupted return regression — 10/10 repeated passes

Per request, local E2E was not rerun after either rebase; CI remains the post-rebase E2E authority.

## Screenshots

The after state permanently reserves the work-status row at the physical latest edge, so phase changes no longer shift the transcript or composer. Detached captures show the order-aware **Latest** affordance in both projections.

### Following at the physical latest edge

| Order | Before | After |
| --- | --- | --- |
| Oldest first | ![Oldest-first following before](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/oldest-following-before.png?raw=true) | ![Oldest-first following after](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/oldest-following-after.png?raw=true) |
| Newest first | ![Newest-first following before](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/newest-following-before.png?raw=true) | ![Newest-first following after](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/newest-following-after.png?raw=true) |

### Manually detached in history

| Order | Before | After |
| --- | --- | --- |
| Oldest first | ![Oldest-first detached before](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/oldest-detached-before.png?raw=true) | ![Oldest-first detached after](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/oldest-detached-after.png?raw=true) |
| Newest first | ![Newest-first detached before](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/newest-detached-before.png?raw=true) | ![Newest-first detached after](https://github.com/JetBrains/thinkrail/blob/73184cf77ebef437b680b6bf8e56c05ae833b64b/newest-detached-after.png?raw=true) |


