### PR TITLE
ci(desktop): skip unused DMGs for signing-input builds

### DIFF
--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -132,9 +132,9 @@ content types. Entitlement extraction requests XML before plist parsing.
 ## Desktop updater qualification and publication
 
 Auto-update scope includes every current native desktop target in the matrix above. Canary qualification
-precedes stable; each target needs an observed installed-version A to version B upgrade before enablement.
-The public build handoff now includes the raw Electrobun manifest and full archive; the private runtime feed
-and publication automation are not yet live. Runtime policy belongs to [[module-desktop]].
+precedes stable; each target needs an observed installed-version A to version B upgrade before stable enablement.
+The public build handoff supplies the raw Electrobun manifest and full archive; the private pipeline
+finalizes and publishes the runtime feed. Runtime policy belongs to [[module-desktop]].
 
 The private pipeline consumes those raw names, finalizes the macOS application through the existing signing
 flow, and creates its update archive from those final bytes. It assigns each finalized archive an immutable,

--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -43,18 +43,23 @@ Native macOS and Linux ARM64 acceptance belongs to the release matrix.
 ## Native build contract
 
 The private native matrix checks out an explicit public source commit and invokes
-`.github/actions/build-binary`. The action accepts `version`, `channel`, and a host-matching `target`.
+`.github/actions/build-binary`. The action accepts `version`, `channel`, a host-matching `target`, and
+`macos-signing-input-only` (default false). That macOS-only opt-in uses the normal package command with
+Electrobun's documented DMG creation disabled; the private signer owns the final installer instead.
 Its stable public outputs are:
 
 - `artifact-name` / `artifact-path` — native CLI;
-- `desktop-artifact-name` / `desktop-artifact-path` — first-install desktop artifact;
+- `desktop-artifact-name` / `desktop-artifact-path` — first-install desktop artifact, empty only in
+  macOS signing-input-only mode;
 - `desktop-app-archive-path` — Electrobun's expanded macOS app archive, empty on non-macOS targets;
 - `desktop-update-manifest-path` / `desktop-update-archive-path` — Electrobun's updater metadata and
   full application archive, both non-empty on every desktop target.
 
 The recipe stamps the shared version, builds and smokes the CLI, invokes the normal Electrobun dev and
 channel builds, runs expanded-app and first-install smoke, then collects exact target/channel outputs.
-Update outputs preserve Electrobun's generated basenames and compressed bytes. The manifest is the exact
+Signing-input-only mode retains expanded-app smoke and requires the app archive and updater pair, but has
+no unsigned DMG to collect or smoke. Default local/CI installers and the private final signed-installer
+verification remain unchanged. Update outputs preserve Electrobun's generated basenames and compressed bytes. The manifest is the exact
 `<stable|canary>-<macos|win|linux>-<arm64|x64>-update.json`. Its `artifact.file` is the archive basename:
 `stable-<platform>-ThinkRail[.app].tar.zst` for stable or
 `canary-<platform>-ThinkRail-canary[.app].tar.zst` for nightly, where `<platform>` is the manifest's
@@ -76,8 +81,8 @@ Supported desktop assets:
 
 Windows and Linux aliases name untouched framework installers. The Windows ZIP contains its setup
 executable and adjacent payload; Linux's tarball contains the installer and README. For macOS, the
-private SRE flow replaces the unsigned framework DMG with a conventional DMG containing the signed
-expanded app, under the same published alias. The app archive is a private signing intermediate, never
+private SRE flow creates a conventional DMG containing the signed expanded app under the same published
+alias; its signing-input-only build avoids a discarded unsigned DMG. The app archive is a private signing intermediate, never
 a public release asset.
 
 On Windows, the packaging invocation puts System32 first so Hutch's bare `tar` resolves to Windows

--- a/.github/SPEC.md
+++ b/.github/SPEC.md
@@ -67,8 +67,10 @@ OS-architecture pair and `.app` occurs only on macOS. Collection resolves both n
 channel and target rather than accepting the first glob match. The paths point directly
 into Electrobun's output tree; updater payloads do not change the installer-only dist aliases. On macOS the
 update archive may be the same expanded-app archive exposed through `desktop-app-archive-path`; the recipe
