### PR TITLE
Focus tab issue

### DIFF
--- a/apps/web/src/panels/SpecsPanel.tsx
+++ b/apps/web/src/panels/SpecsPanel.tsx
@@ -137,7 +137,7 @@ function SpecNodeRow({
 				className={cn(
 					"group flex h-28 min-w-0 items-stretch rounded-[var(--radius-sm)] px-4 transition-colors",
 					isActive
-						? "bg-primary-subtle ring-1 ring-primary-muted ring-inset"
+						? "bg-primary-subtle ring-1 ring-primary-muted ring-inset has-[:focus-visible]:ring-0"
 						: "hover:bg-control-bg-hovered",
 				)}
 			>

--- a/apps/web/src/panels/TreeRow.tsx
+++ b/apps/web/src/panels/TreeRow.tsx
@@ -48,7 +48,7 @@ export function TreeRow({
 			onClick={onClick}
 			onDoubleClick={onDoubleClick}
 			onContextMenu={onContextMenu}
-			className={`flex h-24 w-full min-w-0 items-center gap-4 rounded-[var(--radius-sm)] px-4 text-left tr-text-ui text-text-muted ${
+			className={`flex h-24 w-full min-w-0 items-center gap-4 rounded-[var(--radius-sm)] px-4 text-left tr-text-ui text-text-muted outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary ${
 				highlight === "self"
 					? `hover:bg-control-bg-hovered ${active ? "bg-control-bg-selected" : ""}`
 					: ""

--- a/apps/web/src/shell/layout/Workbench.tsx
+++ b/apps/web/src/shell/layout/Workbench.tsx
@@ -992,7 +992,7 @@ function WorkbenchTab({
 					data-kind={tab.kind === "document" ? "plan" : tab.kind}
 					data-session-id={tab.kind === "chat" ? tab.sessionId : undefined}
 					data-dragging={drag.isDragging || undefined}
-					className="group relative flex min-w-96 max-w-192 shrink-0 items-center border-border-default border-r text-text-muted after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-10 after:h-[2px] after:rounded-full after:content-[''] data-[active=true]:bg-control-bg-selected data-[active=true]:text-text-default data-[active=true]:after:bg-primary data-[dragging]:opacity-40"
+					className="group relative flex min-w-96 max-w-192 shrink-0 items-center border-border-default border-r text-text-muted after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-10 after:h-[2px] after:rounded-full after:content-[''] has-[[role=tab]:focus-visible]:ring-2 has-[[role=tab]:focus-visible]:ring-inset has-[[role=tab]:focus-visible]:ring-primary data-[active=true]:bg-control-bg-selected data-[active=true]:text-text-default data-[active=true]:after:bg-primary data-[dragging]:opacity-40"
 				>
 					<div
 						ref={before.setNodeRef}
@@ -1023,7 +1023,7 @@ function WorkbenchTab({
 						onClick={selectFromClick}
 						onDoubleClick={selectFromDoubleClick}
 						onKeyDown={onKeyDown}
-						className={`flex min-w-0 flex-1 items-center gap-4 py-4 pl-8 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary ${tab.kind === "tool" ? "pr-8" : ""}`}
+						className={`flex min-w-0 flex-1 items-center gap-4 py-4 pl-8 text-left outline-none ${tab.kind === "tool" ? "pr-8" : ""}`}
 					>
 						{tabIcon(tab, active)}
 						<span className={`truncate ${preview ? "italic" : ""}`}>{name}</span>


### PR DESCRIPTION
Cleaned up focus-ring rendering across the shell. TreeRow (file tree) now has a unified inset focus-visible ring matching other lists (committed 63ae5d44). The SpecsPanel single-ring-on-focus behavior was found already present in HEAD, so no change was needed there. This is on top of the earlier tab focus-ring alignment fix (04125dee). Changes are CSS-class-only; not run through e2e since deps aren't installed in this worktree.

## Plan
### Clean up focus-ring rendering
- [x] **SpecsPanel: suppress active-row ring when focused (single ring)** (`c102d33`)
  No-op: SpecsPanel already carries has-[:focus-visible]:ring-0 on the active row in HEAD, so an active+focused row already collapses to a single focus ring. No diff produced.
  Verified: Confirmed via git show HEAD — the class was already present; git diff for SpecsPanel is empty.
- [x] **TreeRow: add unified focus-visible ring**
  Added outline-none + focus-visible:ring-2 ring-inset ring-primary to the TreeRow button (h-24 w-full rounded-sm), so file/dir tree rows now show the same clean inset focus ring as other lists instead of the default browser outline.
  Verified: not verified (CSS-class-only; deps not installed in worktree). Committed as 63ae5d44.
<img width="180" height="61" alt="Screenshot 2026-09-09 at 05 04 38" src="https://github.com/user-attachments/assets/e21cd969-e714-4222-8161-3ed876c59653" />

