### PR TITLE
fix(desktop): use Windows system tar for Electrobun releases

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -69,7 +69,9 @@ private SRE flow replaces the unsigned framework DMG with a conventional DMG con
 expanded app, under the same published alias. The app archive is a private signing intermediate, never
 a public release asset.
 
-The collector resolves exact framework filenames. Stable installers omit the `stable-` prefix; nightly
+The collector resolves exact framework filenames. On Windows, the release invocation puts System32
+first so Hutch's bare `tar` resolves to Windows bsdtar; Git's GNU tar interprets drive-letter paths as
+remote `host:path` operands. Stable installers omit the `stable-` prefix; nightly
 uses Electrobun's `canary` prefix/suffix. Updater metadata and patches are not published. Electrobun 2.0.1
 has no macOS x64 core. Linux requires Ubuntu 24.04+/glibc 2.38 and the declared GTK, WebKitGTK,
 AppIndicator, and librsvg dependencies. CEF and additional installer formats are outside this contract.

--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -97,9 +97,15 @@ runs:
     - name: Package desktop installer
       shell: bash
       env:
+        TARGET: ${{ inputs.target }}
         CHANNEL: ${{ inputs.channel }}
       run: |
         set -eu
+        if [ "$TARGET" = bun-windows-x64 ]; then
+          system32="$(cygpath -u "$SYSTEMROOT")/System32"
+          export PATH="$system32:$PATH"
+          echo "Electrobun tar: $(command -v tar)"
+        fi
         case "$CHANNEL" in
           nightly) environment="canary" ;;
           stable) environment="stable" ;;

--- a/packages/artifact-tests/src/releaseArtifacts.test.ts
+++ b/packages/artifact-tests/src/releaseArtifacts.test.ts
@@ -14,7 +14,7 @@ import { join, resolve } from "node:path";
 const actionPath = resolve(import.meta.dir, "../../../.github/actions/build-binary/action.yml");
 const action = Bun.YAML.parse(readFileSync(actionPath, "utf8")) as {
 	outputs: Record<string, { value: string }>;
-	runs: { steps: { id?: string; run?: string }[] };
+	runs: { steps: { id?: string; name?: string; run?: string }[] };
 };
 const roots: string[] = [];
 
@@ -71,6 +71,23 @@ function fixture(): string {
 	return root;
 }
 
+function packageDesktop(root: string, target: string, channel: string) {
+	const script = action.runs.steps.find((step) => step.name === "Package desktop installer")?.run;
+	if (!script) throw new Error("desktop package script is missing");
+	return Bun.spawnSync(["bash", "-c", script], {
+		cwd: root,
+		env: {
+			...process.env,
+			PATH: `${join(root, "bin")}:${process.env.PATH}`,
+			SYSTEMROOT: "C:\\Windows",
+			TARGET: target,
+			CHANNEL: channel,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+}
+
 function collect(root: string, target: string, channel: string) {
 	const collector = action.runs.steps.find((step) => step.id === "resolve-desktop")?.run;
 	if (!collector) throw new Error("desktop artifact collector is missing");
@@ -86,6 +103,45 @@ function collect(root: string, target: string, channel: string) {
 		stderr: "pipe",
 	});
 }
+
+test("Windows packaging places System32 tar ahead of Git tar", () => {
+	const root = fixture();
+	const bin = join(root, "bin");
+	const system32 = join(root, "windows", "System32");
+	mkdirSync(bin, { recursive: true });
+	mkdirSync(system32, { recursive: true });
+	writeFileSync(
+		join(bin, "cygpath"),
+		`#!/bin/sh\nprintf '%s\\n' ${JSON.stringify(join(root, "windows"))}\n`,
+		{ mode: 0o755 },
+	);
+	writeFileSync(join(system32, "tar"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+	writeFileSync(
+		join(bin, "bun"),
+		`#!/bin/sh\nprintf '%s\\n%s\\n' "$PATH" "$*" > ${JSON.stringify(join(root, "package-call"))}\n`,
+		{ mode: 0o755 },
+	);
+	const result = packageDesktop(root, "bun-windows-x64", "nightly");
+	expect(result.exitCode).toBe(0);
+	const [path, args] = readFileSync(join(root, "package-call"), "utf8").split("\n");
+	expect(path?.split(":")[0]).toBe(system32);
+	expect(args).toBe("run --cwd apps/desktop package:canary");
+});
+
+test("non-Windows packaging does not require cygpath or rewrite PATH", () => {
+	const root = fixture();
+	const bin = join(root, "bin");
+	mkdirSync(bin, { recursive: true });
+	writeFileSync(
+		join(bin, "bun"),
+		`#!/bin/sh\nprintf '%s\\n%s\\n' "$PATH" "$*" > ${JSON.stringify(join(root, "package-call"))}\n`,
+		{ mode: 0o755 },
+	);
+	expect(packageDesktop(root, "bun-linux-x64", "stable").exitCode).toBe(0);
+	const [path, args] = readFileSync(join(root, "package-call"), "utf8").split("\n");
+	expect(path?.split(":")[0]).toBe(bin);
+	expect(args).toBe("run --cwd apps/desktop package:stable");
+});
 
 test("preserves the four public installer/CLI outputs and adds the app archive path", () => {
 	expect(


### PR DESCRIPTION
## Summary

Fix Windows Electrobun release packaging by ensuring Hutch resolves `tar` to Windows' System32 bsdtar instead of Git's GNU tar.

Protected-main nightly validation run https://github.com/JetBrains/thinkrail-signing/actions/runs/34209510672 exposed the failure:

```text
tar: Cannot connect to D: resolve failed
```

Git tar interprets a Windows drive-letter path as a remote `host:path` operand. The native build action now prepends `%SystemRoot%/System32` only for the Windows Electrobun release command. Linux and macOS PATH behavior is unchanged.

The artifact contract test executes the action step with fixture tools and verifies both Windows PATH selection and non-Windows behavior.

After this PR lands, the private pipeline will rerun Nightly on `main` with `validate_only=true`: full build/sign/notary/verification, no public tag or release.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [ ] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior) — not run; this changes only the Windows release-tool selection and is exercised by the action contract test
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
