### PR TITLE
Persist workspace model and thinking preferences

### DIFF
--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -481,7 +481,7 @@ export default function ChatView({
 			const sessions = await getTransport().request("session.list", { workspaceId });
 			const session = sessions.find((candidate) => candidate.sessionId === sessionId);
 			if (session) {
-				useAppStore.getState().applySessionModelSelection(sessionId, workspaceId, session, false);
+				useAppStore.getState().applySessionModelSelection(sessionId, session);
 			}
 		} catch {
 			return;
@@ -504,7 +504,7 @@ export default function ChatView({
 							session?.thinkingLevel ??
 							runtime.thinkingLevel,
 					};
-			state.applySessionModelSelection(sessionId, workspaceId, effective, supported);
+			state.applySessionModelSelection(sessionId, effective);
 			refreshStats();
 		} catch (error) {
 			toast.error(errorText(error), "Couldn't change model");
@@ -532,7 +532,7 @@ export default function ChatView({
 						thinkingLevel:
 							session?.pendingModelSelectionThinkingLevel ?? session?.thinkingLevel ?? level,
 					};
-			state.applySessionModelSelection(sessionId, workspaceId, effective, supported);
+			state.applySessionModelSelection(sessionId, effective);
 		} catch (error) {
 			toast.error(errorText(error), "Couldn't change effort");
 			await reconcileFailedModelSelection();

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -468,19 +468,28 @@ export default function ChatView({
 
 	const onMentionQuery = useCallback((q: string | null) => setMentionQuery(q), []);
 
-	const onSelectModel = (model: WireModel) => {
-		useAppStore.getState().setCurrentModel(sessionId, model);
-		getTransport()
-			.request("session.setModel", { sessionId, model })
-			.then(() => refreshStats())
-			.catch(() => {});
+	const onSelectModel = async (model: WireModel) => {
+		try {
+			const selection = await getTransport().request("session.setModel", { sessionId, model });
+			useAppStore.getState().applySessionModelSelection(sessionId, workspaceId, selection);
+			refreshStats();
+		} catch (error) {
+			toast.error(errorText(error), "Couldn't change model");
+			throw error;
+		}
 	};
 
-	const onSelectThinking = (level: ThinkingLevel) => {
-		useAppStore.getState().setThinkingLevel(sessionId, level);
-		getTransport()
-			.request("session.setThinkingLevel", { sessionId, level })
-			.catch(() => {});
+	const onSelectThinking = async (level: ThinkingLevel) => {
+		try {
+			const selection = await getTransport().request("session.setThinkingLevel", {
+				sessionId,
+				level,
+			});
+			useAppStore.getState().applySessionModelSelection(sessionId, workspaceId, selection);
+		} catch (error) {
+			toast.error(errorText(error), "Couldn't change effort");
+			throw error;
+		}
 	};
 
 	const restoreTextToDraft = (text: string) => {

--- a/apps/web/src/chat/ChatView.tsx
+++ b/apps/web/src/chat/ChatView.tsx
@@ -24,7 +24,7 @@ import {
 	toast,
 	useAppStore,
 } from "@/store";
-import { errorText, getTransport } from "@/transport";
+import { errorText, getTransport, supportsWorkspaceModelPreferences } from "@/transport";
 import { ACTIVITY_BREADCRUMB_HEIGHT, ActivityBreadcrumbTrail } from "./activityBreadcrumbs";
 import { AskStatesContext, deriveAskStates } from "./askState";
 import { type ChatActions, ChatActionsContext } from "./ChatActions";
@@ -220,6 +220,7 @@ export default function ChatView({
 		extUiWidget,
 		model: sessionModel,
 		thinkingLevel,
+		modelSelectionPending,
 	} = runtime;
 
 	const currentModel = selectCatalogModel(models, sessionModel) ?? sessionModel;
@@ -468,27 +469,76 @@ export default function ChatView({
 
 	const onMentionQuery = useCallback((q: string | null) => setMentionQuery(q), []);
 
+	const beginModelSelection = (): boolean =>
+		useAppStore.getState().beginSessionModelSelection(sessionId);
+
+	const finishModelSelection = () => {
+		useAppStore.getState().finishSessionModelSelection(sessionId);
+	};
+
+	const reconcileFailedModelSelection = async () => {
+		try {
+			const sessions = await getTransport().request("session.list", { workspaceId });
+			const session = sessions.find((candidate) => candidate.sessionId === sessionId);
+			if (session) {
+				useAppStore.getState().applySessionModelSelection(sessionId, workspaceId, session, false);
+			}
+		} catch {
+			return;
+		}
+	};
+
 	const onSelectModel = async (model: WireModel) => {
+		if (!beginModelSelection()) return;
 		try {
 			const selection = await getTransport().request("session.setModel", { sessionId, model });
-			useAppStore.getState().applySessionModelSelection(sessionId, workspaceId, selection);
+			const state = useAppStore.getState();
+			const supported = supportsWorkspaceModelPreferences(state.protocolVersion);
+			const session = state.sessions[sessionId];
+			const effective = supported
+				? selection
+				: {
+						model,
+						thinkingLevel:
+							session?.pendingModelSelectionThinkingLevel ??
+							session?.thinkingLevel ??
+							runtime.thinkingLevel,
+					};
+			state.applySessionModelSelection(sessionId, workspaceId, effective, supported);
 			refreshStats();
 		} catch (error) {
 			toast.error(errorText(error), "Couldn't change model");
+			await reconcileFailedModelSelection();
 			throw error;
+		} finally {
+			finishModelSelection();
 		}
 	};
 
 	const onSelectThinking = async (level: ThinkingLevel) => {
+		if (!beginModelSelection()) return;
 		try {
 			const selection = await getTransport().request("session.setThinkingLevel", {
 				sessionId,
 				level,
 			});
-			useAppStore.getState().applySessionModelSelection(sessionId, workspaceId, selection);
+			const state = useAppStore.getState();
+			const supported = supportsWorkspaceModelPreferences(state.protocolVersion);
+			const session = state.sessions[sessionId];
+			const effective = supported
+				? selection
+				: {
+						model: session?.model ?? null,
+						thinkingLevel:
+							session?.pendingModelSelectionThinkingLevel ?? session?.thinkingLevel ?? level,
+					};
+			state.applySessionModelSelection(sessionId, workspaceId, effective, supported);
 		} catch (error) {
 			toast.error(errorText(error), "Couldn't change effort");
+			await reconcileFailedModelSelection();
 			throw error;
+		} finally {
+			finishModelSelection();
 		}
 	};
 
@@ -1006,6 +1056,7 @@ export default function ChatView({
 							onRefreshModels={onRefreshModels}
 							currentModel={currentModel}
 							thinkingLevel={thinkingLevel}
+							modelSelectionPending={modelSelectionPending}
 							onMentionQuery={onMentionQuery}
 							onSlashActive={setSlashActive}
 							onSelectModel={onSelectModel}

--- a/apps/web/src/chat/Composer.tsx
+++ b/apps/web/src/chat/Composer.tsx
@@ -146,6 +146,7 @@ interface ComposerProps {
 	onRefreshModels: (force: boolean) => void;
 	currentModel: WireModel | null;
 	thinkingLevel: ThinkingLevel;
+	modelSelectionPending: boolean;
 	onMentionQuery: (query: string | null) => void;
 	onSlashActive: (active: boolean) => void;
 	onSelectModel: (model: WireModel) => void;
@@ -186,6 +187,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		onRefreshModels,
 		currentModel,
 		thinkingLevel,
+		modelSelectionPending,
 		onMentionQuery,
 		onSlashActive,
 		onSelectModel,
@@ -676,12 +678,14 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 							refreshing={modelsRefreshing}
 							onRefresh={onRefreshModels}
 							onSelect={onSelectModel}
+							disabled={modelSelectionPending}
 							className="max-w-80 gap-4 px-4 sm:max-w-144"
 						/>
 						<ThinkingSelector
 							level={thinkingLevel}
 							levels={currentModel?.thinkingLevels ?? []}
 							onSelect={onSelectThinking}
+							disabled={modelSelectionPending}
 							showLabel={false}
 							className="gap-4 px-4"
 						/>

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -42,7 +42,7 @@ export function ModelSelector({
 }: {
 	models: WireModel[];
 	current: WireModel | null;
-	onSelect: (model: WireModel) => void;
+	onSelect: (model: WireModel) => void | Promise<void>;
 	refreshing: boolean;
 	onRefresh: (force: boolean) => void;
 	container?: HTMLElement | null;
@@ -54,9 +54,13 @@ export function ModelSelector({
 	const [open, setOpen] = useState(false);
 	const providers = [...new Set(models.map((m) => m.provider))];
 
-	const select = (model: WireModel) => {
-		onSelect(model);
-		setOpen(false);
+	const select = async (model: WireModel) => {
+		try {
+			await onSelect(model);
+			setOpen(false);
+		} catch {
+			return;
+		}
 	};
 
 	return (
@@ -114,7 +118,7 @@ export function ModelSelector({
 												value={`${m.provider} ${m.name} ${m.id}`}
 												data-testid="model-option"
 												data-model-id={m.id}
-												onSelect={() => select(m)}
+												onSelect={() => void select(m)}
 											>
 												<span className="flex w-14 shrink-0 justify-center">
 													{isCurrent ? <Check className="size-14 text-primary" /> : null}

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -39,6 +39,7 @@ export function ModelSelector({
 	placeholder,
 	defaultOption,
 	onSelectDefault,
+	disabled = false,
 }: {
 	models: WireModel[];
 	current: WireModel | null;
@@ -50,11 +51,13 @@ export function ModelSelector({
 	placeholder?: string;
 	defaultOption?: string;
 	onSelectDefault?: () => void;
+	disabled?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	const providers = [...new Set(models.map((m) => m.provider))];
 
 	const select = async (model: WireModel) => {
+		if (disabled) return;
 		try {
 			await onSelect(model);
 			setOpen(false);
@@ -67,6 +70,7 @@ export function ModelSelector({
 		<Popover
 			open={open}
 			onOpenChange={(next) => {
+				if (disabled && next) return;
 				setOpen(next);
 				if (next) onRefresh(false);
 			}}
@@ -74,6 +78,7 @@ export function ModelSelector({
 			<PopoverTrigger
 				data-testid="model-selector"
 				data-open={open}
+				disabled={disabled}
 				className={cn(
 					"flex h-32 max-w-[220px] items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
 					className,
@@ -118,6 +123,7 @@ export function ModelSelector({
 												value={`${m.provider} ${m.name} ${m.id}`}
 												data-testid="model-option"
 												data-model-id={m.id}
+												disabled={disabled}
 												onSelect={() => void select(m)}
 											>
 												<span className="flex w-14 shrink-0 justify-center">
@@ -143,7 +149,7 @@ export function ModelSelector({
 					type="button"
 					data-testid="model-refresh"
 					data-refreshing={refreshing}
-					disabled={refreshing}
+					disabled={refreshing || disabled}
 					onClick={() => onRefresh(true)}
 					className="flex w-full items-center gap-8 border-border-default border-t px-8 py-4 tr-text-metadata text-text-muted outline-none transition-colors hover:bg-control-bg-hovered hover:text-text-default disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-text-muted"
 				>

--- a/apps/web/src/chat/ModelSelector.tsx
+++ b/apps/web/src/chat/ModelSelector.tsx
@@ -80,7 +80,7 @@ export function ModelSelector({
 				data-open={open}
 				disabled={disabled}
 				className={cn(
-					"flex h-32 max-w-[220px] items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
+					"flex h-32 max-w-[220px] items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:border-control-disabled-border disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
 					className,
 				)}
 			>

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -505,10 +505,16 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   yet) disables the trigger. It holds **no effort policy of its own**: when a held level isn't one the
   held model can run, the consumer asks the host for pi's `clampThinkingLevel` answer
   (`model.clampThinking`) — `model.default` clamps the same way. In a live chat, both selectors await the
-  host mutation and close only after success; the web then atomically applies its returned model/thinking
-  pair to the live session and workspace mirror. Pi's effective clamp is authoritative, with no optimistic
-  intermediate state, and a rejection is surfaced while the selector stays open. The same successful
-  mutation also sets that workspace's future-chat starting pair on the host. No separate workspace setting
+  host mutation and close only after success; while either mutation is pending both selectors stay disabled.
+  The per-session lock lives in `store`, surviving a chat-tab unmount/remount, and fences Pi's early
+  `thinking_level_changed` until settlement, so provider auth or extension latency cannot reorder choices or
+  expose an old-model/new-effort pair. The web then atomically applies its returned model/thinking pair to the
+  live session and workspace mirror. Pi's effective
+  clamp is authoritative, with no optimistic intermediate state. A rejection is surfaced while the selector
+  stays open and triggers an authoritative `session.list` pair reconciliation before the lock releases; if
+  that read also fails, the prior pair remains intact. A v64 host's legacy ack instead reconciles the requested session choice without
+  mirroring unsupported workspace persistence. The same successful v65+ mutation also sets that workspace's
+  future-chat starting pair on the host. No separate workspace setting
   or selector mode is introduced. Its rows follow the **live catalog** — `ChatView` resolves the
   session's model through `store`'s `selectCatalogModel` before passing it down, rather than reading the
   session's own snapshot, so a `model.refresh` that changes what a model supports changes the offered

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -504,11 +504,12 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   vocabulary: pi owns it, the host projects the per-model slice, and an empty list (no model resolved
   yet) disables the trigger. It holds **no effort policy of its own**: when a held level isn't one the
   held model can run, the consumer asks the host for pi's `clampThinkingLevel` answer
-  (`model.clampThinking`) — `model.default` clamps the same way. In a live chat, both selectors remain
-  responsive through an optimistic session-store write, then reconcile both model and thinking level from
-  the successful host mutation result; Pi's effective clamp is authoritative and a rejection is surfaced
-  rather than silently discarded. The same successful mutation also sets that workspace's future-chat
-  starting pair on the host. No separate workspace setting or selector mode is introduced. Its rows follow the **live catalog** — `ChatView` resolves the
+  (`model.clampThinking`) — `model.default` clamps the same way. In a live chat, both selectors await the
+  host mutation and close only after success; the web then atomically applies its returned model/thinking
+  pair to the live session and workspace mirror. Pi's effective clamp is authoritative, with no optimistic
+  intermediate state, and a rejection is surfaced while the selector stays open. The same successful
+  mutation also sets that workspace's future-chat starting pair on the host. No separate workspace setting
+  or selector mode is introduced. Its rows follow the **live catalog** — `ChatView` resolves the
   session's model through `store`'s `selectCatalogModel` before passing it down, rather than reading the
   session's own snapshot, so a `model.refresh` that changes what a model supports changes the offered
   levels with it), `SessionStatsBar`, `ChatHeader` (the fixed, single-line **panel-header row** —

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -509,12 +509,13 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   The per-session lock lives in `store`, surviving a chat-tab unmount/remount, and fences Pi's early
   `thinking_level_changed` until settlement, so provider auth or extension latency cannot reorder choices or
   expose an old-model/new-effort pair. The web then atomically applies its returned model/thinking pair to the
-  live session and workspace mirror. Pi's effective
+  live session. Pi's effective
   clamp is authoritative, with no optimistic intermediate state. A rejection is surfaced while the selector
   stays open and triggers an authoritative `session.list` pair reconciliation before the lock releases; if
-  that read also fails, the prior pair remains intact. A v64 host's legacy ack instead reconciles the requested session choice without
-  mirroring unsupported workspace persistence. The same successful v65+ mutation also sets that workspace's
-  future-chat starting pair on the host. No separate workspace setting
+  that read also fails, the prior pair remains intact. A v64 host's legacy ack instead reconciles the
+  requested session choice. The same successful v65+ mutation also sets that workspace's future-chat starting
+  pair on the host, which reaches the client as its own `workspace.updated` push rather than a local mirror
+  write. No separate workspace setting
   or selector mode is introduced. Its rows follow the **live catalog** — `ChatView` resolves the
   session's model through `store`'s `selectCatalogModel` before passing it down, rather than reading the
   session's own snapshot, so a `model.refresh` that changes what a model supports changes the offered

--- a/apps/web/src/chat/SPEC.md
+++ b/apps/web/src/chat/SPEC.md
@@ -504,8 +504,11 @@ from their `toolCall` args and reply through **`ChatActions`** (see below). Work
   vocabulary: pi owns it, the host projects the per-model slice, and an empty list (no model resolved
   yet) disables the trigger. It holds **no effort policy of its own**: when a held level isn't one the
   held model can run, the consumer asks the host for pi's `clampThinkingLevel` answer
-  (`model.clampThinking`) — `model.default` clamps the same way, and a live session gets pi's answer
-  directly via `thinking_level_changed`. Its rows follow the **live catalog** — `ChatView` resolves the
+  (`model.clampThinking`) — `model.default` clamps the same way. In a live chat, both selectors remain
+  responsive through an optimistic session-store write, then reconcile both model and thinking level from
+  the successful host mutation result; Pi's effective clamp is authoritative and a rejection is surfaced
+  rather than silently discarded. The same successful mutation also sets that workspace's future-chat
+  starting pair on the host. No separate workspace setting or selector mode is introduced. Its rows follow the **live catalog** — `ChatView` resolves the
   session's model through `store`'s `selectCatalogModel` before passing it down, rather than reading the
   session's own snapshot, so a `model.refresh` that changes what a model supports changes the offered
   levels with it), `SessionStatsBar`, `ChatHeader` (the fixed, single-line **panel-header row** —

--- a/apps/web/src/chat/ThinkingSelector.tsx
+++ b/apps/web/src/chat/ThinkingSelector.tsx
@@ -11,6 +11,7 @@ export function ThinkingSelector({
 	container,
 	className,
 	showLabel = true,
+	disabled = false,
 }: {
 	level: ThinkingLevel;
 	levels: readonly ThinkingLevel[];
@@ -18,9 +19,11 @@ export function ThinkingSelector({
 	container?: HTMLElement | null;
 	className?: string;
 	showLabel?: boolean;
+	disabled?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	const select = async (next: ThinkingLevel) => {
+		if (disabled) return;
 		try {
 			await onSelect(next);
 			setOpen(false);
@@ -29,11 +32,17 @@ export function ThinkingSelector({
 		}
 	};
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
+		<Popover
+			open={open}
+			onOpenChange={(next) => {
+				if (disabled && next) return;
+				setOpen(next);
+			}}
+		>
 			<PopoverTrigger
 				data-testid="thinking-selector"
 				data-open={open}
-				disabled={levels.length === 0}
+				disabled={disabled || levels.length === 0}
 				className={cn(
 					"flex h-32 items-center gap-8 rounded-[var(--radius-sm)] border border-control-border-default bg-clip-padding bg-control-bg px-8 tr-text-ui text-text-default outline-none transition-colors hover:bg-control-bg-hovered focus-visible:ring-2 focus-visible:ring-primary disabled:border-control-disabled-border disabled:bg-control-disabled-bg disabled:text-control-disabled-text data-[open=true]:border-control-border-active data-[open=true]:bg-control-bg-selected",
 					className,
@@ -51,6 +60,7 @@ export function ThinkingSelector({
 						data-testid="thinking-option"
 						data-level={l}
 						aria-pressed={l === level}
+						disabled={disabled}
 						onClick={() => void select(l)}
 						className="flex w-full items-center gap-8 rounded-[var(--radius-sm)] px-8 py-4 text-left tr-text-ui text-text-default capitalize outline-none transition-colors hover:bg-control-bg-hovered"
 					>

--- a/apps/web/src/chat/ThinkingSelector.tsx
+++ b/apps/web/src/chat/ThinkingSelector.tsx
@@ -14,12 +14,20 @@ export function ThinkingSelector({
 }: {
 	level: ThinkingLevel;
 	levels: readonly ThinkingLevel[];
-	onSelect: (level: ThinkingLevel) => void;
+	onSelect: (level: ThinkingLevel) => void | Promise<void>;
 	container?: HTMLElement | null;
 	className?: string;
 	showLabel?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
+	const select = async (next: ThinkingLevel) => {
+		try {
+			await onSelect(next);
+			setOpen(false);
+		} catch {
+			return;
+		}
+	};
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger
@@ -43,10 +51,7 @@ export function ThinkingSelector({
 						data-testid="thinking-option"
 						data-level={l}
 						aria-pressed={l === level}
-						onClick={() => {
-							onSelect(l);
-							setOpen(false);
-						}}
+						onClick={() => void select(l)}
 						className="flex w-full items-center gap-8 rounded-[var(--radius-sm)] px-8 py-4 text-left tr-text-ui text-text-default capitalize outline-none transition-colors hover:bg-control-bg-hovered"
 					>
 						<span className="flex w-14 shrink-0 justify-center">

--- a/apps/web/src/panels/NewWorkspaceDialog.test.ts
+++ b/apps/web/src/panels/NewWorkspaceDialog.test.ts
@@ -30,7 +30,7 @@ describe("reconcileModel", () => {
 		expect(reconcileModel([bedrockTwin, anthropicOriginal], held, true)).toBe(anthropicOriginal);
 	});
 
-	test("a NON-authoritative catalog never declares a model gone — it can't override the host's default", () => {
+	test("a NON-authoritative catalog never declares a held model gone", () => {
 		const stale = [wm("openai", "o9", ["off"])];
 		expect(reconcileModel(stale, wm("anthropic", "opus-6", ["off", "high"]), false)).toBeNull();
 	});

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -60,12 +60,7 @@ import {
 	useTemplateCommandPicker,
 } from "@/prompt";
 import { selectCatalogModel, toast, useAppStore } from "@/store";
-import {
-	createSessionWithSkillBaseline,
-	errorText,
-	getTransport,
-	supportsWorkspaceModelPreferences,
-} from "@/transport";
+import { createSessionWithSkillBaseline, errorText, getTransport } from "@/transport";
 import { BranchPicker } from "./BranchPicker";
 import { useBranchList } from "./branches";
 import { enterDefaultWorkspace } from "./defaultWorkspace";
@@ -366,9 +361,6 @@ export function NewWorkspaceDialog({
 				session.thinkingLevel,
 				syncedTick,
 			);
-			if (model && supportsWorkspaceModelPreferences(useAppStore.getState().protocolVersion)) {
-				store.applySessionModelSelection(session.sessionId, workspace.id, session);
-			}
 			if (!text) return;
 			store.appendUserMessage(session.sessionId, text);
 			getTransport()

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -116,7 +116,6 @@ export function NewWorkspaceDialog({
 		start: number;
 		end: number;
 	} | null>(null);
-	const hostDefaultAsked = useRef(false);
 	const targetGroupName = useId();
 	const [dialogEl, setDialogEl] = useState<HTMLElement | null>(null);
 	const updatePromptDraft = useCallback(
@@ -193,8 +192,9 @@ export function NewWorkspaceDialog({
 		setSelectedProjectId(projectId);
 		updatePromptDraft(initialPrompt ?? "", null);
 		setTarget("worktree");
+		setModel(null);
+		setThinkingLevel("medium");
 		setCreating(false);
-		hostDefaultAsked.current = false;
 	}, [open, projectId, initialPrompt, updatePromptDraft]);
 
 	useEffect(() => {
@@ -260,26 +260,6 @@ export function NewWorkspaceDialog({
 		fresh: catalogFresh,
 	} = useModelCatalog(open);
 
-	const applyHostDefault = useCallback(() => {
-		let cancelled = false;
-		getTransport()
-			.request("model.default", {})
-			.then((d) => {
-				if (cancelled) return;
-				setModel(d.model);
-				setThinkingLevel(d.thinkingLevel);
-			})
-			.catch(() => {});
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
-	useEffect(() => {
-		if (!open) return;
-		return applyHostDefault();
-	}, [open, applyHostDefault]);
-
 	useEffect(() => {
 		if (!open || !model) return;
 		const next = reconcileModel(models, model, catalogFresh);
@@ -288,10 +268,9 @@ export function NewWorkspaceDialog({
 			if (next !== model) setModel(next);
 			return;
 		}
-		if (hostDefaultAsked.current) return;
-		hostDefaultAsked.current = true;
-		return applyHostDefault();
-	}, [open, models, model, catalogFresh, applyHostDefault]);
+		setModel(null);
+		setThinkingLevel("medium");
+	}, [open, models, model, catalogFresh]);
 
 	useEffect(() => {
 		if (!open || !model) return;
@@ -382,6 +361,7 @@ export function NewWorkspaceDialog({
 				session.thinkingLevel,
 				syncedTick,
 			);
+			if (model) store.applySessionModelSelection(session.sessionId, workspace.id, session);
 			if (!text) return;
 			store.appendUserMessage(session.sessionId, text);
 			getTransport()

--- a/apps/web/src/panels/NewWorkspaceDialog.tsx
+++ b/apps/web/src/panels/NewWorkspaceDialog.tsx
@@ -60,7 +60,12 @@ import {
 	useTemplateCommandPicker,
 } from "@/prompt";
 import { selectCatalogModel, toast, useAppStore } from "@/store";
-import { createSessionWithSkillBaseline, errorText, getTransport } from "@/transport";
+import {
+	createSessionWithSkillBaseline,
+	errorText,
+	getTransport,
+	supportsWorkspaceModelPreferences,
+} from "@/transport";
 import { BranchPicker } from "./BranchPicker";
 import { useBranchList } from "./branches";
 import { enterDefaultWorkspace } from "./defaultWorkspace";
@@ -361,7 +366,9 @@ export function NewWorkspaceDialog({
 				session.thinkingLevel,
 				syncedTick,
 			);
-			if (model) store.applySessionModelSelection(session.sessionId, workspace.id, session);
+			if (model && supportsWorkspaceModelPreferences(useAppStore.getState().protocolVersion)) {
+				store.applySessionModelSelection(session.sessionId, workspace.id, session);
+			}
 			if (!text) return;
 			store.appendUserMessage(session.sessionId, text);
 			getTransport()

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -333,8 +333,10 @@ and branch from the request. The rest stays compact: the base-branch combobox (`
 degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
 a project picker, the prompt hero, and the reused
   `chat/ModelSelector`+`ThinkingSelector` in **pre-session** mode — preselected to the host's **pinned**
-  default via `model.default` so the exact model shows when there is one (values held in dialog state,
-  applied at create time). With **no pinned default the host answers `model: null`** and the dialog holds
+  default via `model.default` so the exact model shows when there is one. The dialog still holds and sends
+  the explicit model/thinking pair at create time; after successful session creation the host also seeds that
+  workspace's future-chat pair from Pi's effective result. With **no pinned default the host answers
+  `model: null`** and the dialog holds
   none: the picker reads **Default model**, the effort control is disabled (no model, no supported set), and
   create sends neither — so pi resolves both exactly as it does for a new chat tab. The dialog must not
   substitute a model of its own choosing here; one resolver, pi's, see `submodule-agent`. The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -332,30 +332,26 @@ empty by default); while the prompt is non-empty (worktree mode), a secondary hi
 and branch from the request. The rest stays compact: the base-branch combobox (`git.listBranches`,
 degrading to local branches offline; a Refresh re-lists; `origin/HEAD` is filtered so no stray `origin`),
 a project picker, the prompt hero, and the reused
-  `chat/ModelSelector`+`ThinkingSelector` in **pre-session** mode — preselected to the host's **pinned**
-  default via `model.default` so the exact model shows when there is one. The dialog still holds and sends
-  the explicit model/thinking pair at create time; after successful session creation the host also seeds that
-  workspace's future-chat pair from Pi's effective result. With **no pinned default the host answers
-  `model: null`** and the dialog holds
-  none: the picker reads **Default model**, the effort control is disabled (no model, no supported set), and
-  create sends neither — so pi resolves both exactly as it does for a new chat tab. The dialog must not
-  substitute a model of its own choosing here; one resolver, pi's, see `submodule-agent`. The pickers' popovers portal into the dialog node (so their lists scroll under the Dialog scroll
-  lock). Their catalog is the shared one — `chat/useModelCatalog`, so the dialog and the chat composer
-  cannot drift — which means it is **live**: the picker's Refresh row can replace the list underneath a
-  held selection. The dialog therefore reconciles the held model against it on every change via the pure
-  **`reconcileModel`** (model only — effort is decided by the host's clamp, below): re-point to the same
-  `{provider,id}` (the refreshed object, whose `thinkingLevels` may differ). What it does when the catalog
-  has no such model turns on **`catalogFresh`** — the store's `modelsFresh`, true only for the installed
-  result of an awaited forced refresh the host reported **`complete`** (a capped wait can answer with a
-  current-but-unsettled list, which is no basis for a verdict), dropped by the next `model.list` install from any consumer (whose
-  handler answers from before the detached refresh it starts) *and* dropped up front by any consumer
-  activating. On a fresh catalog it returns **`"unavailable"`** — a verdict, not a replacement: the dialog
-  then asks **`model.default`** (the host's pinned default or none, plus a consistent effort) exactly as it
-  does for the preselect, through **one** `applyHostDefault` — so no client-side copy of the host's default
-  policy exists here. Asked at most once per opening, so a still-missing model can't spin the effect. Effort is a separate concern: one effect keeps the held level
-  runnable by the held model by asking the host for pi's clamp (**`model.clampThinking`**) rather than
-  deciding locally, so an explicit switch and a refresh that shrank a model's set resolve the same way
-  pi would. `model.default` needs no adjustment: the host already returns a self-consistent pair.
+  `chat/ModelSelector`+`ThinkingSelector` in **pre-session** mode. Each opening starts with **no explicit
+  model**: the picker reads **Default model**, the effort control is disabled (no model, no supported set),
+  and creation sends neither field so the host applies its workspace/default precedence. The dialog does
+  not fetch `model.default` or substitute a client-selected fallback. Choosing a model makes that pair
+  explicit; after successful session creation the host seeds the workspace from Pi's effective result and
+  the web mirrors that returned pair. The pickers' popovers portal into the dialog node (so their lists
+  scroll under the Dialog scroll lock). Their catalog is the shared one — `chat/useModelCatalog`, so the
+  dialog and the chat composer cannot drift — which means it is **live**: the picker's Refresh row can
+  replace the list underneath a held selection. The dialog therefore reconciles the held model against it
+  on every change via the pure **`reconcileModel`** (model only — effort is decided by the host's clamp,
+  below): re-point to the same `{provider,id}` (the refreshed object, whose `thinkingLevels` may differ).
+  What it does when the catalog has no such model turns on **`catalogFresh`** — the store's `modelsFresh`,
+  true only for the installed result of an awaited forced refresh the host reported **`complete`** (a capped
+  wait can answer with a current-but-unsettled list, which is no basis for a verdict), dropped by the next
+  `model.list` install from any consumer (whose handler answers from before the detached refresh it starts)
+  *and* dropped up front by any consumer activating. On a fresh catalog it returns **`"unavailable"`** and
+  the dialog clears the explicit choice back to **Default model** without naming a replacement. Effort is a
+  separate concern: one effect keeps an explicit held level runnable by its held model by asking the host
+  for pi's clamp (**`model.clampThinking`**) rather than deciding locally, so an explicit switch and a
+  refresh that shrank a model's set resolve the same way pi would.
   On open and project-picker changes, the dialog reads **`skill.list({projectId})`**; whenever a leading
   slash token becomes active it also reads **`template.list({projectId})`**. It feeds both into the shared
   `prompt` module, so Create Workspace and live chat use the same filtering, menu, keyboard navigation,

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -336,9 +336,10 @@ a project picker, the prompt hero, and the reused
   model**: the picker reads **Default model**, the effort control is disabled (no model, no supported set),
   and creation sends neither field so the host applies its workspace/default precedence. The dialog does
   not fetch `model.default` or substitute a client-selected fallback. Choosing a model makes that pair
-  explicit; after successful session creation a v65+ host seeds the workspace from Pi's effective result and
-  the web mirrors that returned pair. Against an older host the session still opens with its returned effective
-  pair, but the web does not pretend that unsupported workspace persistence occurred. The pickers' popovers portal into the dialog node (so their lists
+  explicit; after successful session creation a v65+ host seeds the workspace from Pi's effective result, and
+  that row reaches the dialog's client as `workspace.updated` — the dialog never writes it, so an older host
+  simply persists nothing and needs no branch here. The session opens with its returned effective pair either
+  way. The pickers' popovers portal into the dialog node (so their lists
   scroll under the Dialog scroll lock). Their catalog is the shared one — `chat/useModelCatalog`, so the
   dialog and the chat composer cannot drift — which means it is **live**: the picker's Refresh row can
   replace the list underneath a held selection. The dialog therefore reconciles the held model against it

--- a/apps/web/src/panels/SPEC.md
+++ b/apps/web/src/panels/SPEC.md
@@ -336,8 +336,9 @@ a project picker, the prompt hero, and the reused
   model**: the picker reads **Default model**, the effort control is disabled (no model, no supported set),
   and creation sends neither field so the host applies its workspace/default precedence. The dialog does
   not fetch `model.default` or substitute a client-selected fallback. Choosing a model makes that pair
-  explicit; after successful session creation the host seeds the workspace from Pi's effective result and
-  the web mirrors that returned pair. The pickers' popovers portal into the dialog node (so their lists
+  explicit; after successful session creation a v65+ host seeds the workspace from Pi's effective result and
+  the web mirrors that returned pair. Against an older host the session still opens with its returned effective
+  pair, but the web does not pretend that unsupported workspace persistence occurred. The pickers' popovers portal into the dialog node (so their lists
   scroll under the Dialog scroll lock). Their catalog is the shared one — `chat/useModelCatalog`, so the
   dialog and the chat composer cannot drift — which means it is **live**: the picker's Refresh row can
   replace the list underneath a held selection. The dialog therefore reconciles the held model against it

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -153,16 +153,24 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   `thinkingLevel` / **`eventRevision`** (browser-local, incremented for every
   received Pi event; the compare-and-install fence for an authoritative transcript read) /
   **`syncedConnectionGeneration`** (which connected host generation the runtime's transcript was last read
-  from) / `stats` / **`statsRefreshTick`** (browser-local invalidation for the mounted chat's authoritative
+  from) / **`modelSelectionPending` + `pendingModelSelectionThinkingLevel`** (per-session mutation lock and
+  hidden Pi-event fence that survive a `ChatView` tab remount) / `stats` / **`statsRefreshTick`**
+  (browser-local invalidation for the mounted chat's authoritative
   stats read) / `commands` / `draft` and its **extension-UI state** (`pendingExtUi` (typed by
   `chat`'s `ExtUiDialogRequest`) + `extUiQueue` (overlapping dialogs FIFO so none orphans its server
   promise) + `extUiStatus` / `extUiWidget`). `openChatSession` creates a runtime; `closeChatRuntime` /
   `clearWorkspaceState` drop it; per-session mutators (`appendUserMessage` / **`appendErrorTurn`** / `setStats` / `setCommands` /
-  `setChatDraft` / `clearPendingExtUi`) take a `sessionId`. **`applySessionModelSelection(sessionId,
-  workspaceId, effectivePair)`** is the one model-selection writer: in one store commit it replaces both live
-  session fields and, when Pi names an effective model, mirrors the complete pair onto the matching workspace
-  row. A null effective model still updates the live session but leaves the persisted workspace mirror alone,
-  so a one-session fallback cannot silently self-heal a stale preference.
+  `setChatDraft` / `clearPendingExtUi`) take a `sessionId`. `beginSessionModelSelection` atomically admits only
+  one model/effort mutation for that runtime; while held, `thinking_level_changed` records a hidden effective
+  level instead of exposing a mixed pair. On rejection `ChatView` reconciles the complete session pair through
+  `session.list`; if that read also fails, `finishSessionModelSelection` discards the hidden level and preserves
+  the previous visible pair rather than manufacturing an old-model/new-effort state.
+  **`applySessionModelSelection(sessionId,
+  workspaceId, effectivePair, mirrorWorkspace?)`** is the one model-selection writer: in one store commit it
+  replaces both live session fields and, for a v65 host when Pi names an effective model, mirrors the complete
+  pair onto the matching workspace row. A pre-v65 reconciliation passes `false` because that host did not
+  persist the pair. A null effective model still updates the live session but leaves the persisted workspace
+  mirror alone, so a one-session fallback cannot silently self-heal a stale preference.
   **`appendErrorTurn(sessionId, text)`** appends an `error` turn for a **rejected** turn-driving wire call
   (`session.prompt`/`steer`/`followUp`/`create`) — e.g. `prompt()` throwing "no API key" / a bad model —
   so a failed send lands in the chat instead of being swallowed; it carries no recovery action because Pi

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -158,7 +158,11 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   `chat`'s `ExtUiDialogRequest`) + `extUiQueue` (overlapping dialogs FIFO so none orphans its server
   promise) + `extUiStatus` / `extUiWidget`). `openChatSession` creates a runtime; `closeChatRuntime` /
   `clearWorkspaceState` drop it; per-session mutators (`appendUserMessage` / **`appendErrorTurn`** / `setStats` / `setCommands` /
-  `setCurrentModel` / `setThinkingLevel` / `setChatDraft` / `clearPendingExtUi`) take a `sessionId`.
+  `setChatDraft` / `clearPendingExtUi`) take a `sessionId`. **`applySessionModelSelection(sessionId,
+  workspaceId, effectivePair)`** is the one model-selection writer: in one store commit it replaces both live
+  session fields and, when Pi names an effective model, mirrors the complete pair onto the matching workspace
+  row. A null effective model still updates the live session but leaves the persisted workspace mirror alone,
+  so a one-session fallback cannot silently self-heal a stale preference.
   **`appendErrorTurn(sessionId, text)`** appends an `error` turn for a **rejected** turn-driving wire call
   (`session.prompt`/`steer`/`followUp`/`create`) — e.g. `prompt()` throwing "no API key" / a bad model —
   so a failed send lands in the chat instead of being swallowed; it carries no recovery action because Pi
@@ -333,7 +337,7 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   becomes real. The host-wide **`models`** list stays global (not per session), plus
   **`modelsRefreshing`** — the awaited `model.refresh` in-flight flag — and **`modelsFresh`**, the
   *provenance* of that list: true only while it holds the installed result of an awaited forced refresh,
-  which `NewWorkspaceDialog` needs before it may substitute a model the catalog lacks. It lives here,
+  which `NewWorkspaceDialog` needs before it may clear an explicit held model the catalog lacks. It lives here,
   beside the list, precisely **because `models` is app-wide**: `setModelsForProviderVersion` (a guarded
   `model.list` snapshot, whose handler answers from before the detached refresh it starts) **drops** it in the same write, so authority
   falls with the list any consumer replaced — held as one consumer's local flag it would outlive its

--- a/apps/web/src/store/SPEC.md
+++ b/apps/web/src/store/SPEC.md
@@ -165,12 +165,12 @@ per-workspace views/attention, terminal catalogs, and one **per-session chat run
   level instead of exposing a mixed pair. On rejection `ChatView` reconciles the complete session pair through
   `session.list`; if that read also fails, `finishSessionModelSelection` discards the hidden level and preserves
   the previous visible pair rather than manufacturing an old-model/new-effort state.
-  **`applySessionModelSelection(sessionId,
-  workspaceId, effectivePair, mirrorWorkspace?)`** is the one model-selection writer: in one store commit it
-  replaces both live session fields and, for a v65 host when Pi names an effective model, mirrors the complete
-  pair onto the matching workspace row. A pre-v65 reconciliation passes `false` because that host did not
-  persist the pair. A null effective model still updates the live session but leaves the persisted workspace
-  mirror alone, so a one-session fallback cannot silently self-heal a stale preference.
+  **`applySessionModelSelection(sessionId, effectivePair)`** is the one model-selection writer: in one store
+  commit it replaces both live session fields, releases the lock, and **advances `eventRevision`** so a
+  transcript read already in flight loses `reconcileSession`'s compare-and-install fence instead of reverting
+  the pair the user just applied. It never writes the workspace row: the host persists the preference and
+  publishes `workspace.updated` before it answers the mutation, so a client-side mirror would be a second
+  writer for state that has already arrived.
   **`appendErrorTurn(sessionId, text)`** appends an `error` turn for a **rejected** turn-driving wire call
   (`session.prompt`/`steer`/`followUp`/`create`) — e.g. `prompt()` throwing "no API key" / a bad model —
   so a failed send lands in the chat instead of being swallowed; it carries no recovery action because Pi

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -215,7 +215,7 @@ test("selectLastOpenChatSession: active chat tab first, then the most recent cha
 	expect(selectLastOpenChatSession(useAppStore.getState(), "ws1")).toBe("s2");
 });
 
-test("effective session selections update runtime and workspace atomically without self-healing null", () => {
+test("effective session selections apply in one commit and fence a stale transcript resync", () => {
 	const oldModel = {
 		id: "old",
 		name: "Old",
@@ -239,45 +239,28 @@ test("effective session selections update runtime and workspace atomically witho
 	const store = useAppStore.getState();
 	store.setWorkspaces("p1", [workspace]);
 	store.openChatSession("ws1", "s1", oldModel, "high");
+	const revisionBefore = rt("s1").eventRevision;
 	let commits = 0;
 	const unsubscribe = useAppStore.subscribe(() => {
 		commits += 1;
 	});
 
-	store.applySessionModelSelection("s1", "ws1", {
-		model: nextModel,
-		thinkingLevel: "off",
-	});
+	store.applySessionModelSelection("s1", { model: nextModel, thinkingLevel: "off" });
 	unsubscribe();
 
 	expect(commits).toBe(1);
 	expect(rt("s1")).toMatchObject({ model: nextModel, thinkingLevel: "off" });
+	expect(rt("s1").eventRevision).toBe(revisionBefore + 1);
 	expect(useAppStore.getState().workspaces.p1?.[0]).toMatchObject({
-		model: nextModel,
-		thinkingLevel: "off",
+		model: oldModel,
+		thinkingLevel: "high",
 	});
 
-	useAppStore.getState().applySessionModelSelection("s1", "ws1", {
-		model: null,
-		thinkingLevel: "medium",
-	});
+	useAppStore.getState().applySessionModelSelection("s1", { model: null, thinkingLevel: "medium" });
 	expect(rt("s1")).toMatchObject({ model: null, thinkingLevel: "medium" });
-	expect(useAppStore.getState().workspaces.p1?.[0]).toMatchObject({
-		model: nextModel,
-		thinkingLevel: "off",
-	});
-
-	useAppStore
-		.getState()
-		.applySessionModelSelection("s1", "ws1", { model: oldModel, thinkingLevel: "high" }, false);
-	expect(rt("s1")).toMatchObject({ model: oldModel, thinkingLevel: "high" });
-	expect(useAppStore.getState().workspaces.p1?.[0]).toMatchObject({
-		model: nextModel,
-		thinkingLevel: "off",
-	});
 });
 
-test("model selection locks survive view remounts and fence thinking events until settlement", () => {
+test("model selection locks survive a chat-tab close/reopen and fence thinking events until settlement", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "s1", null, "high");
 
@@ -289,6 +272,14 @@ test("model selection locks survive view remounts and fence thinking events unti
 		modelSelectionPending: true,
 		pendingModelSelectionThinkingLevel: "off",
 	});
+
+	useAppStore.getState().closeChatToHistory("s1", false, "ws1");
+	useAppStore.getState().openChatSession("ws1", "s1", null, "high");
+	expect(rt("s1")).toMatchObject({
+		modelSelectionPending: true,
+		pendingModelSelectionThinkingLevel: "off",
+	});
+	expect(useAppStore.getState().beginSessionModelSelection("s1")).toBe(false);
 
 	useAppStore.getState().finishSessionModelSelection("s1");
 	expect(rt("s1")).toMatchObject({

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -266,6 +266,36 @@ test("effective session selections update runtime and workspace atomically witho
 		model: nextModel,
 		thinkingLevel: "off",
 	});
+
+	useAppStore
+		.getState()
+		.applySessionModelSelection("s1", "ws1", { model: oldModel, thinkingLevel: "high" }, false);
+	expect(rt("s1")).toMatchObject({ model: oldModel, thinkingLevel: "high" });
+	expect(useAppStore.getState().workspaces.p1?.[0]).toMatchObject({
+		model: nextModel,
+		thinkingLevel: "off",
+	});
+});
+
+test("model selection locks survive view remounts and fence thinking events until settlement", () => {
+	const store = useAppStore.getState();
+	store.openChatSession("ws1", "s1", null, "high");
+
+	expect(store.beginSessionModelSelection("s1")).toBe(true);
+	expect(useAppStore.getState().beginSessionModelSelection("s1")).toBe(false);
+	useAppStore.getState().handlePiEvent({ type: "thinking_level_changed", level: "off" }, "s1");
+	expect(rt("s1")).toMatchObject({
+		thinkingLevel: "high",
+		modelSelectionPending: true,
+		pendingModelSelectionThinkingLevel: "off",
+	});
+
+	useAppStore.getState().finishSessionModelSelection("s1");
+	expect(rt("s1")).toMatchObject({
+		thinkingLevel: "high",
+		modelSelectionPending: false,
+		pendingModelSelectionThinkingLevel: null,
+	});
 });
 
 test("pi events route to the right session runtime; chats stay independent", () => {

--- a/apps/web/src/store/appStore.test.ts
+++ b/apps/web/src/store/appStore.test.ts
@@ -215,6 +215,59 @@ test("selectLastOpenChatSession: active chat tab first, then the most recent cha
 	expect(selectLastOpenChatSession(useAppStore.getState(), "ws1")).toBe("s2");
 });
 
+test("effective session selections update runtime and workspace atomically without self-healing null", () => {
+	const oldModel = {
+		id: "old",
+		name: "Old",
+		provider: "faux",
+		contextWindow: 1000,
+		reasoning: true,
+		thinkingLevels: ["off", "high"],
+	} as WireModel;
+	const nextModel = { ...oldModel, id: "next", name: "Next", reasoning: false };
+	const workspace = {
+		id: "ws1",
+		projectId: "p1",
+		name: "Workspace",
+		branch: "main",
+		baseBranch: "main",
+		worktreePath: "/tmp/ws1",
+		createdAt: 1,
+		model: oldModel,
+		thinkingLevel: "high",
+	} as Workspace;
+	const store = useAppStore.getState();
+	store.setWorkspaces("p1", [workspace]);
+	store.openChatSession("ws1", "s1", oldModel, "high");
+	let commits = 0;
+	const unsubscribe = useAppStore.subscribe(() => {
+		commits += 1;
+	});
+
+	store.applySessionModelSelection("s1", "ws1", {
+		model: nextModel,
+		thinkingLevel: "off",
+	});
+	unsubscribe();
+
+	expect(commits).toBe(1);
+	expect(rt("s1")).toMatchObject({ model: nextModel, thinkingLevel: "off" });
+	expect(useAppStore.getState().workspaces.p1?.[0]).toMatchObject({
+		model: nextModel,
+		thinkingLevel: "off",
+	});
+
+	useAppStore.getState().applySessionModelSelection("s1", "ws1", {
+		model: null,
+		thinkingLevel: "medium",
+	});
+	expect(rt("s1")).toMatchObject({ model: null, thinkingLevel: "medium" });
+	expect(useAppStore.getState().workspaces.p1?.[0]).toMatchObject({
+		model: nextModel,
+		thinkingLevel: "off",
+	});
+});
+
 test("pi events route to the right session runtime; chats stay independent", () => {
 	const store = useAppStore.getState();
 	store.openChatSession("ws1", "a", null, "medium");

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -18,6 +18,7 @@ import type {
 	SessionActivity,
 	SessionActivityPayload,
 	SessionEventPayload,
+	SessionModelSelection,
 	SessionQueueState,
 	SessionStats,
 	SessionSummary,
@@ -982,8 +983,11 @@ interface AppState {
 	beginModelsRefresh: () => number;
 	finishModelsRefresh: (providerVersion: number, result: RefreshedModels | null) => void;
 	dropModelsFreshness: () => void;
-	setCurrentModel: (sessionId: string, model: WireModel) => void;
-	setThinkingLevel: (sessionId: string, level: ThinkingLevel) => void;
+	applySessionModelSelection: (
+		sessionId: string,
+		workspaceId: string,
+		selection: SessionModelSelection,
+	) => void;
 	setStats: (sessionId: string, stats: SessionStats) => void;
 	setCommands: (sessionId: string, commands: SlashCommandInfo[]) => void;
 	setChatDraft: (sessionId: string, text: string) => void;
@@ -3027,10 +3031,39 @@ export const useAppStore = create<AppState>((set, get) => ({
 					}
 				: s,
 		),
-	setCurrentModel: (sessionId, model) =>
-		set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, model }))),
-	setThinkingLevel: (sessionId, level) =>
-		set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, thinkingLevel: level }))),
+	applySessionModelSelection: (sessionId, workspaceId, selection) =>
+		set((s) => {
+			const runtime = s.sessions[sessionId];
+			if (!runtime) return {};
+			const sessions = {
+				...s.sessions,
+				[sessionId]: {
+					...runtime,
+					model: selection.model,
+					thinkingLevel: selection.thinkingLevel,
+				},
+			};
+			const model = selection.model;
+			if (!model) return { sessions };
+			const workspace = selectWorkspaceById(s, workspaceId);
+			const list = workspace ? s.workspaces[workspace.projectId] : undefined;
+			if (!workspace || !list) return { sessions };
+			return {
+				sessions,
+				workspaces: {
+					...s.workspaces,
+					[workspace.projectId]: list.map((candidate) =>
+						candidate.id === workspaceId
+							? {
+									...candidate,
+									model,
+									thinkingLevel: selection.thinkingLevel,
+								}
+							: candidate,
+					),
+				},
+			};
+		}),
 	setStats: (sessionId, stats) => set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, stats }))),
 	setCommands: (sessionId, commands) =>
 		set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, commands }))),

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -335,6 +335,8 @@ export interface SessionRuntime {
 	queue: SessionQueueState;
 	model: WireModel | null;
 	thinkingLevel: ThinkingLevel;
+	modelSelectionPending: boolean;
+	pendingModelSelectionThinkingLevel: ThinkingLevel | null;
 	eventRevision: number;
 	syncedConnectionGeneration: number;
 	stats: SessionStats | null;
@@ -365,6 +367,8 @@ function newRuntime(
 		queue: EMPTY_QUEUE,
 		model,
 		thinkingLevel,
+		modelSelectionPending: false,
+		pendingModelSelectionThinkingLevel: null,
 		eventRevision: 0,
 		syncedConnectionGeneration,
 		stats: null,
@@ -689,7 +693,9 @@ export function reduceSessionEvent(rt: SessionRuntime, event: PiEvent): SessionR
 		case "summarization_retry_finished":
 			return clearRetryTurns(rt, "summarization");
 		case "thinking_level_changed":
-			return { ...rt, thinkingLevel: event.level };
+			return rt.modelSelectionPending
+				? { ...rt, pendingModelSelectionThinkingLevel: event.level }
+				: { ...rt, thinkingLevel: event.level };
 		default:
 			return rt;
 	}
@@ -983,10 +989,13 @@ interface AppState {
 	beginModelsRefresh: () => number;
 	finishModelsRefresh: (providerVersion: number, result: RefreshedModels | null) => void;
 	dropModelsFreshness: () => void;
+	beginSessionModelSelection: (sessionId: string) => boolean;
+	finishSessionModelSelection: (sessionId: string) => void;
 	applySessionModelSelection: (
 		sessionId: string,
 		workspaceId: string,
 		selection: SessionModelSelection,
+		mirrorWorkspace?: boolean,
 	) => void;
 	setStats: (sessionId: string, stats: SessionStats) => void;
 	setCommands: (sessionId: string, commands: SlashCommandInfo[]) => void;
@@ -3031,7 +3040,33 @@ export const useAppStore = create<AppState>((set, get) => ({
 					}
 				: s,
 		),
-	applySessionModelSelection: (sessionId, workspaceId, selection) =>
+	beginSessionModelSelection: (sessionId) => {
+		let began = false;
+		set((s) =>
+			withRuntime(s, sessionId, (runtime) => {
+				if (runtime.modelSelectionPending) return runtime;
+				began = true;
+				return {
+					...runtime,
+					modelSelectionPending: true,
+					pendingModelSelectionThinkingLevel: null,
+				};
+			}),
+		);
+		return began;
+	},
+	finishSessionModelSelection: (sessionId) =>
+		set((s) =>
+			withRuntime(s, sessionId, (runtime) => {
+				if (!runtime.modelSelectionPending) return runtime;
+				return {
+					...runtime,
+					modelSelectionPending: false,
+					pendingModelSelectionThinkingLevel: null,
+				};
+			}),
+		),
+	applySessionModelSelection: (sessionId, workspaceId, selection, mirrorWorkspace = true) =>
 		set((s) => {
 			const runtime = s.sessions[sessionId];
 			if (!runtime) return {};
@@ -3041,10 +3076,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 					...runtime,
 					model: selection.model,
 					thinkingLevel: selection.thinkingLevel,
+					modelSelectionPending: false,
+					pendingModelSelectionThinkingLevel: null,
 				},
 			};
 			const model = selection.model;
-			if (!model) return { sessions };
+			if (!model || !mirrorWorkspace) return { sessions };
 			const workspace = selectWorkspaceById(s, workspaceId);
 			const list = workspace ? s.workspaces[workspace.projectId] : undefined;
 			if (!workspace || !list) return { sessions };

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -991,12 +991,7 @@ interface AppState {
 	dropModelsFreshness: () => void;
 	beginSessionModelSelection: (sessionId: string) => boolean;
 	finishSessionModelSelection: (sessionId: string) => void;
-	applySessionModelSelection: (
-		sessionId: string,
-		workspaceId: string,
-		selection: SessionModelSelection,
-		mirrorWorkspace?: boolean,
-	) => void;
+	applySessionModelSelection: (sessionId: string, selection: SessionModelSelection) => void;
 	setStats: (sessionId: string, stats: SessionStats) => void;
 	setCommands: (sessionId: string, commands: SlashCommandInfo[]) => void;
 	setChatDraft: (sessionId: string, text: string) => void;
@@ -3066,41 +3061,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 				};
 			}),
 		),
-	applySessionModelSelection: (sessionId, workspaceId, selection, mirrorWorkspace = true) =>
-		set((s) => {
-			const runtime = s.sessions[sessionId];
-			if (!runtime) return {};
-			const sessions = {
-				...s.sessions,
-				[sessionId]: {
-					...runtime,
-					model: selection.model,
-					thinkingLevel: selection.thinkingLevel,
-					modelSelectionPending: false,
-					pendingModelSelectionThinkingLevel: null,
-				},
-			};
-			const model = selection.model;
-			if (!model || !mirrorWorkspace) return { sessions };
-			const workspace = selectWorkspaceById(s, workspaceId);
-			const list = workspace ? s.workspaces[workspace.projectId] : undefined;
-			if (!workspace || !list) return { sessions };
-			return {
-				sessions,
-				workspaces: {
-					...s.workspaces,
-					[workspace.projectId]: list.map((candidate) =>
-						candidate.id === workspaceId
-							? {
-									...candidate,
-									model,
-									thinkingLevel: selection.thinkingLevel,
-								}
-							: candidate,
-					),
-				},
-			};
-		}),
+	applySessionModelSelection: (sessionId, selection) =>
+		set((s) =>
+			withRuntime(s, sessionId, (runtime) => ({
+				...runtime,
+				model: selection.model,
+				thinkingLevel: selection.thinkingLevel,
+				eventRevision: runtime.eventRevision + 1,
+				modelSelectionPending: false,
+				pendingModelSelectionThinkingLevel: null,
+			})),
+		),
 	setStats: (sessionId, stats) => set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, stats }))),
 	setCommands: (sessionId, commands) =>
 		set((s) => withRuntime(s, sessionId, (rt) => ({ ...rt, commands }))),

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -123,14 +123,17 @@ batches high-frequency Pi events without allowing later wire messages to overtak
   workspace and session, making that untrusted-response identity check one shared installation boundary rather
   than a caller convention).
 - **Public surface (barrel):** `initTransport`, `getTransport`, `prewarmWorkspaceSkillLoad`, the three
-  skill-load-safe session request wrappers, `errorText`, `RequestError`, `wsErrorCode`, `ConnectionStatus`,
-  `TransportOptions`. `supportsSessionActivity` stays module-internal (its own tests import the file
-  directly) — no sibling decides the activity capability, this module does.
+  skill-load-safe session request wrappers, `supportsWorkspaceModelPreferences`, `errorText`, `RequestError`,
+  `wsErrorCode`, `ConnectionStatus`, `TransportOptions`. `supportsWorkspaceModelPreferences` is the shared
+  `WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION` gate for mutation-result reconciliation and workspace
+  mirroring. `supportsSessionActivity` stays module-internal (its own tests import the file directly) — no
+  sibling decides the activity capability, this module does.
 - **Allowed deps:** `contracts` (method maps, `WS_CHANNELS`, `Project` for welcome + `project.updated`, `SessionEventPayload`
   for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.created`/`updated`,
   `WorkspaceRemoved` for `workspace.removed`, `SessionCreatedPayload` for `session.created`,
   `SessionDeletedPayload` for `session.deleted`, `SessionActivityPayload` +
-  `ACTIVITY_PROTOCOL_VERSION` for `session.activity` and its snapshot gate, `provider.changed`, the empty addressed
+  `ACTIVITY_PROTOCOL_VERSION` for `session.activity` and its snapshot gate,
+  `WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION` for model-preference reconciliation, `provider.changed`, the empty addressed
   `feedback.interview` invitation, `HostUpdateNotice` for `server.welcome` + `host.updateAvailable`,
   `WorkspaceFsChangedPayload` for `workspace.fsChanged`, and `AppConfig` for `server.welcome`'s config +
   `settings.changed`); `store`

--- a/apps/web/src/transport/SPEC.md
+++ b/apps/web/src/transport/SPEC.md
@@ -125,8 +125,9 @@ batches high-frequency Pi events without allowing later wire messages to overtak
 - **Public surface (barrel):** `initTransport`, `getTransport`, `prewarmWorkspaceSkillLoad`, the three
   skill-load-safe session request wrappers, `supportsWorkspaceModelPreferences`, `errorText`, `RequestError`,
   `wsErrorCode`, `ConnectionStatus`, `TransportOptions`. `supportsWorkspaceModelPreferences` is the shared
-  `WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION` gate for mutation-result reconciliation and workspace
-  mirroring. `supportsSessionActivity` stays module-internal (its own tests import the file directly) — no
+  `WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION` gate for mutation-result reconciliation: it decides whether a
+  result carries Pi's effective pair or is a v64 ack the caller must reconstruct the pair around.
+  `supportsSessionActivity` stays module-internal (its own tests import the file directly) — no
   sibling decides the activity capability, this module does.
 - **Allowed deps:** `contracts` (method maps, `WS_CHANNELS`, `Project` for welcome + `project.updated`, `SessionEventPayload`
   for `pi.event`, `ExtUiRequest` for `pi.extensionUi`, `Workspace` for `workspace.created`/`updated`,

--- a/apps/web/src/transport/index.ts
+++ b/apps/web/src/transport/index.ts
@@ -7,4 +7,8 @@ export {
 	reloadSessionResourcesWithSkillBaseline,
 } from "./skillLoad";
 export type { ConnectionStatus, TransportOptions } from "./transport";
-export { getTransport, initTransport } from "./wireTransport";
+export {
+	getTransport,
+	initTransport,
+	supportsWorkspaceModelPreferences,
+} from "./wireTransport";

--- a/apps/web/src/transport/wireTransport.test.ts
+++ b/apps/web/src/transport/wireTransport.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test";
-import { ACTIVITY_PROTOCOL_VERSION } from "@thinkrail/contracts";
-import { supportsSessionActivity } from "./wireTransport";
+import {
+	ACTIVITY_PROTOCOL_VERSION,
+	WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION,
+} from "@thinkrail/contracts";
+import { supportsSessionActivity, supportsWorkspaceModelPreferences } from "./wireTransport";
 
 test("a host at or beyond the activity version supports the layer", () => {
 	expect(supportsSessionActivity(ACTIVITY_PROTOCOL_VERSION)).toBe(true);
@@ -10,4 +13,12 @@ test("a host at or beyond the activity version supports the layer", () => {
 test("an older host and a pre-welcome connection do not, so the client clears rather than keeps glyphs", () => {
 	expect(supportsSessionActivity(ACTIVITY_PROTOCOL_VERSION - 1)).toBe(false);
 	expect(supportsSessionActivity(null)).toBe(false);
+});
+
+test("workspace model preference reconciliation requires a v65 host", () => {
+	expect(supportsWorkspaceModelPreferences(WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION)).toBe(true);
+	expect(supportsWorkspaceModelPreferences(WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION - 1)).toBe(
+		false,
+	);
+	expect(supportsWorkspaceModelPreferences(null)).toBe(false);
 });

--- a/apps/web/src/transport/wireTransport.ts
+++ b/apps/web/src/transport/wireTransport.ts
@@ -14,7 +14,11 @@ import type {
 	WorkspaceFsChangedPayload,
 	WorkspaceRemoved,
 } from "@thinkrail/contracts";
-import { ACTIVITY_PROTOCOL_VERSION, WS_CHANNELS } from "@thinkrail/contracts";
+import {
+	ACTIVITY_PROTOCOL_VERSION,
+	WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION,
+	WS_CHANNELS,
+} from "@thinkrail/contracts";
 import { isConnectedGeneration, useAppStore } from "../store";
 import { createActivityHydration } from "./activityHydration";
 import { createPiEventBatcher, shouldFlushPiEventsBefore } from "./piEventBatcher";
@@ -24,6 +28,10 @@ let transport: WsTransport | null = null;
 
 export function supportsSessionActivity(protocolVersion: number | null): boolean {
 	return protocolVersion !== null && protocolVersion >= ACTIVITY_PROTOCOL_VERSION;
+}
+
+export function supportsWorkspaceModelPreferences(protocolVersion: number | null): boolean {
+	return protocolVersion !== null && protocolVersion >= WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION;
 }
 
 const activityHydration = createActivityHydration({

--- a/e2e/SPEC.md
+++ b/e2e/SPEC.md
@@ -58,6 +58,13 @@ chords read the page's browser-reported platform through one fixture helper and 
 Control elsewhere; hard-coding the runner host's modifier would exercise the wrong product branch under
 browser/platform emulation.
 
+The source-host no-agent lane's existing `@dev-seam` environment also registers two configured,
+non-streaming model fixtures: one reasoning model and one basic model. They never answer a prompt and exist
+only to drive selector/session creation deterministically; `workspace-model-preference.spec.ts` selects the
+reasoner, proves a later chat inherits its effort, switches to the basic model so Pi clamps effort to `off`,
+and proves that effective pair survives a browser reload into another new chat. Binary and desktop lanes
+exclude `@dev-seam`, so no packaged composition root depends on these fixtures.
+
 Provider-backed browser tests (`e2e:agent`) use a dedicated serial real-Central mode; the separate
 headless workflow suite keeps its local PI-auth mode. Concurrent provider turns would alter rate limits,
 cost, and determinism, so neither is sharded. The agent runner builds the web artifact under the caller's

--- a/e2e/ask-user-question.spec.ts
+++ b/e2e/ask-user-question.spec.ts
@@ -16,6 +16,7 @@ import {
 	moveMouseToChatViewport,
 	nestedVerticalScrollSurfaces,
 	readChatScrollGeometry,
+	readChatViewportCenterOffsets,
 	readChatViewportIntersection,
 } from "./fixtures/chatScroll";
 import { E2E_FIXTURE_REPO } from "./fixtures/paths";
@@ -106,21 +107,16 @@ async function wheelUntilChatElementIntersects(
 	target: Locator,
 ): Promise<void> {
 	await moveMouseToChatViewport(page, chatScroll);
-	for (let attempt = 0; attempt < 16; attempt += 1) {
-		if ((await readChatViewportIntersection(target)).intersects) return;
-		const before = await readChatScrollGeometry(chatScroll);
-		await page.mouse.wheel(0, before.clientHeight * 0.75);
-		await expect
-			.poll(async () => {
-				const after = await readChatScrollGeometry(chatScroll);
-				return (
-					(await readChatViewportIntersection(target)).intersects ||
-					after.distanceFromStart > before.distanceFromStart
-				);
-			})
-			.toBe(true);
-	}
-	await expect.poll(async () => (await readChatViewportIntersection(target)).intersects).toBe(true);
+	await expect
+		.poll(async () => {
+			if ((await readChatViewportIntersection(target)).intersects) return true;
+			const { clientHeight } = await readChatScrollGeometry(chatScroll);
+			const [offset = 0] = await readChatViewportCenterOffsets(target, 1);
+			const delta = Math.sign(offset) * Math.min(Math.abs(offset), clientHeight * 0.75);
+			await page.mouse.wheel(0, delta);
+			return false;
+		})
+		.toBe(true);
 }
 
 test("a persisted tall questionnaire reveals page changes and a restored page without hidden review focus", async ({

--- a/e2e/new-workspace.live.spec.ts
+++ b/e2e/new-workspace.live.spec.ts
@@ -17,7 +17,7 @@ async function kickOff(page: import("@playwright/test").Page, prompt: string): P
 	await expect(dialog).toBeHidden();
 }
 
-test("the dialog shows the exact default model and its picker scrolls inside the dialog", {
+test("the dialog defers to the host default and its picker scrolls inside the dialog", {
 	tag: "@agent",
 }, async ({ page }) => {
 	await openFixtureProject(page);
@@ -38,7 +38,9 @@ test("the dialog shows the exact default model and its picker scrolls inside the
 
 	const model = dialog.getByTestId("model-selector");
 	await expect(model).toBeEnabled();
-	await expect(model).toContainText(selected.model.name);
+	await expect(model).toContainText("Default model");
+	const effort = dialog.getByTestId("thinking-selector");
+	await expect(effort).toBeDisabled();
 
 	await model.click();
 	const list = page.locator("[cmdk-list]");
@@ -49,9 +51,8 @@ test("the dialog shows the exact default model and its picker scrolls inside the
 	await list.hover();
 	await page.mouse.wheel(0, 600);
 	await expect.poll(() => list.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
-	await page.keyboard.press("Escape");
+	await exactOption.click();
 
-	const effort = dialog.getByTestId("thinking-selector");
 	await expect(effort).toBeEnabled();
 	await effort.click();
 	const options = page.getByTestId("thinking-option");

--- a/e2e/workspace-model-preference.spec.ts
+++ b/e2e/workspace-model-preference.spec.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+import type { Workspace } from "@thinkrail/contracts";
+import { activeWorktreeRow, openFixtureProject } from "./fixtures/app";
+import { E2E_DATA_DIR } from "./fixtures/paths";
+
+const REASONER_ID = "e2e-sticky-reasoner";
+const REASONER_NAME = "E2E Sticky Reasoner";
+const BASIC_ID = "e2e-sticky-basic";
+const BASIC_NAME = "E2E Sticky Basic";
+
+function persistedWorktree(): Workspace {
+	const workspaces = JSON.parse(
+		readFileSync(join(E2E_DATA_DIR, "workspaces.json"), "utf8"),
+	) as Workspace[];
+	const workspace = workspaces.find((candidate) => candidate.kind !== "default");
+	if (!workspace) throw new Error("persisted worktree missing");
+	return workspace;
+}
+
+function activeModelSelector(page: Page) {
+	return page.locator('[data-testid="model-selector"]:visible');
+}
+
+function activeThinkingSelector(page: Page) {
+	return page.locator('[data-testid="thinking-selector"]:visible');
+}
+
+async function chooseModel(page: Page, id: string): Promise<void> {
+	await activeModelSelector(page).click();
+	await page.locator(`[data-testid="model-option"][data-model-id="${id}"]`).click();
+}
+
+async function expectActiveSelection(page: Page, model: string, level: string): Promise<void> {
+	await expect(activeModelSelector(page)).toContainText(model);
+	await expect(activeThinkingSelector(page)).toContainText(level);
+}
+
+test("a workspace reuses the last effective model and thinking pair for future chats", {
+	tag: "@dev-seam",
+}, async ({ page }) => {
+	await openFixtureProject(page);
+	await page.getByTestId("add-workspace").first().click();
+	const dialog = page.getByTestId("new-workspace-dialog");
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByTestId("model-selector")).toContainText("Default model");
+
+	await chooseModel(page, REASONER_ID);
+	await activeThinkingSelector(page).click();
+	await page.locator('[data-testid="thinking-option"][data-level="xhigh"]').click();
+	await page.getByTestId("create-workspace").click();
+	await expect(dialog).toBeHidden();
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	await expectActiveSelection(page, REASONER_NAME, "xhigh");
+	await expect
+		.poll(() => {
+			const workspace = persistedWorktree();
+			return `${workspace.model?.id}:${workspace.thinkingLevel}`;
+		})
+		.toBe(`${REASONER_ID}:xhigh`);
+
+	const chatTabs = page.locator('[data-testid="editor-tab"][data-kind="chat"]');
+	await page.getByTestId("new-chat").first().click();
+	await expect(chatTabs).toHaveCount(2);
+	await expectActiveSelection(page, REASONER_NAME, "xhigh");
+
+	await chooseModel(page, BASIC_ID);
+	await expectActiveSelection(page, BASIC_NAME, "off");
+	await expect
+		.poll(() => {
+			const workspace = persistedWorktree();
+			return `${workspace.model?.id}:${workspace.thinkingLevel}`;
+		})
+		.toBe(`${BASIC_ID}:off`);
+
+	await page.reload();
+	await expect(page.getByTestId("connection-status")).toHaveAttribute("data-status", "connected");
+	await expect(activeWorktreeRow(page)).toHaveCount(1);
+	const restoredCount = await chatTabs.count();
+	await page.getByTestId("new-chat").first().click();
+	await expect(chatTabs).toHaveCount(restoredCount + 1);
+	await expectActiveSelection(page, BASIC_NAME, "off");
+});

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -358,9 +358,10 @@ of the host.
 - Protocol v65 adds the workspace model/thinking preference fields and changes successful
   `session.setModel` / `session.setThinkingLevel` results to Pi's effective post-mutation
   `{ model, thinkingLevel }` pair. The changes share one protocol advance: older clients ignore the
-  additive workspace fields, while independently shipped clients gate richer mutation reconciliation and
-  workspace mirroring with `WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION` so a v64 `{ ok: true }` result
-  remains safe.
+  additive workspace fields, while independently shipped clients gate mutation-result reconciliation with
+  `WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION` so a v64 `{ ok: true }` result remains safe. The persisted
+  workspace pair reaches clients through `workspace.list` and `workspace.updated`, never by a client rewriting
+  the row it was just pushed.
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.close`** (mark the stable record
   closed without deleting associated state), **`project.inspect`** (classify a path) + **`project.init`**
   (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "contains a registered

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -153,6 +153,10 @@ of the host.
   **`Workspace.skillOverrides`** (per-skill on/off) over that baseline;
   **`SubagentOverride`** (`"on" | "off"`) + optional **`Workspace.subagentsOverride`** let a workspace
   force subagents on/off, while absence inherits the host's `AppConfig.subagentsEnabled` default;
+  optional **`Workspace.model`** (`WireModel`) + **`Workspace.thinkingLevel`** persist one logical
+  workspace preference pair: only a complete pair is usable, while absence or a partial legacy/out-of-band
+  record means “use the host default.” The additive fields are backward-compatible on disk and wire and
+  require no migration;
   "does it have specs?" is **not** a field — it's the lazy `project.hasSpecs` query, since it's a full-tree
   walk), **`ProjectPathStatus`** (a
   candidate path's kind — `repo` / `initable` / `missing` / `notDirectory` — so the UI opens, offers a
@@ -351,6 +355,11 @@ of the host.
 - **`HostUpdateNotice`** — the optional immutable host-wire advisory: current version, newer available version,
   and channel. No status, revision, error, feed URL, artifact, platform path, or shell command crosses the
   wire. Its optional welcome field plus `host.updateAvailable` change pushes enter at protocol v64.
+- Protocol v65 adds the workspace model/thinking preference fields and changes successful
+  `session.setModel` / `session.setThinkingLevel` results to Pi's effective post-mutation
+  `{ model, thinkingLevel }` pair. The changes share one protocol advance: older clients ignore the
+  additive workspace fields, while independently shipped clients must not assume the richer mutation result
+  against a v64 host. No feature-version constant is needed because there is no capability-gated control.
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.close`** (mark the stable record
   closed without deleting associated state), **`project.inspect`** (classify a path) + **`project.init`**
   (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "contains a registered
@@ -437,7 +446,9 @@ of the host.
   session reaches idle, which is Stop's lossless path)/`dispose`/**`delete`**/`setModel`/
   `setThinkingLevel`/`compact`/`getStats`/`getCommands`/`extUiReply`/**`answerQuestion`** (the inline
   `ask_user_question` reply, correlated by tool call id)/**`list`**/**`getMessages`** (the
-  read side) / **`settings.update`** (merge + validate + persist a top-level partial `AppConfig`; when present,
+  read side; successful `setModel` / `setThinkingLevel` return the effective model/thinking pair rather
+  than an ack, so a client can reconcile Pi's clamp instead of trusting its optimistic request) /
+  **`settings.update`** (merge + validate + persist a top-level partial `AppConfig`; when present,
   `customLayoutPresets` and `systemThemePair` are complete replacements; entering system mode requires a
   complete existing-or-incoming pair. A legacy `{ theme }` mutation without explicit `themeMode` means a
   fixed-theme selection and exits system mode; returns the merged config) /

--- a/packages/contracts/SPEC.md
+++ b/packages/contracts/SPEC.md
@@ -358,8 +358,9 @@ of the host.
 - Protocol v65 adds the workspace model/thinking preference fields and changes successful
   `session.setModel` / `session.setThinkingLevel` results to Pi's effective post-mutation
   `{ model, thinkingLevel }` pair. The changes share one protocol advance: older clients ignore the
-  additive workspace fields, while independently shipped clients must not assume the richer mutation result
-  against a v64 host. No feature-version constant is needed because there is no capability-gated control.
+  additive workspace fields, while independently shipped clients gate richer mutation reconciliation and
+  workspace mirroring with `WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION` so a v64 `{ ok: true }` result
+  remains safe.
 - **wsProtocol.ts** — `WS_METHODS` (`project.*` — incl. **`project.close`** (mark the stable record
   closed without deleting associated state), **`project.inspect`** (classify a path) + **`project.init`**
   (`git init` + commit, then open) + **`project.hasSpecs`** (lazy per-project "contains a registered

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -42,6 +42,8 @@ export interface Workspace {
 	diffBase?: string;
 	renamed?: boolean;
 	initialTerminalPending?: true;
+	model?: WireModel;
+	thinkingLevel?: ThinkingLevel;
 	diffStats?: DiffStats;
 	skillOverrides?: Record<string, "on" | "off">;
 	subagentsOverride?: SubagentOverride;

--- a/packages/contracts/src/wsProtocol.test.ts
+++ b/packages/contracts/src/wsProtocol.test.ts
@@ -7,6 +7,7 @@ import {
 	SUBAGENT_SETTINGS_PROTOCOL_VERSION,
 	THEME_SYSTEM_PROTOCOL_VERSION,
 	WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION,
+	WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION,
 	WS_CHANNELS,
 	WS_METHODS,
 } from "./wsProtocol";
@@ -50,5 +51,6 @@ test("host update advisories name their immutable notice channel", () => {
 });
 
 test("sticky workspace model preferences advance the additive wire shape to v65", () => {
-	expect(PROTOCOL_VERSION).toBe(65);
+	expect(WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION).toBe(65);
+	expect(PROTOCOL_VERSION).toBe(WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION);
 });

--- a/packages/contracts/src/wsProtocol.test.ts
+++ b/packages/contracts/src/wsProtocol.test.ts
@@ -45,7 +45,10 @@ test("project template previews advance the additive wire shape to v63", () => {
 	expect(PROTOCOL_VERSION).toBeGreaterThanOrEqual(PROJECT_TEMPLATE_PREVIEW_PROTOCOL_VERSION);
 });
 
-test("host update advisories advance the protocol with an immutable notice channel", () => {
-	expect(PROTOCOL_VERSION).toBe(64);
+test("host update advisories name their immutable notice channel", () => {
 	expect(WS_CHANNELS.hostUpdateAvailable).toBe("host.updateAvailable");
+});
+
+test("sticky workspace model preferences advance the additive wire shape to v65", () => {
+	expect(PROTOCOL_VERSION).toBe(65);
 });

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -97,6 +97,7 @@ export type TemplateReadLocation =
 	| { workspaceId?: never; projectId?: never };
 
 export const PROTOCOL_VERSION = 65;
+export const WORKSPACE_MODEL_PREFERENCE_PROTOCOL_VERSION = 65;
 export const WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION = 62;
 export const PROJECT_TEMPLATE_PREVIEW_PROTOCOL_VERSION = 63;
 export const THEME_SYSTEM_PROTOCOL_VERSION = 58;

--- a/packages/contracts/src/wsProtocol.ts
+++ b/packages/contracts/src/wsProtocol.ts
@@ -96,7 +96,7 @@ export type TemplateReadLocation =
 	| { projectId: string; workspaceId?: never }
 	| { workspaceId?: never; projectId?: never };
 
-export const PROTOCOL_VERSION = 64;
+export const PROTOCOL_VERSION = 65;
 export const WINDOWS_SHELL_SETTINGS_PROTOCOL_VERSION = 62;
 export const PROJECT_TEMPLATE_PREVIEW_PROTOCOL_VERSION = 63;
 export const THEME_SYSTEM_PROTOCOL_VERSION = 58;
@@ -328,6 +328,11 @@ export interface Ack {
 	ok: true;
 }
 
+export interface SessionModelSelection {
+	model: WireModel | null;
+	thinkingLevel: ThinkingLevel;
+}
+
 export interface ReviewSendResult {
 	sessionId: string;
 	model: WireModel | null;
@@ -509,8 +514,14 @@ export interface WsMethodMap {
 	};
 	"session.dispose": { params: { sessionId: string }; result: Ack };
 	"session.delete": { params: { workspaceId: string; sessionId: string }; result: Ack };
-	"session.setModel": { params: { sessionId: string; model: WireModel }; result: Ack };
-	"session.setThinkingLevel": { params: { sessionId: string; level: ThinkingLevel }; result: Ack };
+	"session.setModel": {
+		params: { sessionId: string; model: WireModel };
+		result: SessionModelSelection;
+	};
+	"session.setThinkingLevel": {
+		params: { sessionId: string; level: ThinkingLevel };
+		result: SessionModelSelection;
+	};
 	"session.compact": { params: { sessionId: string; instructions?: string }; result: Ack };
 	"session.getStats": { params: { sessionId: string }; result: SessionStats };
 	"session.getCommands": { params: { sessionId: string }; result: SlashCommandInfo[] };

--- a/packages/server/SPEC.md
+++ b/packages/server/SPEC.md
@@ -92,7 +92,9 @@ internals**. The edges between them are owned here (see the dependency graph), n
 
 `src/index.ts` re-exports `host` + the `agent` barrel's `registerBundledRuntime` seam; explicit package
 subpaths expose build support and sanctioned history fixtures without widening the runtime barrel. `src/dev.ts` boots
-the host from env via `bootHost` for dev/e2e.
+the host from env via `bootHost` for dev/e2e. Only under `THINKRAIL_E2E_FAKE_OAUTH=1`, that source-host
+entrypoint registers the test-owned login providers plus two configured non-streaming model fixtures used to
+prove workspace model/thinking persistence; packaged entrypoints never receive those seams.
 
 ## Internal dependency graph
 

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -277,7 +277,9 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     through the same idle-delivery fallback as `followUpSession` — the first becomes a `prompt`, the rest
     steer into the run it starts; delivery timing may degrade across that race window, content is never lost
     (pinned by the idle-fallback unit test) —
-    `setModel` / `setThinkingLevel` / **manual `compact` guarded per session** (a second overlapping request
+    `setModel` / `setThinkingLevel` (each returns the live session's effective post-mutation
+    `{ model, thinkingLevel }` pair; request values are never echoed because Pi may clamp effort after
+    either mutation) / **manual `compact` guarded per session** (a second overlapping request
     is rejected before Pi can overwrite its one compaction controller; an active Pi compaction also blocks
     entry) / `getSessionStats` (+ contextUsage) / `getSessionCommands` /
     `listAvailableModels` / **`clampThinkingForModel`** (pi's `clampThinkingLevel` for a `{model, level}`
@@ -314,7 +316,8 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     not live, first resolving any model named by the transcript exactly in the active process runtime and
     rejecting with a closed error when that named model is unavailable—never accepting PI's silent fallback
     for an existing model reference; legacy transcripts with no persisted model reference may use the
-    configured default—then returns `{ summary, messages }` —
+    configured default. Attachment reconstructs only that chat and exposes no workspace-preference
+    mutation—then returns `{ summary, messages }` —
     `TranscriptMessage[]`: the pi-canonical subset **plus
     `custom` messages**, which carry the `ask-user-answers` replies the questionnaire card pairs by tool
     call id, **plus `compactionSummary`**, pi's durable marker for the messages compaction summarized away —
@@ -732,6 +735,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
   one `readAvailableWireModels` read so the projection can't be bypassed by adding a caller; every inbound
   model ref (`session.create` /
   `session.setModel`) is **re-resolved** host-side by `{provider,id}` (`resolveWireModel`), never trusted.
+  `createSession.modelOptional` relaxes only failure to resolve the supplied model reference;
+  authentication, resource loading, extension binding, and session creation failures still surface. The
+  host uses that narrow fallback only for a stored potentially-stale workspace preference, never an
+  explicit user selection.
   The wire type `WireModel = Pick<Model, id|name|provider|contextWindow|reasoning> + thinkingLevels` is an
   **allowlist** — it fails closed, so a future `Model` field can't leak by default (a unit test pins the
   exact key set). `thinkingLevels` is the one computed field: pi-ai's `getSupportedThinkingLevels(model)`

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -288,7 +288,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     `defaultProvider`/`defaultModel` when that model is available, else `model: null` — plus the effort that
     pairs with it). **The host never guesses a pre-session model:** pi's own resolver (settings pin →
     provider default → first available) runs inside `createAgentSession`, so a caller without a pinned
-    default omits `model` and lets pi choose, and every creation path agrees by construction. The earlier
+    default omits `model` and lets pi choose, and every creation path agrees by construction. Creation
+    snapshots its returned effective pair only after registration, creation publication, and activity
+    reconciliation, so a mutation accepted through the announced session cannot be overwritten by stale
+    creation-time persistence. The earlier
     `pinned ?? available[0]` was a *second* resolver: with nothing pinned it answered `available[0]` while a
     fresh session got pi's provider default, so the New-Workspace dialog pre-pinned a model no other path
     would have picked — landing on `anthropic/claude-fable-5`, whose `compat.allowedFallbackModels` makes pi

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -185,6 +185,43 @@ test("session creation publishes a domain summary for other frontends", async ()
 	}
 });
 
+test("session creation returns the effective pair after announced-session mutations", async () => {
+	const provider = "created-selection";
+	runtime.registerProvider(provider, {
+		...cfg(fauxA, provider),
+		models: [
+			{
+				...modelDef(provider),
+				api: fauxA.api,
+				reasoning: true,
+				thinkingLevelMap: { low: "low", high: "high" },
+			},
+		],
+	});
+	const model = (await listAvailableModels()).find((candidate) => candidate.provider === provider);
+	if (!model) throw new Error("created-selection model missing");
+	let announcedSelection: ReturnType<typeof setSessionThinkingLevel> | undefined;
+	setSessionCreatedPublisher((summary) => {
+		announcedSelection = setSessionThinkingLevel(summary.sessionId, "high");
+	});
+	let sessionId: string | undefined;
+	try {
+		const created = await createSession({
+			cwd: tmpCwd("trpi-created-selection-"),
+			workspaceId: "ws-created-selection",
+			model,
+			thinkingLevel: "low",
+		});
+		sessionId = created.sessionId;
+		expect(announcedSelection?.thinkingLevel).toBe("high");
+		expect(created.thinkingLevel).toBe("high");
+	} finally {
+		if (sessionId) removeSession(sessionId);
+		setSessionCreatedPublisher(() => {});
+		runtime.unregisterProvider(provider);
+	}
+});
+
 test("two sessions in two worktrees stream independently; disposing one leaves the other working", async () => {
 	fauxA.setResponses([fauxAssistantMessage("ALPHA_REPLY")]);
 	fauxB.setResponses([fauxAssistantMessage("BRAVO_REPLY")]);

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -60,7 +60,9 @@ import {
 	setSessionCreatedPublisher,
 	setSessionDeletedPublisher,
 	setSessionManagerFactory,
+	setSessionModel,
 	setSessionPublisher,
+	setSessionThinkingLevel,
 	setSubagentsEnabledResolver,
 	steerSession,
 	syncSessionActivity,
@@ -801,6 +803,63 @@ test("createSession rejects an unknown/unavailable model ref (no arbitrary baseU
 	await expect(
 		createSession({ cwd: tmpCwd("trpi-bad-"), workspaceId: "ws-bad", model: bogus }),
 	).rejects.toThrow(/Unknown or unavailable model/);
+});
+
+test("createSession modelOptional tolerates only an unavailable supplied model", async () => {
+	const ref = (await listAvailableModels()).find((model) => model.id === "fauxa");
+	if (!ref) throw new Error("faux model missing");
+	const created = await createSession({
+		cwd: tmpCwd("trpi-optional-model-"),
+		workspaceId: "ws-optional-model",
+		model: { ...ref, provider: "gone", id: "gone" },
+		modelOptional: true,
+	});
+	try {
+		expect(created.model).not.toBeNull();
+		expect(created.model).not.toMatchObject({ provider: "gone", id: "gone" });
+	} finally {
+		removeSession(created.sessionId);
+	}
+});
+
+test("session model mutations return Pi's effective model and thinking level", async () => {
+	runtime.registerProvider("reasoner", {
+		...cfg(fauxA, "reasoner"),
+		models: [
+			{
+				...modelDef("reasoner"),
+				api: fauxA.api,
+				reasoning: true,
+				thinkingLevelMap: { xhigh: "xhigh" },
+			},
+		],
+	});
+	let sessionId: string | undefined;
+	try {
+		const models = await listAvailableModels();
+		const reasoner = models.find((model) => model.provider === "reasoner");
+		const nonReasoner = models.find((model) => model.provider === "fauxb");
+		if (!reasoner || !nonReasoner) throw new Error("mutation models missing");
+		const created = await createSession({
+			cwd: tmpCwd("trpi-model-mutation-"),
+			workspaceId: "ws-model-mutation",
+			model: reasoner,
+			thinkingLevel: "low",
+		});
+		sessionId = created.sessionId;
+
+		expect(setSessionThinkingLevel(sessionId, "xhigh")).toEqual({
+			model: reasoner,
+			thinkingLevel: "xhigh",
+		});
+		expect(await setSessionModel(sessionId, nonReasoner)).toEqual({
+			model: nonReasoner,
+			thinkingLevel: "off",
+		});
+	} finally {
+		if (sessionId) removeSession(sessionId);
+		runtime.unregisterProvider("reasoner");
+	}
 });
 
 test("getSessionStats + getSessionCommands read live session info (cheap wins #3, #2)", async () => {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -477,7 +477,6 @@ function resolveWireModel(
 
 interface PreparedSessionEntry {
 	entry: Entry;
-	result: CreateSessionResult;
 }
 
 async function prepareSessionEntry(
@@ -586,10 +585,7 @@ async function prepareSessionEntry(
 		throw error;
 	}
 
-	return {
-		entry,
-		result: { sessionId, ...sessionModelSelection(session) },
-	};
+	return { entry };
 }
 
 async function registerSession(
@@ -605,7 +601,7 @@ async function registerSession(
 	log.debug(`session ${session.sessionId} attached (workspace ${workspaceId})`);
 	if (announceCreation) publishCreated(summaryOf(session.sessionId, prepared.entry));
 	await reconcileWorkspaceActivity(workspaceId);
-	return prepared.result;
+	return { sessionId: session.sessionId, ...sessionModelSelection(session) };
 }
 
 export async function createSession(input: CreateSessionInput): Promise<CreateSessionResult> {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -29,6 +29,7 @@ import type {
 	SessionCreatedPayload,
 	SessionDeletedPayload,
 	SessionEventPayload,
+	SessionModelSelection,
 	SessionQueueContent,
 	SessionQueueState,
 	SessionStats,
@@ -457,6 +458,13 @@ export function toWireModel(model: Model<string>): WireModel {
 	};
 }
 
+function sessionModelSelection(session: AgentSession): SessionModelSelection {
+	return {
+		model: session.model ? toWireModel(session.model as unknown as Model<string>) : null,
+		thinkingLevel: session.thinkingLevel,
+	};
+}
+
 function resolveWireModel(
 	runtime: PiRuntimeGeneration["runtime"],
 	ref: Pick<WireModel, "provider" | "id">,
@@ -580,11 +588,7 @@ async function prepareSessionEntry(
 
 	return {
 		entry,
-		result: {
-			sessionId,
-			model: session.model ? toWireModel(session.model as unknown as Model<string>) : null,
-			thinkingLevel: session.thinkingLevel,
-		},
+		result: { sessionId, ...sessionModelSelection(session) },
 	};
 }
 
@@ -639,8 +643,7 @@ function summaryOf(sessionId: string, entry: Entry): SessionSummary {
 		sessionId,
 		workspaceId: entry.workspaceId,
 		title: session.sessionName ?? "Chat",
-		model: session.model ? toWireModel(session.model as unknown as Model<string>) : null,
-		thinkingLevel: session.thinkingLevel,
+		...sessionModelSelection(session),
 		isStreaming: session.isStreaming,
 		messageCount: session.messages.length,
 		updatedAt: Date.now(),
@@ -1166,13 +1169,22 @@ export async function abortSession(
 	return restoredQueue;
 }
 
-export async function setSessionModel(sessionId: string, model: WireModel): Promise<void> {
+export async function setSessionModel(
+	sessionId: string,
+	model: WireModel,
+): Promise<SessionModelSelection> {
 	const entry = mustGetEntry(sessionId);
 	await entry.session.setModel(resolveWireModel(entry.generation.runtime, model));
+	return sessionModelSelection(entry.session);
 }
 
-export function setSessionThinkingLevel(sessionId: string, level: ThinkingLevel): void {
-	mustGet(sessionId).setThinkingLevel(level);
+export function setSessionThinkingLevel(
+	sessionId: string,
+	level: ThinkingLevel,
+): SessionModelSelection {
+	const session = mustGet(sessionId);
+	session.setThinkingLevel(level);
+	return sessionModelSelection(session);
 }
 
 export function getSessionStats(sessionId: string): SessionStats {

--- a/packages/server/src/agent/runtimeGenerations.test.ts
+++ b/packages/server/src/agent/runtimeGenerations.test.ts
@@ -131,7 +131,10 @@ describe("PI runtime generations", () => {
 		const model = toWireModel(faux.getModel());
 		await activateRuntime(await runtimeWithFaux(false));
 
-		await expect(setSessionModel(session.sessionId, model)).resolves.toBeUndefined();
+		await expect(setSessionModel(session.sessionId, model)).resolves.toEqual({
+			model,
+			thinkingLevel: "off",
+		});
 		await expect(createSession({ cwd, workspaceId: "workspace-new", model })).rejects.toThrow(
 			"Unknown or unavailable model",
 		);

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -1,4 +1,4 @@
-import type { Provider } from "@earendil-works/pi-ai";
+import type { Model, Provider } from "@earendil-works/pi-ai";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai/oauth";
 import { resolveShellEnv } from "@thinkrail/shared/shellEnv";
 import { configurePiRuntimeGenerationInitializer } from "./agent";
@@ -36,8 +36,21 @@ if (process.env.THINKRAIL_E2E_FAKE_OAUTH === "1") {
 		},
 	};
 	const dummyStream = (): never => {
-		throw new Error("e2e-apikey is a login fixture — it never streams");
+		throw new Error("e2e fixture providers never stream");
 	};
+	const stickyModel = (id: string, name: string, reasoning: boolean): Model<string> => ({
+		id,
+		name,
+		provider: "e2e-sticky",
+		api: "openai-completions",
+		baseUrl: "http://e2e-sticky.test",
+		reasoning,
+		...(reasoning ? { thinkingLevelMap: { xhigh: "xhigh" } } : {}),
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 4096,
+	});
 	const fakeApiKeyProvider: Provider = {
 		id: "e2e-apikey",
 		name: "E2E Key Provider",
@@ -80,6 +93,16 @@ if (process.env.THINKRAIL_E2E_FAKE_OAUTH === "1") {
 	configurePiRuntimeGenerationInitializer((runtime) => {
 		runtime.registerProvider("e2e-oauth", { oauth: fakeOauth });
 		runtime.registerNativeProvider(fakeApiKeyProvider);
+		runtime.registerProvider("e2e-sticky", {
+			api: "openai-completions",
+			baseUrl: "http://e2e-sticky.test",
+			apiKey: "e2e",
+			streamSimple: dummyStream,
+			models: [
+				stickyModel("e2e-sticky-reasoner", "E2E Sticky Reasoner", true),
+				stickyModel("e2e-sticky-basic", "E2E Sticky Basic", false),
+			],
+		});
 	});
 }
 

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -351,6 +351,11 @@ channel fan-out, and the process-boot wrapper both launchers share.
   fallback neither clears nor replaces the stored pair; a result with no effective model likewise leaves the
   last complete preference unchanged. Live mutations capture the session's workspace id before awaiting and
   return the same effective pair on the wire that persistence consumes, so host and client have one result.
+  **Persistence is best-effort and never demotes a mutation that already succeeded** (the `track()` rule): the
+  record can be gone by the time it runs, because `workspace.remove` forgets the record synchronously while
+  session teardown is a fire-and-forget `archiveTeardown`, so a stale pane's `setModel` would otherwise report
+  failure for a change pi already applied — and `session.list` would fail the same way, defeating the client's
+  reconciliation.
   Transcript attachment/restoration resolves the saved chat model exactly and never writes workspace
   preference. The user-visible new file-review-chat path uses the same workspace-pair resolution when no
   explicit model is supplied; reused/reattached review chats retain their transcript selection and write

--- a/packages/server/src/host/SPEC.md
+++ b/packages/server/src/host/SPEC.md
@@ -341,6 +341,21 @@ channel fan-out, and the process-boot wrapper both launchers share.
     a failed background teardown is warn-logged, never thrown into the void (nothing awaits it), like
     the auto-rename tee. **Archive keeps the branch but not the chat:** the git branch stays (code is
     recoverable), yet chat history is purged with the worktree — a deliberate scope choice, not a leak.
+- **Workspace model preference is host composition, not agent policy.** New-session precedence is:
+  (1) an explicit request model, resolved strictly and paired with its supplied thinking level when present;
+  (2) a complete stored workspace pair, passed with `modelOptional: true` so an unavailable stale model lets
+  Pi choose its host default; then (3) no model, preserving Pi's ordinary host-default resolution. A
+  thinking-only legacy request remains session-local and does not form a stored pair. Only a successful
+  explicit creation and successful live `session.setModel` / `session.setThinkingLevel` mutation persist a
+  preference, and they persist Pi's effective returned pair rather than request values. A stale stored-model
+  fallback neither clears nor replaces the stored pair; a result with no effective model likewise leaves the
+  last complete preference unchanged. Live mutations capture the session's workspace id before awaiting and
+  return the same effective pair on the wire that persistence consumes, so host and client have one result.
+  Transcript attachment/restoration resolves the saved chat model exactly and never writes workspace
+  preference. The user-visible new file-review-chat path uses the same workspace-pair resolution when no
+  explicit model is supplied; reused/reattached review chats retain their transcript selection and write
+  nothing. Dedicated TODO reviewer and reflector creation remains on the separate `reviewModel` /
+  `reviewEffort` policy and never inherits or updates workspace preference.
 - **Review state is host-composed and serialized per workspace** (`reviewLock.ts`): `review.send*` is
   `reviews` (drafts + package) plus `agent` (session) plus `reviews` again (mark sent + link) — a
   check-then-mark straddling an `await createSession(…)`, the review layer's only non-atomic gap.

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -294,6 +294,31 @@ test("session.create uses a complete workspace pair when the request omits a mod
 	expect(created).toMatchObject({ model: reasoner, thinkingLevel: "xhigh" });
 });
 
+test("a thinking-only request remains session-local instead of inheriting a stored pair", async () => {
+	const baselineWorkspace = await createManagedWorkspace();
+	const workspace = await createManagedWorkspace();
+	const basic = (await availableModels()).find((model) => model.id === "handler-basic");
+	if (!basic) throw new Error("basic model missing");
+	const baseline = (await handleRequest(
+		"session.create",
+		{ workspaceId: baselineWorkspace.id, thinkingLevel: "xhigh" },
+		CTX,
+	)) as SessionModelSelection;
+	setWorkspaceModelPreference(workspace.id, { model: basic, thinkingLevel: "off" });
+
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: workspace.id, thinkingLevel: "xhigh" },
+		CTX,
+	)) as SessionModelSelection;
+
+	expect(created).toMatchObject({ model: baseline.model, thinkingLevel: "xhigh" });
+	expect(await storedWorkspace(workspace.id)).toMatchObject({
+		model: basic,
+		thinkingLevel: "off",
+	});
+});
+
 test("a partial persisted workspace pair is ignored in favor of the host default", async () => {
 	const baselineWorkspace = await createManagedWorkspace();
 	const partialWorkspace = await createManagedWorkspace();

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -21,7 +21,7 @@ import { addComment, getReviewSnapshot } from "../reviews";
 import { resetConfigCache } from "../settings";
 import { todoReviewRecord } from "../todos";
 import { stopAllWatches } from "../watch";
-import { setWorkspaceModelPreference } from "../workspaces";
+import { forgetWorkspace, setWorkspaceModelPreference } from "../workspaces";
 import { handleRequest, requestMethodDiagnostic, shouldRefreshOpenReview } from "./handlers";
 
 const CTX = { clientKey: "test-client" };
@@ -443,6 +443,27 @@ test("a failed live model mutation leaves the previous workspace pair unchanged"
 		model: reasoner,
 		thinkingLevel: "low",
 	});
+});
+
+test("a forgotten workspace cannot fail a mutation Pi already applied", async () => {
+	const workspace = await createManagedWorkspace();
+	const models = await availableModels();
+	const reasoner = models.find((model) => model.id === "handler-reasoner");
+	const basic = models.find((model) => model.id === "handler-basic");
+	if (!reasoner || !basic) throw new Error("handler models missing");
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: workspace.id, model: reasoner, thinkingLevel: "low" },
+		CTX,
+	)) as { sessionId: string };
+	forgetWorkspace(workspace.id);
+
+	const switched = (await handleRequest(
+		"session.setModel",
+		{ sessionId: created.sessionId, model: basic },
+		CTX,
+	)) as SessionModelSelection;
+	expect(switched).toEqual({ model: basic, thinkingLevel: "off" });
 });
 
 test("review comment chats inherit the complete workspace pair", async () => {

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -15,11 +15,7 @@ import type {
 	WorkspaceWatchReadyResult,
 } from "@thinkrail/contracts";
 import { TodoStore } from "pi-todos/core";
-import {
-	configurePiRuntime,
-	disposeAllSessions,
-	setSessionManagerFactory,
-} from "../agent";
+import { configurePiRuntime, disposeAllSessions, setSessionManagerFactory } from "../agent";
 import { recordAcceptedMessage, resetFeedbackForTests, setFeedbackPublisher } from "../feedback";
 import { addComment, getReviewSnapshot } from "../reviews";
 import { resetConfigCache } from "../settings";
@@ -290,11 +286,10 @@ test("session.create uses a complete workspace pair when the request omits a mod
 	if (!reasoner) throw new Error("reasoning model missing");
 	setWorkspaceModelPreference(workspace.id, { model: reasoner, thinkingLevel: "xhigh" });
 
-	const created = (await handleRequest(
-		"session.create",
-		{ workspaceId: workspace.id },
-		CTX,
-	)) as { model: WireModel | null; thinkingLevel: string };
+	const created = (await handleRequest("session.create", { workspaceId: workspace.id }, CTX)) as {
+		model: WireModel | null;
+		thinkingLevel: string;
+	};
 
 	expect(created).toMatchObject({ model: reasoner, thinkingLevel: "xhigh" });
 });
@@ -338,11 +333,10 @@ test("a stale workspace model falls back without rewriting the stored pair", asy
 	const stale = { ...reasoner, provider: "gone", id: "gone" };
 	setWorkspaceModelPreference(workspace.id, { model: stale, thinkingLevel: "xhigh" });
 
-	const created = (await handleRequest(
-		"session.create",
-		{ workspaceId: workspace.id },
-		CTX,
-	)) as { model: WireModel | null; thinkingLevel: string };
+	const created = (await handleRequest("session.create", { workspaceId: workspace.id }, CTX)) as {
+		model: WireModel | null;
+		thinkingLevel: string;
+	};
 
 	expect(created.model).not.toMatchObject({ provider: "gone", id: "gone" });
 	expect(await storedWorkspace(workspace.id)).toMatchObject({

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -2,18 +2,29 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { createFauxCore } from "@earendil-works/pi-ai/providers/faux";
+import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type {
+	SessionModelSelection,
 	Template,
 	TemplateInfo,
+	WireModel,
 	Workspace,
 	WorkspaceWatchReadyResult,
 } from "@thinkrail/contracts";
 import { TodoStore } from "pi-todos/core";
+import {
+	configurePiRuntime,
+	disposeAllSessions,
+	setSessionManagerFactory,
+} from "../agent";
 import { recordAcceptedMessage, resetFeedbackForTests, setFeedbackPublisher } from "../feedback";
 import { addComment, getReviewSnapshot } from "../reviews";
 import { resetConfigCache } from "../settings";
 import { todoReviewRecord } from "../todos";
 import { stopAllWatches } from "../watch";
+import { setWorkspaceModelPreference } from "../workspaces";
 import { handleRequest, requestMethodDiagnostic, shouldRefreshOpenReview } from "./handlers";
 
 const CTX = { clientKey: "test-client" };
@@ -21,6 +32,28 @@ const CTX = { clientKey: "test-client" };
 let dataDir: string;
 let repo: string;
 const savedDataDir = process.env.THINKRAIL_DATA_DIR;
+const savedAgentDir = process.env.PI_CODING_AGENT_DIR;
+const savedOffline = process.env.PI_OFFLINE;
+
+function modelDef(id: string, reasoning: boolean) {
+	return {
+		id,
+		name: id,
+		reasoning,
+		...(reasoning ? { thinkingLevelMap: { xhigh: "xhigh" } } : {}),
+		input: ["text"] as ("text" | "image")[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 4096,
+	};
+}
+
+const faux = createFauxCore({
+	provider: "handler-faux",
+	api: "handler-faux",
+	models: [modelDef("handler-reasoner", true), modelDef("handler-basic", false)],
+	tokensPerSecond: 2_000,
+});
 
 function git(cwd: string, ...args: string[]): void {
 	const result = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "ignore", stderr: "ignore" });
@@ -33,9 +66,47 @@ function gitText(cwd: string, ...args: string[]): string {
 	return new TextDecoder().decode(result.stdout).trim();
 }
 
-beforeEach(() => {
+async function availableModels(): Promise<WireModel[]> {
+	return (await handleRequest("model.list", {}, CTX)) as WireModel[];
+}
+
+async function createManagedWorkspace(): Promise<Workspace> {
+	return (await handleRequest("workspace.create", { projectId: "p1" }, CTX)) as Workspace;
+}
+
+async function storedWorkspace(id: string): Promise<Workspace> {
+	const rows = (await handleRequest(
+		"workspace.list",
+		{ projectId: "p1", includeDiffStats: false },
+		CTX,
+	)) as Workspace[];
+	const workspace = rows.find((row) => row.id === id);
+	if (!workspace) throw new Error(`missing workspace ${id}`);
+	return workspace;
+}
+
+beforeEach(async () => {
 	dataDir = mkdtempSync(join(tmpdir(), "trpi-handlers-test-"));
 	process.env.THINKRAIL_DATA_DIR = dataDir;
+	process.env.PI_CODING_AGENT_DIR = join(dataDir, "agent");
+	process.env.PI_OFFLINE = "1";
+	const runtime = await ModelRuntime.create({
+		credentials: new InMemoryCredentialStore(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	runtime.registerProvider("handler-faux", {
+		api: faux.api,
+		baseUrl: "http://handler-faux.test",
+		apiKey: "faux",
+		streamSimple: faux.streamSimple,
+		models: [
+			{ ...modelDef("handler-reasoner", true), api: faux.api },
+			{ ...modelDef("handler-basic", false), api: faux.api },
+		],
+	});
+	configurePiRuntime(runtime);
+	setSessionManagerFactory(() => SessionManager.inMemory());
 	resetConfigCache();
 	resetFeedbackForTests();
 	repo = join(dataDir, "repo");
@@ -55,11 +126,18 @@ beforeEach(() => {
 
 afterEach(() => {
 	stopAllWatches();
+	disposeAllSessions();
+	configurePiRuntime(null);
+	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
 	resetConfigCache();
 	resetFeedbackForTests();
 	rmSync(dataDir, { recursive: true, force: true });
 	if (savedDataDir === undefined) delete process.env.THINKRAIL_DATA_DIR;
 	else process.env.THINKRAIL_DATA_DIR = savedDataDir;
+	if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = savedAgentDir;
+	if (savedOffline === undefined) delete process.env.PI_OFFLINE;
+	else process.env.PI_OFFLINE = savedOffline;
 });
 
 test("open-review cache reuse is opt-in so older clients remain fresh", () => {
@@ -181,6 +259,166 @@ test("workspace.setSubagentsOverride persists on/off and null restores the globa
 		CTX,
 	)) as Workspace;
 	expect(inherited.subagentsOverride).toBeUndefined();
+});
+
+test("session.create persists a successful explicit effective selection", async () => {
+	const workspace = await createManagedWorkspace();
+	const reasoner = (await availableModels()).find((model) => model.id === "handler-reasoner");
+	if (!reasoner) throw new Error("reasoning model missing");
+
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: workspace.id, model: reasoner, thinkingLevel: "xhigh" },
+		CTX,
+	)) as { sessionId: string; model: WireModel | null; thinkingLevel: string };
+
+	expect(created).toMatchObject({ model: reasoner, thinkingLevel: "xhigh" });
+	expect(await storedWorkspace(workspace.id)).toMatchObject({
+		model: reasoner,
+		thinkingLevel: "xhigh",
+	});
+});
+
+test("session.create uses a complete workspace pair when the request omits a model", async () => {
+	const workspace = await createManagedWorkspace();
+	const reasoner = (await availableModels()).find((model) => model.id === "handler-reasoner");
+	if (!reasoner) throw new Error("reasoning model missing");
+	setWorkspaceModelPreference(workspace.id, { model: reasoner, thinkingLevel: "xhigh" });
+
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: workspace.id },
+		CTX,
+	)) as { model: WireModel | null; thinkingLevel: string };
+
+	expect(created).toMatchObject({ model: reasoner, thinkingLevel: "xhigh" });
+});
+
+test("a partial persisted workspace pair is ignored in favor of the host default", async () => {
+	const baselineWorkspace = await createManagedWorkspace();
+	const partialWorkspace = await createManagedWorkspace();
+	const basic = (await availableModels()).find((model) => model.id === "handler-basic");
+	if (!basic) throw new Error("basic model missing");
+	const baseline = (await handleRequest(
+		"session.create",
+		{ workspaceId: baselineWorkspace.id },
+		CTX,
+	)) as SessionModelSelection;
+	const path = join(dataDir, "workspaces.json");
+	const records = JSON.parse(readFileSync(path, "utf8")) as Workspace[];
+	const partial = records.find((workspace) => workspace.id === partialWorkspace.id);
+	if (!partial) throw new Error("partial workspace missing");
+	partial.model = basic;
+	delete partial.thinkingLevel;
+	writeFileSync(path, JSON.stringify(records));
+
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: partialWorkspace.id },
+		CTX,
+	)) as SessionModelSelection;
+
+	expect(created).toMatchObject({
+		model: baseline.model,
+		thinkingLevel: baseline.thinkingLevel,
+	});
+	expect(await storedWorkspace(partialWorkspace.id)).toMatchObject({ model: basic });
+	expect((await storedWorkspace(partialWorkspace.id)).thinkingLevel).toBeUndefined();
+});
+
+test("a stale workspace model falls back without rewriting the stored pair", async () => {
+	const workspace = await createManagedWorkspace();
+	const reasoner = (await availableModels()).find((model) => model.id === "handler-reasoner");
+	if (!reasoner) throw new Error("reasoning model missing");
+	const stale = { ...reasoner, provider: "gone", id: "gone" };
+	setWorkspaceModelPreference(workspace.id, { model: stale, thinkingLevel: "xhigh" });
+
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: workspace.id },
+		CTX,
+	)) as { model: WireModel | null; thinkingLevel: string };
+
+	expect(created.model).not.toMatchObject({ provider: "gone", id: "gone" });
+	expect(await storedWorkspace(workspace.id)).toMatchObject({
+		model: stale,
+		thinkingLevel: "xhigh",
+	});
+});
+
+test("an explicit unavailable model fails loudly and leaves workspace persistence unchanged", async () => {
+	const workspace = await createManagedWorkspace();
+	const reasoner = (await availableModels()).find((model) => model.id === "handler-reasoner");
+	if (!reasoner) throw new Error("reasoning model missing");
+	setWorkspaceModelPreference(workspace.id, { model: reasoner, thinkingLevel: "low" });
+
+	await expect(
+		handleRequest(
+			"session.create",
+			{
+				workspaceId: workspace.id,
+				model: { ...reasoner, provider: "gone", id: "gone" },
+				thinkingLevel: "xhigh",
+			},
+			CTX,
+		),
+	).rejects.toThrow("Unknown or unavailable model");
+	expect(await storedWorkspace(workspace.id)).toMatchObject({
+		model: reasoner,
+		thinkingLevel: "low",
+	});
+});
+
+test("live selectors persist and return Pi's effective pair", async () => {
+	const workspace = await createManagedWorkspace();
+	const models = await availableModels();
+	const reasoner = models.find((model) => model.id === "handler-reasoner");
+	const basic = models.find((model) => model.id === "handler-basic");
+	if (!reasoner || !basic) throw new Error("handler models missing");
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: workspace.id, model: reasoner, thinkingLevel: "low" },
+		CTX,
+	)) as { sessionId: string };
+
+	const thinking = (await handleRequest(
+		"session.setThinkingLevel",
+		{ sessionId: created.sessionId, level: "xhigh" },
+		CTX,
+	)) as SessionModelSelection;
+	expect(thinking).toEqual({ model: reasoner, thinkingLevel: "xhigh" });
+	expect(await storedWorkspace(workspace.id)).toMatchObject(thinking);
+
+	const switched = (await handleRequest(
+		"session.setModel",
+		{ sessionId: created.sessionId, model: basic },
+		CTX,
+	)) as SessionModelSelection;
+	expect(switched).toEqual({ model: basic, thinkingLevel: "off" });
+	expect(await storedWorkspace(workspace.id)).toMatchObject(switched);
+});
+
+test("a failed live model mutation leaves the previous workspace pair unchanged", async () => {
+	const workspace = await createManagedWorkspace();
+	const reasoner = (await availableModels()).find((model) => model.id === "handler-reasoner");
+	if (!reasoner) throw new Error("reasoning model missing");
+	const created = (await handleRequest(
+		"session.create",
+		{ workspaceId: workspace.id, model: reasoner, thinkingLevel: "low" },
+		CTX,
+	)) as { sessionId: string };
+
+	await expect(
+		handleRequest(
+			"session.setModel",
+			{ sessionId: created.sessionId, model: { ...reasoner, provider: "gone", id: "gone" } },
+			CTX,
+		),
+	).rejects.toThrow("Unknown or unavailable model");
+	expect(await storedWorkspace(workspace.id)).toMatchObject({
+		model: reasoner,
+		thinkingLevel: "low",
+	});
 });
 
 test("workspace.watchReady waits for startup once, then reports an already-ready watcher", async () => {

--- a/packages/server/src/host/handlers.test.ts
+++ b/packages/server/src/host/handlers.test.ts
@@ -6,6 +6,7 @@ import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
 import { createFauxCore } from "@earendil-works/pi-ai/providers/faux";
 import { ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
 import type {
+	ReviewSendResult,
 	SessionModelSelection,
 	Template,
 	TemplateInfo,
@@ -83,6 +84,10 @@ async function storedWorkspace(id: string): Promise<Workspace> {
 	const workspace = rows.find((row) => row.id === id);
 	if (!workspace) throw new Error(`missing workspace ${id}`);
 	return workspace;
+}
+
+async function addDraftReview(workspaceId: string) {
+	return addComment({ workspaceId, kind: "review", anchor: null, body: "Please revise this." });
 }
 
 beforeEach(async () => {
@@ -418,6 +423,48 @@ test("a failed live model mutation leaves the previous workspace pair unchanged"
 	expect(await storedWorkspace(workspace.id)).toMatchObject({
 		model: reasoner,
 		thinkingLevel: "low",
+	});
+});
+
+test("review comment chats inherit the complete workspace pair", async () => {
+	const workspace = await createManagedWorkspace();
+	const reasoner = (await availableModels()).find((model) => model.id === "handler-reasoner");
+	if (!reasoner) throw new Error("reasoning model missing");
+	setWorkspaceModelPreference(workspace.id, { model: reasoner, thinkingLevel: "xhigh" });
+	const comment = await addDraftReview(workspace.id);
+
+	const sent = (await handleRequest(
+		"review.sendComment",
+		{ workspaceId: workspace.id, id: comment.id },
+		CTX,
+	)) as ReviewSendResult;
+
+	expect(sent).toMatchObject({ model: reasoner, thinkingLevel: "xhigh", reused: false });
+	expect(await storedWorkspace(workspace.id)).toMatchObject({
+		model: reasoner,
+		thinkingLevel: "xhigh",
+	});
+});
+
+test("an explicit review comment model persists its effective pair", async () => {
+	const workspace = await createManagedWorkspace();
+	const models = await availableModels();
+	const reasoner = models.find((model) => model.id === "handler-reasoner");
+	const basic = models.find((model) => model.id === "handler-basic");
+	if (!reasoner || !basic) throw new Error("handler models missing");
+	setWorkspaceModelPreference(workspace.id, { model: reasoner, thinkingLevel: "low" });
+	const comment = await addDraftReview(workspace.id);
+
+	const sent = (await handleRequest(
+		"review.sendComment",
+		{ workspaceId: workspace.id, id: comment.id, model: basic, thinkingLevel: "xhigh" },
+		CTX,
+	)) as ReviewSendResult;
+
+	expect(sent).toMatchObject({ model: basic, thinkingLevel: "off", reused: false });
+	expect(await storedWorkspace(workspace.id)).toMatchObject({
+		model: basic,
+		thinkingLevel: "off",
 	});
 });
 

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -13,6 +13,7 @@ import type {
 	ReviewCommentKind,
 	ReviewCommentStatus,
 	ReviewSendResult,
+	SessionModelSelection,
 	SubagentOverride,
 	TemplateReadLocation,
 	TemplateScope,
@@ -36,6 +37,7 @@ import {
 	getSessionCommands,
 	getSessionMessages,
 	getSessionStats,
+	getSessionWorkspaceId,
 	hasSession,
 	isSessionStreaming,
 	listAvailableModels,
@@ -161,6 +163,7 @@ import {
 	reclaimWorktree,
 	renameWorkspace,
 	setWorkspaceDiffBase,
+	setWorkspaceModelPreference,
 	setWorkspaceSkillOverride,
 	setWorkspaceSubagentsOverride,
 	workspaceDiffStats,
@@ -203,6 +206,37 @@ function recordAcceptedSend(mode: SendMode, text: string, clientKey: string): vo
 	if (isControlMessage(text)) return;
 	track({ name: "message_sent", params: { mode } });
 	recordAcceptedMessage(clientKey);
+}
+
+function sessionCreationOptions(
+	workspace: Workspace,
+	request: { model?: WireModel; thinkingLevel?: ThinkingLevel },
+): { model?: WireModel; thinkingLevel?: ThinkingLevel; modelOptional?: boolean } {
+	if (request.model) {
+		return {
+			model: request.model,
+			...(request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {}),
+		};
+	}
+	if (workspace.model && workspace.thinkingLevel) {
+		return {
+			model: workspace.model,
+			thinkingLevel: workspace.thinkingLevel,
+			modelOptional: true,
+		};
+	}
+	return request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {};
+}
+
+function persistEffectiveWorkspaceSelection(
+	workspaceId: string | undefined,
+	selection: SessionModelSelection,
+): void {
+	if (!workspaceId || !selection.model) return;
+	setWorkspaceModelPreference(workspaceId, {
+		model: selection.model,
+		thinkingLevel: selection.thinkingLevel,
+	});
 }
 
 function resolveTemplateReadDirs(params: TemplateReadLocation) {
@@ -618,9 +652,9 @@ const handlers: Record<string, Handler> = {
 		const created = await createSession({
 			cwd: ws.worktreePath,
 			workspaceId: p.workspaceId,
-			...(p.model ? { model: p.model } : {}),
-			...(p.thinkingLevel ? { thinkingLevel: p.thinkingLevel } : {}),
+			...sessionCreationOptions(ws, p),
 		});
+		if (p.model) persistEffectiveWorkspaceSelection(p.workspaceId, created);
 		if (created.model) {
 			track({
 				name: "chat_started",
@@ -677,13 +711,17 @@ const handlers: Record<string, Handler> = {
 	},
 	"session.setModel": async (params) => {
 		const p = params as { sessionId: string; model: WireModel };
-		await setSessionModel(p.sessionId, p.model);
-		return { ok: true } as const;
+		const workspaceId = getSessionWorkspaceId(p.sessionId);
+		const selection = await setSessionModel(p.sessionId, p.model);
+		persistEffectiveWorkspaceSelection(workspaceId, selection);
+		return selection;
 	},
 	"session.setThinkingLevel": (params) => {
 		const p = params as { sessionId: string; level: ThinkingLevel };
-		setSessionThinkingLevel(p.sessionId, p.level);
-		return { ok: true } as const;
+		const workspaceId = getSessionWorkspaceId(p.sessionId);
+		const selection = setSessionThinkingLevel(p.sessionId, p.level);
+		persistEffectiveWorkspaceSelection(workspaceId, selection);
+		return selection;
 	},
 	"session.compact": async (params) => {
 		const p = params as { sessionId: string; instructions?: string };

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -183,6 +183,7 @@ import {
 	startReviewAllFlow,
 	startTodoReviewFlow,
 } from "./todoReview";
+import { workspaceSessionOptions } from "./workspaceSessionOptions";
 
 const log = logger("host");
 
@@ -206,26 +207,6 @@ function recordAcceptedSend(mode: SendMode, text: string, clientKey: string): vo
 	if (isControlMessage(text)) return;
 	track({ name: "message_sent", params: { mode } });
 	recordAcceptedMessage(clientKey);
-}
-
-function sessionCreationOptions(
-	workspace: Workspace,
-	request: { model?: WireModel; thinkingLevel?: ThinkingLevel },
-): { model?: WireModel; thinkingLevel?: ThinkingLevel; modelOptional?: boolean } {
-	if (request.model) {
-		return {
-			model: request.model,
-			...(request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {}),
-		};
-	}
-	if (workspace.model && workspace.thinkingLevel) {
-		return {
-			model: workspace.model,
-			thinkingLevel: workspace.thinkingLevel,
-			modelOptional: true,
-		};
-	}
-	return request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {};
 }
 
 function persistEffectiveWorkspaceSelection(
@@ -325,9 +306,9 @@ async function sendToFileChat(
 	const created = await createSession({
 		cwd: ws.worktreePath,
 		workspaceId,
-		...(opts.model ? { model: opts.model } : {}),
-		...(opts.thinkingLevel ? { thinkingLevel: opts.thinkingLevel } : {}),
+		...workspaceSessionOptions(ws, opts),
 	});
+	if (opts.model) persistEffectiveWorkspaceSelection(workspaceId, created);
 	if (created.model) {
 		track({
 			name: "chat_started",
@@ -652,7 +633,7 @@ const handlers: Record<string, Handler> = {
 		const created = await createSession({
 			cwd: ws.worktreePath,
 			workspaceId: p.workspaceId,
-			...sessionCreationOptions(ws, p),
+			...workspaceSessionOptions(ws, p),
 		});
 		if (p.model) persistEffectiveWorkspaceSelection(p.workspaceId, created);
 		if (created.model) {

--- a/packages/server/src/host/handlers.ts
+++ b/packages/server/src/host/handlers.ts
@@ -214,10 +214,14 @@ function persistEffectiveWorkspaceSelection(
 	selection: SessionModelSelection,
 ): void {
 	if (!workspaceId || !selection.model) return;
-	setWorkspaceModelPreference(workspaceId, {
-		model: selection.model,
-		thinkingLevel: selection.thinkingLevel,
-	});
+	try {
+		setWorkspaceModelPreference(workspaceId, {
+			model: selection.model,
+			thinkingLevel: selection.thinkingLevel,
+		});
+	} catch {
+		log.warn(`workspace model preference not persisted for ${workspaceId}`);
+	}
 }
 
 function resolveTemplateReadDirs(params: TemplateReadLocation) {

--- a/packages/server/src/host/todoReview.test.ts
+++ b/packages/server/src/host/todoReview.test.ts
@@ -35,13 +35,13 @@ import {
 	resolveCommentFromAgent,
 } from "../reviews";
 import { resetConfigCache, updateConfig } from "../settings";
-import { getWorkspace, setWorkspaceModelPreference } from "../workspaces";
 import {
 	readReviewMeta,
 	reviewerSessionFor,
 	startTodoReview,
 	todoReviewAutoCycles,
 } from "../todos";
+import { getWorkspace, setWorkspaceModelPreference } from "../workspaces";
 import {
 	claimItemFix,
 	handleReviewerSettled,

--- a/packages/server/src/host/todoReview.test.ts
+++ b/packages/server/src/host/todoReview.test.ts
@@ -35,6 +35,7 @@ import {
 	resolveCommentFromAgent,
 } from "../reviews";
 import { resetConfigCache, updateConfig } from "../settings";
+import { getWorkspace, setWorkspaceModelPreference } from "../workspaces";
 import {
 	readReviewMeta,
 	reviewerSessionFor,
@@ -88,11 +89,12 @@ afterEach(() => {
 
 // --- A real (faux-model) reviewer session, so the add_review_comment tool seam can be driven the same
 // way a live reviewer chat would — see agentSessionManager.test.ts for the same harness pattern.
-function modelDef(id: string) {
+function modelDef(id: string, reasoning = false) {
 	return {
 		id,
 		name: id,
-		reasoning: false,
+		reasoning,
+		...(reasoning ? { thinkingLevelMap: { xhigh: "xhigh" } } : {}),
 		input: ["text"] as ("text" | "image")[],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 100_000,
@@ -104,6 +106,13 @@ const fauxReviewer = createFauxCore({
 	provider: "faux-reviewer",
 	api: "faux-reviewer",
 	models: [modelDef("faux-reviewer-model")],
+	tokensPerSecond: 2000,
+});
+
+const fauxWorkspace = createFauxCore({
+	provider: "faux-workspace",
+	api: "faux-workspace",
+	models: [modelDef("faux-workspace-model", true)],
 	tokensPerSecond: 2000,
 });
 
@@ -129,6 +138,13 @@ beforeAll(async () => {
 		streamSimple: fauxReviewer.streamSimple,
 		models: [{ ...modelDef("faux-reviewer-model"), api: fauxReviewer.api }],
 	});
+	runtime.registerProvider("faux-workspace", {
+		api: fauxWorkspace.api,
+		baseUrl: "http://faux-workspace.local",
+		apiKey: "faux",
+		streamSimple: fauxWorkspace.streamSimple,
+		models: [{ ...modelDef("faux-workspace-model", true), api: fauxWorkspace.api }],
+	});
 	configurePiRuntime(runtime);
 	setSessionManagerFactory(() => SessionManager.inMemory());
 	setSessionPublisher(() => {});
@@ -153,6 +169,32 @@ function anchorAt(path: string): ReviewAnchor {
 		selectors: [{ kind: "lineRange", startLine: 1, endLine: 1 }],
 	};
 }
+
+test("dedicated reviewers keep global review settings and do not rewrite workspace preferences", async () => {
+	installTodoReviewSeams();
+	fauxReviewer.setResponses([fauxAssistantMessage("Looks fine.")]);
+	const reviewerModel = toWireModel(fauxReviewer.getModel());
+	const workspaceModel = toWireModel(fauxWorkspace.getModel());
+	updateConfig({ reviewModel: reviewerModel, reviewEffort: "medium" });
+	setWorkspaceModelPreference(WS, { model: workspaceModel, thinkingLevel: "xhigh" });
+	const todo = new TodoStore(worktree, SESSION).add({
+		title: "t",
+		artifacts: [{ kind: "commit", sha: "sha1", label: "a" }],
+	});
+
+	const { reviewerSessionId } = await startTodoReviewFlow({
+		workspaceId: WS,
+		sessionId: SESSION,
+		id: todo.id,
+	});
+	const reviewer = (await listSessions(WS, worktree)).find(
+		(session) => session.sessionId === reviewerSessionId,
+	);
+
+	expect(reviewer).toMatchObject({ model: reviewerModel, thinkingLevel: "off" });
+	expect(getWorkspace(WS)).toMatchObject({ model: workspaceModel, thinkingLevel: "xhigh" });
+	handleReviewerSettled(reviewerSessionId, { type: "agent_settled", terminal: null });
+});
 
 test("the per-item fix latch rejects overlap and participates in the removal guard", () => {
 	expect(claimItemFix(SESSION, "t1")).toBe(true);
@@ -584,7 +626,10 @@ test("when reflection refutes every candidate, no empty fix request is sent — 
 		fauxAssistantMessage("This looks wrong."),
 		fauxAssistantMessage("Judging the finding…"),
 	]);
-	updateConfig({ reviewModel: toWireModel(fauxReviewer.getModel()), reviewEffort: "medium" });
+	const reviewerModel = toWireModel(fauxReviewer.getModel());
+	const workspaceModel = toWireModel(fauxWorkspace.getModel());
+	updateConfig({ reviewModel: reviewerModel, reviewEffort: "medium" });
+	setWorkspaceModelPreference(WS, { model: workspaceModel, thinkingLevel: "xhigh" });
 
 	// listSessions(WS, ...) is workspace-scoped only — this file reuses WS across every test and
 	// never disposes a settled test's sessions until afterAll, so a "not the reviewer" filter alone
@@ -659,6 +704,11 @@ test("when reflection refutes every candidate, no empty fix request is sent — 
 		}
 		await new Promise((resolve) => setTimeout(resolve, 20));
 	}
+	const reflector = (await listSessions(WS, worktree)).find(
+		(session) => session.sessionId === reflectorSessionId,
+	);
+	expect(reflector).toMatchObject({ model: reviewerModel, thinkingLevel: "off" });
+	expect(getWorkspace(WS)).toMatchObject({ model: workspaceModel, thinkingLevel: "xhigh" });
 	maybeResumeReflection(reflectorSessionId);
 	while (todoReviewAutoCycles(ref) !== 2) {
 		if (Date.now() > deadline) throw new Error("reflected fix did not settle");

--- a/packages/server/src/host/workspaceSessionOptions.ts
+++ b/packages/server/src/host/workspaceSessionOptions.ts
@@ -10,6 +10,7 @@ export function workspaceSessionOptions(
 			...(request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {}),
 		};
 	}
+	if (request.thinkingLevel) return { thinkingLevel: request.thinkingLevel };
 	if (workspace.model && workspace.thinkingLevel) {
 		return {
 			model: workspace.model,
@@ -17,5 +18,5 @@ export function workspaceSessionOptions(
 			modelOptional: true,
 		};
 	}
-	return request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {};
+	return {};
 }

--- a/packages/server/src/host/workspaceSessionOptions.ts
+++ b/packages/server/src/host/workspaceSessionOptions.ts
@@ -1,0 +1,21 @@
+import type { ThinkingLevel, WireModel, Workspace } from "@thinkrail/contracts";
+
+export function workspaceSessionOptions(
+	workspace: Workspace,
+	request: { model?: WireModel; thinkingLevel?: ThinkingLevel },
+): { model?: WireModel; thinkingLevel?: ThinkingLevel; modelOptional?: boolean } {
+	if (request.model) {
+		return {
+			model: request.model,
+			...(request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {}),
+		};
+	}
+	if (workspace.model && workspace.thinkingLevel) {
+		return {
+			model: workspace.model,
+			thinkingLevel: workspace.thinkingLevel,
+			modelOptional: true,
+		};
+	}
+	return request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {};
+}

--- a/packages/server/src/workspaces/SPEC.md
+++ b/packages/server/src/workspaces/SPEC.md
@@ -113,6 +113,11 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   or delete `Workspace.subagentsOverride` for `null` (inherit), then emit the authoritative full
   `workspace.updated` snapshot. It validates the closed value but never reads the global default or
   resolves effective agent policy; the host composes that across sibling boundaries;
+  **`setWorkspaceModelPreference(id, selection | null)`** — atomically persists or clears both
+  `Workspace.model` and `Workspace.thinkingLevel`; a non-null selection requires the complete pair. It
+  performs one registry save, then emits one authoritative full-snapshot `updated` event, and returns that
+  record. Managed, Default, and external records follow the identical rule; this module stores the pair but
+  never resolves model availability or defaults;
   **`setWorkspaceDiffBase(id, ref | null)`** — re-point the ref this workspace's diff is
   measured against (`Workspace.diffBase`), `null` (or the creation base itself, which would be a redundant
   override) clearing it; persists + **broadcasts the updated record** so every client converges on the push,
@@ -211,7 +216,7 @@ place as `kind: "external"` — outside the data dir, never created or mutated h
   `workspaceDiffStats`, `workspaceDiffKey`, `getWorkspace`, `renameWorkspace`, `refreshUserOwnedWorkspace`,
   `completeInitialTerminalReservation`, `ensureWorkspaceScratchDir`, `setWorkspacePublisher`,
   `WorkspaceLifecycleEvent`, `setWorkspaceDiffBase`, `setWorkspaceSkillOverride`,
-  `setWorkspaceSubagentsOverride`.
+  `setWorkspaceSubagentsOverride`, `setWorkspaceModelPreference`.
 - **Allowed deps:** `projects` (repo lookup), `git` (the runner), `persistence`, `log`; `contracts`;
   `@thinkrail/shared/paths` (the scratch-dir path convention); Node.
 - **Forbidden:** `host`; reaching into another feature's internals (use its barrel).

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -26,6 +26,7 @@ import {
 	removeWorkspace,
 	renameWorkspace,
 	setWorkspaceDiffBase,
+	setWorkspaceModelPreference,
 	setWorkspacePublisher,
 	setWorkspaceSubagentsOverride,
 	type WorkspaceLifecycleEvent,
@@ -48,6 +49,15 @@ function git(cwd: string, ...args: string[]): void {
 async function worktrees(projectId = "p1") {
 	return (await listWorkspaces(projectId)).filter((w) => w.kind !== "default");
 }
+
+const MODEL: NonNullable<Workspace["model"]> = {
+	id: "sticky-model",
+	name: "Sticky model",
+	provider: "test-provider",
+	contextWindow: 100_000,
+	reasoning: false,
+	thinkingLevels: ["off"],
+};
 
 beforeEach(() => {
 	dataDir = realpathSync(mkdtempSync(join(tmpdir(), "trpi-ws-test-")));
@@ -490,6 +500,77 @@ test("setWorkspaceSubagentsOverride rejects unknown workspaces and values outsid
 	expect(() => setWorkspaceSubagentsOverride(ws.id, "sometimes" as "on")).toThrow(
 		"Invalid subagent override",
 	);
+});
+
+test("setWorkspaceModelPreference persists and clears one complete pair per update", async () => {
+	const ws = await createWorkspace("p1");
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((event) => events.push(event));
+
+	const selected = setWorkspaceModelPreference(ws.id, {
+		model: MODEL,
+		thinkingLevel: "off",
+	});
+	expect(selected).toMatchObject({ model: MODEL, thinkingLevel: "off" });
+	expect(listWorkspaceRecords("p1").find((row) => row.id === ws.id)).toMatchObject({
+		model: MODEL,
+		thinkingLevel: "off",
+	});
+	expect(events).toEqual([{ kind: "updated", workspace: selected }]);
+
+	const cleared = setWorkspaceModelPreference(ws.id, null);
+	expect(cleared.model).toBeUndefined();
+	expect(cleared.thinkingLevel).toBeUndefined();
+	expect(listWorkspaceRecords("p1").find((row) => row.id === ws.id)).not.toHaveProperty("model");
+	expect(events).toEqual([
+		{ kind: "updated", workspace: selected },
+		{ kind: "updated", workspace: cleared },
+	]);
+});
+
+test("setWorkspaceModelPreference treats managed, Default, and external records identically", async () => {
+	const managed = await createWorkspace("p1");
+	const defaultWorkspace = (await listWorkspaces("p1")).find((workspace) => workspace.kind === "default");
+	if (!defaultWorkspace) throw new Error("missing Default workspace");
+	const externalPath = join(dataDir, "external-model-worktree");
+	git(repo, "worktree", "add", externalPath, "-b", "feature/external-model", "main");
+	const external = await openExistingWorktree("p1", externalPath);
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((event) => events.push(event));
+
+	for (const workspace of [managed, defaultWorkspace, external]) {
+		setWorkspaceModelPreference(workspace.id, { model: MODEL, thinkingLevel: "off" });
+	}
+	for (const workspace of listWorkspaceRecords("p1")) {
+		expect(workspace).toMatchObject({ model: MODEL, thinkingLevel: "off" });
+	}
+	for (const workspace of [managed, defaultWorkspace, external]) {
+		setWorkspaceModelPreference(workspace.id, null);
+	}
+	for (const workspace of listWorkspaceRecords("p1")) {
+		expect(workspace.model).toBeUndefined();
+		expect(workspace.thinkingLevel).toBeUndefined();
+	}
+	expect(events).toHaveLength(6);
+	expect(events.every((event) => event.kind === "updated")).toBe(true);
+});
+
+test("setWorkspaceModelPreference rejects an unknown workspace without publishing", () => {
+	const events: WorkspaceLifecycleEvent[] = [];
+	setWorkspacePublisher((event) => events.push(event));
+	expect(() =>
+		setWorkspaceModelPreference("missing", { model: MODEL, thinkingLevel: "off" }),
+	).toThrow("Unknown workspace: missing");
+	expect(events).toEqual([]);
+});
+
+test("legacy workspace records without a model pair remain unchanged on read", async () => {
+	await createWorkspace("p1");
+	const path = join(dataDir, "workspaces.json");
+	const before = readFileSync(path, "utf8");
+	const records = listWorkspaceRecords("p1");
+	expect(records.every((workspace) => !workspace.model && !workspace.thinkingLevel)).toBe(true);
+	expect(readFileSync(path, "utf8")).toBe(before);
 });
 
 test("setWorkspaceDiffBase re-points the diff target, leaving creation provenance alone", async () => {

--- a/packages/server/src/workspaces/workspaces.test.ts
+++ b/packages/server/src/workspaces/workspaces.test.ts
@@ -530,7 +530,9 @@ test("setWorkspaceModelPreference persists and clears one complete pair per upda
 
 test("setWorkspaceModelPreference treats managed, Default, and external records identically", async () => {
 	const managed = await createWorkspace("p1");
-	const defaultWorkspace = (await listWorkspaces("p1")).find((workspace) => workspace.kind === "default");
+	const defaultWorkspace = (await listWorkspaces("p1")).find(
+		(workspace) => workspace.kind === "default",
+	);
 	if (!defaultWorkspace) throw new Error("missing Default workspace");
 	const externalPath = join(dataDir, "external-model-worktree");
 	git(repo, "worktree", "add", externalPath, "-b", "feature/external-model", "main");

--- a/packages/server/src/workspaces/workspaces.ts
+++ b/packages/server/src/workspaces/workspaces.ts
@@ -465,6 +465,25 @@ export function setWorkspaceSubagentsOverride(
 	return ws;
 }
 
+export function setWorkspaceModelPreference(
+	id: string,
+	selection: Required<Pick<Workspace, "model" | "thinkingLevel">> | null,
+): Workspace {
+	const all = loadWorkspaces();
+	const ws = all.find((workspace) => workspace.id === id);
+	if (!ws) throw new Error(`Unknown workspace: ${id}`);
+	if (selection) {
+		ws.model = selection.model;
+		ws.thinkingLevel = selection.thinkingLevel;
+	} else {
+		delete ws.model;
+		delete ws.thinkingLevel;
+	}
+	saveWorkspaces(all);
+	emit({ kind: "updated", workspace: ws });
+	return ws;
+}
+
 export function setWorkspaceDiffBase(id: string, ref: string | null): Workspace {
 	const all = loadWorkspaces();
 	const ws = all.find((w) => w.id === id);


### PR DESCRIPTION
## Summary

- Persist each workspace's last successful Pi-effective model and thinking-level pair atomically, and apply it to later normal and review-comment chats without changing global Pi defaults.
- Keep explicit model requests strict, tolerate stale stored models for one-session fallback without self-healing persistence, and leave transcript restore plus dedicated reviewer/reflector sessions isolated.
- Advance the wire to protocol v65, return effective mutation pairs, retain v64 client compatibility, and reconcile live selectors through one remount-stable per-session transaction.
- Start New Workspace on **Default model**, then seed only an explicit successful selection. The persisted row reaches clients through `workspace.list` / `workspace.updated`; the web never writes it back. Add deterministic server, store, protocol, and browser coverage for inheritance, clamps, reload persistence, and compatibility races.

UI note: the visible change is limited to the existing New Workspace and chat model/effort selectors; no new control was introduced.

## Unrelated test-only fix

`e2e/ask-user-question.spec.ts` could not reach a target above the viewport, because `wheelUntilChatElementIntersects` only ever scrolled downward. The helper now scrolls by the signed distance to the target.

## Checklist

- [x] Fast gates pass: `bun run lint`, `bun run typecheck`, `bun run test`
- [x] E2E suite passes for app-affecting changes (`bun run e2e`, or `bun run e2e:full` when touching agent behavior)
- [x] Relevant `SPEC.md` / top-level specs updated to reflect any boundary, contract, or behavior change
- [x] I have read the [Contributing guide](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
