### PR TITLE
feat(desktop): themed macOS title bar merged with the ThinkRail topbar

### DIFF
--- a/apps/desktop/SPEC.md
+++ b/apps/desktop/SPEC.md
@@ -6,7 +6,7 @@ title: Desktop launcher/client (Electrobun)
 parent: architecture
 depends-on: [module-server, module-contracts, module-shared]
 tags: [desktop, v1, launcher, packaging]
-references: [submodule-web-navigation, module-artifact-tests]
+references: [submodule-web-navigation, module-artifact-tests, submodule-web-shell]
 ---
 
 ## Responsibility
@@ -19,7 +19,8 @@ engine architecture.
 
 ## Boundary
 
-- **Owns:** Electrobun configuration and lifecycle; native window policy; local `bootHost()` startup;
+- **Owns:** Electrobun configuration and lifecycle; native window policy, including the per-platform
+  title-bar treatment and the window-chrome geometry it publishes to the web client; local `bootHost()` startup;
   packaged resource staging; the PI-compatible server-runtime bundle; desktop route preload/persistence;
   a bounded generic client-preference adapter under stable backend-profile/window identity; and the
   opt-in live-window test seam. Standalone artifact harnesses belong to [[module-artifact-tests]].
@@ -91,6 +92,47 @@ there; WebKitGTK keeps its renderer-native editing behavior. The policy is platf
 ready seam reports whether registration ran, so unit tests pin menu composition while expanded-app smoke
 pins production wiring.
 
+## Native window chrome
+
+The web topbar ([[submodule-web-shell]]) is the window's title bar wherever the framework lets native
+controls survive without a native strip. Electrobun 2.0.1 exposes no caption-colour API on any platform
+(macOS and Windows only follow the system light/dark setting), so a theme-coloured title bar means
+removing the native strip and letting the web header occupy it. The policy is platform-pure
+(`windowChrome.ts`, pinned by unit tests) and spread into the main `BrowserWindow`:
+
+| platform | `titleBarStyle` | traffic lights | published left inset |
+|---|---|---|---|
+| macOS | `hiddenInset` — transparent strip, hidden title, full-size content view; native traffic lights stay | `trafficLightOffset { x: 0, y: 4 }` centres the 12px buttons in the 40px topbar (measured on a packaged build: the default position centres them at 16px, so +4 lands on 20) | `64px` — the traffic-light zone (7 + 3×12 + 2×8 = 59px on the spacing grid) |
+| Windows, Linux | `default` | — | `0px` |
+
+Windows is deferred because `hiddenInset` there strips the caption *including* minimize/maximize/close,
+which would have to be HTML controls over RPC (and Electrobun has no `HTMAXBUTTON` hit-test, so Win11
+snap layouts would not appear). Linux is not planned: `hiddenInset` is a no-op under GTK and `hidden`
+removes decorations together with WM-provided resize handles. Fully custom macOS chrome
+(`titleBarStyle: "hidden"` with drawn traffic lights) was rejected because the platform provides real
+ones.
+
+**Geometry contract.** The desktop publishes window-chrome geometry to the page as exactly two CSS custom
+properties on `<html>` — `--window-chrome-inset-left` and `--window-chrome-inset-right`, each a `<px>`
+length naming the edge zone native controls occupy — and nothing else: no global the web must call, no
+platform name, no reason. The web consumes them with `0px` fallbacks, so a browser-hosted client and the
+neutral E2E-host window (`about:blank`, no preload) are unaffected and the *web client still has no
+desktop branch*. Initial values ride the preload the same way initial preferences do (a serialized
+`__THINKRAIL_INITIAL_WINDOW_CHROME__` prepended to the preload source; the preload validates finite
+non-negative numbers, writes both properties at document-start, and deletes the global). Later changes
+arrive as the one bun→webview message in the RPC schema, `windowChromeChanged { insetLeft, insetRight }`,
+applied identically. The right inset is always `0px` today and exists so the Windows follow-up changes a
+value, not the contract.
+
+**Fullscreen.** macOS native fullscreen auto-hides the traffic lights with the menu bar, so the main
+process watches the window `resize` event, reads `isFullScreen()`, and on a transition sends
+`windowChromeChanged` with a `0px` left inset (fullscreen) or the policy value (normal).
+
+**Dragging** needs no desktop involvement: the web header declares `-webkit-app-region: drag` (inert in
+a browser tab), and Electrobun's own injected preload rewrites app-region declarations from same-origin
+stylesheets into a mirrored custom property it hit-tests against. Double-click-to-zoom on the header is
+not promised — the webview covers the strip, so the click reaches `NSWindow` only incidentally.
+
 ## Navigation and window security
 
 The native window permits navigation only within its exact loopback origin. User-requested external URLs
