### PR TITLE
docs(testing): record packaging action test ownership

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -51,8 +51,8 @@ Its stable public outputs are:
 
 The recipe stamps the shared version, builds and smokes the CLI, invokes the normal Electrobun dev and
 channel builds, runs expanded-app and first-install smoke, then collects exact target/channel outputs.
-[[module-artifact-tests]] owns isolated collector contract tests; this module owns the action and delivery
-contract.
+[[module-artifact-tests]] owns isolated packaging-invocation and collector contract tests; this module
+owns the action and delivery contract.
 
 Supported desktop assets:
 
@@ -69,9 +69,9 @@ private SRE flow replaces the unsigned framework DMG with a conventional DMG con
 expanded app, under the same published alias. The app archive is a private signing intermediate, never
 a public release asset.
 
-The collector resolves exact framework filenames. On Windows, the release invocation puts System32
-first so Hutch's bare `tar` resolves to Windows bsdtar; Git's GNU tar interprets drive-letter paths as
-remote `host:path` operands. Stable installers omit the `stable-` prefix; nightly
+On Windows, the packaging invocation puts System32 first so Hutch's bare `tar` resolves to Windows
+bsdtar; Git's GNU tar interprets drive-letter paths as remote `host:path` operands. The collector resolves
+exact framework filenames. Stable installers omit the `stable-` prefix; nightly
 uses Electrobun's `canary` prefix/suffix. Updater metadata and patches are not published. Electrobun 2.0.1
 has no macOS x64 core. Linux requires Ubuntu 24.04+/glibc 2.38 and the declared GTK, WebKitGTK,
 AppIndicator, and librsvg dependencies. CEF and additional installer formats are outside this contract.

--- a/packages/artifact-tests/SPEC.md
+++ b/packages/artifact-tests/SPEC.md
@@ -18,12 +18,13 @@ It consumes finished artifacts; it does not build the application or supply appl
 ## Boundary
 
 - **Owns:** artifact locators, isolated environments, native/installer smoke entrypoints, shared host
-  probes, their fixtures and helper unit tests, and the public build action's desktop-artifact collector
-  contract tests.
+  probes, their fixtures and helper unit tests, and the public build action's desktop packaging-invocation
+  and artifact-collector contract tests.
 - **Public surface:** `locateDesktopLauncher`
 - **Allowed deps:** CLI's public artifact-name helper; server's sanctioned history-fixture export;
   shared retrying teardown; read-only access to `.github/actions/build-binary/action.yml` for executing
-  its collector in isolated fixture directories; Bun/Node and native installer tools.
+  its packaging invocation and collector in isolated fixture directories; Bun/Node and native installer
+  tools.
 - **Forbidden:** application or SDK source internals, Electrobun imports/dependency, a fake host or agent,
   production packages importing this package, or real-user state mutation during tests.
 


### PR DESCRIPTION
## Summary

Align the artifact-test and CI specifications with the packaging-invocation coverage added by #445.

The action contract test now executes two distinct public build-action surfaces:

- the desktop packaging invocation, including Windows System32 bsdtar selection;
- the exact platform/channel artifact collector.

The owning specs previously described only the collector. This change records both responsibilities and keeps the Windows PATH invariant beside the packaging step it constrains.

No runtime, build, workflow, or test behavior changes.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [ ] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior) — not run; specification-only correction
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