-does not duplicate or repackage it. [[module-artifact-tests]] owns isolated packaging-invocation and
-collector contract tests; this module owns the action and delivery contract.
+does not duplicate or repackage it. The collector's installer path determines whether first-install
+smoke runs; consumers do not repeat its mode/target decision. [[module-artifact-tests]] owns isolated
+packaging-invocation, mode-validation and collector contract tests; this module owns the action and
+delivery contract.
 
 Supported desktop assets:
 

--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -218,7 +218,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Smoke desktop first-install artifact
-      if: ${{ inputs.macos-signing-input-only != 'true' || inputs.target != 'bun-darwin-arm64' }}
+      if: ${{ steps.resolve-desktop.outputs.path != '' }}
       shell: bash
       env:
         CHANNEL: ${{ inputs.channel }}

--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -13,6 +13,10 @@ inputs:
   target:
     description: "Bun compile target matching this native runner"
     required: true
+  macos-signing-input-only:
+    description: "Build macOS signing inputs without creating the unsigned DMG"
+    required: false
+    default: "false"
 outputs:
   artifact-name:
     description: "CLI artifact filename"
@@ -21,10 +25,10 @@ outputs:
     description: "CLI artifact path"
     value: ${{ steps.resolve-cli.outputs.path }}
   desktop-artifact-name:
-    description: "Desktop first-install artifact filename"
+    description: "Desktop first-install artifact filename; empty in macOS signing-input-only mode"
     value: ${{ steps.resolve-desktop.outputs.name }}
   desktop-artifact-path:
-    description: "Desktop first-install artifact path"
+    description: "Desktop first-install artifact path; empty in macOS signing-input-only mode"
     value: ${{ steps.resolve-desktop.outputs.path }}
   desktop-app-archive-path:
     description: "Official expanded macOS app archive for private signing; empty on other targets"
@@ -39,6 +43,27 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate macOS signing input mode
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+        MACOS_SIGNING_INPUT_ONLY: ${{ inputs.macos-signing-input-only }}
+      run: |
+        set -eu
+        case "$MACOS_SIGNING_INPUT_ONLY" in
+          false) ;;
+          true)
+            [ "$TARGET" = bun-darwin-arm64 ] || {
+              echo "::error::macos-signing-input-only is unsupported for target $TARGET"
+              exit 1
+            }
+            ;;
+          *)
+            echo "::error::macos-signing-input-only must be true or false"
+            exit 1
+            ;;
+        esac
+
     - name: Stamp shared release identity
       shell: bash
       env:
@@ -88,6 +113,7 @@ runs:
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
+        THINKRAIL_MACOS_SIGNING_INPUT_ONLY: ${{ inputs.macos-signing-input-only }}
       run: |
         set -eu
         bun run desktop:build
@@ -105,6 +131,7 @@ runs:
       env:
         TARGET: ${{ inputs.target }}
         CHANNEL: ${{ inputs.channel }}
+        THINKRAIL_MACOS_SIGNING_INPUT_ONLY: ${{ inputs.macos-signing-input-only }}
       run: |
         set -eu
         if [ "$TARGET" = bun-windows-x64 ]; then
@@ -125,6 +152,7 @@ runs:
       env:
         TARGET: ${{ inputs.target }}
         CHANNEL: ${{ inputs.channel }}
+        MACOS_SIGNING_INPUT_ONLY: ${{ inputs.macos-signing-input-only }}
       run: |
         set -eu
         mkdir -p apps/desktop/dist
@@ -137,10 +165,15 @@ runs:
         case "$TARGET" in
           bun-darwin-arm64)
             platform='macos-arm64'
-            source="${prefix}${platform}-ThinkRail${suffix}.dmg"
-            name='thinkrail-desktop-darwin-arm64.dmg'
             update_archive_name="${environment}-${platform}-ThinkRail${suffix}.app.tar.zst"
             app_archive_path="apps/desktop/artifacts/$update_archive_name"