@@ -101,7 +143,8 @@ SDK event factories, not copied into local declarations. Detail can be a raw URL
 serialized navigation JSON; bounded decoding retains only a string URL and the HTTP/HTTPS/mailto
 allowlist. Native `navigationRules` enforce confinement: navigation-event responses cannot cancel it.
 
-A desktop preload sends typed, one-way route and local-preference messages. It wraps
+A desktop preload sends typed, one-way route and local-preference messages, and is the only writer of
+the window-chrome CSS properties described above. It wraps
 `history.replaceState` and `history.pushState` before page scripts and also reports initial/hash/pop
 navigation, because Electrobun's native navigation events do not observe History API route changes. The
 main process accepts messages only from the main window. Routes persist as bounded fragment strings in a
@@ -215,5 +258,6 @@ release checks described in [[module-ci-release]].
 
 ## Deferred
 
-Shared/remote backend profiles, profile selection, multi-window/deep-link routing, CEF, and Electrobun
-updater UX.
+Shared/remote backend profiles, profile selection, multi-window/deep-link routing, CEF, Electrobun
+updater UX, and the Windows frameless title bar (HTML minimize/maximize/close over RPC behind a
+window-controls capability the geometry contract does not yet carry).

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -21,6 +21,11 @@ import { RouteStore } from "./routeStore";
 import type { DesktopRpc } from "./rpc";
 import { ptyLibraryName, runtimeTarget } from "./runtimeTarget";
 import type { DesktopServerRuntime } from "./serverRuntime";
+import {
+	desktopWindowChrome,
+	injectInitialWindowChrome,
+	windowChromeGeometry,
+} from "./windowChrome";
 
 type BeforeQuitEvent = ReturnType<typeof Electrobun.events.events.app.beforeQuit>;
 
@@ -83,11 +88,15 @@ async function start(): Promise<void> {
 			},
 		},
 	});
+	const windowChrome = desktopWindowChrome(process.platform);
 	const preload = neutral
 		? null
