### PR TITLE
Plan pane's top toolbar

### DIFF
--- a/apps/web/src/panels/PlanCommitsMenu.tsx
+++ b/apps/web/src/panels/PlanCommitsMenu.tsx
@@ -1,0 +1,82 @@
+import {
+	RiArrowDownSLine as ChevronDown,
+	RiGitCommitLine as GitCommitHorizontal,
+} from "@remixicon/react";
+import type { GitCommit } from "@thinkrail/contracts";
+import { useEffect, useRef, useState } from "react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { relativeTime } from "@/lib";
+import { getTransport } from "../transport";
+
+export function PlanCommitsMenu({
+	workspaceId,
+	reloadSignal,
+	onOpenCommit,
+}: {
+	workspaceId: string;
+	reloadSignal: number;
+	onOpenCommit: (sha: string) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const [commits, setCommits] = useState<GitCommit[] | null>(null);
+	const generation = useRef(0);
+
+	useEffect(() => {
+		const mine = ++generation.current;
+		const live = () => generation.current === mine;
+		void getTransport()
+			.request("git.listCommits", { workspaceId })
+			.then(({ commits: list }) => {
+				if (live()) setCommits(list);
+			})
+			.catch(() => {
+				if (live()) setCommits([]);
+			});
+	}, [workspaceId, reloadSignal]);
+
+	if (commits === null || commits.length === 0) return null;
+	const count = commits.length;
+
+	return (
+		<DropdownMenu open={open} onOpenChange={setOpen}>
+			<DropdownMenuTrigger
+				data-testid="plan-commits-trigger"
+				data-open={open}
+				title="Commits on this branch"
+				className="flex h-24 shrink-0 items-center gap-4 rounded-[var(--radius-sm)] px-4 tr-text-metadata text-text-subtle outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:bg-control-bg-selected data-[open=true]:text-text-default"
+			>
+				<GitCommitHorizontal className="size-12 shrink-0" />
+				<span>
+					{count} {count === 1 ? "commit" : "commits"}
+				</span>
+				<ChevronDown className="size-14 shrink-0" />
+			</DropdownMenuTrigger>
+			<DropdownMenuContent data-testid="plan-commits-menu" align="start" className="max-w-[24rem]">
+				<DropdownMenuLabel>Commits</DropdownMenuLabel>
+				{commits.map((commit) => (
+					<DropdownMenuItem
+						key={commit.sha}
+						data-testid="plan-commits-item"
+						data-sha={commit.sha}
+						onSelect={() => onOpenCommit(commit.sha)}
+					>
+						<GitCommitHorizontal />
+						<span className="flex min-w-0 flex-col">
+							<span className="truncate">{commit.subject || commit.shortSha}</span>
+							<span className="truncate tr-text-metadata text-text-muted">
+								{commit.shortSha} · {commit.author}
+								{commit.committedAt ? ` · ${relativeTime(Date.parse(commit.committedAt))}` : ""}
+							</span>
+						</span>
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/web/src/panels/PlanPane.tsx
+++ b/apps/web/src/panels/PlanPane.tsx
@@ -524,8 +524,8 @@ export default function PlanPane({
 	const [prCompose, setPrCompose] = useState<PrComposeState | null>(null);
 	const lastPrSubmit = useRef<{
 		draft: boolean;
-		title: string;
-		body: string;
+		title?: string | undefined;
+		body?: string | undefined;
 		titleEdited: boolean;
 	} | null>(null);
 	const [focusRequest, setFocusRequest] = useState<{ id: string; tick: number } | null>(null);
@@ -581,8 +581,17 @@ export default function PlanPane({
 	};
 	const unpushed = openReview?.unpushedCommits ?? 0;
 	const openPrFlow = async (draft: boolean): Promise<void> => {
+		if (openReview) {
+			await submitPr({ draft: false });
+			return;
+		}
 		const edited = lastPrSubmit.current;
-		if (edited && edited.draft === draft) {
+		if (
+			edited &&
+			edited.title !== undefined &&
+			edited.body !== undefined &&
+			edited.draft === draft
+		) {
 			setPrCompose({
 				draft,
 				title: edited.title,
@@ -601,13 +610,19 @@ export default function PlanPane({
 			setPrBusy(false);
 		}
 	};
-	const submitPr = async (
-		draft: boolean,
-		prTitle: string,
-		prBody: string,
-		titleEdited: boolean,
-	): Promise<void> => {
-		lastPrSubmit.current = { draft, title: prTitle, body: prBody, titleEdited };
+	const submitPr = async (opts: {
+		draft: boolean;
+		title?: string | undefined;
+		body?: string | undefined;
+		titleEdited?: boolean | undefined;
+	}): Promise<void> => {
+		const { draft, title: prTitle, body: prBody, titleEdited } = opts;
+		lastPrSubmit.current = {
+			draft,
+			title: prTitle,
+			body: prBody,
+			titleEdited: Boolean(titleEdited),
+		};
 		setPrBusy(true);
 		try {
 			const result = await getTransport().request(
@@ -615,9 +630,9 @@ export default function PlanPane({
 				{
 					workspaceId,
 					sessionId,
-					title: prTitle,
+					...(prTitle !== undefined ? { title: prTitle } : {}),
 					...(titleEdited ? { titleEdited: true } : {}),
-					body: prBody,
+					...(prBody !== undefined ? { body: prBody } : {}),
 					...(draft ? { draft: true } : {}),
 				},
 				{ timeoutMs: 180_000 },
@@ -677,7 +692,7 @@ export default function PlanPane({
 	const retryPrSetup = () => {
 		setPrSetup(null);
 		const last = lastPrSubmit.current;
-		if (last) void submitPr(last.draft, last.title, last.body, last.titleEdited);
+		if (last) void submitPr(last);
 	};
 	const runPrSetupCommand = (command: string) => {
 		setPrSetup(null);
@@ -761,7 +776,8 @@ export default function PlanPane({
 					lastPrSubmit.current = null;
 				}}
 				onSubmit={(prTitle, prBody, titleEdited) => {
-					if (prCompose) void submitPr(prCompose.draft, prTitle, prBody, titleEdited);
+					if (prCompose)
+						void submitPr({ draft: prCompose.draft, title: prTitle, body: prBody, titleEdited });
 				}}
 			/>
 			<PrSetupDialog
@@ -886,7 +902,7 @@ export default function PlanPane({
 						) : (
 							<GitPullRequestArrow className="size-14" />
 						)}
-						{prBusy && prCompose
+						{prBusy && (prCompose || openReview)
 							? "Pushing…"
 							: openReview
 								? unpushed > 0

--- a/apps/web/src/panels/PlanPane.tsx
+++ b/apps/web/src/panels/PlanPane.tsx
@@ -55,6 +55,7 @@ import { errorText, getTransport, wsErrorCode } from "../transport";
 import { DiffStatBadge } from "./DiffStatBadge";
 import { openChatInTab } from "./openChat";
 import { openDiffInTab } from "./openTabs";
+import { PlanCommitsMenu } from "./PlanCommitsMenu";
 import { PrComposeDialog, type PrComposeState } from "./PrComposeDialog";
 import { PrSetupDialog, type PrSetupState } from "./PrSetupDialog";
 import { FileRow } from "./planFileRow";
@@ -830,14 +831,14 @@ export default function PlanPane({
 								<span className="flex min-w-0 items-center gap-4">
 									<GitBranch className="size-12 shrink-0" />
 									<span className="truncate">
-										{workspace.branch} ← {workspace.baseBranch}
+										{workspace.baseBranch} ← {workspace.branch}
 									</span>
 								</span>
-								{commitCount > 0 ? (
-									<span className="shrink-0">
-										{commitCount} {commitCount === 1 ? "commit" : "commits"}
-									</span>
-								) : null}
+								<PlanCommitsMenu
+									workspaceId={workspaceId}
+									reloadSignal={commitCount}
+									onOpenCommit={onOpenCommit}
+								/>
 								{workspace.diffStats ? (
 									<DiffStatBadge
 										added={workspace.diffStats.added}

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -652,18 +652,23 @@ own section. The kebab menu (`plan-menu`, a
   (disabled when none are unsettled; a toast reports how many were queued, the per-row `Reviewing…` pulses
   track progress), plus **Open draft PR** (`plan-open-draft-pr`, hidden once a PR exists). **The header
   also owns the plan's finish line — Open PR** (`plan-open-pr`, task-open-pr): a deterministic
-  host-side flow (push + `gh`, NEVER an agent prompt) that goes through the **compose dialog**
-  (`PrComposeDialog.tsx`, `pr-compose-dialog`): the click fetches `pr.preview` and opens editable
+  host-side flow (push + `gh`, NEVER an agent prompt) that, **for first-time creation only**
+  (`openReview` absent), goes through the **compose dialog** (`PrComposeDialog.tsx`,
+  `pr-compose-dialog`): the click fetches `pr.preview` and opens editable
   Title (`pr-compose-title`) + Description (`pr-compose-body`, prefilled from the plan) fields;
-  only the submit (`pr-compose-submit`, label follows the action — Open PR / Open draft PR / Push
-  updates) runs `pr.open` with the edited `title`/`body`. The dialog closes on success, stays open
+  only the submit (`pr-compose-submit`, label follows the action — Open PR / Open draft PR) runs
+  `pr.open` with the edited `title`/`body`. The dialog closes on success, stays open
   on a generic failure (edits survive the toast), and hands off to `PrSetupDialog` on
   `PUSH_AUTH_FAILED` — whose Try again re-submits the LAST edited title/body (kept in a ref), never
   a re-rendered draft. The header button is primary-filled when the plan is
   *ready* (all done + all reviews settled) and quiet otherwise; once an open PR exists (the same
   `workspace.openReview` lookup the shell's scope label uses, via `useOpenBranchReview` — the hook
   lives in `panels` because nothing may import `shell`) the label flips to **Push updates**
-  (same call — the host pushes to the SAME branch/PR and refreshes its body); when the lookup reports
+  and the button **bypasses the compose dialog entirely** — pressing it (or the next-action `push`
+  arm) calls `pr.open` directly with no `title`/`body`, so the host pushes to the SAME branch/PR and
+  silently refreshes its body from the plan (`renderPrBody`) while leaving the PR title untouched
+  (no `titleEdited`). Re-editing a PR's description each push read as "set up the PR again"; the modal
+  is only the creation affordance. When the lookup reports
   **`unpushedCommits`** the label appends the count (`Push updates (N)`), the button turns
   primary-filled, and the next-action banner grows a `push` arm ("N new commits aren't in PR #N
   yet" + Push updates) so new work after the PR never sits silently local — a successful push

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -628,9 +628,15 @@ a project picker, the prompt hero, and the reused
   plan is currently at), pending (muted). The PR stage reads the same `useOpenBranchReview` lookup
   as the button and shows `PR #N` once one is open; "merged" is unknowable in V1 (the lookup only
   sees OPEN reviews), so the funnel honestly ends at PR-open. Under the stepper sits the **work
-  CONTEXT line** (`plan-context`): `branch ← baseBranch · N commits · +A −R` — commits summed over
-  `itemRevisions`, the total diff from the workspace record's `diffStats`; each piece hides when
-  unknown. Between header and summary lives the **NEXT-ACTION banner** (`plan-next-action`,
+  CONTEXT line** (`plan-context`): `baseBranch ← branch · N commits · +A −R` — the arrow points at the
+  merge TARGET (base ← head, the GitHub PR convention: changes flow from the workspace branch into
+  its base). `N commits` is the **`PlanCommitsMenu`** (`plan-commits-trigger`) — a dropdown mirroring
+  the Changes scope menu's commit list: `git.listCommits` (eager-loaded, reloaded whenever the plan's
+  commit count ticks) is the ONE source for both the count and the list, so they never diverge; each
+  row (`plan-commits-item`, `data-sha`) opens that commit's diff in the Changes panel via the same
+  `openChanges({ sha })` the per-step commit chip uses. The chip self-hides while loading and when the
+  branch has no commits. The total diff comes from the workspace record's `diffStats`; each piece
+  hides when unknown. Between header and summary lives the **NEXT-ACTION banner** (`plan-next-action`,
   `data-kind`) — the report's one "what now", rendering the FIRST matching state by urgency:
   `fix` (N steps carry changes_requested → **Show step** scrolls to the first flagged item and
   auto-expands it via the `focusRequest` token — `{ id, tick }`, tick bumped per click and consumed

--- a/e2e/plan-review.spec.ts
+++ b/e2e/plan-review.spec.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { createWorkspaceViaDialog, openFixtureProject } from "./fixtures/app";
-import { commitFile } from "./fixtures/git";
+import { commitFile, gitAs } from "./fixtures/git";
 
 // The TODO → review workflow's user-visible half, no agent: a seeded plan whose done steps carry
 // completion summaries + real commit artifacts (the host's change-set shape) renders on the plan page
@@ -142,8 +142,22 @@ test("reviewable steps show the reviewed counter, Start review, and the settled 
 	await expect(pane.getByTestId("plan-progress")).toContainText("4/4 done");
 	await expect(pane.getByTestId("plan-review-progress")).toContainText("1/3 reviewed");
 	await expect(pane.getByTestId("plan-pr-stage")).toHaveAttribute("data-state", "pending");
-	// The report's context line: branch ← base and the commit count summed over revisions.
-	await expect(pane.getByTestId("plan-context")).toContainText("4 commits");
+	// The report's context line: the arrow points at the merge TARGET (base ← head), so the workspace
+	// branch renders AFTER the arrow.
+	const branch = gitAs(workspace.worktreePath, "rev-parse", "--abbrev-ref", "HEAD");
+	await expect(pane.getByTestId("plan-context")).toContainText(new RegExp(`\u2190\\s*${branch}`));
+	// N commits is a dropdown of the branch's git commits (git.listCommits, base..HEAD, the ONE source
+	// for both the count and the list); each row opens that commit's diff in the Changes panel.
+	const commitsTrigger = pane.getByTestId("plan-commits-trigger");
+	await expect(commitsTrigger).toContainText("4 commits");
+	await commitsTrigger.click();
+	const commitsMenu = page.getByTestId("plan-commits-menu");
+	await expect(commitsMenu.getByTestId("plan-commits-item")).toHaveCount(4);
+	await commitsMenu
+		.getByTestId("plan-commits-item")
+		.filter({ hasText: "add the retry policy" })
+		.click();
+	await expect(page.getByTestId("changes-scope-label")).toContainText(shaDone.slice(0, 7));
 	// The next-action banner picks the most urgent state — the flagged step wins over Review All —
 	// and its action scrolls to that step and auto-expands it.
 	const nextAction = pane.getByTestId("plan-next-action");


### PR DESCRIPTION
Reworked the Plan pane's top toolbar context line. (1) The branch arrow now points at the merge target — {baseBranch} ← {branch} (e.g. origin/main ← pr-description-setup) — matching the GitHub PR convention. (2) The "N commits" chip became PlanCommitsMenu, a dropdown mirroring the Changes scope menu: the count and the list both come from git.listCommits (base..HEAD), eager-loaded and reloaded when the plan's commit count ticks, and each row opens that commit's diff in the Changes panel. apps/web/src/panels/SPEC.md updated; e2e/plan-review.spec.ts extended to cover the arrow direction, the 4-commit dropdown, and click-through. Verified: typecheck/lint/boundaries green, affected specs pass; full e2e's only failures were pre-existing unrelated flakes (chat-order, layout), each green in isolation.

## Plan
### Plan toolbar: branch direction + commits dropdown
- [x] **Brainstorm & validate the design (task-spec)**
  Design recorded in TASK-plan-toolbar-commits.md. Two changes: (1) swap arrow to base ← head; (2) turn the commit chip into a dropdown listing git.listCommits, with the count sourced from git (user's choice) via eager load keyed on the plan commit count as a reload signal.
  Verified: not verified (design step)
- [x] **Fix branch arrow direction (base ← head)** (`7c85d45`)
  Swapped the plan-context arrow to base ← head ({baseBranch} ← {branch}), so it reads e.g. origin/main ← pr-description-setup (merge direction).
  Verified: typecheck @thinkrail/web green
- [x] **Make commit count a dropdown listing commits (like Changes)**
  Added PlanCommitsMenu (apps/web/src/panels): a dropdown mirroring the Changes scope menu's commit list. Trigger shows the git commit count (from git.listCommits, eager load keyed on the plan commit count as reload signal); each row opens that commit's diff in Changes via onOpenCommit. Self-hides while loading or when the branch has 0 commits.
  Verified: typecheck + biome green
- [x] **Update specs + tests** (`318754a`)
  Updated apps/web/src/panels/SPEC.md plan-context description (base ← head arrow; PlanCommitsMenu as the single git-sourced count+list). Extended e2e/plan-review.spec.ts: asserts the branch renders after the arrow, the commits dropdown lists 4 git commits, and clicking one opens that commit's diff scope in Changes.
  Verified: bun run e2e -- e2e/plan-review.spec.ts — 1 passed
- [x] **Verify (typecheck/lint/e2e)**
  typecheck/lint/boundaries green; diff audit clean (no suppressions; comments only in the e2e test, matching that file's style). Ran the full no-agent e2e suite twice; each run's only failure was a different pre-existing flaky test (chat-order scroll, then layout multi-window drag), both passing in isolation. All Plan-touching specs (plan-review, plan-open-pr) pass.
  Verified: plan-review.spec.ts pass; full e2e — only unrelated flakes (chat-order, layout), each re-run green in isolation; typecheck/lint/check:boundaries green
### Push updates without re-showing PR compose dialog
- [x] **Brainstorm & validate the design (spec-graph task-spec)**
  Design recorded in .thinkrail/context/TASK-push-updates-no-compose.md. User chose: push-updates on an open PR bypasses the compose dialog and silently refreshes the PR body from the plan (client omits title/body; server renders from plan; title untouched). Client-only change.
  Verified: not verified (design step)
- [x] **Implement: push-only path for already-open PR** (`90d8028`)
  PlanPane.openPrFlow now bypasses pr.preview + PrComposeDialog when openReview is present and calls submitPr directly with no title/body (server regenerates body from plan, title untouched). submitPr refactored to an options object; lastPrSubmit widened to optional title/body. Button shows Pushing… during a dialog-less push. First-time creation flow unchanged.
  Verified: bunx turbo typecheck --filter=@thinkrail/web — green; biome check --write clean
- [x] **Update tests + specs**
  Updated apps/web/src/panels/SPEC.md: compose dialog is now the first-time-creation affordance only; Push updates bypasses it and silently refreshes the body from the plan. No new unit test added — the update path needs a real GitHub PR (offline suite can't produce openReview); it stays pinned by packages/server/src/pr/pr.test.ts (37 pass) and the creation flow by plan-open-pr.spec.ts.
  Verified: bun test packages/server/src/pr/pr.test.ts — 37 pass; plan-open-pr.spec.ts — 2 pass
- [x] **Verify with e2e/affected suite**
  Ran the full no-agent e2e gate — all 8 shards passed (exit 0). The first run had one flaky shard (unrelated to this change; a clean re-run passed). Typecheck, lint, and boundaries all green.
  Verified: bun run e2e — all 8 shards passed (exit 0); typecheck @thinkrail/web green; lint exit 0; check:boundaries 4 pass