+            if [ "$MACOS_SIGNING_INPUT_ONLY" = true ]; then
+              source=''
+              name=''
+            else
+              source="${prefix}${platform}-ThinkRail${suffix}.dmg"
+              name='thinkrail-desktop-darwin-arm64.dmg'
+            fi
             ;;
           bun-windows-x64)
             platform='win-x64'
@@ -165,14 +198,17 @@ runs:
         if [ -n "$app_archive_path" ]; then
           [ -f "$app_archive_path" ] || { echo "::error::desktop app archive not found at $app_archive_path"; exit 1; }
         fi
-        source="apps/desktop/artifacts/$source"
-        [ -f "$source" ] || { echo "::error::desktop installer not found at $source"; exit 1; }
+        path=''
+        if [ -n "$source" ]; then
+          source="apps/desktop/artifacts/$source"
+          [ -f "$source" ] || { echo "::error::desktop installer not found at $source"; exit 1; }
+          path="apps/desktop/dist/$name"
+          cp "$source" "$path"
+        fi
         update_manifest_path="apps/desktop/artifacts/${environment}-${platform}-update.json"
         [ -f "$update_manifest_path" ] || { echo "::error::desktop update manifest not found at $update_manifest_path"; exit 1; }
         update_archive_path="apps/desktop/artifacts/$update_archive_name"
         [ -f "$update_archive_path" ] || { echo "::error::desktop update archive not found at $update_archive_path"; exit 1; }
-        path="apps/desktop/dist/$name"
-        cp "$source" "$path"
         {
           echo "name=$name"
           echo "path=$path"
@@ -182,6 +218,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Smoke desktop first-install artifact
+      if: ${{ inputs.macos-signing-input-only != 'true' || inputs.target != 'bun-darwin-arm64' }}
       shell: bash
       env:
         CHANNEL: ${{ inputs.channel }}

--- a/apps/desktop/SPEC.md
+++ b/apps/desktop/SPEC.md
@@ -199,8 +199,10 @@ The native macOS build also exposes Electrobun's standard expanded `.app.tar.zst
 input. The approved JetBrains SRE flow signs the expanded app and finalizes a conventional DMG around it,
 then signs/notarizes/staples that container. It does not mutate Electrobun's compressed self-extractor
 payload or use an incorrect pre-metadata sealing hook. Local framework DMGs remain unsigned build outputs;
-only the private pipeline's verified final DMG is a signed release. The handoff and verification contract
-belong to [[module-ci-release]].
+only the private pipeline's verified final DMG is a signed release. The build-only opt-in
+`THINKRAIL_MACOS_SIGNING_INPUT_ONLY=true` selects the SDK's `build.mac.createDmg: false` while retaining
+the expanded app and update archive; it changes no runtime behavior. The default still creates a DMG.
+The handoff and verification contract belong to [[module-ci-release]].
 
 Linux uses native WebKitGTK without CEF and declares Ubuntu 24.04+/glibc 2.38 plus `libgtk-3-0`,
 `libwebkit2gtk-4.1-0`, `libayatana-appindicator3-1`, and `librsvg2-2`. Xvfb software-rendering flags are

--- a/apps/desktop/electrobun.config.ts
+++ b/apps/desktop/electrobun.config.ts
@@ -22,7 +22,11 @@ export default {
 			"../web/dist": "views/web",
 			".stage/runtime": "runtime",
 		},
-		mac: { bundleCEF: false, icons: "assets/icon.iconset" },
+		mac: {
+			bundleCEF: false,
+			icons: "assets/icon.iconset",
+			createDmg: process.env.THINKRAIL_MACOS_SIGNING_INPUT_ONLY !== "true",
+		},
 		linux: { bundleCEF: false, icon: "assets/icon.png" },
 		win: { bundleCEF: false, icon: "assets/icon.ico" },
 	},