-		: injectInitialDesktopPreferences(
-				await Bun.file(join(PATHS.VIEWS_FOLDER, "preload", "index.js")).text(),
-				initialPreferences,
+		: injectInitialWindowChrome(
+				injectInitialDesktopPreferences(
+					await Bun.file(join(PATHS.VIEWS_FOLDER, "preload", "index.js")).text(),
+					initialPreferences,
+				),
+				windowChrome.geometry,
 			);
 	const mainWindow = new BrowserWindow({
 		title: "ThinkRail",
@@ -99,7 +108,20 @@ async function start(): Promise<void> {
 			process.env.THINKRAIL_DESKTOP_E2E_HOST === "1",
 		navigationRules: neutral ? null : JSON.stringify(["^*", `${origin}/*`]),
 		frame: { x: 80, y: 60, width: 1440, height: 920 },
+		titleBarStyle: windowChrome.titleBarStyle,
+		...(windowChrome.trafficLightOffset
+			? { trafficLightOffset: windowChrome.trafficLightOffset }
+			: {}),
 	});
+	if (!neutral) {
+		let fullScreen = false;
+		mainWindow.on("resize", () => {
+			const next = mainWindow.isFullScreen();
+			if (next === fullScreen) return;
+			fullScreen = next;
+			rpc.send.windowChromeChanged(windowChromeGeometry(windowChrome, fullScreen));
+		});
+	}
 	const navigationProbePath = neutral
 		? undefined
 		: process.env.THINKRAIL_DESKTOP_NAVIGATION_PROBE_FILE;

--- a/apps/desktop/src/preferenceAdapter.ts
+++ b/apps/desktop/src/preferenceAdapter.ts
@@ -1,3 +1,5 @@
+import { prependPreloadGlobal } from "./preloadGlobals";
+
 export const INITIAL_DESKTOP_PREFERENCES_GLOBAL = "__THINKRAIL_INITIAL_DESKTOP_PREFERENCES__";
 export const STABLE_PREFERENCES_GLOBAL = "__THINKRAIL_STABLE_PREFERENCES__";
 export const MAX_DESKTOP_PREFERENCE_KEY_LENGTH = 128;
@@ -49,16 +51,9 @@ export function readDesktopPreferenceRemove(payload: unknown): { key: string } |
 	return isDesktopPreferenceKey(key) ? { key } : null;
 }
 
-function serializeForPreload(values: Readonly<Record<string, string>>): string {
-	return JSON.stringify(JSON.stringify(values))
-		.replaceAll("<", "\\u003c")
-		.replaceAll("\u2028", "\\u2028")
-		.replaceAll("\u2029", "\\u2029");
-}
-
 export function injectInitialDesktopPreferences(
 	preloadSource: string,
 	values: Readonly<Record<string, string>>,
 ): string {
-	return `Object.defineProperty(globalThis, ${JSON.stringify(INITIAL_DESKTOP_PREFERENCES_GLOBAL)}, { value: JSON.parse(${serializeForPreload(values)}), configurable: true });\n${preloadSource}`;
+	return prependPreloadGlobal(preloadSource, INITIAL_DESKTOP_PREFERENCES_GLOBAL, values);
 }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,7 +5,14 @@ import {
 	isDesktopPreferenceValue,
 	STABLE_PREFERENCES_GLOBAL,
 } from "./preferenceAdapter";
+import { takePreloadGlobal } from "./preloadGlobals";
 import type { DesktopRpc } from "./rpc";
+import {
+	INITIAL_WINDOW_CHROME_GLOBAL,
+	readWindowChromeGeometry,
+	type WindowChromeGeometry,
+	windowChromeCssDeclarations,
+} from "./windowChrome";
 
 interface DesktopPreferenceAdapter {
 	getItem(key: string): string | null;
@@ -13,13 +20,36 @@ interface DesktopPreferenceAdapter {
 	removeItem(key: string): void;
 }
 
+function applyWindowChrome(geometry: WindowChromeGeometry): void {
+	const apply = () => {
+		for (const [property, value] of windowChromeCssDeclarations(geometry)) {
+			document.documentElement.style.setProperty(property, value);
+		}
+	};
+	if (document.documentElement) apply();
+	else window.addEventListener("DOMContentLoaded", apply, { once: true });
+}
+
+const initialWindowChrome = readWindowChromeGeometry(
+	takePreloadGlobal(INITIAL_WINDOW_CHROME_GLOBAL),
+);
+if (initialWindowChrome) applyWindowChrome(initialWindowChrome);
+
 const rpc = Electroview.defineRPC<DesktopRpc>({
 	maxRequestTime: 5000,
-	handlers: { requests: {}, messages: {} },
+	handlers: {
+		requests: {},
+		messages: {
+			windowChromeChanged: (payload) => {
+				const geometry = readWindowChromeGeometry(payload);
+				if (geometry) applyWindowChrome(geometry);
+			},
+		},
+	},
 });
 const electroview = new Electrobun.Electroview({ rpc });
 const globals = globalThis as typeof globalThis & Record<string, unknown>;
-const injectedPreferences = Reflect.get(globals, INITIAL_DESKTOP_PREFERENCES_GLOBAL);
+const injectedPreferences = takePreloadGlobal(INITIAL_DESKTOP_PREFERENCES_GLOBAL);
 const preferences = new Map<string, string>();
 if (typeof injectedPreferences === "object" && injectedPreferences !== null) {
 	for (const key of Object.keys(injectedPreferences)) {
@@ -29,7 +59,6 @@ if (typeof injectedPreferences === "object" && injectedPreferences !== null) {
 		}
 	}
 }
-Reflect.deleteProperty(globals, INITIAL_DESKTOP_PREFERENCES_GLOBAL);
 const preferenceAdapter: DesktopPreferenceAdapter = Object.freeze({
 	getItem: (key: string) => (isDesktopPreferenceKey(key) ? (preferences.get(key) ?? null) : null),
 	setItem: (key: string, value: string) => {

--- a/apps/desktop/src/preloadGlobals.ts
+++ b/apps/desktop/src/preloadGlobals.ts
@@ -1,0 +1,21 @@
+function serializeForPreload(value: unknown): string {
+	return JSON.stringify(JSON.stringify(value))
+		.replaceAll("<", "\\u003c")
+		.replaceAll("\u2028", "\\u2028")
+		.replaceAll("\u2029", "\\u2029");
+}
+
+export function prependPreloadGlobal(
+	preloadSource: string,
+	globalName: string,
+	value: unknown,
+): string {
+	return `Object.defineProperty(globalThis, ${JSON.stringify(globalName)}, { value: JSON.parse(${serializeForPreload(value)}), configurable: true });\n${preloadSource}`;
+}
+
+export function takePreloadGlobal(globalName: string): unknown {
+	const globals = globalThis as typeof globalThis & Record<string, unknown>;
+	const value = Reflect.get(globals, globalName);
+	Reflect.deleteProperty(globals, globalName);
+	return value;
+}

--- a/apps/desktop/src/rpc.ts
+++ b/apps/desktop/src/rpc.ts
@@ -1,3 +1,5 @@
+import type { WindowChromeGeometry } from "./windowChrome";
+
 export type DesktopRpc = {
 	bun: {
 		requests: Record<string, never>;
@@ -9,6 +11,8 @@ export type DesktopRpc = {
 	};
 	webview: {
 		requests: Record<string, never>;
-		messages: Record<string, never>;
+		messages: {
+			windowChromeChanged: WindowChromeGeometry;
+		};
 	};
 };

--- a/apps/desktop/src/windowChrome.test.ts
+++ b/apps/desktop/src/windowChrome.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import {
+	desktopWindowChrome,
+	INITIAL_WINDOW_CHROME_GLOBAL,
+	injectInitialWindowChrome,
+	MAX_WINDOW_CHROME_INSET,
+	readWindowChromeGeometry,
+	windowChromeCssDeclarations,
+	windowChromeGeometry,
+} from "./windowChrome";
+
+test("macOS hides the native strip, keeps the traffic lights centred in the 40px topbar, and reserves their zone", () => {
+	expect(desktopWindowChrome("darwin")).toEqual({
+		titleBarStyle: "hiddenInset",
+		trafficLightOffset: { x: 0, y: 4 },
+		geometry: { insetLeft: 64, insetRight: 0 },
+	});
+});
+
+test("Windows and Linux keep the default native chrome and publish no inset", () => {
+	for (const platform of ["win32", "linux", "freebsd"] as const) {
+		expect(desktopWindowChrome(platform)).toEqual({
+			titleBarStyle: "default",
+			trafficLightOffset: null,
+			geometry: { insetLeft: 0, insetRight: 0 },
+		});
+	}
+});
+
+test("native fullscreen collapses the left inset and restores it afterwards", () => {
+	const policy = desktopWindowChrome("darwin");
+	expect(windowChromeGeometry(policy, true)).toEqual({ insetLeft: 0, insetRight: 0 });
+	expect(windowChromeGeometry(policy, false)).toEqual(policy.geometry);
+});
+
+test("geometry payloads accept only finite non-negative bounded insets", () => {
+	expect(readWindowChromeGeometry({ insetLeft: 64, insetRight: 0 })).toEqual({
+		insetLeft: 64,
+		insetRight: 0,
+	});
+	expect(readWindowChromeGeometry({ insetLeft: 0, insetRight: MAX_WINDOW_CHROME_INSET })).toEqual({
+		insetLeft: 0,
+		insetRight: MAX_WINDOW_CHROME_INSET,
+	});
+	for (const malformed of [
+		null,
+		[],
+		"64",
+		{ insetLeft: 64 },
+		{ insetLeft: -1, insetRight: 0 },
+		{ insetLeft: Number.NaN, insetRight: 0 },
+		{ insetLeft: Number.POSITIVE_INFINITY, insetRight: 0 },
+		{ insetLeft: MAX_WINDOW_CHROME_INSET + 1, insetRight: 0 },
+		{ insetLeft: "64", insetRight: 0 },
+		{ insetLeft: 64, insetRight: 0, extra: true, __proto__: { polluted: true } },
+	]) {
+		const read = readWindowChromeGeometry(malformed);
+		if (read) expect(Object.keys(read)).toEqual(["insetLeft", "insetRight"]);
+		else expect(read).toBeNull();
+	}
+});
+
+test("geometry maps onto exactly the two published CSS custom properties", () => {
+	expect(windowChromeCssDeclarations({ insetLeft: 64, insetRight: 0 })).toEqual([
+		["--window-chrome-inset-left", "64px"],
+		["--window-chrome-inset-right", "0px"],
+	]);
+});
+
+test("preload injection installs the initial geometry before the bundled source", () => {
+	const preload = injectInitialWindowChrome("globalThis.preloadStarted = true;", {
+		insetLeft: 64,
+		insetRight: 0,
+	});
+	expect(preload.indexOf(INITIAL_WINDOW_CHROME_GLOBAL)).toBeGreaterThanOrEqual(0);
+	expect(preload.indexOf(INITIAL_WINDOW_CHROME_GLOBAL)).toBeLessThan(
+		preload.indexOf("globalThis.preloadStarted"),
+	);
+	expect(preload).toContain('\\"insetLeft\\":64');
+});

--- a/apps/desktop/src/windowChrome.ts
+++ b/apps/desktop/src/windowChrome.ts
@@ -1,0 +1,71 @@
+import { prependPreloadGlobal } from "./preloadGlobals";
+
+export type WindowChromeGeometry = {
+	insetLeft: number;
+	insetRight: number;
+};
+
+export type WindowChromePolicy = {
+	titleBarStyle: "default" | "hiddenInset";
+	trafficLightOffset: { x: number; y: number } | null;
+	geometry: WindowChromeGeometry;
+};
+
+export const INITIAL_WINDOW_CHROME_GLOBAL = "__THINKRAIL_INITIAL_WINDOW_CHROME__";
+export const WINDOW_CHROME_INSET_LEFT_PROPERTY = "--window-chrome-inset-left";
+export const WINDOW_CHROME_INSET_RIGHT_PROPERTY = "--window-chrome-inset-right";
+export const MAX_WINDOW_CHROME_INSET = 512;
+
+const NO_INSETS: WindowChromeGeometry = { insetLeft: 0, insetRight: 0 };
+
+export function desktopWindowChrome(platform: NodeJS.Platform): WindowChromePolicy {
+	if (platform === "darwin") {
+		return {
+			titleBarStyle: "hiddenInset",
+			trafficLightOffset: { x: 0, y: 4 },
+			geometry: { insetLeft: 64, insetRight: 0 },
+		};
+	}
+	return { titleBarStyle: "default", trafficLightOffset: null, geometry: NO_INSETS };
+}
+
+export function windowChromeGeometry(
+	policy: WindowChromePolicy,
+	fullScreen: boolean,
+): WindowChromeGeometry {
+	return fullScreen ? { ...policy.geometry, insetLeft: 0 } : policy.geometry;
+}
+
+function isWindowChromeInset(value: unknown): value is number {
+	return (
+		typeof value === "number" &&
+		Number.isFinite(value) &&
+		value >= 0 &&
+		value <= MAX_WINDOW_CHROME_INSET
+	);
+}
+
+export function readWindowChromeGeometry(payload: unknown): WindowChromeGeometry | null {
+	if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return null;
+	const insetLeft = Reflect.get(payload, "insetLeft");
+	const insetRight = Reflect.get(payload, "insetRight");
+	return isWindowChromeInset(insetLeft) && isWindowChromeInset(insetRight)
+		? { insetLeft, insetRight }
+		: null;
+}
+
+export function injectInitialWindowChrome(
+	preloadSource: string,
+	geometry: WindowChromeGeometry,
+): string {
+	return prependPreloadGlobal(preloadSource, INITIAL_WINDOW_CHROME_GLOBAL, geometry);
+}
+
+export function windowChromeCssDeclarations(
+	geometry: WindowChromeGeometry,
+): ReadonlyArray<readonly [property: string, value: string]> {
+	return [
+		[WINDOW_CHROME_INSET_LEFT_PROPERTY, `${geometry.insetLeft}px`],
+		[WINDOW_CHROME_INSET_RIGHT_PROPERTY, `${geometry.insetRight}px`],
+	];
+}

--- a/apps/web/SPEC.md
+++ b/apps/web/SPEC.md
@@ -104,6 +104,14 @@ themselves.
   `px-12`) and a **generated semantic typography class** for type (`tr-text-ui`, `tr-title-dialog`,
   `tr-code-text`, …) — **never inline `style` objects, never raw hex.** Responsive (`md:` …) and states (`hover:` / `focus-visible:`) come
   from Tailwind (inline styles can't express them, and the responsive shell needs them).
+- **Chrome geometry lives in `index.css`, host geometry arrives as CSS custom properties.** Beside the
+  generated colour/spacing layers, `index.css` maps the shell's structural rows (`--spacing-panel-header-row`,
+  `--spacing-topbar-row` from `tokens.css`) and the two host-published window-chrome insets
+  (`--spacing-window-chrome-inset-left|right: var(--window-chrome-inset-*, 0px)`), and declares the only
+  two non-typographic handwritten utilities, `window-drag` / `window-no-drag` (`-webkit-app-region` +
+  `app-region`). A native host may set the inset properties on `<html>`; the app never detects the host,
+  it reads the properties with their `0px` fallbacks ([[submodule-web-shell]] owns the consumer,
+  [[module-desktop]] the publisher).
 - **The colour and type systems are this app's, not the monorepo's.** `apps/website` keeps its own
   hardcoded stylesheet on purpose — a static page with no theming has no use for a token layer, and
   reaching across apps would couple them for nothing.

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -43,6 +43,9 @@
 	--font-mono: var(--tr-font-family-code);
 
 	--spacing-panel-header-row: var(--panel-header-row-height);
+	--spacing-topbar-row: var(--topbar-row-height);
+	--spacing-window-chrome-inset-left: var(--window-chrome-inset-left, 0px);
+	--spacing-window-chrome-inset-right: var(--window-chrome-inset-right, 0px);
 
 	/* A block appearing in place (e.g. the ask-question card's atomic reveal once its args are final). */
 	--animate-reveal: reveal 150ms ease-out;
@@ -88,6 +91,15 @@
 			transform: translateY(12px);
 		}
 	}
+}
+
+@utility window-drag {
+	-webkit-app-region: drag;
+	app-region: drag;
+}
+@utility window-no-drag {
+	-webkit-app-region: no-drag;
+	app-region: no-drag;
 }
 
 /* Review Monaco surfaces (panels/reviewGutter.ts + reviewWidgets.ts): commented-line decorations, the

--- a/apps/web/src/shell/JbcentralQuotaIndicator.tsx
+++ b/apps/web/src/shell/JbcentralQuotaIndicator.tsx
@@ -43,7 +43,7 @@ export function JbcentralQuotaIndicator({
 					data-testid="jbcentral-quota"
 					data-state="unavailable"
 					onClick={onRetry}
-					className="inline-flex shrink-0 items-center gap-4 whitespace-nowrap rounded-[var(--radius-sm)] text-text-muted tr-text-ui outline-none hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
+					className="window-no-drag inline-flex shrink-0 items-center gap-4 whitespace-nowrap rounded-[var(--radius-sm)] text-text-muted tr-text-ui outline-none hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
 				>
 					<Coins className="size-14" aria-hidden="true" />
 					<span>Quota unavailable</span>
@@ -90,7 +90,7 @@ export function JbcentralQuotaIndicator({
 					data-state="stale"
 					aria-label={label}
 					onClick={onRetry}
-					className={`${className} rounded-[var(--radius-sm)] outline-none hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary`}
+					className={`${className} window-no-drag rounded-[var(--radius-sm)] outline-none hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary`}
 				>
 					{content}
 				</button>

--- a/apps/web/src/shell/SPEC.md
+++ b/apps/web/src/shell/SPEC.md
@@ -5,6 +5,7 @@ status: active
 title: shell — responsive frame
 parent: module-web
 tags: [v1, ui]
+references: [module-desktop]
 ---
 
 ## Responsibility
@@ -33,7 +34,20 @@ The sibling dependency graph is: `layoutState → layout`; `chatReconciliation �
 
 ## Composition
 
-The topbar keeps ThinkRail identity, connection state, Settings, and compact location context. The identity
+The topbar keeps ThinkRail identity, connection state, Settings, and compact location context, and doubles
+as the **window title bar** when a native host removes its own strip ([[module-desktop]], *Native window
+chrome*). It is a fixed `h-topbar-row` (`--topbar-row-height`, 40px — macOS title-bar proportions, so
+native traffic lights sit centred in it) with `px-16`, and it is host-agnostic: the only host-shaped input
+is two CSS custom properties, `--window-chrome-inset-left` / `--window-chrome-inset-right`, consumed
+through the `w-window-chrome-inset-*` spacing tokens by one `aria-hidden` edge spacer on each side
+(`window-chrome-inset-left|right`). Unset (any browser) they resolve to `0px` and the header looks as
+before; the desktop publishes `64px` on macOS so content starts at 80px and collapses it to `0px` in
+fullscreen. Padding was deliberately not used for the inset: the `spacingUsage` gate lets padding
+utilities name only canonical steps, and a CSS `padding-left: max(…)` would need a gate exemption. The
+whole header is a window-drag region (`window-drag select-none`; inert outside a native host) and every
+interactive control inside it — the Settings gear, the quota Retry, any future button or link — must
+carry `window-no-drag`, while plain text (breadcrumb, connection label) stays draggable. `SettingsDialog`
+portals out of the header and is unaffected. Nothing in the shell names or imports the desktop host. The identity
 is the icon-only ThinkRail mark—the same vector served as `public/favicon.svg`, inlined at 32×32 and rendered
 through semantic `text-primary`—with no divider before location. An active workspace shows one line of
 `project / workspace  branch · from baseBranch` plus optional review metadata on `tr-text-ui`; project and

--- a/apps/web/src/shell/Shell.tsx
+++ b/apps/web/src/shell/Shell.tsx
@@ -110,7 +110,12 @@ export function Shell() {
 	});
 	return (
 		<div data-testid="shell" className="grid h-full grid-rows-[auto_1fr]">
-			<header className="flex items-center justify-between border-b border-border-default bg-container-header-bg px-16 py-8">
+			<header className="window-drag flex h-topbar-row select-none items-center border-b border-border-default bg-container-header-bg px-16">
+				<div
+					aria-hidden="true"
+					data-testid="window-chrome-inset-left"
+					className="w-window-chrome-inset-left shrink-0"
+				/>
 				<div className="flex min-w-0 items-center gap-12">
 					<BrandLogo />
 					{contextProject ? (
@@ -159,7 +164,7 @@ export function Shell() {
 						</div>
 					) : null}
 				</div>
-				<div className="flex shrink-0 items-center gap-12">
+				<div className="ml-auto flex shrink-0 items-center gap-12">
 					<JbcentralQuotaTopbar />
 					<span
 						data-testid="connection-status"
@@ -182,12 +187,17 @@ export function Shell() {
 							data-testid="open-settings"
 							aria-label="Settings"
 							onClick={() => useAppStore.getState().openSettings()}
-							className="flex size-28 items-center justify-center rounded-[var(--radius-sm)] text-text-muted outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
+							className="window-no-drag flex size-28 items-center justify-center rounded-[var(--radius-sm)] text-text-muted outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary"
 						>
 							<Settings className="size-16" />
 						</button>
 					</IconTooltip>
 				</div>
+				<div
+					aria-hidden="true"
+					data-testid="window-chrome-inset-right"
+					className="w-window-chrome-inset-right shrink-0"
+				/>
 				<SettingsDialog layoutSettings={<LayoutSettings />} />
 			</header>
 			{hasActiveWorkspace && activeWorkspaceId ? (

--- a/apps/web/src/shell/jbcentralQuota.test.tsx
+++ b/apps/web/src/shell/jbcentralQuota.test.tsx
@@ -175,6 +175,9 @@ test("stale and unavailable quota are Retry buttons while zero stays neutral", (
 	const unavailable = render({ state: "unavailable" });
 	expect(unavailable).toContain("Quota unavailable");
 	expect(unavailable).toContain("Retry");
+	for (const markup of [stale, unavailable]) {
+		expect(markup).toMatch(/<button[^>]*class="[^"]*\bwindow-no-drag\b/);
+	}
 
 	const zero = render({ ...AVAILABLE, remaining: 0 });
 	expect(zero).toContain("0 / 20");

--- a/apps/web/src/shell/topbarChrome.test.ts
+++ b/apps/web/src/shell/topbarChrome.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const shellSource = readFileSync(new URL("./Shell.tsx", import.meta.url), "utf8");
+const headerStart = shellSource.indexOf("<header");
+const headerEnd = shellSource.indexOf("</header>");
+const header = shellSource.slice(headerStart, headerEnd);
+const jsxTag = (name: string) => new RegExp(`<${name}\\b(?:=>|[^>])*>`, "g");
+const openingTag = jsxTag("header").exec(header)?.[0] ?? "";
+
+const classAttribute = (tag: string) => /className="([^"]*)"/.exec(tag)?.[1]?.split(/\s+/) ?? [];
+
+test("the topbar is a fixed-height window-drag region on the topbar row token", () => {
+	expect(headerStart).toBeGreaterThanOrEqual(0);
+	expect(headerEnd).toBeGreaterThan(headerStart);
+	const classes = classAttribute(openingTag);
+	expect(classes).toContain("window-drag");
+	expect(classes).toContain("select-none");
+	expect(classes).toContain("h-topbar-row");
+	expect(classes.some((c) => /^py-/.test(c))).toBe(false);
+});
+
+test("every button inside the topbar opts out of window dragging", () => {
+	const buttons = [...header.matchAll(jsxTag("button"))].map((m) => m[0]);
+	expect(buttons.length).toBeGreaterThan(0);
+	for (const button of buttons) expect(classAttribute(button)).toContain("window-no-drag");
+});
+
+test("the topbar reserves host-published window-chrome insets at both edges through width tokens", () => {
+	for (const edge of ["left", "right"]) {
+		const spacer = [...header.matchAll(jsxTag("div"))]
+			.map((m) => m[0])
+			.find((tag) => tag.includes(`data-testid="window-chrome-inset-${edge}"`));
+		expect(spacer).toContain('aria-hidden="true"');
+		expect(spacer).toBeDefined();
+		expect(classAttribute(spacer ?? "")).toContain(`w-window-chrome-inset-${edge}`);
+	}
+});

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -22,6 +22,7 @@
 	--transition-normal: 200ms ease;
 
 	--panel-header-row-height: 32px;
+	--topbar-row-height: 40px;
 }
 
 /*

--- a/e2e/ask-user-question.spec.ts
+++ b/e2e/ask-user-question.spec.ts
@@ -190,7 +190,7 @@ test("a persisted tall questionnaire reveals page changes and a restored page wi
 			.toEqual({ heading: true, firstOption: true });
 
 		await reopenedFirstOption.click();
-		await page.setViewportSize({ width: 1280, height: 480 });
+		await page.setViewportSize({ width: 1280, height: 440 });
 		const reviewNext = reopenedCard.getByTestId("ask-continue");
 		await wheelUntilChatElementIntersects(page, chatScroll, reviewNext);
 		await reviewNext.click();

--- a/e2e/chat-order.spec.ts
+++ b/e2e/chat-order.spec.ts
@@ -199,6 +199,7 @@ test("newest-first scrolls down into history and returns upward to the latest gr
 				};
 			})
 			.toEqual({ atPhysicalLatestEdge: true, latestRowIntersectsViewport: true });
+		await expect(chatScroll).toHaveAttribute("data-scroll-moving", "false");
 
 		await page.mouse.wheel(0, 10_000);
 		await expect(latest).toBeVisible();


### PR DESCRIPTION
## Summary

The desktop app's native title bar was a white/system-coloured, empty strip above a dark-themed UI. Electrobun exposes no caption-colour API on any platform, so the only way to theme it is to remove the native strip and let the ThinkRail topbar *be* the title bar.

On **macOS** the window now uses `titleBarStyle: "hiddenInset"`: the native traffic lights stay and sit vertically centred in a 40px topbar (logo · project › workspace · branch · quota · connection · Settings), which wears the theme's header colour edge to edge and is a window-drag region. In native fullscreen the reserved traffic-light zone collapses so the logo sits flush left. **Windows** and **Linux** keep their native chrome for now — on Windows `hiddenInset` also strips minimize/maximize/close (they would need HTML controls over RPC), and on Linux it is a no-op; both are recorded in `apps/desktop/SPEC.md` (Windows as a deferred follow-up).

The desktop → web seam is deliberately narrow so `apps/web` keeps having **no desktop branch**: the desktop publishes two CSS custom properties on `<html>` (`--window-chrome-inset-left/right`, initial values injected into the preload like preferences, updates over the first bun→webview RPC message) and the header consumes them through spacer width tokens with `0px` fallbacks. A plain browser (`apps/cli`) renders the header exactly as before, only 40px tall instead of ~48px.

## Changes

**`apps/desktop`**
- `windowChrome.ts` — platform-pure policy (`hiddenInset` + `trafficLightOffset {x:0, y:4}` + 64px zone on macOS; default elsewhere), payload validation, CSS declarations, preload injection; pinned by unit tests.
- `preload.ts` writes the two properties at document-start and on `windowChromeChanged`; `rpc.ts` gains that first bun→webview message; `index.ts` spreads the policy into `BrowserWindow` and watches `resize` → `isFullScreen()`.
- `preloadGlobals.ts` — the preload-global injection previously private to preferences, now shared.

**`apps/web`**
- `tokens.css` `--topbar-row-height: 40px`; `index.css` maps `--spacing-topbar-row` + the two inset tokens and declares `window-drag` / `window-no-drag` utilities.
- `Shell.tsx` header: `h-topbar-row window-drag select-none`, `aria-hidden` edge spacers, right group via `ml-auto`; Settings and quota Retry are `window-no-drag`. `topbarChrome.test.ts` gates the rule (every button in the header must opt out of dragging).

**Specs** — `apps/desktop/SPEC.md` (new *Native window chrome* section, Windows in *Deferred*), `apps/web/src/shell/SPEC.md`, `apps/web/SPEC.md`.

**e2e** — two geometry-sensitive specs adjusted, each A/B-confirmed against the pre-change build: `ask-user-question` (review viewport 480→440 so Submit stays off-screen with slack) and `chat-order` (wait for `data-scroll-moving="false"` before wheeling after *Latest*, the suite's existing idiom). The latter exposed a pre-existing engine race, filed separately — see below.

Not verified automatically: the fullscreen inset collapse (driving native fullscreen needs Accessibility permission); checked by design, please try it in the build.

## Testing

- `bun run lint` — 0 errors (6 pre-existing warnings); `bun run typecheck` — 15/15; `bun run test` — every workspace green (web 986, desktop 41).
- `bun run check:deps`, `check:boundaries`, `check:seams`, `check:spec-surface` — OK.
- `bun run e2e` — complete no-agent suite, 8 shards, **389 passed** (run after the rebase onto `main`).
- `electrobun build --env=dev` → launched and measured from window screenshots: title strip `#1f1f23` (theme header) vs. `#fffeff` on the current canary; traffic lights at CSS x 9–63, centre y **20.0 of 40**; logo at x 80.

## Screenshots

macOS, dark theme, top of the window (2× retina crops).

**Before** — white system title bar above the app header:

![before: white system title bar](https://github.com/JetBrains/thinkrail/blob/3a1ab69b5f6d116c4df65afb150099103ff1e69e/titlebar-before-white-system-strip.png?raw=true)

**After** — the header *is* the title bar; traffic lights centred in the 40px strip, content from 80px:

![after: themed topbar as title bar](https://github.com/JetBrains/thinkrail/blob/3a1ab69b5f6d116c4df65afb150099103ff1e69e/titlebar-after-themed-topbar.png?raw=true)

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

