### PR TITLE
TODO queue bug vs ask user question

### DIFF
--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -468,10 +468,23 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     race-free; **(b)** while a question is pending (derived from the transcript via
     `awaitingQuestionToolCallId`, the single authority), `promptSession`/`steerSession`/`followUpSession`
     park into the same buffer instead of touching pi. The buffer is unioned into every queue projection
-    (`queueContentOf`/`queueStateOf`/`hasQueuedImages`/the `queue_update` fan-out and the `summaryOf`
-    queue field) so held messages still render as queued chips; it is **not** counted in
-    `pendingMessageCount`, which is why the status stays `waiting` rather than `queued`. `clearQueue`
-    empties it too, so Stop/`abortSession(..., true)` stay lossless. Pinned by `agentSessionManager.test.ts`.
+    (`queueContentOf`/`queueStateOf`/`hasQueuedImages`/`queueUpdateEventOf` and the `summaryOf` queue
+    field) so held messages still render as queued chips; it is **not** counted in `pendingMessageCount`
+    (nor `effectivePendingCount`), which is why the status stays `waiting` rather than `queued`. Capture
+    also **resets `stuckEmptyDeliveries`** since it empties pi's lanes (the same invariant
+    `clearQueueSession` holds), and it always clears — even when only stuck-empty placeholders are queued —
+    so no phantom entry drains past the boundary. `clearQueueSession` empties the buffer too, so
+    `removeQueuedSession` (re-queued keepers re-park while the question is still pending) and
+    Stop/`abortSession(..., true)` stay lossless. Pinned by `agentSessionManager.test.ts`.
+
+    **The buffer is in-memory, deliberately** — like pi's own queue, which is also lost on a host
+    restart. A restart while a question is pending is still safe: the transcript stays provider-valid,
+    the question re-derives as `waiting`, and answering runs normally; only the user's *typed-ahead*
+    follow-ups are dropped (the pending window is long, so the exposure is larger than for a normally
+    draining queue). Persisting them would need a store pi does not offer and is deferred. The pending
+    ask is the transcript **tail**, so it survives compaction and `questionPending` stays true until
+    answered — the buffer never orphans (supersession by a later user message cannot happen either, since
+    such a message is itself parked).
 
     The reply arrives over `session.answerQuestion` → the manager's
     `answerQuestion(sessionId, toolCallId, result)`: it vets the reply against the transcript with the

--- a/packages/server/src/agent/SPEC.md
+++ b/packages/server/src/agent/SPEC.md
@@ -171,9 +171,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     - **A dialog outranks streaming** because pi is technically mid-turn while blocked on it, yet the person
       is the blocker. Reporting `running` would hide a prompt waiting for an answer.
     - **`queued` outranks `failed`** (you already sent the follow-up, so the failure is handled and nagging
-      would be wrong) **and outranks `waiting`** — a queued message supersedes a pending questionnaire, but
-      it is still in pi's queue and *not yet in the transcript*, so `assessAnswerability` cannot see it.
-      This is why supersession is not modelled as mutable "awaiting" state on the entry: `waiting` is
+      would be wrong) **and outranks `waiting`** — but the two never co-occur, because a pending
+      questionnaire **holds the queue** (see `askUserQuestion` below): while a question is unanswered every
+      queued or newly-sent message is parked in `entry.heldWhileAsking`, *out* of pi's queue, so
+      `pendingMessageCount` is 0 and the status derives `waiting`, not `queued`. `waiting` itself is
       **derived from the transcript** via `awaitingQuestionToolCallId`, which reuses `assessAnswerability`
       rather than duplicating its already-answered/superseded rules. One authority, nothing to keep in sync.
     - **`aborted` is idle, not `failed`** — cancelling is a choice, not a fault, and a red row for every
@@ -445,13 +446,34 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     only from pi's own CLI entrypoints, never when pi is embedded via `createAgentSession`. Every
     embedder of pi-as-a-library hits this; an upstream fix would not reach us until a deliberate pi bump.
   - `askUserQuestion` — the host-owned **`ask_user_question`** pi custom tool (`createAskUserQuestionTool`,
-    registered on every session via the `askUserQuestionExtension` factory in `extensions`), designed
+    registered on every host chat session via the `askUserQuestionExtensionFor(hold?)` factory in
+    `extensions`), designed
     **ack + terminate** so a questionnaire survives host restarts: `execute` renders nothing and **awaits
     nothing** — it guards on `ctx.hasUI`, runs the pure `validateQuestionnaire`, then immediately returns
     the ack (`details {kind:"ack"}`) with **`terminate: true`**, ending the turn at the tool batch with no
     further LLM call. Nothing pends in memory, the transcript is complete and provider-valid the moment
     the ack lands, and the session is genuinely **idle** while the user thinks — restarts need no