--- a/apps/desktop/src/buildConfig.test.ts
+++ b/apps/desktop/src/buildConfig.test.ts
@@ -6,7 +6,12 @@ import manifest from "../package.json";
 
 const desktopDir = resolve(import.meta.dir, "..");
 
-test("selects real Bun and preserves the physical runtime resources without retired v1 fields", () => {
+function loadBuildConfig(macosSigningInputOnly?: string) {
+	const env = { ...process.env };
+	delete env.THINKRAIL_MACOS_SIGNING_INPUT_ONLY;
+	if (macosSigningInputOnly !== undefined) {
+		env.THINKRAIL_MACOS_SIGNING_INPUT_ONLY = macosSigningInputOnly;
+	}
 	const result = Bun.spawnSync(
 		[
 			process.execPath,
@@ -15,13 +20,17 @@ test("selects real Bun and preserves the physical runtime resources without reti
 		],
 		{
 			cwd: desktopDir,
-			env: process.env,
+			env,
 			stdout: "pipe",
 			stderr: "pipe",
 		},
 	);
 	expect(result.exitCode).toBe(0);
-	const config = JSON.parse(result.stdout.toString());
+	return JSON.parse(result.stdout.toString());
+}
+
+test("selects real Bun and preserves the physical runtime resources without retired v1 fields", () => {
+	const config = loadBuildConfig();
 	expect(config.app).toEqual({
 		name: "ThinkRail",
 		identifier: "ai.thinkrail.app",
@@ -33,13 +42,18 @@ test("selects real Bun and preserves the physical runtime resources without reti
 		bun: { entrypoint: "src/index.ts" },
 		views: { preload: { entrypoint: "src/preload.ts", format: "iife" } },
 		copy: { "../web/dist": "views/web", ".stage/runtime": "runtime" },
-		mac: { bundleCEF: false, icons: "assets/icon.iconset" },
+		mac: { bundleCEF: false, icons: "assets/icon.iconset", createDmg: true },
 		linux: { bundleCEF: false, icon: "assets/icon.png" },
 		win: { bundleCEF: false, icon: "assets/icon.ico" },
 	});
 	expect(config.scripts).toEqual({ preBuild: "preBuild.ts", postBuild: "postBuild.ts" });
 	expect(config.build).not.toHaveProperty("bunVersion");
 	expect(config.build).not.toHaveProperty("useAsar");
+});
+
+test("disables macOS DMG creation only for signing-input builds", () => {
+	expect(loadBuildConfig("true").build.mac.createDmg).toBe(false);
+	expect(loadBuildConfig("false").build.mac.createDmg).toBe(true);
 });
 
 test("uses the exact npm bootstrap pin while Bun owns the workspace dependency graph", () => {

--- a/packages/artifact-tests/SPEC.md
+++ b/packages/artifact-tests/SPEC.md
@@ -18,13 +18,13 @@ It consumes finished artifacts; it does not build the application or supply appl
 ## Boundary
 
 - **Owns:** artifact locators, isolated environments, native/installer smoke entrypoints, shared host
-  probes, their fixtures and helper unit tests, and the public build action's desktop packaging-invocation
-  and artifact-collector contract tests.
+  probes, their fixtures and helper unit tests, and the public build action's desktop packaging,
+  signing-input mode validation, input/step-gating and artifact-collector contract tests.
 - **Public surface:** `locateDesktopLauncher`
 - **Allowed deps:** CLI's public artifact-name helper; server's sanctioned history-fixture export;
   shared retrying teardown; read-only access to `.github/actions/build-binary/action.yml` for executing
-  its packaging invocation and collector in isolated fixture directories; Bun/Node and native installer
-  tools.
+  its packaging invocation, signing-input mode validation and collector in isolated fixture directories,
+  and checking the action's input and step-gating contract; Bun/Node and native installer tools.
 - **Forbidden:** application or SDK source internals, Electrobun imports/dependency, a fake host or agent,
   production packages importing this package, or real-user state mutation during tests.
 

--- a/packages/artifact-tests/src/releaseArtifacts.test.ts
+++ b/packages/artifact-tests/src/releaseArtifacts.test.ts
@@ -13,8 +13,17 @@ import { join, resolve } from "node:path";
 
 const actionPath = resolve(import.meta.dir, "../../../.github/actions/build-binary/action.yml");
 const action = Bun.YAML.parse(readFileSync(actionPath, "utf8")) as {
+	inputs: Record<string, { default?: string }>;
 	outputs: Record<string, { value: string }>;
-	runs: { steps: { id?: string; name?: string; run?: string }[] };
+	runs: {
+		steps: {
+			id?: string;
+			name?: string;
+			run?: string;
+			if?: string;
+			env?: Record<string, string>;
+		}[];
+	};
 };
 const roots: string[] = [];
 
@@ -109,7 +118,29 @@ function fixture(): string {
 	return root;
 }
 
-function packageDesktop(root: string, target: string, channel: string) {
+function validateSigningInput(root: string, target: string, macosSigningInputOnly: string) {
+	const script = action.runs.steps.find(
+		(step) => step.name === "Validate macOS signing input mode",
+	)?.run;
+	if (!script) throw new Error("macOS signing input validation script is missing");
+	return Bun.spawnSync(["bash", "-c", script], {
+		cwd: root,
+		env: {
+			...process.env,
+			TARGET: target,
+			MACOS_SIGNING_INPUT_ONLY: macosSigningInputOnly,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+}
+
+function packageDesktop(
+	root: string,
+	target: string,
+	channel: string,
+	macosSigningInputOnly = "false",
+) {
 	const script = action.runs.steps.find((step) => step.name === "Package desktop installer")?.run;
 	if (!script) throw new Error("desktop package script is missing");
 	return Bun.spawnSync(["bash", "-c", script], {
@@ -120,13 +151,14 @@ function packageDesktop(root: string, target: string, channel: string) {
 			SYSTEMROOT: "C:\\Windows",
 			TARGET: target,
 			CHANNEL: channel,
+			THINKRAIL_MACOS_SIGNING_INPUT_ONLY: macosSigningInputOnly,
 		},
 		stdout: "pipe",
 		stderr: "pipe",
 	});
 }
 
-function collect(root: string, target: string, channel: string) {
+function collect(root: string, target: string, channel: string, macosSigningInputOnly = "false") {
 	const collector = action.runs.steps.find((step) => step.id === "resolve-desktop")?.run;
 	if (!collector) throw new Error("desktop artifact collector is missing");
 	return Bun.spawnSync(["bash", "-c", collector], {
@@ -135,6 +167,7 @@ function collect(root: string, target: string, channel: string) {
 			...process.env,
 			TARGET: target,
 			CHANNEL: channel,
+			MACOS_SIGNING_INPUT_ONLY: macosSigningInputOnly,
 			GITHUB_OUTPUT: join(root, "outputs"),
 		},
 		stdout: "pipe",
@@ -156,14 +189,17 @@ test("Windows packaging places System32 tar ahead of Git tar", () => {
 	writeFileSync(join(system32, "tar"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
 	writeFileSync(
 		join(bin, "bun"),
-		`#!/bin/sh\nprintf '%s\\n%s\\n' "$PATH" "$*" > ${JSON.stringify(join(root, "package-call"))}\n`,
+		`#!/bin/sh\nprintf '%s\\n%s\\n%s\\n' "$PATH" "$*" "\${THINKRAIL_MACOS_SIGNING_INPUT_ONLY-}" > ${JSON.stringify(join(root, "package-call"))}\n`,
 		{ mode: 0o755 },
 	);
 	const result = packageDesktop(root, "bun-windows-x64", "nightly");
 	expect(result.exitCode).toBe(0);
-	const [path, args] = readFileSync(join(root, "package-call"), "utf8").split("\n");
+	const [path, args, signingInputOnly] = readFileSync(join(root, "package-call"), "utf8").split(
+		"\n",
+	);
 	expect(path?.split(":")[0]).toBe(system32);
 	expect(args).toBe("run --cwd apps/desktop package:canary");
+	expect(signingInputOnly).toBe("false");
 });
 
 test("non-Windows packaging does not require cygpath or rewrite PATH", () => {
@@ -172,13 +208,46 @@ test("non-Windows packaging does not require cygpath or rewrite PATH", () => {
 	mkdirSync(bin, { recursive: true });
 	writeFileSync(
 		join(bin, "bun"),
-		`#!/bin/sh\nprintf '%s\\n%s\\n' "$PATH" "$*" > ${JSON.stringify(join(root, "package-call"))}\n`,
+		`#!/bin/sh\nprintf '%s\\n%s\\n%s\\n' "$PATH" "$*" "\${THINKRAIL_MACOS_SIGNING_INPUT_ONLY-}" > ${JSON.stringify(join(root, "package-call"))}\n`,
 		{ mode: 0o755 },
 	);
 	expect(packageDesktop(root, "bun-linux-x64", "stable").exitCode).toBe(0);
-	const [path, args] = readFileSync(join(root, "package-call"), "utf8").split("\n");
+	const [path, args, signingInputOnly] = readFileSync(join(root, "package-call"), "utf8").split(
+		"\n",
+	);
 	expect(path?.split(":")[0]).toBe(bin);
 	expect(args).toBe("run --cwd apps/desktop package:stable");
+	expect(signingInputOnly).toBe("false");
+});
+
+test("macOS signing-input packaging keeps the stable command and selects the build-only config mode", () => {
+	const root = fixture();
+	const bin = join(root, "bin");
+	mkdirSync(bin, { recursive: true });
+	writeFileSync(
+		join(bin, "bun"),
+		`#!/bin/sh\nprintf '%s\\n%s\\n' "$*" "$THINKRAIL_MACOS_SIGNING_INPUT_ONLY" > ${JSON.stringify(join(root, "package-call"))}\n`,
+		{ mode: 0o755 },
+	);
+	expect(validateSigningInput(root, "bun-darwin-arm64", "true").exitCode).toBe(0);
+	expect(packageDesktop(root, "bun-darwin-arm64", "stable", "true").exitCode).toBe(0);
+	expect(readFileSync(join(root, "package-call"), "utf8")).toBe(
+		"run --cwd apps/desktop package:stable\ntrue\n",
+	);
+});
+
+test("declares signing-input-only as an opt-in and skips installer smoke only for its valid target", () => {
+	expect(action.inputs["macos-signing-input-only"]?.default).toBe("false");
+	for (const name of ["Build and smoke desktop app", "Package desktop installer"]) {
+		expect(
+			action.runs.steps.find((step) => step.name === name)?.env?.THINKRAIL_MACOS_SIGNING_INPUT_ONLY,
+		).toBe(`\${{ inputs.macos-signing-input-only }}`);
+	}
+	expect(
+		action.runs.steps.find((step) => step.name === "Smoke desktop first-install artifact")?.if,
+	).toBe(
+		`\${{ inputs.macos-signing-input-only != 'true' || inputs.target != 'bun-darwin-arm64' }}`,
+	);
 });
 
 test("preserves existing public outputs and adds both update artifact paths", () => {
@@ -222,6 +291,29 @@ for (const target of targets) {
 	}
 }
 
+for (const channel of ["stable", "nightly"] as const) {
+	test(`collects exact ${channel} macOS signing inputs without requiring or emitting an installer`, () => {
+		const root = fixture();
+		const target = targets[0];
+		rmSync(join(root, "apps/desktop/artifacts", target[channel]));
+		const result = collect(root, target.target, channel, "true");
+		expect(result.exitCode).toBe(0);
+		const update = target.updates[channel];
+		const appArchivePath = `apps/desktop/artifacts/${update.archive}`;
+		const updateManifestPath = `apps/desktop/artifacts/${update.manifest}`;
+		expect(readFileSync(join(root, "outputs"), "utf8")).toBe(
+			`name=\npath=\napp-archive-path=${appArchivePath}\nupdate-manifest-path=${updateManifestPath}\nupdate-archive-path=${appArchivePath}\n`,
+		);
+		expect(readdirSync(join(root, "apps/desktop/dist"))).toEqual([]);
+		expect(readFileSync(join(root, updateManifestPath), "utf8")).toBe(
+			`${channel}:${target.target}:manifest`,
+		);
+		expect(readFileSync(join(root, appArchivePath), "utf8")).toBe(
+			`${channel}:${target.target}:archive`,
+		);
+	});
+}
+
 test("refuses a missing requested installer instead of collecting a stale channel", () => {
 	const root = fixture();
 	rmSync(join(root, "apps/desktop/artifacts/macos-arm64-ThinkRail.dmg"));
@@ -229,16 +321,30 @@ test("refuses a missing requested installer instead of collecting a stale channe
 });
 
 test.each([
-	"stable",
-	"nightly",
-] as const)("refuses a missing requested %s macOS app archive instead of falling back to another artifact", (channel) => {
+	["stable", "false"],
+	["nightly", "false"],
+	["stable", "true"],
+	["nightly", "true"],
+] as const)("refuses a missing %s macOS app archive (signing-input-only=%s)", (channel, signingInputOnly) => {
 	const root = fixture();
 	const appArchivePath = `apps/desktop/artifacts/${targets[0].updates[channel].archive}`;
 	rmSync(join(root, appArchivePath));
-	const result = collect(root, targets[0].target, channel);
+	const result = collect(root, targets[0].target, channel, signingInputOnly);
 	expect(result.exitCode).not.toBe(0);
 	expect(result.stdout.toString()).toContain(
 		`::error::desktop app archive not found at ${appArchivePath}`,
+	);
+	expect(existsSync(join(root, "outputs"))).toBe(false);
+});
+
+test("refuses missing macOS signing-input metadata", () => {
+	const root = fixture();
+	const manifestPath = `apps/desktop/artifacts/${targets[0].updates.stable.manifest}`;
+	rmSync(join(root, manifestPath));
+	const result = collect(root, targets[0].target, "stable", "true");
+	expect(result.exitCode).not.toBe(0);
+	expect(result.stdout.toString()).toContain(
+		`::error::desktop update manifest not found at ${manifestPath}`,
 	);
 	expect(existsSync(join(root, "outputs"))).toBe(false);
 });
@@ -257,6 +363,34 @@ test.each([
 		`::error::desktop update ${kind} not found at ${expectedPath}`,
 	);
 	expect(existsSync(join(root, "outputs"))).toBe(false);
+});
+
+test("validates explicit signing-input mode values before building", () => {
+	for (const [target, mode] of [
+		["bun-darwin-arm64", "true"],
+		["bun-darwin-arm64", "false"],
+		["bun-windows-x64", "false"],
+	]) {
+		expect(validateSigningInput(fixture(), target, mode).exitCode).toBe(0);
+	}
+	for (const mode of ["", "yes", "1"]) {
+		const result = validateSigningInput(fixture(), "bun-darwin-arm64", mode);
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stdout.toString()).toContain("macos-signing-input-only must be true or false");
+	}
+});
+
+test.each([
+	"bun-darwin-x64",
+	"bun-windows-x64",
+	"bun-linux-x64",
+	"bun-linux-arm64",
+])("rejects macOS signing-input-only mode for target %s", (target) => {
+	const result = validateSigningInput(fixture(), target, "true");
+	expect(result.exitCode).not.toBe(0);
+	expect(result.stdout.toString()).toContain(
+		`::error::macos-signing-input-only is unsupported for target ${target}`,
+	);
 });
 
 test.each([

--- a/packages/artifact-tests/src/releaseArtifacts.test.ts
+++ b/packages/artifact-tests/src/releaseArtifacts.test.ts
@@ -370,7 +370,7 @@ test("validates explicit signing-input mode values before building", () => {
 		["bun-darwin-arm64", "true"],
 		["bun-darwin-arm64", "false"],
 		["bun-windows-x64", "false"],
-	]) {
+	] as const) {
 		expect(validateSigningInput(fixture(), target, mode).exitCode).toBe(0);
 	}
 	for (const mode of ["", "yes", "1"]) {

--- a/packages/artifact-tests/src/releaseArtifacts.test.ts
+++ b/packages/artifact-tests/src/releaseArtifacts.test.ts
@@ -236,7 +236,7 @@ test("macOS signing-input packaging keeps the stable command and selects the bui
 	);
 });
 
-test("declares signing-input-only as an opt-in and skips installer smoke only for its valid target", () => {
+test("declares signing-input-only as an opt-in and derives installer smoke from the collector output", () => {
 	expect(action.inputs["macos-signing-input-only"]?.default).toBe("false");
 	for (const name of ["Build and smoke desktop app", "Package desktop installer"]) {
 		expect(
@@ -245,9 +245,7 @@ test("declares signing-input-only as an opt-in and skips installer smoke only fo
 	}
 	expect(
 		action.runs.steps.find((step) => step.name === "Smoke desktop first-install artifact")?.if,
-	).toBe(
-		`\${{ inputs.macos-signing-input-only != 'true' || inputs.target != 'bun-darwin-arm64' }}`,
-	);
+	).toBe(`\${{ steps.resolve-desktop.outputs.path != '' }}`);
 });
 
 test("preserves existing public outputs and adds both update artifact paths", () => {


### PR DESCRIPTION
## Summary

Avoid creating the unsigned macOS DMG that the private release pipeline discards. The triggering nightly failed in that redundant framework `hdiutil create` step with `Resource busy` before signing or publication.

- Add opt-in `macos-signing-input-only` to the public build action, restricted to macOS ARM64.
- Select Electrobun's documented `build.mac.createDmg: false` through an explicit build-only environment value, without changing the normal package commands or SDK.
- Return the mandatory expanded app and updater pair with empty installer outputs in that mode. Default local/CI installers remain unchanged.
- Skip only the nonexistent unsigned-DMG installer smoke in that opt-in path; expanded-app smoke and private final signed-installer verification remain mandatory.

Companion private workflow: https://github.com/JetBrains/thinkrail-signing/pull/9

## Related issues

None.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [ ] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

## Verification

Using repository-pinned Bun 1.4.0:

- `bun test apps/desktop/src/buildConfig.test.ts packages/artifact-tests/src/releaseArtifacts.test.ts` — 33 passed, including default and input-only paths, target/value rejection, mandatory outputs and smoke gating.
- `bun run check:deps`, `check:boundaries`, `check:seams`, `check:spec-surface` — passed.
- `bun run lint` — passed with six pre-existing unused-suppression warnings; no new suppressions.
- `bun run typecheck` and `bun run test` — all 15 workspace tasks passed.
- `bun run e2e` — the initial complete run passed all 389 tests. After rebasing onto `2f16bd63`, the complete rerun was **388 passed / 1 failed** at `e2e/chat-order.spec.ts:117` (`scroll-to-top`, assertion at line 204). This is the same previously established local baseline flake; chat/test sources are outside this diff, and no test was skipped or weakened. The E2E checkbox awaits an observed CI pass for the submitted head.
- Real `THINKRAIL_MACOS_SIGNING_INPUT_ONLY=true bun run --cwd apps/desktop package:canary` in a fresh disposable worktree — passed; produced the exact macOS manifest and app archive, and no DMG. This was a build-only probe, not signed-install qualification.
- `git diff --check` — passed. Spec validation retains three unrelated pre-existing dangling task links.
- Cross-repository `claude-opus-5` review — Approve; both non-blocking cleanup suggestions were addressed (collector-owned smoke gating and explicit test-module ownership).

## Rollout and scope

Merge the private consumer first, then this public producer. Older sources may still create an unused DMG; the updated private handoff ignores it. No runtime updater changes, new dependencies, SDK patches, global cleanup or security-service changes.

Nightly `.47` completed successfully using its original commits, independently of this draft. The owning spec's obsolete pre-launch feed statement is now removed; installed A→B qualification remains separate and required before stable enablement. No installed application was replaced or restarted by this follow-up.
