### PR TITLE
fix: retry EACCES in removeTree, not just EBUSY/EPERM

### DIFF
--- a/packages/shared/SPEC.md
+++ b/packages/shared/SPEC.md
@@ -81,14 +81,16 @@ bundled into `apps/web`. Exposed through explicit subpath exports, not a barrel.
   host's request handler reads it onto `WsResponse.errorCode`.
 - **/removeTree** — `removeTree(path, options?)`: delete a tree that a child process ran from, and keep
   trying while the failure is one a short wait can resolve (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`,
-  `EPERM`) — ten attempts with a linear 100 ms backoff by default. It exists because Windows releases
-  executable handles asynchronously after a child exits, so a bare recursive remove of a smoke/e2e temp
-  tree throws `EBUSY` *after* every assertion has already passed, and because **`rmSync`'s own
-  `maxRetries`/`retryDelay` are inert under Bun** — nightly run 33166583594 threw `EBUSY` 252 ms after
-  printing `installer smoke OK` under a policy that mandated seconds of backoff. The retry is teardown
-  resilience, not error suppression: a tree still locked past the backoff throws, and a failure no delay
-  can fix (`EACCES`, `ENOTDIR`, …) throws on the first attempt. `options.remove` is the injected-remover
-  seam the unit test drives; `attempts`/`delayMs` let a caller trade patience for speed.
+  `EPERM`, `EACCES`) — ten attempts with a linear 100 ms backoff by default. It exists because Windows
+  releases executable handles asynchronously after a child exits, so a bare recursive remove of a
+  smoke/e2e temp tree throws `EBUSY` *after* every assertion has already passed, and because **`rmSync`'s
+  own `maxRetries`/`retryDelay` are inert under Bun** — nightly run 33166583594 threw `EBUSY` 252 ms after
+  printing `installer smoke OK` under a policy that mandated seconds of backoff. `EACCES` joined the
+  retryable set after nightly run 33949193053: the same not-yet-released handle surfaces as `EACCES` as
+  often as `EBUSY` on Windows. The retry is teardown resilience, not error suppression: a tree still
+  locked past the backoff throws, and a failure no delay can fix (`ENOTDIR`, …) throws on the first
+  attempt. `options.remove` is the injected-remover seam the unit test drives; `attempts`/`delayMs` let a
+  caller trade patience for speed.
 - **/paths** — the worktree-relative path conventions ThinkRail owns, named once so current and future
   consumers agree (today: `workspaces` *creates* the scratch dir and git *ignores* it):
   `WORKSPACE_INTERNAL_DIR` (`.thinkrail` — the repo-local host-managed dir, today holding the ephemeral

--- a/packages/shared/src/removeTree.test.ts
+++ b/packages/shared/src/removeTree.test.ts
@@ -48,12 +48,20 @@ test("gives up on a tree that stays locked past the backoff", () => {
 });
 
 test("never retries a failure that a delay cannot resolve", () => {
-	const attempt = failing("EACCES", Number.POSITIVE_INFINITY);
+	const attempt = failing("ENOENT", Number.POSITIVE_INFINITY);
 
 	expect(() => removeTree("/does-not-matter", { remove: attempt.remove, delayMs: 1 })).toThrow(
-		"EACCES: simulated",
+		"ENOENT: simulated",
 	);
 	expect(attempt.calls()).toBe(1);
+});
+
+test("retries EACCES, since Windows reports a file a just-exited process still holds this way", () => {
+	const attempt = failing("EACCES", 3);
+
+	removeTree("/does-not-matter", { remove: attempt.remove, delayMs: 1 });
+
+	expect(attempt.calls()).toBe(3);
 });
 
 test("waits between attempts instead of spinning", () => {

--- a/packages/shared/src/removeTree.ts
+++ b/packages/shared/src/removeTree.ts
@@ -1,7 +1,5 @@
 import { rmSync } from "node:fs";
 
-// EACCES is included alongside EPERM/EBUSY because Windows surfaces a file still held by a
-// just-exited process as EACCES as often as the more obviously-transient codes.
 const RETRYABLE_CODES = new Set(["EBUSY", "EMFILE", "ENFILE", "ENOTEMPTY", "EPERM", "EACCES"]);
 const DEFAULT_ATTEMPTS = 10;
 const DEFAULT_DELAY_MS = 100;

--- a/packages/shared/src/removeTree.ts
+++ b/packages/shared/src/removeTree.ts
@@ -1,6 +1,8 @@
 import { rmSync } from "node:fs";
 
-const RETRYABLE_CODES = new Set(["EBUSY", "EMFILE", "ENFILE", "ENOTEMPTY", "EPERM"]);
+// EACCES is included alongside EPERM/EBUSY because Windows surfaces a file still held by a
+// just-exited process as EACCES as often as the more obviously-transient codes.
+const RETRYABLE_CODES = new Set(["EBUSY", "EMFILE", "ENFILE", "ENOTEMPTY", "EPERM", "EACCES"]);
 const DEFAULT_ATTEMPTS = 10;
 const DEFAULT_DELAY_MS = 100;
 


### PR DESCRIPTION
## Summary
- The 2026-09-05 nightly build failed on `build (windows-latest, bun-windows-x64)`: `installerSmoke.ts`'s cleanup called `removeTree()` on the temp install dir right after the spawned app process exited, and Windows reported the still-briefly-held file as `EACCES` rather than `EBUSY`/`EPERM`.
- `EACCES` wasn't in `removeTree`'s retryable set, so this transient lock aborted the whole release build instead of clearing on retry like the other lock-related codes already do.
- Adds `EACCES` to `RETRYABLE_CODES`, and updates the test that previously asserted `EACCES` is never retried (it now uses `ENOENT` to keep covering the "genuinely non-retryable" case) plus adds a test that `EACCES` now retries and succeeds.

## Test plan
- [x] `bun test packages/shared/src/removeTree.test.ts` — 6 pass
- [x] pre-commit hooks (catalog check, module boundaries, binary seams, typography/colors/spacing, biome, `turbo run typecheck`) all passed on commit