### PR TITLE
fix(terminal): make shell start failures actionable

### DIFF
--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -1360,8 +1360,10 @@ own section. The kebab menu (`plan-menu`, a
   `fontFamily` toggle), so a font that finishes loading late cannot re-lay-out an already-attached terminal.
   This ordering also prevents a fallback-width attach followed by a corrective resize from producing
   post-snapshot shell redraws that can erase replayed rows. Its pre-bind output buffer is a bounded waiting
-  state: successful bind filters it to the adopted PTY, while permanent creation failure
-  clears it and stops accepting page-wide terminal frames. **Historical replay is input-inert:** the PTY id
+  state: successful bind filters it to the adopted PTY, while creation failure clears it and stops accepting
+  page-wide terminal frames. That failure renders the host's stable guidance as escaped DOM text rather than
+  executable terminal output, with Terminal Settings and Retry actions; retry enters a fresh bounded attach
+  attempt after the user corrects the shell choice or installation. **Historical replay is input-inert:** the PTY id
   remains unadopted until xterm's replay callback, which rechecks attach freshness before binding and draining
   genuinely live frames; replies xterm synthesizes for recorded terminal queries can therefore never enter the
   live shell. PTY sizing distinguishes desired, in-flight, and

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -1362,8 +1362,14 @@ own section. The kebab menu (`plan-menu`, a
   post-snapshot shell redraws that can erase replayed rows. Its pre-bind output buffer is a bounded waiting
   state: successful bind filters it to the adopted PTY, while creation failure clears it and stops accepting
   page-wide terminal frames. That failure renders the host's stable guidance as escaped DOM text rather than
-  executable terminal output, with Terminal Settings and Retry actions; retry enters a fresh bounded attach
-  attempt after the user corrects the shell choice or installation. **Historical replay is input-inert:** the PTY id
+  executable terminal output, with Terminal Settings and Retry actions. The failed xterm subtree is inert;
+  an explicit retry keeps that recovery surface mounted and its actions disabled until the request settles,
+  preserving focus without stealing unrelated workbench focus. Initial xterm focus is deferred until a
+  successful attach and applies only while the terminal tab that requested it still owns focus; Retry keeps
+  its overlay mounted through the successful handoff and restores xterm focus only while focus remains in that
+  terminal region. A competing detach invalidates that handoff and clears its retry state before exposing Take
+  Back again.
+  **Historical replay is input-inert:** the PTY id
   remains unadopted until xterm's replay callback, which rechecks attach freshness before binding and draining
   genuinely live frames; replies xterm synthesizes for recorded terminal queries can therefore never enter the
   live shell. PTY sizing distinguishes desired, in-flight, and

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -12,6 +12,7 @@ import { type ITheme, Terminal as XTerm } from "@xterm/xterm";
 import { useCallback, useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { type QuietScrollEdges, QuietScrollFrame } from "@/components/QuietScrollArea";
+import { Button } from "@/components/ui/button";
 import { cssColorToHex } from "@/lib";
 import { SettingsSection, useAppStore } from "../store";
 import { onThemeSwap } from "../themes";
@@ -106,6 +107,7 @@ interface Props {
 }
 
 export default function TerminalInstance({ tabKey, workspaceId, initialCommand }: Props) {
+	const rootRef = useRef<HTMLDivElement>(null);
 	const hostRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<XTerm | null>(null);
 	const serverIdRef = useRef<string | null>(null);
@@ -115,6 +117,7 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 	const [ready, setReady] = useState(false);
 	const [exited, setExited] = useState(false);
 	const [failureMessage, setFailureMessage] = useState<string | null>(null);
+	const [retrying, setRetrying] = useState(false);
 	const [detached, setDetached] = useState(false);
 	const [scrollEdges, setScrollEdges] = useState<QuietScrollEdges>({
 		top: false,
@@ -127,6 +130,10 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 		const host = hostRef.current;
 		if (!host) return;
 
+		const initialFocusTarget = document.activeElement;
+		const focusedTab =
+			initialFocusTarget instanceof Element ? initialFocusTarget.closest('[role="tab"]') : null;
+		const initialFocusRequestsTerminal = focusedTab?.parentElement?.dataset.kind === "terminal";
 		const term = new XTerm({
 			allowProposedApi: true,
 			cursorBlink: true,
@@ -235,14 +242,18 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 				serverIdRef.current = null;
 				attachGeneration += 1;
 				setReady(false);
+				setRetrying(false);
 				setDetached(true);
 			},
 		);
 
 		let disposed = false;
 
-		const attach = (): void => {
-			setFailureMessage(null);
+		const focusIsInTerminal = (): boolean =>
+			rootRef.current?.contains(document.activeElement) === true;
+		const attach = (restoreFocus = false): void => {
+			if (restoreFocus) setRetrying(true);
+			else setFailureMessage(null);
 			const spawnedAt = { cols: term.cols, rows: term.rows };
 			const startedAt = attachGeneration;
 			prebind.stop();
@@ -266,9 +277,31 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 						const buffered = attemptPrebind.bind(id);
 						if (buffered.truncated) writeTruncation();
 						for (const ev of buffered.frames) writeFrame(ev);
-						setDetached(false);
+						const restoreTerminalFocus = restoreFocus
+							? focusIsInTerminal()
+							: initialFocusRequestsTerminal && document.activeElement === initialFocusTarget;
 						setExited(false);
 						setReady(true);
+						if (restoreTerminalFocus) {
+							requestAnimationFrame(() => {
+								if (disposed || attachGeneration !== startedAt || prebind !== attemptPrebind) {
+									return;
+								}
+								if (
+									(restoreFocus && focusIsInTerminal()) ||
+									(!restoreFocus && document.activeElement === initialFocusTarget)
+								) {
+									term.focus();
+								}
+								setDetached(false);
+								setFailureMessage(null);
+								setRetrying(false);
+							});
+						} else {
+							setDetached(false);
+							setFailureMessage(null);
+							setRetrying(false);
+						}
 						if (buffered.exit) handleExit(buffered.exit);
 						applyFit();
 						if (created && serverIdRef.current === id && initialCommandRef.current) {
@@ -292,10 +325,11 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 					}
 					attemptPrebind.stop();
 					setDetached(false);
+					setRetrying(false);
 					setFailureMessage(errorText(error, "Couldn’t start or attach the shell."));
 				});
 		};
-		reattachRef.current = attach;
+		reattachRef.current = () => attach(true);
 		void runAfterTerminalRelayout(
 			() => webFonts.relayout(),
 			() => {
@@ -341,7 +375,6 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 		const frame = requestAnimationFrame(() => {
 			fitFnRef.current?.();
 			termRef.current?.scrollToBottom();
-			termRef.current?.focus();
 		});
 		return () => cancelAnimationFrame(frame);
 	}, []);
@@ -354,6 +387,7 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 
 	return (
 		<div
+			ref={rootRef}
 			data-testid="terminal-instance"
 			data-tab-key={tabKey}
 			data-ready={ready}
@@ -367,6 +401,7 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 				viewportSelector=".xterm-scrollable-element"
 				surface="terminal"
 				edges={scrollEdges}
+				inert={failureMessage !== null && !ready}
 				className="absolute inset-12"
 			>
 				<div ref={hostRef} className="absolute inset-0" />
@@ -380,38 +415,43 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 					<button
 						type="button"
 						data-testid="terminal-take-back"
-						onClick={retry}
+						aria-disabled={retrying}
+						onClick={retrying ? undefined : retry}
 						className="rounded-[var(--radius-sm)] bg-control-bg px-8 py-4 tr-text-ui text-text-default hover:bg-control-bg-hovered"
 					>
-						Take it back
+						{retrying ? "Taking it back…" : "Take it back"}
 					</button>
 				</div>
 			) : null}
 			{failureMessage !== null && !detached ? (
 				<div
-					role="alert"
 					data-testid="terminal-start-failure"
-					className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-8 bg-overlay px-24 text-center"
+					className="absolute inset-0 z-30 flex items-center justify-center bg-overlay p-24 text-center"
 				>
-					<p className="tr-title-compact text-text-default">Terminal couldn’t start</p>
-					<p className="tr-text-metadata text-text-muted">{failureMessage}</p>
-					<div className="flex items-center gap-8">
-						<button
-							type="button"
-							data-testid="terminal-open-settings"
-							onClick={openTerminalSettings}
-							className="rounded-[var(--radius-sm)] bg-control-bg px-8 py-4 tr-text-ui text-text-default hover:bg-control-bg-hovered"
-						>
-							Terminal settings
-						</button>
-						<button
-							type="button"
-							data-testid="terminal-start-retry"
-							onClick={retry}
-							className="rounded-[var(--radius-sm)] bg-primary px-8 py-4 tr-text-ui text-text-on-primary hover:opacity-90"
-						>
-							Retry
-						</button>
+					<div className="flex flex-col items-center gap-8 rounded-[var(--radius-md)] border border-border-default bg-container-elevated-bg p-16 shadow-sm">
+						<div role="alert" className="flex flex-col items-center gap-4">
+							<p className="tr-title-compact text-text-default">Terminal couldn’t start</p>
+							<p className="tr-text-metadata text-text-muted">{failureMessage}</p>
+						</div>
+						<div className="flex items-center gap-8">
+							<Button
+								variant="outline"
+								size="sm"
+								data-testid="terminal-open-settings"
+								disabled={retrying}
+								onClick={openTerminalSettings}
+							>
+								Terminal settings
+							</Button>
+							<Button
+								size="sm"
+								data-testid="terminal-start-retry"
+								aria-disabled={retrying}
+								onClick={retrying ? undefined : retry}
+							>
+								{retrying ? "Retrying…" : "Retry"}
+							</Button>
+						</div>
 					</div>
 				</div>
 			) : null}

--- a/apps/web/src/panels/TerminalInstance.tsx
+++ b/apps/web/src/panels/TerminalInstance.tsx
@@ -13,9 +13,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { type QuietScrollEdges, QuietScrollFrame } from "@/components/QuietScrollArea";
 import { cssColorToHex } from "@/lib";
-import { useAppStore } from "../store";
+import { SettingsSection, useAppStore } from "../store";
 import { onThemeSwap } from "../themes";
-import { getTransport } from "../transport";
+import { errorText, getTransport } from "../transport";
 import { createPtySizeSync, runAfterTerminalRelayout } from "./ptySizeSync";
 import { stripAnsiDim, terminalContrastFloor } from "./terminalContrast";
 import { createTerminalPrebindBuffer } from "./terminalPrebindBuffer";
@@ -114,7 +114,7 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 	const initialCommandRef = useRef(initialCommand);
 	const [ready, setReady] = useState(false);
 	const [exited, setExited] = useState(false);
-	const [failed, setFailed] = useState(false);
+	const [failureMessage, setFailureMessage] = useState<string | null>(null);
 	const [detached, setDetached] = useState(false);
 	const [scrollEdges, setScrollEdges] = useState<QuietScrollEdges>({
 		top: false,
@@ -242,6 +242,7 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 		let disposed = false;
 
 		const attach = (): void => {
+			setFailureMessage(null);
 			const spawnedAt = { cols: term.cols, rows: term.rows };
 			const startedAt = attachGeneration;
 			prebind.stop();
@@ -284,14 +285,14 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 					if (replay) writeOutput(replay, finishAttach);
 					else finishAttach();
 				})
-				.catch(() => {
+				.catch((error) => {
 					if (disposed || attachGeneration !== startedAt || prebind !== attemptPrebind) {
 						attemptPrebind.stop();
 						return;
 					}
 					attemptPrebind.stop();
-					term.write("\r\n[could not start a shell — close this tab and open a new one]\r\n");
-					setFailed(true);
+					setDetached(false);
+					setFailureMessage(errorText(error, "Couldn’t start or attach the shell."));
 				});
 		};
 		reattachRef.current = attach;
@@ -345,7 +346,11 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 		return () => cancelAnimationFrame(frame);
 	}, []);
 
-	const takeBack = useCallback(() => reattachRef.current?.(), []);
+	const retry = useCallback(() => reattachRef.current?.(), []);
+	const openTerminalSettings = useCallback(
+		() => useAppStore.getState().openSettings(SettingsSection.Terminal),
+		[],
+	);
 
 	return (
 		<div
@@ -353,7 +358,7 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 			data-tab-key={tabKey}
 			data-ready={ready}
 			data-exited={exited}
-			data-failed={failed}
+			data-failed={failureMessage !== null}
 			data-detached={detached}
 			data-visible="true"
 			className="absolute inset-0 z-0"
@@ -375,11 +380,39 @@ export default function TerminalInstance({ tabKey, workspaceId, initialCommand }
 					<button
 						type="button"
 						data-testid="terminal-take-back"
-						onClick={takeBack}
+						onClick={retry}
 						className="rounded-[var(--radius-sm)] bg-control-bg px-8 py-4 tr-text-ui text-text-default hover:bg-control-bg-hovered"
 					>
 						Take it back
 					</button>
+				</div>
+			) : null}
+			{failureMessage !== null && !detached ? (
+				<div
+					role="alert"
+					data-testid="terminal-start-failure"
+					className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-8 bg-overlay px-24 text-center"
+				>
+					<p className="tr-title-compact text-text-default">Terminal couldn’t start</p>
+					<p className="tr-text-metadata text-text-muted">{failureMessage}</p>
+					<div className="flex items-center gap-8">
+						<button
+							type="button"
+							data-testid="terminal-open-settings"
+							onClick={openTerminalSettings}
+							className="rounded-[var(--radius-sm)] bg-control-bg px-8 py-4 tr-text-ui text-text-default hover:bg-control-bg-hovered"
+						>
+							Terminal settings
+						</button>
+						<button
+							type="button"
+							data-testid="terminal-start-retry"
+							onClick={retry}
+							className="rounded-[var(--radius-sm)] bg-primary px-8 py-4 tr-text-ui text-text-on-primary hover:opacity-90"
+						>
+							Retry
+						</button>
+					</div>
 				</div>
 			) : null}
 		</div>

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type WebSocketRoute } from "@playwright/test";
+import { INITIAL_TERMINAL_TAB_KEY } from "@thinkrail/contracts";
 import {
 	activeWorktreeRow,
 	createWorkspaceViaDialog,
@@ -43,39 +44,103 @@ test("a workspace opens a terminal automatically, rooted in the worktree, with w
 test("a shell start failure explains recovery and retries the same tab", async ({ page }) => {
 	const failure =
 		"Couldn’t start PowerShell 7 (pwsh.exe). Make sure it is installed and available to ThinkRail.";
-	let failNextAttach = true;
+	let attachFailuresRemaining = 0;
+	let holdNextSuccess = false;
+	let heldSuccessId: string | undefined;
+	let browserSocket: WebSocketRoute | undefined;
+	let releaseFailure: (() => void) | undefined;
+	let releaseRetryFailure: (() => void) | undefined;
+	let releaseSuccess: (() => void) | undefined;
 	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		browserSocket = ws;
 		const server = ws.connectToServer();
 		ws.onMessage((message) => {
 			try {
 				const frame = JSON.parse(message.toString()) as { id?: string; method?: string };
-				if (failNextAttach && frame.method === "terminal.attach" && frame.id) {
-					failNextAttach = false;
-					ws.send(JSON.stringify({ id: frame.id, ok: false, error: failure }));
+				if (attachFailuresRemaining > 0 && frame.method === "terminal.attach" && frame.id) {
+					const response = JSON.stringify({ id: frame.id, ok: false, error: failure });
+					if (attachFailuresRemaining === 2) releaseFailure = () => ws.send(response);
+					else releaseRetryFailure = () => ws.send(response);
+					attachFailuresRemaining -= 1;
 					return;
+				}
+				if (holdNextSuccess && frame.method === "terminal.attach" && frame.id) {
+					holdNextSuccess = false;
+					heldSuccessId = frame.id;
 				}
 			} catch {}
 			server.send(message);
 		});
-		server.onMessage((message) => ws.send(message));
+		server.onMessage((message) => {
+			try {
+				const frame = JSON.parse(message.toString()) as { id?: string };
+				if (frame.id && frame.id === heldSuccessId) {
+					releaseSuccess = () => ws.send(message);
+					return;
+				}
+			} catch {}
+			ws.send(message);
+		});
 	});
 
 	await openFixtureProject(page);
-	await createWorkspaceViaDialog(page);
+	const workspace = await createWorkspaceViaDialog(page);
+	await waitTerminalReady(page);
+	attachFailuresRemaining = 2;
+	await page.getByTestId("project-item").first().click();
+	await expect(page.getByTestId("terminal-panel")).toHaveCount(0);
+	await worktreeRows(page).first().getByRole("button").first().click();
+	const chatTab = page.locator('[data-testid="editor-tab"][data-kind="chat"]').getByRole("tab");
+	await expect(chatTab).toBeVisible();
+	await chatTab.focus();
+	await expect(chatTab).toBeFocused();
+	await expect.poll(() => releaseFailure !== undefined).toBe(true);
+	releaseFailure?.();
 	const terminal = visibleTerminal(page);
 	await expect(terminal).toHaveAttribute("data-failed", "true");
 	await expect(terminal.getByTestId("terminal-start-failure")).toContainText(failure);
-
+	await expect(terminal.locator('[data-quiet-scroll-surface="terminal"]')).toHaveAttribute(
+		"inert",
+		"",
+	);
+	await expect(chatTab).toBeFocused();
 	await terminal.getByTestId("terminal-open-settings").click();
 	await expect(page.getByTestId("settings-terminal")).toBeVisible();
 	await expect(page.getByTestId("settings-nav-terminal")).toHaveAttribute("data-active", "true");
 	await page.keyboard.press("Escape");
 	await expect(page.getByTestId("settings-dialog")).toHaveCount(0);
 
-	await terminal.getByTestId("terminal-start-retry").click();
+	const retryButton = terminal.getByTestId("terminal-start-retry");
+	await retryButton.click();
+	await expect(retryButton).toHaveAttribute("aria-disabled", "true");
+	await expect.poll(() => releaseRetryFailure !== undefined).toBe(true);
+	releaseRetryFailure?.();
+	await expect(retryButton).toHaveAttribute("aria-disabled", "false");
+	await expect(retryButton).toBeFocused();
+
+	holdNextSuccess = true;
+	await retryButton.click();
+	await expect(retryButton).toHaveAttribute("aria-disabled", "true");
+	await expect.poll(() => releaseSuccess !== undefined).toBe(true);
+	browserSocket?.send(
+		JSON.stringify({
+			channel: "terminal.detached",
+			data: { workspaceId: workspace.id, tabKey: INITIAL_TERMINAL_TAB_KEY },
+		}),
+	);
+	await expect(terminal).toHaveAttribute("data-detached", "true");
+	const takeBack = terminal.getByTestId("terminal-take-back");
+	await expect(takeBack).toHaveAttribute("aria-disabled", "false");
+	releaseSuccess?.();
+	await takeBack.click();
 	await waitTerminalReady(page);
 	await expect(terminal).toHaveAttribute("data-failed", "false");
 	await expect(terminal.getByTestId("terminal-start-failure")).toHaveCount(0);
+	await expect(terminal.locator('[data-quiet-scroll-surface="terminal"]')).not.toHaveAttribute(
+		"inert",
+		"",
+	);
+	await expect(terminal.locator(".xterm-helper-textarea")).toBeFocused();
 	await page.getByTestId("terminal-tab-close").click();
 	await expect(page.getByTestId("terminal-tab")).toHaveCount(0);
 });

--- a/e2e/terminals.spec.ts
+++ b/e2e/terminals.spec.ts
@@ -40,6 +40,46 @@ test("a workspace opens a terminal automatically, rooted in the worktree, with w
 	await expect(term).toContainText("TR_MARKER_IO");
 });
 
+test("a shell start failure explains recovery and retries the same tab", async ({ page }) => {
+	const failure =
+		"Couldn’t start PowerShell 7 (pwsh.exe). Make sure it is installed and available to ThinkRail.";
+	let failNextAttach = true;
+	await page.routeWebSocket(/\/ws(\?|$)/, (ws) => {
+		const server = ws.connectToServer();
+		ws.onMessage((message) => {
+			try {
+				const frame = JSON.parse(message.toString()) as { id?: string; method?: string };
+				if (failNextAttach && frame.method === "terminal.attach" && frame.id) {
+					failNextAttach = false;
+					ws.send(JSON.stringify({ id: frame.id, ok: false, error: failure }));
+					return;
+				}
+			} catch {}
+			server.send(message);
+		});
+		server.onMessage((message) => ws.send(message));
+	});
+
+	await openFixtureProject(page);
+	await createWorkspaceViaDialog(page);
+	const terminal = visibleTerminal(page);
+	await expect(terminal).toHaveAttribute("data-failed", "true");
+	await expect(terminal.getByTestId("terminal-start-failure")).toContainText(failure);
+
+	await terminal.getByTestId("terminal-open-settings").click();
+	await expect(page.getByTestId("settings-terminal")).toBeVisible();
+	await expect(page.getByTestId("settings-nav-terminal")).toHaveAttribute("data-active", "true");
+	await page.keyboard.press("Escape");
+	await expect(page.getByTestId("settings-dialog")).toHaveCount(0);
+
+	await terminal.getByTestId("terminal-start-retry").click();
+	await waitTerminalReady(page);
+	await expect(terminal).toHaveAttribute("data-failed", "false");
+	await expect(terminal.getByTestId("terminal-start-failure")).toHaveCount(0);
+	await page.getByTestId("terminal-tab-close").click();
+	await expect(page.getByTestId("terminal-tab")).toHaveCount(0);
+});
+
 test("xterm uses the shared quiet rail and directional curtains", async ({ page }) => {
 	await openFixtureProject(page);
 	await createWorkspaceViaDialog(page);

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -47,8 +47,10 @@ identities. A tab's shell outlives every client that looks at it; each frontend 
     `resolveShellEnv()`'s later-repaired live `process.env.PATH`.
   - `"pwsh"` / `"powershell"` / `"cmd"`: literal pins to `pwsh.exe` / `powershell.exe` / `cmd.exe` — no
     existence check, no silent substitution. A pin that turns out to be missing fails to spawn the same
-    way a stale custom `SHELL` already does; not a new failure class, and the only mode with graceful
-    substitution is `auto`.
+    way a stale custom `SHELL` already does, and the only mode with graceful substitution is `auto`.
+    The synchronous PTY spawn is the authoritative availability check: its opaque native failure is wrapped
+    in stable guidance derived from the selected shell source. The client receives no native error text,
+    executable path, or raw `SHELL` value.
   - Non-Windows platforms are unaffected: `/bin/bash` regardless of `terminalWindowsShell`.
   `cmd.exe` was the unconditional prior default; `"auto"`'s baseline is `powershell.exe`, a plain
   fallback swap (ships on every supported Windows release, so no new dependency), because it is more
@@ -71,8 +73,8 @@ identities. A tab's shell outlives every client that looks at it; each frontend 
   and get the exact prior, fully-detectable behavior back.
 - **Not building a `listAvailableShells`-style host probe** to gray out an uninstalled pick in the Settings
   picker, unlike `editors`' `listAvailableEditors`: `auto` already gets the graceful substitution most users
-  want, and probing purely to decorate three static buttons wasn't asked for — a second detection mechanism
-  earning less than it costs.
+  want, while a probe cannot prove ConPTY launchability and would duplicate the real spawn check. A failed
+  launch instead stays recoverable through the client's Settings and Retry actions.
 - **macOS PTYs start the user's shell in login mode (`-l`)** to match Terminal.app and the platform's
   terminal convention; other platforms keep a plain interactive shell. The PTY itself supplies
   interactivity, so no explicit `-i` is needed.

--- a/packages/server/src/terminal/SPEC.md
+++ b/packages/server/src/terminal/SPEC.md
@@ -142,8 +142,10 @@ identities. A tab's shell outlives every client that looks at it; each frontend 
   every change** (open / close / archive), not only at `stop()` — the host has no crash isolation, so an
   ungraceful exit is an ordinary path and a shutdown-only file would resurrect a closed tab and spawn a shell
   for it. `stop()` additionally captures a full set of recordings before `closeAllTerminals()`;
-  `reviveTerminalSessions()` restores tabs whose first attach spawns a fresh shell showing the old picture.
-  Recordings are best-effort, so an unclean exit gives back the right tabs with blank screens.
+  `reviveTerminalSessions()` restores tabs whose first successful attach spawns a fresh shell showing the old
+  picture. A failed spawn does not consume the pending recording, so correcting the shell and retrying the
+  same tab still restores it. Recordings are best-effort, so an unclean exit gives back the right tabs with
+  blank screens.
 - **Not tmux.** Would buy restart survival at the cost of a dep we can't assume on Windows, a competing tab
   model, env-propagation breakage, and `capture-pane` polling. We already accept no crash isolation.
 

--- a/packages/server/src/terminal/shellArgs.test.ts
+++ b/packages/server/src/terminal/shellArgs.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { terminalShell, terminalShellArgs } from "./shellArgs";
+import { terminalShell, terminalShellArgs, terminalShellStartFailure } from "./shellArgs";
 
 const noPwsh = () => null;
 const withPwsh = (bin: string) => (bin === "pwsh.exe" ? "C:\\pwsh\\pwsh.exe" : null);
@@ -24,6 +24,32 @@ test("an explicit preference is a literal pin, never probed or substituted", () 
 	expect(terminalShell("win32", {}, "pwsh", noPwsh)).toBe("pwsh.exe");
 	expect(terminalShell("win32", {}, "powershell", noPwsh)).toBe("powershell.exe");
 	expect(terminalShell("win32", {}, "cmd", withPwsh)).toBe("cmd.exe");
+});
+
+test("shell start failures identify the selected Windows shell without substituting it", () => {
+	expect(terminalShellStartFailure("win32", {}, "pwsh")).toContain(
+		"Couldn’t start PowerShell 7 (pwsh.exe)",
+	);
+	expect(terminalShellStartFailure("win32", {}, "powershell")).toContain(
+		"Couldn’t start Windows PowerShell (powershell.exe)",
+	);
+	expect(terminalShellStartFailure("win32", {}, "cmd")).toContain(
+		"Couldn’t start Command Prompt (cmd.exe)",
+	);
+});
+
+test("shell start failure guidance follows the executable source", () => {
+	const fromOverride = terminalShellStartFailure(
+		"win32",
+		{ SHELL: "C:\\private\\broken.exe" },
+		"pwsh",
+	);
+	expect(fromOverride).toContain("configured by SHELL");
+	expect(fromOverride).not.toContain("C:\\private\\broken.exe");
+	expect(terminalShellStartFailure("win32", {}, "auto")).toContain(
+		"automatically selected Windows shell",
+	);
+	expect(terminalShellStartFailure("linux", {})).toContain("configured shell");
 });
 
 test("ComSpec/COMSPEC no longer influence the Windows default", () => {

--- a/packages/server/src/terminal/shellArgs.ts
+++ b/packages/server/src/terminal/shellArgs.ts
@@ -6,6 +6,12 @@ const WINDOWS_SHELL_BINARY: Record<Exclude<TerminalWindowsShell, "auto">, string
 	cmd: "cmd.exe",
 };
 
+const WINDOWS_SHELL_NAME: Record<Exclude<TerminalWindowsShell, "auto">, string> = {
+	pwsh: "PowerShell 7",
+	powershell: "Windows PowerShell",
+	cmd: "Command Prompt",
+};
+
 export type WhichFn = (bin: string) => string | null;
 
 export const defaultWhich: WhichFn = (bin) =>
@@ -21,6 +27,23 @@ export function terminalShell(
 	if (platform !== "win32") return "/bin/bash";
 	if (preference !== "auto") return WINDOWS_SHELL_BINARY[preference];
 	return which("pwsh.exe") ?? "powershell.exe";
+}
+
+export function terminalShellStartFailure(
+	platform: string,
+	env: Record<string, string | undefined>,
+	preference: TerminalWindowsShell = "auto",
+): string {
+	if (env.SHELL) {
+		return "Couldn’t start the shell configured by SHELL. Fix or clear SHELL in the host environment, restart ThinkRail, then retry.";
+	}
+	if (platform !== "win32") {
+		return "Couldn’t start the configured shell. Check the host’s shell installation, then retry.";
+	}
+	if (preference === "auto") {
+		return "Couldn’t start the automatically selected Windows shell. Check the host’s shell installation, or choose another shell in Settings → Terminal, then retry.";
+	}
+	return `Couldn’t start ${WINDOWS_SHELL_NAME[preference]} (${WINDOWS_SHELL_BINARY[preference]}). Make sure it is installed and available to ThinkRail. Restart ThinkRail after installation or PATH changes, or choose another shell in Settings → Terminal, then retry.`;
 }
 
 export function terminalShellArgs(platform: string): string[] {

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -142,9 +142,12 @@ afterEach(() => {
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
 });
 
-test("a shell spawn failure is actionable and the reserved tab can retry", () => {
+test("a shell spawn failure is actionable and preserves replay for retry", () => {
 	const savedShell = process.env.SHELL;
-	reserveTerminal(WS, "tab-a", "Terminal");
+	saveTerminalSessions({
+		[WS]: [{ tabKey: "tab-a", title: "Terminal", recorded: "remembered output" }],
+	});
+	reviveTerminalSessions();
 	process.env.SHELL = join(dataDir, "missing-shell");
 	try {
 		expect(() => attachTerminal(WS, "tab-a", "client-1")).toThrow(
@@ -157,7 +160,9 @@ test("a shell spawn failure is actionable and the reserved tab can retry", () =>
 		else process.env.SHELL = savedShell;
 	}
 
-	expect(attachTerminal(WS, "tab-a", "client-1").created).toBe(true);
+	const retried = attachTerminal(WS, "tab-a", "client-1");
+	expect(retried.created).toBe(true);
+	expect(retried.replay).toContain("remembered output");
 });
 
 test("attaching twice to a tab returns the SAME shell", () => {

--- a/packages/server/src/terminal/terminalManager.test.ts
+++ b/packages/server/src/terminal/terminalManager.test.ts
@@ -142,6 +142,24 @@ afterEach(() => {
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
 });
 
+test("a shell spawn failure is actionable and the reserved tab can retry", () => {
+	const savedShell = process.env.SHELL;
+	reserveTerminal(WS, "tab-a", "Terminal");
+	process.env.SHELL = join(dataDir, "missing-shell");
+	try {
+		expect(() => attachTerminal(WS, "tab-a", "client-1")).toThrow(
+			"Couldn’t start the shell configured by SHELL",
+		);
+		expect(listTerminals(WS)).toEqual([{ tabKey: "tab-a", title: "Terminal" }]);
+		expect(pushed).toEqual([]);
+	} finally {
+		if (savedShell === undefined) delete process.env.SHELL;
+		else process.env.SHELL = savedShell;
+	}
+
+	expect(attachTerminal(WS, "tab-a", "client-1").created).toBe(true);
+});
+
 test("attaching twice to a tab returns the SAME shell", () => {
 	const first = attachTerminal(WS, "tab-a", "client-1");
 	const second = attachTerminal(WS, "tab-a", "client-1");

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -22,7 +22,7 @@ import {
 } from "./outputBatcher";
 import { createOutputRecorder, type OutputRecorder } from "./outputRecorder";
 import { nudgePtyRedraw, type PtyGrid, resizePtyIfChanged } from "./ptyGrid";
-import { terminalShell, terminalShellArgs } from "./shellArgs";
+import { terminalShell, terminalShellArgs, terminalShellStartFailure } from "./shellArgs";
 import { hasChildProcesses } from "./shellBusy";
 
 type PushToClient = (clientKey: string, channel: string, data: unknown) => TerminalDeliveryResult;
@@ -148,17 +148,25 @@ function spawnForTab(
 	const ws = loadWorkspaces().find((w) => w.id === workspaceId);
 	if (!ws) throw new Error(`Unknown workspace: ${workspaceId}`);
 
-	const shell = terminalShell(process.platform, process.env, loadConfig().terminalWindowsShell);
+	const preference = loadConfig().terminalWindowsShell;
+	const shell = terminalShell(process.platform, process.env, preference);
 	const grid = {
 		cols: size.cols ?? DEFAULT_PTY_SIZE.cols,
 		rows: size.rows ?? DEFAULT_PTY_SIZE.rows,
 	};
-	const pty = spawn(shell, terminalShellArgs(process.platform), {
-		name: "xterm-256color",
-		cwd: ws.worktreePath,
-		...grid,
-		env: ptyEnv(),
-	});
+	let pty: IPty;
+	try {
+		pty = spawn(shell, terminalShellArgs(process.platform), {
+			name: "xterm-256color",
+			cwd: ws.worktreePath,
+			...grid,
+			env: ptyEnv(),
+		});
+	} catch (cause) {
+		throw new Error(terminalShellStartFailure(process.platform, process.env, preference), {
+			cause,
+		});
+	}
 
 	const id = randomUUID();
 	const recorder = createOutputRecorder({ maxChars: replayBudgetChars() });

--- a/packages/server/src/terminal/terminalManager.ts
+++ b/packages/server/src/terminal/terminalManager.ts
@@ -289,8 +289,8 @@ export function attachTerminal(
 	}
 
 	const revived = pendingReplay.get(index);
-	pendingReplay.delete(index);
 	const { id, entry } = spawnForTab(workspaceId, tabKey, clientKey, options, revived);
+	pendingReplay.delete(index);
 	if (isNewTab) membershipChanged(workspaceId);
 	const replay = entry.recorder.snapshot();
 	return { id, created: true, ...(replay ? { replay } : {}) };


### PR DESCRIPTION
## Summary

Replace the opaque terminal spawn failure with safe, shell-specific guidance and a recoverable UI. Users can open Terminal Settings or retry the same tab without weakening explicit shell pins or adding protocol/state complexity.

## Changes

- Wrap synchronous PTY spawn failures at the authoritative launch point with stable guidance for `SHELL`, Auto, PowerShell 7, Windows PowerShell, and Command Prompt.
- Render failures as escaped DOM content over an inert terminal with Terminal Settings and Retry actions.
- Preserve revived terminal replay across failed spawns and make retry/focus state safe across repeated failures and contested terminal takeovers.
- Update terminal and panel specs and add server plus browser regressions.

## Testing

- `bun run check:deps && bun run check:boundaries && bun run check:seams` — passed.
- `bun run lint` — passed with 5 pre-existing unused-suppression warnings.
- `bun run typecheck` — 15/15 packages passed.
- `cd packages/server && bun test src/terminal/shellArgs.test.ts src/terminal/terminalManager.test.ts --test-name-pattern "shell start|shell spawn failure"` — 3 passed.
- `bun run e2e -- e2e/terminals.spec.ts --grep "a shell start failure"` — 1 passed using a temporary Windows PATH repair that was reverted immediately afterward.
- `bun run test` — attempted, but the existing Windows path/symlink assumptions fail in CLI, website, shared, and spec-graph tests outside this diff.
- Complete `bun run e2e` — attempted, but the existing Windows harness cannot complete because its hermetic PATH omits required executables and live PTYs leave fixture worktrees locked with `EBUSY` during teardown.

## Checklist

- [ ] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [ ] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


## Screenshots

| Before | After |
| --- | --- |
| ![Before: generic terminal failure](https://github.com/JetBrains/thinkrail/blob/1301096cff69b3f392a82805dd2cacd6b400bd41/terminal-recovery-before.png?raw=true) | ![After: actionable terminal recovery](https://github.com/JetBrains/thinkrail/blob/1301096cff69b3f392a82805dd2cacd6b400bd41/terminal-recovery-after.png?raw=true) |
