### PR TITLE
feat(terminal): make the Windows shell configurable

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -478,9 +478,11 @@ a project picker, the prompt hero, and the reused
   global nor imports the update capability, while ordinary browsers therefore have no Update row);
   **`TerminalSettings`** — a **Replayed output** size picker (`store.terminalReplayKb`, five presets from
   Off to 1 MB, `settings.update { terminalReplayKb }`, applies to terminals opened from now on) and, on
-  Windows only (`store.hostPlatform === "win32"`), a **Windows shell** picker (Auto / PowerShell 7 (pwsh) /
-  Windows PowerShell / Command Prompt, `settings.update { terminalWindowsShell }` — see
-  `submodule-server-terminal`'s shell-selection decision for what each choice spawns). The Windows-shell
+  Windows hosts at `protocolVersion >= WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION`, a **Windows shell** picker
+  (Auto / PowerShell 7 (pwsh) / Windows PowerShell / Command Prompt,
+  `settings.update { terminalWindowsShell }` — see `submodule-server-terminal`'s shell-selection decision
+  for what each choice spawns). The protocol gate keeps a newer independently shipped client from presenting
+  a setting an older host preserves but does not act on. The Windows-shell
   half is split into a **props-driven** `WindowsShellSettings` component rather than reading the store
   inline like the replay picker: zustand's React binding feeds `renderToStaticMarkup` its frozen
   `getInitialState()` snapshot (`useSyncExternalStore`'s `getServerSnapshot` argument), never a test's

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -475,7 +475,17 @@ a project picker, the prompt hero, and the reused
   to replace this window's frame and atomically preserve/reflow open resource identities in every retained
   workspace view; no current layout is published); the optional **shell-owned injected Update section**
   (the Settings shell includes its row only when content is provided; `panels` neither discovers a native
-  global nor imports the update capability, while ordinary browsers therefore have no Update row); and
+  global nor imports the update capability, while ordinary browsers therefore have no Update row);
+  **`TerminalSettings`** — a **Replayed output** size picker (`store.terminalReplayKb`, five presets from
+  Off to 1 MB, `settings.update { terminalReplayKb }`, applies to terminals opened from now on) and, on
+  Windows only (`store.hostPlatform === "win32"`), a **Windows shell** picker (Auto / PowerShell 7 (pwsh) /
+  Windows PowerShell / Command Prompt, `settings.update { terminalWindowsShell }` — see
+  `submodule-server-terminal`'s shell-selection decision for what each choice spawns). The Windows-shell
+  half is split into a **props-driven** `WindowsShellSettings` component rather than reading the store
+  inline like the replay picker: zustand's React binding feeds `renderToStaticMarkup` its frozen
+  `getInitialState()` snapshot (`useSyncExternalStore`'s `getServerSnapshot` argument), never a test's
+  `setState`, so any settings section that must stay assertable under that render path takes its store
+  values as props instead — the same shape `ChatSettings` already uses for `SubagentSettings`; and
   **`TemplatesSettings`** — two groups, **Global** and **This
   project** (the project group renders only with an active workspace), each a header with a **New**
   button plus its rows, fetched via **two independent `template.list` calls** (both refetched whenever the

--- a/apps/web/src/panels/TerminalSettings.test.tsx
+++ b/apps/web/src/panels/TerminalSettings.test.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { WindowsShellSettings } from "./TerminalSettings";
+
+test("the Windows shell picker is hidden off Windows", () => {
+	const markup = renderToStaticMarkup(
+		<WindowsShellSettings platform="darwin" value="auto" onSelect={() => {}} />,
+	);
+
+	expect(markup).toBe("");
+});
+
+test("Windows shows all four choices with the configured one active", () => {
+	const markup = renderToStaticMarkup(
+		<WindowsShellSettings platform="win32" value="cmd" onSelect={() => {}} />,
+	);
+
+	expect(markup).toContain("Windows shell");
+	expect(markup).toContain('data-testid="terminal-shell-auto" data-active="false"');
+	expect(markup).toContain('data-testid="terminal-shell-pwsh" data-active="false"');
+	expect(markup).toContain('data-testid="terminal-shell-powershell" data-active="false"');
+	expect(markup).toContain('data-testid="terminal-shell-cmd" data-active="true"');
+});

--- a/apps/web/src/panels/TerminalSettings.test.tsx
+++ b/apps/web/src/panels/TerminalSettings.test.tsx
@@ -1,10 +1,29 @@
 import { expect, test } from "bun:test";
+import { WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION } from "@thinkrail/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { WindowsShellSettings } from "./TerminalSettings";
 
 test("the Windows shell picker is hidden off Windows", () => {
 	const markup = renderToStaticMarkup(
-		<WindowsShellSettings platform="darwin" value="auto" onSelect={() => {}} />,
+		<WindowsShellSettings
+			platform="darwin"
+			protocolVersion={WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION}
+			value="auto"
+			onSelect={() => {}}
+		/>,
+	);
+
+	expect(markup).toBe("");
+});
+
+test("the Windows shell picker is hidden against older hosts", () => {
+	const markup = renderToStaticMarkup(
+		<WindowsShellSettings
+			platform="win32"
+			protocolVersion={WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION - 1}
+			value="auto"
+			onSelect={() => {}}
+		/>,
 	);
 
 	expect(markup).toBe("");
@@ -12,7 +31,12 @@ test("the Windows shell picker is hidden off Windows", () => {
 
 test("Windows shows all four choices with the configured one active", () => {
 	const markup = renderToStaticMarkup(
-		<WindowsShellSettings platform="win32" value="cmd" onSelect={() => {}} />,
+		<WindowsShellSettings
+			platform="win32"
+			protocolVersion={WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION}
+			value="cmd"
+			onSelect={() => {}}
+		/>,
 	);
 
 	expect(markup).toContain("Windows shell");

--- a/apps/web/src/panels/TerminalSettings.tsx
+++ b/apps/web/src/panels/TerminalSettings.tsx
@@ -1,6 +1,6 @@
 import { RiCheckLine as Check } from "@remixicon/react";
 import type { HostPlatform, TerminalWindowsShell } from "@thinkrail/contracts";
-import { TERMINAL_REPLAY_KB } from "@thinkrail/contracts";
+import { TERMINAL_REPLAY_KB, WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION } from "@thinkrail/contracts";
 import { cn } from "@/lib";
 import { toast, useAppStore } from "@/store";
 import { getTransport } from "@/transport";
@@ -48,14 +48,22 @@ const WINDOWS_SHELL_CHOICES: SettingsRadioChoice<TerminalWindowsShell>[] = [
 /** Windows-only; props-driven so it stays testable under `renderToStaticMarkup` (see panels/SPEC.md). */
 export function WindowsShellSettings({
 	platform,
+	protocolVersion,
 	value,
 	onSelect,
 }: {
 	platform: HostPlatform | null;
+	protocolVersion: number | null;
 	value: TerminalWindowsShell;
 	onSelect: (shell: TerminalWindowsShell) => void;
 }) {
-	if (platform !== "win32") return null;
+	if (
+		platform !== "win32" ||
+		protocolVersion === null ||
+		protocolVersion < WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION
+	) {
+		return null;
+	}
 	return (
 		<div className="flex flex-col gap-8 border-border-default border-t pt-16">
 			<div className="flex flex-col gap-4">
@@ -79,6 +87,7 @@ export function TerminalSettings() {
 	const replayKb = useAppStore((s) => s.terminalReplayKb);
 	const windowsShell = useAppStore((s) => s.terminalWindowsShell);
 	const hostPlatform = useAppStore((s) => s.hostPlatform);
+	const protocolVersion = useAppStore((s) => s.protocolVersion);
 
 	const select = (kb: number) => {
 		if (kb === replayKb) return;
@@ -134,6 +143,7 @@ export function TerminalSettings() {
 
 			<WindowsShellSettings
 				platform={hostPlatform}
+				protocolVersion={protocolVersion}
 				value={windowsShell}
 				onSelect={selectWindowsShell}
 			/>

--- a/apps/web/src/panels/TerminalSettings.tsx
+++ b/apps/web/src/panels/TerminalSettings.tsx
@@ -1,8 +1,10 @@
 import { RiCheckLine as Check } from "@remixicon/react";
+import type { HostPlatform, TerminalWindowsShell } from "@thinkrail/contracts";
 import { TERMINAL_REPLAY_KB } from "@thinkrail/contracts";
 import { cn } from "@/lib";
 import { toast, useAppStore } from "@/store";
 import { getTransport } from "@/transport";
+import { SettingsRadioCards, type SettingsRadioChoice } from "./SettingsRadioCards";
 
 const REPLAY_CHOICES: { kb: number; label: string; hint: string }[] = [
 	{ kb: 0, label: "Off", hint: "Reattaching shows an empty screen over the live shell" },
@@ -12,8 +14,71 @@ const REPLAY_CHOICES: { kb: number; label: string; hint: string }[] = [
 	{ kb: TERMINAL_REPLAY_KB.max, label: "1 MB", hint: "Maximum" },
 ];
 
+const WINDOWS_SHELL_CHOICES: SettingsRadioChoice<TerminalWindowsShell>[] = [
+	{
+		id: "auto",
+		label: "Auto",
+		hint: "Recommended",
+		description: "PowerShell 7 (pwsh) when installed, otherwise Windows PowerShell.",
+		testId: "terminal-shell-auto",
+	},
+	{
+		id: "pwsh",
+		label: "PowerShell 7",
+		hint: "pwsh",
+		description: "Always use pwsh. Requires it to be installed and on PATH.",
+		testId: "terminal-shell-pwsh",
+	},
+	{
+		id: "powershell",
+		label: "Windows PowerShell",
+		hint: "5.1",
+		description: "Built into every Windows install.",
+		testId: "terminal-shell-powershell",
+	},
+	{
+		id: "cmd",
+		label: "Command Prompt",
+		hint: "cmd",
+		description: "The classic default.",
+		testId: "terminal-shell-cmd",
+	},
+];
+
+/** Windows-only; props-driven so it stays testable under `renderToStaticMarkup` (see panels/SPEC.md). */
+export function WindowsShellSettings({
+	platform,
+	value,
+	onSelect,
+}: {
+	platform: HostPlatform | null;
+	value: TerminalWindowsShell;
+	onSelect: (shell: TerminalWindowsShell) => void;
+}) {
+	if (platform !== "win32") return null;
+	return (
+		<div className="flex flex-col gap-8 border-border-default border-t pt-16">
+			<div className="flex flex-col gap-4">
+				<h3 className="tr-title-section text-text-default">Windows shell</h3>
+				<p className="text-text-muted tr-text-metadata">
+					Which shell new terminal tabs start. Applies to terminals opened from now on.
+				</p>
+			</div>
+			<SettingsRadioCards
+				name="terminal-windows-shell"
+				label="Windows shell"
+				choices={WINDOWS_SHELL_CHOICES}
+				value={value}
+				onSelect={onSelect}
+			/>
+		</div>
+	);
+}
+
 export function TerminalSettings() {
 	const replayKb = useAppStore((s) => s.terminalReplayKb);
+	const windowsShell = useAppStore((s) => s.terminalWindowsShell);
+	const hostPlatform = useAppStore((s) => s.hostPlatform);
 
 	const select = (kb: number) => {
 		if (kb === replayKb) return;
@@ -22,41 +87,56 @@ export function TerminalSettings() {
 			.catch(() => toast.error("Couldn't change the replay size"));
 	};
 
+	const selectWindowsShell = (shell: TerminalWindowsShell) => {
+		if (shell === windowsShell) return;
+		getTransport()
+			.request("settings.update", { config: { terminalWindowsShell: shell } })
+			.catch(() => toast.error("Couldn't change the Windows shell"));
+	};
+
 	return (
-		<section data-testid="settings-terminal" className="flex flex-col gap-8">
-			<div className="flex flex-col gap-4">
-				<h3 className="tr-title-section text-text-default">Replayed output</h3>
-				<p className="text-text-muted tr-text-metadata">
-					A terminal keeps running when you leave it, but the view is rebuilt from scratch when you
-					come back. This is how much of its recent output the host keeps so the screen is restored
-					too. Applies to terminals opened from now on.
-				</p>
+		<section data-testid="settings-terminal" className="flex flex-col gap-16">
+			<div className="flex flex-col gap-8">
+				<div className="flex flex-col gap-4">
+					<h3 className="tr-title-section text-text-default">Replayed output</h3>
+					<p className="text-text-muted tr-text-metadata">
+						A terminal keeps running when you leave it, but the view is rebuilt from scratch when
+						you come back. This is how much of its recent output the host keeps so the screen is
+						restored too. Applies to terminals opened from now on.
+					</p>
+				</div>
+				<div className="flex flex-col gap-4">
+					{REPLAY_CHOICES.map(({ kb, label, hint }) => {
+						const active = kb === replayKb;
+						return (
+							<button
+								key={kb}
+								type="button"
+								aria-pressed={active}
+								data-testid={`terminal-replay-${kb}`}
+								data-active={active}
+								onClick={() => select(kb)}
+								className={cn(
+									"flex items-center gap-8 rounded-[var(--radius-sm)] border px-12 py-8 text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
+									active
+										? "border-primary-muted bg-clip-padding bg-primary-subtle text-text-default"
+										: "border-border-default text-text-muted hover:bg-control-bg-hovered hover:text-text-default",
+								)}
+							>
+								<span className="flex-1">{label}</span>
+								<span className="shrink-0 text-text-muted tr-text-metadata">{hint}</span>
+								{active ? <Check className="size-16 shrink-0 text-primary" /> : null}
+							</button>
+						);
+					})}
+				</div>
 			</div>
-			<div className="flex flex-col gap-4">
-				{REPLAY_CHOICES.map(({ kb, label, hint }) => {
-					const active = kb === replayKb;
-					return (
-						<button
-							key={kb}
-							type="button"
-							aria-pressed={active}
-							data-testid={`terminal-replay-${kb}`}
-							data-active={active}
-							onClick={() => select(kb)}
-							className={cn(
-								"flex items-center gap-8 rounded-[var(--radius-sm)] border px-12 py-8 text-left tr-text-ui outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary",
-								active
-									? "border-primary-muted bg-clip-padding bg-primary-subtle text-text-default"
-									: "border-border-default text-text-muted hover:bg-control-bg-hovered hover:text-text-default",
-							)}
-						>
-							<span className="flex-1">{label}</span>
-							<span className="shrink-0 text-text-muted tr-text-metadata">{hint}</span>
-							{active ? <Check className="size-16 shrink-0 text-primary" /> : null}
-						</button>
-					);
-				})}
-			</div>
+
+			<WindowsShellSettings
+				platform={hostPlatform}
+				value={windowsShell}
+				onSelect={selectWindowsShell}
+			/>
 		</section>
 	);
 }

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -366,13 +366,17 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   Defaults remain fixed `DEFAULT_CONFIG.theme` with no pair, but while existing `welcomeGeneration === 0`
   shell retains the pre-React preference hint instead of applying those placeholders over it. Reusing that
   readiness edge avoids a second derived config-hydration flag; after the first welcome, disconnect/reconnect
-  keeps the last authoritative config while a later welcome can replace it. **`composerGrowthLimit: ComposerGrowthLimit`**,
+  keeps the last authoritative config while a later welcome can replace it. **`terminalReplayKb: number`**,
+  **`terminalWindowsShell: TerminalWindowsShell`**, **`composerGrowthLimit: ComposerGrowthLimit`**,
   **`chatLineWidth` / `fileLineWidth`**, their independent **`chatLineWidthBounded` /
   `fileLineWidthBounded`** switches, **`customLayoutPresets: LayoutPreset[]`**,
   **`analyticsEnabled: boolean`**, **`subagentsEnabled: boolean`**, **`jbcentralQuotaEnabled: boolean`**,
   and **`jbcentralQuotaRefreshSeconds: number`** ride the same `applyConfig` fold (host-owned, fieldwise
   defaulted/validated from the contracts helpers so an older or malformed host snapshot cannot poison
-  geometry) — the Line width, Chat, shared Layout catalog, Privacy, provider controls, and shell quota read sides.
+  the store). `terminalWindowsShell` narrows through `isTerminalWindowsShell` and otherwise uses
+  `DEFAULT_CONFIG.terminalWindowsShell`; `TerminalSettings` consumes both terminal fields, while terminal
+  spawning remains server-owned — the Terminal, Line width, Chat, shared Layout catalog, Privacy, provider
+  controls, and shell quota read sides.
   **`chatMessageOrder: ChatMessageOrder`** and **`streamingResponseMovement:
   StreamingResponseMovement`** are instead client-local presentation preferences, hydrated together by
   the chat preference seam from host-qualified browser localStorage or the native shell's injected

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -3019,6 +3019,23 @@ test("applyConfig folds and normalizes the server-synced theme preference", () =
 	});
 });
 
+test("applyConfig projects and validates the Windows terminal shell", () => {
+	useAppStore.getState().applyConfig({
+		...DEFAULT_CONFIG,
+		terminalWindowsShell: "cmd",
+	});
+	expect(useAppStore.getState()).toHaveProperty("terminalWindowsShell", "cmd");
+
+	useAppStore.getState().applyConfig({
+		...DEFAULT_CONFIG,
+		terminalWindowsShell: "future-shell",
+	} as unknown as AppConfig);
+	expect(useAppStore.getState()).toHaveProperty(
+		"terminalWindowsShell",
+		DEFAULT_CONFIG.terminalWindowsShell,
+	);
+});
+
 test("applyConfig projects the composer growth limit", () => {
 	useAppStore.getState().applyConfig({
 		...DEFAULT_CONFIG,

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -40,6 +40,7 @@ import {
 	isControlMessage,
 	isLineWidth,
 	isSubagentCompletionMessage,
+	isTerminalWindowsShell,
 	normalizeThemePreference,
 } from "@thinkrail/contracts";
 import { create } from "zustand";
@@ -1020,7 +1021,9 @@ function configPatch(config: AppConfig) {
 		jbcentralQuotaRefreshSeconds:
 			config.jbcentralQuotaRefreshSeconds ?? DEFAULT_CONFIG.jbcentralQuotaRefreshSeconds,
 		terminalReplayKb: config.terminalReplayKb,
-		terminalWindowsShell: config.terminalWindowsShell ?? DEFAULT_CONFIG.terminalWindowsShell,
+		terminalWindowsShell: isTerminalWindowsShell(config.terminalWindowsShell)
+			? config.terminalWindowsShell
+			: DEFAULT_CONFIG.terminalWindowsShell,
 		composerGrowthLimit: config.composerGrowthLimit ?? DEFAULT_CONFIG.composerGrowthLimit,
 		chatLineWidth: isLineWidth(config.chatLineWidth)
 			? config.chatLineWidth

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -24,6 +24,7 @@ import type {
 	SpecGraphNode,
 	SystemThemePair,
 	TerminalTabInfo,
+	TerminalWindowsShell,
 	ThemeId,
 	ThemeMode,
 	ThinkingLevel,
@@ -796,6 +797,7 @@ interface AppState {
 	jbcentralQuotaEnabled: boolean;
 	jbcentralQuotaRefreshSeconds: number;
 	terminalReplayKb: number;
+	terminalWindowsShell: TerminalWindowsShell;
 	composerGrowthLimit: ComposerGrowthLimit;
 	chatLineWidth: number;
 	fileLineWidth: number;
@@ -1018,6 +1020,7 @@ function configPatch(config: AppConfig) {
 		jbcentralQuotaRefreshSeconds:
 			config.jbcentralQuotaRefreshSeconds ?? DEFAULT_CONFIG.jbcentralQuotaRefreshSeconds,
 		terminalReplayKb: config.terminalReplayKb,
+		terminalWindowsShell: config.terminalWindowsShell ?? DEFAULT_CONFIG.terminalWindowsShell,
 		composerGrowthLimit: config.composerGrowthLimit ?? DEFAULT_CONFIG.composerGrowthLimit,
 		chatLineWidth: isLineWidth(config.chatLineWidth)
 			? config.chatLineWidth
@@ -1670,6 +1673,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 	jbcentralQuotaEnabled: DEFAULT_CONFIG.jbcentralQuotaEnabled,
 	jbcentralQuotaRefreshSeconds: DEFAULT_CONFIG.jbcentralQuotaRefreshSeconds,
 	terminalReplayKb: DEFAULT_CONFIG.terminalReplayKb,
+	terminalWindowsShell: DEFAULT_CONFIG.terminalWindowsShell,
 	composerGrowthLimit: DEFAULT_CONFIG.composerGrowthLimit,
 	chatLineWidth: DEFAULT_CONFIG.chatLineWidth,
 	fileLineWidth: DEFAULT_CONFIG.fileLineWidth,

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -238,10 +238,12 @@ of the host.
   introduction so a later web client hides them against an older host without comparing against the moving
   latest protocol; **`JBCENTRAL_QUOTA_PROTOCOL_VERSION`** likewise pins the v59 quota read + settings;
   **`AppConfig`** (`{ theme, themeMode, systemThemePair?, analyticsEnabled, terminalReplayKb,
-  composerGrowthLimit, chatLineWidth, fileLineWidth, chatLineWidthBounded, fileLineWidthBounded,
-  customLayoutPresets, reviewModel?, reviewEffort?, reviewAutoFix, subagentsEnabled,
+  terminalWindowsShell, composerGrowthLimit, chatLineWidth, fileLineWidth, chatLineWidthBounded,
+  fileLineWidthBounded, customLayoutPresets, reviewModel?, reviewEffort?, reviewAutoFix, subagentsEnabled,
   jbcentralQuotaEnabled, jbcentralQuotaRefreshSeconds }` — an extensible bag; the line-width fields join
-  the wire at protocol v61. `themeMode` defaults to `"fixed"` and no pair, preserving both legacy configs
+  the wire at protocol v61. `terminalWindowsShell` (`"auto" | "pwsh" | "powershell" | "cmd"`, default
+  `"auto"`) is read only by `server/terminal` on Windows and ignored elsewhere — see
+  `submodule-server-terminal`'s shell-selection decision for what each value spawns. `themeMode` defaults to `"fixed"` and no pair, preserving both legacy configs
   and the explicit Dark default; `subagentsEnabled` is the host-wide subagent default (`true` for current
   behavior), overridden only by `Workspace.subagentsOverride`; `customLayoutPresets` is the bounded
   resource-free catalog and is the **only** layout value synchronized by the host; current/default preset

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -237,12 +237,15 @@ of the host.
   **`SUBAGENT_SETTINGS_PROTOCOL_VERSION`** pins the global/workspace controls to their v57 wire
   introduction so a later web client hides them against an older host without comparing against the moving
   latest protocol; **`JBCENTRAL_QUOTA_PROTOCOL_VERSION`** likewise pins the v59 quota read + settings;
+  **`WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION`** pins the v62 Windows-shell setting so a later web client
+  hides it against a host that can preserve but cannot apply that config field;
   **`AppConfig`** (`{ theme, themeMode, systemThemePair?, analyticsEnabled, terminalReplayKb,
   terminalWindowsShell, composerGrowthLimit, chatLineWidth, fileLineWidth, chatLineWidthBounded,
   fileLineWidthBounded, customLayoutPresets, reviewModel?, reviewEffort?, reviewAutoFix, subagentsEnabled,
   jbcentralQuotaEnabled, jbcentralQuotaRefreshSeconds }` — an extensible bag; the line-width fields join
-  the wire at protocol v61. `terminalWindowsShell` (`"auto" | "pwsh" | "powershell" | "cmd"`, default
-  `"auto"`) is read only by `server/terminal` on Windows and ignored elsewhere — see
+  the wire at protocol v61 and `terminalWindowsShell` at v62. `terminalWindowsShell`
+  (`"auto" | "pwsh" | "powershell" | "cmd"`, default `"auto"`) is read only by `server/terminal` on
+  Windows and ignored elsewhere — see
   `submodule-server-terminal`'s shell-selection decision for what each value spawns. `themeMode` defaults to `"fixed"` and no pair, preserving both legacy configs
   and the explicit Dark default; `subagentsEnabled` is the host-wide subagent default (`true` for current
   behavior), overridden only by `Workspace.subagentsOverride`; `customLayoutPresets` is the bounded

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -522,6 +522,8 @@ export interface AppConfig extends ThemePreference {
 	subagentsEnabled: boolean;
 	jbcentralQuotaEnabled: boolean;
 	jbcentralQuotaRefreshSeconds: number;
+	/** Which shell new workspace terminals start on Windows; ignored on other platforms. */
+	terminalWindowsShell: TerminalWindowsShell;
 }
 
 /** The `settings.update` payload: `null` clears an optional override back to unset (⇒ the default). */
@@ -533,6 +535,14 @@ export type AppConfigUpdate = Partial<Omit<AppConfig, "reviewModel" | "reviewEff
 export type InterviewResponse = "book" | "postpone" | "never";
 
 export const TERMINAL_REPLAY_KB = { min: 0, max: 1024, default: 64 } as const;
+
+export const TERMINAL_WINDOWS_SHELLS = ["auto", "pwsh", "powershell", "cmd"] as const;
+export type TerminalWindowsShell = (typeof TERMINAL_WINDOWS_SHELLS)[number];
+
+export function isTerminalWindowsShell(value: unknown): value is TerminalWindowsShell {
+	return TERMINAL_WINDOWS_SHELLS.some((shell) => shell === value);
+}
+
 export const JBCENTRAL_QUOTA_REFRESH_SECONDS = { min: 1, max: 3600, default: 30 } as const;
 
 export function isJbcentralQuotaRefreshSeconds(value: unknown): value is number {
@@ -549,6 +559,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 	themeMode: "fixed",
 	analyticsEnabled: true,
 	terminalReplayKb: TERMINAL_REPLAY_KB.default,
+	terminalWindowsShell: "auto",
 	composerGrowthLimit: "half-chat",
 	chatLineWidth: LINE_WIDTH_COLUMNS.default,
 	fileLineWidth: LINE_WIDTH_COLUMNS.default,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -13,6 +13,7 @@ export {
 	isLineWidth,
 	isRetriedAttempt,
 	isSystemThemePair,
+	isTerminalWindowsShell,
 	isThemeMode,
 	JBCENTRAL_QUOTA_REFRESH_SECONDS,
 	LINE_WIDTH_COLUMNS,
@@ -21,6 +22,7 @@ export {
 	normalizeThemePreference,
 	REQUEST_IMAGE_BASE64_BUDGET,
 	TERMINAL_REPLAY_KB,
+	TERMINAL_WINDOWS_SHELLS,
 	THEME_MODES,
 	TODO_NUDGE_PREFIX,
 } from "./domain";

--- a/packages/contracts/src/wsProtocol.test.ts
+++ b/packages/contracts/src/wsProtocol.test.ts
@@ -5,6 +5,7 @@ import {
 	PROTOCOL_VERSION,
 	SUBAGENT_SETTINGS_PROTOCOL_VERSION,
 	THEME_SYSTEM_PROTOCOL_VERSION,
+	WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION,
 	WS_CHANNELS,
 	WS_METHODS,
 } from "./wsProtocol";
@@ -33,6 +34,7 @@ test("JetBrains quota advances the protocol and names its read", () => {
 	expect(WS_METHODS.providerJbcentralQuota).toBe("provider.jbcentralQuota");
 });
 
-test("line-width config advances the additive wire shape to v61", () => {
-	expect(PROTOCOL_VERSION).toBe(61);
+test("Windows shell settings advance the protocol", () => {
+	expect(WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION).toBe(62);
+	expect(PROTOCOL_VERSION).toBe(WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION);
 });

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -91,7 +91,8 @@ export interface TerminalTabsPush {
 	tabs: TerminalTabInfo[];
 }
 
-export const PROTOCOL_VERSION = 61;
+export const PROTOCOL_VERSION = 62;
+export const WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION = 62;
 export const THEME_SYSTEM_PROTOCOL_VERSION = 58;
 export const SUBAGENT_SETTINGS_PROTOCOL_VERSION = 57;
 export const JBCENTRAL_QUOTA_PROTOCOL_VERSION = 59;

--- a/packages/server/src/persistence/SPEC.md
+++ b/packages/server/src/persistence/SPEC.md
@@ -16,12 +16,14 @@ Durable host state—projects, workspaces, cross-frontend app config, terminal c
 
 - **Owns:** `dataDir()` (`THINKRAIL_DATA_DIR` for dev/e2e isolation, else `~/.thinkrail`); project/workspace/config load-save operations; fieldwise config validation over `DEFAULT_CONFIG` while preserving unknown top-level extension fields; and `ensureInstallation` / `saveInstallation` over `installation.json` (`{ id, announced }`, the non-rotating per-install uuid4 plus `app_installed`-sent bit, server-only and never wire-broadcast). JSON remains tab-indented.
 - **Public surface (barrel):** `dataDir`, project/workspace/config and terminal-catalog load-save operations, and installation identity operations.
-- **Allowed deps:** `contracts` (`Project`, `Workspace`, `AppConfig`, `LayoutPreset`, `DEFAULT_CONFIG`); Node `fs`/`os`/`path`.
+- **Allowed deps:** `contracts` (`Project`, `Workspace`, `AppConfig`, `LayoutPreset`, `DEFAULT_CONFIG`,
+  `isTerminalWindowsShell`); Node `fs`/`os`/`path`.
 - **Forbidden:** importing feature siblings or `host`; persisting a current frame/view, selection/focus, or frontend-surface identity; reading alternate config keys or old schemas; or reading, rewriting, or deleting old host layout snapshots.
 
 Config validation normalizes the closed theme mode plus complete opaque system pair, the closed
-composer-growth preference, chat/file line widths plus their pane-bound switches, and the JetBrains quota
-boolean + whole `1–3600` second cadence over their defaults; it accepts only the current bounded
+composer-growth preference, the closed Windows terminal-shell preference (invalid/absent →
+`DEFAULT_CONFIG.terminalWindowsShell`), chat/file line widths plus their pane-bound switches, and the
+JetBrains quota boolean + whole `1–3600` second cadence over their defaults; it accepts only the current bounded
 `customLayoutPresets` catalog as synchronized layout data. Current/default preset ids, group limits, and
 chat message order are not config fields; retired config shapes are stripped rather than upgraded or
 preserved as extensions. Historical `layouts/` files remain untouched and inert.

--- a/packages/server/src/persistence/persistence.ts
+++ b/packages/server/src/persistence/persistence.ts
@@ -8,6 +8,7 @@ import {
 	isComposerGrowthLimit,
 	isJbcentralQuotaRefreshSeconds,
 	isLineWidth,
+	isTerminalWindowsShell,
 	normalizeThemePreference,
 	type Project,
 	type Workspace,
@@ -115,6 +116,9 @@ export function loadConfig(): AppConfig {
 		customLayoutPresets: Array.isArray(value.customLayoutPresets)
 			? value.customLayoutPresets
 			: DEFAULT_CONFIG.customLayoutPresets,
+		terminalWindowsShell: isTerminalWindowsShell(value.terminalWindowsShell)
+			? value.terminalWindowsShell
+			: DEFAULT_CONFIG.terminalWindowsShell,
 	};
 }
 

--- a/packages/server/src/settings/SPEC.md
+++ b/packages/server/src/settings/SPEC.md
@@ -11,7 +11,8 @@ tags: [v1]
 ## Responsibility
 
 The server-synchronized app config: opaque fixed-theme selection, fixed/system mode and optional light/dark
-pair, analytics switch, terminal replay budget, chat composer growth preset, chat/file visual line widths
+pair, analytics switch, terminal replay budget and Windows shell preference, chat composer growth preset,
+chat/file visual line widths
 plus independent pane bounds, bounded custom layout-preset catalog, JetBrains quota display/cadence, the
 host-wide subagent default, and plan-review policy. `reviewModel` /
 `reviewEffort` select the reviewer/reflector runtime (unset means pi
@@ -31,12 +32,17 @@ interval (`1–3600`, default 30), because those values govern host process cade
 
 - **Owns:** cached current `AppConfig`; `getConfig()`; `updateConfig(partial)` (merge → validate known fields → persist → broadcast); line-width and resource-free custom-preset validation/normalization; custom-preset safety caps; `setSettingsPublisher`; and `resetConfigCache` for tests.
 - **Public surface (barrel):** `getConfig`, `updateConfig`, `setSettingsPublisher`, `resetConfigCache`, plus pure custom-preset normalization used by host startup after persistence load.
-- **Allowed deps:** `persistence` (`loadConfig`/`saveConfig`); `contracts` (`AppConfig`, `LayoutPreset`).
+- **Allowed deps:** `persistence` (`loadConfig`/`saveConfig`); `contracts` (`AppConfig`, `LayoutPreset`,
+  `isTerminalWindowsShell`).
 - **Forbidden:** host or another feature sibling; current-layout document/snapshot types; workspace ids/resources; current frame validation; owning WS channels; or importing web preset definitions.
 
 ## Get right
 
 - **Converge on broadcast, no client optimism.** `updateConfig` persists before replacing the live cache or publishing; a failed write changes neither runtime reads nor frontends. Every frontend, including the initiator, adopts `settings.changed`. `server.welcome` seeds the same cached value.
+- `terminalWindowsShell` defaults to `"auto"`; persisted values fall back through persistence's shared
+  `isTerminalWindowsShell` guard, while a wire mutation outside the closed shell union rejects the complete
+  update before cache, persistence, or broadcast changes. Settings owns validation and synchronization;
+  `terminal` owns executable resolution and spawning.
 - `chatLineWidth` / `fileLineWidth` independently default to 120 and accept only finite integers from 40 through 240; their `Bounded` switches independently default to `true`. A malformed stored field falls back without discarding valid siblings; any invalid supplied field rejects the complete mutation before cache, persistence, or broadcast changes.
 - `subagentsEnabled` defaults to `true` when absent so old config preserves current behavior; a present non-boolean update is rejected before cache, persistence, or broadcast changes. Settings owns only that global default; workspace override and effective-value resolution stay outside this module.
 - JetBrains quota display defaults on and its interval defaults to 30 seconds when either stored field is absent/invalid. Wire updates reject a non-boolean flag or a non-integer/out-of-range interval atomically; they never clamp a caller's value into a different persisted choice.

--- a/packages/server/src/settings/settings.test.ts
+++ b/packages/server/src/settings/settings.test.ts
@@ -218,6 +218,26 @@ test("subagents default on; an old config inherits that default; toggling off ro
 	expect(getConfig().subagentsEnabled).toBe(false);
 });
 
+test("Windows shell updates reject unknown values before persistence or broadcast", () => {
+	const published: AppConfig[] = [];
+	setSettingsPublisher((config) => published.push(config));
+	const before = getConfig();
+
+	expect(() =>
+		updateConfig({ terminalWindowsShell: "future-shell" } as unknown as AppConfigUpdate),
+	).toThrow("terminalWindowsShell must be auto, pwsh, powershell, or cmd");
+	expect(getConfig()).toEqual(before);
+	expect(published).toEqual([]);
+	expect(existsSync(join(dataDir, "config.json"))).toBe(false);
+
+	expect(updateConfig({ terminalWindowsShell: "cmd" }).terminalWindowsShell).toBe("cmd");
+	expect(published).toHaveLength(1);
+	expect(JSON.parse(readFileSync(join(dataDir, "config.json"), "utf8"))).toHaveProperty(
+		"terminalWindowsShell",
+		"cmd",
+	);
+});
+
 test("JetBrains quota preferences default, persist, and survive an old partial config", () => {
 	expect(DEFAULT_CONFIG.jbcentralQuotaEnabled).toBe(true);
 	expect(DEFAULT_CONFIG.jbcentralQuotaRefreshSeconds).toBe(30);

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -4,6 +4,7 @@ import {
 	isJbcentralQuotaRefreshSeconds,
 	isLineWidth,
 	isSystemThemePair,
+	isTerminalWindowsShell,
 	isThemeMode,
 	LINE_WIDTH_COLUMNS,
 } from "@thinkrail/contracts";
@@ -74,6 +75,12 @@ export function updateConfig(partial: AppConfigUpdate): AppConfig {
 	}
 	if (jbcentralQuotaEnabled !== undefined && typeof jbcentralQuotaEnabled !== "boolean") {
 		throw new Error("jbcentralQuotaEnabled must be a boolean");
+	}
+	if (
+		runtimeUpdate.terminalWindowsShell !== undefined &&
+		!isTerminalWindowsShell(runtimeUpdate.terminalWindowsShell)
+	) {
+		throw new Error("terminalWindowsShell must be auto, pwsh, powershell, or cmd");
 	}
 	if (
 		jbcentralQuotaRefreshSeconds !== undefined &&

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -27,15 +27,52 @@ identities. A tab's shell outlives every client that looks at it; each frontend 
   `setTerminalPublisher`,
   `setTerminalTabsPublisher`;
   the `TerminalDeliveryResult` type shared with the host publisher adapter.
-- **Allowed deps:** `persistence`, `contracts` (`WS_CHANNELS`), `bun-pty`, `process.env`.
+- **Allowed deps:** `persistence`, `contracts` (`WS_CHANNELS`, `TerminalWindowsShell`), `bun-pty`,
+  `Bun.which`, `process.env`.
 - **Forbidden:** `host`; sibling features. No WebSocket type crosses this boundary — clients are opaque keys.
 
 ## Decisions
 
-- **Shell selection is terminal-local.** An explicit `SHELL` always wins. Without one, Windows uses
-  `ComSpec`/`COMSPEC` and finally `cmd.exe`; other platforms retain `/bin/bash`. The host does not invent a
-  global `SHELL` on Windows: it is a Unix login-shell convention, and mutating it would affect the in-process
-  agent and every unrelated child process merely to configure this module's PTY executable.
+- **Shell selection is terminal-local**, and Windows' choice is additionally user-configurable
+  (`AppConfig.terminalWindowsShell`, `apps/web/src/panels/TerminalSettings.tsx`'s Windows-only picker;
+  [[task-windows-default-terminal-shell]]). Precedence, highest first: an explicit `SHELL` env var always
+  wins (unchanged — the host does not invent a global `SHELL` on Windows, since it's a Unix login-shell
+  convention and mutating it would affect the in-process agent and every unrelated child process merely to
+  configure this module's PTY executable); then, on Windows only, `terminalWindowsShell`:
+  - `"auto"` (default): `pwsh.exe` (PowerShell 7+) if `Bun.which` resolves it on PATH, else
+    `powershell.exe`. No further fallback to `cmd.exe` — `powershell.exe` ships on every supported
+    Windows release, so it is already the guaranteed floor. `defaultWhich` passes an explicit
+    `{ PATH: process.env.PATH }` rather than calling `Bun.which` bare, the same trap `editors`'
+    `defaultWhich` guards against: `Bun.which` alone reads the PATH snapshotted at process start, not
+    `resolveShellEnv()`'s later-repaired live `process.env.PATH`.
+  - `"pwsh"` / `"powershell"` / `"cmd"`: literal pins to `pwsh.exe` / `powershell.exe` / `cmd.exe` — no
+    existence check, no silent substitution. A pin that turns out to be missing fails to spawn the same
+    way a stale custom `SHELL` already does; not a new failure class, and the only mode with graceful
+    substitution is `auto`.
+  - Non-Windows platforms are unaffected: `/bin/bash` regardless of `terminalWindowsShell`.
+  `cmd.exe` was the unconditional prior default; `"auto"`'s baseline is `powershell.exe`, a plain
+  fallback swap (ships on every supported Windows release, so no new dependency), because it is more
+  functional than `cmd.exe` (line editing, tab completion, VS Code's own default) with no downside for the
+  default install. **The Windows default deliberately never consults `ComSpec`/`COMSPEC`**: that variable
+  is virtually always the OS's own `cmd.exe` path — it names the interpreter for `cmd /c`/batch-file
+  invocations, not a documented "pick my interactive shell" knob — so honoring it ahead of `powershell.exe`
+  would leave the default unchanged for nearly every install; a user who deliberately swapped their command
+  interpreter already has the `SHELL` override, and a second, weaker override would just be dead code. VS
+  Code's own default Windows terminal profile detection makes the same call.
+- **Known, accepted limitation: PowerShell weakens busy-close detection.** `closeTerminalTab`'s busy check
+  (`shellBusy.ts`) counts the shell's OS child processes. Many PowerShell cmdlets do their work in-process
+  rather than shelling out — `sleep` is a built-in alias for `Start-Sleep`, which blocks inside
+  `powershell.exe` itself and spawns zero children, unlike `cmd.exe`'s external `sleep.exe` — so a
+  PowerShell terminal genuinely busy in a native cmdlet (`Start-Sleep`, `Invoke-WebRequest`, `Copy-Item`,
+  a dot-sourced script) can read as idle and be force-closed without warning. Everyday dev-tool invocations
+  (`git`, `npm`, `bun`, `python`, `docker`, `node`, ...) are still external executables and stay correctly
+  detected — this is a real but narrow gap, same accepted-limitation category as `shellBusy.test.ts`'s
+  "an unanswerable platform reports not busy" case. A user who hits it can pick **Command Prompt (cmd)**
+  and get the exact prior, fully-detectable behavior back.
+- **Not building a `listAvailableShells`-style host probe** to gray out an uninstalled pick in the Settings
+  picker, unlike `editors`' `listAvailableEditors`: `auto` already gets the graceful substitution most users
+  want, and probing purely to decorate three static buttons wasn't asked for — a second detection mechanism
+  earning less than it costs.
 - **macOS PTYs start the user's shell in login mode (`-l`)** to match Terminal.app and the platform's
   terminal convention; other platforms keep a plain interactive shell. The PTY itself supplies
   interactivity, so no explicit `-i` is needed.
@@ -133,7 +170,9 @@ identities. A tab's shell outlives every client that looks at it; each frontend 
   keeping mode sequences out of the body (incl. a recording persisted by a host that still replayed them).
 - `outputBatcher.test.ts` — batching, backpressure, truncation, `reset`.
 - `shellBusy.test.ts` — child detection, including that an unanswerable platform reports *not* busy.
-- `shellArgs.test.ts` — shell executable precedence across Unix and Windows plus platform-specific arguments.
+- `shellArgs.test.ts` — shell executable precedence across Unix and Windows plus platform-specific
+  arguments; `auto`'s pwsh-then-powershell resolution via an injected `WhichFn`; every explicit preference
+  is a literal pin regardless of what `which` reports; `ComSpec`/`COMSPEC` no longer influence the result.
 - `terminalManager.test.ts` — transactional durable reservation without spawn, catalog bounds, attach
   idempotency (incl. concurrent), takeover, displaced-client rejection, tab-list broadcast, close/busy,
   revive. Replay-persistence and natural-exit cases use bounded publisher-observed data/exit conditions as

--- a/packages/server/src/terminal/shellArgs.test.ts
+++ b/packages/server/src/terminal/shellArgs.test.ts
@@ -1,26 +1,43 @@
 import { expect, test } from "bun:test";
 import { terminalShell, terminalShellArgs } from "./shellArgs";
 
-test("an explicit shell wins on every platform", () => {
-	expect(terminalShell("win32", { SHELL: "C:\\tools\\bash.exe", ComSpec: "cmd.exe" })).toBe(
+const noPwsh = () => null;
+const withPwsh = (bin: string) => (bin === "pwsh.exe" ? "C:\\pwsh\\pwsh.exe" : null);
+
+test("an explicit shell wins on every platform, over any preference", () => {
+	expect(terminalShell("win32", { SHELL: "C:\\tools\\bash.exe" }, "cmd", withPwsh)).toBe(
 		"C:\\tools\\bash.exe",
 	);
 	expect(terminalShell("linux", { SHELL: "/bin/zsh" })).toBe("/bin/zsh");
 });
 
-test("Windows terminals fall back through ComSpec to cmd", () => {
-	expect(terminalShell("win32", { ComSpec: "C:\\Windows\\System32\\cmd.exe" })).toBe(
-		"C:\\Windows\\System32\\cmd.exe",
-	);
-	expect(terminalShell("win32", { COMSPEC: "C:\\Windows\\System32\\cmd.exe" })).toBe(
-		"C:\\Windows\\System32\\cmd.exe",
-	);
-	expect(terminalShell("win32", {})).toBe("cmd.exe");
+test("auto prefers pwsh when it resolves on PATH", () => {
+	expect(terminalShell("win32", {}, "auto", withPwsh)).toBe("C:\\pwsh\\pwsh.exe");
 });
 
-test("Unix terminals retain the bash fallback", () => {
+test("auto falls back to Windows PowerShell when pwsh is not installed", () => {
+	expect(terminalShell("win32", {}, "auto", noPwsh)).toBe("powershell.exe");
+	expect(terminalShell("win32", {})).toBe("powershell.exe");
+});
+
+test("an explicit preference is a literal pin, never probed or substituted", () => {
+	expect(terminalShell("win32", {}, "pwsh", noPwsh)).toBe("pwsh.exe");
+	expect(terminalShell("win32", {}, "powershell", noPwsh)).toBe("powershell.exe");
+	expect(terminalShell("win32", {}, "cmd", withPwsh)).toBe("cmd.exe");
+});
+
+test("ComSpec/COMSPEC no longer influence the Windows default", () => {
+	expect(
+		terminalShell("win32", { ComSpec: "C:\\Windows\\System32\\cmd.exe" }, "auto", noPwsh),
+	).toBe("powershell.exe");
+	expect(
+		terminalShell("win32", { COMSPEC: "C:\\Windows\\System32\\cmd.exe" }, "auto", noPwsh),
+	).toBe("powershell.exe");
+});
+
+test("Unix terminals retain the bash fallback regardless of preference", () => {
 	expect(terminalShell("linux", {})).toBe("/bin/bash");
-	expect(terminalShell("darwin", {})).toBe("/bin/bash");
+	expect(terminalShell("darwin", {}, "cmd")).toBe("/bin/bash");
 });
 
 test("macOS terminals start login shells", () => {

--- a/packages/server/src/terminal/shellArgs.ts
+++ b/packages/server/src/terminal/shellArgs.ts
@@ -1,7 +1,26 @@
-export function terminalShell(platform: string, env: Record<string, string | undefined>): string {
+import type { TerminalWindowsShell } from "@thinkrail/contracts";
+
+const WINDOWS_SHELL_BINARY: Record<Exclude<TerminalWindowsShell, "auto">, string> = {
+	pwsh: "pwsh.exe",
+	powershell: "powershell.exe",
+	cmd: "cmd.exe",
+};
+
+export type WhichFn = (bin: string) => string | null;
+
+export const defaultWhich: WhichFn = (bin) =>
+	Bun.which(bin, { PATH: process.env.PATH ?? "" }) ?? null;
+
+export function terminalShell(
+	platform: string,
+	env: Record<string, string | undefined>,
+	preference: TerminalWindowsShell = "auto",
+	which: WhichFn = defaultWhich,
+): string {
 	if (env.SHELL) return env.SHELL;
-	if (platform === "win32") return env.ComSpec ?? env.COMSPEC ?? "cmd.exe";
-	return "/bin/bash";
+	if (platform !== "win32") return "/bin/bash";
+	if (preference !== "auto") return WINDOWS_SHELL_BINARY[preference];
+	return which("pwsh.exe") ?? "powershell.exe";
 }
 
 export function terminalShellArgs(platform: string): string[] {

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Workspace, WS_CHANNELS } from "@thinkrail/contracts";
+import { removeTree } from "@thinkrail/shared/removeTree";
 import { saveTerminalSessions, saveWorkspaces } from "../persistence";
 import {
 	attachTerminal,
@@ -26,6 +27,8 @@ interface PublishedFrame {
 }
 
 const WS = "ws-1";
+// An external, real child process on every platform (PowerShell's `sleep` alias runs in-process; see terminal/SPEC.md).
+const BUSY_LOOP_COMMAND = process.platform === "win32" ? "ping -n 30 127.0.0.1" : "sleep 30";
 const TERMINAL_CONDITION_TIMEOUT_MS = 15_000;
 const TERMINAL_TEST_TIMEOUT_MS = TERMINAL_CONDITION_TIMEOUT_MS * 3 + 5_000;
 let dataDir: string;
@@ -133,7 +136,8 @@ afterEach(() => {
 	resetTerminalState();
 	setTerminalPublisher(() => "unavailable");
 	setTerminalTabsPublisher(() => {});
-	rmSync(dataDir, { recursive: true, force: true });
+	// Windows releases a just-killed pty's cwd handle asynchronously; see shared/SPEC.md's removeTree.
+	removeTree(dataDir);
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
 });
@@ -295,7 +299,7 @@ test("a shell with something running refuses to close until forced", async () =>
 	const attached = attachTerminal(WS, "tab-a", "client-1");
 	expect(attached.created).toBe(true);
 	await Bun.sleep(600);
-	writeTerminal(attached.id, "sleep 30\r", "client-1");
+	writeTerminal(attached.id, `${BUSY_LOOP_COMMAND}\r`, "client-1");
 	await Bun.sleep(800);
 
 	const refused = closeTerminalTab(WS, "tab-a");

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -148,7 +148,7 @@ function spawnForTab(
 	const ws = loadWorkspaces().find((w) => w.id === workspaceId);
 	if (!ws) throw new Error(`Unknown workspace: ${workspaceId}`);
 
-	const shell = terminalShell(process.platform, process.env);
+	const shell = terminalShell(process.platform, process.env, loadConfig().terminalWindowsShell);
 	const grid = {
 		cols: size.cols ?? DEFAULT_PTY_SIZE.cols,
 		rows: size.rows ?? DEFAULT_PTY_SIZE.rows,


### PR DESCRIPTION
## Summary

Windows workspace terminals defaulted to `cmd.exe`. Adds a configurable **Windows shell** picker
(Settings → Terminal, Windows-only): **Auto** (default — prefers `pwsh.exe`, falls back to
`powershell.exe`), PowerShell 7, Windows PowerShell, or Command Prompt. `SHELL` env var still wins
over everything.

Also fixes a real bug found while testing: PowerShell's `sleep` alias runs in-process (no child
process), which silently broke the existing busy-terminal-close-confirmation check. Retargeted the
affected test to a real external process; the residual limitation (native PowerShell cmdlets only)
is documented as an accepted, known gap.

## Changes

- `packages/contracts` — `AppConfig.terminalWindowsShell`
- `packages/server/src/{persistence,terminal}` — selection logic + config wiring
- `apps/web/src/{store,panels}` — settings UI
- `SPEC.md` updates in `terminal`, `contracts`, `panels`

## Testing

- `bun run typecheck`, `bun run lint`, `check:deps`/`boundaries`/`seams` — clean
- `bun test` (contracts/server/web) — no regressions vs. base (confirmed via `git stash`/checkout diff)
- `bun run e2e -- e2e/settings.spec.ts` — passed; `e2e/terminals.spec.ts` hits a pre-existing,
  environment-specific fixture failure in this sandbox present on the base commit too (unrelated to
  this change)
