### PR TITLE
fix(windows): prevent descendant console flashes

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -36,8 +36,9 @@ artifact probes under Xvfb with test-only software-rendering flags, and runs des
 Real-provider tests remain explicitly authorized and separate.
 
 A platform's native behavior is proven only on that platform. Windows remains a PR gate because its
-executable, environment, path, and trash behavior differs materially from POSIX hosts. Native macOS and
-Linux ARM64 acceptance belongs to the release matrix.
+executable, environment, path, and trash behavior differs materially from POSIX hosts. Its subprocess
+unit gate also exercises native descendant-console behavior, which the Linux unit run cannot prove.
+Native macOS and Linux ARM64 acceptance belongs to the release matrix.
 
 ## Native build contract
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
       - run: bun test packages/spec-graph
+      - run: bun test packages/server/src/subprocess
       - run: bun run build:binary
       - run: bun run smoke:binary
 

--- a/architecture.md
+++ b/architecture.md
@@ -251,10 +251,11 @@ dependency. This keeps test process drivers outside both launchers and the serve
 - `pi` owns state and emits the truth; the host is a thin bridge — it **exposes** `pi`'s state through read
   methods (it does not recompute it) and forwards `pi`'s events as deltas. Clients **hydrate from the reads,
   then stream the deltas** — they hold only view state of their own.
-- Every background console child process the host or CLI spawns sets **`windowsHide: true`**. Bun 1.4.0
-  maps that option to libuv `UV_PROCESS_WINDOWS_HIDE`; omitting it flashes a transient, focus-stealing
-  console window on Windows. The flash is worst on pollers that fire on **workspace/terminal switch and
-  window focus** (git status, terminal-busy probes, Central quota). Sync + detached cases go through
+- Background console children launched by the host or CLI set **`windowsHide: true`**. Bounded Windows
+  children also remain **non-detached**, so ordinary helpers inherit a nonvisual console rather than
+  opening their own; the platform policy and native regression belong to [[submodule-server-subprocess]].
+  This includes PR revalidation on window focus; terminal-busy checks are close actions and Central quota
+  resumes on visibility changes, not ordinary focus. Sync and fire-and-forget cases use
   `@thinkrail/shared/spawn`; bespoke bounded runners set the option directly. Exempt: spawns that inherit
   an existing terminal's stdio (the `update`/`uninstall` CLI subcommands, the build script) and shell
   probes that are no-ops on win32 (`shellEnv`).

--- a/packages/server/src/subprocess/SPEC.md
+++ b/packages/server/src/subprocess/SPEC.md
@@ -17,8 +17,9 @@ never what a particular child's output means.
 ## Boundary
 
 - **Owns:** `runBounded(argv, { timeoutMs, cwd?, env? })` →
-  `{ ok, out, err, timedOut, launchFailed, waitedMs }`: spawn detached, capture both streams, complete on
-  the child's **exit**, and on expiry kill the whole process group. A failed launch is a result
+  `{ ok, out, err, timedOut, launchFailed, waitedMs }`: capture both streams and complete on the child's
+  **exit**; POSIX children are detached process-group leaders, while Windows children retain a nonvisual
+  console. Expiry kills the POSIX group or the direct Windows child. A failed launch is a result
   (`ok: false`, `launchFailed: true`, the launch error as `err`), never a throw; callers can distinguish
   infrastructure failure from a child that ran and exited nonzero.
 - **Public surface:** `runBounded`, `BoundedRun`, `BoundedRunOptions`.
@@ -85,7 +86,7 @@ never what a particular child's output means.
   reading: "not a number" is a broken caller, and the safe failure for a broken budget is to expire at
   once, not to wait 24 days. Finite values clamp into `[0, 2^31-1]`, and a negative budget expires
   immediately because it already had.
-- **On expiry, kill the process group — that, not the timer, is what releases the descriptors.**
+- **On POSIX expiry, kill the process group — that, not the timer, is what releases the descriptors.**
   `detached: true` (`setsid`) makes the child a group leader, so `process.kill(-pid, "SIGKILL")` reaps the
   grandchildren still holding our pipes; the reads then hit EOF on their own. Abandoning reads instead is
   what pins Bun's event loop for the orphan's whole lifetime — measured at a 20s hold against an unref'd