-    question-specific handling at all. The reply arrives over `session.answerQuestion` → the manager's
+    question-specific handling at all.
+
+    **A pending question holds the queue.** `terminate: true` ends the turn, and pi's generic behaviour is
+    to drain its follow-up queue at that boundary — so a message the user queued while the agent was
+    working would start a new turn and *supersede* the unanswered question. That is the cost of our ack +
+    terminate choice (pi's own blocking `ctx.ui.*` dialogs never end the turn, so pi never drains; our
+    tool trades that for restart-survivability), so the host closes it, not pi. The seam is a per-session
+    **`QuestionHold`** wired through `buildResourceLoader(..., questionHold?)` and bound to the entry in
+    `prepareSessionEntry`. Two paths are held into `entry.heldWhileAsking` (a host-owned park buffer,
+    *not* pi's queue): **(a)** inside `execute`, before the ack, if `ctx.hasPendingMessages()` the tool
+    synchronously drains pi's lanes (complete-content snapshot + `clearQueue`) into the buffer — running
+    *inside the tool tick* means pi meets an empty queue at the boundary and settles into `waiting`,
+    race-free; **(b)** while a question is pending (derived from the transcript via
+    `awaitingQuestionToolCallId`, the single authority), `promptSession`/`steerSession`/`followUpSession`
+    park into the same buffer instead of touching pi. The buffer is unioned into every queue projection
+    (`queueContentOf`/`queueStateOf`/`hasQueuedImages`/the `queue_update` fan-out and the `summaryOf`
+    queue field) so held messages still render as queued chips; it is **not** counted in
+    `pendingMessageCount`, which is why the status stays `waiting` rather than `queued`. `clearQueue`
+    empties it too, so Stop/`abortSession(..., true)` stay lossless. Pinned by `agentSessionManager.test.ts`.
+
+    The reply arrives over `session.answerQuestion` → the manager's
     `answerQuestion(sessionId, toolCallId, result)`: it vets the reply against the transcript with the
     pure **`assessAnswerability`** (unknown call / already answered / `not_awaiting` legacy-final results /
     **superseded** — a later free-form user message replaced the answer, so the card is terminal and a
@@ -460,8 +482,10 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     text = the same `buildQuestionnaireResponse` envelope the blocking design fed the model; a partial
     submission lists its unanswered questions explicitly as declined) — via pi's public
     `AgentSession.sendCustomMessage({triggerTurn: true})`, which starts a new turn when idle and steers
-    the current one when streaming. **Answering live and answering after a restart are the same code
-    path.** The questionnaire is rendered **inline** in chat by `apps/web`'s `AskUserQuestionCard`
+    the current one when streaming, **then flushes `entry.heldWhileAsking` in order** through the same
+    idle-delivery fallback as `followUpSession` (answer first, the user's held follow-ups after). An
+    answer and a Skip/decline flush identically. **Answering live and answering after a restart are the
+    same code path.** The questionnaire is rendered **inline** in chat by `apps/web`'s `AskUserQuestionCard`
     (joined by tool name; lifecycle derived from the transcript — see the chat tools SPEC).
     **Rejected alternatives** (the one place these decisions are recorded): (1) the original **blocking
     design** — `execute` parked on an in-memory promise until the browser replied. A host restart
@@ -572,7 +596,7 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     raw third-party `.ts` must stay out of the strict tsc graph.
   - `extensions` — Pi resource wiring. Candidate generation loads the reviewed external Central path once
     through a headless `DefaultResourceLoader` to apply provider registrations, without inspecting it.
-    `buildResourceLoader(cwd, settingsManager, getAdmission, excludedPaths, extraFactories?)` then resolves
+    `buildResourceLoader(cwd, settingsManager, getAdmission, excludedPaths, extraFactories?, questionHold?)` then resolves
     Pi's normal settings/package +
     `.pi` / `.agents` extension set, removes that exact opaque identity **before loading**, and explicitly loads
     the remaining paths: sessions use the provider objects already owned by their retained generation, so
@@ -663,7 +687,7 @@ answer-injection path, and the **restart repair** that keeps re-opened transcrip
     Jiti seam; it is never bundled, staged, or copied into ThinkRail. Both modes append
     `extensionFactories`: a **headless-search policy** (a `tool_call` hook defaulting
     `web_search`'s `workflow` to `"none"`, since pi-web-access would otherwise open a browser curator our
-    `rpc` host can't render), `askUserQuestionExtension` (registers the `ask_user_question` tool),
+    `rpc` host can't render), `askUserQuestionExtensionFor(hold?)` (registers the `ask_user_question` tool),
     `oversizedImageGuard` (the context-level image-size guard, see the `imageGuard` bullet), **and the
     caller's `extraFactories`** — per-session host bindings (the workspace-bound subagents extension),
     value-imported so dev and the compiled binary take the same path.

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -18,6 +18,7 @@ import {
 import {
 	createFauxCore,
 	fauxAssistantMessage,
+	fauxText,
 	fauxToolCall,
 } from "@earendil-works/pi-ai/providers/faux";
 import { AgentSession, ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
@@ -31,6 +32,7 @@ import type {
 import { defaultSessionDirFor, writeFixtureSession } from "../history/testFixtures";
 import {
 	abortSession,
+	answerQuestion,
 	buildSessionSettings,
 	clampThinkingForModel,
 	clearQueueSession,
@@ -1226,6 +1228,87 @@ test("followUpSession on an IDLE session runs the turn — pi's follow-up queue 
 		setSessionManagerFactory(() => SessionManager.inMemory());
 	}
 });
+
+test("a pending ask_user_question holds the queue — a mid-turn follow-up does not supersede the question (status stays waiting) and flushes in order on answer", async () => {
+	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
+	const slow = createFauxCore({
+		provider: "fauxask",
+		api: "fauxask",
+		models: [modelDef("fauxask")],
+		tokensPerSecond: 40,
+	});
+	runtime.registerProvider("fauxask", cfg(slow, "fauxask"));
+	setActivityProjectResolver(() => "project-hold");
+	try {
+		slow.setResponses([
+			fauxAssistantMessage([
+				fauxText(`ASKING ${"word ".repeat(60)}`),
+				fauxToolCall(
+					"ask_user_question",
+					{
+						questions: [
+							{
+								question: "Which one?",
+								header: "Pick",
+								options: [
+									{ label: "A", description: "first" },
+									{ label: "B", description: "second" },
+								],
+							},
+						],
+					},
+					{ id: "ask-hold-1" },
+				),
+			]),
+		]);
+		const cwd = tmpCwd("trpi-hold-");
+		const s = await createSession({
+			cwd,
+			workspaceId: "ws-hold",
+			model: toWireModel(slow.getModel()),
+		});
+		const turn = promptSession(s.sessionId, "work on the first thing");
+		turn.catch(() => {});
+		const streamedBy = Date.now() + 5000;
+		while (!seen(s.sessionId).includes("message_update")) {
+			if (Date.now() > streamedBy) throw new Error("first turn never started streaming");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		await followUpSession(s.sessionId, "then do the second thing");
+		await turn;
+
+		const status = (await listSessionActivity()).find(
+			(row) => row.sessionId === s.sessionId,
+		)?.status;
+		expect(status).toBe("waiting");
+		const held = (await listSessions("ws-hold", cwd)).find((row) => row.sessionId === s.sessionId);
+		expect(held?.queue).toEqual({ steering: [], followUp: ["then do the second thing"] });
+		expect(seen(s.sessionId)).not.toContain("SECOND_TURN");
+
+		slow.appendResponses([
+			fauxAssistantMessage("ANSWER_TURN"),
+			fauxAssistantMessage("SECOND_TURN"),
+		]);
+		await answerQuestion(s.sessionId, "ask-hold-1", {
+			answers: [{ questionIndex: 0, question: "Which one?", kind: "option", answer: "A" }],
+			cancelled: false,
+		});
+		const ranBy = Date.now() + 5000;
+		while (!seen(s.sessionId).includes("SECOND_TURN")) {
+			if (Date.now() > ranBy) throw new Error("held follow-up never ran after the answer");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		expect(seen(s.sessionId)).toContain("ANSWER_TURN");
+		expect(
+			(await listSessions("ws-hold", cwd)).find((row) => row.sessionId === s.sessionId)?.queue,
+		).toBeUndefined();
+		removeSession(s.sessionId);
+	} finally {
+		runtime.unregisterProvider("fauxask");
+		setActivityProjectResolver(() => null);
+		setSessionManagerFactory(() => SessionManager.inMemory());
+	}
+}, 20000);
 
 test("stop losslessly restores an image-bearing queue before aborting", async () => {
 	setSessionManagerFactory((cwd) => SessionManager.create(cwd));

--- a/packages/server/src/agent/agentSessionManager.test.ts
+++ b/packages/server/src/agent/agentSessionManager.test.ts
@@ -1229,6 +1229,69 @@ test("followUpSession on an IDLE session runs the turn — pi's follow-up queue 
 	}
 });
 
+test("a message sent while a question is already pending is held (idle send), stays waiting, and flushes on answer", async () => {
+	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
+	setActivityProjectResolver(() => "project-hold-idle");
+	try {
+		fauxA.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall(
+					"ask_user_question",
+					{
+						questions: [
+							{
+								question: "Q?",
+								header: "H",
+								options: [
+									{ label: "A", description: "a" },
+									{ label: "B", description: "b" },
+								],
+							},
+						],
+					},
+					{ id: "ask-idle-1" },
+				),
+			),
+		]);
+		const cwd = tmpCwd("trpi-hold-idle-");
+		const s = await createSession({
+			cwd,
+			workspaceId: "ws-hold-idle",
+			model: toWireModel(fauxA.getModel()),
+		});
+		await promptSession(s.sessionId, "ask me");
+		const statusOf = async () =>
+			(await listSessionActivity()).find((row) => row.sessionId === s.sessionId)?.status;
+		expect(await statusOf()).toBe("waiting");
+
+		await followUpSession(s.sessionId, "later task");
+		expect(
+			(await listSessions("ws-hold-idle", cwd)).find((row) => row.sessionId === s.sessionId)?.queue,
+		).toEqual({ steering: [], followUp: ["later task"] });
+		expect(await statusOf()).toBe("waiting");
+		expect(seen(s.sessionId)).not.toContain("LATER_DONE");
+
+		fauxA.appendResponses([fauxAssistantMessage("ANSWERED"), fauxAssistantMessage("LATER_DONE")]);
+		await answerQuestion(s.sessionId, "ask-idle-1", {
+			answers: [{ questionIndex: 0, question: "Q?", kind: "option", answer: "A" }],
+			cancelled: false,
+		});
+		const ranBy = Date.now() + 5000;
+		while (!seen(s.sessionId).includes("LATER_DONE")) {
+			if (Date.now() > ranBy) throw new Error("held follow-up never ran after the answer");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		expect(seen(s.sessionId)).toContain("ANSWERED");
+		expect(
+			(await listSessions("ws-hold-idle", cwd)).find((row) => row.sessionId === s.sessionId)?.queue,
+		).toBeUndefined();
+		removeSession(s.sessionId);
+	} finally {
+		setActivityProjectResolver(() => null);
+		setSessionManagerFactory(() => SessionManager.inMemory());
+	}
+});
+
 test("a pending ask_user_question holds the queue — a mid-turn follow-up does not supersede the question (status stays waiting) and flushes in order on answer", async () => {
 	setSessionManagerFactory((cwd) => SessionManager.create(cwd));
 	const slow = createFauxCore({

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -1047,13 +1047,12 @@ function publishHeldQueueUpdate(entry: Entry): void {
 
 function captureHeldQueue(entry: Entry): void {
 	synchronizeQueueFromSession(entry);
-	const captured = [
+	entry.heldWhileAsking.push(
 		...entry.queuedMessages.steering.map((message) => cloneTracked(entry, message)),
 		...entry.queuedMessages.followUp.map((message) => cloneTracked(entry, message)),
-	];
-	if (captured.length === 0) return;
-	entry.heldWhileAsking.push(...captured);
+	);
 	entry.session.clearQueue();
+	entry.stuckEmptyDeliveries = { steering: 0, followUp: 0 };
 }
 
 function parkHeld(entry: Entry, text: string, images?: ImageContent[]): void {

--- a/packages/server/src/agent/agentSessionManager.ts
+++ b/packages/server/src/agent/agentSessionManager.ts
@@ -52,7 +52,13 @@ import {
 	TRANSCRIPT_TAIL_MAX_BYTES,
 	type WorkspaceActivityRow,
 } from "./activity";
-import { ANSWERABILITY_ERRORS, assessAnswerability, buildAnswersMessage } from "./askUserQuestion";
+import {
+	ANSWERABILITY_ERRORS,
+	assessAnswerability,
+	awaitingQuestionToolCallId,
+	buildAnswersMessage,
+	type QuestionHold,
+} from "./askUserQuestion";
 import {
 	disposeSessionChildren,
 	removeWorkspaceDelegation,
@@ -93,6 +99,7 @@ interface Entry {
 	lastSettlement: AgentSettlement | null | undefined;
 	queuedMessages: Record<QueueLane, TrackedQueuedMessage[]>;
 	stuckEmptyDeliveries: Record<QueueLane, number>;
+	heldWhileAsking: TrackedQueuedMessage[];
 	nextQueuedMessageId: number;
 	manualCompactionInProgress: boolean;
 	piCompactionInProgress: boolean;
@@ -101,6 +108,14 @@ interface Entry {
 	publishedActivity: ActivityStatus | null;
 	rawActivity: ActivityStatus | null;
 	lastActivityMs: number;
+}
+
+interface MutableQuestionHold extends QuestionHold {
+	capture: () => void;
+}
+
+function newQuestionHold(): MutableQuestionHold {
+	return { capture: () => {} };
 }
 
 const sessions = new Map<string, Entry>();
@@ -477,6 +492,7 @@ async function prepareSessionEntry(
 	workspaceId: string,
 	generation: PiRuntimeGeneration,
 	lastSettlement: AgentSettlement | null | undefined = undefined,
+	hold?: MutableQuestionHold,
 ): Promise<PreparedSessionEntry> {
 	const { sessionId } = session;
 	let terminal: AgentSettlement | null = null;
@@ -488,6 +504,7 @@ async function prepareSessionEntry(
 		lastSettlement,
 		queuedMessages: { steering: [], followUp: [] },
 		stuckEmptyDeliveries: { steering: 0, followUp: 0 },
+		heldWhileAsking: [],
 		nextQueuedMessageId: 1,
 		manualCompactionInProgress: false,
 		piCompactionInProgress: false,
@@ -500,6 +517,7 @@ async function prepareSessionEntry(
 	entry.rawActivity = activityOf(entry);
 	const seededRecencyMs = messagesActivityMs(session.messages);
 	if (seededRecencyMs !== null) entry.lastActivityMs = seededRecencyMs;
+	if (hold) hold.capture = () => captureHeldQueue(entry);
 	entry.unsubscribe = session.subscribe((event) => {
 		if (event.type === "message_start" && event.message.role === "user") {
 			const lane = deliveredStuckEmptyLane(entry, event.message.content);
@@ -533,15 +551,7 @@ async function prepareSessionEntry(
 				: null;
 		}
 		const baseEvent = projectSessionEvent(event, terminal);
-		const projected =
-			baseEvent.type === "queue_update"
-				? {
-						type: "queue_update" as const,
-						steering: displayedLane(entry, "steering", baseEvent.steering),
-						followUp: displayedLane(entry, "followUp", baseEvent.followUp),
-						...(hasQueuedImages(entry) ? { hasImages: true as const } : {}),
-					}
-				: baseEvent;
+		const projected = baseEvent.type === "queue_update" ? queueUpdateEventOf(entry) : baseEvent;
 		if (event.type === "agent_settled") {
 			entry.lastSettlement = terminal;
 			if (entry.subagentToolsRefreshPending) applySubagentTools(entry);
@@ -593,8 +603,9 @@ async function registerSession(
 	workspaceId: string,
 	generation: PiRuntimeGeneration,
 	announceCreation = false,
+	hold?: MutableQuestionHold,
 ): Promise<CreateSessionResult> {
-	const prepared = await prepareSessionEntry(session, workspaceId, generation);
+	const prepared = await prepareSessionEntry(session, workspaceId, generation, undefined, hold);
 	prepared.entry.registered = true;
 	sessions.set(session.sessionId, prepared.entry);
 	applySubagentTools(prepared.entry);
@@ -615,6 +626,7 @@ export async function createSession(input: CreateSessionInput): Promise<CreateSe
 			if (!input.modelOptional) throw err;
 		}
 	}
+	const questionHold = newQuestionHold();
 	const { session } = await createAgentSession({
 		cwd: input.cwd,
 		modelRuntime: generation.runtime,
@@ -626,11 +638,12 @@ export async function createSession(input: CreateSessionInput): Promise<CreateSe
 			() => skillAdmissionResolver(input.workspaceId),
 			generation.excludedSessionExtensionPaths,
 			[subagentsExtensionFor(input.workspaceId, () => subagentsEnabled(input.workspaceId))],
+			questionHold,
 		),
 		...(model ? { model } : {}),
 		...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
 	});
-	return registerSession(session, input.workspaceId, generation, true);
+	return registerSession(session, input.workspaceId, generation, true, questionHold);
 }
 
 function summaryOf(sessionId: string, entry: Entry): SessionSummary {
@@ -646,7 +659,9 @@ function summaryOf(sessionId: string, entry: Entry): SessionSummary {
 		updatedAt: Date.now(),
 		live: true,
 		...(entry.lastSettlement !== undefined ? { lastSettlement: entry.lastSettlement } : {}),
-		...(effectivePendingCount(entry) > 0 ? { queue: queueStateOf(entry) } : {}),
+		...(effectivePendingCount(entry) > 0 || entry.heldWhileAsking.length > 0
+			? { queue: queueStateOf(entry) }
+			: {}),
 	};
 }
 
@@ -830,6 +845,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 		}
 	}
 	repairDanglingToolCalls(sessionManager);
+	const questionHold = newQuestionHold();
 	const { session } = await createAgentSession({
 		cwd,
 		modelRuntime: generation.runtime,
@@ -841,6 +857,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 			() => skillAdmissionResolver(workspaceId),
 			generation.excludedSessionExtensionPaths,
 			[subagentsExtensionFor(workspaceId, () => subagentsEnabled(workspaceId))],
+			questionHold,
 		),
 		...(exactModel ? { model: exactModel } : {}),
 	});
@@ -848,7 +865,7 @@ async function openDiskSession(sessionId: string, workspaceId: string, cwd: stri
 		session.dispose();
 		return;
 	}
-	await registerSession(session, workspaceId, generation);
+	await registerSession(session, workspaceId, generation, false, questionHold);
 }
 
 async function ensureSessionAttachedInternal(
@@ -913,12 +930,14 @@ export async function answerQuestion(
 	toolCallId: string,
 	result: AskUserQuestionResult,
 ): Promise<void> {
-	const session = mustGet(sessionId);
+	const entry = mustGetEntry(sessionId);
+	const { session } = entry;
 	const verdict = assessAnswerability(session.messages, toolCallId);
 	if (!verdict.ok) throw new Error(`${ANSWERABILITY_ERRORS[verdict.reason]}: ${toolCallId}`);
 	await session.sendCustomMessage(buildAnswersMessage(toolCallId, verdict.args, result), {
 		triggerTurn: true,
 	});
+	await flushHeldQueue(entry);
 	syncSessionActivity(sessionId);
 }
 
@@ -973,7 +992,10 @@ function queueUpdateEventOf(entry: Entry): PiEvent {
 	return {
 		type: "queue_update",
 		steering: displayedLane(entry, "steering"),
-		followUp: displayedLane(entry, "followUp"),
+		followUp: [
+			...displayedLane(entry, "followUp"),
+			...entry.heldWhileAsking.map((message) => message.text),
+		],
 		...(hasQueuedImages(entry) ? { hasImages: true as const } : {}),
 	};
 }
@@ -1004,7 +1026,60 @@ function userContentHasImage(content: unknown): boolean {
 	return userContentBlocks(content).some((block) => block.type === "image");
 }
 
+function questionPending(entry: Entry): boolean {
+	return awaitingQuestionToolCallId(entry.session.messages) !== null;
+}
+
+function cloneTracked(entry: Entry, message: TrackedQueuedMessage): TrackedQueuedMessage {
+	return {
+		id: entry.nextQueuedMessageId++,
+		text: message.text,
+		...(message.images && message.images.length > 0 ? { images: [...message.images] } : {}),
+	};
+}
+
+function publishHeldQueueUpdate(entry: Entry): void {
+	const { sessionId } = entry.session;
+	if (sessions.get(sessionId) !== entry) return;
+	publish({ sessionId, event: queueUpdateEventOf(entry) });
+	syncSessionActivity(sessionId);
+}
+
+function captureHeldQueue(entry: Entry): void {
+	synchronizeQueueFromSession(entry);
+	const captured = [
+		...entry.queuedMessages.steering.map((message) => cloneTracked(entry, message)),
+		...entry.queuedMessages.followUp.map((message) => cloneTracked(entry, message)),
+	];
+	if (captured.length === 0) return;
+	entry.heldWhileAsking.push(...captured);
+	entry.session.clearQueue();
+}
+
+function parkHeld(entry: Entry, text: string, images?: ImageContent[]): void {
+	entry.heldWhileAsking.push({
+		id: entry.nextQueuedMessageId++,
+		text,
+		...(images && images.length > 0 ? { images: [...images] } : {}),
+	});
+	publishHeldQueueUpdate(entry);
+}
+
+async function flushHeldQueue(entry: Entry): Promise<void> {
+	if (entry.heldWhileAsking.length === 0) return;
+	const held = entry.heldWhileAsking;
+	entry.heldWhileAsking = [];
+	for (const message of held) {
+		await followUpSession(
+			entry.session.sessionId,
+			message.text,
+			message.images ? [...message.images] : undefined,
+		);
+	}
+}
+
 function hasQueuedImages(entry: Entry): boolean {
+	if (entry.heldWhileAsking.some((message) => (message.images?.length ?? 0) > 0)) return true;
 	return (["steering", "followUp"] as const).some((kind) =>
 		entry.queuedMessages[kind].some((message) => (message.images?.length ?? 0) > 0),
 	);
@@ -1018,7 +1093,10 @@ function queueContentOf(entry: Entry): SessionQueueContent {
 	});
 	return {
 		steering: entry.queuedMessages.steering.map(project),
-		followUp: entry.queuedMessages.followUp.map(project),
+		followUp: [
+			...entry.queuedMessages.followUp.map(project),
+			...entry.heldWhileAsking.map(project),
+		],
 	};
 }
 
@@ -1052,6 +1130,10 @@ export async function promptSession(
 	images?: ImageContent[],
 ): Promise<void> {
 	const entry = mustGetEntry(sessionId);
+	if (questionPending(entry)) {
+		parkHeld(entry, text, images);
+		return;
+	}
 	if (entry.session.isStreaming) {
 		await queueSessionMessage(entry, "steering", text, images, () =>
 			entry.session.steer(text, images),
@@ -1067,6 +1149,10 @@ export async function steerSession(
 	images?: ImageContent[],
 ): Promise<void> {
 	const entry = mustGetEntry(sessionId);
+	if (questionPending(entry)) {
+		parkHeld(entry, text, images);
+		return;
+	}
 	await queueSessionMessage(entry, "steering", text, images, () =>
 		entry.session.steer(text, images),
 	);
@@ -1078,6 +1164,10 @@ export async function followUpSession(
 	images?: ImageContent[],
 ): Promise<void> {
 	const entry = mustGetEntry(sessionId);
+	if (questionPending(entry)) {
+		parkHeld(entry, text, images);
+		return;
+	}
 	if (entry.session.isStreaming) {
 		await queueSessionMessage(entry, "followUp", text, images, () =>
 			entry.session.followUp(text, images),
@@ -1104,7 +1194,10 @@ function queueStateOf(entry: Entry): SessionQueueState {
 	synchronizeQueueFromSession(entry);
 	return {
 		steering: displayedLane(entry, "steering"),
-		followUp: displayedLane(entry, "followUp"),
+		followUp: [
+			...displayedLane(entry, "followUp"),
+			...entry.heldWhileAsking.map((message) => message.text),
+		],
 		...(hasQueuedImages(entry) ? { hasImages: true as const } : {}),
 	};
 }
@@ -1115,6 +1208,7 @@ export function clearQueueSession(sessionId: string, requireTextOnly = false): S
 	if (requireTextOnly && hasQueuedImages(entry)) {
 		throw new Error("Cannot restore queued image messages as text");
 	}
+	entry.heldWhileAsking = [];
 	entry.session.clearQueue();
 	entry.stuckEmptyDeliveries = { steering: 0, followUp: 0 };
 	syncSessionActivity(sessionId);

--- a/packages/server/src/agent/askUserQuestion.ts
+++ b/packages/server/src/agent/askUserQuestion.ts
@@ -287,10 +287,13 @@ export function buildAnswersMessage(
 
 export const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
 
-export function createAskUserQuestionTool(): ToolDefinition<
-	typeof AskUserQuestionSchema,
-	AskUserQuestionAckDetails | AskUserQuestionResult
-> {
+export interface QuestionHold {
+	capture(): void;
+}
+
+export function createAskUserQuestionTool(
+	hold?: QuestionHold,
+): ToolDefinition<typeof AskUserQuestionSchema, AskUserQuestionAckDetails | AskUserQuestionResult> {
 	return {
 		name: ASK_USER_QUESTION_TOOL_NAME,
 		label: "Ask User Question",
@@ -304,6 +307,8 @@ export function createAskUserQuestionTool(): ToolDefinition<
 			const validation = validateQuestionnaire(args);
 			if (!validation.ok) return toolResult(validation.message, { answers: [], cancelled: true });
 
+			if (hold && ctx.hasPendingMessages()) hold.capture();
+
 			return {
 				content: [{ type: "text", text: ASK_ACK_TEXT }],
 				details: { kind: "ack" } satisfies AskUserQuestionAckDetails,
@@ -313,6 +318,6 @@ export function createAskUserQuestionTool(): ToolDefinition<
 	};
 }
 
-export function askUserQuestionExtension(pi: ExtensionAPI): void {
-	pi.registerTool(createAskUserQuestionTool());
+export function askUserQuestionExtensionFor(hold?: QuestionHold): (pi: ExtensionAPI) => void {
+	return (pi) => pi.registerTool(createAskUserQuestionTool(hold));
 }

--- a/packages/server/src/agent/extensions.ts
+++ b/packages/server/src/agent/extensions.ts
@@ -15,7 +15,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { SkillCatalogEntry, SlashCommandInfo } from "@thinkrail/contracts";
 import specGraphExtension from "pi-spec-graph";
-import { askUserQuestionExtension } from "./askUserQuestion";
+import { askUserQuestionExtensionFor, type QuestionHold } from "./askUserQuestion";
 import { oversizedImageGuard } from "./imageGuard";
 import { reviewToolExtension } from "./reviewTool";
 import { decideSkill, type SkillAdmissionContext } from "./skillAdmission";
@@ -189,10 +189,11 @@ export async function buildResourceLoader(
 	getAdmission: () => SkillAdmissionContext,
 	excludedExtensionPaths: readonly string[] = [],
 	extraFactories: ExtensionFactory[] = [],
+	questionHold?: QuestionHold,
 ): Promise<ResourceLoader> {
 	const sharedFactories = [
 		headlessSearchPolicy,
-		askUserQuestionExtension,
+		askUserQuestionExtensionFor(questionHold),
 		reviewToolExtension,
 		oversizedImageGuard,
 		...extraFactories,


### PR DESCRIPTION
Fixed the bug where a message queued while the agent was working would supersede a pending ask_user_question (the agent jumped to the queued task instead of waiting for the answer). Diagnosed it as a consequence of our host-owned ack+terminate ask design (not a pi bug — pi's own blocking dialogs never drain the queue), and confirmed the fix belongs in the host with the user (Approach A; Skip flushes held messages in order). Implemented a per-session QuestionHold seam: the ask tool synchronously drains pi's queue into entry.heldWhileAsking before terminating (race-free), all send paths park while a question is pending, the held buffer is unioned into every queue projection but excluded from pendingMessageCount (so status stays "waiting", not "queued"), and answerQuestion (answer or Skip) flushes held messages in order after the reply. Updated packages/server/src/agent/SPEC.md and added an integration test. Verified: typecheck 15/15, agent unit tests 207 pass, lint clean, full e2e gate all 8 shards green (one unrelated flake self-resolved).

## Plan
### Fix: queued message shouldn't supersede a pending question
- [x] **Confirm scenario + desired behavior with user**
  User confirmed scenario A (queued followUp superseded a pending ask_user_question) and chose: the pending question should hold the queue until answered/dismissed.
  Verified: not verified (clarification only)
- [x] **Brainstorm the fix (task-spec) against agent/activity specs**
  Diagnosed root cause (our ack+terminate design, not a pi bug) and recorded Approach A + Skip-flush decision in .thinkrail/context/TASK-question-holds-queue.md with a concrete host-side implementation plan.
  Verified: not verified (design only)
- [x] **QuestionHold seam: hold-aware ask tool + buildResourceLoader wiring** (`3785165`)
  Added a QuestionHold seam: createAskUserQuestionTool(hold?)/askUserQuestionExtensionFor(hold?), buildResourceLoader threads an optional questionHold, and the two host-session creation paths bind it to the entry.
  Verified: bun run typecheck green; agent unit tests pass
- [x] **Capture on question + hold sends + flush on answer in manager**
  Tool execute synchronously captures+clears pi's queue into entry.heldWhileAsking when a question is raised; prompt/steer/followUp park while a question is pending; answerQuestion flushes held in order after the answer.
  Verified: new integration test in agentSessionManager.test.ts passes (hold→waiting→flush)
- [x] **Union held buffer into queue projection + clear/abort integration**
  Held buffer unioned into queueContentOf/queueStateOf/hasQueuedImages and the queue_update projection (heldQueueEvent); summaryOf queue gate includes held; clearQueueSession clears held (so abort-restore stays lossless). Activity stays waiting because held is not in pi's pendingMessageCount.
  Verified: agent unit tests pass (49) incl. queue/abort/remove cases
- [x] **Update agent SPEC + tests, run agent unit tests** (`171a75d`)
  Updated agent/SPEC.md: rewrote the activity-precedence rationale (a pending question now holds the queue, so queued never co-occurs with waiting) and the askUserQuestion block (QuestionHold seam, capture/park/flush, projection union), plus the buildResourceLoader signature. Added an integration test covering hold→waiting→ordered flush.
  Verified: bun run typecheck green (15/15); bun test packages/server/src/agent 207 pass; bun run lint clean
- [x] **Full e2e gate**
  Ran the full e2e gate. First run had one flaky failure (chat-order.spec scroll ordering, unrelated to this change); it passed on --last-failed and the full re-run passed all 8 shards.
  Verified: bun run e2e — all 8 shards passed in 177.3s

Review: 1/6 steps reviewed in ThinkRail.