@@ -106,11 +107,15 @@ never what a particular child's output means.
   host terminal's signal group, so the budget — never a `Ctrl-C` on the host — is what ends a stalled call.
   Surfacing the passphrase request in the UI (#209's headline ask, as opposed to its "at minimum" clause)
   stays unbuilt and needs the cancellation seam `dialog` wants above.
-- **Windows has no process groups.** `detached` maps to `UV_PROCESS_DETACHED` and the kill falls back to
-  the direct child, so a grandchild there survives the timeout as before. The group-kill test is skipped
-  there rather than pretending otherwise. Bounded children set `windowsHide: true`; Bun 1.4.0 maps it to
-  libuv `UV_PROCESS_WINDOWS_HIDE`. Background lookups must not create a visible console window or steal
-  focus from the browser client (see `architecture.md` Invariants; `@thinkrail/shared/spawn`).
+- **Windows children are hidden, not detached.** `windowsHide: true` with `detached: false` preserves a
+  nonvisual console for ordinary descendants to inherit. Detachment removes that console: the immediate
+  child stays hidden, but a helper it launches can allocate a visible console. This is why a focus-triggered
+  `gh` lookup could still flash `tzutil`, Git, and SSH windows despite hiding the direct child. Windows
+  does not support the POSIX group-kill path; expiry still terminates only the direct child, not a promised
+  whole tree. Non-detached children participate in libuv's normal job lifetime; this runner is for bounded
+  host-owned work, not independently surviving daemons. The native Windows regression uses a no-console
+  driver, the real runner, and an ordinary console grandchild, with a detached positive control. It checks
+  native console ownership/window state rather than option presence, output success, or browser DOM.
 - **The env defaults to the live `process.env`, not the launch-time snapshot** — `boot`'s
   `resolveShellEnv()` repairs `PATH`/`LANG` by mutating `process.env` *after* startup, and a child spawned
   from the snapshot silently misses that repair. Both halves are pinned separately — a caller's `env`/`cwd`

--- a/packages/server/src/subprocess/runBounded.ts
+++ b/packages/server/src/subprocess/runBounded.ts
@@ -78,7 +78,7 @@ export async function runBounded(argv: string[], opts: BoundedRunOptions): Promi
 			stdin: "ignore",
 			stdout: "pipe",
 			stderr: "pipe",
-			detached: true,
+			detached: process.platform !== "win32",
 			windowsHide: process.platform === "win32",
 		});
 	} catch (cause) {

--- a/packages/server/src/subprocess/windowsConsole.fixture.ts
+++ b/packages/server/src/subprocess/windowsConsole.fixture.ts
@@ -1,0 +1,68 @@
+import { dlopen } from "bun:ffi";
+import { fileURLToPath } from "node:url";
+import { runBounded } from "./runBounded";
+
+const kernel = dlopen("kernel32.dll", {
+	GetConsoleWindow: { args: [], returns: "ptr" },
+	GetConsoleCP: { args: [], returns: "u32" },
+	FreeConsole: { args: [], returns: "bool" },
+});
+const user = dlopen("user32.dll", {
+	IsWindowVisible: { args: ["ptr"], returns: "bool" },
+});
+
+function consoleState() {
+	const window = kernel.symbols.GetConsoleWindow();
+	return {
+		window,
+		codePage: kernel.symbols.GetConsoleCP(),
+		visible: window !== null && user.symbols.IsWindowVisible(window),
+	};
+}
+
+const argv = (mode: string) => [process.execPath, fileURLToPath(import.meta.url), mode];
+
+async function capture(mode: string, detached: boolean, windowsHide: boolean): Promise<unknown> {
+	const child = Bun.spawn(argv(mode), {
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+		detached,
+		windowsHide,
+	});
+	const [out, err, code] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	if (code !== 0) throw new Error(`console fixture exited ${code}: ${err}`);
+	return JSON.parse(out);
+}
+
+try {
+	const mode = process.argv[2];
+	if (mode === "probe") {
+		console.log(JSON.stringify(consoleState()));
+	} else if (mode === "child") {
+		const self = consoleState();
+		const grandchild = await capture("probe", false, false);
+		console.log(JSON.stringify({ self, grandchild }));
+	} else if (mode === "bounded" || mode === "detached-control") {
+		kernel.symbols.FreeConsole();
+		const driver = consoleState();
+		let child: unknown;
+		if (mode === "bounded") {
+			const result = await runBounded(argv("child"), { timeoutMs: 5_000 });
+			if (!result.ok) throw new Error(`bounded console fixture failed: ${result.err}`);
+			child = JSON.parse(result.out);
+		} else {
+			child = await capture("child", true, true);
+		}
+		console.log(JSON.stringify({ driver, child }));
+	} else {
+		throw new Error(`unknown console fixture mode: ${mode}`);
+	}
+} finally {
+	user.close();
+	kernel.close();
+}

--- a/packages/server/src/subprocess/windowsConsole.test.ts
+++ b/packages/server/src/subprocess/windowsConsole.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const windows = test.skipIf(process.platform !== "win32");
+const fixture = fileURLToPath(new URL("./windowsConsole.fixture.ts", import.meta.url));
+
+function scenario(mode: string): unknown {
+	const result = Bun.spawnSync([process.execPath, fixture, mode], {
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+		windowsHide: true,
+		timeout: 10_000,
+	});
+	expect(result.stderr.toString()).toBe("");
+	expect(result.exitCode).toBe(0);
+	return JSON.parse(result.stdout.toString());
+}
+
+windows("detached control gives an ordinary grandchild its own console", () => {
+	expect(scenario("detached-control")).toMatchObject({
+		driver: { window: null, codePage: 0, visible: false },
+		child: {
+			self: { window: null, codePage: 0, visible: false },
+			grandchild: { window: expect.any(Number), codePage: expect.any(Number) },
+		},
+	});
+});
+
+windows("bounded children preserve a nonvisual console for ordinary grandchildren", () => {
+	const result = scenario("bounded");
+	expect(result).toMatchObject({
+		driver: { window: null, codePage: 0, visible: false },
+		child: {
+			self: { window: null, visible: false },
+			grandchild: { window: null, visible: false },
+		},
+	});
+	expect(result).not.toMatchObject({ child: { self: { codePage: 0 } } });
+	expect(result).not.toMatchObject({ child: { grandchild: { codePage: 0 } } });
+});


### PR DESCRIPTION
## Summary

Keep bounded Windows processes non-detached so focus-refresh helpers stay hidden. Adds native regression tests and Windows CI coverage; POSIX unchanged.

Native A/B: **3 popups → 0**. `bun test packages/server/src/subprocess`: **9 pass, 4 skips**. **CI passes.** Full local unit/E2E runs hit existing Windows harness/path failures.

## Related issues

Follow-up to #448.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

